### PR TITLE
M6.05: investigate workflow

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -242,6 +242,8 @@ async function runAgentCommand(rawArgs: string[]): Promise<void> {
     toolBundles: skillConfig.toolBundles,
     toolExtras: [],
     budgets: { maxTurns: 10, maxBudgetUsd: 1.0 },
+    // CLI runs don't use persona routing — use a placeholder persona ID
+    personaId: `cli/${skillConfig.role ?? 'developer'}/0`,
     modelOverride: undefined,
     appendSystemPrompt,
   };

--- a/apps/server/src/domains/workflows/triage-batch.test.ts
+++ b/apps/server/src/domains/workflows/triage-batch.test.ts
@@ -14,6 +14,10 @@ vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
   toJsonSchema: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue('goose-hub-self/triager/0'),
+}));
+
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     appendEvent: vi

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import { RepoMatchOutputSchema } from '../../../../../skills/repo-match/schema.js';
@@ -61,6 +62,8 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
     const projectId = stateSource.projectId;
     const workItemId = item.id;
 
+    const triagerPersonaId = selectPersona(projectId, 'triager');
+
     // Run triage skill
     const triageResult = await runtime.run({
       runId,
@@ -72,6 +75,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       toolBundles: [],
       toolExtras: [],
       budgets: { maxTurns: 5, maxBudgetUsd: 0.05 },
+      personaId: triagerPersonaId,
       outputJsonSchema: triageJsonSchema,
       appendSystemPrompt: triagePrompt,
     });
@@ -91,6 +95,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
 
     // Run repo-match skill
     const repoMatchRunId = crypto.randomUUID();
+    const researcherPersonaId = selectPersona(projectId, 'researcher');
     const repoMatchResult = await runtime.run({
       runId: repoMatchRunId,
       role: 'researcher',
@@ -106,6 +111,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       toolBundles: [],
       toolExtras: [],
       budgets: { maxTurns: 5, maxBudgetUsd: 0.05 },
+      personaId: researcherPersonaId,
       outputJsonSchema: repoMatchJsonSchema,
       appendSystemPrompt: repoMatchPrompt,
     });

