### PR TITLE
M3.02: Approve / reject / request-changes gate actions

### DIFF
--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -2,7 +2,7 @@ import { fetchIssue, fetchIssues, startFakeRun } from '@/lib/api';
 import { LANES, laneForState, sortLaneItems } from '@/lib/lanes.config';
 import type { WorkItemDto } from '@/lib/types';
 import { useActiveMilestone } from '@/state/active-milestone';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -23,6 +23,8 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
   const { slug = 'goose-hub-self', id = '' } = useParams<{ slug: string; id: string }>();
   const navigate = useNavigate();
   const { activeNumber } = useActiveMilestone();
+
+  const queryClient = useQueryClient();
 
   const {
     data: item,
@@ -188,7 +190,15 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
 
         <TaskHeader item={item} projectSlug={slug} />
 
-        <GatePendingBanner state={item?.state} />
+        <GatePendingBanner
+          state={item?.state}
+          projectSlug={slug}
+          id={id}
+          onTransitioned={() => {
+            void queryClient.invalidateQueries({ queryKey: ['issue', slug, id] });
+            void queryClient.invalidateQueries({ queryKey: ['issues', slug] });
+          }}
+        />
 
         <div className="flex-1 min-h-0 flex">
           <LeftRail />

--- a/apps/web/src/components/detail/components/GatePendingBanner.tsx
+++ b/apps/web/src/components/detail/components/GatePendingBanner.tsx
@@ -1,17 +1,65 @@
+import { transitionState } from '@/lib/api';
 import { cn } from '@/lib/cn';
 import { GATE_STATES } from '@/lib/constants';
 import { ShieldAlert } from 'lucide-react';
+import { useState } from 'react';
 
 export { GATE_STATES } from '@/lib/constants';
 
+const GATE_ACTIONS: Record<string, { approve?: string; reject?: string; requestChanges?: string }> =
+  {
+    'factory:prd-review': { approve: 'factory:decomposing' },
+    'factory:needs-review': {
+      approve: 'factory:approved',
+      reject: 'factory:rejected',
+      requestChanges: 'factory:needs-fix',
+    },
+    'factory:approved': { approve: 'factory:retrospecting' },
+    'factory:needs-human': {},
+  };
+
+export { GATE_ACTIONS };
+
 interface GatePendingBannerProps {
   state?: string;
+  projectSlug?: string;
+  id?: string;
+  onTransitioned?: () => void;
 }
 
-export function GatePendingBanner({ state }: GatePendingBannerProps) {
+export function GatePendingBanner({
+  state,
+  projectSlug,
+  id,
+  onTransitioned,
+}: GatePendingBannerProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   if (!state || !(state in GATE_STATES)) return null;
 
   const message = GATE_STATES[state];
+  const actions = GATE_ACTIONS[state] ?? {};
+
+  const handleAction = async (target: string) => {
+    if (!projectSlug || !id) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await transitionState(projectSlug, id, state, target);
+      if (result.status >= 400) {
+        setError(
+          (result.data as { error?: string }).error ?? `Transition failed (${result.status})`,
+        );
+      } else {
+        onTransitioned?.();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <div
@@ -25,6 +73,58 @@ export function GatePendingBanner({ state }: GatePendingBannerProps) {
     >
       <ShieldAlert size={14} className="shrink-0" />
       <span>{message}</span>
+      {error && <span className="text-[color:var(--danger)] ml-2">{error}</span>}
+      <span className="grow" />
+      <span className="flex items-center gap-2">
+        {actions.requestChanges && (
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="gate-action-request-changes"
+            onClick={() => void handleAction(actions.requestChanges ?? '')}
+            className={cn(
+              'h-6 px-2.5 rounded text-[11.5px] font-medium border',
+              'border-[color:var(--warning)]/60 text-[color:var(--warning)]',
+              'hover:bg-[color:var(--warning)]/20',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            Request Changes
+          </button>
+        )}
+        {actions.reject && (
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="gate-action-reject"
+            onClick={() => void handleAction(actions.reject ?? '')}
+            className={cn(
+              'h-6 px-2.5 rounded text-[11.5px] font-medium border',
+              'border-[color:var(--danger)]/60 text-[color:var(--danger)]',
+              'hover:bg-[color:var(--danger)]/20',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            Reject
+          </button>
+        )}
+        {actions.approve && (
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="gate-action-approve"
+            onClick={() => void handleAction(actions.approve ?? '')}
+            className={cn(
+              'h-6 px-2.5 rounded text-[11.5px] font-medium border',
+              'border-[color:var(--accent)]/60 text-[color:var(--accent)]',
+              'hover:bg-[color:var(--accent)]/20',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            Approve
+          </button>
+        )}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { GATE_STATES } from '../../lib/constants';
 import { renderMarkdownToHtml } from '../../lib/markdown';
 import { LEGAL_TARGETS } from '../../lib/transitions';
+import { GATE_ACTIONS } from './components/GatePendingBanner';
 import { SECTIONS } from './lib/sections';
 
 describe('detail page — sections config', () => {
@@ -78,6 +79,45 @@ describe('GatePendingBanner — gate state map', () => {
     expect(GATE_STATES['factory:in-progress']).toBeUndefined();
     expect(GATE_STATES['factory:triaging']).toBeUndefined();
     expect(GATE_STATES['factory:done']).toBeUndefined();
+  });
+});
+
+describe('gate actions — GATE_ACTIONS mapping', () => {
+  it('prd-review has only approve → decomposing', () => {
+    const actions = GATE_ACTIONS['factory:prd-review'];
+    expect(actions.approve).toBe('factory:decomposing');
+    expect(actions.reject).toBeUndefined();
+    expect(actions.requestChanges).toBeUndefined();
+  });
+
+  it('needs-review has all three actions', () => {
+    const actions = GATE_ACTIONS['factory:needs-review'];
+    expect(actions.approve).toBe('factory:approved');
+    expect(actions.reject).toBe('factory:rejected');
+    expect(actions.requestChanges).toBe('factory:needs-fix');
+  });
+
+  it('approved has only approve → retrospecting', () => {
+    const actions = GATE_ACTIONS['factory:approved'];
+    expect(actions.approve).toBe('factory:retrospecting');
+    expect(actions.reject).toBeUndefined();
+    expect(actions.requestChanges).toBeUndefined();
+  });
+
+  it('needs-human has no actions', () => {
+    const actions = GATE_ACTIONS['factory:needs-human'];
+    expect(actions.approve).toBeUndefined();
+    expect(actions.reject).toBeUndefined();
+    expect(actions.requestChanges).toBeUndefined();
+  });
+
+  it('reject and requestChanges are absent for non-needs-review gate states', () => {
+    const nonNeedsReviewGates = ['factory:prd-review', 'factory:approved', 'factory:needs-human'];
+    for (const gate of nonNeedsReviewGates) {
+      const actions = GATE_ACTIONS[gate];
+      expect(actions.reject).toBeUndefined();
+      expect(actions.requestChanges).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
Adds Approve, Reject, and Request Changes action buttons to the GatePendingBanner component, enabling human gate-review actions directly from the detail page.

Closes #48

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfB9tdVxYz1N8YZaQUFhz4)_