### PR TITLE
M1.02: transition table

### DIFF
--- a/core/state-machine/transitions.test.ts
+++ b/core/state-machine/transitions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { isLegalTransition, legalTargets } from './transitions.js';
+
+describe('isLegalTransition — section 9.1 happy paths', () => {
+  // triaging
+  it('triaging → accepted', () => expect(isLegalTransition('factory:triaging', 'factory:accepted')).toBe(true));
+  it('triaging → rejected', () => expect(isLegalTransition('factory:triaging', 'factory:rejected')).toBe(true));
+  it('rejected → archived', () => expect(isLegalTransition('factory:rejected', 'factory:archived')).toBe(true));
+
+  // feature path
+  it('accepted → grilling', () => expect(isLegalTransition('factory:accepted', 'factory:grilling')).toBe(true));
+  it('grilling → prd-drafting', () => expect(isLegalTransition('factory:grilling', 'factory:prd-drafting')).toBe(true));
+  it('prd-drafting → prd-review', () => expect(isLegalTransition('factory:prd-drafting', 'factory:prd-review')).toBe(true));
+  it('prd-review → decomposing', () => expect(isLegalTransition('factory:prd-review', 'factory:decomposing')).toBe(true));
+  it('decomposing → issues-created', () => expect(isLegalTransition('factory:decomposing', 'factory:issues-created')).toBe(true));
+  it('issues-created → dev-ready', () => expect(isLegalTransition('factory:issues-created', 'factory:dev-ready')).toBe(true));
+
+  // bug path
+  it('accepted → investigating', () => expect(isLegalTransition('factory:accepted', 'factory:investigating')).toBe(true));
+  it('investigating → investigation-complete', () => expect(isLegalTransition('factory:investigating', 'factory:investigation-complete')).toBe(true));
+  it('investigation-complete → dev-ready', () => expect(isLegalTransition('factory:investigation-complete', 'factory:dev-ready')).toBe(true));
+
+  // chore path
+  it('accepted → dev-ready', () => expect(isLegalTransition('factory:accepted', 'factory:dev-ready')).toBe(true));
+
+  // research path
+  it('accepted → research-pending', () => expect(isLegalTransition('factory:accepted', 'factory:research-pending')).toBe(true));
+  it('research-pending → research-complete', () => expect(isLegalTransition('factory:research-pending', 'factory:research-complete')).toBe(true));
+  it('research-complete → dev-ready', () => expect(isLegalTransition('factory:research-complete', 'factory:dev-ready')).toBe(true));
+
+  // dev loop
+  it('dev-ready → in-progress', () => expect(isLegalTransition('factory:dev-ready', 'factory:in-progress')).toBe(true));
+  it('in-progress → needs-qa', () => expect(isLegalTransition('factory:in-progress', 'factory:needs-qa')).toBe(true));
+  it('needs-qa → qa-failed', () => expect(isLegalTransition('factory:needs-qa', 'factory:qa-failed')).toBe(true));
+  it('needs-qa → needs-review', () => expect(isLegalTransition('factory:needs-qa', 'factory:needs-review')).toBe(true));
+  it('qa-failed → needs-fix', () => expect(isLegalTransition('factory:qa-failed', 'factory:needs-fix')).toBe(true));
+  it('needs-review → needs-fix', () => expect(isLegalTransition('factory:needs-review', 'factory:needs-fix')).toBe(true));
+  it('needs-review → approved', () => expect(isLegalTransition('factory:needs-review', 'factory:approved')).toBe(true));
+  it('needs-review → needs-human (retries exhausted)', () => expect(isLegalTransition('factory:needs-review', 'factory:needs-human')).toBe(true));
+  it('needs-fix → needs-human (retries exhausted)', () => expect(isLegalTransition('factory:needs-fix', 'factory:needs-human')).toBe(true));
+  it('approved → retrospecting', () => expect(isLegalTransition('factory:approved', 'factory:retrospecting')).toBe(true));
+  it('retrospecting → done', () => expect(isLegalTransition('factory:retrospecting', 'factory:done')).toBe(true));
+  it('done → archived', () => expect(isLegalTransition('factory:done', 'factory:archived')).toBe(true));
+});
+
+describe('isLegalTransition — section 9.2 PR-close paths', () => {
+  it('needs-review → rejected (human explicitly cancelled)', () =>
+    expect(isLegalTransition('factory:needs-review', 'factory:rejected')).toBe(true));
+});
+
+describe('isLegalTransition — re-entry loop (needs-fix → in-progress → needs-qa)', () => {
+  it('needs-fix → in-progress', () => expect(isLegalTransition('factory:needs-fix', 'factory:in-progress')).toBe(true));
+  it('in-progress → needs-qa (second pass)', () => expect(isLegalTransition('factory:in-progress', 'factory:needs-qa')).toBe(true));
+  it('needs-qa → needs-review (second pass)', () => expect(isLegalTransition('factory:needs-qa', 'factory:needs-review')).toBe(true));
+});
+
+describe('isLegalTransition — illegal jumps', () => {
+  it('triaging → done', () => expect(isLegalTransition('factory:triaging', 'factory:done')).toBe(false));
+  it('triaging → archived', () => expect(isLegalTransition('factory:triaging', 'factory:archived')).toBe(false));
+  it('in-progress → approved (skips qa/review)', () => expect(isLegalTransition('factory:in-progress', 'factory:approved')).toBe(false));
+  it('dev-ready → needs-qa (skips in-progress)', () => expect(isLegalTransition('factory:dev-ready', 'factory:needs-qa')).toBe(false));
+  it('approved → done (skips retrospecting)', () => expect(isLegalTransition('factory:approved', 'factory:done')).toBe(false));
+  it('accepted → triaging (backwards)', () => expect(isLegalTransition('factory:accepted', 'factory:triaging')).toBe(false));
+});
+
+describe('terminal states', () => {
+  it('archived has no exits', () => expect(legalTargets('factory:archived')).toHaveLength(0));
+  it('needs-human has no exits', () => expect(legalTargets('factory:needs-human')).toHaveLength(0));
+  it('archived → done is illegal', () => expect(isLegalTransition('factory:archived', 'factory:done')).toBe(false));
+  it('archived → triaging is illegal', () => expect(isLegalTransition('factory:archived', 'factory:triaging')).toBe(false));
+});
+
+describe('legalTargets', () => {
+  it('triaging yields accepted and rejected', () =>
+    expect(legalTargets('factory:triaging')).toStrictEqual(['factory:accepted', 'factory:rejected']));
+
+  it('accepted yields four targets', () =>
+    expect(legalTargets('factory:accepted')).toHaveLength(4));
+
+  it('dev-ready yields only in-progress', () =>
+    expect(legalTargets('factory:dev-ready')).toStrictEqual(['factory:in-progress']));
+});

--- a/core/state-machine/transitions.ts
+++ b/core/state-machine/transitions.ts
@@ -1,0 +1,36 @@
+import { type StateName } from './states.js';
+
+const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
+  'factory:triaging':              ['factory:accepted', 'factory:rejected'],
+  'factory:accepted':              ['factory:grilling', 'factory:investigating', 'factory:dev-ready', 'factory:research-pending'],
+  'factory:rejected':              ['factory:archived'],
+  'factory:grilling':              ['factory:prd-drafting'],
+  'factory:prd-drafting':         ['factory:prd-review'],
+  'factory:prd-review':            ['factory:decomposing'],
+  'factory:decomposing':           ['factory:issues-created'],
+  'factory:issues-created':        ['factory:dev-ready'],
+  'factory:research-pending':      ['factory:research-complete'],
+  'factory:research-complete':     ['factory:dev-ready'],
+  'factory:investigating':         ['factory:investigation-complete'],
+  'factory:investigation-complete': ['factory:dev-ready'],
+  'factory:dev-ready':             ['factory:in-progress'],
+  'factory:in-progress':           ['factory:needs-qa'],
+  'factory:needs-qa':              ['factory:qa-failed', 'factory:needs-review'],
+  'factory:qa-failed':             ['factory:needs-fix'],
+  // needs-review → rejected covers the "human explicitly cancelled" case from section 9.2
+  'factory:needs-review':          ['factory:needs-fix', 'factory:approved', 'factory:needs-human', 'factory:rejected'],
+  'factory:needs-fix':             ['factory:in-progress', 'factory:needs-human'],
+  'factory:approved':              ['factory:retrospecting'],
+  'factory:retrospecting':         ['factory:done'],
+  'factory:needs-human':           [],
+  'factory:done':                  ['factory:archived'],
+  'factory:archived':              [],
+} as const;
+
+export function legalTargets(from: StateName): readonly StateName[] {
+  return TRANSITIONS[from];
+}
+
+export function isLegalTransition(from: StateName, to: StateName): boolean {
+  return (TRANSITIONS[from] as readonly string[]).includes(to);
+}


### PR DESCRIPTION
Closes #2

Adds `core/state-machine/transitions.ts` — the legal transition table for all 23 factory states.

- `TRANSITIONS` is a `const` record keyed by `StateName`; TypeScript ensures exhaustiveness
- `legalTargets(from)` returns the readonly array of valid next states
- `isLegalTransition(from, to)` is the single call-site predicate used by every workflow
- `needs-review → rejected` covers the "human explicitly cancelled" case from PLAN section 9.2
- Terminal states (`archived`, `needs-human`) have empty target arrays