--- a/core/agent-runtime/context-assembly.ts
+++ b/core/agent-runtime/context-assembly.ts
@@ -9,13 +9,20 @@ export interface SpawnContext {
  * When freshContext is true, only allowlist-filtered keys from spec.context are rendered —
  * no event-stream, persona history, or inbox injection. At M4, non-fresh path is identical.
  *
+ * `spec.personaId` is accepted here and will be used to load persona history in M9+.
+ * For now, the non-fresh path is a no-op stub.
+ *
  * ESLint rule: any access to event-stream or persona-history from core/agent-runtime/
  * outside this file should be flagged (enforced manually until ESLint plugin is wired).
  */
 export function assembleSpawnContext(spec: AgentSpec): SpawnContext {
+  // personaId is available on spec for future M9 persona history injection.
+  // At M6, persona history loading is a stub — the field is wired into AgentSpec
+  // so the runtime can record persona attribution in events without injecting history.
+  void spec.personaId; // consumed in M9 persona history injection
   const base = renderManifest(spec.context, spec.contextAllowlist);
   if (spec.freshContext) return base;
-  // Non-fresh ambient injection (event stream, persona history) deferred to M5+
+  // Non-fresh ambient injection (event stream, persona history) deferred to M9+
   return base;
 }
 

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -34,6 +34,8 @@ export type AgentSpec<R extends RoleSpec = RoleSpec> = {
   toolBundles: string[];
   toolExtras: string[];
   budgets: AgentBudgets;
+  /** Persona identity for this run. Format: "<projectId>/<role>/<index>". Required. */
+  personaId: string;
   modelOverride?: string;
   /** JSON Schema derived from the skill's output Zod schema, passed to --json-schema */
   outputJsonSchema?: Record<string, unknown>;

--- a/core/agent-runtime/select-persona.ts
+++ b/core/agent-runtime/select-persona.ts
@@ -1,0 +1,46 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { personaRouting } from '../db/schema.js';
+
+const PERSONAS_PER_ROLE = 3;
+
+/**
+ * Round-robin persona selector. Returns a stable persona identifier for the given
+ * (projectId, role) pair, incrementing the round-robin index in SQLite on each call.
+ *
+ * Persona ID format: "<projectId>/<role>/<index>" — e.g. "goose-hub-self/investigator/0"
+ *
+ * Implementation resolves CONTEXT.md decision:
+ * - Selection strategy: round-robin within role (option a)
+ * - 3 seeded personas per role per project
+ * - lastIndex increments by 1 modulo PERSONAS_PER_ROLE on each call
+ * - No stats weighting until M9 provides sufficient data
+ */
+export function selectPersona(projectId: string, role: string): string {
+  const existing = db
+    .select()
+    .from(personaRouting)
+    .where(and(eq(personaRouting.projectId, projectId), eq(personaRouting.role, role)))
+    .all();
+
+  let currentIndex: number;
+
+  if (existing.length === 0) {
+    // First call for this (projectId, role) pair — insert with lastIndex 0
+    db.insert(personaRouting).values({ projectId, role, lastIndex: 0 }).run();
+    currentIndex = 0;
+  } else {
+    currentIndex = existing[0].lastIndex;
+  }
+
+  const personaId = `${projectId}/${role}/${currentIndex % PERSONAS_PER_ROLE}`;
+
+  // Advance the index for the next caller
+  const nextIndex = (currentIndex + 1) % PERSONAS_PER_ROLE;
+  db.update(personaRouting)
+    .set({ lastIndex: nextIndex })
+    .where(and(eq(personaRouting.projectId, projectId), eq(personaRouting.role, role)))
+    .run();
+
+  return personaId;
+}

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -62,6 +62,7 @@ describe('interface types', () => {
       toolBundles: ['read-only'],
       toolExtras: [],
       budgets: { maxTurns: 10, maxBudgetUsd: 1.0 },
+      personaId: 'test-project/developer/0',
     };
     expect(spec.runId).toBe('01HZQKG8APXV3TYS2EW4VR6MSB');
   });
@@ -77,6 +78,7 @@ describe('interface types', () => {
       toolBundles: [],
       toolExtras: [],
       budgets: { maxTurns: 5, maxBudgetUsd: 0.5 },
+      personaId: 'test-project/developer/0',
     };
     expect(spec.modelOverride).toBeUndefined();
   });
@@ -200,6 +202,7 @@ describe('assembleSpawnContext', () => {
     toolBundles: [],
     toolExtras: [],
     budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: 'test-project/developer/0',
     ...overrides,
   });
 
@@ -323,6 +326,7 @@ describe('withFallback', () => {
     toolBundles: [],
     toolExtras: [],
     budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: 'test-project/developer/0',
     modelOverride: 'claude-opus-4-7',
     ...overrides,
   });
@@ -408,6 +412,7 @@ function makeSecuritySpec(): AgentSpec {
     toolBundles: [],
     toolExtras: [],
     budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: 'test-project/developer/0',
   };
 }
 

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 export const projectState = sqliteTable('project_state', {
   projectId: text('project_id').primaryKey(),
@@ -41,3 +41,13 @@ export const inboxItems = sqliteTable('inbox_items', {
   type: text('type').notNull().default('feature'), // feature | bug | chore | research
   createdAt: text('created_at').notNull().default(sql`(current_timestamp)`),
 });
+
+export const personaRouting = sqliteTable(
+  'persona_routing',
+  {
+    projectId: text('project_id').notNull(),
+    role: text('role').notNull(),
+    lastIndex: integer('last_index').notNull().default(0),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.projectId, t.role] }) }),
+);

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -22,7 +22,8 @@ export type EventKind =
   | 'agent.run-failed'
   | 'agent.fallback-triggered'
   | 'agent.triage-complete'
