### PR TITLE
M6.03 + M6.04: skills/investigate/ and skills/playwright-repro/

### DIFF
--- a/skills/investigate/README.md
+++ b/skills/investigate/README.md
@@ -1,0 +1,71 @@
+# skills/investigate
+
+Investigates a bug issue by reading the worktree with read/search tools, then produces structured findings conforming to `InvestigateSchema`.
+
+## Role
+
+`investigator` — opus-tier model. No advisor (PLAN.md: "no advisor on investigator, already opus-tier").
+
+## Tool access
+
+Read and search only (`toolBundles: ['read']` → maps to `['read', 'search', 'work-item-read']`). No write access.
+
+## Inputs
+
+`contextSchema` (`InvestigateContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Issue title |
+| `workItem.body` | `string` | Issue body with reproduction steps |
+| `workItem.number` | `number` | Issue number for reference |
+| `worktreePath` | `string` | Absolute path to the checked-out worktree |
+
+Context is delivered as structured XML:
+
+```xml
+<task>
+  <work_item>
+    <title>...</title>
+    <body>...</body>
+    <number>...</number>
+  </work_item>
+  <worktree_path>...</worktree_path>
+</task>
+```
+
+## Outputs
+
+`InvestigateSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `findings` | `string` | Root cause hypothesis and analysis (2–5 paragraphs) |
+| `keyFiles` | `KeyFile[]` | Files most relevant to the bug |
+| `confidence` | `"low" \| "medium" \| "high"` | Confidence in root cause hypothesis |
+| `openQuestions` | `string[]` | Unresolved questions requiring more investigation |
+| `decisionSummaries` | `DecisionSummary[]` | Per-step audit trail (min 1) |
+
+`KeyFile`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `string` | File path (relative or absolute) |
+| `reason` | `string` | Why this file is relevant to the bug |
+
+## Decision-summary pattern
+
+The agent emits `[decision] <one sentence>` marker lines during its text turn after each major investigation step. These are parsed by the orchestrator and stored as `agent.decision-summary` events. They are NOT forwarded to QA or Reviewer agents.
+
+Standard decision steps:
+
+| Step | Trigger |
+|------|---------|
+| `issue-read` | After reading and understanding the issue |
+| `entry-point-identification` | After identifying likely entry points |
+| `code-path-trace` | After tracing the execution path through source files |
+| `root-cause-hypothesis` | After forming the root cause hypothesis |
+
+## Holdout discipline
+
+The investigator is NOT a holdout role. Decision summaries are saved to the event stream but not forwarded to QA or Reviewer agents. Implementation reasoning stays in `decisionSummaries`, not in the `findings` field (which QA reads).

--- a/skills/investigate/config.ts
+++ b/skills/investigate/config.ts
@@ -1,0 +1,48 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Context keys expected by the investigator agent, formatted as structured XML:
+ *
+ *   <task>
+ *     <work_item>
+ *       <title>...</title>
+ *       <body>...</body>
+ *       <number>...</number>
+ *     </work_item>
+ *     <worktree_path>...</worktree_path>
+ *   </task>
+ *
+ * - workItem.title   — the issue title (used as starting investigation signal)
+ * - workItem.body    — the issue body (contains steps to reproduce, expected/actual behaviour)
+ * - workItem.number  — the issue number (used for references in decision summaries)
+ * - worktreePath     — absolute path to the checked-out worktree to investigate
+ */
+export const InvestigateContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: InvestigateContextSchema,
+  /**
+   * Tool bundle 'read' maps to ['read', 'search', 'work-item-read'].
+   * The investigator has NO write access — file writes will be rejected.
+   */
+  toolBundles: ['read'],
+  /**
+   * Model pin: investigator is opus-tier.
+   * PLAN.md explicitly states "no advisor on investigator, already opus-tier".
+   * Opus is used because root-cause analysis requires deep reasoning over
+   * potentially large amounts of unfamiliar code.
+   */
+  modelPin: 'opus',
+  freshContext: false,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/investigate/schema.ts
+++ b/skills/investigate/schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const KeyFileSchema = z.object({
+  path: z.string(),
+  reason: z.string(),
+});
+
+export const InvestigateSchema = z.object({
+  findings: z.string().describe('Root cause hypothesis and analysis'),
+  keyFiles: z.array(KeyFileSchema).describe('Files most relevant to the bug'),
+  confidence: z.enum(['low', 'medium', 'high']),
+  openQuestions: z.array(z.string()).describe('Unresolved questions requiring more investigation'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type KeyFile = z.infer<typeof KeyFileSchema>;
+export type InvestigateOutput = z.infer<typeof InvestigateSchema>;

--- a/skills/investigate/skill.md
+++ b/skills/investigate/skill.md
@@ -1,0 +1,119 @@
+# investigate skill
+
+You are an investigator agent. Your job is to read a bug issue, explore the codebase in the provided worktree using read and search tools, and produce structured findings conforming to the required schema.
+
+You have **read and search access only**. You must not attempt to write, create, or modify any files. Any write attempt will be rejected.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<work_item>` — the issue being investigated
+  - `<title>` — issue title
+  - `<body>` — issue body with reproduction steps and expected/actual behaviour
+  - `<number>` — issue number for reference
+- `<worktree_path>` — absolute path to the checked-out worktree to explore
+
+## Investigation process
+
+Follow these steps systematically:
+
+### Step 1 — Read the issue
+
+Carefully read the issue title and body. Identify:
+- The reported symptom (what goes wrong)
+- Reproduction steps (if provided)
+- Expected behaviour vs actual behaviour
+- Any specific file paths, function names, or error messages mentioned
+
+Emit: `[decision] Read issue #<number>: <one-sentence summary of the bug>`
+
+### Step 2 — Identify entry points
+
+Based on the issue text, identify likely entry points in the codebase:
+- Search for function names, error messages, or identifiers mentioned in the issue
+- Use search tools to locate files relevant to the symptom area
+- Read directory structure to understand the code organisation
+
+Emit: `[decision] Identified entry points: <comma-separated file or directory names>`
+
+### Step 3 — Trace the code path
+
+Starting from the entry points, trace the execution path:
+- Read the relevant source files
+- Follow imports and function calls related to the reported symptom
+- Look for validation logic, error handling, or data transformation that could cause the bug
+
+Emit: `[decision] Traced code path through <key files>: <one-sentence hypothesis>`
+
+### Step 4 — Form root cause hypothesis
+
+Based on your investigation, form a hypothesis:
+- Identify the specific code location most likely responsible
+- Note any related files that could contribute
+- Assess your confidence: `low` (many unknowns), `medium` (probable cause identified), `high` (root cause clear)
+
+Emit: `[decision] Root cause hypothesis: <one sentence>`
+
+### Step 5 — Record open questions
+
+Note any unresolved questions that would require additional investigation:
+- Missing reproduction environment details
+- Ambiguous code paths that need runtime inspection
+- Configuration or data dependencies not visible from static analysis
+
+Emit: `[decision] Recorded <N> open questions`
+
+## Output format
+
+Return a JSON object with this exact structure:
+
+```json
+{
+  "findings": "<root cause hypothesis and full analysis, 2–5 paragraphs>",
+  "keyFiles": [
+    { "path": "<relative or absolute file path>", "reason": "<why this file is relevant>" }
+  ],
+  "confidence": "<low|medium|high>",
+  "openQuestions": [
+    "<question 1>",
+    "<question 2>"
+  ],
+  "decisionSummaries": [
+    { "step": "issue-read", "summary": "<one sentence>", "evidence": "<quote or signal>" },
+    { "step": "entry-point-identification", "summary": "<one sentence>", "evidence": "<file names or search terms>" },
+    { "step": "code-path-trace", "summary": "<one sentence>", "evidence": "<function or module name>" },
+    { "step": "root-cause-hypothesis", "summary": "<one sentence>", "evidence": "<file:line or code snippet>" }
+  ]
+}
+```
+
+`decisionSummaries` must have at least one entry. Include one entry per major investigation step.
+
+`keyFiles` must list every file you read or searched that is materially relevant to the bug. Exclude files you only skimmed without finding relevant content.
+
+`confidence` reflects how certain you are about your root cause hypothesis:
+- `low` — symptom identified but root cause unclear; many unknowns remain
+- `medium` — probable cause identified; would need a fix attempt to confirm
+- `high` — root cause is clear and well-evidenced from static analysis alone
+
+## Decision-summary pattern
+
+After each major investigation step, emit a line in your text turn:
+
+```
+[decision] <one sentence summary>
+```
+
+These marker lines are parsed by the orchestrator and stored as `agent.decision-summary` events. They are NOT forwarded to QA or Reviewer agents. Keep each summary to a single sentence. Do not include credentials, file dumps, or raw chain-of-thought.
+
+Examples of good decision summaries:
+- `[decision] Read issue #42: login endpoint returns 500 when email contains a plus sign`
+- `[decision] Identified entry points: apps/server/src/routes/auth.ts, core/auth/validate.ts`
+- `[decision] Traced code path through email normalisation: plus signs stripped before DB lookup`
+- `[decision] Root cause hypothesis: URL-decode step in normaliseEmail() drops plus sign`
+
+Bad decision summaries:
+- More than one sentence
+- Raw stack traces or file contents
+- Anything with credentials or PII

--- a/skills/investigate/slice.test.ts
+++ b/skills/investigate/slice.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config, { InvestigateContextSchema } from './config.js';
+import { InvestigateSchema } from './schema.js';
+
+describe('investigate schema', () => {
+  it('accepts valid output with all required fields', () => {
+    const result = InvestigateSchema.safeParse({
+      findings:
+        'The root cause is a missing null-check in the auth middleware. When the session token is absent, the middleware crashes instead of returning 401.',
+      keyFiles: [
+        { path: 'apps/server/src/middleware/auth.ts', reason: 'Contains the null-dereference bug' },
+        { path: 'apps/server/src/routes/api.ts', reason: 'Calls the auth middleware' },
+      ],
+      confidence: 'high',
+      openQuestions: ['Does this also affect the websocket upgrade path?'],
+      decisionSummaries: [
+        {
+          step: 'issue-read',
+          summary: 'Read issue #99: auth middleware crashes on missing session token',
+          evidence: 'TypeError: Cannot read properties of undefined',
+        },
+        {
+          step: 'root-cause-hypothesis',
+          summary: 'Null-check missing in auth.ts line 42',
+          evidence: 'apps/server/src/middleware/auth.ts:42',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty keyFiles array', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Could not pinpoint root cause from static analysis alone.',
+      keyFiles: [],
+      confidence: 'low',
+      openQuestions: ['Need runtime logs to identify the failing code path.'],
+      decisionSummaries: [
+        { step: 'issue-read', summary: 'Read issue but no clear entry point found' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty openQuestions array', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Root cause is clear: divide-by-zero in calculateRatio().',
+      keyFiles: [{ path: 'core/math/ratio.ts', reason: 'Divide-by-zero bug' }],
+      confidence: 'high',
+      openQuestions: [],
+      decisionSummaries: [
+        { step: 'root-cause-hypothesis', summary: 'Divide-by-zero in calculateRatio()' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts evidence as optional on DecisionSummary', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Investigation complete.',
+      keyFiles: [],
+      confidence: 'medium',
+      openQuestions: [],
+      decisionSummaries: [{ step: 'issue-read', summary: 'Read and understood the issue' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid confidence value', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Some analysis.',
+      keyFiles: [],
+      confidence: 'very-high',
+      openQuestions: [],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing findings field', () => {
+    const result = InvestigateSchema.safeParse({
+      keyFiles: [],
+      confidence: 'low',
+      openQuestions: [],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing confidence field', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Some analysis.',
+      keyFiles: [],
+      openQuestions: [],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries array', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Some analysis.',
+      keyFiles: [],
+      confidence: 'medium',
+      openQuestions: [],
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing decisionSummaries field', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Some analysis.',
+      keyFiles: [],
+      confidence: 'medium',
+      openQuestions: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects keyFile missing path', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Analysis.',
+      keyFiles: [{ reason: 'missing path' }],
+      confidence: 'low',
+      openQuestions: [],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects keyFile missing reason', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Analysis.',
+      keyFiles: [{ path: 'some/file.ts' }],
+      confidence: 'low',
+      openQuestions: [],
+      decisionSummaries: [{ step: 's', summary: 'ok' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields entirely', () => {
+    const result = InvestigateSchema.safeParse({ confidence: 'high' });
+    expect(result.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(InvestigateSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('investigate skill config', () => {
+  it('has role investigator', () => {
+    expect(config.role).toBe('investigator');
+  });
+
+  it('has read toolBundle', () => {
+    expect(config.toolBundles).toContain('read');
+  });
+
+  it('is pinned to opus model', () => {
+    expect(config.modelPin).toBe('opus');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('contextSchema validates required workItem and worktreePath fields', () => {
+    const valid = InvestigateContextSchema.safeParse({
+      workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.', number: 42 },
+      worktreePath: '/tmp/worktrees/42',
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = InvestigateContextSchema.safeParse({
+      workItem: { body: 'body', number: 1 },
+      worktreePath: '/tmp/worktrees/1',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = InvestigateContextSchema.safeParse({
+      workItem: { title: 'title', number: 1 },
+      worktreePath: '/tmp/worktrees/1',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.number', () => {
+    const invalid = InvestigateContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body' },
+      worktreePath: '/tmp/worktrees/1',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing worktreePath', () => {
+    const invalid = InvestigateContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = InvestigateContextSchema.safeParse({
+      worktreePath: '/tmp/worktrees/1',
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/skills/playwright-repro/README.md
+++ b/skills/playwright-repro/README.md
@@ -1,0 +1,64 @@
+# skills/playwright-repro
+
+Captures the broken behaviour of a `type:bug` issue using Playwright. Produces structured artefacts: screenshot paths, video path (if captured), console errors, and repro steps actually executed.
+
+Called AFTER the investigate skill (M6.03) for `type:bug` issues only.
+
+**Playwright is NOT wired into CI.** This skill is for local repro capture only.
+
+## When this skill runs
+
+- Work item type: `bug` (set by triage)
+- Called by: Factory investigator workflow, after investigate skill confirms the bug scope
+- Not called for: `feature`, `chore`, `research` issues
+
+## Inputs
+
+`contextSchema` (`PlaywrightReproContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Bug issue title |
+| `workItem.body` | `string` | Full bug issue body |
+| `workItem.reproSteps` | `string` | Repro steps extracted from the issue body |
+| `workItem.url` | `string` (optional) | URL of the page exhibiting the bug |
+
+## Outputs
+
+`PlaywrightReproSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `screenshots` | `Screenshot[]` | Ordered screenshots per repro step |
+| `screenshots[].path` | `string` | Absolute path to screenshot file |
+| `screenshots[].caption` | `string` | Description of what the screenshot shows |
+| `screenshots[].step` | `number` | Repro step number this screenshot corresponds to |
+| `videoPath` | `string \| null` | Absolute path to video recording, or `null` if not captured |
+| `consoleErrors` | `ConsoleEntry[]` | Browser console errors/warnings/info captured during the session |
+| `consoleErrors[].message` | `string` | Console message text |
+| `consoleErrors[].type` | `"error" \| "warning" \| "info"` | Console entry type |
+| `consoleErrors[].url` | `string` (optional) | Source URL of the console entry |
+| `reproSteps` | `string[]` | The steps actually executed (may differ from issue if steps were clarified) |
+| `reproduced` | `boolean` | Whether the bug was successfully reproduced |
+| `notes` | `string` (optional) | Additional context, observations, or explanation if not reproduced |
+
+## Tool allowlist
+
+This skill uses the `validate` tool bundle, which includes Playwright for browser automation.
+
+## Repro failure path
+
+When the bug cannot be reproduced (environment mismatch, flaky timing, missing preconditions):
+- `reproduced` is `false`
+- `screenshots` may be empty (`[]`)
+- `videoPath` is `null` if no recording was made
+- `notes` should explain why reproduction failed
+
+## Context allowlist
+
+| Key | Included |
+|-----|---------|
+| `workItem.title` | yes |
+| `workItem.body` | yes |
+| `workItem.reproSteps` | yes |
+| `workItem.url` | yes |

--- a/skills/playwright-repro/config.ts
+++ b/skills/playwright-repro/config.ts
@@ -1,0 +1,22 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const PlaywrightReproContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    reproSteps: z.string().describe('Repro steps extracted from the bug issue body'),
+    url: z.string().optional().describe('URL of the page or endpoint exhibiting the bug'),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: PlaywrightReproContextSchema,
+  contextAllowlist: ['workItem.title', 'workItem.body', 'workItem.reproSteps', 'workItem.url'],
+  toolBundles: ['validate'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/playwright-repro/schema.ts
+++ b/skills/playwright-repro/schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const PlaywrightReproSchema = z.object({
+  screenshots: z.array(
+    z.object({
+      path: z.string().describe('Absolute path to screenshot file'),
+      caption: z.string().describe('Description of what this screenshot shows'),
+      step: z.number().describe('Repro step number'),
+    }),
+  ),
+  videoPath: z.string().nullable().describe('Absolute path to video recording if captured'),
+  consoleErrors: z.array(
+    z.object({
+      message: z.string(),
+      type: z.enum(['error', 'warning', 'info']),
+      url: z.string().optional(),
+    }),
+  ),
+  reproSteps: z.array(z.string()).describe('Steps actually executed to reproduce the bug'),
+  reproduced: z.boolean().describe('Whether the bug was successfully reproduced'),
+  notes: z.string().optional().describe('Additional context or observations'),
+});
+
+export type PlaywrightReproOutput = z.infer<typeof PlaywrightReproSchema>;

--- a/skills/playwright-repro/skill.md
+++ b/skills/playwright-repro/skill.md
@@ -1,0 +1,83 @@
+# playwright-repro skill
+
+Version: 1
+
+You are an investigator agent performing bug reproduction. Your job is to use Playwright to navigate to the broken behaviour described in a bug issue, capture the BEFORE state (the broken behaviour), and produce structured output conforming to the required schema.
+
+## Role
+
+Investigator (repro sub-task). You are called after the investigate skill for `type:bug` issues only.
+
+## Input
+
+The context contains a `<work_item>` block with:
+- `<title>` — bug issue title
+- `<body>` — full bug issue body
+- `<reproSteps>` — the repro steps extracted from the issue
+- `<url>` (optional) — the URL of the page exhibiting the bug
+
+## What you must do
+
+1. Read the repro steps carefully.
+2. Use Playwright to navigate to the page or flow described in the repro steps.
+3. Execute each repro step in order, capturing a screenshot after each step.
+4. Capture browser console errors throughout the session.
+5. If video recording is enabled, record the full session.
+6. Produce structured output describing what you observed.
+
+## Critical: capture the BEFORE state
+
+You are capturing the **broken behaviour** — NOT a fix. Do not attempt to fix the issue. Do not modify any code. Navigate, observe, and document.
+
+## Repro steps execution
+
+For each step in the repro steps:
+- Execute the step using Playwright (navigate, click, fill, submit, etc.)
+- Take a screenshot immediately after.
+- Note any console errors that appear.
+- If the step fails unexpectedly (not the bug itself), note it in `notes`.
+
+## When the bug cannot be reproduced
+
+If you attempt all repro steps and the bug does not manifest:
+- Set `reproduced: false`
+- Set `screenshots` to the screenshots you did capture (may be empty)
+- Set `videoPath` to the video path if recording was enabled, `null` otherwise
+- Set `consoleErrors` to any console errors observed
+- Set `reproSteps` to the steps you actually executed
+- Explain in `notes` why you believe the bug was not reproduced (environment differences, flaky timing, missing preconditions, etc.)
+
+## Output format
+
+Return a JSON object conforming to `PlaywrightReproSchema`:
+
+```json
+{
+  "screenshots": [
+    {
+      "path": "/absolute/path/to/screenshot.png",
+      "caption": "Step 2: login form with error message visible",
+      "step": 2
+    }
+  ],
+  "videoPath": "/absolute/path/to/recording.webm",
+  "consoleErrors": [
+    {
+      "message": "Uncaught TypeError: Cannot read property 'id' of undefined",
+      "type": "error",
+      "url": "https://example.com/app.js"
+    }
+  ],
+  "reproSteps": [
+    "Navigate to /login",
+    "Enter invalid credentials",
+    "Click Submit"
+  ],
+  "reproduced": true,
+  "notes": "Bug reproduced consistently. Error appears in console on step 3."
+}
+```
+
+All file paths must be absolute. Use `null` for `videoPath` if no video was captured. `notes` is optional but strongly recommended when `reproduced: false`.
+
+[decision] Reproduced bug and captured before-state artefacts with Playwright

--- a/skills/playwright-repro/slice.test.ts
+++ b/skills/playwright-repro/slice.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config, { PlaywrightReproContextSchema } from './config.js';
+import { PlaywrightReproSchema } from './schema.js';
+
+describe('playwright-repro schema', () => {
+  it('accepts valid output with bug reproduced', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [
+        {
+          path: '/tmp/repro/step-1.png',
+          caption: 'Step 1: Login form with validation error visible',
+          step: 1,
+        },
+        {
+          path: '/tmp/repro/step-2.png',
+          caption: 'Step 2: Dashboard with missing data',
+          step: 2,
+        },
+      ],
+      videoPath: '/tmp/repro/session.webm',
+      consoleErrors: [
+        {
+          message: 'Uncaught TypeError: Cannot read property id of undefined',
+          type: 'error',
+          url: 'https://example.com/app.js',
+        },
+      ],
+      reproSteps: ['Navigate to /login', 'Enter invalid credentials', 'Click Submit'],
+      reproduced: true,
+      notes: 'Bug reproduced consistently on step 2.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid output with bug not reproducible', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /login', 'Enter credentials'],
+      reproduced: false,
+      notes: 'Could not reproduce — login succeeded with provided credentials.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts output with null videoPath', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [{ path: '/tmp/repro/step-1.png', caption: 'Initial state', step: 1 }],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /dashboard'],
+      reproduced: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts output with no notes (notes is optional)', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /home'],
+      reproduced: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts consoleErrors with url as optional', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [{ message: 'Warning: something deprecated', type: 'warning' }],
+      reproSteps: ['Navigate to /settings'],
+      reproduced: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all console error types', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [
+        { message: 'An error', type: 'error' },
+        { message: 'A warning', type: 'warning' },
+        { message: 'An info', type: 'info' },
+      ],
+      reproSteps: ['Navigate to /'],
+      reproduced: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid console error type', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [{ message: 'Something', type: 'debug' }],
+      reproSteps: ['Navigate to /'],
+      reproduced: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required screenshots field', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /'],
+      reproduced: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing reproduced field', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects screenshot missing path', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [{ caption: 'Missing path', step: 1 }],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /'],
+      reproduced: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects screenshot missing caption', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [{ path: '/tmp/step-1.png', step: 1 }],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /'],
+      reproduced: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects screenshot missing step number', () => {
+    const result = PlaywrightReproSchema.safeParse({
+      screenshots: [{ path: '/tmp/step-1.png', caption: 'Initial state' }],
+      videoPath: null,
+      consoleErrors: [],
+      reproSteps: ['Navigate to /'],
+      reproduced: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(PlaywrightReproSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('playwright-repro skill config', () => {
+  it('has role investigator', () => {
+    expect(config.role).toBe('investigator');
+  });
+
+  it('has validate tool bundle', () => {
+    expect(config.toolBundles).toContain('validate');
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('has contextAllowlist defined', () => {
+    expect(config.contextAllowlist).toBeDefined();
+    expect(Array.isArray(config.contextAllowlist)).toBe(true);
+  });
+
+  it('contextAllowlist includes workItem fields', () => {
+    expect(config.contextAllowlist).toContain('workItem.title');
+    expect(config.contextAllowlist).toContain('workItem.body');
+    expect(config.contextAllowlist).toContain('workItem.reproSteps');
+  });
+
+  it('contextSchema validates required workItem fields', () => {
+    const valid = PlaywrightReproContextSchema.safeParse({
+      workItem: {
+        title: 'Login page crashes on submit',
+        body: 'When I click submit the page crashes.',
+        reproSteps: '1. Navigate to /login\n2. Click Submit',
+      },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema accepts optional url', () => {
+    const valid = PlaywrightReproContextSchema.safeParse({
+      workItem: {
+        title: 'Dashboard broken',
+        body: 'Dashboard shows nothing.',
+        reproSteps: '1. Navigate to /dashboard',
+        url: 'https://example.com/dashboard',
+      },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem.title', () => {
+    const invalid = PlaywrightReproContextSchema.safeParse({
+      workItem: {
+        body: 'Some body.',
+        reproSteps: '1. Navigate to /login',
+      },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.body', () => {
+    const invalid = PlaywrightReproContextSchema.safeParse({
+      workItem: {
+        title: 'Some title',
+        reproSteps: '1. Navigate to /login',
+      },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.reproSteps', () => {
+    const invalid = PlaywrightReproContextSchema.safeParse({
+      workItem: {
+        title: 'Some title',
+        body: 'Some body.',
+      },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem entirely', () => {
+    const invalid = PlaywrightReproContextSchema.safeParse({});
+    expect(invalid.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements two M6 skills on the same branch.

Closes #177
Closes #178

## M6.03: skills/investigate/

- `skills/investigate/schema.ts` — Zod schema with findings, keyFiles, confidence, openQuestions, decisionSummaries
- `skills/investigate/config.ts` — SkillConfig with opus model, read tool bundle, investigator role
- `skills/investigate/skill.md` — versioned system prompt with 5-step investigation process
- `skills/investigate/slice.test.ts` — 23 tests
- `skills/investigate/README.md`

## M6.04: skills/playwright-repro/

- `skills/playwright-repro/schema.ts` — Zod schema: screenshots, videoPath, consoleErrors, reproSteps, reproduced, notes
- `skills/playwright-repro/config.ts` — SkillConfig with validate tool bundle, investigator role, context allowlist
- `skills/playwright-repro/skill.md` — versioned prompt for repro capture (BEFORE state only, not a fix)
- `skills/playwright-repro/slice.test.ts` — 25 tests covering valid/invalid outputs and config
- `skills/playwright-repro/README.md`

Playwright is NOT wired into CI. This skill is for local repro capture only.