### PR TITLE
M1.05: StateSource interface

### DIFF
--- a/core/state-source/interface.test.ts
+++ b/core/state-source/interface.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  Artifact,
+  CreateIssueInput,
+  Milestone,
+  SourceEvent,
+  StateSource,
+  Subscription,
+  WorkItem,
+} from './interface.js';
+import type { StateName } from '../state-machine/states.js';
+
+class StubStateSource implements StateSource {
+  projectId = 'stub-project';
+  repoRef = 'stub-owner/stub-repo';
+
+  listOpenWork(): Promise<WorkItem[]> {
+    return Promise.resolve([]);
+  }
+
+  getItem(_itemId: string): Promise<WorkItem> {
+    return Promise.reject(new Error('not implemented'));
+  }
+
+  listMilestones(): Promise<Milestone[]> {
+    return Promise.resolve([]);
+  }
+
+  getActiveMilestone(): Promise<Milestone | null> {
+    return Promise.resolve(null);
+  }
+
+  transitionState(
+    _itemId: string,
+    _from: StateName,
+    _to: StateName,
+    _note?: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  comment(_itemId: string, _body: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  attach(_itemId: string, _artifact: Artifact): Promise<void> {
+    return Promise.resolve();
+  }
+
+  createIssue(_input: CreateIssueInput): Promise<WorkItem> {
+    return Promise.reject(new Error('not implemented'));
+  }
+
+  watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {
+    return Promise.resolve({ unsubscribe: () => {} });
+  }
+}
+
+describe('StateSource interface', () => {
+  it('stub compiles', () => {
+    expect(true).toBe(true);
+  });
+
+  it('stub satisfies StateSource shape', () => {
+    const source: StateSource = new StubStateSource();
+    expect(source.projectId).toBe('stub-project');
+    expect(source.repoRef).toBe('stub-owner/stub-repo');
+  });
+});

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -1,0 +1,77 @@
+import type { StateName } from '../state-machine/states.js';
+
+// Supporting types
+export type WorkItemType = 'feature' | 'bug' | 'chore' | 'research';
+export type Priority = 'critical' | 'high' | 'medium' | 'low';
+export type Mode = 'interactive' | 'supervised' | 'autonomous';
+export type Schedule = 'current' | 'next' | 'later' | 'blocked-by';
+export type ExecMode = 'serial' | 'parallel';
+
+export interface WorkItem {
+  id: string; // global: "github:shaunnez/goose-hub#42"
+  externalId: string; // "42" or "PROJ-123"
+  repoRef: string; // "shaunnez/goose-hub"
+  title: string;
+  body: string;
+  type: WorkItemType;
+  priority: Priority;
+  mode: Mode;
+  state: StateName;
+  parentId?: string;
+  authorIsOwner: boolean;
+  milestoneId?: string;
+  schedule: Schedule;
+  exec: ExecMode;
+  dependsOn: string[]; // repo-qualified refs parsed from body
+  blocks: string[];
+  createdAt: Date;
+}
+
+export interface Milestone {
+  id: string;
+  title: string;
+  number: number;
+  description?: string;
+  dueOn?: Date;
+  isActive: boolean;
+}
+
+export interface Artifact {
+  kind: string;
+  url?: string;
+  content?: string;
+}
+
+export interface CreateIssueInput {
+  title: string;
+  body: string;
+  type?: WorkItemType;
+  priority?: Priority;
+  milestoneId?: string;
+}
+
+export interface SourceEvent {
+  kind: 'created' | 'updated' | 'deleted';
+  item: WorkItem;
+}
+
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+export interface StateSource {
+  projectId: string;
+  repoRef: string;
+
+  listOpenWork(): Promise<WorkItem[]>;
+  getItem(itemId: string): Promise<WorkItem>;
+  listMilestones(): Promise<Milestone[]>;
+  getActiveMilestone(): Promise<Milestone | null>;
+
+  transitionState(itemId: string, from: StateName, to: StateName, note?: string): Promise<void>;
+  comment(itemId: string, body: string): Promise<void>;
+  attach(itemId: string, artifact: Artifact): Promise<void>;
+  createIssue(input: CreateIssueInput): Promise<WorkItem>;
+
+  watchForUpdates(callback: (event: SourceEvent) => void): Promise<Subscription>;
+}


### PR DESCRIPTION
Adds `core/state-source/interface.ts` with the `StateSource` interface and all supporting types (`WorkItem`, `Milestone`, `Artifact`, `CreateIssueInput`, `SourceEvent`, `Subscription`, plus the primitive union types). Pure types only — no implementation logic.

Includes `core/state-source/interface.test.ts` with a fully-typed stub class implementing `StateSource` to validate the interface compiles correctly.

Closes #5