### PR TITLE
redesign M3.09: pill selects in TaskHeader, comments in overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 .claude/worktrees/
 goose-hub.db
+claude-design/

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -60,6 +60,44 @@ vi.mock('./source.js', () => ({
         createdAt: new Date('2024-01-01'),
       },
     ]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([
+      {
+        id: 'github:owner/repo#5',
+        externalId: '5',
+        repoRef: 'owner/repo',
+        title: 'Done item',
+        body: '',
+        type: 'feature',
+        priority: 'medium',
+        mode: 'supervised',
+        state: 'factory:done',
+        authorIsOwner: true,
+        milestoneId: '3',
+        schedule: 'current',
+        exec: 'parallel',
+        dependsOn: [],
+        blocks: [],
+        createdAt: new Date('2024-01-01'),
+      },
+      {
+        id: 'github:owner/repo#6',
+        externalId: '6',
+        repoRef: 'owner/repo',
+        title: 'Open item',
+        body: '',
+        type: 'feature',
+        priority: 'medium',
+        mode: 'supervised',
+        state: 'factory:in-progress',
+        authorIsOwner: true,
+        milestoneId: '3',
+        schedule: 'current',
+        exec: 'parallel',
+        dependsOn: [],
+        blocks: [],
+        createdAt: new Date('2024-01-02'),
+      },
+    ]),
   }),
 }));
 
