### PR TITLE
chore(claude.md): advance active milestone marker to M8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Before touching any file in an app, read its `README.md` first. The README will 
 
 When prompted with "start the next issue" (or similar), resolve the issue to work on as follows:
 
-1. Run: `gh issue list --milestone "M5: Real Triage and Repo Matching" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
+1. Run: `gh issue list --milestone "M8: QA and Review Holdouts" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
 2. Skip any issue already labeled `factory:in-progress`.
 3. For each remaining issue in ascending number order, check its body for `Depends on #N` lines. Fetch each referenced issue number with `gh issue view <N> --json state` and skip this issue if any dependency is still open.
 4. Pick the lowest-numbered issue that passes the dependency check.


### PR DESCRIPTION
## Summary

Single-line update to `CLAUDE.md` "Starting the next issue" runbook so the next Claude session's `gh issue list` query returns the M8 backlog (#239–#249) instead of the now-empty M5 result.

## Context

- M7 milestone shipped via PRs #237, #238, #250.
- M7 audit follow-ups shipped via PR #251 (ADRs 0012/0013, README, PLAN §6, slice alias, M8 handoff doc).
- `docs/m8-handoff.md` already documents the M8 reading order and issue picking sequence.

## Note on FACTORY_RULES rule 12

Governance files are flagged as immutable to Factory PRs. This edit was made at explicit human direction in the session. Recording for review: clarify whether "human-directed governance edits via the assistant" is permitted, or whether all governance edits should be direct-push only. The CLAUDE.md line itself (`Update the milestone name as the active milestone advances`) implies the file is intended to be advanced, just not unilaterally by an agent.

## Test plan

- [x] Single-character change in a comment-like position; no test impact
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` unchanged from prior PR (735 / 57 files)
- [ ] Next session: `gh issue list --milestone "M8: QA and Review Holdouts" --label "schedule:current"` returns the M8 backlog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWtsvudsztkFuNpjWj5ua6)_