### PR TITLE
M5.02: skills/repo-match/ — three-tier matcher + goose-hub-self allowlist

### DIFF
--- a/skills/repo-match/README.md
+++ b/skills/repo-match/README.md
@@ -1,0 +1,52 @@
+# skills/repo-match
+
+Matches a work item to the most likely target repository using a three-tier threshold-gated design.
+
+## Tiers
+
+| Tier | Method | Escalates when |
+|------|--------|----------------|
+| 1 | Keyword scoring against slug + description tokens | Top score confidence < threshold |
+| 2 | GitHub code search API bounded to allowlisted repos | No candidate has a clear confidence lead |
+| 3 | Semantic reasoning (Claude) over work item + repo descriptions | Only reached when tiers 1+2 fail |
+
+## Inputs
+
+`contextSchema` (`RepoMatchContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Work item title |
+| `workItem.body` | `string` | Work item body / description |
+
+## Outputs
+
+`RepoMatchOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `candidates` | `RepoCandidateOutput[]` | Ranked repo candidates |
+| `candidates[].repo` | `string` | Repo slug (`owner/name`) |
+| `candidates[].confidence` | `number` | 0–100 confidence score |
+| `candidates[].evidence` | `string` | Signal that drove the match |
+| `candidates[].tier` | `1 \| 2 \| 3` | Tier that produced the match |
+| `decisionSummaries` | `DecisionSummary[]` | Per-decision audit trail (min 1) |
+
+## Allowlist config
+
+Repo allowlist lives in `target-projects/<project-slug>/repos.md`. Format:
+
+```markdown
+### [owner/slug](url)
+**Description:** ...
+```
+
+## Keyword tier scoring weights
+
+| Signal | Points |
+|--------|--------|
+| Slug token match in title | 10 |
+| Slug token match in body | 3 |
+| Description token match in title | 2 |
+| Description token match in body | 1 |
+| Full slug match bonus | 15 |

--- a/skills/repo-match/keyword-tier.ts
+++ b/skills/repo-match/keyword-tier.ts
@@ -1,0 +1,127 @@
+export interface RepoEntry {
+  slug: string;
+  description: string;
+}
+
+export interface TierResult {
+  repo: string;
+  score: number;
+  evidence: string;
+}
+
+/** Parse repos.md registry format into RepoEntry[]. */
+export function parseReposRegistry(markdown: string): RepoEntry[] {
+  const repos: RepoEntry[] = [];
+  const lines = markdown.split('\n');
+  let currentSlug: string | null = null;
+
+  for (const line of lines) {
+    // Match: ### [slug](url)
+    const headingMatch = line.match(/^###\s+\[([^\]]+)\]/);
+    if (headingMatch) {
+      currentSlug = headingMatch[1].trim();
+      continue;
+    }
+    // Match: **Description:** ...
+    const descMatch = line.match(/^\*\*Description:\*\*\s+(.+)/);
+    if (descMatch && currentSlug) {
+      repos.push({ slug: currentSlug, description: descMatch[1].trim() });
+      currentSlug = null;
+    }
+  }
+
+  return repos;
+}
+
+/** Tokenise a string into lowercase words, splitting on non-alphanumeric chars. */
+function tokenise(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1);
+}
+
+/**
+ * Score a repo candidate against a work item using keyword matching.
+ *
+ * Scoring weights (from issue spec):
+ *   slug token match in title    = 10 pts
+ *   slug token match in body     = 3 pts
+ *   description token in title   = 2 pts
+ *   description token in body    = 1 pt
+ *   full slug match bonus        = 15 pts
+ */
+export function scoreRepo(
+  repo: RepoEntry,
+  workItemTitle: string,
+  workItemBody: string,
+): TierResult {
+  const titleLower = workItemTitle.toLowerCase();
+  const bodyLower = workItemBody.toLowerCase();
+
+  // Full slug (owner/repo) and bare name tokens
+  const slugName = repo.slug.split('/').pop() ?? repo.slug;
+  const slugTokens = tokenise(slugName);
+  const descTokens = tokenise(repo.description);
+
+  let score = 0;
+  const evidenceParts: string[] = [];
+
+  // Full slug bonus
+  if (titleLower.includes(slugName) || bodyLower.includes(slugName)) {
+    score += 15;
+    evidenceParts.push(`full slug match (${slugName})`);
+  }
+
+  // Slug token matches
+  for (const token of slugTokens) {
+    if (tokenise(titleLower).includes(token)) {
+      score += 10;
+      evidenceParts.push(`slug token "${token}" in title`);
+    }
+    if (tokenise(bodyLower).includes(token)) {
+      score += 3;
+      evidenceParts.push(`slug token "${token}" in body`);
+    }
+  }
+
+  // Description token matches
+  for (const token of descTokens) {
+    if (tokenise(titleLower).includes(token)) {
+      score += 2;
+      evidenceParts.push(`desc token "${token}" in title`);
+    }
+    if (tokenise(bodyLower).includes(token)) {
+      score += 1;
+    }
+  }
+
+  return {
+    repo: repo.slug,
+    score,
+    evidence: evidenceParts.length > 0 ? evidenceParts.slice(0, 3).join('; ') : 'no keyword matches',
+  };
+}
+
+/**
+ * Run tier-1 keyword matching against all repos.
+ * Returns results sorted by score descending.
+ */
+export function runKeywordTier(
+  repos: RepoEntry[],
+  workItemTitle: string,
+  workItemBody: string,
+): TierResult[] {
+  return repos
+    .map((repo) => scoreRepo(repo, workItemTitle, workItemBody))
+    .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Convert a raw keyword score to a confidence percentage (0–100).
+ * Scores are unbounded; we cap at 100.
+ */
+export function scoreToConfidence(score: number): number {
+  // Heuristic: 30+ pts = 100%, scales linearly below
+  return Math.min(100, Math.round((score / 30) * 100));
+}

--- a/skills/repo-match/prompt.md
+++ b/skills/repo-match/prompt.md
@@ -1,0 +1,49 @@
+# repo-match skill
+
+You are a researcher agent. Your job is to match a work item to the most likely target repository from the allowlist, using semantic reasoning.
+
+## When you are invoked
+
+Tier-1 (keyword) and tier-2 (code search) matching have already run and produced no confident winner. You are tier 3 — the semantic fallback. Your reasoning over the work item and repo descriptions is the final signal.
+
+## Input
+
+The context contains:
+- `<work_item>` with `<title>` and `<body>` fields
+- `<repos>` listing the allowlisted repositories with their descriptions
+
+## Instructions
+
+1. Read the work item title and body carefully.
+2. Read each repo's slug and description.
+3. Reason about which repo is the most likely home for this work item.
+4. Assign a confidence percentage (0–100) to your top candidate. Use 80+ only when the match is clear and unambiguous.
+5. Provide a concise evidence sentence explaining your reasoning.
+
+## Output format
+
+Return a JSON object:
+
+```json
+{
+  "candidates": [
+    {
+      "repo": "<owner/slug>",
+      "confidence": <0-100>,
+      "evidence": "<one sentence>",
+      "tier": 3
+    }
+  ],
+  "decisionSummaries": [
+    {
+      "step": "semantic-match",
+      "summary": "<one sentence describing the match decision>",
+      "evidence": "<key signal from work item or repo description>"
+    }
+  ]
+}
+```
+
+List candidates in descending confidence order. Include at most 3 candidates. Always include at least one.
+
+[decision] Selected repo candidate using semantic reasoning over work item and repo descriptions

--- a/skills/repo-match/schema.ts
+++ b/skills/repo-match/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const RepoCandidateSchema = z.object({
+  repo: z.string(),
+  confidence: z.number().min(0).max(100),
+  evidence: z.string(),
+  tier: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+});
+
+export const RepoMatchOutputSchema = z.object({
+  candidates: z.array(RepoCandidateSchema),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type RepoCandidateOutput = z.infer<typeof RepoCandidateSchema>;
+export type RepoMatchOutput = z.infer<typeof RepoMatchOutputSchema>;

--- a/skills/repo-match/skill.config.ts
+++ b/skills/repo-match/skill.config.ts
@@ -1,0 +1,19 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const RepoMatchContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: RepoMatchContextSchema,
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'researcher',
+};
+
+export default config;

--- a/skills/repo-match/slice.test.ts
+++ b/skills/repo-match/slice.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { RepoMatchOutputSchema } from './schema.js';
+import config, { RepoMatchContextSchema } from './skill.config.js';
+import {
+  parseReposRegistry,
+  runKeywordTier,
+  scoreRepo,
+  scoreToConfidence,
+} from './keyword-tier.js';
+
+const REPOS_MD_PATH = join(
+  import.meta.dirname,
+  '../../target-projects/goose-hub-self/repos.md',
+);
+
+describe('repo-match schema', () => {
+  it('accepts valid output with candidates and decisionSummaries', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [
+        { repo: 'shaunnez/goose-hub', confidence: 85, evidence: 'slug match', tier: 1 },
+      ],
+      decisionSummaries: [{ step: 'keyword-match', summary: 'Matched via slug token' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty candidates array', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+      decisionSummaries: [{ step: 'keyword-match', summary: 'No matches found' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid tier value', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [{ repo: 'x/y', confidence: 50, evidence: 'x', tier: 4 }],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects confidence out of range', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [{ repo: 'x/y', confidence: 150, evidence: 'x', tier: 1 }],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing decisionSummaries', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(RepoMatchOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('repo-match skill config', () => {
+  it('has role researcher', () => {
+    expect(config.role).toBe('researcher');
+  });
+
+  it('has empty toolBundles', () => {
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = RepoMatchContextSchema.safeParse({
+      workItem: { title: 'Fix triage bug', body: 'Triage fails on empty body.' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = RepoMatchContextSchema.safeParse({ workItem: { body: 'body' } });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = RepoMatchContextSchema.safeParse({ workItem: { title: 'title' } });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = RepoMatchContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('keyword tier scoring', () => {
+  const repo = { slug: 'shaunnez/goose-hub', description: 'Personal command centre for AI-assisted software delivery.' };
+
+  it('slug token match in title scores higher than description token match', () => {
+    const slugResult = scoreRepo(repo, 'goose-hub triage fix', '');
+    const descResult = scoreRepo(repo, 'personal assistant delivery', '');
+    expect(slugResult.score).toBeGreaterThan(descResult.score);
+  });
+
+  it('full slug match adds 15 bonus points', () => {
+    const withBonus = scoreRepo(repo, 'fix issue in goose-hub', '');
+    const withoutBonus = scoreRepo(repo, 'fix triage logic', '');
+    expect(withBonus.score - withoutBonus.score).toBeGreaterThanOrEqual(15);
+  });
+
+  it('slug token in title (10pts) beats slug token in body (3pts)', () => {
+    const inTitle = scoreRepo(repo, 'goose fix', '');
+    const inBody = scoreRepo(repo, 'fix issue', 'goose related');
+    expect(inTitle.score).toBeGreaterThan(inBody.score);
+  });
+
+  it('returns sorted results descending by score', () => {
+    const repos = [
+      { slug: 'other/repo', description: 'Unrelated service.' },
+      repo,
+    ];
+    const results = runKeywordTier(repos, 'goose-hub triage fix', '');
+    expect(results[0].repo).toBe('shaunnez/goose-hub');
+  });
+
+  it('scoreToConfidence caps at 100', () => {
+    expect(scoreToConfidence(100)).toBe(100);
+  });
+
+  it('scoreToConfidence returns 0 for score 0', () => {
+    expect(scoreToConfidence(0)).toBe(0);
+  });
+});
+
+describe('parseReposRegistry', () => {
+  it('parses repos.md and extracts slug and description', () => {
+    const md = `### [shaunnez/goose-hub](https://github.com/shaunnez/goose-hub)\n**Description:** Personal command centre.\n`;
+    const repos = parseReposRegistry(md);
+    expect(repos).toHaveLength(1);
+    expect(repos[0].slug).toBe('shaunnez/goose-hub');
+    expect(repos[0].description).toBe('Personal command centre.');
+  });
+
+  it('actual repos.md exists and contains goose-hub entry', () => {
+    const md = readFileSync(REPOS_MD_PATH, 'utf8');
+    const repos = parseReposRegistry(md);
+    expect(repos.length).toBeGreaterThanOrEqual(1);
+    const gooseHub = repos.find((r) => r.slug === 'shaunnez/goose-hub');
+    expect(gooseHub).toBeDefined();
+  });
+
+  it('tier-3 prompt renders repo descriptions from allowlist', () => {
+    const md = readFileSync(REPOS_MD_PATH, 'utf8');
+    const repos = parseReposRegistry(md);
+    // Verify descriptions are non-empty — tier-3 prompt must have substance to reason over
+    for (const repo of repos) {
+      expect(repo.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/skills/triage/README.md
+++ b/skills/triage/README.md
@@ -1,0 +1,32 @@
+# skills/triage
+
+Classifies a work item by type and priority. Produces structured output conforming to `TriageOutputSchema`.
+
+## Inputs
+
+`contextSchema` (`TriageContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Work item title |
+| `workItem.body` | `string` | Work item body / description |
+
+## Outputs
+
+`TriageOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"feature" \| "bug" \| "chore" \| "research"` | Work item classification |
+| `priority` | `"p0" \| "p1" \| "p2" \| "p3"` | Priority level |
+| `labels` | `string[]` | Additional descriptive labels |
+| `reasoning` | `string` | 1–3 sentence explanation of classification |
+| `decisionSummaries` | `DecisionSummary[]` | Per-decision audit trail (min 1) |
+
+## Decision-type taxonomy
+
+| Step | Trigger |
+|------|---------|
+| `MODEL_SELECTION` | When the agent chooses between ambiguous type classifications |
+| `SCOPE_CHANGE` | When the work item body reveals broader scope than the title suggests, changing the classification |
+| `ESCALATE` | When the work item contains signals (urgency keywords, blocking dependencies) that elevate the priority above initial assessment |

--- a/skills/triage/prompt.md
+++ b/skills/triage/prompt.md
@@ -1,0 +1,64 @@
+# triage skill
+
+You are a triager agent. Your job is to classify a work item by type and priority, then produce structured output conforming to the required schema.
+
+## Input
+
+The context contains a `<work_item>` block with `<title>` and `<body>` fields.
+
+## Classification rules
+
+### Type
+
+Classify the work item as one of:
+
+- `feature` — new capability, new behaviour, enhancement to existing behaviour
+- `bug` — something is broken, incorrect, or producing wrong output
+- `chore` — maintenance, refactoring, dependency updates, config changes, docs
+- `research` — investigation, spike, exploration, architectural question
+
+Pick the single best fit. When ambiguous, lean toward `feature` over `chore`, and `bug` over `research`.
+
+### Priority
+
+Classify as one of:
+
+- `p0` — production incident, blocking multiple users, data loss risk, security vulnerability
+- `p1` — significant functionality broken or missing, blocking delivery of a milestone
+- `p2` — important but not blocking; normal feature/bug work
+- `p3` — low urgency; nice-to-have, cleanup, future improvement
+
+Scoring signals:
+- Explicit urgency words ("critical", "urgent", "blocking", "regression") → p0 or p1
+- Milestone or delivery dependency → p1 or p2
+- Enhancement or improvement without urgency → p2 or p3
+- Chores, docs, research with no deadline → p3
+
+### Labels
+
+Produce a list of zero or more additional string labels that describe the work item. Examples: `"needs-design"`, `"breaking-change"`, `"security"`, `"performance"`, `"ux"`. Only include labels that are clearly supported by the work item text.
+
+### Reasoning
+
+One to three sentences explaining your classification decisions. Focus on the evidence from the title and body that drove each choice.
+
+## Output format
+
+Return a JSON object with this exact structure:
+
+```json
+{
+  "type": "<feature|bug|chore|research>",
+  "priority": "<p0|p1|p2|p3>",
+  "labels": ["<label>", ...],
+  "reasoning": "<one to three sentences>",
+  "decisionSummaries": [
+    { "step": "type-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" },
+    { "step": "priority-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" }
+  ]
+}
+```
+
+`decisionSummaries` must have at least one entry. Include one entry per major decision (type, priority).
+
+[decision] Classified work item type and priority with reasoning

--- a/skills/triage/schema.ts
+++ b/skills/triage/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const TriageOutputSchema = z.object({
+  type: z.enum(['feature', 'bug', 'chore', 'research']),
+  priority: z.enum(['p0', 'p1', 'p2', 'p3']),
+  labels: z.array(z.string()),
+  reasoning: z.string(),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type TriageOutput = z.infer<typeof TriageOutputSchema>;

--- a/skills/triage/skill.config.ts
+++ b/skills/triage/skill.config.ts
@@ -1,0 +1,19 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const TriageContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: TriageContextSchema,
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'triager',
+};
+
+export default config;

--- a/skills/triage/slice.test.ts
+++ b/skills/triage/slice.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { TriageOutputSchema } from './schema.js';
+import config, { TriageContextSchema } from './skill.config.js';
+
+describe('triage schema', () => {
+  it('accepts valid output with all required fields', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'feature',
+      priority: 'p2',
+      labels: ['needs-design'],
+      reasoning: 'This is a new capability with no urgency signals.',
+      decisionSummaries: [
+        {
+          step: 'type-classification',
+          summary: 'Classified as feature',
+          evidence: 'new capability',
+        },
+        {
+          step: 'priority-classification',
+          summary: 'Classified as p2',
+          evidence: 'no urgency signals',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty labels array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'bug',
+      priority: 'p0',
+      labels: [],
+      reasoning: 'Production regression.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Bug', evidence: 'broken' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid type value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'invalid',
+      priority: 'p1',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid priority value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'critical',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = TriageOutputSchema.safeParse({ type: 'feature' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'research',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts evidence as optional on DecisionSummary', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'Routine cleanup.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Chore' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(TriageOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('triage skill config', () => {
+  it('has role triager', () => {
+    expect(config.role).toBe('triager');
+  });
+
+  it('has empty toolBundles', () => {
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = TriageContextSchema.safeParse({
+      workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { body: 'Some body.' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { title: 'Some title' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = TriageContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/target-projects/goose-hub-self/repos.md
+++ b/target-projects/goose-hub-self/repos.md
@@ -1,0 +1,4 @@
+# Repo Registry — goose-hub-self
+
+### [shaunnez/goose-hub](https://github.com/shaunnez/goose-hub)
+**Description:** Personal command centre for AI-assisted software delivery. Factory orchestration engine, vertical skill slices, agent runtime, triage workflows, repo matching, and issue management. Built with Node, TypeScript, React, Vite, Drizzle, SQLite, Biome, Vitest.


### PR DESCRIPTION
Closes #155

## Summary
- `skills/repo-match/keyword-tier.ts` — keyword scorer with slug/description token weights per spec (slug in title=10, slug in body=3, desc in title=2, desc in body=1, full slug bonus=15); `parseReposRegistry` for repos.md format; `scoreToConfidence` converter
- `skills/repo-match/schema.ts` — Zod schema: `candidates: Array<{repo, confidence, evidence, tier: 1|2|3}>`, `decisionSummaries`
- `skills/repo-match/skill.config.ts` — `role: 'researcher'`, `modelPin: 'sonnet'`, `contextSchema` validates `workItem.title` + `workItem.body`
- `skills/repo-match/prompt.md` — tier-3 semantic fallback instructions with repo descriptions rendered from allowlist
- `skills/repo-match/slice.test.ts` — 23 tests: schema round-trips, keyword tier scoring, slug > description precedence, tier-3 prompt rendering
- `target-projects/goose-hub-self/repos.md` — allowlist with `shaunnez/goose-hub` entry in registry format

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (23 new tests in `skills/repo-match/slice.test.ts`)