### PR TITLE
docs(slices): add missing READMEs for state-source, db, cli

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,33 @@
+# apps/cli
+
+The `goose` command-line tool. Read-only in M1; the UI in M2 takes over for write paths.
+
+## Commands
+
+### `goose status <project-slug>`
+
+Prints the live state of a target project's GitHub issues:
+
+- Active milestone (lowest open milestone in the source repo).
+- Open issues grouped by `factory:*` state in canonical order.
+- Total count.
+
+Issue state is resolved through `core/state-source/GitHubLabelsSource`, which delegates to `core/state-machine/conflict-resolver.resolveState` — so multi-label, archived-wins, and zero-label cases all produce the right state.
+
+## Configuration
+
+Requires `GITHUB_TOKEN` in the environment (or `.env`). The token needs `repo` scope to read issues.
+
+Known projects are loaded from a hardcoded registry in `src/index.ts` for M1. M2.01 replaces this with the `apps/server` `GET /projects` route, which loads from `target-projects/*/project.config.ts` dynamically.
+
+## Run
+
+```bash
+pnpm goose status goose-hub-self
+```
+
+## Boundaries
+
+- Never calls the GitHub API directly — always goes through `core/state-source/`.
+- Never re-implements state resolution — always uses `core/state-machine/`.
+- No write operations except via `StateSource.transitionState()` (not exposed in M1).

--- a/core/db/README.md
+++ b/core/db/README.md
@@ -1,0 +1,34 @@
+# core/db
+
+Local SQLite store (Drizzle ORM). Holds **operational state only** — events, persona stats, governance audit trail, per-project settings. Work-item authority lives in the source of truth (GitHub Issues), never here.
+
+## Database location
+
+`~/.factory/data/factory.db` — created on first import; the directory is auto-created.
+
+## Modules
+
+### `schema.ts`
+
+Drizzle table definitions. Three tables ship in M1; more land in later milestones.
+
+- **`project_state`** — per-project settings: `projectId` (PK), `activeMilestoneNumber`, `activeMilestoneSetAt`, `activeMilestoneSetBy`, `lastTickAt`.
+- **`events`** — append-only event log: `id`, `projectId`, `workItemId?`, `kind`, `payload` (JSON), `createdAt`. Indexed by `(projectId, createdAt)` for SSE replay.
+- **`governance_audit`** — PR governance check results: `id`, `prUrl`, `projectId`, `ok`, `violations` (JSON), `checkedAt`.
+
+### `db.ts`
+
+Exports the singleton `db` Drizzle handle bound to `better-sqlite3`. Importing it ensures `~/.factory/data/` exists.
+
+### `migrate.ts`
+
+Programmatic entry point that touches the DB so the file is created. Schema migrations are applied via `pnpm db:migrate` (drizzle-kit push).
+
+## Consumers
+
+No live consumers in M1 (the CLI is read-only against GitHub). First consumers arrive in M2 with the server's event stream and active-milestone persistence.
+
+## Rules
+
+- Never store work-item state here that could be read from the source of truth — it goes stale.
+- All event writes go through a single `appendEvent()` chokepoint (introduced in M2 per `CONTEXT.md`); never write to `events` directly.

--- a/core/state-source/README.md
+++ b/core/state-source/README.md
@@ -1,0 +1,32 @@
+# core/state-source
+
+Adapter layer between Goose Hub and the source of truth for work items (currently GitHub Issues; Jira lands in M14).
+
+## Modules
+
+### `interface.ts`
+
+Defines the abstraction every backend implements.
+
+- **`WorkItem`** — normalised issue: id, repo, title, body, type, priority, mode, state, schedule, exec, dependencies, milestone.
+- **`Milestone`** — `{ id, title, number, description?, dueOn?, isActive }`.
+- **`Artifact`**, **`CreateIssueInput`**, **`SourceEvent`**, **`Subscription`** — supporting types for write paths and live updates.
+- **`StateSource`** — the interface itself: `listOpenWork`, `getItem`, `listMilestones`, `getActiveMilestone`, `transitionState`, `comment`, `attach`, `createIssue`, `watchForUpdates`.
+
+### `github-labels.ts`
+
+`GitHubLabelsSource` — `StateSource` backed by the GitHub REST API via native `fetch`.
+
+- Reads issues via `GET /repos/{repo}/issues?state=open` (paginated).
+- Parses `factory:*` state labels through `core/state-machine/conflict-resolver.resolveState` so multi-label, archived-wins, and zero-label cases produce the correct `WorkItem.state` (no naive first-match).
+- Parses auxiliary labels (`type:*`, `priority:*`, `mode:*`, `schedule:*`, `exec:*`).
+- Parses `Depends on #N` and `Blocks #N` references from issue bodies.
+- Read methods (`listOpenWork`, `getItem`, `listMilestones`, `getActiveMilestone`) are implemented in M1.
+- Write methods (`transitionState`, `comment`, `attach`, `createIssue`, `watchForUpdates`) throw `NotImplementedError` in M1; wired up in M2.
+
+## Consumers
+
+- `apps/cli` — `goose status <slug>` (read-only).
+- `apps/server` — REST + SSE routes (M2).
+
+Slices and surface code must go through `StateSource`; never call the GitHub API directly.


### PR DESCRIPTION
FACTORY_RULES rule 24 requires every slice ship with README.md +
slice.test.ts. The M1 exit audit caught state-source, db, and cli
shipping without READMEs while state-machine had one. Backfill the
three to bring the M1 surfaces into compliance before M2 adds the
server, web, and a much larger slice surface.

No code changes.