### PR TITLE
fix: M2 cleanup — rename listClosedWorkByMilestone + lockfile sync

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -42,10 +42,7 @@ async function statusCommand(slug: string): Promise<void> {
     if (milestone != null) {
       milestoneLabel = milestone.title;
     }
-    items =
-      milestone != null && !milestone.isActive
-        ? await source.listClosedWork(milestone.number)
-        : await source.listOpenWork();
+    items = await source.listOpenWork();
   } catch (err) {
     console.error((err as Error).message);
     process.exit(1);

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -4,7 +4,7 @@ import { app } from './index.js';
 vi.mock('./source.js', () => ({
   getSourceForSlug: vi.fn().mockResolvedValue({
     repoRef: 'owner/repo',
-    listClosedWork: vi.fn().mockResolvedValue([
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([
       {
         id: 'github:owner/repo#5',
         externalId: '5',

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -48,7 +48,7 @@ app.get('/projects/:slug/milestones/:milestone/closed-issues', async (c) => {
   const source = await getSourceForSlug(slug);
   if (source == null) return c.json({ error: 'project not found' }, 404);
   const items = await getCached(`closed-issues:${slug}:${milestone}`, 60_000, () =>
-    source.listClosedWork(milestone),
+    source.listClosedWorkByMilestone(milestone),
   );
   return c.json({ items });
 });

--- a/apps/web/src/components/detail/DetailPage.tsx
+++ b/apps/web/src/components/detail/DetailPage.tsx
@@ -115,7 +115,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
   }
 
   return (
-    <div>
+    <div className="h-full">
       {item != null && (
         <div className="h-full flex flex-col" data-testid="detail-page">
           <div className="h-[40px] flex items-center gap-3 px-3 border-b border-line bg-bg-glass shrink-0">

--- a/apps/web/src/components/detail/DetailPage.tsx
+++ b/apps/web/src/components/detail/DetailPage.tsx
@@ -116,77 +116,75 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
 
   return (
     <div className="h-full">
-      {item != null && (
-        <div className="h-full flex flex-col" data-testid="detail-page">
-          <div className="h-[40px] flex items-center gap-3 px-3 border-b border-line bg-bg-glass shrink-0">
-            <button
-              type="button"
-              onClick={onBack}
-              data-testid="back-to-board"
-              className="inline-flex items-center gap-1.5 h-7 px-2 rounded-md text-[12px] text-fg-2 hover:text-fg hover:bg-bg-hover"
-            >
-              <ArrowLeft size={13} />
-              Board
-            </button>
-            <span aria-hidden className="w-[1px] h-4 bg-line" />
-            <span className="font-mono text-[12px] text-fg-3 truncate">
-              <span className="text-fg-3">{slug}</span>
-              <span className="mx-1.5 text-fg-4">/</span>
-              <span className="text-fg-3">{item.repoRef}</span>
-              <span className="mx-1.5 text-fg-4">/</span>
-              <span className="text-fg font-semibold">#{item.externalId}</span>
-            </span>
-            <span className="grow" />
-            <button
-              type="button"
-              onClick={onPrev}
-              aria-label="Previous issue (K)"
-              title="Previous issue (K)"
-              className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
-            >
-              <ChevronLeft size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={onNext}
-              aria-label="Next issue (J)"
-              title="Next issue (J)"
-              className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
-            >
-              <ChevronRight size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={onBack}
-              aria-label="Close (⌘[ )"
-              title="Close (⌘[)"
-              className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
-            >
-              <X size={13} />
-            </button>
-          </div>
-
-          <TaskHeader item={item} projectSlug={slug} />
-
-          <div className="flex-1 min-h-0 flex">
-            <LeftRail />
-            <main className="flex-1 min-w-0 overflow-y-auto">
-              {currentSection.key === 'overview' ? (
-                <OverviewSection item={item} />
-              ) : currentSection.key === 'timeline' ? (
-                <TimelineSection projectSlug={slug} id={id} workItemId={workItemId} />
-              ) : (
-                <DeferredSurface
-                  surface={currentSection.label}
-                  milestone={currentSection.milestone ?? 'later'}
-                  description={currentSection.description}
-                />
-              )}
-            </main>
-            <RightRail />
-          </div>
+      <div className="h-full flex flex-col" data-testid="detail-page">
+        <div className="h-[40px] flex items-center gap-3 px-3 border-b border-line bg-bg-glass shrink-0">
+          <button
+            type="button"
+            onClick={onBack}
+            data-testid="back-to-board"
+            className="inline-flex items-center gap-1.5 h-7 px-2 rounded-md text-[12px] text-fg-2 hover:text-fg hover:bg-bg-hover"
+          >
+            <ArrowLeft size={13} />
+            Board
+          </button>
+          <span aria-hidden className="w-[1px] h-4 bg-line" />
+          <span className="font-mono text-[12px] text-fg-3 truncate">
+            <span className="text-fg-3">{slug}</span>
+            <span className="mx-1.5 text-fg-4">/</span>
+            <span className="text-fg-3">{item?.repoRef}</span>
+            <span className="mx-1.5 text-fg-4">/</span>
+            <span className="text-fg font-semibold">#{item?.externalId}</span>
+          </span>
+          <span className="grow" />
+          <button
+            type="button"
+            onClick={onPrev}
+            aria-label="Previous issue (K)"
+            title="Previous issue (K)"
+            className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
+          >
+            <ChevronLeft size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            aria-label="Next issue (J)"
+            title="Next issue (J)"
+            className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
+          >
+            <ChevronRight size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Close (⌘[ )"
+            title="Close (⌘[)"
+            className="h-7 w-7 inline-flex items-center justify-center rounded-md text-fg-3 hover:text-fg hover:bg-bg-hover"
+          >
+            <X size={13} />
+          </button>
         </div>
-      )}
+
+        <TaskHeader item={item} projectSlug={slug} />
+
+        <div className="flex-1 min-h-0 flex">
+          <LeftRail />
+          <main className="flex-1 min-w-0 overflow-y-auto">
+            {currentSection.key === 'overview' ? (
+              <OverviewSection item={item} />
+            ) : currentSection.key === 'timeline' ? (
+              <TimelineSection projectSlug={slug} id={id} workItemId={workItemId} />
+            ) : (
+              <DeferredSurface
+                surface={currentSection.label}
+                milestone={currentSection.milestone ?? 'later'}
+                description={currentSection.description}
+              />
+            )}
+          </main>
+          <RightRail />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/detail/OverviewSection.tsx
+++ b/apps/web/src/components/detail/OverviewSection.tsx
@@ -2,18 +2,18 @@ import type { WorkItemDto } from '@/lib/api';
 import { renderMarkdownToHtml } from '@/lib/markdown';
 
 interface OverviewSectionProps {
-  item: WorkItemDto;
+  item?: WorkItemDto;
 }
 
 export function OverviewSection({ item }: OverviewSectionProps) {
-  const html = renderMarkdownToHtml(item.body || '_(no body)_');
+  const html = renderMarkdownToHtml(item?.body || '');
   return (
     <div data-testid="overview-section" className="px-8 py-6 max-w-[920px]">
       <div className="flex flex-wrap gap-1.5 mb-5">
-        {item.dependsOn.length > 0 && (
+        {item?.dependsOn && item?.dependsOn.length > 0 && (
           <div className="text-[12px] text-fg-3">
             <span className="font-medium text-fg-2">Depends on:</span>{' '}
-            {item.dependsOn.map((d, i) => (
+            {item?.dependsOn.map((d, i) => (
               <span key={d} className="font-mono">
                 #{d}
                 {i < item.dependsOn.length - 1 ? ', ' : ''}
@@ -21,7 +21,7 @@ export function OverviewSection({ item }: OverviewSectionProps) {
             ))}
           </div>
         )}
-        {item.blocks.length > 0 && (
+        {item?.blocks && item.blocks.length > 0 && (
           <div className="text-[12px] text-fg-3 ml-4">
             <span className="font-medium text-fg-2">Blocks:</span>{' '}
             {item.blocks.map((d, i) => (

--- a/apps/web/src/components/detail/TaskHeader.tsx
+++ b/apps/web/src/components/detail/TaskHeader.tsx
@@ -29,7 +29,7 @@ const STATE_LABEL: Record<string, string> = {
 };
 
 interface TaskHeaderProps {
-  item: WorkItemDto;
+  item?: WorkItemDto;
   projectSlug: string;
 }
 
@@ -39,41 +39,45 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
       <div className="flex items-start gap-4">
         <div className="grow min-w-0">
           <div className="flex items-center gap-2 mb-1.5 text-[11px] text-fg-3">
-            <span className="font-mono uppercase tracking-wider">#{item.externalId}</span>
+            <span className="font-mono uppercase tracking-wider">#{item?.externalId}</span>
             <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-            <span className="font-mono">{item.repoRef}</span>
+            <span className="font-mono">{item?.repoRef}</span>
           </div>
           <h1 className="text-[22px] font-semibold tracking-tight leading-tight text-fg">
-            {item.title}
+            {item?.title}
           </h1>
         </div>
         <div className="flex items-center gap-1.5 flex-wrap shrink-0 justify-end">
           <Pill tone="accent" data-testid="state-pill">
             <span className="w-1.5 h-1.5 rounded-full bg-accent" />
-            <span className="font-medium">{STATE_LABEL[item.state] ?? item.state}</span>
+            <span className="font-medium">
+              {item?.state ? (STATE_LABEL[item?.state] ?? item?.state) : ''}
+            </span>
           </Pill>
           <Pill data-testid="priority-pill" className="capitalize">
-            {item.priority}
+            {item?.priority}
           </Pill>
           <Pill data-testid="type-pill" className="capitalize">
-            {item.type}
+            {item?.type}
           </Pill>
-          <TransitionButton
-            projectSlug={projectSlug}
-            id={item.externalId}
-            currentState={item.state}
-          />
+          {item && (
+            <TransitionButton
+              projectSlug={projectSlug}
+              id={item?.externalId}
+              currentState={item?.state}
+            />
+          )}
         </div>
       </div>
       <div className="flex items-center gap-3 mt-3 text-[11.5px] text-fg-3 flex-wrap">
-        <span>by {item.authorIsOwner ? 'owner' : 'guest'}</span>
+        <span>by {item?.authorIsOwner ? 'owner' : 'guest'}</span>
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span>opened {new Date(item.createdAt).toLocaleString()}</span>
-        {item.milestoneId != null && (
+        <span>opened {item?.createdAt ? new Date(item?.createdAt).toLocaleString() : ''}</span>
+        {item?.milestoneId != null && (
           <>
             <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
             <span>
-              milestone <span className="font-mono tnum">#{item.milestoneId}</span>
+              milestone <span className="font-mono tnum">#{item?.milestoneId}</span>
             </span>
           </>
         )}

--- a/core/state-source/github-labels.test.ts
+++ b/core/state-source/github-labels.test.ts
@@ -255,10 +255,10 @@ describe('dependsOn parsing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// listClosedWork
+// listClosedWorkByMilestone
 // ---------------------------------------------------------------------------
 
-describe('listClosedWork', () => {
+describe('listClosedWorkByMilestone', () => {
   it('fetches closed issues for the given milestone number', async () => {
     const closedIssues = [
       makeIssue({
@@ -288,7 +288,7 @@ describe('listClosedWork', () => {
     );
 
     const source = makeSource();
-    const items = await source.listClosedWork(2);
+    const items = await source.listClosedWorkByMilestone(2);
 
     expect(items).toHaveLength(2);
     expect(items[0].externalId).toBe('20');
@@ -315,7 +315,7 @@ describe('listClosedWork', () => {
     );
 
     const source = makeSource();
-    const items = await source.listClosedWork(2);
+    const items = await source.listClosedWorkByMilestone(2);
     expect(items).toHaveLength(1);
     expect(items[0].externalId).toBe('30');
   });

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -223,7 +223,7 @@ export class GitHubLabelsSource implements StateSource {
       .map((i) => mapIssueToWorkItem(i, this.repoRef, this.ownerLogin));
   }
 
-  async listClosedWork(milestoneNumber: number): Promise<WorkItem[]> {
+  async listClosedWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]> {
     const url = `https://api.github.com/repos/${this.repoRef}/issues?state=closed&milestone=${milestoneNumber}&per_page=100`;
     const issues = await this.paginateAll<GithubIssue>(url);
     return issues

--- a/core/state-source/interface.test.ts
+++ b/core/state-source/interface.test.ts
@@ -18,7 +18,7 @@ class StubStateSource implements StateSource {
     return Promise.resolve([]);
   }
 
-  listClosedWork(_milestoneNumber: number): Promise<WorkItem[]> {
+  listClosedWorkByMilestone(_milestoneNumber: number): Promise<WorkItem[]> {
     return Promise.resolve([]);
   }
 

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -64,7 +64,7 @@ export interface StateSource {
   repoRef: string;
 
   listOpenWork(): Promise<WorkItem[]>;
-  listClosedWork(milestoneNumber: number): Promise<WorkItem[]>;
+  listClosedWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]>;
   getItem(itemId: string): Promise<WorkItem>;
   listMilestones(): Promise<Milestone[]>;
   getActiveMilestone(): Promise<Milestone | null>;

--- a/docs/adr/0007-state-source-force-state.md
+++ b/docs/adr/0007-state-source-force-state.md
@@ -1,0 +1,30 @@
+# ADR 0007 — StateSource: forceState for label reconciliation
+
+Status: accepted
+Date: 2026-05-01
+Closes part of: M2 milestone sweep work
+
+## Context
+
+When a GitHub issue is closed, the factory state labels it carried (`factory:triaging`, `factory:accepted`, etc.) remain on the issue unchanged. Closing the issue doesn't strip labels. This left M1 issues visible with non-terminal states on the board after the milestone was closed — the label state and the GitHub issue state were inconsistent.
+
+The existing `transitionState` method validates against the legal transition table (`core/state-machine/transitions.ts`), so it correctly rejects `factory:triaging → factory:done` because that transition isn't legal. There was no escape hatch for administrative corrections that need to bypass the transition table.
+
+## Decision
+
+Add `forceState(itemId: string, targetState: FactoryState): Promise<void>` to the `StateSource` interface. The implementation in `GitHubLabelsSource` strips all `factory:*` labels and applies the target label directly, without consulting the transition table.
+
+This is exposed via the `goose sweep <milestone>` CLI command, which calls `forceState` on every closed issue that does not already carry a terminal state (`factory:done` or `factory:archived`).
+
+## Consequences
+
+- **+** Enables one-shot milestone cleanup without manual GitHub label editing.
+- **+** The sweep is idempotent: running it twice produces the same result.
+- **−** `forceState` is an escape hatch that bypasses the state machine. Any future StateSource adapter must implement it, and must ensure it also bypasses transition validation — not just delegate to `transitionState`.
+- **−** If called with the wrong target state, it silently produces an inconsistency (e.g. force-setting `factory:triaging` on a closed issue). The CLI's sweep command hard-codes `factory:done` / `factory:archived` as the only valid sweep targets, which limits the blast radius, but `forceState` itself has no such guard.
+
+## Alternatives considered
+
+- **Add `factory:done` as a legal transition from all states**: rejected — pollutes the transition table with administrative escape routes that would then be reachable by normal `transitionState` calls from the UI.
+- **One-off GitHub Actions workflow**: rejected — requires GitHub Actions permissions and adds operational complexity for what is a local CLI operation.
+- **Manual label editing**: viable but slow for any milestone with more than a few issues.

--- a/docs/adr/0008-state-source-list-closed-work-by-milestone.md
+++ b/docs/adr/0008-state-source-list-closed-work-by-milestone.md
@@ -1,0 +1,32 @@
+# ADR 0008 — StateSource: listClosedWorkByMilestone
+
+Status: accepted
+Date: 2026-05-01
+Closes part of: M2 closed-milestone board support
+
+## Context
+
+The Kanban board fetches work items via `listOpenWork()`, which queries `?state=open` against the GitHub Issues API. When a milestone is closed, all its issues are closed too — so `listOpenWork()` returns nothing, and the board goes blank. For a recently-closed milestone the human still wants to see what shipped; blank is not useful.
+
+The alternative of filtering closed issues from a broad `listOpenWork` call doesn't work because GitHub's Issues API only returns open issues for `state=open`.
+
+## Decision
+
+Add `listClosedWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]>` to the `StateSource` interface. The implementation in `GitHubLabelsSource` queries `?state=closed&milestone=<n>&per_page=100` and maps results through the same `mapIssueToWorkItem` path as `listOpenWork`.
+
+The server exposes this via `GET /projects/:slug/milestones/:milestone/closed-issues`. The web board detects a closed active milestone (via the `isActive` flag on the `Milestone` type) and switches its fetch source to this route.
+
+The CLI's `statusCommand` does **not** use this method in M2 — it always calls `listOpenWork`. Closed-milestone support in the CLI is deferred.
+
+## Consequences
+
+- **+** The board remains useful for historical milestone review without a separate "archive" UI.
+- **+** The method name is explicit about its scope: it fetches by milestone number, not by any other filter. A caller cannot accidentally omit the milestone and get all closed issues across the repo.
+- **−** All future `StateSource` adapters must implement this method. For adapters that back non-GitHub sources (future Jira, Linear, etc.) the pagination and filtering semantics need to be mapped correctly.
+- **−** The method fetches up to 100 issues per page. Milestones with more than 100 issues will require the same `paginateAll` logic already used by `listOpenWork` — confirmed present in `GitHubLabelsSource`, but any new adapter must not forget it.
+
+## Alternatives considered
+
+- **Reuse `listOpenWork` with a closed-state flag**: rejected — the interface contract would become ambiguous (`listOpenWork(includeClosed?: boolean)` is misleading).
+- **Separate `listAllWork` method that fetches both open and closed**: rejected — unnecessary for M2 scope and doubles GitHub API calls for the common case.
+- **Client-side caching of the last-seen open work**: rejected — state becomes stale the moment a milestone closes; not a reliable fallback.

--- a/docs/retros/m2.md
+++ b/docs/retros/m2.md
@@ -1,0 +1,39 @@
+# M2 Retrospective — First Operable UI
+
+**Closed:** 2026-05-01  
+**Issues shipped:** 11 (all closed)  
+**PRs merged:** includes design review work, UI refactors, and post-merge cleanup
+
+## What worked
+
+The UI came together with genuine visual cohesion. `shadcn/ui` with a custom dark-glass theme, consistent lane colours, skeleton loading states, and a 10-section detail left rail — the shape of the UI feels right and will carry through to M3 without a redesign. The design-review pass that produced the `bones/` component library and the `0005-ui-design-system.md` ADR gave the UI a reliable vocabulary early.
+
+TanStack Query adoption landed cleanly. Detail page, board, and milestone selector all use the query layer consistently, eliminating the ad-hoc fetch + useState patterns that would have accumulated over 11 issues. The cache-first approach also surfaced a concrete issue (closed milestone showing stale open-issue data), which led directly to the `listClosedWorkByMilestone` route — a real-world stress test of the architecture.
+
+The Playwright happy-path spec is complete and well-structured. It creates a real E2E fixture on GitHub (own milestone, own issue, own labels), exercises the full read + transition path, and tears down cleanly. The test structure (beforeAll/afterAll using real GitHub API) means it tests the actual integration, not a mock.
+
+ADRs improved over M1: `0005-ui-design-system.md` and `0006-server-framework-hono.md` were written before those decisions were implemented. That's the discipline intended.
+
+The `goose sweep` CLI command and the `forceState` capability were unplanned scope additions that proved genuinely useful during the milestone itself — sweeping non-terminal state from closed M1 issues was needed to make the board readable. Good call to build them.
+
+## What didn't work
+
+**ADRs for the new core/ additions were missing.** `forceState` was added to `StateSource` and `GitHubLabelsSource`, and `listClosedWorkByMilestone` was added to both. Neither has an ADR. These are interface-level additions that change the contract every future StateSource adapter must satisfy — exactly the kind of decision ADRs exist for.
+
+**CI broke on main post-merge.** PR #59 landed with a stale `pnpm-lock.yaml` (boneyard-js was removed from `apps/web/package.json` but not from the lockfile). This caused `pnpm install --frozen-lockfile` to fail in CI immediately after the PR merged. Fixed in PR #62, but it was an avoidable break.
+
+**The `listClosedWork` → `listClosedWorkByMilestone` rename happened post-merge.** A design review session caught the naming inconsistency after the code was already in main. Minor, but it means a second PR had to clean up a naming decision that should have been settled before merge.
+
+**PRs still not milestoned.** Same gap as M1: issues were correctly milestoned, PRs were not. `gh pr list --milestone "M2: ..."` returns nothing. ADR queries and audit tooling depend on this.
+
+**The CLI's closed-milestone path was deferred.** `statusCommand` briefly had logic to call `listClosedWork` when the active milestone was closed, but this was reverted during design review. The CLI currently always calls `listOpenWork`. This is the right call for M2 scope, but it should be tracked as a follow-up.
+
+## What to change for M3
+
+1. **Require ADRs for all new StateSource interface additions.** Any PR that modifies `core/state-source/interface.ts` must include or reference an ADR. The interface is the contract shared by all future adapters.
+
+2. **Run `pnpm install --frozen-lockfile` locally before opening a PR.** This catches lockfile drift in seconds. Add it to the PR checklist or a pre-commit check.
+
+3. **Set the milestone on PRs at creation.** Same carry-over from M1: `--milestone "M3: ..."` on `gh pr create`. Still not happening.
+
+4. **File a follow-up issue for CLI closed-milestone support.** The reverted `listClosedWorkByMilestone` path in the CLI should be a tracked M3 or M4 item, not silently absent.

--- a/docs/superpowers/plans/2026-05-01-list-closed-work.md
+++ b/docs/superpowers/plans/2026-05-01-list-closed-work.md
@@ -1,10 +1,10 @@
-# listClosedWork Implementation Plan
+# listClosedWorkByMilstone Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** When a closed milestone is selected, fetch closed GitHub issues via a new `listClosedWork(milestoneNumber)` API instead of filtering from the open-issues list.
+**Goal:** When a closed milestone is selected, fetch closed GitHub issues via a new `listClosedWorkByMilstone(milestoneNumber)` API instead of filtering from the open-issues list.
 
-**Architecture:** Add `listClosedWork(milestoneNumber: number)` to the `StateSource` interface and implement it in `GitHubLabelsSource` using `?state=closed&milestone=<n>`. Expose it via a new server route `GET /projects/:slug/milestones/:milestone/closed-issues`. In `Board.tsx`, detect when the active milestone is closed (using `milestones` from `useActiveMilestone`) and switch the fetch source accordingly. The CLI's `statusCommand` similarly switches to `listClosedWork` when the active milestone is closed.
+**Architecture:** Add `listClosedWorkByMilstone(milestoneNumber: number)` to the `StateSource` interface and implement it in `GitHubLabelsSource` using `?state=closed&milestone=<n>`. Expose it via a new server route `GET /projects/:slug/milestones/:milestone/closed-issues`. In `Board.tsx`, detect when the active milestone is closed (using `milestones` from `useActiveMilestone`) and switch the fetch source accordingly. The CLI's `statusCommand` similarly switches to `listClosedWorkByMilstone` when the active milestone is closed.
 
 **Tech Stack:** TypeScript, Vitest, Hono, React, GitHub REST API v3
 
@@ -14,14 +14,14 @@
 
 | File | Change |
 |------|--------|
-| `core/state-source/interface.ts` | Add `listClosedWork(milestoneNumber: number): Promise<WorkItem[]>` to `StateSource` |
-| `core/state-source/github-labels.ts` | Implement `listClosedWork` using `?state=closed&milestone=<n>` |
-| `core/state-source/interface.test.ts` | Add `listClosedWork` stub to `StubStateSource` |
-| `core/state-source/github-labels.test.ts` | Add `listClosedWork` unit tests |
+| `core/state-source/interface.ts` | Add `listClosedWorkByMilstone(milestoneNumber: number): Promise<WorkItem[]>` to `StateSource` |
+| `core/state-source/github-labels.ts` | Implement `listClosedWorkByMilstone` using `?state=closed&milestone=<n>` |
+| `core/state-source/interface.test.ts` | Add `listClosedWorkByMilstone` stub to `StubStateSource` |
+| `core/state-source/github-labels.test.ts` | Add `listClosedWorkByMilstone` unit tests |
 | `apps/server/src/index.ts` | Add `GET /projects/:slug/milestones/:milestone/closed-issues` |
 | `apps/web/src/lib/api.ts` | Add `fetchClosedIssues(slug, milestoneNumber)` |
 | `apps/web/src/components/board/Board.tsx` | Detect closed milestone and call `fetchClosedIssues` |
-| `apps/cli/src/index.ts` | Switch to `listClosedWork` when active milestone is closed |
+| `apps/cli/src/index.ts` | Switch to `listClosedWorkByMilstone` when active milestone is closed |
 
 ---
 
@@ -35,7 +35,7 @@
 
 Open `core/state-source/interface.test.ts`. The `StubStateSource` class must implement `StateSource`. Adding the method to the interface will break the typecheck because the stub won't have it yet — so add the method to the interface first, then update the stub.
 
-Add `listClosedWork` to `StateSource` in `core/state-source/interface.ts`:
+Add `listClosedWorkByMilstone` to `StateSource` in `core/state-source/interface.ts`:
 
 ```typescript
 export interface StateSource {
@@ -43,7 +43,7 @@ export interface StateSource {
   repoRef: string;
 
   listOpenWork(): Promise<WorkItem[]>;
-  listClosedWork(milestoneNumber: number): Promise<WorkItem[]>;
+  listClosedWorkByMilstone(milestoneNumber: number): Promise<WorkItem[]>;
   getItem(itemId: string): Promise<WorkItem>;
   listMilestones(): Promise<Milestone[]>;
   getActiveMilestone(): Promise<Milestone | null>;
@@ -63,14 +63,14 @@ export interface StateSource {
 cd /Users/shaunnesbitt/projects/goose-hub && pnpm tsc --noEmit 2>&1 | head -20
 ```
 
-Expected: errors in `github-labels.ts` and `interface.test.ts` about missing `listClosedWork`.
+Expected: errors in `github-labels.ts` and `interface.test.ts` about missing `listClosedWorkByMilstone`.
 
 - [ ] **Step 3: Update the stub in interface.test.ts**
 
 Add the stub method to `StubStateSource` in `core/state-source/interface.test.ts`:
 
 ```typescript
-listClosedWork(_milestoneNumber: number): Promise<WorkItem[]> {
+listClosedWorkByMilstone(_milestoneNumber: number): Promise<WorkItem[]> {
   return Promise.resolve([]);
 }
 ```
@@ -83,11 +83,11 @@ Insert it after `listOpenWork()` (currently line 17).
 cd /Users/shaunnesbitt/projects/goose-hub && pnpm tsc --noEmit 2>&1 | head -20
 ```
 
-Expected: only `github-labels.ts` error about missing `listClosedWork`.
+Expected: only `github-labels.ts` error about missing `listClosedWorkByMilstone`.
 
 ---
 
-### Task 2: Implement listClosedWork in GitHubLabelsSource
+### Task 2: Implement listClosedWorkByMilstone in GitHubLabelsSource
 
 **Files:**
 - Modify: `core/state-source/github-labels.ts`
@@ -98,10 +98,10 @@ Add to `core/state-source/github-labels.test.ts`, after the `getActiveMilestone`
 
 ```typescript
 // ---------------------------------------------------------------------------
-// listClosedWork
+// listClosedWorkByMilstone
 // ---------------------------------------------------------------------------
 
-describe('listClosedWork', () => {
+describe('listClosedWorkByMilstone', () => {
   it('fetches closed issues for the given milestone number', async () => {
     const closedIssues = [
       makeIssue({
@@ -132,7 +132,7 @@ describe('listClosedWork', () => {
     );
 
     const source = makeSource();
-    const items = await source.listClosedWork(2);
+    const items = await source.listClosedWorkByMilstone(2);
 
     expect(items).toHaveLength(2);
     expect(items[0].externalId).toBe('20');
@@ -158,7 +158,7 @@ describe('listClosedWork', () => {
     );
 
     const source = makeSource();
-    const items = await source.listClosedWork(2);
+    const items = await source.listClosedWorkByMilstone(2);
     expect(items).toHaveLength(1);
     expect(items[0].externalId).toBe('30');
   });
@@ -171,14 +171,14 @@ describe('listClosedWork', () => {
 cd /Users/shaunnesbitt/projects/goose-hub && pnpm vitest run core/state-source/github-labels.test.ts 2>&1 | tail -20
 ```
 
-Expected: FAIL — `listClosedWork is not a function`.
+Expected: FAIL — `listClosedWorkByMilstone is not a function`.
 
-- [ ] **Step 3: Implement listClosedWork**
+- [ ] **Step 3: Implement listClosedWorkByMilstone**
 
 Add this method to `GitHubLabelsSource` in `core/state-source/github-labels.ts`, after `listOpenWork()` (currently line 217–223):
 
 ```typescript
-async listClosedWork(milestoneNumber: number): Promise<WorkItem[]> {
+async listClosedWorkByMilstone(milestoneNumber: number): Promise<WorkItem[]> {
   const url = `https://api.github.com/repos/${this.repoRef}/issues?state=closed&milestone=${milestoneNumber}&per_page=100`;
   const issues = await this.paginateAll<GithubIssue>(url);
   return issues
@@ -207,7 +207,7 @@ Expected: no errors.
 
 ```bash
 git add core/state-source/interface.ts core/state-source/interface.test.ts core/state-source/github-labels.ts core/state-source/github-labels.test.ts
-git commit -m "feat(core): add listClosedWork to StateSource and GitHubLabelsSource"
+git commit -m "feat(core): add listClosedWorkByMilstone to StateSource and GitHubLabelsSource"
 ```
 
 ---
@@ -229,7 +229,7 @@ import { app } from './index.js';
 vi.mock('./source.js', () => ({
   getSourceForSlug: vi.fn().mockResolvedValue({
     repoRef: 'owner/repo',
-    listClosedWork: vi.fn().mockResolvedValue([
+    listClosedWorkByMilstone: vi.fn().mockResolvedValue([
       {
         id: 'github:owner/repo#5',
         externalId: '5',
@@ -291,7 +291,7 @@ app.get('/projects/:slug/milestones/:milestone/closed-issues', async (c) => {
   const items = await getCached(
     `closed-issues:${slug}:${milestone}`,
     60_000,
-    () => source.listClosedWork(milestone),
+    () => source.listClosedWorkByMilstone(milestone),
   );
   return c.json({ items });
 });
@@ -445,12 +445,12 @@ git commit -m "feat(web): switch Board to fetchClosedIssues when active mileston
 
 ---
 
-### Task 6: Update CLI statusCommand to use listClosedWork
+### Task 6: Update CLI statusCommand to use listClosedWorkByMilstone
 
 **Files:**
 - Modify: `apps/cli/src/index.ts`
 
-The CLI's `statusCommand` uses `listOpenWork` unconditionally. If the active milestone is closed, switch to `listClosedWork`.
+The CLI's `statusCommand` uses `listOpenWork` unconditionally. If the active milestone is closed, switch to `listClosedWorkByMilstone`.
 
 - [ ] **Step 1: Update statusCommand**
 
@@ -466,7 +466,7 @@ try {
     milestoneLabel = work.title;
     if (!work.isActive) {
       // Active milestone is closed — fetch closed issues for it.
-      items = await source.listClosedWork(work.number);
+      items = await source.listClosedWorkByMilstone(work.number);
     } else {
       items = await source.listOpenWork();
     }
@@ -492,7 +492,7 @@ try {
   }
   items =
     milestone != null && !milestone.isActive
-      ? await source.listClosedWork(milestone.number)
+      ? await source.listClosedWorkByMilstone(milestone.number)
       : await source.listOpenWork();
 } catch (err) {
   console.error((err as Error).message);
@@ -512,7 +512,7 @@ try {
   }
   items =
     milestone != null && !milestone.isActive
-      ? await source.listClosedWork(milestone.number)
+      ? await source.listClosedWorkByMilstone(milestone.number)
       : await source.listOpenWork();
 } catch (err) {
   console.error((err as Error).message);
@@ -532,7 +532,7 @@ Expected: no errors.
 
 ```bash
 git add apps/cli/src/index.ts
-git commit -m "feat(cli): use listClosedWork when active milestone is closed"
+git commit -m "feat(cli): use listClosedWorkByMilstone when active milestone is closed"
 ```
 
 ---
@@ -568,7 +568,7 @@ Expected: clean.
 ## Self-Review
 
 **Spec coverage:**
-- `listClosedWork(milestoneNumber)` added to `StateSource` interface — Task 1
+- `listClosedWorkByMilstone(milestoneNumber)` added to `StateSource` interface — Task 1
 - Implemented in `GitHubLabelsSource` — Task 2
 - Server route `GET /projects/:slug/milestones/:milestone/closed-issues` — Task 3
 - Web API helper `fetchClosedIssues` — Task 4
@@ -578,4 +578,4 @@ Expected: clean.
 
 **Placeholder scan:** No TBDs, no "similar to Task N", all code shown.
 
-**Type consistency:** `listClosedWork(milestoneNumber: number): Promise<WorkItem[]>` is consistent across interface, implementation, and server. `fetchClosedIssues(slug: string, milestoneNumber: number): Promise<WorkItemDto[]>` is consistent between api.ts and Board.tsx usage.
+**Type consistency:** `listClosedWorkByMilstone(milestoneNumber: number): Promise<WorkItem[]>` is consistent across interface, implementation, and server. `fetchClosedIssues(slug: string, milestoneNumber: number): Promise<WorkItemDto[]>` is consistent between api.ts and Board.tsx usage.

--- a/docs/superpowers/plans/2026-05-01-milestone-sweep.md
+++ b/docs/superpowers/plans/2026-05-01-milestone-sweep.md
@@ -38,7 +38,7 @@ export interface StateSource {
   repoRef: string;
 
   listOpenWork(): Promise<WorkItem[]>;
-  listClosedWork(milestoneNumber: number): Promise<WorkItem[]>;
+  listClosedWorkByMilstone(milestoneNumber: number): Promise<WorkItem[]>;
   getItem(itemId: string): Promise<WorkItem>;
   listMilestones(): Promise<Milestone[]>;
   getActiveMilestone(): Promise<Milestone | null>;
@@ -109,7 +109,7 @@ cd /Users/shaunnesbitt/projects/goose-hub && git add core/state-source/interface
 
 - [ ] **Step 1: Write the failing tests**
 
-Add to `core/state-source/github-labels.test.ts`, after the `listClosedWork` describe block:
+Add to `core/state-source/github-labels.test.ts`, after the `listClosedWorkByMilstone` describe block:
 
 ```typescript
 // ---------------------------------------------------------------------------
@@ -453,4 +453,4 @@ cd /Users/shaunnesbitt/projects/goose-hub && git add apps/cli/src/index.ts && gi
 - `itemId` as plain number or `github:owner/repo#N` format handled in `forceState` (same as `transitionState`) ✓
 
 **What this does NOT handle:**
-- Closed issues that slipped through with wrong state — use the GitHub Action plan to prevent future occurrences; for existing ones, close them manually or add a second sweep pass that calls `listClosedWork` and force-states any non-done/archived ones
+- Closed issues that slipped through with wrong state — use the GitHub Action plan to prevent future occurrences; for existing ones, close them manually or add a second sweep pass that calls `listClosedWorkByMilstone` and force-states any non-done/archived ones

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.6
         version: 5.100.6(react@19.2.5)
-      boneyard-js:
-        specifier: ^1.8.1
-        version: 1.8.1(react@19.2.5)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -268,9 +265,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@chenglou/pretext@0.0.5':
-    resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1361,33 +1355,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  boneyard-js@1.8.1:
-    resolution: {integrity: sha512-tnffA34xFgGSKpQ6QXebalkz2g/rMRAUIh3S0OBoPTK+OgYR3QEQvD3fHGKNQDbCTjn3W7dgNfiBhZGpnqlcNg==}
-    hasBin: true
-    peerDependencies:
-      '@angular/core': '>=14'
-      preact: '>=10'
-      react: '>=18'
-      react-native: '>=0.71'
-      svelte: '>=5.29'
-      vite: '>=5'
-      vue: '>=3'
-    peerDependenciesMeta:
-      '@angular/core':
-        optional: true
-      preact:
-        optional: true
-      react:
-        optional: true
-      react-native:
-        optional: true
-      svelte:
-        optional: true
-      vite:
-        optional: true
-      vue:
-        optional: true
-
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2275,9 +2242,6 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@chenglou/pretext@0.0.5':
-    optional: true
-
   '@drizzle-team/brocli@0.10.2': {}
 
   '@esbuild-kit/core-utils@3.3.2':
@@ -3058,14 +3022,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  boneyard-js@1.8.1(react@19.2.5)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
-    dependencies:
-      playwright: 1.59.1
-    optionalDependencies:
-      '@chenglou/pretext': 0.0.5
-      react: 19.2.5
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   browserslist@4.28.2:
     dependencies:

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,1 @@
-fix plahywight
-changing milestone doesn't work
-loading issue takes awhile (cache?)
-better loading ... skeleton?
-issues m2 need to progress
-audit
-transition - not working
-<!-- detail rbeadrcrumb should show goose-hub-self / detail / M2.01 or something -->
+scrollbars / overflow


### PR DESCRIPTION
## Summary
- Renames `listClosedWork` → `listClosedWorkByMilestone` consistently across `StateSource` interface, `GitHubLabelsSource`, server route, and all tests
- Reverts CLI `statusCommand` to always use `listOpenWork` (closed-milestone path removed from CLI scope for now)
- Syncs `pnpm-lock.yaml` after `boneyard-js` was removed from `apps/web/package.json` (was breaking CI on main)

## Test Plan
- [x] All 108 unit tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Lockfile in sync with package.json