### PR TITLE
M7-audit-followups: ADRs, README + PLAN, skill alias, M8 handoff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -350,6 +350,7 @@ improvement_candidate:
 
 ## Deferred / Open Questions (to resolve at their milestone)
 
+- **M8**: starting M8 work — read `docs/m8-handoff.md` first. Lists outstanding M7 follow-ups, the M8 issue picking order (#239–#249), recommended PR groupings, holdout-discipline reminders, and the still-required real-Claude chore-shipping demo for M7 close.
 - **M11**: `parseDependsOn` regex in `github-labels.ts` requires a colon (`depends on:`). Plan examples use `Depends on #42` (no colon). Tolerant parser spec says also accept `Depends-On`, `blocked by`. Fix before M11 dependency checks go live.
 - **M12**: Governance PR check CI wiring — how does `core/governance/pr-check.ts` get access to the PR diff and labels in GitHub Actions?
 - **Post-v0**: Claude CLI vs Claude Agent SDK — reference audit (#10) said "compare honestly." SDK lacks subprocess overhead and suits non-coding skills (triage, retro) better. Revisit when v0 ships.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,36 @@ See `docs/PLAN.md` for the full plan and milestone ladder.
 
 A Kanban-style board at `/projects/<slug>` shows all open issues grouped by factory state (backlog → in-progress → needs-qa → needs-review → done). Click any card to open the detail page, which shows the issue description, a state-transition panel (to manually advance or force-state an issue), and a timeline of events. Run the dev server with `pnpm --filter web dev`.
 
+The detail page also exposes:
+
+- **Investigation tab** (M6) — root-cause findings + key files + before-state Playwright captures for `type:bug` issues
+- **Code tab** (M7) — live worktree diff polled every 5 s while the dev workflow is running, plus per-step Playwright captures
+- **Approval gate** (M7) — when an issue reaches `factory:approved`, the gate banner shows Approve / Reject buttons (Approve merges the linked PR via the GitHub connector; Reject takes a required note and routes to `factory:needs-fix`)
+- **Markdown image rendering** in overview comments — screenshots posted by `evidence-post` from `raw.githubusercontent.com` / `github.com` / `user-images.githubusercontent.com` render inline
+
 ### CLI
 
-The `goose` CLI (built with `pnpm --filter cli build`, then `node apps/cli/dist/index.js`) has two commands:
+The `goose` CLI (built with `pnpm --filter cli build`, then `node apps/cli/dist/index.js`) has these commands:
 
 - `goose status <project-slug>` — prints open issues grouped by factory state for the given project, with the active milestone shown at the top.
 - `goose sweep <project-slug> <milestone-number>` — lists all non-terminal issues in the given milestone, prompts for confirmation, then bulk-archives them by forcing the `factory:archived` label.
-
 - `goose run-agent --skill=<name> --input='<json>' [--dry-run]` — runs a skill agent against the Claude CLI. `--dry-run` prints the assembled AgentSpec without spawning. Requires `ANTHROPIC_API_KEY`.
 
 Both `status` and `sweep` require `GITHUB_TOKEN` set in the environment or a `.env` file.
+
+### Workflows (orchestrator)
+
+End-to-end workflows live in `slices/<name>/workflow.ts` and are dispatched by webhook label flips via `apps/server/src/shared/dispatch.ts`:
+
+- **`triage-batch`** (M5) — picks up `factory:triaging` issues, runs the triage + repo-match skills, applies type/priority labels, transitions to `factory:accepted`.
+- **`investigate`** (M6) — picks up `factory:investigating` issues, runs the investigate skill (with playwright-repro for `type:bug`), records findings, transitions to `factory:investigation-complete`.
+- **`fix-issue`** (M7) — picks up `factory:dev-ready` issues, creates a worktree, runs the advisor for `priority:high|critical`, runs the implement skill (TDD-first), opens a PR via the GitHub connector, runs `evidence-post` (best-effort), transitions to `factory:approved` for the human gate.
+
+### Skills (`@goose-hub/skills`)
+
+Versioned markdown prompts + Zod schemas under `skills/<name>/`. Current set: `triage`, `repo-match`, `investigate`, `playwright-repro`, `spec-author`, `evidence-post`, `implement`, `advise-on-plan`. Each ships with `slice.test.ts`, `eval/eval.json`, and `README.md`. Skills follow the channel-split convention from CONTEXT.md: `skill.md` is the system prompt, per-run context is rendered as XML in the user message.
+
+### Standards & ADRs
+
+- `docs/standards/verification.md` — the three-tier (Structural / Functional / Regression) verification framework + 8-category code-quality rubric (≥ 70/100 threshold). Ships ahead of the M8 QA holdout.
+- `docs/adr/` — architectural decisions in chronological order. M7 added ADR 0011 (Playwright agents), 0012 (advisor wrapping + per-step typed timeouts), 0013 (GitHub connectors + fix-issue workflow shape).

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -202,20 +202,27 @@ goose-hub/
 │       ├── FACTORY_RULES.md
 │       ├── project.config.ts
 │       └── personas/
-├── skills/                              # composable skill packages (M5+)
+├── skills/                              # composable skill packages (M5+, @goose-hub/skills workspace pkg)
+│   ├── package.json                     # exports: { "./*": "./*" }
 │   ├── triage/
-│   │   ├── skill.config.ts
-│   │   ├── prompt.md
-│   │   ├── schema.ts
-│   │   ├── examples/
-│   │   └── README.md
+│   │   ├── config.ts                    # SkillConfig (toolBundles, modelPin, freshContext, role, contextSchema)
+│   │   ├── skill.md                     # versioned system prompt; ends with [decision] footer
+│   │   ├── schema.ts                    # Zod output schema
+│   │   ├── slice.test.ts                # always required
+│   │   ├── eval/eval.json               # at least one eval case
+│   │   └── README.md                    # always required
 │   └── ...
-├── slices/                              # orchestrator workflow slices (M5+)
+├── slices/                              # named orchestrator workflow slices (M5+)
+│   │                                    # Each slice is one workflow; named by what it does (NOT numbered).
 │   │                                    # NOT UI component slices — those live in apps/web/src/components/
-│   ├── 0001-cli-status/
-│   │   ├── slice.config.ts
-│   │   ├── api.ts                       # only files that exist for this slice
+│   ├── investigate/                     # M6 (#197)
+│   │   ├── workflow.ts                  # exports runInvestigateWorkflow(item, source, projectId, repo)
+│   │   ├── slice.test.ts                # always required
+│   │   └── README.md                    # always required
+│   ├── fix-issue/                       # M7 supervised dev (#183)
+│   │   ├── workflow.ts                  # exports runFixIssueWorkflow(item, source, projectId, repo, deps?)
 │   │   ├── slice.test.ts
+│   │   ├── chore-shipping.test.ts       # full state-machine integration test (#187)
 │   │   └── README.md
 │   └── ...
 ├── core/                                # @goose-hub/core workspace package
@@ -239,9 +246,11 @@ goose-hub/
 │   │   └── migrate.ts
 │   ├── orchestrator/                    # M5+
 │   │   ├── tick.ts
-│   │   ├── workflows/
 │   │   ├── locks.ts
 │   │   └── scheduler.ts
+│   │                                    # NOTE: workflow modules live in /slices/<name>/workflow.ts,
+│   │                                    # NOT under core/orchestrator/workflows/. The orchestrator
+│   │                                    # tick dispatches to slice workflows via apps/server/src/shared/dispatch.ts.
 │   ├── agent-runtime/                   # M4+
 │   │   ├── interface.ts
 │   │   ├── claude-cli.ts
@@ -266,6 +275,9 @@ goose-hub/
 │   ├── retrospective/                   # M9+
 │   ├── bootstrap/
 │   └── connectors/
+│       └── github/                      # M7+ (#184/#186)
+│           ├── open-pr.ts
+│           └── merge-pr.ts
 ├── apps/
 │   ├── cli/                             # `goose status`, `goose tick`, etc.
 │   │   └── src/index.ts

--- a/docs/adr/0012-advisor-wrapping-and-typed-timeouts.md
+++ b/docs/adr/0012-advisor-wrapping-and-typed-timeouts.md
@@ -1,0 +1,81 @@
+# ADR 0012 — Advisor wrapping and per-step typed-timeout scaffolding (M7)
+
+Status: accepted
+Date: 2026-05-03
+Closes part of: M7 (#182, #219)
+
+## Context
+
+Two infrastructure patterns landed in M7 to support the supervised dev workflow (#183 / `slices/fix-issue/workflow.ts`):
+
+- **(A) Advisor wrapping.** `skills/advise-on-plan/` (#181) defines the canonical advisor verdict (`proceed | revise | abort`) per CONTEXT.md "Advisor Flow". The orchestrator needed a thin wrapper that constructs the spec, validates the typed output, emits per-summary `agent.decision-summary` events, and surfaces parse failures as `agent.run-failed`. That is `core/agent-runtime/advisor.ts`.
+- **(B) Per-step typed timeouts.** Multi-step lifecycle work (worktree create, hook exec, agent spawn, agent idle, tool call) needed a uniform way to cap each step with a typed error so callers can pattern-match on the failure mode. Reference inspiration: `@ai-hero/sandcastle` `docs/adr/0001-per-step-timeouts.md` (Effect-based; Goose Hub adopts the shape, not the dependency). That is `core/agent-runtime/with-timeout.ts`.
+
+Both pieces are foundational — they shape every M7+ workflow that touches Claude. Recording the design here so #183's heir (M8 `run-qa.ts`, `run-review.ts`) doesn't re-derive the contract from the call sites.
+
+## Decisions
+
+### 1. `adviseOnPlan(input)` is a thin wrapper, not a class
+
+A function, not a class — there's no per-instance state. The wrapper:
+
+- Reads the skill's `config.ts` (`toolBundles`, `contextAllowlist`, `freshContext`, `role`) and constructs the `AgentSpec` from those values plus the caller's `runId` / `projectId` / `workItem` / `plan` / optional `revisionPass` + `previousAdvisorFeedback`.
+- Hard-fails (throws) if the work-item priority is not `high` or `critical`. The advisor is gated to those two priorities (FACTORY_RULES rule 22); a caller passing `medium` is a bug, not a runtime concern.
+- Validates `result.output` against the canonical Zod `AdviseOnPlanSchema`. Parse failure: emits `agent.run-failed` and throws.
+- Emits one `agent.decision-summary` event per entry in `parsed.data.decisionSummaries`, with `skill: 'advise-on-plan'` in the payload (#206 pattern).
+- Accepts a `runtime: AgentRuntime` override so tests can stub the spawn without mocking module imports.
+
+### 2. `revisionPass` discipline lives in the workflow, not the wrapper
+
+The wrapper is a single-spawn primitive. The state-machine table in CONTEXT.md ("Advisor Flow", §"State-machine table") — pass 0 / pass 1 / abort handling — is implemented by `slices/fix-issue/workflow.ts`. The wrapper accepts `revisionPass: 0 | 1` and `previousAdvisorFeedback?: string` and forwards them into the spec context, but it doesn't enforce the maximum-one-revise rule. That belongs at the orchestration layer where the developer re-spawn happens.
+
+### 3. `withTimeout(promise, options)` is promise-only — does NOT kill subprocesses
+
+The helper races a wrapped promise against a timer and rejects with a typed error from `errorFactory()` if the timer wins. It deliberately does not own subprocess cleanup:
+
+- Promise-only is composable. Wrapping any awaited work is one line.
+- Subprocess cleanup is caller-specific (`ClaudeCliRuntime` already captures the child handle in closure and calls `.kill('SIGKILL')` on its own internal timeout).
+- Mixing promise timeouts with process-cleanup responsibilities would force every caller to pass a "kill function" — verbose for the common case (no subprocess) and brittle for the spawn case.
+
+The header comment in `with-timeout.ts` makes this explicit so future callers don't assume cleanup is handled.
+
+### 4. AbortSignal beats timeout
+
+When `options.signal` aborts before the timer fires, the wrapping promise rejects with `signal.reason` — NOT the typed timeout error. Rationale: an explicit cancellation cause is more informative than an opportunistic timeout at the same instant. Loss of the timeout signal is acceptable because the signal carries strictly more information.
+
+### 5. Defaults table is internal — not configurable from skill prompts
+
+`DEFAULT_TIMEOUTS` exposes the per-step defaults (worktree 10 s, hook 5 s, spawn 60 s, idle 60 s, tool 30 s). These are NOT user-configurable from skill prompts because:
+
+- Skill authors don't have visibility into orchestrator-level concerns (subprocess spawn time, hook RTT).
+- Letting prompts adjust timeouts gives an LLM a knob to wave through hangs as legitimate work.
+- The numbers are tuned against FACTORY_RULES rule 32 (30 s tool-call cap) and Anthropic's typical agent latency. Per-call override is allowed via `withTimeout({ timeoutMs })` from the caller side.
+
+### 6. Typed errors carry `_tag` and `context`, not just `name`
+
+Each subclass (`WorktreeCreateTimeoutError`, `HookExecTimeoutError`, etc.) inherits `LifecycleTimeoutError` and exposes:
+
+- `_tag: LifecycleStepTag` — the discriminator. Pattern-matchable in TypeScript without `instanceof`.
+- `timeoutMs: number` — the envelope value, for diagnostic surfaces.
+- `context: Record<string, unknown>` — free-form per-call context (e.g. `{ runId, skill }`) so error reports carry the WHAT, not just the WHICH.
+
+Equivalent to Effect's `Data.TaggedError` discipline without depending on Effect.
+
+### 7. Synchronous lifecycle paths are NOT retrofitted in this PR
+
+`createWorktree` (`core/workspaces/worktree.ts`) uses `execFileSync` and runs synchronously. Wrapping it in `withTimeout` would require converting it to async and rewriting all callers. That retrofit is intentionally out of scope — the primitives land first, the retrofit follows when the synchronous-call path becomes a problem (it hasn't yet; M7 created precisely one worktree per workflow run).
+
+## Consequences
+
+- New runtime surfaces under `core/agent-runtime/` — `advisor.ts` and `with-timeout.ts`.
+- M8 `run-qa.ts` and `run-review.ts` should follow the same pattern: a thin wrapper that constructs the spec from the skill's `config.ts`, validates the output, emits per-summary events. The spawn is delegated to the runtime.
+- The 5 typed timeout errors in `DEFAULT_TIMEOUTS` cover the lifecycle steps in `slices/fix-issue/workflow.ts` today. New steps (e.g. `BootDevServerTimeout` for `evidence-post`) get a new subclass and a new entry in the table.
+- Skill authors do not see `withTimeout` — it's runtime-side. Skill authors do see `adviseOnPlan` only via the workflow, not directly.
+
+## References
+
+- CONTEXT.md "Advisor Flow" — canonical verdict union and state-machine table
+- FACTORY_RULES rules 21 (max one revise pass), 22 (advisor disabled in autonomous by default), 32 (30 s tool-call cap)
+- `@ai-hero/sandcastle` `docs/adr/0001-per-step-timeouts.md` — pattern reference for the typed-timeout shape
+- `core/agent-runtime/advisor.ts` and `core/agent-runtime/with-timeout.ts`
+- `slices/fix-issue/workflow.ts` (consumer)

--- a/docs/adr/0013-github-connectors-and-fix-issue-workflow.md
+++ b/docs/adr/0013-github-connectors-and-fix-issue-workflow.md
@@ -1,0 +1,117 @@
+# ADR 0013 — GitHub connectors and fix-issue workflow shape (M7)
+
+Status: accepted
+Date: 2026-05-03
+Closes part of: M7 (#183, #184, #186, #234)
+
+## Context
+
+The M7 milestone introduced two GitHub-side connectors and the orchestration glue that composes them into the supervised dev workflow:
+
+- **`core/connectors/github/open-pr.ts` (#184)** — pushes a worktree HEAD to a feature branch and opens a PR via the REST API.
+- **`core/connectors/github/merge-pr.ts` (#186)** — merges a PR via the REST API for the human-approval gate.
+- **`slices/fix-issue/workflow.ts` (#183 + #234)** — the full M7 supervised dev state machine: `factory:dev-ready` → worktree → optional advisor → implement → openPR → evidence-post (best-effort) → `factory:approved`.
+
+This ADR records the shaping decisions so M8 (`run-qa`, `run-review`, fix-issue workflow update for QA/Review insertion per #244) and later milestones (M9 retro, M11 multi-issue scheduling) can compose against the same shape without re-litigating it.
+
+## Decisions
+
+### 1. Connectors are stateless functions, not classes
+
+Both `openPR` and `mergePR` are exported functions taking an input record and returning a result record. Reasons:
+
+- No per-instance state to manage (the GitHub token is per-call).
+- Mocking in tests is trivial — pass `fetchImpl` (and for openPR, `gitExec`) overrides; no module-level mocks needed.
+- Each connector is a standalone module; composition happens at the workflow layer.
+
+The existing `GitHubLabelsSource` class predates this convention and stays as-is — it carries auth state and is consumed via the `StateSource` interface. New per-call connectors follow the function pattern.
+
+### 2. PR body is contract-validated; PR title is not
+
+`validatePrBody(body, issueNumber)` enforces:
+
+- `Closes #N` on its own line (anchored regex `/^Closes #(\d+)$/m`).
+- The N matches the supplied `issueNumber`.
+
+PR title is constrained only to length (1–70 chars). The CLAUDE.md `M<milestone>.<task>: <description>` format is enforced by the **caller** (the workflow), not the connector — the connector doesn't know the milestone name.
+
+The body validation is critical: a missing `Closes #N` means GitHub doesn't auto-close the issue on merge, which silently breaks the milestone-completion path. The body is also the boundary that QA/Review holdouts see — implementation reasoning must NOT appear there (FACTORY_RULES rule 1). The connector cannot enforce "no reasoning" mechanically; the workflow's `buildPrBody` constructs a thin summary (files written, tests written, `Closes #N`) and the chore-shipping integration test asserts no reasoning leaks.
+
+### 3. `--force-with-lease` on push, not `--force`
+
+`openPR` pushes the worktree HEAD to a feature branch via `git push --force-with-lease origin HEAD:refs/heads/<branchName>`. Reasons:
+
+- Workflow retry replays the same logical change to the same branch (`factory/<runId>`). Forcing without lease would clobber concurrent upstream commits.
+- `--force-with-lease` aborts if the remote ref has moved unexpectedly — refusing to clobber surprises.
+- Plain `git push` would fail on retry once the branch exists.
+
+The branch name is `factory/<runId>` (one branch per workflow run). UUID-based names avoid collisions; a future M11+ scheduler may want a more human-readable scheme but that's a follow-up.
+
+### 4. Merge method default is `merge`, not `squash`
+
+`mergePR` defaults `mergeMethod: 'merge'`. Squash and rebase are exposed for future use. The `merge` default matches:
+
+- Manual PRs in this repo's history (PR #237, #238, #250 are all merge commits).
+- The default `gh pr merge` setting.
+- A merge commit preserves the per-issue commit history so `git log core/agent-runtime/models.ts` (CONTEXT.md "Pin, not float") works for forensics.
+
+### 5. Workflow uses dependency injection for testability — not for production swap-out
+
+`runFixIssueWorkflow(workItem, source, projectId, repo, deps)` accepts a `deps` parameter:
+
+```ts
+{
+  runtime?: AgentRuntime;
+  openPRImpl?: typeof openPR;
+  adviseOnPlanImpl?: typeof adviseOnPlan;
+  createWorktreeImpl?: typeof createWorktree;
+  cleanupWorktreeImpl?: typeof cleanupWorktree;
+}
+```
+
+All defaults route to the real implementations. The DI surface exists exclusively so the slice test can exercise the full state machine without spawning agents or calling GitHub. Production callers always pass `{}`.
+
+This is deliberately NOT a generic plugin point. If a future workflow needs to swap (say) the OpenPR implementation for a non-GitHub Git host, the right move is a new connector module + a new workflow, not a runtime-pluggable workflow. Workflows are read-once-per-run; predictability beats flexibility.
+
+### 6. evidence-post wiring is best-effort, never blocking
+
+`runEvidencePost` runs after PR open, before the `factory:approved` transition. Three outcomes are emitted as events:
+
+- **`evidence.posted`** — success; payload includes `commentUrl`.
+- **`evidence.post-failed`** — caught error; workflow continues to `factory:approved`.
+- **`evidence.no-spec-declared`** — `evidenceSpecPath` was null; workflow logs and skips.
+
+A failing evidence post does NOT roll back the PR or fail the workflow. Rationale: evidence is observability for the human reviewer, not a correctness requirement. Blocking the gate on a flaky video capture would be a worse failure mode than missing screenshots. The `evidence.post-failed` event surfaces the issue for retro / manual investigation.
+
+### 7. Approval gate is UI-only
+
+The `/approve` and `/reject` routes (`apps/server/src/domains/issues/router.ts`) are NOT in `apps/server/src/shared/dispatch.ts` and NOT triggered by webhook label flips. Only the UI invokes them. Reasons:
+
+- Approval is a categorical human decision. Letting an agent or webhook trigger it would defeat the gate's purpose.
+- The label change `factory:approved → factory:done` is the side effect of approval, NOT the trigger. A webhook on `factory:done` wouldn't make sense.
+- Single-user local-first tool — no need for multi-actor approval ceremony.
+
+Future M16 autonomous mode will define how `factory:approved → factory:done` happens without UI; until then, the human is the gate.
+
+### 8. No state-source coupling in the connector layer
+
+`openPR` does NOT call `transitionState`. `mergePR` does NOT call `transitionState`. The workflow (`fix-issue.ts`) and the gate service (`approveIssue`) are responsible for state transitions. The connector is a pure REST primitive.
+
+This decoupling matters for testability and for future reuse — if a non-fix-issue workflow wants to open a PR (e.g., M9 improvement-candidate auto-PR), it shouldn't get the M7 state transitions for free.
+
+## Consequences
+
+- New module tree under `core/connectors/github/`. Future Git-host connectors (GitLab, Gitea) get sibling directories.
+- M8 `run-qa.ts` will sit between `pr.opened` and `factory:approved`. It consumes the same `pr.opened` event that triggers the M7 path; the workflow update (#244) replaces `factory:approved` with `factory:needs-qa` after PR open.
+- The chore-shipping integration test (`slices/fix-issue/chore-shipping.test.ts`) is the regression net for the workflow shape. Subsequent workflows (`run-qa`, `run-review`) should follow the same four-layer test pyramid: workflow integration test + per-skill slice test + connector test + UI test.
+- The M8 fix-issue update (#244) only changes one transition target — the rest of the workflow (advisor, implement, openPR, evidence-post) stays intact.
+
+## References
+
+- FACTORY_RULES rules 1 (holdouts never see reasoning), 9 (state labels live on issues), 26 (workflows in TS not YAML)
+- CLAUDE.md "PR conventions"
+- CONTEXT.md "Gate Mechanics" — UI vs. label-edit equivalence
+- `core/connectors/github/open-pr.ts`, `core/connectors/github/merge-pr.ts`
+- `slices/fix-issue/workflow.ts`, `slices/fix-issue/README.md`, `slices/fix-issue/chore-shipping.test.ts`
+- `apps/server/src/domains/issues/service.ts` (`approveIssue`, `rejectIssue`)
+- `apps/web/src/components/detail/components/ApprovalGateSection.tsx`

--- a/docs/m8-handoff.md
+++ b/docs/m8-handoff.md
@@ -1,0 +1,99 @@
+# M8 handoff — for the next Claude session
+
+This doc is the entry point when you start work on M8 ("QA and Review Holdouts"). Read it before touching any M8 issue.
+
+## State as of M7 close
+
+**Active milestone (per `CLAUDE.md`):** still says `M5: Real Triage and Repo Matching` — that line is stale. The human needs to update it to `M8: QA and Review Holdouts`. Until they do, the `gh issue list --milestone "M8: QA and Review Holdouts"` query is the source of truth.
+
+**M7 status:** all 22 M7 issues shipped and merged across PRs #237, #238, #250. Three follow-up items from the M7 exit audit are addressed in the same PR as this handoff: ADRs 0012/0013 written, README updated, slice imports migrated to `@goose-hub/skills/*` alias, PLAN §6 updated to reflect actual workflow placement.
+
+**M7 audit verdict:** `KEEP-OPEN`. The single hard-fail is Check 2 (headline exit criterion not yet demonstrated). The chore-shipping path is wired and tested with mocked deps; a real Claude-driven run on a `type:chore` issue still needs to be performed by a human before M7 can be closed. The follow-up is filed as `M7.exit: real chore-shipping demo run`.
+
+## What M8 is
+
+PLAN §28 M8 in one sentence: **sequential QA → Review runs after the developer opens a PR, both as holdouts (fresh context, no implementation reasoning), gating `factory:approved`.**
+
+Read these in order before starting M8 work:
+1. `CLAUDE.md` — agent rules, especially holdout discipline
+2. `docs/PLAN.md` §28 M8 — full scope + exit criteria
+3. `docs/standards/verification.md` — three-tier framework + 8-category rubric (this is what `skills/qa/` implements)
+4. `CONTEXT.md` "Context Assembly and Holdout Enforcement" — the contract `skills/qa/` and `skills/review/` must satisfy
+5. `docs/adr/0012-advisor-wrapping-and-typed-timeouts.md` — pattern `run-qa.ts` and `run-review.ts` should follow
+6. `docs/adr/0013-github-connectors-and-fix-issue-workflow.md` — the workflow shape M8 extends (#244)
+
+## Issue picking order (filed and ready)
+
+The CLAUDE.md "lowest schedule:current with no unmet open deps" algorithm picks them in this order. They're all currently `schedule:next` — the human flips to `schedule:current` when M8 starts.
+
+1. **#239** `skills/qa/` — full QA holdout skill
+2. **#240** `skills/review/` — full Review holdout skill (depends on #239)
+3. **#241** Holdout enforcement at runtime layer (`contextAllowlist` + `freshContext`) — independent
+4. **#242** `run-qa` workflow (depends on #239 + #241)
+5. **#243** `run-review` workflow (depends on #240 + #241 + #242)
+6. **#244** Update `fix-issue` to transition to `factory:needs-qa` instead of `factory:approved` (depends on #242)
+7. **#245** Retry-and-escalate for `factory:qa-failed` / `factory:needs-fix` (depends on #242 + #243)
+8. **#246** Fallback policy: no down-tier on holdouts (depends on #241)
+9. **#247** QA tab UI (depends on #242 + #239)
+10. **#248** Review tab UI (depends on #243 + #240)
+11. **#249** Holdout boundary test — adversarial `tool.violation` proof (depends on #241 + #242 + #243)
+
+Recommended grouping for PR efficiency (mirrors how M7 was shipped):
+- **PR A (foundation):** #241 (runtime), #239 (QA skill), #240 (Review skill), #246 (fallback policy)
+- **PR B (workflow chain):** #242 (run-qa), #243 (run-review), #244 (fix-issue update), #245 (retry), #249 (boundary test)
+- **PR C (UI):** #247, #248
+
+## What you must NOT do
+
+- **Modify governance files.** `MISSION.md`, `FACTORY_RULES.md`, `CLAUDE.md`, `target-projects/**`. The active-milestone line in `CLAUDE.md` is stale; recommend the human update it but do not edit it yourself (FACTORY_RULES rule 12).
+- **Bypass holdout discipline.** If you find yourself wanting to pass `decisionSummaries` to a QA spec for "convenience," stop — that defeats the entire M8 purpose (FACTORY_RULES rule 1, CONTEXT.md "Context Assembly").
+- **Run advisor on QA or Review.** FACTORY_RULES rule 20. Holdouts are unconditionally non-advised.
+- **Down-tier fallback on holdouts.** FACTORY_RULES rule 23. On primary failure, escalate to `factory:needs-human`. #246 enforces this.
+- **Create new heavyweight dependencies.** No vector DB, no embedding service. Reuse existing `core/` primitives.
+- **Skip the slice-test discipline.** Every new slice ships with `slice.test.ts` + `README.md`.
+
+## Patterns from M7 that M8 should follow
+
+- **Workflow shape:** copy `slices/fix-issue/workflow.ts` as the structural template. Same DI parameter for `runtime`/`adviseOnPlanImpl`/etc., same try/catch around the lifecycle, same `agent.decision-summary` per-summary emission via the `agent-runtime/advisor.ts` pattern.
+- **Skill imports use the workspace alias:** `@goose-hub/skills/<name>/schema.js` (NOT `../../skills/<name>/schema.js`). The tsconfig path is set up.
+- **Connector decoupling:** new connectors live in `core/connectors/<provider>/`. They are stateless functions, do not call `transitionState` themselves.
+- **Event kinds:** add new kinds to `core/event-stream/store.ts` `EventKind` union, then write a round-trip test in `core/event-stream/store.test.ts`.
+- **Standards doc as contract:** `docs/standards/verification.md` defines the three tiers and the 8-category rubric. `skills/qa/` implements it. New standards docs go under `docs/standards/`.
+
+## Risks specific to M8
+
+1. **`docs/standards/verification.md` was written without QA in hand.** When implementing `skills/qa/`, you may discover the doc is wrong about the cost profile, the rubric weights, or the tier sequencing. Update the doc as part of #239's PR if so. The doc is mutable.
+2. **Holdout fresh-context test (#249) is adversarial.** You're asserting that the runtime drops `devDecisionSummaries` from the rendered XML even when the caller tries to inject it. The current `assembleSpawnContext` (`core/agent-runtime/context-assembly.ts`) filters by `contextAllowlist` — confirm that's airtight before calling #249 done.
+3. **Workflow update #244 is a one-line transition target change** but `slices/fix-issue/chore-shipping.test.ts` asserts the transition order. Update both.
+4. **Retry counter (#245) needs a storage location.** Per the issue body, `project_state` or `agent_runs`. Pick one in the PR, document in the README.
+
+## Manual M7 demo still required
+
+Before M8 closes (or before M7 closes per the audit), a real Claude-driven `fix-issue` run on a `type:chore` issue must land a merged PR. The recipe:
+
+1. Set `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in `.env`.
+2. Pick or file a small `type:chore` issue (e.g. "rename a constant in `core/utils/`").
+3. Label it `factory:dev-ready`.
+4. Trigger the workflow via webhook (label flip) or directly: `pnpm tsx -e "import { runFixIssueWorkflow } from './slices/fix-issue/workflow.js'; …"`.
+5. Watch the timeline for `pr.opened`, `agent.implement-complete`, `evidence.posted` (or `evidence.no-spec-declared`).
+6. Open the PR in GitHub, click Approve in the gate UI, confirm `pr.merged` event.
+7. Attach the merged PR URL + the timeline events to issue `M7.exit: real chore-shipping demo run` as evidence.
+
+## Outstanding M7 follow-ups (filed but not done)
+
+- **M7.exit:** real chore-shipping demo run (above)
+- **M7.adr:** ADRs 0012 + 0013 (✅ done in this PR)
+- **M7.docs:** README + PLAN §6 updates (✅ done in this PR)
+- **M7.skills-alias:** slice imports via `@goose-hub/skills/*` (✅ done in this PR)
+
+## When M8 issues are exhausted
+
+Run the exit audit per `docs/exit-audit.md`. Generic checks plus PLAN §28 M8 specific criteria:
+
+- "QA + Review run sequentially after Dev"
+- "Holdout enforcement test passes" (this is #249)
+- "Fallback policy enforced: no down-tier on holdouts"
+- "Retry logic: factory:qa-failed and factory:needs-fix count toward maxRetries; fix runs are fresh-context"
+- "deliberately-broken implementation cycles needs-fix twice then ends in factory:needs-human"
+
+The audit is strict on Checks 1, 2, 5, 6, 9, 12 — those are hard exits. The others (Check 7 ADR coverage, Check 11 README freshness) are FOLLOW-UP-NEEDED at worst. Run them mechanically; the format is in `docs/exit-audit.md`.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@goose-hub/core": "workspace:*",
+    "@goose-hub/skills": "workspace:*",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@goose-hub/core':
+        specifier: workspace:*
+        version: link:core
+      '@goose-hub/skills':
+        specifier: workspace:*
+        version: link:skills
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -9,8 +9,8 @@ import { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { cleanupWorktree, createWorktree } from '@goose-hub/core/workspaces/worktree.js';
-import { EvidencePostSchema } from '../../skills/evidence-post/schema.js';
-import { ImplementSchema } from '../../skills/implement/schema.js';
+import { EvidencePostSchema } from '@goose-hub/skills/evidence-post/schema.js';
+import { ImplementSchema } from '@goose-hub/skills/implement/schema.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -6,8 +6,8 @@ import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { cleanupWorktree, createWorktree } from '@goose-hub/core/workspaces/worktree.js';
-import { InvestigateSchema } from '../../skills/investigate/schema.js';
-import { PlaywrightReproSchema } from '../../skills/playwright-repro/schema.js';
+import { InvestigateSchema } from '@goose-hub/skills/investigate/schema.js';
+import { PlaywrightReproSchema } from '@goose-hub/skills/playwright-repro/schema.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@goose-hub/core/*": ["./core/*"]
+      "@goose-hub/core/*": ["./core/*"],
+      "@goose-hub/skills/*": ["./skills/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

Addresses the four FOLLOW-UP-NEEDED items from the M7 exit audit and prepares the M8 handoff for the next Claude session.

| Audit check | Action |
|---|---|
| **Check 4** — slices import via package alias | tsconfig path + root deps + rewrites in `slices/{fix-issue,investigate}/workflow.ts` from `../../skills/...` → `@goose-hub/skills/...` |
| **Check 7** — ADRs for M7 `core/` surfaces | New `docs/adr/0012-advisor-wrapping-and-typed-timeouts.md` and `docs/adr/0013-github-connectors-and-fix-issue-workflow.md` |
| **Check 10** — PLAN §6 reflects actual layout | Updated to show workflows under `slices/<name>/workflow.ts` (not `core/orchestrator/workflows/`), `@goose-hub/skills` workspace package, full per-skill file list, `core/connectors/github/` |
| **Check 11** — README current with M7 capabilities | Code tab live diff, approval gate, markdown image rendering, three workflows, `@goose-hub/skills` set, ADR pointers |

## M8 handoff

`docs/m8-handoff.md` — entry-point doc for the next Claude session. Covers:

- M7 status (audit verdict KEEP-OPEN until real chore-shipping run)
- M8 reading order (CLAUDE.md → PLAN §28 M8 → verification.md → CONTEXT.md holdouts → ADRs 0012/0013)
- Issue picking sequence #239–#249 with dependency chain
- Recommended PR groupings (foundation / workflow chain / UI)
- Don't-do list (governance, holdout discipline, advisor on QA, downtier on holdouts, heavyweight deps)
- M7 patterns to follow in M8
- M8-specific risks (verification.md may need updating, #249 adversarial test, #244 transition target, #245 retry storage)
- Recipe for the still-required M7 chore-shipping demo

`CONTEXT.md` "Deferred / Open Questions" gets an M8 entry pointing at `docs/m8-handoff.md`.

## CLAUDE.md note (out of scope per FACTORY_RULES rule 12)

`CLAUDE.md` "Starting the next issue" still references `M5: Real Triage and Repo Matching` — that line is stale and should read `M8: QA and Review Holdouts`. Per FACTORY_RULES rule 12, this PR cannot modify governance files. The handoff doc reminds the human to flip it before the next session starts.

## Test plan

- [x] `pnpm install --frozen-lockfile`-equivalent resolves the new root deps
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 735 tests across 57 files passing (slice imports via the alias work at runtime)
- [ ] Manual: confirm next-session Claude reads `docs/m8-handoff.md` and proceeds from #239


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWtsvudsztkFuNpjWj5ua6)_