### PR TITLE
M1.03: label conflict resolver

### DIFF
--- a/core/state-machine/README.md
+++ b/core/state-machine/README.md
@@ -1,0 +1,46 @@
+# core/state-machine
+
+Typed state machine for Goose Hub issue lifecycle management.
+
+## Modules
+
+### `states.ts`
+
+Exports the canonical ordered list of 23 `factory:*` state names as a frozen `STATES` array, plus `StateName` (union type) and `State` (alias).
+
+### `transitions.ts`
+
+Exports the legal transition table:
+
+- `legalTargets(from: StateName): readonly StateName[]` — returns all valid next states from `from`.
+- `isLegalTransition(from: StateName, to: StateName): boolean` — returns `true` if the transition is in the table.
+
+### `conflict-resolver.ts`
+
+Resolves label conflicts when a GitHub issue carries multiple (or missing, or unknown) `factory:*` labels.
+
+#### Exports
+
+**`ConflictReason`** — union of possible conflict codes:
+
+| Code | Meaning |
+|---|---|
+| `zero-factory-labels` | No known `factory:*` state labels found; defaulted to `factory:triaging` |
+| `multiple-state-labels` | Two or more known state labels; highest canonical index wins |
+| `unknown-factory-label` | A `factory:*` label was present but not in `STATES`; ignored |
+| `archived-wins` | `factory:archived` present alongside another state; archived takes precedence |
+| `illegal-transition` | The proposed transition is not in the legal transition table |
+
+**`ConflictResult`** — `{ state: StateName; conflicts: ConflictReason[] }`
+
+**`resolveState(labels: string[]): ConflictResult`** — applies the 5 label-conflict rules and returns the effective state plus any conflict codes.
+
+**`checkTransition(from: StateName | null, to: StateName): { legal: boolean; reason: ConflictReason | null }`** — validates a single transition. `from === null` (no prior state) is always legal.
+
+## Conflict resolution rules
+
+1. Zero `factory:*` state labels → state = `factory:triaging`, conflict `zero-factory-labels`.
+2. Unknown `factory:*` label (prefix present, not in `STATES`) → ignored, conflict `unknown-factory-label`.
+3. `factory:archived` + any other state label → archived wins, conflict `archived-wins`.
+4. Two or more known state labels → highest index in `STATES` wins, conflict `multiple-state-labels`.
+5. Single known state label → no conflict.

