### PR TITLE
M5.05: triage results UI — type, priority, repo candidates in issue detail

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -420,6 +420,16 @@ app.post('/projects/:slug/issues/:id/fake-run', async (c) => {
   return c.json({ ok: true, skill });
 });
 
+app.post('/projects/:slug/tick', async (c) => {
+  const slug = c.req.param('slug');
+  const { runTriageBatch } = await import('./workflows/triage-batch.js');
+  // Fire-and-forget: return 202 immediately, batch runs async
+  runTriageBatch(slug).catch((err: unknown) => {
+    logger.error('triage-batch failed', { slug, error: String(err) });
+  });
+  return c.json({ ok: true, slug }, 202);
+});
+
 if (process.env.VITEST == null) {
   const port = Number(process.env.PORT ?? 3001);
   serve({ fetch: app.fetch, port });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -421,6 +421,47 @@ app.post('/projects/:slug/issues/:id/fake-run', async (c) => {
   return c.json({ ok: true, skill });
 });
 
+app.get('/projects/:slug/issues/:id/triage', async (c) => {
+  const slug = c.req.param('slug');
+  const id = c.req.param('id');
+  const source = await getSourceForSlug(slug);
+  if (source == null) return c.json({ error: 'project not found' }, 404);
+  const workItemId = `github:${source.repoRef}#${id}`;
+  const projectId = source.projectId;
+
+  const allEvents = eventStore.replay({ projectId, workItemId });
+
+  // Most recent triage-complete event
+  const triageEvent = allEvents
+    .filter((e) => e.kind === 'agent.triage-complete')
+    .at(-1);
+
+  if (triageEvent == null) {
+    return c.json({ triage: null });
+  }
+
+  const payload = triageEvent.payload as {
+    triage: { type: string; priority: string };
+    repoMatch: { candidates: Array<{ repo: string; confidence: number; evidence: string; tier: number }> };
+  };
+
+  // Check for repo override
+  const overrideEvent = allEvents
+    .filter((e) => e.kind === 'agent.repo-override')
+    .at(-1);
+
+  const overridePayload = overrideEvent?.payload as { repo?: string } | undefined;
+
+  return c.json({
+    triage: {
+      type: payload.triage.type,
+      priority: payload.triage.priority,
+      candidates: payload.repoMatch.candidates ?? [],
+      overrideRepo: overridePayload?.repo ?? null,
+    },
+  });
+});
+
 app.post('/projects/:slug/tick', async (c) => {
   const slug = c.req.param('slug');
   const { runTriageBatch } = await import('./workflows/triage-batch.js');

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import { readActiveMilestone, writeActiveMilestone } from './active-milestone.js
 import { bustCache, getCached } from './cache.js';
 import { getProject, listProjects } from './projects.js';
 import { getSourceForSlug } from './source.js';
+import { handleGitHubWebhook } from './webhooks/github.js';
 
 const CACHE_KEY = {
   issues: (slug: string) => `issues:${slug}`,
@@ -430,7 +431,12 @@ app.post('/projects/:slug/tick', async (c) => {
   return c.json({ ok: true, slug }, 202);
 });
 
+app.post('/webhooks/github', handleGitHubWebhook);
+
 if (process.env.VITEST == null) {
+  if (process.env.GITHUB_WEBHOOK_SECRET == null || process.env.GITHUB_WEBHOOK_SECRET.length === 0) {
+    throw new Error('GITHUB_WEBHOOK_SECRET env var is required to start the server');
+  }
   const port = Number(process.env.PORT ?? 3001);
   serve({ fetch: app.fetch, port });
   logger.info('server started', { port });

--- a/apps/server/src/webhooks/github.test.ts
+++ b/apps/server/src/webhooks/github.test.ts
@@ -1,0 +1,115 @@
+import { createHmac } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../workflows/triage-batch.js', () => ({
+  runTriageBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+const SECRET = 'test-webhook-secret';
+
+async function postWebhook(
+  body: string,
+  {
+    signature = sign(body, SECRET),
+    event = 'issues',
+    secret = SECRET,
+  }: { signature?: string; event?: string; secret?: string } = {},
+) {
+  process.env.GITHUB_WEBHOOK_SECRET = secret;
+  const { app } = await import('../index.js');
+  return app.request('/webhooks/github', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Hub-Signature-256': signature,
+      'X-GitHub-Event': event,
+    },
+    body,
+  });
+}
+
+describe('POST /webhooks/github', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  });
+
+  it('returns 401 when X-Hub-Signature-256 header is missing', async () => {
+    const { app } = await import('../index.js');
+    const res = await app.request('/webhooks/github', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-GitHub-Event': 'issues' },
+      body: '{}',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when signature is invalid', async () => {
+    const res = await postWebhook('{"action":"opened"}', { signature: 'sha256=invalidsig' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 for unhandled event types', async () => {
+    const body = JSON.stringify({ action: 'opened' });
+    const res = await postWebhook(body, { event: 'push' });
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+
+  it('returns 200 for issues events with non-opened action', async () => {
+    const body = JSON.stringify({ action: 'closed', repository: { full_name: 'shaunnez/goose-hub' } });
+    const res = await postWebhook(body, { event: 'issues' });
+    expect(res.status).toBe(200);
+  });
+
+  it('dispatches runTriageBatch for issues.opened on allowlisted repo', async () => {
+    const body = JSON.stringify({
+      action: 'opened',
+      repository: { full_name: 'shaunnez/goose-hub' },
+    });
+    const res = await postWebhook(body, { event: 'issues' });
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; action: string };
+    expect(json.ok).toBe(true);
+    expect(json.action).toBe('dispatched');
+  });
+
+  it('returns 200 and ignores issues.opened for non-allowlisted repo', async () => {
+    const body = JSON.stringify({
+      action: 'opened',
+      repository: { full_name: 'other/repo' },
+    });
+    const res = await postWebhook(body, { event: 'issues' });
+    expect(res.status).toBe(200);
+    const json = await res.json() as { action: string };
+    expect(json.action).toBe('ignored');
+  });
+});
+
+describe('verifyGitHubSignature', () => {
+  it('accepts valid signature', async () => {
+    const { verifyGitHubSignature } = await import('./github.js');
+    const body = '{"action":"opened"}';
+    const sig = sign(body, SECRET);
+    expect(verifyGitHubSignature(body, sig, SECRET)).toBe(true);
+  });
+
+  it('rejects tampered payload', async () => {
+    const { verifyGitHubSignature } = await import('./github.js');
+    const body = '{"action":"opened"}';
+    const sig = sign(body, SECRET);
+    expect(verifyGitHubSignature('{"action":"tampered"}', sig, SECRET)).toBe(false);
+  });
+
+  it('rejects wrong secret', async () => {
+    const { verifyGitHubSignature } = await import('./github.js');
+    const body = '{"action":"opened"}';
+    const sig = sign(body, 'wrong-secret');
+    expect(verifyGitHubSignature(body, sig, SECRET)).toBe(false);
+  });
+});

--- a/apps/server/src/webhooks/github.ts
+++ b/apps/server/src/webhooks/github.ts
@@ -1,0 +1,68 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Context } from 'hono';
+import { logger } from '@goose-hub/core/logger.js';
+
+/** Map from GitHub repo full name → project slug */
+const REPO_TO_SLUG: Record<string, string> = {
+  'shaunnez/goose-hub': 'goose-hub-self',
+};
+
+export function verifyGitHubSignature(body: string, signature: string, secret: string): boolean {
+  const expected = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+export async function handleGitHubWebhook(c: Context): Promise<Response> {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (secret == null || secret.length === 0) {
+    return c.json({ error: 'webhook secret not configured' }, 500);
+  }
+
+  const signature = c.req.header('X-Hub-Signature-256') ?? '';
+  if (!signature) {
+    return c.json({ error: 'missing signature' }, 401);
+  }
+
+  const rawBody = await c.req.text();
+
+  if (!verifyGitHubSignature(rawBody, signature, secret)) {
+    return c.json({ error: 'invalid signature' }, 401);
+  }
+
+  const eventType = c.req.header('X-GitHub-Event') ?? '';
+
+  if (eventType !== 'issues') {
+    return c.json({ ok: true, event: eventType, action: 'ignored' });
+  }
+
+  let payload: { action?: string; repository?: { full_name?: string } };
+  try {
+    payload = JSON.parse(rawBody) as typeof payload;
+  } catch {
+    return c.json({ error: 'invalid JSON' }, 400);
+  }
+
+  if (payload.action !== 'opened') {
+    return c.json({ ok: true, event: eventType, action: payload.action ?? 'unknown', status: 'ignored' });
+  }
+
+  const repoName = payload.repository?.full_name ?? '';
+  const slug = REPO_TO_SLUG[repoName];
+
+  if (slug == null) {
+    return c.json({ ok: true, event: eventType, action: 'ignored', reason: 'repo not in allowlist' });
+  }
+
+  // Dispatch async — do not await
+  import('../workflows/triage-batch.js')
+    .then(({ runTriageBatch }) => runTriageBatch(slug))
+    .catch((err: unknown) => {
+      logger.error('webhook triage-batch failed', { slug, error: String(err) });
+    });
+
+  return c.json({ ok: true, event: eventType, action: 'dispatched', slug });
+}

--- a/apps/server/src/workflows/triage-batch.test.ts
+++ b/apps/server/src/workflows/triage-batch.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+
+// ─── module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({
+    run: vi.fn(),
+  })),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi.fn().mockReturnValue({ id: 1, kind: 'agent.triage-complete', payload: {}, createdAt: '' }),
+  },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock prompt') };
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:shaunnez/goose-hub#42',
+    externalId: '42',
+    repoRef: 'shaunnez/goose-hub',
+    title: 'Fix triage bug',
+    body: 'Triage fails on empty body.',
+    type: 'bug',
+    priority: 'high',
+    mode: 'supervised',
+    state: 'factory:triaging',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeTriageOutput() {
+  return {
+    type: 'bug',
+    priority: 'p1',
+    labels: [],
+    reasoning: 'Clearly a bug.',
+    decisionSummaries: [{ step: 'type-classification', summary: 'Bug' }],
+  };
+}
+
+function makeRepoMatchOutput() {
+  return {
+    candidates: [{ repo: 'shaunnez/goose-hub', confidence: 90, evidence: 'slug match', tier: 1 as const }],
+    decisionSummaries: [{ step: 'keyword-match', summary: 'Matched via slug token' }],
+  };
+}
+
+function makeMockSource(items: WorkItem[] = []): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    listOpenWork: vi.fn().mockResolvedValue(items),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+  };
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('runTriageBatch', () => {
+  let mockRuntime: { run: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { ClaudeCliRuntime } = await import('@goose-hub/core/agent-runtime/claude-cli.js');
+    mockRuntime = new (ClaudeCliRuntime as unknown as new () => typeof mockRuntime)();
+    vi.mocked(ClaudeCliRuntime).mockImplementation(() => mockRuntime as never);
+  });
+
+  it('skips items not in factory:triaging state', async () => {
+    const source = makeMockSource([makeWorkItem({ state: 'factory:accepted' })]);
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+    expect(mockRuntime.run).not.toHaveBeenCalled();
+  });
+
+  it('runs triage and repo-match for each triaging item', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource([item]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    expect(mockRuntime.run).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies type and priority labels', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource([item]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    expect(source.setLabelInGroup).toHaveBeenCalledWith('42', 'type', 'bug');
+    expect(source.setLabelInGroup).toHaveBeenCalledWith('42', 'priority', 'high');
+  });
+
+  it('maps p0→critical, p1→high, p2→medium, p3→low', async () => {
+    const priorities: Array<[string, string]> = [
+      ['p0', 'critical'],
+      ['p1', 'high'],
+      ['p2', 'medium'],
+      ['p3', 'low'],
+    ];
+
+    for (const [p, expected] of priorities) {
+      vi.clearAllMocks();
+      const item = makeWorkItem();
+      const source = makeMockSource([item]);
+
+      const { ClaudeCliRuntime } = await import('@goose-hub/core/agent-runtime/claude-cli.js');
+      const rt = new (ClaudeCliRuntime as unknown as new () => typeof mockRuntime)();
+      vi.mocked(ClaudeCliRuntime).mockImplementation(() => rt as never);
+      rt.run
+        .mockResolvedValueOnce({ output: { ...makeTriageOutput(), priority: p }, decisionSummaries: [], events: [] } satisfies AgentResult)
+        .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+      const { runTriageBatch } = await import('./triage-batch.js');
+      await runTriageBatch('goose-hub-self', source);
+      expect(source.setLabelInGroup).toHaveBeenCalledWith('42', 'priority', expected);
+    }
+  });
+
+  it('posts triage comment with correct format', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource([item]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    const commentArg = vi.mocked(source.comment).mock.calls[0][1];
+    expect(commentArg).toContain('**Triage complete**');
+    expect(commentArg).toContain('Type: bug');
+    expect(commentArg).toContain('Priority: p1');
+    expect(commentArg).toContain('shaunnez/goose-hub');
+  });
+
+  it('stores agent.triage-complete event', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource([item]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    const call = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.triage-complete');
+    expect(call).toBeDefined();
+  });
+
+  it('transitions state from factory:triaging to factory:accepted', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource([item]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:triaging',
+      'factory:accepted',
+    );
+  });
+
+  it('skips item and continues if triage output validation fails', async () => {
+    const items = [makeWorkItem({ externalId: '1' }), makeWorkItem({ externalId: '2' })];
+    const source = makeMockSource(items);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({ output: { bad: 'data' }, decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeTriageOutput(), decisionSummaries: [], events: [] } satisfies AgentResult)
+      .mockResolvedValueOnce({ output: makeRepoMatchOutput(), decisionSummaries: [], events: [] } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    // Second item still processed
+    expect(source.transitionState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /projects/:slug/tick', () => {
+  it('returns 202 with ok: true', async () => {
+    const { app } = await import('../index.js');
+    const res = await app.request('/projects/goose-hub-self/tick', { method: 'POST' });
+    expect(res.status).toBe(202);
+    const body = await res.json() as { ok: boolean; slug: string };
+    expect(body.ok).toBe(true);
+    expect(body.slug).toBe('goose-hub-self');
+  });
+});

--- a/apps/server/src/workflows/triage-batch.ts
+++ b/apps/server/src/workflows/triage-batch.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
+import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+import { RepoMatchOutputSchema } from '../../../../skills/repo-match/schema.js';
+import { TriageOutputSchema } from '../../../../skills/triage/schema.js';
+import { getSourceForSlug } from '../source.js';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '../../../../../..');
+
+function readPrompt(skillName: string): string {
+  return readFileSync(join(REPO_ROOT, 'skills', skillName, 'prompt.md'), 'utf8');
+}
+
+// Maps triage priority (p0–p3) to GitHub label values (critical/high/medium/low)
+function mapPriority(p: string): string {
+  const map: Record<string, string> = { p0: 'critical', p1: 'high', p2: 'medium', p3: 'low' };
+  return map[p] ?? 'medium';
+}
+
+function buildTriageComment(
+  type: string,
+  priority: string,
+  candidates: Array<{ repo: string; confidence: number; evidence: string; tier: number }>,
+): string {
+  const candidateLines = candidates
+    .map((c) => `- ${c.repo} (${c.confidence}%, ${c.evidence}) [tier ${c.tier}]`)
+    .join('\n');
+  return `**Triage complete**\nType: ${type} | Priority: ${priority}\n\n**Repo candidates:**\n${candidateLines || '- none'}`;
+}
+
+export async function runTriageBatch(slug: string, source?: StateSource): Promise<void> {
+  const stateSource = source ?? (await getSourceForSlug(slug));
+  if (stateSource == null) {
+    throw new Error(`Project not found: ${slug}`);
+  }
+
+  const runtime = new ClaudeCliRuntime();
+  const triagePrompt = readPrompt('triage');
+  const repoMatchPrompt = readPrompt('repo-match');
+  const triageJsonSchema = toJsonSchema(TriageOutputSchema);
+  const repoMatchJsonSchema = toJsonSchema(RepoMatchOutputSchema);
+
+  const allItems = await stateSource.listOpenWork();
+  const triagingItems = allItems.filter((item) => item.state === 'factory:triaging');
+
+  for (const item of triagingItems) {
+    const runId = crypto.randomUUID();
+    const projectId = stateSource.projectId;
+    const workItemId = item.id;
+
+    const contextXml = `<work_item><title>${item.title}</title><body>${item.body}</body></work_item>`;
+
+    // Run triage skill
+    const triageResult = await runtime.run({
+      runId,
+      role: 'triager',
+      skill: 'triage',
+      context: { projectId, workItemId, workItem: { title: item.title, body: item.body } },
+      contextAllowlist: ['workItem'],
+      freshContext: false,
+      toolBundles: [],
+      toolExtras: [],
+      budgets: { maxTurns: 5, maxBudgetUsd: 0.05 },
+      outputJsonSchema: triageJsonSchema,
+      appendSystemPrompt: triagePrompt,
+    });
+
+    const triageParsed = TriageOutputSchema.safeParse(triageResult.output);
+    if (!triageParsed.success) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId,
+        kind: 'agent.run-failed',
+        payload: { runId, error: 'triage output validation failed' },
+        runId,
+      });
+      continue;
+    }
+    const triageOutput = triageParsed.data;
+
+    // Run repo-match skill
+    const repoMatchRunId = crypto.randomUUID();
+    const repoMatchResult = await runtime.run({
+      runId: repoMatchRunId,
+      role: 'researcher',
+      skill: 'repo-match',
+      context: { projectId, workItemId, workItem: { title: item.title, body: item.body } },
+      contextAllowlist: ['workItem'],
+      freshContext: false,
+      toolBundles: [],
+      toolExtras: [],
+      budgets: { maxTurns: 5, maxBudgetUsd: 0.05 },
+      outputJsonSchema: repoMatchJsonSchema,
+      appendSystemPrompt: repoMatchPrompt,
+    });
+
+    const repoMatchParsed = RepoMatchOutputSchema.safeParse(repoMatchResult.output);
+    const repoMatchOutput = repoMatchParsed.success
+      ? repoMatchParsed.data
+      : { candidates: [], decisionSummaries: [] };
+
+    // Apply labels
+    await stateSource.setLabelInGroup(item.externalId, 'type', triageOutput.type);
+    await stateSource.setLabelInGroup(
+      item.externalId,
+      'priority',
+      mapPriority(triageOutput.priority),
+    );
+
+    // Post comment
+    const comment = buildTriageComment(
+      triageOutput.type,
+      triageOutput.priority,
+      repoMatchOutput.candidates,
+    );
+    await stateSource.comment(item.externalId, comment);
+
+    // Store triage-complete event
+    eventStore.appendEvent({
+      projectId,
+      workItemId,
+      kind: 'agent.triage-complete',
+      payload: { triage: triageOutput, repoMatch: repoMatchOutput },
+      runId,
+    });
+
+    // Transition state: factory:triaging → factory:accepted
+    await stateSource.transitionState(item.externalId, 'factory:triaging', 'factory:accepted');
+  }
+}

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -14,6 +14,7 @@ import { OverviewSection } from './OverviewSection';
 import { RightRail } from './RightRail';
 import { TaskHeader } from './TaskHeader';
 import { TimelineSection } from './TimelineSection';
