### PR TITLE
fix(core): add agent.log to EventKind + M3 retrospective

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Use these. Don't introduce new heavyweight dependencies without an ADR.
 
 When prompted with "start the next issue" (or similar), resolve the issue to work on as follows:
 
-1. Run: `gh issue list --milestone "M3: Manual Workflow Cockpit" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
+1. Run: `gh issue list --milestone "M4: Controlled Claude CLI Runtime Spike" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
 2. Skip any issue already labeled `factory:in-progress`.
 3. For each remaining issue in ascending number order, check its body for `Depends on #N` lines. Fetch each referenced issue number with `gh issue view <N> --json state` and skip this issue if any dependency is still open.
 4. Pick the lowest-numbered issue that passes the dependency check.

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -8,6 +8,7 @@ export type EventKind =
   | 'milestone.activated'
   | 'agent.spawned'
   | 'agent.decision-summary'
+  | 'agent.log'
   | 'agent.terminated'
   | 'gate.awaiting-human'
   | 'system.note'

--- a/docs/retros/m3.md
+++ b/docs/retros/m3.md
@@ -1,0 +1,33 @@
+# M3 Retrospective — Manual Workflow Cockpit
+
+**Closed:** 2026-05-01  
+**Issues shipped:** 15 (all closed)  
+**PRs merged:** ~14 across the milestone (including refactors and post-merge fixes)
+
+## What worked
+
+The fake-agent pattern delivered exactly what M3 promised: the entire workflow shape is exercised — gate handling, log streaming, structured output, inbox capture — without any real agent risk. The timeline UX proved itself clearly before M4 introduces the real runtime. Building fakes first was the right call.
+
+The parallel PR execution pattern compressed delivery time significantly. Issues like M3.04 (fake structured output), M3.05 (fake log streaming), M3.07 (inbox list), and M3.08 (target-repo picker) landed within the same session. The orchestration of parallel branches is a net positive for throughput.
+
+The mid-milestone frontend refactor (PR #80) was the right call made at the right time. Extracting `lib/types.ts`, `lib/constants.ts`, `lib/utils.ts`, and formalising `apps/web/STANDARDS.md` before the M3 component surface grew eliminated duplication that would have compounded across 11 remaining issues. The refactor landed cleanly with 182 tests green.
+
+Playwright test coverage reached genuine M3 criterion depth: capture→inbox→promote, gate-pending→approve, and fake-run→timeline→structured output are all exercised with real GitHub fixture issues and proper teardown.
+
+## What didn't work
+
+**Parallel merges introduced a typecheck regression on main.** PR #84 (M3.05 fake log streaming) added `agent.log` as an event kind in `apps/server/src/index.ts` but did not add it to the `EventKind` union in `core/event-stream/store.ts`. The parallel branch it merged into (`claude/parallel-task-execution-RtSlP`) was not typecheck-validated before being merged to main via PR #87. CI caught it post-merge but the fix landed only during the exit audit, not as part of the milestone's normal flow.
+
+**CI was red on main at milestone close.** The last PR (#88, M3.12) merged with a failing "Lint, typecheck, test" CI run. The exit audit was what surfaced this — it should have been caught and fixed before the issue was closed.
+
+**PRs continue to be merged without CI green.** Same pattern as M2: individual issue PRs were closed before the integration branch CI completed. The `issue-close.yml` workflow runs independently of CI status, which gives a false impression of completion.
+
+## What to change for M4
+
+1. **Never merge a PR with a failing typecheck.** If a parallel integration branch is used, run `pnpm typecheck` locally on the merged state before the final merge to main. The `agent.log` miss would have been caught in seconds.
+
+2. **Treat EventKind as a core contract.** Any new event kind emitted by surface code must be added to `EventKind` in `core/event-stream/store.ts` in the same PR that introduces it. New kinds that belong to a future milestone (e.g. M4's `agent.log` variants with `runId`) should still be added when first used, not deferred.
+
+3. **CI must be green before closing issues.** The close-issues workflow should not run on a PR with a failing CI job. Until GitHub enforces this automatically, add a manual check: confirm CI green on the PR before merging.
+
+4. **File a chore for docs/m2-imp-plan/ cleanup.** The directory is not in the expected repository layout from PLAN section 6 and should be moved to docs/retros/ or deleted.


### PR DESCRIPTION
Fixes the typecheck/CI regression that blocked M3 close, and adds the M3 retrospective.

## Changes

- `core/event-stream/store.ts` — add `'agent.log'` to `EventKind` union (missed in PR #84, M3.05)
- `docs/retros/m3.md` — M3 exit retrospective per the audit process

## Why

`agent.log` was emitted in `apps/server/src/index.ts:347` and asserted in `apps/server/src/index.test.ts:219` but was absent from the `EventKind` type. TypeScript caught it; CI failed on main. This is the sole fix needed for CI to go green.

https://claude.ai/code/session_01LuDh4QYWcK2kEnheZJj5fr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuDh4QYWcK2kEnheZJj5fr)_