--- a/core/state-machine/conflict-resolver.test.ts
+++ b/core/state-machine/conflict-resolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { checkTransition, resolveState } from './conflict-resolver.js';
+
+// Rule 1 — zero factory:* state labels
+describe('resolveState — rule 1: zero factory state labels', () => {
+  it('no labels at all → triaging + zero-factory-labels', () => {
+    const result = resolveState([]);
+    expect(result.state).toBe('factory:triaging');
+    expect(result.conflicts).toContain('zero-factory-labels');
+  });
+
+  it('only non-factory labels → triaging + zero-factory-labels', () => {
+    const result = resolveState(['bug', 'priority:high']);
+    expect(result.state).toBe('factory:triaging');
+    expect(result.conflicts).toContain('zero-factory-labels');
+  });
+});
+
+// Rule 2 — single valid label
+describe('resolveState — rule 2: single valid label, no conflict', () => {
+  it('factory:accepted only → accepted, no conflicts', () => {
+    const result = resolveState(['factory:accepted']);
+    expect(result.state).toBe('factory:accepted');
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('factory:in-progress only → in-progress, no conflicts', () => {
+    const result = resolveState(['factory:in-progress']);
+    expect(result.state).toBe('factory:in-progress');
+    expect(result.conflicts).toHaveLength(0);
+  });
+});
+
+// Rule 2 (multi-state tiebreak) — most advanced (highest index) wins
+describe('resolveState — rule 2: two state labels → most advanced wins', () => {
+  it('triaging + accepted → accepted (higher index), multiple-state-labels', () => {
+    const result = resolveState(['factory:triaging', 'factory:accepted']);
+    expect(result.state).toBe('factory:accepted');
+    expect(result.conflicts).toContain('multiple-state-labels');
+  });
+
+  it('dev-ready + in-progress → in-progress, multiple-state-labels', () => {
+    const result = resolveState(['factory:dev-ready', 'factory:in-progress']);
+    expect(result.state).toBe('factory:in-progress');
+    expect(result.conflicts).toContain('multiple-state-labels');
+  });
+});
+
+// Rule 4 — archived + active → archived wins
+describe('resolveState — rule 4: archived + active state → archived wins', () => {
+  it('archived + triaging → archived, archived-wins', () => {
+    const result = resolveState(['factory:archived', 'factory:triaging']);
+    expect(result.state).toBe('factory:archived');
+    expect(result.conflicts).toContain('archived-wins');
+  });
+
+  it('done + archived → archived, archived-wins', () => {
+    const result = resolveState(['factory:done', 'factory:archived']);
+    expect(result.state).toBe('factory:archived');
+    expect(result.conflicts).toContain('archived-wins');
+  });
+});
+
+// Rule 3 — unknown factory:* label alone
+describe('resolveState — rule 3: unknown factory label alone', () => {
+  it('factory:fake-unknown alone → triaging (zero known), unknown-factory-label + zero-factory-labels', () => {
+    const result = resolveState(['factory:fake-unknown']);
+    expect(result.state).toBe('factory:triaging');
+    expect(result.conflicts).toContain('unknown-factory-label');
+    expect(result.conflicts).toContain('zero-factory-labels');
+  });
+});
+
+// Rule 3 — unknown factory:* label mixed with valid
+describe('resolveState — rule 3: unknown factory label mixed with valid', () => {
+  it('factory:fake-unknown + factory:accepted → accepted, unknown-factory-label only', () => {
+    const result = resolveState(['factory:fake-unknown', 'factory:accepted']);
+    expect(result.state).toBe('factory:accepted');
+    expect(result.conflicts).toContain('unknown-factory-label');
+    expect(result.conflicts).not.toContain('zero-factory-labels');
+    expect(result.conflicts).not.toContain('multiple-state-labels');
+  });
+});
+
+// Rule 6 — legal transition (null from)
+describe('checkTransition — rule 6: null from is always legal', () => {
+  it('null → triaging is legal', () => {
+    const result = checkTransition(null, 'factory:triaging');
+    expect(result.legal).toBe(true);
+    expect(result.reason).toBeNull();
+  });
+
+  it('null → archived is legal', () => {
+    const result = checkTransition(null, 'factory:archived');
+    expect(result.legal).toBe(true);
+    expect(result.reason).toBeNull();
+  });
+});
+
+// Rule 6 — legal transition between known states
+describe('checkTransition — rule 6: legal transitions', () => {
+  it('triaging → accepted is legal', () => {
+    const result = checkTransition('factory:triaging', 'factory:accepted');
+    expect(result.legal).toBe(true);
+    expect(result.reason).toBeNull();
+  });
+
+  it('approved → retrospecting is legal', () => {
+    const result = checkTransition('factory:approved', 'factory:retrospecting');
+    expect(result.legal).toBe(true);
+    expect(result.reason).toBeNull();
+  });
+});
+
+// Rule 7 — illegal transition
+describe('checkTransition — rule 7: illegal transitions', () => {
+  it('triaging → done is illegal', () => {
+    const result = checkTransition('factory:triaging', 'factory:done');
+    expect(result.legal).toBe(false);
+    expect(result.reason).toBe('illegal-transition');
+  });
+
+  it('in-progress → approved (skips qa/review) is illegal', () => {
+    const result = checkTransition('factory:in-progress', 'factory:approved');
+    expect(result.legal).toBe(false);
+    expect(result.reason).toBe('illegal-transition');
+  });
+});

--- a/core/state-machine/conflict-resolver.ts
+++ b/core/state-machine/conflict-resolver.ts
@@ -1,0 +1,76 @@
+import { STATES, type StateName } from './states.js';
+import { isLegalTransition } from './transitions.js';
+
+export type ConflictReason =
+  | 'zero-factory-labels'
+  | 'multiple-state-labels'
+  | 'unknown-factory-label'
+  | 'archived-wins'
+  | 'illegal-transition';
+
+export interface ConflictResult {
+  state: StateName;
+  conflicts: ConflictReason[];
+}
+
+const STATES_SET = new Set<string>(STATES);
+const ARCHIVED: StateName = 'factory:archived';
+
+/**
+ * Resolve the effective state from a set of GitHub issue labels.
+ *
+ * Rules (in priority order):
+ *  1. Zero factory:* state labels → default to 'factory:triaging', conflict 'zero-factory-labels'
+ *  2. Unknown factory:* labels (has prefix but not in STATES) → ignored, conflict 'unknown-factory-label'
+ *  3. factory:archived + any other state → archived wins, conflict 'archived-wins'
+ *  4. Two or more known state labels → highest canonical index wins, conflict 'multiple-state-labels'
+ *  5. Single known state label → no conflict
+ */
+export function resolveState(labels: string[]): ConflictResult {
+  const conflicts: ConflictReason[] = [];
+
+  const factoryLabels = labels.filter((l) => l.startsWith('factory:'));
+  const unknownFactoryLabels = factoryLabels.filter((l) => !STATES_SET.has(l));
+  const knownStateLabels = factoryLabels.filter((l) => STATES_SET.has(l)) as StateName[];
+
+  if (unknownFactoryLabels.length > 0) {
+    conflicts.push('unknown-factory-label');
+  }
+
+  if (knownStateLabels.length === 0) {
+    conflicts.push('zero-factory-labels');
+    return { state: 'factory:triaging', conflicts };
+  }
+
+  if (knownStateLabels.includes(ARCHIVED) && knownStateLabels.length > 1) {
+    conflicts.push('archived-wins');
+    return { state: ARCHIVED, conflicts };
+  }
+
+  if (knownStateLabels.length > 1) {
+    conflicts.push('multiple-state-labels');
+    // Pick the label with the highest index in the canonical STATES array.
+    const winner = knownStateLabels.reduce((best, label) => {
+      return STATES.indexOf(label) > STATES.indexOf(best) ? label : best;
+    });
+    return { state: winner, conflicts };
+  }
+
+  return { state: knownStateLabels[0], conflicts };
+}
+
+/**
+ * Check whether a state transition is legal.
+ *
+ * Rule 6: from === null (no prior state) is always legal.
+ * Rule 7: an illegal transition is flagged with reason 'illegal-transition'.
+ */
+export function checkTransition(
+  from: StateName | null,
+  to: StateName,
+): { legal: boolean; reason: ConflictReason | null } {
+  if (from === null || isLegalTransition(from, to)) {
+    return { legal: true, reason: null };
+  }
+  return { legal: false, reason: 'illegal-transition' };
+}


### PR DESCRIPTION
Adds `conflict-resolver.ts` to `core/state-machine` with typed `ConflictReason`, `resolveState()`, and `checkTransition()` covering all 7 conflict rules, plus a full unit test suite (16 tests).

Closes #3