### PR TITLE
M1.01: state enum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,13 @@ Use these. Don't introduce new heavyweight dependencies without an ADR.
 6. If still unsure, label the issue `factory:gate-pending` and request human input. Do not guess on architectural decisions.
 7. Follow TDD: write the failing test first, then the implementation, then refactor.
 8. Run lint and tests before opening a PR.
-9. Open PR with a clear description linking back to the issue. Do not include implementation reasoning the QA/Reviewer agents shouldn't see — that goes in `agent.decision-summary` events, not PR descriptions.
+9. Open PR with a clear description linking back to the issue. Always include `Closes #N` (where N is the issue number) in the PR body so GitHub auto-closes the issue on merge. Do not include implementation reasoning the QA/Reviewer agents shouldn't see — that goes in `agent.decision-summary` events, not PR descriptions.
+
+## PR conventions
+
+- Title format: `M<milestone>.<task>: <short description>` — e.g. `M1.01: state enum`
+- Body must contain `Closes #N` on its own line to trigger GitHub's auto-close on merge
+- No implementation reasoning in the body (QA/Review are holdouts)
 
 ## Decision summaries
 

--- a/core/state-machine/states.test.ts
+++ b/core/state-machine/states.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { STATES } from './states.js';
+
+describe('STATES', () => {
+  it('has exactly 23 canonical states', () => {
+    expect(STATES).toHaveLength(23);
+  });
+
+  it('contains all canonical factory:* states in order', () => {
+    expect([...STATES]).toStrictEqual([
+      'factory:triaging',
+      'factory:accepted',
+      'factory:rejected',
+      'factory:grilling',
+      'factory:prd-drafting',
+      'factory:prd-review',
+      'factory:decomposing',
+      'factory:issues-created',
+      'factory:research-pending',
+      'factory:research-complete',
+      'factory:investigating',
+      'factory:investigation-complete',
+      'factory:dev-ready',
+      'factory:in-progress',
+      'factory:needs-qa',
+      'factory:qa-failed',
+      'factory:needs-review',
+      'factory:needs-fix',
+      'factory:approved',
+      'factory:retrospecting',
+      'factory:needs-human',
+      'factory:done',
+      'factory:archived',
+    ]);
+  });
+
+  it('is frozen at runtime', () => {
+    expect(Object.isFrozen(STATES)).toBe(true);
+  });
+});

--- a/core/state-machine/states.ts
+++ b/core/state-machine/states.ts
@@ -1,0 +1,28 @@
+export const STATES = Object.freeze([
+  'factory:triaging',
+  'factory:accepted',
+  'factory:rejected',
+  'factory:grilling',
+  'factory:prd-drafting',
+  'factory:prd-review',
+  'factory:decomposing',
+  'factory:issues-created',
+  'factory:research-pending',
+  'factory:research-complete',
+  'factory:investigating',
+  'factory:investigation-complete',
+  'factory:dev-ready',
+  'factory:in-progress',
+  'factory:needs-qa',
+  'factory:qa-failed',
+  'factory:needs-review',
+  'factory:needs-fix',
+  'factory:approved',
+  'factory:retrospecting',
+  'factory:needs-human',
+  'factory:done',
+  'factory:archived',
+] as const);
+
+export type StateName = (typeof STATES)[number];
+export type State = StateName;


### PR DESCRIPTION
Closes #1

Adds `core/state-machine/states.ts` — the canonical typed source of truth for all 23 `factory:*` states.

- `STATES` frozen const-as-tuple with `as const`; `StateName` is the derived union type; `State` aliases it
- Any assignment of a non-canonical string to `State` is a TypeScript error
- `states.test.ts` asserts count (23), exact membership, and freeze status
- Zero runtime side effects on import