### PR TITLE
M6.02: read and search tools with workspace sandboxing

### DIFF
--- a/core/tool-layer/README.md
+++ b/core/tool-layer/README.md
@@ -11,6 +11,7 @@ Tool management and security infrastructure for agent runtime.
 | `allowlist.ts` | `computeAllowlist`, `TOOL_BUNDLES` | M4.08 |
 | `sandbox.ts` | `writeWorkspaceSandbox` | M4.08 |
 | `pre-tool-use-hook.ts` | `deployHooks`, `HOOK_PATH` | M4.08 |
+| `tools/read.ts` | `readFile`, `searchFiles`, `SandboxViolationError` | M6.02 |
 
 ## Secret Redaction
 
@@ -21,6 +22,13 @@ Patterns detected: AWS AKIA keys, GitHub tokens (`ghp_`, `ghs_`, `github_pat_`),
 ## Tool Bundles
 
 Named bundles passed via `AgentSpec.toolBundles`. At spawn, `computeAllowlist(spec)` expands them into a flat list for `--allowedTools`.
+
+| Bundle | Tools | Used by |
+|--------|-------|---------|
+| `read-only` | `Read`, `Glob`, `Grep`, `Bash(cat *)`, `Bash(ls *)` | General read-only agents |
+| `read-write` | `Read`, `Write`, `Edit`, `Glob`, `Grep` | Developer agents |
+| `bash-restricted` | `Bash` | Shell agents |
+| `read` | `read`, `search`, `work-item-read` | Investigator agents (sandboxed) |
 
 ## Workspace Sandbox
 
@@ -37,3 +45,61 @@ Called once at workspace bootstrap; never mutated per run.
 1. Validates tool name against per-run allowlist (`FACTORY_RUN_ALLOWLIST` env var)
 2. Denies out-of-allowlist tools (exits with block decision)
 3. Audits every call to the event store as `agent.tool-call`
+
+## Sandboxed Read and Search Tools
+
+`tools/read.ts` provides workspace-sandboxed file access for the investigator agent. Both functions enforce that all access stays within the workspace root.
+
+### `readFile({ workspaceRoot, path })`
+
+Reads a file at `path` relative to `workspaceRoot`. Returns the file contents as a UTF-8 string.
+
+Security constraints:
+- `path` must be a non-empty relative path — absolute paths (starting with `/`) are rejected.
+- After resolution, the resulting path must remain within `workspaceRoot` — `../` traversal is rejected.
+- Throws `SandboxViolationError` on any violation.
+
+```ts
+import { readFile, SandboxViolationError } from './tools/read.js';
+
+const content = await readFile({
+  workspaceRoot: '/home/user/.factory/workspaces/run-123/repo',
+  path: 'src/index.ts',
+});
+```
+
+### `searchFiles({ workspaceRoot, pattern, glob? })`
+
+Runs ripgrep (`rg`) within `workspaceRoot` to find lines matching `pattern`. Returns the ripgrep stdout (with filename and line number), or `""` when no matches are found.
+
+Security constraints:
+- `pattern` must be non-empty.
+- `pattern` must not contain `../` — the search path is always `workspaceRoot`, never user-supplied.
+- Throws `SandboxViolationError` on any violation.
+- Optionally accepts a `glob` parameter to restrict which file types are searched (e.g. `*.ts`).
+
+```ts
+import { searchFiles } from './tools/read.js';
+
+const results = await searchFiles({
+  workspaceRoot: '/home/user/.factory/workspaces/run-123/repo',
+  pattern: 'TODO',
+  glob: '*.ts',
+});
+```
+
+### `SandboxViolationError`
+
+Typed error class thrown when path traversal or invalid input is detected. Callers should catch this specifically to distinguish sandbox violations from filesystem errors.
+
+```ts
+import { SandboxViolationError } from './tools/read.js';
+
+try {
+  await readFile({ workspaceRoot, path: '../escape' });
+} catch (err) {
+  if (err instanceof SandboxViolationError) {
+    // path escape attempt
+  }
+}
+```