@@ -127,6 +165,27 @@ describe('GET /projects/:slug/milestones/:milestone/closed-issues', () => {
     const { getSourceForSlug } = await import('./source.js');
     vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
     const res = await app.request('/projects/unknown/milestones/3/closed-issues');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /projects/:slug/milestones/:milestone/issues', () => {
+  it('returns all work items (open and closed) for the milestone', async () => {
+    const res = await app.request('/projects/goose-hub-self/milestones/3/issues');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toHaveLength(2);
+  });
+
+  it('returns 400 for a non-numeric milestone', async () => {
+    const res = await app.request('/projects/goose-hub-self/milestones/abc/issues');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown project', async () => {
+    const { getSourceForSlug } = await import('./source.js');
+    vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
+    const res = await app.request('/projects/unknown/milestones/3/issues');
     expect(res.status).toBe(404);
   });
 });

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -37,6 +37,7 @@ vi.mock('./source.js', () => ({
   getSourceForSlug: vi.fn().mockResolvedValue({
     repoRef: 'owner/repo',
     comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
     setMilestone: vi.fn().mockResolvedValue(undefined),
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     listClosedWorkByMilestone: vi.fn().mockResolvedValue([

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -53,6 +53,18 @@ app.get('/projects/:slug/milestones/:milestone/closed-issues', async (c) => {
   return c.json({ items });
 });
 
+app.get('/projects/:slug/milestones/:milestone/issues', async (c) => {
+  const slug = c.req.param('slug');
+  const milestone = Number(c.req.param('milestone'));
+  if (Number.isNaN(milestone)) return c.json({ error: 'invalid milestone number' }, 400);
+  const source = await getSourceForSlug(slug);
+  if (source == null) return c.json({ error: 'project not found' }, 404);
+  const items = await getCached(`milestone-issues:${slug}:${milestone}`, 60_000, () =>
+    source.listWorkByMilestone(milestone),
+  );
+  return c.json({ items });
+});
+
 app.get('/projects/:slug/milestones', async (c) => {
   const slug = c.req.param('slug');
   const source = await getSourceForSlug(slug);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -131,6 +131,18 @@ app.post('/projects/:slug/issues/:id/transition', async (c) => {
   return c.json({ ok: true, from, to });
 });
 
+app.get('/projects/:slug/issues/:id/comments', async (c) => {
+  const slug = c.req.param('slug');
+  const id = c.req.param('id');
+  const source = await getSourceForSlug(slug);
+  if (source == null) return c.json({ error: 'project not found' }, 404);
+  const cfg = await getProject(slug);
+  const repoRef = cfg?.source.kind === 'github' ? cfg.source.repo : slug;
+  const workItemId = `github:${repoRef}#${id}`;
+  const comments = await source.listComments(workItemId);
+  return c.json({ comments });
+});
+
 app.post('/projects/:slug/issues/:id/comment', async (c) => {
   const slug = c.req.param('slug');
   const id = c.req.param('id');

--- a/apps/web/src/components/board/Board.tsx
+++ b/apps/web/src/components/board/Board.tsx
@@ -1,4 +1,4 @@
-import { type WorkItemDto, fetchClosedIssues, fetchIssues } from '@/lib/api';
+import { type WorkItemDto, fetchIssues, fetchMilestoneIssues } from '@/lib/api';
 import { LANES, laneForState, sortLaneItems } from '@/lib/lanes.config';
 import { useActiveMilestone } from '@/state/active-milestone';
 import { useLaneVisibility } from '@/state/lane-visibility';
@@ -14,13 +14,7 @@ interface BoardProps {
 export function Board({ projectSlug }: BoardProps) {
   const queryClient = useQueryClient();
   const { hidden, toggle, reset } = useLaneVisibility();
-  const { activeNumber: resolvedMilestone, milestones } = useActiveMilestone();
-
-  const activeMilestone = useMemo(
-    () => milestones.find((m) => m.number === resolvedMilestone) ?? null,
-    [milestones, resolvedMilestone],
-  );
-  const isClosed = activeMilestone != null && !activeMilestone.isActive;
+  const { activeNumber: resolvedMilestone } = useActiveMilestone();
 
   const {
     data: items = [],
@@ -30,12 +24,12 @@ export function Board({ projectSlug }: BoardProps) {
     refetch,
   } = useQuery({
     queryKey:
-      isClosed && resolvedMilestone != null
-        ? ['closed-issues', projectSlug, resolvedMilestone]
+      resolvedMilestone != null
+        ? ['milestone-issues', projectSlug, resolvedMilestone]
         : ['issues', projectSlug],
     queryFn: () =>
-      isClosed && resolvedMilestone != null
-        ? fetchClosedIssues(projectSlug, resolvedMilestone)
+      resolvedMilestone != null
+        ? fetchMilestoneIssues(projectSlug, resolvedMilestone)
         : fetchIssues(projectSlug),
   });
 
@@ -52,8 +46,12 @@ export function Board({ projectSlug }: BoardProps) {
         if (payload.workItemId == null || payload.payload?.to == null) return;
         const externalId = payload.workItemId.split('#').pop();
         if (externalId == null) return;
+        const cacheKey =
+          resolvedMilestone != null
+            ? ['milestone-issues', projectSlug, resolvedMilestone]
+            : ['issues', projectSlug];
         queryClient.setQueryData<WorkItemDto[]>(
-          ['issues', projectSlug],
+          cacheKey,
           (prev) =>
             prev?.map((it) =>
               it.externalId === externalId ? { ...it, state: payload.payload.to as string } : it,
@@ -68,17 +66,12 @@ export function Board({ projectSlug }: BoardProps) {
       es.removeEventListener('state.transitioned', onTransition as EventListener);
       es.close();
     };
-  }, [projectSlug, queryClient]);
-
-  const filtered = useMemo(() => {
-    if (resolvedMilestone == null) return items;
-    return items.filter((item) => item.milestoneId === String(resolvedMilestone));
-  }, [items, resolvedMilestone]);
+  }, [projectSlug, resolvedMilestone, queryClient]);
 
   const itemsByLane = useMemo(() => {
     const out = new Map<string, WorkItemDto[]>();
     for (const lane of LANES) out.set(lane.key, []);
-    for (const item of filtered) {
+    for (const item of items) {
       const laneKey = laneForState(item.state);
       if (laneKey == null) continue;
       out.get(laneKey)?.push(item);
@@ -88,7 +81,7 @@ export function Board({ projectSlug }: BoardProps) {
       if (arr != null) out.set(key, sortLaneItems(arr));
     }
     return out;
-  }, [filtered]);
+  }, [items]);
 
   const visibleLanes = useMemo(() => LANES.filter((l) => !hidden.has(l.key)), [hidden]);
   const hiddenLanes = useMemo(() => LANES.filter((l) => hidden.has(l.key)), [hidden]);
@@ -115,7 +108,7 @@ export function Board({ projectSlug }: BoardProps) {
     <div className="h-full flex flex-col" data-testid="board">
       <div className="flex items-center gap-2 px-4 py-2 border-b border-line shrink-0 text-[12px] text-fg-3">
         <span data-testid="board-issue-count">
-          {filtered.length} issue{filtered.length === 1 ? '' : 's'}
+          {items.length} issue{items.length === 1 ? '' : 's'}
         </span>
         {resolvedMilestone != null && (
           <span>

--- a/apps/web/src/components/detail/OverviewSection.tsx
+++ b/apps/web/src/components/detail/OverviewSection.tsx
@@ -1,10 +1,96 @@
+import { type IssueCommentDto, addComment, fetchComments } from '@/lib/api';
 import type { WorkItemDto } from '@/lib/api';
 import { renderMarkdownToHtml } from '@/lib/markdown';
-import { ManualActions } from './ManualActions';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 interface OverviewSectionProps {
   item?: WorkItemDto;
   projectSlug?: string;
+}
+
+function CommentsSection({
+  projectSlug,
+  id,
+  externalId,
+}: {
+  projectSlug: string;
+  id: string;
+  externalId: string;
+}) {
+  const queryClient = useQueryClient();
+  const { data: comments = [], isLoading } = useQuery<IssueCommentDto[]>({
+    queryKey: ['comments', projectSlug, id],
+    queryFn: () => fetchComments(projectSlug, id),
+  });
+
+  const [text, setText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await addComment(projectSlug, externalId, trimmed);
+      setText('');
+      void queryClient.invalidateQueries({ queryKey: ['comments', projectSlug, id] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to post comment');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-8">
+      <h2 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-4">Comments</h2>
+
+      {isLoading ? (
+        <p className="text-[12.5px] text-fg-4">Loading comments…</p>
+      ) : comments.length === 0 ? (
+        <p className="text-[12.5px] text-fg-4">No comments yet.</p>
+      ) : (
+        <ol className="flex flex-col gap-3 mb-6">
+          {comments.map((c) => (
+            <li key={c.id} className="flex flex-col gap-1">
+              <div className="flex items-center gap-2 text-[11px] text-fg-4">
+                <span className="font-mono font-medium text-fg-3">{c.authorLogin}</span>
+                <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+                <span>{new Date(c.createdAt).toLocaleString()}</span>
+              </div>
+              <p className="text-[13px] text-fg-2 whitespace-pre-wrap leading-relaxed">{c.body}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-2 mt-4">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Add a comment…"
+          rows={3}
+          className="w-full rounded-md border border-line bg-bg text-[13px] px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-accent placeholder:text-fg-4"
+        />
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving || !text.trim()}
+            className="h-7 px-3 rounded-md text-[12px] border border-line bg-bg-elev text-fg-2 hover:bg-bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          {error != null && (
+            <span className="text-[11.5px] text-[color:var(--danger)]">{error}</span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
 }
 
 export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
@@ -44,9 +130,11 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
       />
 
       {item != null && projectSlug != null && (
-        <div className="mt-6">
-          <ManualActions projectSlug={projectSlug} id={item.externalId} />
-        </div>
+        <CommentsSection
+          projectSlug={projectSlug}
+          id={item.externalId}
+          externalId={item.externalId}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/detail/TaskHeader.tsx
+++ b/apps/web/src/components/detail/TaskHeader.tsx
@@ -90,9 +90,9 @@ function PillSelect({
         data-testid={testId}
         onClick={() => setOpen((o) => !o)}
         className={cn(
-          'inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] border cursor-pointer',
-          'hover:brightness-110 transition-all',
-          saving && 'opacity-60 cursor-wait',
+          'inline-flex items-center gap-1 h-6 px-2.5 rounded-full text-[11.5px] border cursor-pointer',
+          'hover:brightness-110 hover:opacity-90 transition-opacity',
+          saving && 'opacity-50 cursor-wait',
         )}
         style={pillStyle}
         title={`Change ${label}`}
@@ -206,13 +206,18 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
             {item?.title}
           </h1>
         </div>
-        <div className="flex items-center gap-1.5 flex-wrap shrink-0 justify-end">
+        <div className="flex items-center gap-2 flex-wrap shrink-0 justify-end">
+          {/* Type — static, leftmost */}
+          <span className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">
+            {item?.type}
+          </span>
+
           {/* State — static accent pill */}
           <span
             data-testid="state-pill"
-            className="inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] bg-accent-soft border border-accent-line text-fg"
+            className="inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full text-[11.5px] bg-accent-soft border border-accent-line text-fg"
           >
-            <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+            <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />
             <span className="font-medium">
               {item?.state ? (STATE_LABEL[item?.state] ?? item?.state) : ''}
             </span>
@@ -277,11 +282,6 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
               onSelect={(v) => void onMilestone(v)}
             />
           )}
-
-          {/* Type — static */}
-          <span className="inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">
-            {item?.type}
-          </span>
 
           {item && (
             <TransitionButton

--- a/apps/web/src/components/detail/TaskHeader.tsx
+++ b/apps/web/src/components/detail/TaskHeader.tsx
@@ -1,5 +1,8 @@
-import { Pill } from '@/components/ui/pill';
+import { type MilestoneDto, fetchMilestones, setLabel, setMilestone } from '@/lib/api';
 import type { WorkItemDto } from '@/lib/api';
+import { cn } from '@/lib/cn';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { TransitionButton } from './TransitionButton';
 
 const STATE_LABEL: Record<string, string> = {
@@ -28,12 +31,168 @@ const STATE_LABEL: Record<string, string> = {
   'factory:archived': 'archived',
 };
 
+const PRIORITY_COLOR: Record<string, string> = {
+  critical: 'oklch(0.66 0.20 22)',
+  high: 'oklch(0.74 0.15 50)',
+  medium: 'oklch(0.78 0.14 78)',
+  low: 'var(--fg-3)',
+};
+
+const PRIORITY_BG: Record<string, string> = {
+  critical: 'oklch(0.66 0.20 22 / 0.12)',
+  high: 'oklch(0.74 0.15 50 / 0.12)',
+  medium: 'oklch(0.78 0.14 78 / 0.12)',
+  low: 'oklch(0.42 0.01 260 / 0.12)',
+};
+
+const PRIORITY_BORDER: Record<string, string> = {
+  critical: 'oklch(0.66 0.20 22 / 0.4)',
+  high: 'oklch(0.74 0.15 50 / 0.4)',
+  medium: 'oklch(0.78 0.14 78 / 0.4)',
+  low: 'oklch(0.42 0.01 260 / 0.4)',
+};
+
+interface PillSelectProps {
+  value: string;
+  label: string;
+  options: { value: string; label: string }[];
+  onSelect: (value: string) => void;
+  saving?: boolean;
+  pillStyle?: React.CSSProperties;
+  'data-testid'?: string;
+}
+
+function PillSelect({
+  value,
+  label,
+  options,
+  onSelect,
+  saving,
+  pillStyle,
+  'data-testid': testId,
+}: PillSelectProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          'inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] border cursor-pointer',
+          'hover:brightness-110 transition-all',
+          saving && 'opacity-60 cursor-wait',
+        )}
+        style={pillStyle}
+        title={`Change ${label}`}
+      >
+        {value}
+        <span className="text-[9px] opacity-60">▾</span>
+      </button>
+      {open && (
+        <div className="absolute top-full mt-1 left-0 z-50 min-w-[120px] rounded-md border border-line bg-bg-elev shadow-md py-1">
+          {options.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => {
+                onSelect(o.value);
+                setOpen(false);
+              }}
+              className={cn(
+                'w-full text-left px-3 py-1.5 text-[12px] hover:bg-bg-hover',
+                o.value === value ? 'text-fg font-medium' : 'text-fg-2',
+              )}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface TaskHeaderProps {
   item?: WorkItemDto;
   projectSlug: string;
 }
 
 export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
+  const queryClient = useQueryClient();
+  const [savingPriority, setSavingPriority] = useState(false);
+  const [savingSchedule, setSavingSchedule] = useState(false);
+  const [savingMilestone, setSavingMilestone] = useState(false);
+
+  const { data: milestones = [] } = useQuery<MilestoneDto[]>({
+    queryKey: ['milestones', projectSlug],
+    queryFn: () => fetchMilestones(projectSlug),
+    enabled: item != null,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, item?.externalId] });
+    void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
+  };
+
+  const onPriority = async (value: string) => {
+    if (!item) return;
+    setSavingPriority(true);
+    try {
+      await setLabel(projectSlug, item.externalId, 'priority', value);
+      invalidate();
+    } finally {
+      setSavingPriority(false);
+    }
+  };
+
+  const onSchedule = async (value: string) => {
+    if (!item) return;
+    setSavingSchedule(true);
+    try {
+      await setLabel(projectSlug, item.externalId, 'schedule', value);
+      invalidate();
+    } finally {
+      setSavingSchedule(false);
+    }
+  };
+
+  const onMilestone = async (value: string) => {
+    if (!item) return;
+    setSavingMilestone(true);
+    try {
+      const num = value === 'none' ? null : Number(value);
+      await setMilestone(projectSlug, item.externalId, num);
+      invalidate();
+    } finally {
+      setSavingMilestone(false);
+    }
+  };
+
+  const priorityColor = PRIORITY_COLOR[item?.priority ?? ''] ?? 'var(--fg-3)';
+  const priorityBg = PRIORITY_BG[item?.priority ?? ''] ?? 'oklch(0.42 0.01 260 / 0.12)';
+  const priorityBorder = PRIORITY_BORDER[item?.priority ?? ''] ?? 'oklch(0.42 0.01 260 / 0.4)';
+
+  const milestoneOptions = [
+    { value: 'none', label: 'No milestone' },
+    ...milestones.map((m) => ({ value: String(m.number), label: m.title })),
+  ];
+
+  const currentMilestoneLabel =
+    milestones.find((m) => String(m.number) === item?.milestoneId)?.title ??
+    (item?.milestoneId != null ? `#${item.milestoneId}` : 'milestone');
+
   return (
     <div data-testid="task-header" className="px-6 py-4 border-b border-line bg-bg-elev shrink-0">
       <div className="flex items-start gap-4">
@@ -48,18 +207,82 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
           </h1>
         </div>
         <div className="flex items-center gap-1.5 flex-wrap shrink-0 justify-end">
-          <Pill tone="accent" data-testid="state-pill">
+          {/* State — static accent pill */}
+          <span
+            data-testid="state-pill"
+            className="inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] bg-accent-soft border border-accent-line text-fg"
+          >
             <span className="w-1.5 h-1.5 rounded-full bg-accent" />
             <span className="font-medium">
               {item?.state ? (STATE_LABEL[item?.state] ?? item?.state) : ''}
             </span>
-          </Pill>
-          <Pill data-testid="priority-pill" className="capitalize">
-            {item?.priority}
-          </Pill>
-          <Pill data-testid="type-pill" className="capitalize">
+          </span>
+
+          {/* Priority — pill select */}
+          {item && (
+            <PillSelect
+              data-testid="priority-pill"
+              value={item.priority}
+              label="priority"
+              saving={savingPriority}
+              pillStyle={{
+                color: priorityColor,
+                background: priorityBg,
+                borderColor: priorityBorder,
+              }}
+              options={[
+                { value: 'low', label: 'low' },
+                { value: 'medium', label: 'medium' },
+                { value: 'high', label: 'high' },
+                { value: 'critical', label: 'critical' },
+              ]}
+              onSelect={(v) => void onPriority(v)}
+            />
+          )}
+
+          {/* Schedule — pill select */}
+          {item && (
+            <PillSelect
+              data-testid="schedule-pill"
+              value={item.schedule}
+              label="schedule"
+              saving={savingSchedule}
+              pillStyle={{
+                color: 'var(--fg-2)',
+                background: 'var(--bg-elev)',
+                borderColor: 'var(--line)',
+              }}
+              options={[
+                { value: 'current', label: 'current' },
+                { value: 'backlog', label: 'backlog' },
+                { value: 'icebox', label: 'icebox' },
+              ]}
+              onSelect={(v) => void onSchedule(v)}
+            />
+          )}
+
+          {/* Milestone — pill select */}
+          {item && milestones.length > 0 && (
+            <PillSelect
+              data-testid="milestone-pill"
+              value={currentMilestoneLabel}
+              label="milestone"
+              saving={savingMilestone}
+              pillStyle={{
+                color: 'var(--fg-2)',
+                background: 'var(--bg-elev)',
+                borderColor: 'var(--line)',
+              }}
+              options={milestoneOptions}
+              onSelect={(v) => void onMilestone(v)}
+            />
+          )}
+
+          {/* Type — static */}
+          <span className="inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">
             {item?.type}
-          </Pill>
+          </span>
+
           {item && (
             <TransitionButton
               projectSlug={projectSlug}
@@ -73,14 +296,6 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
         <span>by {item?.authorIsOwner ? 'owner' : 'guest'}</span>
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span>opened {item?.createdAt ? new Date(item?.createdAt).toLocaleString() : ''}</span>
-        {item?.milestoneId != null && (
-          <>
-            <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-            <span>
-              milestone <span className="font-mono tnum">#{item?.milestoneId}</span>
-            </span>
-          </>
-        )}
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span title="Cost tracking available in M9" data-testid="cost-placeholder">
           cost <span className="font-mono">$—</span>

--- a/apps/web/src/components/detail/TransitionButton.tsx
+++ b/apps/web/src/components/detail/TransitionButton.tsx
@@ -1,7 +1,6 @@
 import { type WorkItemDto, transitionState } from '@/lib/api';
 import { LEGAL_TARGETS } from '@/lib/transitions';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowRight } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 interface TransitionButtonProps {
@@ -33,7 +32,7 @@ export function TransitionButton({ projectSlug, id, currentState }: TransitionBu
         disabled
         title={`Terminal state: ${currentState} has no legal next states`}
         data-testid="transition-button-disabled"
-        className="h-7 px-2.5 rounded-md text-[12px] border border-line text-fg-4 cursor-not-allowed"
+        className="h-6 px-2.5 rounded-full text-[11.5px] border border-line text-fg-4 cursor-not-allowed"
       >
         No transitions
       </button>
@@ -73,10 +72,9 @@ export function TransitionButton({ projectSlug, id, currentState }: TransitionBu
         data-testid="transition-button"
         onClick={() => setOpen((o) => !o)}
         disabled={busy}
-        className="h-7 px-2.5 rounded-md text-[12px] bg-accent text-[color:var(--accent-fg)] hover:brightness-110 disabled:opacity-60 inline-flex items-center gap-1.5 font-medium"
+        className="h-6 px-2.5 rounded-full text-[11.5px] bg-accent text-[color:var(--accent-fg)] hover:brightness-110 disabled:opacity-60 inline-flex items-center font-medium border border-accent-line"
       >
         Transition
-        <ArrowRight size={12} />
       </button>
       {open && (
         <div

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -29,3 +29,15 @@
   --radius-lg: var(--r-lg);
   --radius-xl: var(--r-xl);
 }
+
+
+/* Scrollbars */
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb {
+  background: oklch(from var(--fg-3) l c h / 0.25);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 999px;
+}
+*::-webkit-scrollbar-thumb:hover { background: oklch(from var(--fg-3) l c h / 0.4); background-clip: content-box; border: 2px solid transparent; }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -97,6 +97,16 @@ export async function fetchClosedIssues(
   return items;
 }
 
+export async function fetchMilestoneIssues(
+  slug: string,
+  milestoneNumber: number,
+): Promise<WorkItemDto[]> {
+  const { items } = await getJson<{ items: WorkItemDto[] }>(
+    `/projects/${slug}/milestones/${milestoneNumber}/issues`,
+  );
+  return items;
+}
+
 export async function fetchMilestones(slug: string): Promise<MilestoneDto[]> {
   const { milestones } = await getJson<{ milestones: MilestoneDto[] }>(
     `/projects/${slug}/milestones`,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,13 @@ export interface WorkItemDto {
   createdAt: string;
 }
 
+export interface IssueCommentDto {
+  id: number;
+  body: string;
+  authorLogin: string;
+  createdAt: string;
+}
+
 export interface MilestoneDto {
   id: string;
   title: string;
@@ -117,6 +124,13 @@ export async function fetchEvents(slug: string, id: string): Promise<AgentEventD
     `/projects/${slug}/issues/${id}/events`,
   );
   return events;
+}
+
+export async function fetchComments(slug: string, id: string): Promise<IssueCommentDto[]> {
+  const { comments } = await getJson<{ comments: IssueCommentDto[] }>(
+    `/projects/${slug}/issues/${id}/comments`,
+  );
+  return comments;
 }
 
 export async function addComment(slug: string, id: string, body: string): Promise<void> {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -99,7 +99,7 @@ body {
 .tnum {
   font-variant-numeric: tabular-nums;
 }
-
+/* 
 button {
   font-family: inherit;
   font-size: inherit;
@@ -108,7 +108,7 @@ button {
   border: 0;
   padding: 0;
   cursor: pointer;
-}
+} */
 
 ::selection {
   background: var(--accent-soft-2);
@@ -121,20 +121,17 @@ button {
   scrollbar-color: var(--line) transparent;
 }
 
-::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
+
+*::-webkit-scrollbar {
+  width: 12px;               /* width of the entire scrollbar */
 }
 
-::-webkit-scrollbar-track {
-  background: transparent;
+*::-webkit-scrollbar-track {
+  background: orange;        /* color of the tracking area */
 }
 
-::-webkit-scrollbar-thumb {
-  background: var(--line);
-  border-radius: 2px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--line-2);
+*::-webkit-scrollbar-thumb {
+  background-color: blue;    /* color of the scroll thumb */
+  border-radius: 20px;       /* roundness of the scroll thumb */
+  border: 3px solid orange;  /* creates padding around scroll thumb */
 }

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -232,6 +232,14 @@ export class GitHubLabelsSource implements StateSource {
       .map((i) => mapIssueToWorkItem(i, this.repoRef, this.ownerLogin));
   }
 
+  async listWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]> {
+    const url = `https://api.github.com/repos/${this.repoRef}/issues?state=all&milestone=${milestoneNumber}&per_page=100`;
+    const issues = await this.paginateAll<GithubIssue>(url);
+    return issues
+      .filter((i) => i.pull_request == null)
+      .map((i) => mapIssueToWorkItem(i, this.repoRef, this.ownerLogin));
+  }
+
   async getItem(itemId: string): Promise<WorkItem> {
     // itemId may be "github:owner/repo#42" or a raw number string.
     const match = itemId.match(/#(\d+)$/);

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -4,6 +4,7 @@ import type {
   Artifact,
   CreateIssueInput,
   ExecMode,
+  IssueComment,
   Milestone,
   Mode,
   Priority,
@@ -321,6 +322,25 @@ export class GitHubLabelsSource implements StateSource {
     if (!addRes.ok) {
       throw new Error(`Failed to add label ${to}: ${addRes.status} ${addRes.statusText}`);
     }
+  }
+
+  async listComments(itemId: string): Promise<IssueComment[]> {
+    const match = itemId.match(/#(\d+)$/);
+    const number = match != null ? match[1] : itemId;
+    const url = `https://api.github.com/repos/${this.repoRef}/issues/${number}/comments?per_page=100`;
+    const res = await this.ghFetch(url);
+    const raw = (await res.json()) as {
+      id: number;
+      body: string;
+      user: { login: string } | null;
+      created_at: string;
+    }[];
+    return raw.map((c) => ({
+      id: c.id,
+      body: c.body,
+      authorLogin: c.user?.login ?? 'unknown',
+      createdAt: c.created_at,
+    }));
   }
 
   async comment(itemId: string, body: string): Promise<void> {

--- a/core/state-source/interface.test.ts
+++ b/core/state-source/interface.test.ts
@@ -3,6 +3,7 @@ import type { StateName } from '../state-machine/states.js';
 import type {
   Artifact,
   CreateIssueInput,
+  IssueComment,
   Milestone,
   SourceEvent,
   StateSource,
@@ -49,6 +50,10 @@ class StubStateSource implements StateSource {
 
   comment(_itemId: string, _body: string): Promise<void> {
     return Promise.resolve();
+  }
+
+  listComments(_itemId: string): Promise<IssueComment[]> {
+    return Promise.resolve([]);
   }
 
   setMilestone(_itemId: string, _milestoneNumber: number | null): Promise<void> {

--- a/core/state-source/interface.test.ts
+++ b/core/state-source/interface.test.ts
@@ -23,6 +23,10 @@ class StubStateSource implements StateSource {
     return Promise.resolve([]);
   }
 
+  listWorkByMilestone(_milestoneNumber: number): Promise<WorkItem[]> {
+    return Promise.resolve([]);
+  }
+
   getItem(_itemId: string): Promise<WorkItem> {
     return Promise.reject(new Error('not implemented'));
   }

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -55,6 +55,13 @@ export interface SourceEvent {
   item: WorkItem;
 }
 
+export interface IssueComment {
+  id: number;
+  body: string;
+  authorLogin: string;
+  createdAt: string;
+}
+
 export interface Subscription {
   unsubscribe(): void;
 }
@@ -72,6 +79,7 @@ export interface StateSource {
   transitionState(itemId: string, from: StateName, to: StateName, note?: string): Promise<void>;
   forceState(itemId: string, to: StateName): Promise<void>;
   comment(itemId: string, body: string): Promise<void>;
+  listComments(itemId: string): Promise<IssueComment[]>;
   setMilestone(itemId: string, milestoneNumber: number | null): Promise<void>;
   setLabelInGroup(itemId: string, group: 'priority' | 'schedule', value: string): Promise<void>;
   attach(itemId: string, artifact: Artifact): Promise<void>;

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -72,6 +72,7 @@ export interface StateSource {
 
   listOpenWork(): Promise<WorkItem[]>;
   listClosedWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]>;
+  listWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]>;
   getItem(itemId: string): Promise<WorkItem>;
   listMilestones(): Promise<Milestone[]>;
   getActiveMilestone(): Promise<Milestone | null>;


### PR DESCRIPTION
Reworks the M3.09 manual actions UX per design feedback.

**Priority / schedule / milestone** — now clickable pill selects in the TaskHeader pills strip. Click to open a dropdown, select to write to GitHub and invalidate the cache. Milestone moves out of the metadata row into the pills strip.

**Comments** — fetched from GitHub and rendered in OverviewSection under a "Comments" heading, with a bare textarea + Save button below (no box wrapper).

**Removed** the collapsible ManualActions panel entirely.