### PR TITLE
M3.11: cost/duration placeholders on cards and detail

### DIFF
--- a/apps/web/src/components/board/IssueCard.tsx
+++ b/apps/web/src/components/board/IssueCard.tsx
@@ -2,6 +2,7 @@ import { Pill } from '@/components/ui/pill';
 import type { WorkItemDto } from '@/lib/api';
 import { cn } from '@/lib/cn';
 import { Link } from 'react-router-dom';
+import { COST_PLACEHOLDER } from './placeholders';
 
 // Priority colour-coding per #32:
 // critical = red, high = orange, medium = yellow, low = grey.
@@ -98,6 +99,13 @@ export function IssueCard({
         <Pill tone="default" className="h-5 text-[10.5px] px-2 capitalize">
           {item.priority}
         </Pill>
+        <span
+          className="ml-auto font-mono text-[10.5px] text-fg-4"
+          title="Cost tracking available in M9"
+          data-testid="cost-placeholder"
+        >
+          {COST_PLACEHOLDER}
+        </span>
       </div>
     </Link>
   );

--- a/apps/web/src/components/board/issue-card.test.ts
+++ b/apps/web/src/components/board/issue-card.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { sortLaneItems } from '../../lib/lanes.config';
+import { COST_PLACEHOLDER } from './placeholders';
 
 // IssueCard rendering is exercised by the Playwright happy-path (#36).
 // Here we lock the sort/ordering rule it relies on (priority desc, then
 // issue number asc), which IS the visual order in each lane.
+
+describe('IssueCard — cost placeholder', () => {
+  it('renders the cost placeholder as "$—" without error', () => {
+    expect(COST_PLACEHOLDER).toBe('$—');
+  });
+});
 
 describe('issue card lane ordering', () => {
   it('orders by priority desc, then issue number asc', () => {

--- a/apps/web/src/components/board/placeholders.ts
+++ b/apps/web/src/components/board/placeholders.ts
@@ -1,0 +1,2 @@
+/** Placeholder shown in the cost slot on issue cards until M9 wires real data. */
+export const COST_PLACEHOLDER = '$—';

--- a/apps/web/src/components/detail/TaskHeader.tsx
+++ b/apps/web/src/components/detail/TaskHeader.tsx
@@ -81,6 +81,14 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
             </span>
           </>
         )}
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span title="Cost tracking available in M9" data-testid="cost-placeholder">
+          cost <span className="font-mono">$—</span>
+        </span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span title="Duration tracking available in M9" data-testid="duration-placeholder">
+          duration <span className="font-mono">—</span>
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
Add static cost and duration placeholder fields to issue cards and the detail page header.

Closes #57