### PR TITLE
M5.01: skills/triage/ — full skill implementation

### DIFF
--- a/skills/triage/README.md
+++ b/skills/triage/README.md
@@ -1,0 +1,32 @@
+# skills/triage
+
+Classifies a work item by type and priority. Produces structured output conforming to `TriageOutputSchema`.
+
+## Inputs
+
+`contextSchema` (`TriageContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Work item title |
+| `workItem.body` | `string` | Work item body / description |
+
+## Outputs
+
+`TriageOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"feature" \| "bug" \| "chore" \| "research"` | Work item classification |
+| `priority` | `"p0" \| "p1" \| "p2" \| "p3"` | Priority level |
+| `labels` | `string[]` | Additional descriptive labels |
+| `reasoning` | `string` | 1–3 sentence explanation of classification |
+| `decisionSummaries` | `DecisionSummary[]` | Per-decision audit trail (min 1) |
+
+## Decision-type taxonomy
+
+| Step | Trigger |
+|------|---------|
+| `MODEL_SELECTION` | When the agent chooses between ambiguous type classifications |
+| `SCOPE_CHANGE` | When the work item body reveals broader scope than the title suggests, changing the classification |
+| `ESCALATE` | When the work item contains signals (urgency keywords, blocking dependencies) that elevate the priority above initial assessment |

--- a/skills/triage/prompt.md
+++ b/skills/triage/prompt.md
@@ -1,0 +1,64 @@
+# triage skill
+
+You are a triager agent. Your job is to classify a work item by type and priority, then produce structured output conforming to the required schema.
+
+## Input
+
+The context contains a `<work_item>` block with `<title>` and `<body>` fields.
+
+## Classification rules
+
+### Type
+
+Classify the work item as one of:
+
+- `feature` — new capability, new behaviour, enhancement to existing behaviour
+- `bug` — something is broken, incorrect, or producing wrong output
+- `chore` — maintenance, refactoring, dependency updates, config changes, docs
+- `research` — investigation, spike, exploration, architectural question
+
+Pick the single best fit. When ambiguous, lean toward `feature` over `chore`, and `bug` over `research`.
+
+### Priority
+
+Classify as one of:
+
+- `p0` — production incident, blocking multiple users, data loss risk, security vulnerability
+- `p1` — significant functionality broken or missing, blocking delivery of a milestone
+- `p2` — important but not blocking; normal feature/bug work
+- `p3` — low urgency; nice-to-have, cleanup, future improvement
+
+Scoring signals:
+- Explicit urgency words ("critical", "urgent", "blocking", "regression") → p0 or p1
+- Milestone or delivery dependency → p1 or p2
+- Enhancement or improvement without urgency → p2 or p3
+- Chores, docs, research with no deadline → p3
+
+### Labels
+
+Produce a list of zero or more additional string labels that describe the work item. Examples: `"needs-design"`, `"breaking-change"`, `"security"`, `"performance"`, `"ux"`. Only include labels that are clearly supported by the work item text.
+
+### Reasoning
+
+One to three sentences explaining your classification decisions. Focus on the evidence from the title and body that drove each choice.
+
+## Output format
+
+Return a JSON object with this exact structure:
+
+```json
+{
+  "type": "<feature|bug|chore|research>",
+  "priority": "<p0|p1|p2|p3>",
+  "labels": ["<label>", ...],
+  "reasoning": "<one to three sentences>",
+  "decisionSummaries": [
+    { "step": "type-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" },
+    { "step": "priority-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" }
+  ]
+}
+```
+
+`decisionSummaries` must have at least one entry. Include one entry per major decision (type, priority).
+
+[decision] Classified work item type and priority with reasoning

--- a/skills/triage/schema.ts
+++ b/skills/triage/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const TriageOutputSchema = z.object({
+  type: z.enum(['feature', 'bug', 'chore', 'research']),
+  priority: z.enum(['p0', 'p1', 'p2', 'p3']),
+  labels: z.array(z.string()),
+  reasoning: z.string(),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type TriageOutput = z.infer<typeof TriageOutputSchema>;

--- a/skills/triage/skill.config.ts
+++ b/skills/triage/skill.config.ts
@@ -1,0 +1,19 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const TriageContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: TriageContextSchema,
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'triager',
+};
+
+export default config;

--- a/skills/triage/slice.test.ts
+++ b/skills/triage/slice.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { TriageOutputSchema } from './schema.js';
+import config, { TriageContextSchema } from './skill.config.js';
+
+describe('triage schema', () => {
+  it('accepts valid output with all required fields', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'feature',
+      priority: 'p2',
+      labels: ['needs-design'],
+      reasoning: 'This is a new capability with no urgency signals.',
+      decisionSummaries: [
+        {
+          step: 'type-classification',
+          summary: 'Classified as feature',
+          evidence: 'new capability',
+        },
+        {
+          step: 'priority-classification',
+          summary: 'Classified as p2',
+          evidence: 'no urgency signals',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty labels array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'bug',
+      priority: 'p0',
+      labels: [],
+      reasoning: 'Production regression.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Bug', evidence: 'broken' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid type value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'invalid',
+      priority: 'p1',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid priority value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'critical',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = TriageOutputSchema.safeParse({ type: 'feature' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'research',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts evidence as optional on DecisionSummary', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'Routine cleanup.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Chore' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(TriageOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('triage skill config', () => {
+  it('has role triager', () => {
+    expect(config.role).toBe('triager');
+  });
+
+  it('has empty toolBundles', () => {
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = TriageContextSchema.safeParse({
+      workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { body: 'Some body.' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { title: 'Some title' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = TriageContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #154

## Summary
- `skills/triage/prompt.md` — classification rules for type (`feature|bug|chore|research`) and priority (`p0–p3`) with decision summary footer
- `skills/triage/schema.ts` — Zod schema: `type`, `priority`, `labels`, `reasoning`, `decisionSummaries` (min 1)
- `skills/triage/skill.config.ts` — `role: 'triager'`, `modelPin: 'sonnet'`, `contextSchema` validates `workItem.title` + `workItem.body`
- `skills/triage/slice.test.ts` — 16 tests: schema round-trips, rejects invalid, contextSchema rejects missing fields
- `skills/triage/README.md` — inputs, outputs, decision-type taxonomy

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (16 new tests in `skills/triage/slice.test.ts`)