### PR TITLE
M7/M8-prep: spec-author + evidence-post + verification framework

### DIFF
--- a/apps/web/src/lib/markdown.test.ts
+++ b/apps/web/src/lib/markdown.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdownToHtml } from './markdown.js';
+
+describe('renderMarkdownToHtml', () => {
+  describe('image rendering for trusted hosts', () => {
+    it('renders raw.githubusercontent.com image as <img>', () => {
+      const md =
+        '![Step 1](https://raw.githubusercontent.com/shaunnez/goose-hub/abc1234/evidence/issue-233/step-1.png)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+      expect(html).toContain(
+        'src="https://raw.githubusercontent.com/shaunnez/goose-hub/abc1234/evidence/issue-233/step-1.png"',
+      );
+      expect(html).toContain('alt="Step 1"');
+      expect(html).toContain('loading="lazy"');
+    });
+
+    it('renders user-images.githubusercontent.com image as <img>', () => {
+      const md = '![](https://user-images.githubusercontent.com/1751766/abc.png)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+      expect(html).toContain('src="https://user-images.githubusercontent.com/1751766/abc.png"');
+    });
+
+    it('renders camo.githubusercontent.com proxied image as <img>', () => {
+      const md = '![proxied](https://camo.githubusercontent.com/hash)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+    });
+
+    it('renders github.com image (e.g. /blob/.../file.png) as <img>', () => {
+      const md = '![diagram](https://github.com/shaunnez/goose-hub/blob/main/docs/diagram.png)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+    });
+
+    it('renders an image inside a paragraph along with surrounding text', () => {
+      const md =
+        'See ![Step 1](https://raw.githubusercontent.com/owner/repo/sha/x.png) for the result.';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+      expect(html).toContain('See ');
+      expect(html).toContain(' for the result.');
+    });
+  });
+
+  describe('image rendering for untrusted hosts', () => {
+    it('renders evil.com image as a plain link, not <img>', () => {
+      const md = '![harmless-looking](https://evil.com/payload.png)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).not.toContain('<img');
+      expect(html).toContain('<a');
+      expect(html).toContain('href="https://evil.com/payload.png"');
+      expect(html).toContain('harmless-looking');
+    });
+
+    it('uses URL as link text when alt is empty for untrusted host', () => {
+      const md = '![](https://evil.com/p.png)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<a');
+      expect(html).toContain('https://evil.com/p.png');
+    });
+
+    it('does not produce an executable <img src=javascript:> or <a href=javascript:>', () => {
+      // The regex requires https?:// so this should not match the image OR link rule.
+      // The literal text passes through escapeHtml as harmless paragraph content.
+      const md = '![bad](javascript:alert(1))';
+      const html = renderMarkdownToHtml(md);
+      expect(html).not.toContain('<img');
+      expect(html).not.toMatch(/href="javascript:/);
+      expect(html).not.toMatch(/src="javascript:/);
+    });
+  });
+
+  describe('regression: existing markdown features still work', () => {
+    it('renders a regular link', () => {
+      const md = '[Goose Hub](https://github.com/shaunnez/goose-hub)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<a href="https://github.com/shaunnez/goose-hub"');
+      expect(html).toContain('Goose Hub');
+    });
+
+    it('renders headings, lists, and code blocks', () => {
+      const md = '# Title\n\nA paragraph with `code`.\n\n- item 1\n- item 2';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<h1');
+      expect(html).toContain('<code');
+      expect(html).toContain('<ul');
+    });
+
+    it('escapes html entities in plain text', () => {
+      const md = 'A & B < C';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('&amp;');
+      expect(html).toContain('&lt;');
+      expect(html).not.toContain('A & B');
+    });
+
+    it('does not double-process when image precedes a link', () => {
+      const md =
+        '![img](https://raw.githubusercontent.com/o/r/sha/a.png) and [link](https://example.com)';
+      const html = renderMarkdownToHtml(md);
+      expect(html).toContain('<img');
+      expect(html).toContain('<a href="https://example.com"');
+      // Critical: no leftover `!<a>` from the link rule consuming the image syntax
+      expect(html).not.toContain('!<a');
+    });
+  });
+});

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -13,6 +13,29 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Hosts whose images we are willing to inline as <img>. Other hosts render
+ * as a plain link to defend against XSS via attacker-controlled comment bodies
+ * (a posted `![](javascript:...)` would not match, since the regex requires
+ * https?://; but we also restrict the host to known-safe origins).
+ */
+const TRUSTED_IMAGE_HOSTS = new Set([
+  'raw.githubusercontent.com',
+  'user-images.githubusercontent.com',
+  'camo.githubusercontent.com',
+  'github.com',
+]);
+
+function isTrustedImageUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    return TRUSTED_IMAGE_HOSTS.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 function renderInline(value: string): string {
   let out = escapeHtml(value);
   out = out.replace(
@@ -21,6 +44,17 @@ function renderInline(value: string): string {
   );
   out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
   out = out.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
+  // Image syntax — must run BEFORE the link rule so the leading `!` is consumed.
+  // Trusted hosts → <img>. Untrusted hosts → plain link (alt text as link label).
+  out = out.replace(
+    /!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_match, alt: string, url: string) => {
+      if (isTrustedImageUrl(url)) {
+        return `<img src="${url}" alt="${alt}" loading="lazy" class="my-3 max-w-full rounded border border-line" />`;
+      }
+      return `<a href="${url}" class="text-accent hover:underline" target="_blank" rel="noreferrer noopener">${alt || url}</a>`;
+    },
+  );
   out = out.replace(
     /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
     '<a href="$2" class="text-accent hover:underline" target="_blank" rel="noreferrer noopener">$1</a>',

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { eventStore } from '../event-stream/store.js';
@@ -15,6 +15,26 @@ const STDOUT_CAP = 4 * 1024 * 1024; // 4 MB
 const TIMEOUT_MS = 30_000; // 30 seconds — FACTORY_RULES rule 32
 const WORKSPACES_DIR = join(homedir(), '.factory', 'workspaces');
 const MCP_CONFIG_PATH = join(homedir(), '.factory', 'mcp-config.json');
+
+/** Bundle name → workspace-relative MCP config path. */
+const MCP_CONFIG_FOR_BUNDLE: Record<string, string> = {
+  'playwright-mcp': 'apps/web/.mcp.json',
+};
+
+/**
+ * Resolves which MCP config to pass via --mcp-config based on the spec's tool bundles.
+ * When a bundle is mapped to a workspace-relative path AND that file exists, that path
+ * is returned. Otherwise the global empty MCP config is used.
+ */
+export function resolveMcpConfigPath(workspaceDir: string, toolBundles: string[]): string {
+  for (const bundle of toolBundles) {
+    const relPath = MCP_CONFIG_FOR_BUNDLE[bundle];
+    if (relPath == null) continue;
+    const candidate = join(workspaceDir, relPath);
+    if (existsSync(candidate)) return candidate;
+  }
+  return MCP_CONFIG_PATH;
+}
 
 /**
  * Resolves the absolute path to the `claude` binary.
@@ -77,6 +97,7 @@ export class ClaudeCliRuntime implements AgentRuntime {
     const { contextXml } = assembleSpawnContext(spec);
     const allowedTools = computeAllowlist(spec);
     const model = spec.modelOverride ?? defaultModelForTier('sonnet');
+    const mcpConfigPath = resolveMcpConfigPath(workspaceDir, spec.toolBundles);
 
     // Build argv array — Security rule: never use shell: true
     const binaryPath = resolveBinary('claude');
@@ -92,7 +113,7 @@ export class ClaudeCliRuntime implements AgentRuntime {
       '--output-format',
       'json',
       '--mcp-config',
-      MCP_CONFIG_PATH,
+      mcpConfigPath,
       '--strict-mcp-config',
     ];
 

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { eventStore } from '../event-stream/store.js';
-import { ClaudeCliRuntime } from './claude-cli.js';
+import { ClaudeCliRuntime, resolveMcpConfigPath } from './claude-cli.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import { withFallback } from './fallback.js';
 import type { AgentResult, AgentRuntime, AgentSpec, DecisionSummary } from './interface.js';
@@ -23,7 +23,11 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn().mockReturnValue('/mock/bin/claude'),
   spawn: vi.fn(),
 }));
-vi.mock('node:fs', () => ({ mkdirSync: vi.fn(), writeFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+}));
 vi.mock('node:os', () => ({ homedir: vi.fn().mockReturnValue('/mock-home') }));
 vi.mock('../event-stream/store.js', () => ({
   eventStore: {
@@ -415,6 +419,40 @@ function makeSecuritySpec(): AgentSpec {
     personaId: 'test-project/developer/0',
   };
 }
+
+// ─── resolveMcpConfigPath ─────────────────────────────────────────────────────
+
+describe('resolveMcpConfigPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns workspace mcp.json when playwright-mcp bundle is present and file exists', async () => {
+    const fs = await import('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const result = resolveMcpConfigPath('/work/dir', ['playwright-mcp']);
+    expect(result).toBe('/work/dir/apps/web/.mcp.json');
+  });
+
+  it('falls back to global empty config when bundle file does not exist', async () => {
+    const fs = await import('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const result = resolveMcpConfigPath('/work/dir', ['playwright-mcp']);
+    expect(result).toBe('/mock-home/.factory/mcp-config.json');
+  });
+
+  it('falls back to global empty config when no MCP-mapped bundle is present', () => {
+    const result = resolveMcpConfigPath('/work/dir', ['read-only', 'validate']);
+    expect(result).toBe('/mock-home/.factory/mcp-config.json');
+  });
+
+  it('returns first matching bundle when multiple are present', async () => {
+    const fs = await import('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const result = resolveMcpConfigPath('/work/dir', ['validate', 'playwright-mcp']);
+    expect(result).toBe('/work/dir/apps/web/.mcp.json');
+  });
+});
 
 describe('ClaudeCliRuntime subprocess security', () => {
   beforeEach(() => {

--- a/core/event-stream/store.test.ts
+++ b/core/event-stream/store.test.ts
@@ -193,6 +193,14 @@ describe('EventStore — M4 runtime events', () => {
     }
   });
 
+  it('accepts the three-tier QA verification event kinds (docs/standards/verification.md)', () => {
+    const kinds = ['qa.structural-failed', 'qa.functional-failed', 'qa.regression-failed'] as const;
+    for (const kind of kinds) {
+      const e = eventStore.appendEvent({ projectId: RUN_PROJECT, kind, payload: {} });
+      expect(e.kind).toBe(kind);
+    }
+  });
+
   it('stores and retrieves runId on events', () => {
     const runId = 'run-test-abc123';
     const e = eventStore.appendEvent({

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -23,7 +23,11 @@ export type EventKind =
   | 'agent.fallback-triggered'
   | 'agent.triage-complete'
   | 'agent.repo-override'
-  | 'agent.investigation-complete';
+  | 'agent.investigation-complete'
+  // Three-tier verification framework — see docs/standards/verification.md
+  | 'qa.structural-failed'
+  | 'qa.functional-failed'
+  | 'qa.regression-failed';
 
 export interface AgentEvent {
   id: number;

--- a/core/tool-layer/bundles.ts
+++ b/core/tool-layer/bundles.ts
@@ -8,6 +8,64 @@ export const TOOL_BUNDLES = {
    * `work-item-read` is the work-item query tool.
    */
   read: ['read', 'search', 'work-item-read'],
+  /**
+   * Playwright validation bundle. Used by skills that run e2e specs and
+   * commit/push evidence artefacts (skills/playwright-repro, skills/evidence-post).
+   * Bash patterns scoped to test invocation, evidence I/O, and git push of evidence.
+   */
+  validate: [
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'Bash(pnpm test:e2e*)',
+    'Bash(pnpm --filter @goose-hub/web test:e2e*)',
+    'Bash(pnpm --filter @goose-hub/web exec playwright*)',
+    'Bash(npx playwright*)',
+    'Bash(mkdir -p evidence/*)',
+    'Bash(git add evidence/*)',
+    'Bash(git commit -m *)',
+    'Bash(git push*)',
+    'Bash(git rev-parse HEAD)',
+  ],
+  /**
+   * Playwright-test MCP bundle. Tool list extracted from Microsoft's
+   * apps/web/.claude/agents/playwright-test-{planner,generator}.md.
+   *
+   * When this bundle is on a skill, the runtime merges apps/web/.mcp.json into
+   * the spawn-time MCP config so the `playwright-test` server is reachable
+   * inside the subprocess (see core/agent-runtime/claude-cli.ts).
+   */
+  'playwright-mcp': [
+    'mcp__playwright-test__browser_click',
+    'mcp__playwright-test__browser_close',
+    'mcp__playwright-test__browser_console_messages',
+    'mcp__playwright-test__browser_drag',
+    'mcp__playwright-test__browser_evaluate',
+    'mcp__playwright-test__browser_file_upload',
+    'mcp__playwright-test__browser_handle_dialog',
+    'mcp__playwright-test__browser_hover',
+    'mcp__playwright-test__browser_navigate',
+    'mcp__playwright-test__browser_navigate_back',
+    'mcp__playwright-test__browser_network_requests',
+    'mcp__playwright-test__browser_press_key',
+    'mcp__playwright-test__browser_run_code',
+    'mcp__playwright-test__browser_select_option',
+    'mcp__playwright-test__browser_snapshot',
+    'mcp__playwright-test__browser_take_screenshot',
+    'mcp__playwright-test__browser_type',
+    'mcp__playwright-test__browser_wait_for',
+    'mcp__playwright-test__browser_verify_element_visible',
+    'mcp__playwright-test__browser_verify_list_visible',
+    'mcp__playwright-test__browser_verify_text_visible',
+    'mcp__playwright-test__browser_verify_value',
+    'mcp__playwright-test__planner_setup_page',
+    'mcp__playwright-test__planner_save_plan',
+    'mcp__playwright-test__generator_read_log',
+    'mcp__playwright-test__generator_setup_page',
+    'mcp__playwright-test__generator_write_test',
+  ],
 } satisfies Record<string, string[]>;
 
 export type BundleName = keyof typeof TOOL_BUNDLES;

--- a/core/tool-layer/slice.test.ts
+++ b/core/tool-layer/slice.test.ts
@@ -86,6 +86,32 @@ describe('TOOL_BUNDLES', () => {
     expect(TOOL_BUNDLES['read-write']).toContain('Write');
     expect(TOOL_BUNDLES['read-write']).toContain('Edit');
   });
+
+  it('validate bundle contains Read, Write, and scoped Bash patterns', () => {
+    expect(TOOL_BUNDLES.validate).toContain('Read');
+    expect(TOOL_BUNDLES.validate).toContain('Write');
+    expect(TOOL_BUNDLES.validate).toContain('Bash(pnpm test:e2e*)');
+    expect(TOOL_BUNDLES.validate).toContain('Bash(git push*)');
+  });
+
+  it('validate bundle does not include unrestricted Bash', () => {
+    expect(TOOL_BUNDLES.validate).not.toContain('Bash');
+  });
+
+  it('playwright-mcp bundle contains browser_* and planner_* and generator_* tools', () => {
+    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__browser_navigate');
+    expect(TOOL_BUNDLES['playwright-mcp']).toContain(
+      'mcp__playwright-test__browser_take_screenshot',
+    );
+    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__planner_save_plan');
+    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__generator_write_test');
+  });
+
+  it('playwright-mcp bundle entries are all mcp__playwright-test__ prefixed', () => {
+    for (const tool of TOOL_BUNDLES['playwright-mcp']) {
+      expect(tool.startsWith('mcp__playwright-test__')).toBe(true);
+    }
+  });
 });
 
 describe('computeAllowlist', () => {

--- a/docs/standards/verification.md
+++ b/docs/standards/verification.md
@@ -1,0 +1,110 @@
+# Three-tier verification framework (Factory standard)
+
+Status: standard, M8 scope
+Owner: human (immutable contract for the QA holdout)
+Last updated: 2026-05-02
+
+This document defines the canonical mental model for all verification layers in Factory. The QA holdout (`skills/qa/`, M8) is the primary implementer, but every Factory skill that asserts correctness — at any layer — uses these tier names and maps its checks to one of them.
+
+## Tiers
+
+Verification proceeds in strict order: **structural → functional → regression**. A failure in any tier short-circuits the remaining tiers (the tier-specific event records the stop point).
+
+### Tier 1 — Structural
+
+Catches shape regressions before any execution.
+
+- Schema validation (Zod, JSON Schema)
+- Type checks (`tsc --noEmit`)
+- Lint and format (Biome)
+- Contract tests (DTO ↔ wire format)
+- Migration validity (Drizzle: schema vs. database in sync)
+
+**Cost profile:** seconds. Always run first.
+
+**Skill emission:** `qa.structural-failed` on failure.
+
+### Tier 2 — Functional
+
+Catches behaviour regressions.
+
+- Unit tests (Vitest) — pure-function and component-level
+- Integration tests — module boundaries, DB writes, route handlers
+- Workflow tests — orchestrator state transitions, persona selection, skill spawn
+
+**Cost profile:** seconds to a couple of minutes.
+
+**Skill emission:** `qa.functional-failed` on failure.
+
+### Tier 3 — Regression
+
+Catches UX and cross-cutting regressions.
+
+- Playwright E2E (`apps/web/e2e/*.spec.ts`)
+- Visual diff (when wired — currently out of scope; placeholder for M9+)
+- Accessibility checks (axe, when wired)
+
+**Cost profile:** minutes (browser bring-up + multi-page interaction).
+
+**Skill emission:** `qa.regression-failed` on failure.
+
+## Fix-or-register rule
+
+A finding that blocks tier 1 or tier 2 has exactly two acceptable resolutions:
+
+1. **Fix in-run** — the developer skill (or a follow-up `fix-issue` invocation) makes the change, re-runs the failing tier, and proceeds when green.
+2. **Register as `priority:critical`** — a new GitHub issue is filed in the relevant target repo, labelled `priority:critical`, blocking further work on the affected slice.
+
+**Suppressing** (e.g. `// vitest-ignore`, `expect(thing).toBeTruthy()` placeholders, removing the assertion) is forbidden. **Skipping** (`it.skip`, `test.skip`) is forbidden. The QA holdout fails the gate when it detects either pattern in the diff under review.
+
+For tier 3 regressions: same rule, but the registered issue may be `priority:high` if the affected surface is non-critical (e.g. a design polish slice). The discriminator: would a user notice within 24 hours? If yes, `critical`; if no, `high`.
+
+## 8-category code quality rubric
+
+Used by the QA holdout's `code_quality_audit` gate. Each category produces a numeric score; the aggregate must meet a threshold (≥ 70/100) for the gate to pass. Sub-threshold aggregates surface as `qa.functional-failed` (the rubric is a functional-tier check — it asserts that the code is maintainable, which is a behavioural property of the codebase over time).
+
+| Category | Weight | What it measures |
+|---|---:|---|
+| Open/Closed principle | 20 | Extension without modification |
+| Concept count | 15 | Distinct abstractions per module |
+| Time-to-capability | 15 | How fast a new dev can use the module |
+| Complecting | 15 | Accidental coupling of unrelated concerns |
+| LOC | 10 | Raw size signal |
+| Coupling | 10 | Cross-module dependencies |
+| Gall's Law | 10 | Complexity grew from a simple working system? |
+| Cyclomatic complexity | 5 | Branch count per function |
+
+**Threshold:** aggregate ≥ 70/100 to pass. Any single category at zero forces the gate to fail regardless of aggregate (a structural risk in one dimension is not redeemed by averaging).
+
+The rubric is sourced from `docs/steves-training-materials-analysis.md` (`07-code-quality-audit.md`).
+
+## Event schema
+
+Three new event kinds are reserved for tier-specific failures. They extend `EventKind` in `core/event-stream/store.ts`:
+
+- `qa.structural-failed` — payload includes `{ tool, output, exitCode }` (e.g. tsc output)
+- `qa.functional-failed` — payload includes `{ suite, failingTests: string[], output }`
+- `qa.regression-failed` — payload includes `{ specPath, failingSteps: string[], evidencePaths: string[] }`
+
+Generic `qa.passed` and `qa.failed` events remain for aggregate transitions; the tier-specific kinds are additive and let downstream consumers (the UI, the retro skill) distinguish which tier short-circuited.
+
+## How this contract binds existing M7 skills
+
+- **`skills/spec-author/`** authors the tier-3 spec for a slice. The spec is the regression check the tier-3 stage will execute.
+- **`skills/evidence-post/`** captures the post-implementation visual evidence used as the input to tier-3 verification (and to the human-facing comment on the issue).
+- **`skills/playwright-repro/`** is the BEFORE-state capture for `type:bug` issues — its output feeds the tier-3 regression check (does the fix make the captured failing scenario pass?).
+
+Each of those skills' output schema already includes `decisionSummaries`, satisfying FACTORY_RULES rule 6. None of them implement tier verification themselves; they produce the artefacts the QA holdout will consume in M8.
+
+## What this document does NOT do
+
+- It does NOT implement `skills/qa/` — that is M8 work (issue #76's framing places this doc as the contract; the implementing skill ships separately).
+- It does NOT modify `FACTORY_RULES.md` — per rule 12, governance files are immutable to Factory PRs. The standards doc lives under `docs/standards/` and is referenced from `docs/PLAN.md` (non-governance, mutable) for discoverability.
+- It does NOT define the visual-diff tooling for tier 3 — that is an M9+ concern.
+
+## References
+
+- `docs/PLAN.md` § 13.7 (M8 — QA and Review Holdouts)
+- `docs/steves-training-materials-analysis.md` — `03-lifecycle-harness.md`, `04-qa-routine.md`, `07-code-quality-audit.md`
+- `FACTORY_RULES.md` rules 1, 3, 4, 6, 12
+- Issue #76 (this document is the resolution)

--- a/skills/evidence-post/README.md
+++ b/skills/evidence-post/README.md
@@ -1,0 +1,79 @@
+# skills/evidence-post
+
+Runs the slice's Playwright spec on the PR commit, captures screenshots and a continuous WebM walkthrough to `evidence/issue-<N>/`, commits those artefacts to the PR branch, and posts a comment on the linked issue with the screenshots embedded inline via `raw.githubusercontent.com` URLs **pinned to the PR head commit SHA**.
+
+The capture pattern was proven by the smoke test on issue #217. This is its productionisation as a Factory skill.
+
+## Why this is a Factory skill, not a CI workflow
+
+Per ADR 0011 §4 and FACTORY_RULES rule 26: posting evidence is a product workflow, not a CI concern. Wrapping it in a skill keeps it in the runtime layer with a tool allowlist, schema-validated output, and decision-summary discipline — the same shape as `skills/playwright-repro/`.
+
+## When this skill runs
+
+- M7 supervised dev workflow, after the implementation skill ships the slice and the PR is open
+- Before any QA/Review (M8) so the posted comment is canonical project state on GitHub by the time a holdout reads the issue
+- Best-effort: a failure here must not block PR open or the state transition. The wiring is the responsibility of `core/orchestrator/workflows/fix-issue.ts` (separate issue, deferred until #183 lands).
+
+## Inputs
+
+`EvidencePostContextSchema`:
+
+| Field | Type | Description |
+|---|---|---|
+| `workItem.number` | `number` | Issue number to comment on |
+| `workItem.repo` | `string` | `owner/repo`, e.g. `shaunnez/goose-hub` |
+| `workItem.title` | `string` | Issue title (used in the comment header) |
+| `prNumber` | `number` | Pull request number |
+| `prHeadSha` | `string` (≥ 7 chars) | Head commit SHA — every raw URL pins to this SHA |
+| `specPath` | `string` | Workspace-relative path to the Playwright spec to run |
+
+## Outputs
+
+`EvidencePostSchema`:
+
+| Field | Type | Description |
+|---|---|---|
+| `screenshots` | `Screenshot[]` | Workspace-relative paths under `evidence/issue-<N>/` |
+| `screenshots[].path` | `string` | e.g. `evidence/issue-233/step-1.png` |
+| `screenshots[].caption` | `string` | What the screenshot shows |
+| `screenshots[].step` | `number` (integer) | Ordinal step in the walkthrough |
+| `videoPath` | `string \| null` | Workspace-relative WebM path, or `null` |
+| `commentUrl` | `string` (URL) | Permalink to the posted comment |
+| `commitSha` | `string` (≥ 7 chars) | SHA the raw URLs pin to |
+| `decisionSummaries` | `DecisionSummary[]` | Canonical decision-summary record |
+
+## Tool allowlist
+
+`validate` bundle: Read, Write, Edit, Glob, Grep, plus scoped Bash patterns for Playwright invocation, evidence I/O (`mkdir -p evidence/*`, `git add evidence/*`), commit, and push. The skill does NOT include unrestricted `Bash`.
+
+## Comparison strategy (v1)
+
+After-only. For `type:bug` issues, the BEFORE state already exists from `skills/playwright-repro/` (M6) — the comment can reference those artefacts when present. For `type:feature` and `type:chore`, the after-capture stands on its own.
+
+Worktree-based dual-run (BEFORE on `main`, AFTER on PR) is out of scope. File a separate enhancement when after-only proves limiting.
+
+## SHA pinning
+
+Every URL into the repo MUST pin to `prHeadSha`, never the branch name. Branch URLs break on merge once the branch is deleted. SHA URLs are immutable.
+
+```md
+![<caption>](https://raw.githubusercontent.com/<repo>/<sha>/evidence/issue-<N>/step-1.png)
+[walkthrough.webm](https://github.com/<repo>/blob/<sha>/evidence/issue-<N>/walkthrough.webm)
+```
+
+## Operational gotchas (from #217 smoke test)
+
+- Pin the `playwright-core` version + the browser bundle as a unit. The browser ABI must match `playwright-core`.
+- Default to `localhost:5173` or `page.setContent()` with inline HTML — external URLs may be sandboxed off in some run environments.
+- Set `{ video: 'on' }` in the spec config so video records continuously across screenshot points.
+
+## Context allowlist
+
+| Key | Included |
+|---|---|
+| `workItem.number` | yes |
+| `workItem.repo` | yes |
+| `workItem.title` | yes |
+| `prNumber` | yes |
+| `prHeadSha` | yes |
+| `specPath` | yes |

--- a/skills/evidence-post/config.ts
+++ b/skills/evidence-post/config.ts
@@ -1,0 +1,58 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Context expected by the evidence-post agent. Rendered as XML in the user prompt:
+ *
+ *   <task>
+ *     <work_item>
+ *       <number>...</number>
+ *       <repo>owner/repo</repo>
+ *       <title>...</title>
+ *     </work_item>
+ *     <pr_number>...</pr_number>
+ *     <pr_head_sha>...</pr_head_sha>
+ *     <spec_path>apps/web/e2e/issue-N.spec.ts</spec_path>
+ *   </task>
+ */
+export const EvidencePostContextSchema = z.object({
+  workItem: z.object({
+    number: z.number().describe('Issue number to comment on'),
+    repo: z.string().describe('owner/repo, e.g. shaunnez/goose-hub'),
+    title: z.string(),
+  }),
+  prNumber: z.number().describe('Pull request number that closes this issue'),
+  prHeadSha: z
+    .string()
+    .min(7)
+    .describe('Head commit SHA of the PR — every raw URL must pin to this SHA, never the branch'),
+  specPath: z
+    .string()
+    .describe(
+      'Workspace-relative path to the Playwright spec to run, e.g. apps/web/e2e/issue-N.spec.ts',
+    ),
+});
+
+const config: SkillConfig = {
+  contextSchema: EvidencePostContextSchema,
+  contextAllowlist: [
+    'workItem.number',
+    'workItem.repo',
+    'workItem.title',
+    'prNumber',
+    'prHeadSha',
+    'specPath',
+  ],
+  /**
+   * `validate` bundle — Playwright invocation, evidence I/O, git push of
+   * artefacts, and SHA resolution. The skill posts the issue comment via
+   * a separate workflow-layer GitHub call (NOT a tool the agent invokes
+   * directly), so no GitHub MCP/CLI access is needed in the bundle.
+   */
+  toolBundles: ['validate'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'developer',
+};
+
+export default config;

--- a/skills/evidence-post/schema.ts
+++ b/skills/evidence-post/schema.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+/**
+ * Screenshot shape mirrors skills/playwright-repro/PlaywrightReproSchema for
+ * symmetry — both before- and after-state captures share the same field names.
+ */
+export const ScreenshotSchema = z.object({
+  path: z.string().describe('Workspace-relative path under evidence/issue-<N>/'),
+  caption: z.string().describe('Description of what this screenshot shows'),
+  step: z.number().int().describe('Ordinal step in the captured walkthrough'),
+});
+
+export const EvidencePostSchema = z.object({
+  screenshots: z.array(ScreenshotSchema),
+  videoPath: z
+    .string()
+    .nullable()
+    .describe('Workspace-relative path to the WebM walkthrough, or null if not captured'),
+  commentUrl: z.string().url().describe('Permalink to the comment posted on the linked issue'),
+  commitSha: z
+    .string()
+    .min(7)
+    .describe('Full or short SHA the raw.githubusercontent.com URLs pin to (NEVER the branch)'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type EvidencePostOutput = z.infer<typeof EvidencePostSchema>;

--- a/skills/evidence-post/skill.md
+++ b/skills/evidence-post/skill.md
@@ -1,0 +1,70 @@
+# evidence-post skill
+
+Version: 1
+
+You are a developer agent producing post-implementation visual evidence. Your job is to run the Playwright spec authored for the slice, capture screenshots and a continuous walkthrough video to `evidence/issue-<N>/`, commit those artefacts to the PR branch, and post a comment on the linked issue with the screenshots embedded inline via `raw.githubusercontent.com` URLs **pinned to the PR head commit SHA** (NEVER the branch — branch URLs break on merge).
+
+## Role
+
+Developer (post-implementation evidence). You are NOT a holdout — you run after the implementation skill ships the slice and before any QA/Review (M8) runs.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<work_item>`
+  - `<number>` — issue number to comment on
+  - `<repo>` — `owner/repo`
+  - `<title>` — issue title (for the comment header)
+- `<pr_number>` — pull request number
+- `<pr_head_sha>` — head commit SHA the raw URLs MUST pin to
+- `<spec_path>` — workspace-relative path to the Playwright spec to run
+
+## What you must do
+
+1. **Capture.** Run the spec at `<spec_path>` with video recording enabled (`{ video: 'on' }` in the spec's project config or via `PLAYWRIGHT_VIDEO=on`). Use `pnpm --filter @goose-hub/web exec playwright test <spec_path>` — never raw `npx`.
+2. **Move artefacts.** Move every screenshot and the WebM video into `evidence/issue-<N>/`. Create the directory if it does not exist (`mkdir -p evidence/issue-<N>`). Each screenshot gets a stable filename like `step-1.png`, `step-2.png`, …
+3. **Commit and push.** `git add evidence/issue-<N>/`, commit with message `evidence: capture for issue #<N>` (single line, no body), push to the PR branch.
+4. **Build the comment.** Compose markdown with:
+   - A header line: `## Evidence for issue #<N>: <title>`
+   - One inline image per screenshot: `![<caption>](https://raw.githubusercontent.com/<repo>/<commitSha>/evidence/issue-<N>/<filename>.png)`
+   - A video link (NOT embedded — GitHub renders WebM inline only on the file blob page): `[walkthrough.webm](https://github.com/<repo>/blob/<commitSha>/evidence/issue-<N>/walkthrough.webm)` if a video was captured
+   - A trailer line: `Pinned to <commitSha> · PR #<prNumber>`
+5. **Post the comment.** Post to issue #<N> in <repo>. Capture the returned comment URL.
+
+## Critical: pin URLs to the SHA
+
+Every URL into the repo must use `<pr_head_sha>`, not the branch name. Branch-pinned URLs break the moment the PR merges and the branch is deleted. SHA-pinned URLs are immutable.
+
+## When the spec fails
+
+If the spec fails to run (browser missing, server unreachable, syntax error), do NOT post a placeholder comment. Return decisionSummaries describing the failure and let the workflow record `evidence.post-failed`. The workflow caller treats evidence posting as best-effort — a failure must not block PR open or the state transition.
+
+In that case still produce a valid output:
+- `screenshots: []`
+- `videoPath: null`
+- `commentUrl`: leave as the empty string `""` is invalid (URL constraint) — instead, throw the error so the workflow records the failure.
+
+## Output format
+
+Return a JSON object conforming to `EvidencePostSchema`:
+
+```json
+{
+  "screenshots": [
+    { "path": "evidence/issue-233/step-1.png", "caption": "Project overview before evidence panel", "step": 1 },
+    { "path": "evidence/issue-233/step-2.png", "caption": "Evidence panel expanded with inline screenshot", "step": 2 }
+  ],
+  "videoPath": "evidence/issue-233/walkthrough.webm",
+  "commentUrl": "https://github.com/shaunnez/goose-hub/issues/233#issuecomment-9876543210",
+  "commitSha": "abc1234def5678901234567890abcdef12345678",
+  "decisionSummaries": [
+    { "step": "capture", "summary": "Ran apps/web/e2e/issue-233.spec.ts; captured 2 screenshots and a 12 s WebM walkthrough" },
+    { "step": "post", "summary": "Posted comment on issue #233 with SHA-pinned image URLs and video link" }
+  ]
+}
+```
+
+Paths in the schema are workspace-relative. URLs in the rendered comment are absolute and SHA-pinned.
+
+[decision] Captured Playwright evidence for slice and posted SHA-pinned comment to linked issue

--- a/skills/evidence-post/slice.test.ts
+++ b/skills/evidence-post/slice.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config, { EvidencePostContextSchema } from './config.js';
+import { EvidencePostSchema } from './schema.js';
+
+describe('evidence-post schema', () => {
+  it('accepts a fully-populated valid output', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [
+        {
+          path: 'evidence/issue-233/step-1.png',
+          caption: 'Project overview before evidence panel',
+          step: 1,
+        },
+        {
+          path: 'evidence/issue-233/step-2.png',
+          caption: 'Evidence panel expanded with inline screenshot',
+          step: 2,
+        },
+      ],
+      videoPath: 'evidence/issue-233/walkthrough.webm',
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/233#issuecomment-9876543210',
+      commitSha: 'abc1234def5678901234567890abcdef12345678',
+      decisionSummaries: [
+        { step: 'capture', summary: 'Ran spec; captured 2 screenshots and a video' },
+        { step: 'post', summary: 'Posted comment on issue #233 with SHA-pinned URLs' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts videoPath as null (no video captured)', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [{ path: 'evidence/issue-233/step-1.png', caption: 'Initial state', step: 1 }],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/233#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'capture', summary: 'Captured screenshot only' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty screenshots array (when only the video matters)', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [],
+      videoPath: 'evidence/issue-233/walkthrough.webm',
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/233#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'capture', summary: 'Video-only capture' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts short SHA (≥ 7 chars)', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/1#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'post', summary: 'posted' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects SHA shorter than 7 chars', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/1#issuecomment-1',
+      commitSha: 'abc12',
+      decisionSummaries: [{ step: 'post', summary: 'posted' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-URL commentUrl', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      commentUrl: 'not-a-url',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'post', summary: 'posted' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/1#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects screenshot missing path', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [{ caption: 'no path', step: 1 }],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/1#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'post', summary: 'posted' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects screenshot.step as float (must be integer)', () => {
+    const result = EvidencePostSchema.safeParse({
+      screenshots: [{ path: 'evidence/issue-1/step-1.png', caption: 'c', step: 1.5 }],
+      videoPath: null,
+      commentUrl: 'https://github.com/shaunnez/goose-hub/issues/1#issuecomment-1',
+      commitSha: 'abc1234',
+      decisionSummaries: [{ step: 'post', summary: 'posted' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(EvidencePostSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('evidence-post skill config', () => {
+  it('has role developer (NOT a holdout)', () => {
+    expect(config.role).toBe('developer');
+  });
+
+  it('declares validate tool bundle (Playwright + git push)', () => {
+    expect(config.toolBundles).toContain('validate');
+  });
+
+  it('does NOT declare playwright-mcp (this skill runs the spec, does not author it)', () => {
+    expect(config.toolBundles).not.toContain('playwright-mcp');
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('contextAllowlist includes workItem fields, prNumber, prHeadSha, specPath', () => {
+    expect(config.contextAllowlist).toContain('workItem.number');
+    expect(config.contextAllowlist).toContain('workItem.repo');
+    expect(config.contextAllowlist).toContain('workItem.title');
+    expect(config.contextAllowlist).toContain('prNumber');
+    expect(config.contextAllowlist).toContain('prHeadSha');
+    expect(config.contextAllowlist).toContain('specPath');
+  });
+});
+
+describe('evidence-post context schema', () => {
+  it('accepts valid context', () => {
+    const valid = EvidencePostContextSchema.safeParse({
+      workItem: { number: 233, repo: 'shaunnez/goose-hub', title: 'Add evidence panel' },
+      prNumber: 999,
+      prHeadSha: 'abc1234def5678901234567890abcdef12345678',
+      specPath: 'apps/web/e2e/issue-233.spec.ts',
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('rejects prHeadSha shorter than 7 chars', () => {
+    const invalid = EvidencePostContextSchema.safeParse({
+      workItem: { number: 233, repo: 'shaunnez/goose-hub', title: 't' },
+      prNumber: 999,
+      prHeadSha: 'abc',
+      specPath: 'apps/web/e2e/x.spec.ts',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects missing workItem.repo', () => {
+    const invalid = EvidencePostContextSchema.safeParse({
+      workItem: { number: 233, title: 't' },
+      prNumber: 999,
+      prHeadSha: 'abc1234',
+      specPath: 'apps/web/e2e/x.spec.ts',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects missing prNumber', () => {
+    const invalid = EvidencePostContextSchema.safeParse({
+      workItem: { number: 233, repo: 'shaunnez/goose-hub', title: 't' },
+      prHeadSha: 'abc1234',
+      specPath: 'apps/web/e2e/x.spec.ts',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects missing specPath', () => {
+    const invalid = EvidencePostContextSchema.safeParse({
+      workItem: { number: 233, repo: 'shaunnez/goose-hub', title: 't' },
+      prNumber: 999,
+      prHeadSha: 'abc1234',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects workItem.number as a string', () => {
+    const invalid = EvidencePostContextSchema.safeParse({
+      workItem: { number: '233', repo: 'shaunnez/goose-hub', title: 't' },
+      prNumber: 999,
+      prHeadSha: 'abc1234',
+      specPath: 'apps/web/e2e/x.spec.ts',
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/skills/spec-author/README.md
+++ b/skills/spec-author/README.md
@@ -1,0 +1,70 @@
+# skills/spec-author
+
+Authors a runnable Playwright e2e spec for a new slice. Used by the M7 supervised dev workflow before the implementation skill ships the feature, so the slice has a failing-then-passing test from the start (TDD).
+
+## How this differs from Microsoft's playwright-test subagents
+
+`apps/web/.claude/agents/playwright-test-{planner,generator,healer}.md` are **dev-time scaffolding** invoked by a human running Claude Code interactively in the IDE. They are NOT Factory skills.
+
+`spec-author` is a **Factory skill** — invoked by the supervised dev workflow inside an autonomous-friendly subprocess with a tool allowlist, schema-validated output, and decision-summary discipline. It uses the same `playwright-test` MCP server that the human-facing subagents use (registered at `apps/web/.mcp.json`), so the underlying browser-driving capability is identical. The difference is the call site:
+
+| | Microsoft subagents | `skills/spec-author/` (this skill) |
+|---|---|---|
+| Invoked by | Human in IDE | Factory workflow |
+| Tool allowlist | None enforced | `playwright-mcp` + `read-write` |
+| Output validation | Free-form | Zod schema (`SpecAuthorSchema`) |
+| Decision summaries | None | Required (FACTORY_RULES rule 6) |
+| Runs in | Live IDE session | `claude -p` subprocess |
+
+ADR 0011 records the rationale.
+
+## When this skill runs
+
+- M7 supervised dev workflow, before the implementation skill (`skills/implement/`, separate issue) ships the slice
+- Either as a sub-spawn of the developer skill or as an upstream node in the workflow — wired at the workflow level so the developer skill's output schema stays simple
+
+## Inputs
+
+`SpecAuthorContextSchema`:
+
+| Field | Type | Description |
+|---|---|---|
+| `workItem.title` | `string` | Issue title |
+| `workItem.body` | `string` | Issue body (slice scope, acceptance criteria) |
+| `workItem.number` | `number` | Issue number (used to derive the spec filename) |
+| `targetUrl` | `string` | Running dev server URL (e.g. `http://localhost:5173`) |
+| `sliceDescription` | `string` | User-facing scenario the spec must exercise |
+
+## Outputs
+
+`SpecAuthorSchema`:
+
+| Field | Type | Description |
+|---|---|---|
+| `specPath` | `string` | Workspace-relative path to the written spec, e.g. `apps/web/e2e/issue-235.spec.ts` |
+| `planSummary` | `string` | One-paragraph summary of what the spec asserts |
+| `screenshotsTaken` | `number` (≥ 0, integer) | Number of screenshots captured during exploration |
+| `decisionSummaries` | `DecisionSummary[]` | Canonical decision-summary record (FACTORY_RULES rule 6) |
+
+## Tool allowlist
+
+- **`playwright-mcp`** — Microsoft's playwright-test MCP server (`browser_*`, `planner_*`, `generator_*`). The runtime auto-merges `apps/web/.mcp.json` into the spawn-time MCP config when this bundle is present.
+- **`read-write`** — Read, Write, Edit, Glob, Grep. Lets the agent read existing fixtures and write the spec file under `apps/web/e2e/` if `generator_write_test` declines.
+
+## Dev-server assumption
+
+The skill assumes the dev server is reachable at the provided `targetUrl`. The Playwright config under `apps/web/playwright.config.ts` already has `webServer` auto-start, so the workflow does not need to boot the server explicitly.
+
+## Filename convention
+
+The skill writes specs to `apps/web/e2e/issue-<number>.spec.ts` to keep them traceable to the originating issue and easy to find in PR diffs.
+
+## Context allowlist
+
+| Key | Included |
+|---|---|
+| `workItem.title` | yes |
+| `workItem.body` | yes |
+| `workItem.number` | yes |
+| `targetUrl` | yes |
+| `sliceDescription` | yes |

--- a/skills/spec-author/config.ts
+++ b/skills/spec-author/config.ts
@@ -1,0 +1,56 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Context expected by the spec-author agent. Rendered as XML in the user prompt:
+ *
+ *   <task>
+ *     <work_item>
+ *       <title>...</title>
+ *       <body>...</body>
+ *       <number>...</number>
+ *     </work_item>
+ *     <target_url>http://localhost:5173/...</target_url>
+ *     <slice_description>...</slice_description>
+ *   </task>
+ */
+export const SpecAuthorContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  targetUrl: z
+    .string()
+    .describe('URL of the running dev server (e.g. http://localhost:5173) the agent will explore'),
+  sliceDescription: z
+    .string()
+    .describe('User-facing description of the scenario the spec must exercise'),
+});
+
+const config: SkillConfig = {
+  contextSchema: SpecAuthorContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'targetUrl',
+    'sliceDescription',
+  ],
+  /**
+   * `playwright-mcp` exposes Microsoft's playwright-test MCP server tools
+   * (browser_*, planner_*, generator_*). The runtime auto-merges
+   * apps/web/.mcp.json into the spawn-time MCP config when this bundle
+   * is present (see core/agent-runtime/claude-cli.ts:resolveMcpConfigPath).
+   *
+   * `read-write` is included so the agent can read existing fixtures and
+   * write the spec file under apps/web/e2e/ if the MCP write_test tool
+   * declines (defensive — generator_write_test is the primary path).
+   */
+  toolBundles: ['playwright-mcp', 'read-write'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'developer',
+};
+
+export default config;

--- a/skills/spec-author/schema.ts
+++ b/skills/spec-author/schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const SpecAuthorSchema = z.object({
+  specPath: z
+    .string()
+    .describe(
+      'Workspace-relative path to the written Playwright spec, e.g. apps/web/e2e/<slug>.spec.ts',
+    ),
+  planSummary: z
+    .string()
+    .describe('One-paragraph summary of what the spec asserts and how it exercises the slice'),
+  screenshotsTaken: z
+    .number()
+    .int()
+    .min(0)
+    .describe('Number of screenshots captured during exploration of the running dev server'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type SpecAuthorOutput = z.infer<typeof SpecAuthorSchema>;

--- a/skills/spec-author/skill.md
+++ b/skills/spec-author/skill.md
@@ -1,0 +1,66 @@
+# spec-author skill
+
+Version: 1
+
+You are a developer agent authoring a Playwright end-to-end spec for a new slice. Your job is to explore the running dev server using the `playwright-test` MCP server tools, observe the user-facing scenario described in the slice, and produce a runnable spec file at `apps/web/e2e/<slug>.spec.ts`.
+
+## Role
+
+Developer (spec-authoring sub-task). You are called as part of the supervised dev workflow before the implementation skill ships the slice. You are NOT a holdout — your output may be referenced downstream.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<work_item>` — the issue describing the slice
+  - `<title>` — issue title
+  - `<body>` — full issue body
+  - `<number>` — issue number (used to derive the spec filename slug)
+- `<target_url>` — URL of the running dev server (e.g. `http://localhost:5173/projects/foo`)
+- `<slice_description>` — the user-facing scenario the spec must exercise
+
+## What you must do
+
+1. Read the slice description and identify the user actions that exercise it (navigate, click, type, assert visible text, etc.).
+2. Use the `mcp__playwright-test__planner_setup_page` tool to open the target URL.
+3. Use `mcp__playwright-test__browser_*` tools to walk through the scenario, taking a screenshot via `mcp__playwright-test__browser_take_screenshot` at each meaningful step. Track the count.
+4. Use `mcp__playwright-test__planner_save_plan` to persist the explored plan.
+5. Use `mcp__playwright-test__generator_write_test` to emit a runnable spec at `apps/web/e2e/issue-<number>.spec.ts`. The spec must:
+   - import `{ test, expect }` from `@playwright/test`
+   - use a single `test.describe(...)` block with a clear name derived from the slice description
+   - include at least one `expect(...)` assertion per meaningful step (prefer `verify_text_visible` / `verify_element_visible` style assertions)
+   - rely on the `webServer` auto-start configured in `apps/web/playwright.config.ts` (do NOT manually start the dev server in the spec)
+
+## Critical: do not implement the feature
+
+You are authoring the spec, not the feature. The spec is allowed (and expected) to FAIL on the current branch — that is the TDD red state. Do not modify any source under `apps/web/src/` or anywhere else outside `apps/web/e2e/`.
+
+## Filename and slug
+
+Use `apps/web/e2e/issue-<number>.spec.ts` where `<number>` is the work-item number. Do NOT include slashes, spaces, or non-ASCII characters in the path.
+
+## Output format
+
+Return a JSON object conforming to `SpecAuthorSchema`:
+
+```json
+{
+  "specPath": "apps/web/e2e/issue-235.spec.ts",
+  "planSummary": "Exercises the new project-overview screenshot panel: navigate to /projects/foo, open the issue detail view, expand the evidence section, and assert the inline screenshot is visible and clickable.",
+  "screenshotsTaken": 4,
+  "decisionSummaries": [
+    {
+      "step": "explore",
+      "summary": "Walked the slice scenario via playwright-mcp and captured 4 screenshots at the key transitions"
+    },
+    {
+      "step": "author",
+      "summary": "Wrote spec at apps/web/e2e/issue-235.spec.ts with 3 expect assertions"
+    }
+  ]
+}
+```
+
+`specPath` must be workspace-relative (start with `apps/web/e2e/`). `screenshotsTaken` must be a non-negative integer. `decisionSummaries` requires at least one entry.
+
+[decision] Authored Playwright spec for slice and captured exploration evidence

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config, { SpecAuthorContextSchema } from './config.js';
+import { SpecAuthorSchema } from './schema.js';
+
+describe('spec-author schema', () => {
+  it('accepts a fully-populated valid output', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/issue-235.spec.ts',
+      planSummary:
+        'Exercises the new evidence panel: navigate to /projects/foo, open the issue detail view, expand the evidence section, assert the inline screenshot is visible.',
+      screenshotsTaken: 4,
+      decisionSummaries: [
+        {
+          step: 'explore',
+          summary: 'Walked the slice scenario via playwright-mcp and captured 4 screenshots',
+        },
+        {
+          step: 'author',
+          summary: 'Wrote spec at apps/web/e2e/issue-235.spec.ts with 3 expect assertions',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts zero screenshotsTaken (skill may use evaluate-only flow)', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/issue-99.spec.ts',
+      planSummary: 'Asserts API contract via page.evaluate; no visual capture.',
+      screenshotsTaken: 0,
+      decisionSummaries: [
+        { step: 'author', summary: 'Wrote API-contract spec without screenshots' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts decisionSummary with optional evidence field', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/issue-1.spec.ts',
+      planSummary: 'Spec.',
+      screenshotsTaken: 1,
+      decisionSummaries: [
+        { step: 'explore', summary: 'walked it', evidence: 'screenshot at /tmp/exp.png' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing specPath', () => {
+    const result = SpecAuthorSchema.safeParse({
+      planSummary: 'Some summary.',
+      screenshotsTaken: 2,
+      decisionSummaries: [{ step: 'a', summary: 'b' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing planSummary', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      screenshotsTaken: 2,
+      decisionSummaries: [{ step: 'a', summary: 'b' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative screenshotsTaken', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      planSummary: 'p',
+      screenshotsTaken: -1,
+      decisionSummaries: [{ step: 'a', summary: 'b' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer screenshotsTaken', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      planSummary: 'p',
+      screenshotsTaken: 2.5,
+      decisionSummaries: [{ step: 'a', summary: 'b' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    const result = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      planSummary: 'p',
+      screenshotsTaken: 0,
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects decisionSummary missing step or summary', () => {
+    const missingSummary = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      planSummary: 'p',
+      screenshotsTaken: 0,
+      decisionSummaries: [{ step: 'a' }],
+    });
+    expect(missingSummary.success).toBe(false);
+
+    const missingStep = SpecAuthorSchema.safeParse({
+      specPath: 'apps/web/e2e/x.spec.ts',
+      planSummary: 'p',
+      screenshotsTaken: 0,
+      decisionSummaries: [{ summary: 'b' }],
+    });
+    expect(missingStep.success).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(SpecAuthorSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+describe('spec-author skill config', () => {
+  it('has role developer (NOT a holdout)', () => {
+    expect(config.role).toBe('developer');
+  });
+
+  it('declares playwright-mcp tool bundle (per #235 acceptance criteria)', () => {
+    expect(config.toolBundles).toContain('playwright-mcp');
+  });
+
+  it('also declares read-write so it can write the spec file', () => {
+    expect(config.toolBundles).toContain('read-write');
+  });
+
+  it('is pinned to sonnet model', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('does not require fresh context (developer skills may use ambient context)', () => {
+    expect(config.freshContext).toBe(false);
+  });
+
+  it('has contextAllowlist defined and includes targetUrl + sliceDescription', () => {
+    expect(config.contextAllowlist).toBeDefined();
+    expect(config.contextAllowlist).toContain('targetUrl');
+    expect(config.contextAllowlist).toContain('sliceDescription');
+    expect(config.contextAllowlist).toContain('workItem.title');
+    expect(config.contextAllowlist).toContain('workItem.body');
+    expect(config.contextAllowlist).toContain('workItem.number');
+  });
+});
+
+describe('spec-author context schema', () => {
+  it('accepts valid context with all fields', () => {
+    const valid = SpecAuthorContextSchema.safeParse({
+      workItem: {
+        title: 'Add overview screenshots',
+        body: 'When I open the overview...',
+        number: 235,
+      },
+      targetUrl: 'http://localhost:5173/projects/goose-hub',
+      sliceDescription: 'Open the overview, see the inline screenshot from the linked PR.',
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('rejects missing targetUrl', () => {
+    const invalid = SpecAuthorContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      sliceDescription: 's',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects missing sliceDescription', () => {
+    const invalid = SpecAuthorContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      targetUrl: 'http://localhost:5173',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects missing workItem.number', () => {
+    const invalid = SpecAuthorContextSchema.safeParse({
+      workItem: { title: 't', body: 'b' },
+      targetUrl: 'http://localhost:5173',
+      sliceDescription: 's',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('rejects workItem.number as a string (must be number)', () => {
+    const invalid = SpecAuthorContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: '235' },
+      targetUrl: 'http://localhost:5173',
+      sliceDescription: 's',
+    });
+    expect(invalid.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the M7 testing-infrastructure skills (spec-author + evidence-post), the markdown rendering needed to surface their evidence in the overview, and the M8 prep doc that frames the three-tier verification model.

### Skills (M7)
- `skills/spec-author/` — authors Playwright e2e specs via the `playwright-test` MCP server (Microsoft's `apps/web/.mcp.json` server, repurposed as a Factory tool bundle)
- `skills/evidence-post/` — runs the slice's spec, captures screenshots + WebM walkthrough, commits to the PR branch, posts a SHA-pinned comment on the linked issue

### Plumbing
- `validate` and `playwright-mcp` tool bundles in `core/tool-layer/bundles.ts` (the `validate` reference in `skills/playwright-repro/config.ts:16` was previously dangling — `computeAllowlist` silently produced zero tools)
- `resolveMcpConfigPath()` in `core/agent-runtime/claude-cli.ts` — when `playwright-mcp` is in `toolBundles`, the runtime points `--mcp-config` at `apps/web/.mcp.json` in the workspace
- Markdown image rendering for trusted hosts in `apps/web/src/lib/markdown.ts` so screenshots posted by `evidence-post` appear inline in `OverviewSection` and `CommentsSection`

### Standards (M8 prep)
- `docs/standards/verification.md` — three-tier (Structural / Functional / Regression) framework, fix-or-register rule, 8-category code-quality rubric (≥ 70/100 threshold)
- Three new event kinds in `core/event-stream/store.ts`: `qa.structural-failed`, `qa.functional-failed`, `qa.regression-failed`
- Per FACTORY_RULES rule 12 (governance immutability), `FACTORY_RULES.md` is NOT modified — the standards doc lives under `docs/standards/`

### Out of scope
- #234 (wire `evidence-post` into `fix-issue.ts`) — deferred. The workflow file does not exist yet; #234 will land alongside #183.

## Test plan
- [x] `pnpm lint` clean (Biome)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 579 tests across 46 files passing
- [ ] Manual: spawn `spec-author` against a fixture page with `apps/web` dev server running; verify a runnable spec lands at `apps/web/e2e/issue-<N>.spec.ts`
- [ ] Manual: run `evidence-post` against a real PR + spec; verify SHA-pinned comment appears on the linked issue with images embedded
- [ ] Manual: post a `raw.githubusercontent.com` image in a comment via GitHub; verify it renders inline in the project overview

Closes #235
Closes #233
Closes #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWtsvudsztkFuNpjWj5ua6)_