### PR TITLE
M6.01: worktree creation and cleanup

### DIFF
--- a/core/workspaces/README.md
+++ b/core/workspaces/README.md
@@ -1,0 +1,57 @@
+# core/workspaces
+
+Git worktree lifecycle management for Factory investigation runs.
+
+## Files
+
+| File | Exports |
+|------|---------|
+| `worktree.ts` | `createWorktree`, `cleanupWorktree` |
+
+## Interface
+
+### `createWorktree(repo, runId): string`
+
+Creates a git worktree for the given local repo at `~/.factory/workspaces/<runId>/`.
+
+- **`repo`** — Absolute path to a local git repository (already cloned on disk).
+- **`runId`** — Canonical workflow isolation key (ULID/UUID string). Matches the `runId` used by `AgentSpec`, events, and tool hooks.
+- **Returns** — The absolute path to the created worktree (`~/.factory/workspaces/<runId>/`).
+- **Throws** — If `git worktree add` fails (e.g. repo path is invalid or not a git repo).
+
+Internally uses `git worktree add --detach` so the worktree starts at the current HEAD without creating or checking out a branch. This avoids branch conflicts when multiple parallel runs use the same repo.
+
+### `cleanupWorktree(runId): void`
+
+Removes the worktree directory at `~/.factory/workspaces/<runId>/`.
+
+- **`runId`** — The same isolation key used in `createWorktree`.
+- **Idempotent** — Calling this on a path that does not exist is a no-op (no error thrown).
+- If `git worktree remove` fails (e.g. the backing git repo has already been deleted), the directory is still removed via `fs.rmSync` with `force: true`.
+
+## Workspace path pattern
+
+```
+~/.factory/workspaces/<runId>/
+```
+
+All worktrees live under `~/.factory/workspaces/`. Each runId gets its own isolated subdirectory.
+
+## Import path
+
+```ts
+import { createWorktree, cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
+```
+
+## Usage example
+
+```ts
+import { createWorktree, cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
+
+// During investigation setup:
+const wtPath = createWorktree('/path/to/cloned/repo', runId);
+// wtPath === '~/.factory/workspaces/<runId>/'
+
+// After investigation completes or errors:
+cleanupWorktree(runId); // idempotent — safe to call multiple times
+```

--- a/core/workspaces/slice.test.ts
+++ b/core/workspaces/slice.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanupWorktree, createWorktree } from './worktree.js';
+
+// ─── module mocks (hoisted by vitest) ────────────────────────────────────────
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+vi.mock('node:os', () => ({ homedir: vi.fn().mockReturnValue('/mock-home') }));
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+
+describe('createWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mkdirSync).mockReturnValue(undefined);
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates the parent directory before calling git worktree add', () => {
+    createWorktree('/repo/path', 'run-abc-123');
+
+    expect(vi.mocked(mkdirSync)).toHaveBeenCalledWith('/mock-home/.factory/workspaces', {
+      recursive: true,
+    });
+  });
+
+  it('calls git worktree add with the correct path and detach flag', () => {
+    createWorktree('/repo/path', 'run-abc-123');
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'add', '--detach', '/mock-home/.factory/workspaces/run-abc-123'],
+      expect.objectContaining({ cwd: '/repo/path' }),
+    );
+  });
+
+  it('returns the worktree path', () => {
+    const result = createWorktree('/repo/path', 'run-abc-123');
+    expect(result).toBe('/mock-home/.factory/workspaces/run-abc-123');
+  });
+
+  it('propagates errors from git worktree add', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('git worktree add failed');
+    });
+    expect(() => createWorktree('/repo/path', 'run-abc-123')).toThrow('git worktree add failed');
+  });
+});
+
+describe('cleanupWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls git worktree remove --force when path exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    cleanupWorktree('run-abc-123');
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'remove', '--force', '/mock-home/.factory/workspaces/run-abc-123'],
+      expect.any(Object),
+    );
+  });
+
+  it('removes the directory after git worktree remove', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    cleanupWorktree('run-abc-123');
+
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith('/mock-home/.factory/workspaces/run-abc-123', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('is idempotent — does not throw when path does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(() => cleanupWorktree('run-abc-123')).not.toThrow();
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — does not throw on second call when path is gone', () => {
+    vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    // First call: exists, removes it
+    cleanupWorktree('run-abc-123');
+    // Second call: already gone, no-op
+    expect(() => cleanupWorktree('run-abc-123')).not.toThrow();
+  });
+
+  it('is idempotent — does not throw when git worktree remove fails (already removed)', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+
+    // Should still not throw — git error is swallowed, rmSync with force cleans up
+    expect(() => cleanupWorktree('run-abc-123')).not.toThrow();
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith('/mock-home/.factory/workspaces/run-abc-123', {
+      recursive: true,
+      force: true,
+    });
+  });
+});

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const WORKSPACES_DIR = join(homedir(), '.factory', 'workspaces');
+
+/**
+ * Resolves the worktree path for a given runId.
+ * Pattern: ~/.factory/workspaces/<runId>/
+ */
+function worktreePath(runId: string): string {
+  return join(WORKSPACES_DIR, runId);
+}
+
+/**
+ * Creates a git worktree for the given repo at ~/.factory/workspaces/<runId>/.
+ *
+ * Uses `git worktree add --detach` to create a detached HEAD worktree,
+ * which avoids branch conflicts when multiple runs use the same repo.
+ *
+ * @param repo - Absolute path to the local git repository (already cloned).
+ * @param runId - Canonical workflow isolation key (ULID/UUID).
+ * @returns The absolute path to the created worktree.
+ */
+export function createWorktree(repo: string, runId: string): string {
+  const wtPath = worktreePath(runId);
+
+  // Ensure the parent workspaces directory exists
+  mkdirSync(WORKSPACES_DIR, { recursive: true });
+
+  execFileSync('git', ['worktree', 'add', '--detach', wtPath], {
+    cwd: repo,
+    stdio: 'pipe',
+  });
+
+  return wtPath;
+}
+
+/**
+ * Removes the git worktree for the given runId.
+ *
+ * Idempotent: if the worktree path does not exist, this is a no-op.
+ * If `git worktree remove` fails (e.g. repo already gone), the directory
+ * is still removed via rmSync with force.
+ *
+ * @param runId - Canonical workflow isolation key (ULID/UUID).
+ */
+export function cleanupWorktree(runId: string): void {
+  const wtPath = worktreePath(runId);
+
+  if (!existsSync(wtPath)) {
+    return;
+  }
+
+  try {
+    execFileSync('git', ['worktree', 'remove', '--force', wtPath], {
+      cwd: wtPath,
+      stdio: 'pipe',
+    });
+  } catch {
+    // git worktree remove may fail if the git repo is gone or corrupted.
+    // Fall through and forcibly remove the directory.
+  }
+
+  // Ensure directory is fully removed regardless of git outcome
+  rmSync(wtPath, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #175

Adds `core/workspaces/worktree.ts` with `createWorktree(repo, runId)` and `cleanupWorktree(runId)`.

- Worktrees created under `~/.factory/workspaces/<runId>/` via `git worktree add --detach`
- Cleanup is idempotent — no-op if path does not exist; git errors during remove are swallowed and directory force-removed
- Unit tests cover: successful creation, correct args, return value, error propagation, cleanup happy path, idempotency (path gone, second call, git failure)
- `core/workspaces/README.md` documents the public interface
- All 412 tests pass, lint clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5nfpAYbP1YzBLvSAB7aJP)_