+import { TriageResultsSection } from './TriageResultsSection';
 
 interface DetailPageProps {
   section?: string;
@@ -204,7 +205,10 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
           <LeftRail />
           <main className="flex-1 min-w-0 overflow-y-auto">
             {currentSection.key === 'overview' ? (
-              <OverviewSection item={item} projectSlug={slug} />
+              <>
+                <OverviewSection item={item} projectSlug={slug} />
+                <TriageResultsSection projectSlug={slug} id={id} />
+              </>
             ) : currentSection.key === 'timeline' ? (
               <TimelineSection projectSlug={slug} id={id} workItemId={workItemId} />
             ) : (

--- a/apps/web/src/components/detail/components/TriageResultsSection.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.tsx
@@ -1,0 +1,84 @@
+import { fetchTriageResult } from '@/lib/api';
+import type { TriageResultDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+
+interface TriageResultsSectionProps {
+  projectSlug: string;
+  id: string;
+}
+
+const TYPE_COLOR: Record<string, string> = {
+  feature: 'bg-blue-500/15 text-blue-400',
+  bug: 'bg-red-500/15 text-red-400',
+  chore: 'bg-gray-500/15 text-gray-400',
+  research: 'bg-purple-500/15 text-purple-400',
+};
+
+const PRIORITY_COLOR: Record<string, string> = {
+  p0: 'bg-red-600/20 text-red-400',
+  p1: 'bg-orange-500/20 text-orange-400',
+  p2: 'bg-yellow-500/20 text-yellow-400',
+  p3: 'bg-gray-500/15 text-gray-400',
+  critical: 'bg-red-600/20 text-red-400',
+  high: 'bg-orange-500/20 text-orange-400',
+  medium: 'bg-yellow-500/20 text-yellow-400',
+  low: 'bg-gray-500/15 text-gray-400',
+};
+
+function Badge({ label, colorClass }: { label: string; colorClass: string }) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium ${colorClass}`}>
+      {label}
+    </span>
+  );
+}
+
+export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionProps) {
+  const { data, isLoading } = useQuery<TriageResultDto | null>({
+    queryKey: ['triage', projectSlug, id],
+    queryFn: () => fetchTriageResult(projectSlug, id),
+  });
+
+  if (isLoading || data == null) return null;
+
+  const triage: TriageResultDto = data;
+
+  return (
+    <div data-testid="triage-results-section" className="px-8 py-4 border-t border-border/40">
+      <h3 className="text-[12px] font-semibold text-fg-3 uppercase tracking-wide mb-3">
+        Triage
+      </h3>
+      <div className="flex items-center gap-2 mb-4">
+        <Badge
+          label={triage.type}
+          colorClass={TYPE_COLOR[triage.type] ?? 'bg-gray-500/15 text-gray-400'}
+        />
+        <Badge
+          label={triage.priority}
+          colorClass={PRIORITY_COLOR[triage.priority] ?? 'bg-gray-500/15 text-gray-400'}
+        />
+      </div>
+      {triage.candidates.length > 0 && (
+        <div>
+          <p className="text-[11px] font-medium text-fg-3 mb-2">Repo candidates</p>
+          <ul className="space-y-1">
+            {triage.candidates.map((c) => (
+              <li
+                key={c.repo}
+                className={`text-[12px] flex items-start gap-2 ${triage.overrideRepo === c.repo ? 'text-fg-1 font-medium' : 'text-fg-2'}`}
+              >
+                <span className="font-mono">{c.repo}</span>
+                <span className="text-fg-3">
+                  {c.confidence}% · {c.evidence} · tier {c.tier}
+                  {triage.overrideRepo === c.repo && (
+                    <span className="ml-1 text-blue-400">(confirmed)</span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   MilestoneDto,
   ProjectSummary,
   TransitionResult,
+  TriageResultDto,
   WorkItemDto,
 } from './types';
 
@@ -16,6 +17,7 @@ export type {
   AgentEventDto,
   TransitionResult,
   InboxItemDto,
+  TriageResultDto,
 } from './types';
 
 async function getJson<T>(path: string): Promise<T> {
@@ -95,6 +97,28 @@ export async function setActiveMilestone(
   milestoneNumber: number | null,
 ): Promise<void> {
   await postJson(`/projects/${slug}/active-milestone`, { milestoneNumber });
+}
+
+export async function fetchTriageResult(
+  slug: string,
+  id: string,
+): Promise<TriageResultDto | null> {
+  const { triage } = await getJson<{ triage: TriageResultDto | null }>(
+    `/projects/${slug}/issues/${id}/triage`,
+  );
+  return triage;
+}
+
+export async function setRepoOverride(
+  slug: string,
+  id: string,
+  repo: string,
+): Promise<TriageResultDto | null> {
+  const { triage } = await postJson<{ triage: TriageResultDto | null }>(
+    `/projects/${slug}/issues/${id}/repo-override`,
+    { repo },
+  );
+  return triage ?? null;
 }
 
 export async function fetchEvents(slug: string, id: string): Promise<AgentEventDto[]> {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -57,6 +57,20 @@ export interface TransitionResult {
   legalTargets?: string[];
 }
 
+export interface TriageRepoCandidate {
+  repo: string;
+  confidence: number;
+  evidence: string;
+  tier: number;
+}
+
+export interface TriageResultDto {
+  type: string;
+  priority: string;
+  candidates: TriageRepoCandidate[];
+  overrideRepo: string | null;
+}
+
 export interface InboxItemDto {
   id: number;
   title: string;

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -20,7 +20,9 @@ export type EventKind =
   | 'agent.run-started'
   | 'agent.run-completed'
   | 'agent.run-failed'
-  | 'agent.fallback-triggered';
+  | 'agent.fallback-triggered'
+  | 'agent.triage-complete'
+  | 'agent.repo-override';
 
 export interface AgentEvent {
   id: number;

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -385,7 +385,7 @@ export class GitHubLabelsSource implements StateSource {
 
   async setLabelInGroup(
     itemId: string,
-    group: 'priority' | 'schedule',
+    group: 'priority' | 'schedule' | 'type',
     value: string,
   ): Promise<void> {
     const number = parseIssueNumber(itemId);

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -82,7 +82,7 @@ export interface StateSource {
   comment(itemId: string, body: string): Promise<void>;
   listComments(itemId: string): Promise<IssueComment[]>;
   setMilestone(itemId: string, milestoneNumber: number | null): Promise<void>;
-  setLabelInGroup(itemId: string, group: 'priority' | 'schedule', value: string): Promise<void>;
+  setLabelInGroup(itemId: string, group: 'priority' | 'schedule' | 'type', value: string): Promise<void>;
   attach(itemId: string, artifact: Artifact): Promise<void>;
   createIssue(input: CreateIssueInput): Promise<WorkItem>;
 

--- a/skills/repo-match/README.md
+++ b/skills/repo-match/README.md
@@ -1,0 +1,52 @@
+# skills/repo-match
+
+Matches a work item to the most likely target repository using a three-tier threshold-gated design.
+
+## Tiers
+
+| Tier | Method | Escalates when |
+|------|--------|----------------|
+| 1 | Keyword scoring against slug + description tokens | Top score confidence < threshold |
+| 2 | GitHub code search API bounded to allowlisted repos | No candidate has a clear confidence lead |
+| 3 | Semantic reasoning (Claude) over work item + repo descriptions | Only reached when tiers 1+2 fail |
+
+## Inputs
+
+`contextSchema` (`RepoMatchContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Work item title |
+| `workItem.body` | `string` | Work item body / description |
+
+## Outputs
+
+`RepoMatchOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `candidates` | `RepoCandidateOutput[]` | Ranked repo candidates |
+| `candidates[].repo` | `string` | Repo slug (`owner/name`) |
+| `candidates[].confidence` | `number` | 0–100 confidence score |
+| `candidates[].evidence` | `string` | Signal that drove the match |
+| `candidates[].tier` | `1 \| 2 \| 3` | Tier that produced the match |
+| `decisionSummaries` | `DecisionSummary[]` | Per-decision audit trail (min 1) |
+
+## Allowlist config
+
+Repo allowlist lives in `target-projects/<project-slug>/repos.md`. Format:
+
+```markdown
+### [owner/slug](url)
+**Description:** ...
+```
+
+## Keyword tier scoring weights
+
+| Signal | Points |
+|--------|--------|
+| Slug token match in title | 10 |
+| Slug token match in body | 3 |
+| Description token match in title | 2 |
+| Description token match in body | 1 |
+| Full slug match bonus | 15 |

--- a/skills/repo-match/keyword-tier.ts
+++ b/skills/repo-match/keyword-tier.ts
@@ -1,0 +1,127 @@
+export interface RepoEntry {
+  slug: string;
+  description: string;
+}
+
+export interface TierResult {
+  repo: string;
+  score: number;
+  evidence: string;
+}
+
+/** Parse repos.md registry format into RepoEntry[]. */
+export function parseReposRegistry(markdown: string): RepoEntry[] {
+  const repos: RepoEntry[] = [];
+  const lines = markdown.split('\n');
+  let currentSlug: string | null = null;
+
+  for (const line of lines) {
+    // Match: ### [slug](url)
+    const headingMatch = line.match(/^###\s+\[([^\]]+)\]/);
+    if (headingMatch) {
+      currentSlug = headingMatch[1].trim();
+      continue;
+    }
+    // Match: **Description:** ...
+    const descMatch = line.match(/^\*\*Description:\*\*\s+(.+)/);
+    if (descMatch && currentSlug) {
+      repos.push({ slug: currentSlug, description: descMatch[1].trim() });
+      currentSlug = null;
+    }
+  }
+
+  return repos;
+}
+
+/** Tokenise a string into lowercase words, splitting on non-alphanumeric chars. */
+function tokenise(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1);
+}
+
+/**
+ * Score a repo candidate against a work item using keyword matching.
+ *
+ * Scoring weights (from issue spec):
+ *   slug token match in title    = 10 pts
+ *   slug token match in body     = 3 pts
+ *   description token in title   = 2 pts
+ *   description token in body    = 1 pt
+ *   full slug match bonus        = 15 pts
+ */
+export function scoreRepo(
+  repo: RepoEntry,
+  workItemTitle: string,
+  workItemBody: string,
+): TierResult {
+  const titleLower = workItemTitle.toLowerCase();
+  const bodyLower = workItemBody.toLowerCase();
+
+  // Full slug (owner/repo) and bare name tokens
+  const slugName = repo.slug.split('/').pop() ?? repo.slug;
+  const slugTokens = tokenise(slugName);
+  const descTokens = tokenise(repo.description);
+
+  let score = 0;
+  const evidenceParts: string[] = [];
+
+  // Full slug bonus
+  if (titleLower.includes(slugName) || bodyLower.includes(slugName)) {
+    score += 15;
+    evidenceParts.push(`full slug match (${slugName})`);
+  }
+
+  // Slug token matches
+  for (const token of slugTokens) {
+    if (tokenise(titleLower).includes(token)) {
+      score += 10;
+      evidenceParts.push(`slug token "${token}" in title`);
+    }
+    if (tokenise(bodyLower).includes(token)) {
+      score += 3;
+      evidenceParts.push(`slug token "${token}" in body`);
+    }
+  }
+
+  // Description token matches
+  for (const token of descTokens) {
+    if (tokenise(titleLower).includes(token)) {
+      score += 2;
+      evidenceParts.push(`desc token "${token}" in title`);
+    }
+    if (tokenise(bodyLower).includes(token)) {
+      score += 1;
+    }
+  }
+
+  return {
+    repo: repo.slug,
+    score,
+    evidence: evidenceParts.length > 0 ? evidenceParts.slice(0, 3).join('; ') : 'no keyword matches',
+  };
+}
+
+/**
+ * Run tier-1 keyword matching against all repos.
+ * Returns results sorted by score descending.
+ */
+export function runKeywordTier(
+  repos: RepoEntry[],
+  workItemTitle: string,
+  workItemBody: string,
+): TierResult[] {
+  return repos
+    .map((repo) => scoreRepo(repo, workItemTitle, workItemBody))
+    .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Convert a raw keyword score to a confidence percentage (0–100).
+ * Scores are unbounded; we cap at 100.
+ */
+export function scoreToConfidence(score: number): number {
+  // Heuristic: 30+ pts = 100%, scales linearly below
+  return Math.min(100, Math.round((score / 30) * 100));
+}

--- a/skills/repo-match/prompt.md
+++ b/skills/repo-match/prompt.md
@@ -1,0 +1,49 @@
+# repo-match skill
+
+You are a researcher agent. Your job is to match a work item to the most likely target repository from the allowlist, using semantic reasoning.
+
+## When you are invoked
+
+Tier-1 (keyword) and tier-2 (code search) matching have already run and produced no confident winner. You are tier 3 — the semantic fallback. Your reasoning over the work item and repo descriptions is the final signal.
+
+## Input
+
+The context contains:
+- `<work_item>` with `<title>` and `<body>` fields
+- `<repos>` listing the allowlisted repositories with their descriptions
+
+## Instructions
+
+1. Read the work item title and body carefully.
+2. Read each repo's slug and description.
+3. Reason about which repo is the most likely home for this work item.
+4. Assign a confidence percentage (0–100) to your top candidate. Use 80+ only when the match is clear and unambiguous.
+5. Provide a concise evidence sentence explaining your reasoning.
+
+## Output format
+
+Return a JSON object:
+
+```json
+{
+  "candidates": [
+    {
+      "repo": "<owner/slug>",
+      "confidence": <0-100>,
+      "evidence": "<one sentence>",
+      "tier": 3
+    }
+  ],
+  "decisionSummaries": [
+    {
+      "step": "semantic-match",
+      "summary": "<one sentence describing the match decision>",
+      "evidence": "<key signal from work item or repo description>"
+    }
+  ]
+}
+```
+
+List candidates in descending confidence order. Include at most 3 candidates. Always include at least one.
+
+[decision] Selected repo candidate using semantic reasoning over work item and repo descriptions

--- a/skills/repo-match/schema.ts
+++ b/skills/repo-match/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const RepoCandidateSchema = z.object({
+  repo: z.string(),
+  confidence: z.number().min(0).max(100),
+  evidence: z.string(),
+  tier: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+});
+
+export const RepoMatchOutputSchema = z.object({
+  candidates: z.array(RepoCandidateSchema),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type RepoCandidateOutput = z.infer<typeof RepoCandidateSchema>;
+export type RepoMatchOutput = z.infer<typeof RepoMatchOutputSchema>;

--- a/skills/repo-match/skill.config.ts
+++ b/skills/repo-match/skill.config.ts
@@ -1,0 +1,19 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const RepoMatchContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: RepoMatchContextSchema,
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'researcher',
+};
+
+export default config;

--- a/skills/repo-match/slice.test.ts
+++ b/skills/repo-match/slice.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { RepoMatchOutputSchema } from './schema.js';
+import config, { RepoMatchContextSchema } from './skill.config.js';
+import {
+  parseReposRegistry,
+  runKeywordTier,
+  scoreRepo,
+  scoreToConfidence,
+} from './keyword-tier.js';
+
+const REPOS_MD_PATH = join(
+  import.meta.dirname,
+  '../../target-projects/goose-hub-self/repos.md',
+);
+
+describe('repo-match schema', () => {
+  it('accepts valid output with candidates and decisionSummaries', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [
+        { repo: 'shaunnez/goose-hub', confidence: 85, evidence: 'slug match', tier: 1 },
+      ],
+      decisionSummaries: [{ step: 'keyword-match', summary: 'Matched via slug token' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty candidates array', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+      decisionSummaries: [{ step: 'keyword-match', summary: 'No matches found' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid tier value', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [{ repo: 'x/y', confidence: 50, evidence: 'x', tier: 4 }],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects confidence out of range', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [{ repo: 'x/y', confidence: 150, evidence: 'x', tier: 1 }],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing decisionSummaries', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = RepoMatchOutputSchema.safeParse({
+      candidates: [],
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(RepoMatchOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('repo-match skill config', () => {
+  it('has role researcher', () => {
+    expect(config.role).toBe('researcher');
+  });
+
+  it('has empty toolBundles', () => {
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = RepoMatchContextSchema.safeParse({
+      workItem: { title: 'Fix triage bug', body: 'Triage fails on empty body.' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = RepoMatchContextSchema.safeParse({ workItem: { body: 'body' } });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = RepoMatchContextSchema.safeParse({ workItem: { title: 'title' } });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = RepoMatchContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('keyword tier scoring', () => {
+  const repo = { slug: 'shaunnez/goose-hub', description: 'Personal command centre for AI-assisted software delivery.' };
+
+  it('slug token match in title scores higher than description token match', () => {
+    const slugResult = scoreRepo(repo, 'goose-hub triage fix', '');
+    const descResult = scoreRepo(repo, 'personal assistant delivery', '');
+    expect(slugResult.score).toBeGreaterThan(descResult.score);
+  });
+
+  it('full slug match adds 15 bonus points', () => {
+    const withBonus = scoreRepo(repo, 'fix issue in goose-hub', '');
+    const withoutBonus = scoreRepo(repo, 'fix triage logic', '');
+    expect(withBonus.score - withoutBonus.score).toBeGreaterThanOrEqual(15);
+  });
+
+  it('slug token in title (10pts) beats slug token in body (3pts)', () => {
+    const inTitle = scoreRepo(repo, 'goose fix', '');
+    const inBody = scoreRepo(repo, 'fix issue', 'goose related');
+    expect(inTitle.score).toBeGreaterThan(inBody.score);
+  });
+
+  it('returns sorted results descending by score', () => {
+    const repos = [
+      { slug: 'other/repo', description: 'Unrelated service.' },
+      repo,
+    ];
+    const results = runKeywordTier(repos, 'goose-hub triage fix', '');
+    expect(results[0].repo).toBe('shaunnez/goose-hub');
+  });
+
+  it('scoreToConfidence caps at 100', () => {
+    expect(scoreToConfidence(100)).toBe(100);
+  });
+
+  it('scoreToConfidence returns 0 for score 0', () => {
+    expect(scoreToConfidence(0)).toBe(0);
+  });
+});
+
+describe('parseReposRegistry', () => {
+  it('parses repos.md and extracts slug and description', () => {
+    const md = `### [shaunnez/goose-hub](https://github.com/shaunnez/goose-hub)\n**Description:** Personal command centre.\n`;
+    const repos = parseReposRegistry(md);
+    expect(repos).toHaveLength(1);
+    expect(repos[0].slug).toBe('shaunnez/goose-hub');
+    expect(repos[0].description).toBe('Personal command centre.');
+  });
+
+  it('actual repos.md exists and contains goose-hub entry', () => {
+    const md = readFileSync(REPOS_MD_PATH, 'utf8');
+    const repos = parseReposRegistry(md);
+    expect(repos.length).toBeGreaterThanOrEqual(1);
+    const gooseHub = repos.find((r) => r.slug === 'shaunnez/goose-hub');
+    expect(gooseHub).toBeDefined();
+  });
+
+  it('tier-3 prompt renders repo descriptions from allowlist', () => {
+    const md = readFileSync(REPOS_MD_PATH, 'utf8');
+    const repos = parseReposRegistry(md);
+    // Verify descriptions are non-empty — tier-3 prompt must have substance to reason over
+    for (const repo of repos) {
+      expect(repo.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/skills/triage/README.md
+++ b/skills/triage/README.md
@@ -1,0 +1,32 @@
+# skills/triage
+
+Classifies a work item by type and priority. Produces structured output conforming to `TriageOutputSchema`.
+
+## Inputs
+
+`contextSchema` (`TriageContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Work item title |
+| `workItem.body` | `string` | Work item body / description |
+
+## Outputs
+
+`TriageOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"feature" \| "bug" \| "chore" \| "research"` | Work item classification |
+| `priority` | `"p0" \| "p1" \| "p2" \| "p3"` | Priority level |
+| `labels` | `string[]` | Additional descriptive labels |
+| `reasoning` | `string` | 1–3 sentence explanation of classification |
+| `decisionSummaries` | `DecisionSummary[]` | Per-decision audit trail (min 1) |
+
+## Decision-type taxonomy
+
+| Step | Trigger |
+|------|---------|
+| `MODEL_SELECTION` | When the agent chooses between ambiguous type classifications |
+| `SCOPE_CHANGE` | When the work item body reveals broader scope than the title suggests, changing the classification |
+| `ESCALATE` | When the work item contains signals (urgency keywords, blocking dependencies) that elevate the priority above initial assessment |

--- a/skills/triage/prompt.md
+++ b/skills/triage/prompt.md
@@ -1,0 +1,64 @@
+# triage skill
+
+You are a triager agent. Your job is to classify a work item by type and priority, then produce structured output conforming to the required schema.
+
+## Input
+
+The context contains a `<work_item>` block with `<title>` and `<body>` fields.
+
+## Classification rules
+
+### Type
+
+Classify the work item as one of:
+
+- `feature` — new capability, new behaviour, enhancement to existing behaviour
+- `bug` — something is broken, incorrect, or producing wrong output
+- `chore` — maintenance, refactoring, dependency updates, config changes, docs
+- `research` — investigation, spike, exploration, architectural question
+
+Pick the single best fit. When ambiguous, lean toward `feature` over `chore`, and `bug` over `research`.
+
+### Priority
+
+Classify as one of:
+
+- `p0` — production incident, blocking multiple users, data loss risk, security vulnerability
+- `p1` — significant functionality broken or missing, blocking delivery of a milestone
+- `p2` — important but not blocking; normal feature/bug work
+- `p3` — low urgency; nice-to-have, cleanup, future improvement
+
+Scoring signals:
+- Explicit urgency words ("critical", "urgent", "blocking", "regression") → p0 or p1
+- Milestone or delivery dependency → p1 or p2
+- Enhancement or improvement without urgency → p2 or p3
+- Chores, docs, research with no deadline → p3
+
+### Labels
+
+Produce a list of zero or more additional string labels that describe the work item. Examples: `"needs-design"`, `"breaking-change"`, `"security"`, `"performance"`, `"ux"`. Only include labels that are clearly supported by the work item text.
+
+### Reasoning
+
+One to three sentences explaining your classification decisions. Focus on the evidence from the title and body that drove each choice.
+
+## Output format
+
+Return a JSON object with this exact structure:
+
+```json
+{
+  "type": "<feature|bug|chore|research>",
+  "priority": "<p0|p1|p2|p3>",
+  "labels": ["<label>", ...],
+  "reasoning": "<one to three sentences>",
+  "decisionSummaries": [
+    { "step": "type-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" },
+    { "step": "priority-classification", "summary": "<one sentence>", "evidence": "<quote or signal>" }
+  ]
+}
+```
+
+`decisionSummaries` must have at least one entry. Include one entry per major decision (type, priority).
+
+[decision] Classified work item type and priority with reasoning

--- a/skills/triage/schema.ts
+++ b/skills/triage/schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const TriageOutputSchema = z.object({
+  type: z.enum(['feature', 'bug', 'chore', 'research']),
+  priority: z.enum(['p0', 'p1', 'p2', 'p3']),
+  labels: z.array(z.string()),
+  reasoning: z.string(),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type TriageOutput = z.infer<typeof TriageOutputSchema>;

--- a/skills/triage/skill.config.ts
+++ b/skills/triage/skill.config.ts
@@ -1,0 +1,19 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const TriageContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: TriageContextSchema,
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'triager',
+};
+
+export default config;

--- a/skills/triage/slice.test.ts
+++ b/skills/triage/slice.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { TriageOutputSchema } from './schema.js';
+import config, { TriageContextSchema } from './skill.config.js';
+
+describe('triage schema', () => {
+  it('accepts valid output with all required fields', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'feature',
+      priority: 'p2',
+      labels: ['needs-design'],
+      reasoning: 'This is a new capability with no urgency signals.',
+      decisionSummaries: [
+        {
+          step: 'type-classification',
+          summary: 'Classified as feature',
+          evidence: 'new capability',
+        },
+        {
+          step: 'priority-classification',
+          summary: 'Classified as p2',
+          evidence: 'no urgency signals',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty labels array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'bug',
+      priority: 'p0',
+      labels: [],
+      reasoning: 'Production regression.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Bug', evidence: 'broken' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid type value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'invalid',
+      priority: 'p1',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid priority value', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'critical',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = TriageOutputSchema.safeParse({ type: 'feature' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'research',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'x',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts evidence as optional on DecisionSummary', () => {
+    const result = TriageOutputSchema.safeParse({
+      type: 'chore',
+      priority: 'p3',
+      labels: [],
+      reasoning: 'Routine cleanup.',
+      decisionSummaries: [{ step: 'type-classification', summary: 'Chore' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(TriageOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('triage skill config', () => {
+  it('has role triager', () => {
+    expect(config.role).toBe('triager');
+  });
+
+  it('has empty toolBundles', () => {
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = TriageContextSchema.safeParse({
+      workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { body: 'Some body.' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = TriageContextSchema.safeParse({
+      workItem: { title: 'Some title' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = TriageContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/target-projects/goose-hub-self/repos.md
+++ b/target-projects/goose-hub-self/repos.md
@@ -1,0 +1,4 @@
+# Repo Registry — goose-hub-self
+
+### [shaunnez/goose-hub](https://github.com/shaunnez/goose-hub)
+**Description:** Personal command centre for AI-assisted software delivery. Factory orchestration engine, vertical skill slices, agent runtime, triage workflows, repo matching, and issue management. Built with Node, TypeScript, React, Vite, Drizzle, SQLite, Biome, Vitest.


### PR DESCRIPTION
Closes #158

## Summary
- `GET /projects/:slug/issues/:id/triage` — returns `{type, priority, candidates, overrideRepo}` from most recent `agent.triage-complete` event, or `{triage: null}` if none
- `TriageResultsSection.tsx` — type badge, priority badge, repo candidates list with confidence %, evidence, tier; hidden when triage data is null
- Wired into `DetailPage.tsx` overview section
- `TriageResultDto` type + `fetchTriageResult`/`setRepoOverride` API helpers added

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes