### PR TITLE
M3.05: Fake log streaming via SSE

### DIFF
--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -146,6 +146,36 @@ describe('POST /projects/:slug/issues/:id/fake-run', () => {
     });
     expect(res.status).toBe(404);
   });
+
+  it('emits agent.log events with line payloads in the async sequence', async () => {
+    vi.useFakeTimers();
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    vi.mocked(eventStore.appendEvent).mockClear();
+
+    await app.request('/projects/goose-hub-self/issues/99/fake-run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skill: 'triage' }),
+    });
+
+    // Flush the async IIFE (runs with setTimeout delays — advance fake timers)
+    await vi.runAllTimersAsync();
+
+    const calls = vi.mocked(eventStore.appendEvent).mock.calls;
+    const logCalls = calls.filter((c) => c[0].kind === 'agent.log');
+    expect(logCalls.length).toBeGreaterThanOrEqual(3);
+    expect(logCalls.length).toBeLessThanOrEqual(5);
+    for (const [arg] of logCalls) {
+      expect(arg.payload).toMatchObject({ line: expect.any(String) });
+    }
+
+    // Verify ordering: spawned first, terminated last
+    const kinds = calls.map((c) => c[0].kind);
+    expect(kinds[0]).toBe('agent.spawned');
+    expect(kinds[kinds.length - 1]).toBe('agent.terminated');
+
+    vi.useRealTimers();
+  });
 });
 
 describe('GET /projects/:slug/milestones/:milestone/closed-issues', () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -288,17 +288,29 @@ app.post('/projects/:slug/issues/:id/fake-run', async (c) => {
   const repoRef = cfg?.source.kind === 'github' ? cfg.source.repo : slug;
   const workItemId = `github:${repoRef}#${id}`;
 
+  const LOG_LINES = [
+    'Fetching issue metadata from GitHub...',
+    'Parsing labels and body content...',
+    'Scoring priority and work type...',
+    'Drafting decision summary...',
+    'Finalising structured output...',
+  ];
+
   // Fire-and-forget: emit events with delays
   (async () => {
     eventStore.appendEvent({ projectId, workItemId, kind: 'agent.spawned', payload: { skill } });
-    await new Promise((r) => setTimeout(r, 1500));
+    await new Promise((r) => setTimeout(r, 700));
+    for (const line of LOG_LINES) {
+      eventStore.appendEvent({ projectId, workItemId, kind: 'agent.log', payload: { line } });
+      await new Promise((r) => setTimeout(r, 600));
+    }
     eventStore.appendEvent({
       projectId,
       workItemId,
       kind: 'agent.decision-summary',
       payload: { summary: `Running ${skill} skill on issue #${id}` },
     });
-    await new Promise((r) => setTimeout(r, 1500));
+    await new Promise((r) => setTimeout(r, 700));
     eventStore.appendEvent({
       projectId,
       workItemId,

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -1,4 +1,5 @@
 import { fetchEvents } from '@/lib/api';
+import { cn } from '@/lib/cn';
 import type { AgentEventDto } from '@/lib/types';
 import { useEffect, useRef, useState } from 'react';
 
@@ -14,6 +15,7 @@ const STATE_LABEL: Record<string, string> = {
   'agent.spawned': 'Agent spawned',
   'agent.decision-summary': 'Decision summary',
   'agent.terminated': 'Agent terminated',
+  'agent.log': 'Agent log',
   'gate.awaiting-human': 'Gate — awaiting human',
   'system.note': 'Note',
 };
@@ -24,6 +26,10 @@ function summarizePayload(kind: string, payload: unknown): string {
     if (p.from != null && p.to != null) {
       return `${p.from} → ${p.to}${p.by != null ? ` (by ${p.by})` : ''}`;
     }
+  }
+  if (kind === 'agent.log' && payload != null && typeof payload === 'object') {
+    const p = payload as { line?: string };
+    if (p.line != null) return p.line;
   }
   const text = typeof payload === 'string' ? payload : JSON.stringify(payload ?? {});
   return text.length <= 80 ? text : `${text.slice(0, 79)}…`;
@@ -114,7 +120,12 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
           <li
             key={event.id}
             data-event-kind={event.kind}
-            className="rounded-md border border-line bg-bg-elev/60 px-4 py-3"
+            className={cn(
+              'rounded-md border px-4 py-3',
+              event.kind === 'agent.log'
+                ? 'border-line/50 bg-bg/40 text-fg-4'
+                : 'border-line bg-bg-elev/60',
+            )}
           >
             <div className="flex items-center gap-2 mb-1 text-[11px] text-fg-3">
               <span className="font-mono uppercase tracking-wider">
@@ -123,7 +134,12 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
               <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
               <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
             </div>
-            <div className="text-[12.5px] text-fg-2">
+            <div
+              className={cn(
+                'text-fg-2',
+                event.kind === 'agent.log' ? 'font-mono text-[11.5px]' : 'text-[12.5px]',
+              )}
+            >
               {summarizePayload(event.kind, event.payload)}
             </div>
           </li>


### PR DESCRIPTION
Closes #51

Adds `agent.log` event streaming to the fake-run dispatcher and renders log events in the timeline with distinct monospace styling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfB9tdVxYz1N8YZaQUFhz4)_