-  | 'agent.repo-override';
+  | 'agent.repo-override'
+  | 'agent.investigation-complete';
 
 export interface AgentEvent {
   id: number;

--- a/slices/investigate/README.md
+++ b/slices/investigate/README.md
@@ -1,0 +1,54 @@
+# slices/investigate
+
+Workflow slice that drives `type:bug` and `type:chore` work items through the investigation phase.
+
+## State Transition
+
+```
+factory:investigating → factory:investigation-complete
+factory:investigating → factory:needs-human  (on failure)
+```
+
+## Workflow Steps
+
+1. **createWorktree** — Creates a detached git worktree of the target repo at `~/.factory/workspaces/<runId>/`
+2. **investigate skill** — Runs the `investigate` skill (role: investigator, tier: opus) to analyse the codebase and produce structured findings
+3. **playwright-repro skill** — If `workItem.type === 'bug'`, runs the `playwright-repro` skill (role: investigator, tool bundle: validate) to capture the before-state
+4. **persist findings** — Appends `agent.investigation-complete` event with `{ investigate, playwrightRepro? }` payload
+5. **transition state** — Moves the work item to `factory:investigation-complete`
+6. **cleanupWorktree** — Always runs (finally block, idempotent)
+
+## On Failure
+
+If any step throws:
+- `agent.run-failed` event is persisted
+- A GitHub comment is posted: `Investigation failed: <error.message>`
+- State transitions to `factory:needs-human`
+- Worktree is cleaned up (finally block ensures this)
+
+## Persona Routing
+
+Uses `selectPersona(projectId, 'investigator')` for both the investigate and playwright-repro runs. Round-robin across 3 seeded personas per `(projectId, role)` pair.
+
+## Event Payload
+
+```ts
+{
+  kind: 'agent.investigation-complete',
+  payload: {
+    investigate: InvestigateOutput,    // always present
+    playwrightRepro?: PlaywrightReproOutput,  // only for type:bug
+  }
+}
+```
+
+## Skills
+
+- `skills/investigate/` — Static analysis, root-cause hypothesis, key file identification
+- `skills/playwright-repro/` — Browser-based before-state capture (bug type only)
+
+## Files
+
+- `workflow.ts` — Main workflow implementation
+- `slice.test.ts` — Unit tests covering happy path, bug type, failure path, and AgentSpec fields
+- `README.md` — This file

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -1,0 +1,506 @@
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── module mocks ──────────────────────────────────────────────────────────────
+
+// Single shared mock for the runtime run fn — reset in beforeEach
+const mockRun = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue('test-project/investigator/0'),
+}));
+
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi
+      .fn()
+      .mockReturnValue({ id: 1, kind: 'agent.investigation-complete', payload: {}, createdAt: '' }),
+  },
+}));
+
+vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
+  createWorktree: vi.fn().mockReturnValue('/tmp/test-worktree'),
+  cleanupWorktree: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock prompt') };
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:shaunnez/goose-hub#42',
+    externalId: '42',
+    repoRef: 'shaunnez/goose-hub',
+    title: 'Fix auth bug',
+    body: 'Auth breaks on login.\n\nRepro steps:\n1. Go to /login\n2. Enter credentials\n3. Observe 500 error',
+    type: 'bug',
+    priority: 'high',
+    mode: 'supervised',
+    state: 'factory:investigating',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeInvestigateOutput() {
+  return {
+    findings: 'Root cause is a null-check missing in auth middleware.',
+    keyFiles: [{ path: 'apps/server/src/middleware/auth.ts', reason: 'Contains null-dereference' }],
+    confidence: 'high',
+    openQuestions: ['Does this also affect WebSocket upgrade path?'],
+    decisionSummaries: [
+      {
+        step: 'issue-read',
+        summary: 'Read issue #42: auth middleware crashes on missing session token',
+      },
+    ],
+  };
+}
+
+function makePlaywrightReproOutput() {
+  return {
+    screenshots: [{ path: '/tmp/screenshot.png', caption: 'Login error visible', step: 3 }],
+    videoPath: null,
+    consoleErrors: [
+      { message: 'TypeError: Cannot read property of undefined', type: 'error' as const },
+    ],
+    reproSteps: ['Navigate to /login', 'Enter credentials', 'Click submit'],
+    reproduced: true,
+    notes: 'Bug reproduced consistently.',
+  };
+}
+
+function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    listOpenWork: vi.fn().mockResolvedValue([]),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── test setup ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Reset call history and queued return values on all mocks.
+  // mockRun is a hoisted vi.fn() so we reset it directly.
+  // vi.clearAllMocks() only clears call history, not return value queues,
+  // so we use mockReset() on the shared run mock to prevent once-value leakage.
+  mockRun.mockReset();
+  // Clear call history on the module-level mocks so per-test counts are accurate.
+  vi.clearAllMocks();
+  // Re-set mockRun after clearAllMocks since clearAllMocks doesn't remove implementations
+  // but does reset the cleared call counters — the mockReset above already cleared the queue.
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('runInvestigateWorkflow', () => {
+  describe('happy path — non-bug type', () => {
+    it('creates a worktree with the target repo and runId', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { createWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(createWorktree).toHaveBeenCalledWith('/path/to/repo', expect.any(String));
+    });
+
+    it('runs the investigate skill once for a non-bug item', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const callArg = mockRun.mock.calls[0][0] as { skill: string };
+      expect(callArg.skill).toBe('investigate');
+    });
+
+    it('persists agent.investigation-complete event with findings', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const call = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
+      expect(call).toBeDefined();
+      const payload = call?.[0].payload as { investigate: unknown };
+      expect(payload.investigate).toBeDefined();
+    });
+
+    it('transitions state from factory:investigating to factory:investigation-complete', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:investigating',
+        'factory:investigation-complete',
+      );
+    });
+
+    it('always cleans up the worktree via finally block', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(cleanupWorktree).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('bug type — playwright-repro also runs', () => {
+    it('runs both investigate and playwright-repro skills for type:bug', async () => {
+      const item = makeWorkItem({ type: 'bug' });
+      const source = makeMockSource();
+
+      mockRun
+        .mockResolvedValueOnce({
+          output: makeInvestigateOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult)
+        .mockResolvedValueOnce({
+          output: makePlaywrightReproOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(mockRun).toHaveBeenCalledTimes(2);
+      const firstCall = mockRun.mock.calls[0][0] as { skill: string };
+      const secondCall = mockRun.mock.calls[1][0] as { skill: string };
+      expect(firstCall.skill).toBe('investigate');
+      expect(secondCall.skill).toBe('playwright-repro');
+    });
+
+    it('persists playwrightRepro in investigation-complete event for type:bug', async () => {
+      const item = makeWorkItem({ type: 'bug' });
+      const source = makeMockSource();
+
+      mockRun
+        .mockResolvedValueOnce({
+          output: makeInvestigateOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult)
+        .mockResolvedValueOnce({
+          output: makePlaywrightReproOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const call = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
+      expect(call).toBeDefined();
+      const payload = call?.[0].payload as { playwrightRepro: unknown };
+      expect(payload.playwrightRepro).toBeDefined();
+    });
+
+    it('uses validate tool bundle for playwright-repro skill', async () => {
+      const item = makeWorkItem({ type: 'bug' });
+      const source = makeMockSource();
+
+      mockRun
+        .mockResolvedValueOnce({
+          output: makeInvestigateOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult)
+        .mockResolvedValueOnce({
+          output: makePlaywrightReproOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const playwrightCall = mockRun.mock.calls[1][0] as { toolBundles: string[] };
+      expect(playwrightCall.toolBundles).toContain('validate');
+    });
+
+    it('does NOT run playwright-repro for non-bug items', async () => {
+      for (const type of ['feature', 'chore', 'research'] as const) {
+        mockRun.mockReset();
+        mockRun.mockResolvedValueOnce({
+          output: makeInvestigateOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult);
+
+        const item = makeWorkItem({ type });
+        const source = makeMockSource();
+
+        const { runInvestigateWorkflow } = await import('./workflow.js');
+        await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+        expect(mockRun).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('failure path', () => {
+    it('cleans up worktree on failure', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockRejectedValueOnce(new Error('Agent failed'));
+
+      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      // cleanupWorktree is called in finally — always runs
+      expect(cleanupWorktree).toHaveBeenCalled();
+    });
+
+    it('transitions to factory:needs-human on failure', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockRejectedValueOnce(new Error('Subprocess error'));
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:investigating',
+        'factory:needs-human',
+      );
+    });
+
+    it('posts a GitHub comment on failure', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+      const errorMessage = 'Subprocess timed out';
+
+      mockRun.mockRejectedValueOnce(new Error(errorMessage));
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(source.comment).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('Investigation failed'),
+      );
+    });
+
+    it('persists agent.run-failed event on failure', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockRejectedValueOnce(new Error('Runtime crashed'));
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const failCall = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+      expect(failCall).toBeDefined();
+    });
+
+    it('does not throw — handles errors gracefully', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockRejectedValueOnce(new Error('Unexpected crash'));
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await expect(
+        runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo'),
+      ).resolves.not.toThrow();
+    });
+
+    it('handles validation failure as an error — transitions to factory:needs-human', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      // Returns invalid output that fails schema validation
+      mockRun.mockResolvedValueOnce({
+        output: { bad: 'data', missing_required: true },
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:investigating',
+        'factory:needs-human',
+      );
+    });
+  });
+
+  describe('AgentSpec fields', () => {
+    it('uses opus model override for investigate skill', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const callArg = mockRun.mock.calls[0][0] as { modelOverride: string };
+      expect(callArg.modelOverride).toBe('claude-opus-4-7');
+    });
+
+    it('includes personaId in investigate AgentSpec', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const callArg = mockRun.mock.calls[0][0] as { personaId: string };
+      expect(callArg.personaId).toBe('test-project/investigator/0');
+    });
+
+    it('passes worktreePath in investigate context', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const callArg = mockRun.mock.calls[0][0] as {
+        context: Record<string, unknown>;
+        contextAllowlist: string[];
+      };
+      expect(callArg.context.worktreePath).toBe('/tmp/test-worktree');
+      expect(callArg.contextAllowlist).toContain('worktreePath');
+    });
+
+    it('uses read tool bundle for investigate skill', async () => {
+      const item = makeWorkItem({ type: 'chore' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      const callArg = mockRun.mock.calls[0][0] as { toolBundles: string[] };
+      expect(callArg.toolBundles).toContain('read');
+    });
+  });
+});
+
+describe('selectPersona', () => {
+  it('returns round-robin persona IDs for sequential calls (mocked)', async () => {
+    // The actual round-robin is DB-backed; here we verify the mock integration
+    const { selectPersona } = await import('@goose-hub/core/agent-runtime/select-persona.js');
+
+    const result = selectPersona('test-project', 'investigator');
+    expect(result).toBe('test-project/investigator/0');
+    expect(selectPersona).toHaveBeenCalledWith('test-project', 'investigator');
+  });
+});

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
+import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { cleanupWorktree, createWorktree } from '@goose-hub/core/workspaces/worktree.js';
+import { InvestigateSchema } from '../../skills/investigate/schema.js';
+import { PlaywrightReproSchema } from '../../skills/playwright-repro/schema.js';
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+
+function readPrompt(skillName: string): string {
+  return readFileSync(join(REPO_ROOT, 'skills', skillName, 'prompt.md'), 'utf8');
+}
+
+/**
+ * Runs the investigate workflow for a work item in `factory:investigating` state.
+ *
+ * Workflow:
+ * 1. createWorktree for the target repo
+ * 2. Run the `investigate` skill (investigator persona, opus-tier)
+ * 3. If type:bug, run the `playwright-repro` skill
+ * 4. Persist findings as `agent.investigation-complete` event
+ * 5. Transition state: factory:investigating → factory:investigation-complete
+ *
+ * On failure: cleanup worktree, persist agent.run-failed event,
+ * post GitHub comment, transition to factory:needs-human.
+ */
+export async function runInvestigateWorkflow(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  projectId: string,
+  targetRepo: string,
+): Promise<void> {
+  const runId = crypto.randomUUID();
+  const runtime = new ClaudeCliRuntime();
+  const investigatePrompt = readPrompt('investigate');
+  const playwrightReproPrompt = readPrompt('playwright-repro');
+  const investigateJsonSchema = toJsonSchema(InvestigateSchema);
+  const playwrightReproJsonSchema = toJsonSchema(PlaywrightReproSchema);
+
+  const personaId = selectPersona(projectId, 'investigator');
+  const worktreePath = createWorktree(targetRepo, runId);
+
+  try {
+    // Step a: Run the investigate skill
+    const investigateResult = await runtime.run({
+      runId,
+      role: 'investigator',
+      skill: 'investigate',
+      context: {
+        projectId,
+        workItemId: workItem.id,
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        worktreePath,
+      },
+      contextAllowlist: ['workItem', 'worktreePath'],
+      freshContext: false,
+      toolBundles: ['read'],
+      toolExtras: [],
+      budgets: { maxTurns: 20, maxBudgetUsd: 0.5 },
+      personaId,
+      modelOverride: 'claude-opus-4-7',
+      outputJsonSchema: investigateJsonSchema,
+      appendSystemPrompt: investigatePrompt,
+    });
+
+    // Step b: Validate investigate output
+    const investigateParsed = InvestigateSchema.safeParse(investigateResult.output);
+    if (!investigateParsed.success) {
+      throw new Error(
+        `Investigate output validation failed: ${JSON.stringify(investigateParsed.error.issues)}`,
+      );
+    }
+    const findings = investigateParsed.data;
+
+    // Step c: If type:bug, run playwright-repro skill
+    let reproOutput: unknown | undefined;
+    if (workItem.type === 'bug') {
+      const playwrightPersonaId = selectPersona(projectId, 'investigator');
+      const playwrightRunId = crypto.randomUUID();
+
+      const playwrightResult = await runtime.run({
+        runId: playwrightRunId,
+        role: 'investigator',
+        skill: 'playwright-repro',
+        context: {
+          projectId,
+          workItemId: workItem.id,
+          workItem: {
+            title: workItem.title,
+            body: workItem.body,
+            reproSteps: workItem.body, // repro steps extracted from body
+          },
+        },
+        contextAllowlist: ['workItem'],
+        freshContext: false,
+        toolBundles: ['validate'],
+        toolExtras: [],
+        budgets: { maxTurns: 15, maxBudgetUsd: 0.3 },
+        personaId: playwrightPersonaId,
+        outputJsonSchema: playwrightReproJsonSchema,
+        appendSystemPrompt: playwrightReproPrompt,
+      });
+
+      const reproparsed = PlaywrightReproSchema.safeParse(playwrightResult.output);
+      if (reproparsed.success) {
+        reproOutput = reproparsed.data;
+      }
+      // playwright-repro failure is non-fatal — we still persist investigate findings
+    }
+
+    // Step d: Persist findings as agent.investigation-complete event
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.investigation-complete',
+      payload: {
+        investigate: findings,
+        playwrightRepro: reproOutput,
+      },
+      runId,
+    });
+
+    // Step e: Transition state
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:investigating',
+      'factory:investigation-complete',
+    );
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+
+    // Persist failure event
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.run-failed',
+      payload: { runId, error: error.message },
+      runId,
+    });
+
+    // Post GitHub comment
+    await stateSource.comment(workItem.externalId, `Investigation failed: ${error.message}`);
+
+    // Transition to error state
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:investigating',
+      'factory:needs-human',
+    );
+  } finally {
+    // Always cleanup the worktree — cleanupWorktree is idempotent
+    cleanupWorktree(runId);
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `slices/investigate/workflow.ts`: `factory:investigating` → `factory:investigation-complete` state transition, with `playwright-repro` for `type:bug` issues
- Adds `personaId` as required field to `AgentSpec` in `core/agent-runtime/interface.ts`
- Adds `selectPersona(projectId, role)` round-robin utility in `core/agent-runtime/select-persona.ts` with `persona_routing` SQLite table
- Updates `assembleSpawnContext` to accept `personaId` (M9 stub)
- Backfills `triage-batch.ts` to include `personaId` on both AgentSpecs
- Adds `agent.investigation-complete` to `EventKind`

Closes #189

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5nfpAYbP1YzBLvSAB7aJP)_