### PR TITLE
M3.01: gate-pending state UI surface

### DIFF
--- a/apps/web/src/components/detail/DetailPage.tsx
+++ b/apps/web/src/components/detail/DetailPage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { DeferredSurface } from './DeferredSurface';
+import { GatePendingBanner } from './GatePendingBanner';
 import { LeftRail } from './LeftRail';
 import { OverviewSection } from './OverviewSection';
 import { RightRail } from './RightRail';
@@ -166,6 +167,8 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
         </div>
 
         <TaskHeader item={item} projectSlug={slug} />
+
+        <GatePendingBanner state={item?.state} />
 
         <div className="flex-1 min-h-0 flex">
           <LeftRail />

--- a/apps/web/src/components/detail/GatePendingBanner.tsx
+++ b/apps/web/src/components/detail/GatePendingBanner.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/cn';
+import { ShieldAlert } from 'lucide-react';
+import { GATE_STATES } from './gate-states';
+
+export { GATE_STATES } from './gate-states';
+
+interface GatePendingBannerProps {
+  state?: string;
+}
+
+export function GatePendingBanner({ state }: GatePendingBannerProps) {
+  if (!state || !(state in GATE_STATES)) return null;
+
+  const message = GATE_STATES[state];
+
+  return (
+    <div
+      data-testid="gate-pending-banner"
+      className={cn(
+        'flex items-center gap-2.5 px-6 py-2.5 shrink-0',
+        'border-b border-[color:var(--warning)]/40',
+        'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+        'text-[12.5px] font-medium',
+      )}
+    >
+      <ShieldAlert size={14} className="shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/README.md
+++ b/apps/web/src/components/detail/README.md
@@ -18,3 +18,5 @@ Components:
 - `TimelineSection.tsx` — fetches `events` for the work item; subscribes to `/events?workItemId=…` SSE so new transitions appear without a refresh.
 - `DeferredSurface.tsx` — small "Available in M&lt;N&gt;" empty-state for the 8 inert sections.
 - `sections.ts` — single source of truth for the 10-section list, milestone tags, descriptions.
+- `GatePendingBanner.tsx` — amber callout rendered between `TaskHeader` and the main content rails when the issue is in a gate state (a state requiring human action). Renders null for non-gate states.
+- `gate-states.ts` — pure-logic map of gate state keys to human-readable banner messages. Kept separate from the component so the vitest suite (no `@/` alias resolution) can import it directly.

--- a/apps/web/src/components/detail/gate-states.ts
+++ b/apps/web/src/components/detail/gate-states.ts
@@ -1,0 +1,6 @@
+export const GATE_STATES: Record<string, string> = {
+  'factory:prd-review': 'PRD Review pending — human approval required',
+  'factory:needs-review': 'Code Review pending — human approval required',
+  'factory:approved': 'Approved — ready for retrospecting',
+  'factory:needs-human': 'Human intervention required',
+};

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { renderMarkdownToHtml } from '../../lib/markdown';
 import { LEGAL_TARGETS } from '../../lib/transitions';
+import { GATE_STATES } from './gate-states';
 import { SECTIONS } from './sections';
 
 describe('detail page — sections config', () => {
@@ -51,6 +52,32 @@ describe('detail page — markdown sanitization', () => {
     expect(html).toContain('<h2');
     expect(html).toContain('<ul');
     expect(html).toContain('<li>one</li>');
+  });
+});
+
+describe('GatePendingBanner — gate state map', () => {
+  it('returns banner text for prd-review gate state', () => {
+    expect(GATE_STATES['factory:prd-review']).toBe('PRD Review pending — human approval required');
+  });
+
+  it('returns banner text for approved gate state', () => {
+    expect(GATE_STATES['factory:approved']).toBe('Approved — ready for retrospecting');
+  });
+
+  it('returns banner text for needs-review gate state', () => {
+    expect(GATE_STATES['factory:needs-review']).toBe(
+      'Code Review pending — human approval required',
+    );
+  });
+
+  it('returns banner text for needs-human gate state', () => {
+    expect(GATE_STATES['factory:needs-human']).toBe('Human intervention required');
+  });
+
+  it('does not include non-gate states', () => {
+    expect(GATE_STATES['factory:in-progress']).toBeUndefined();
+    expect(GATE_STATES['factory:triaging']).toBeUndefined();
+    expect(GATE_STATES['factory:done']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #47

Adds a prominent gate-pending banner to the issue detail page that surfaces when an issue is in a state requiring human action.