### PR TITLE
fix: remove duplicate API exports and fix formatter after parallel merge

### DIFF
--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -10,7 +10,13 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 // destructures [item] from the result. A plain array resolves immediately
 // when awaited (non-Promises do), and array destructuring works natively.
 vi.mock('@goose-hub/core/db/db.js', () => {
-  const inboxRow = { id: 1, title: 'Test idea', body: '', type: 'feature', createdAt: '2026-05-01 00:00:00' };
+  const inboxRow = {
+    id: 1,
+    title: 'Test idea',
+    body: '',
+    type: 'feature',
+    createdAt: '2026-05-01 00:00:00',
+  };
   return {
     db: {
       insert: vi.fn().mockReturnValue({
@@ -157,7 +163,6 @@ describe('POST /inbox', () => {
     expect(res.status).toBe(400);
   });
 });
-
 
 describe('POST /projects/:slug/issues/:id/comment', () => {
   it('returns 200 when body is valid', async () => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -162,27 +162,6 @@ export async function createInboxItem(data: {
   await postJson('/inbox', data);
 }
 
-export async function addComment(slug: string, id: string, body: string): Promise<void> {
-  await postJson(`/projects/${slug}/issues/${id}/comment`, { body });
-}
-
-export async function setMilestone(
-  slug: string,
-  id: string,
-  milestoneNumber: number | null,
-): Promise<void> {
-  await postJson(`/projects/${slug}/issues/${id}/set-milestone`, { milestoneNumber });
-}
-
-export async function setLabel(
-  slug: string,
-  id: string,
-  group: 'priority' | 'schedule',
-  value: string,
-): Promise<void> {
-  await postJson(`/projects/${slug}/issues/${id}/set-label`, { group, value });
-}
-
 export async function transitionState(
   slug: string,
   id: string,


### PR DESCRIPTION
Removes duplicate `addComment`, `setMilestone`, `setLabel` exports introduced by concurrent parallel merges (#70 and #72 both added them to api.ts). Fixes biome formatter issue in index.test.ts.