--- a/core/tool-layer/bundles.ts
+++ b/core/tool-layer/bundles.ts
@@ -2,6 +2,12 @@ export const TOOL_BUNDLES = {
   'read-only': ['Read', 'Glob', 'Grep', 'Bash(cat *)', 'Bash(ls *)'],
   'read-write': ['Read', 'Write', 'Edit', 'Glob', 'Grep'],
   'bash-restricted': ['Bash'],
+  /**
+   * Sandboxed read bundle for investigator agents.
+   * Uses workspace-sandboxed `read` and `search` tools (no raw filesystem access).
+   * `work-item-read` is the work-item query tool.
+   */
+  read: ['read', 'search', 'work-item-read'],
 } satisfies Record<string, string[]>;
 
 export type BundleName = keyof typeof TOOL_BUNDLES;

--- a/core/tool-layer/tools/read.ts
+++ b/core/tool-layer/tools/read.ts
@@ -1,0 +1,137 @@
+import { spawn } from 'node:child_process';
+import { readFile as fsReadFile } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+
+/**
+ * Typed error thrown when a tool call attempts to escape the workspace root.
+ * Callers should catch this specifically to distinguish from filesystem errors.
+ */
+export class SandboxViolationError extends Error {
+  readonly kind = 'SandboxViolationError' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'SandboxViolationError';
+  }
+}
+
+interface ReadFileParams {
+  /** Absolute path to the workspace root (the git worktree directory). */
+  workspaceRoot: string;
+  /** Relative path to the file within the workspace. Must not be absolute or traverse above root. */
+  path: string;
+}
+
+/**
+ * Reads a file at `path` relative to `workspaceRoot`.
+ *
+ * Security constraints:
+ * - `path` must be a non-empty relative path (no leading `/`)
+ * - After resolution, the resulting absolute path must start with `workspaceRoot`
+ *   (prevents `../` traversal)
+ *
+ * @throws {SandboxViolationError} if the resolved path would escape the workspace root.
+ */
+export async function readFile(params: ReadFileParams): Promise<string> {
+  const { workspaceRoot, path } = params;
+
+  if (path.length === 0) {
+    throw new SandboxViolationError('path must not be empty');
+  }
+
+  if (isAbsolute(path)) {
+    throw new SandboxViolationError(
+      `Absolute paths are not permitted: "${path}". Use a path relative to the workspace root.`,
+    );
+  }
+
+  const resolved = resolve(workspaceRoot, path);
+  const rootNormalized = resolve(workspaceRoot);
+
+  if (!resolved.startsWith(`${rootNormalized}/`) && resolved !== rootNormalized) {
+    throw new SandboxViolationError(
+      `Path traversal detected: "${path}" resolves outside workspace root "${workspaceRoot}".`,
+    );
+  }
+
+  return fsReadFile(resolved, 'utf8');
+}
+
+interface SearchFilesParams {
+  /** Absolute path to the workspace root. Ripgrep is constrained to this directory. */
+  workspaceRoot: string;
+  /** The search pattern (regex or literal). Must not be empty or contain `../`. */
+  pattern: string;
+  /** Optional glob pattern to restrict which files are searched (e.g. `*.ts`). */
+  glob?: string;
+}
+
+/**
+ * Searches for `pattern` within `workspaceRoot` using ripgrep (`rg`).
+ *
+ * Security constraints:
+ * - `pattern` must be non-empty
+ * - `pattern` must not contain `../` to prevent path-escape attempts
+ * - Ripgrep is always invoked with `workspaceRoot` as the search path (never user-supplied)
+ *
+ * Returns the combined stdout of ripgrep, or `""` when there are no matches (exit code 1).
+ *
+ * @throws {SandboxViolationError} if the pattern fails validation.
+ */
+export async function searchFiles(params: SearchFilesParams): Promise<string> {
+  const { workspaceRoot, pattern, glob } = params;
+
+  if (pattern.length === 0) {
+    throw new SandboxViolationError('pattern must not be empty');
+  }
+
+  if (pattern.includes('../')) {
+    throw new SandboxViolationError(
+      `Pattern "${pattern}" contains path traversal sequence "../". This is not permitted.`,
+    );
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const args: string[] = ['--no-heading', '--with-filename', '--line-number'];
+
+    if (glob != null && glob.length > 0) {
+      args.push('--glob', glob);
+    }
+
+    // Always pin the search path to workspaceRoot — never user-supplied.
+    args.push(pattern, workspaceRoot);
+
+    const child = spawn('rg', args, {
+      cwd: workspaceRoot,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      // ripgrep exits with 0 on match, 1 on no match, 2+ on error.
+      if (code === 0) {
+        resolve(stdout);
+      } else if (code === 1) {
+        // No matches — not an error.
+        resolve('');
+      } else {
+        reject(new Error(`ripgrep exited with code ${code}: ${stderr.trim()}`));
+      }
+    });
+
+    child.on('error', (err) => {
+      reject(new Error(`Failed to spawn ripgrep: ${err.message}`));
+    });
+  });
+}

--- a/core/tool-layer/tools/slice.test.ts
+++ b/core/tool-layer/tools/slice.test.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SandboxViolationError, readFile, searchFiles } from './read.js';
+
+// ─── readFile ─────────────────────────────────────────────────────────────────
+
+describe('readFile', () => {
+  it('reads a file within the workspace root', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      writeFileSync(join(dir, 'hello.txt'), 'hello world');
+      const content = await readFile({ workspaceRoot: dir, path: 'hello.txt' });
+      expect(content).toBe('hello world');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('reads a file in a subdirectory', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      mkdirSync(join(dir, 'sub'));
+      writeFileSync(join(dir, 'sub', 'nested.txt'), 'nested content');
+      const content = await readFile({ workspaceRoot: dir, path: 'sub/nested.txt' });
+      expect(content).toBe('nested content');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects absolute paths', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      await expect(readFile({ workspaceRoot: dir, path: '/etc/passwd' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects ../ traversal', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      await expect(readFile({ workspaceRoot: dir, path: '../outside.txt' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects deeply nested traversal that escapes root', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      await expect(readFile({ workspaceRoot: dir, path: 'sub/../../outside.txt' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects empty path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'read-tool-test-'));
+    try {
+      await expect(readFile({ workspaceRoot: dir, path: '' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
+// ─── searchFiles ──────────────────────────────────────────────────────────────
+
+describe('searchFiles', () => {
+  it('returns grep matches within the workspace', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      writeFileSync(join(dir, 'foo.ts'), 'const greeting = "hello";\nconst farewell = "goodbye";');
+      const results = await searchFiles({ workspaceRoot: dir, pattern: 'hello' });
+      expect(results).toContain('hello');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('returns empty string when no matches found', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      writeFileSync(join(dir, 'foo.ts'), 'const greeting = "hello";');
+      const results = await searchFiles({ workspaceRoot: dir, pattern: 'zzznomatch' });
+      expect(results).toBe('');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('searches recursively across subdirectories', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      mkdirSync(join(dir, 'sub'));
+      writeFileSync(join(dir, 'sub', 'bar.ts'), 'export const SECRET_MARKER = 42;');
+      const results = await searchFiles({ workspaceRoot: dir, pattern: 'SECRET_MARKER' });
+      expect(results).toContain('SECRET_MARKER');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects patterns containing path traversal (../)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      await expect(searchFiles({ workspaceRoot: dir, pattern: '../outside' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('rejects empty pattern', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      await expect(searchFiles({ workspaceRoot: dir, pattern: '' })).rejects.toThrow(
+        SandboxViolationError,
+      );
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('accepts optional glob filter', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'search-tool-test-'));
+    try {
+      writeFileSync(join(dir, 'app.ts'), 'const x = "findme";');
+      writeFileSync(join(dir, 'app.txt'), 'const y = "findme";');
+      const results = await searchFiles({
+        workspaceRoot: dir,
+        pattern: 'findme',
+        glob: '*.ts',
+      });
+      expect(results).toContain('app.ts');
+      expect(results).not.toContain('app.txt');
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #176

Adds workspace-sandboxed `readFile` and `searchFiles` tools for the investigator agent, plus the `read` bundle in `TOOL_BUNDLES`.

## What's included

- `core/tool-layer/tools/read.ts` — `readFile`, `searchFiles`, and `SandboxViolationError`
- `core/tool-layer/bundles.ts` — adds the `read` bundle (`['read', 'search', 'work-item-read']`) per PLAN.md spec
- `core/tool-layer/tools/slice.test.ts` — 12 tests covering: successful read, subdirectory read, absolute path rejection, `../` traversal rejection, deeply nested traversal rejection, empty path rejection; successful grep, no-match empty string, recursive search, `../` pattern rejection, empty pattern rejection, glob filter
- `core/tool-layer/README.md` — updated to document both tools, `SandboxViolationError`, and the new `read` bundle

All 415 tests pass. Lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5nfpAYbP1YzBLvSAB7aJP)_