### PR TITLE
fix(fix-issue): resolve real worktree HEAD SHA for evidence-post

### DIFF
--- a/docs/m8-handoff.md
+++ b/docs/m8-handoff.md
@@ -82,9 +82,11 @@ Before M8 closes (or before M7 closes per the audit), a real Claude-driven `fix-
 ## Outstanding M7 follow-ups (filed but not done)
 
 - **M7.exit:** real chore-shipping demo run (above)
-- **M7.adr:** ADRs 0012 + 0013 (✅ done in this PR)
-- **M7.docs:** README + PLAN §6 updates (✅ done in this PR)
-- **M7.skills-alias:** slice imports via `@goose-hub/skills/*` (✅ done in this PR)
+- **M7.adr:** ADRs 0012 + 0013 (✅ done in PR #251)
+- **M7.docs:** README + PLAN §6 updates (✅ done in PR #251)
+- **M7.skills-alias:** slice imports via `@goose-hub/skills/*` (✅ done in PR #251)
+- **M7.bug:** `prHeadSha` placeholder in `slices/fix-issue/workflow.ts` — actual SHA from `git rev-parse HEAD` (✅ done in PR #253)
+- **CLAUDE.md milestone marker:** flipped M5 → M8 (✅ done in PR #252)
 
 ## When M8 issues are exhausted
 

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -8,9 +8,10 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
   selectPersona: vi.fn().mockReturnValue('proj/developer/0'),
 }));
-vi.mock('node:fs', () => ({
-  readFileSync: vi.fn().mockReturnValue('# mock skill prompt'),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock skill prompt') };
+});
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 
@@ -342,5 +343,71 @@ describe('runFixIssueWorkflow (#183)', () => {
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'agent.implement-complete');
     expect(completeEvent).toBeDefined();
+  });
+});
+
+describe('resolveWorktreeHeadSha (M7.bug fix — #233 SHA pinning)', () => {
+  it('returns the real HEAD SHA from a git repo', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const dir = mkdtempSync(join(tmpdir(), 'wt-sha-'));
+    try {
+      // Run all git commands in this throwaway fixture repo with global +
+      // system config disabled so the host's commit-signing setup doesn't
+      // bleed in. Signing is off; user identity is set per-call via
+      // -c flags.
+      const isolatedEnv = {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_SYSTEM: '/dev/null',
+      };
+      execFileSync('git', ['init', '-q'], { cwd: dir, env: isolatedEnv });
+      execFileSync(
+        'git',
+        [
+          '-c',
+          'commit.gpgsign=false',
+          '-c',
+          'user.email=test@example.com',
+          '-c',
+          'user.name=Test',
+          'commit',
+          '--allow-empty',
+          '-m',
+          'seed',
+        ],
+        { cwd: dir, env: isolatedEnv },
+      );
+
+      const { resolveWorktreeHeadSha } = await import('./workflow.js');
+      const sha = resolveWorktreeHeadSha(dir);
+
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+      // Must satisfy EvidencePostSchema's >= 7 char constraint (#233 contract).
+      expect(sha.length).toBeGreaterThanOrEqual(7);
+      expect(sha).not.toBe('HEAD');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to "HEAD" when the path is not a git repo (loud failure path)', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'wt-sha-bad-'));
+    try {
+      const { resolveWorktreeHeadSha } = await import('./workflow.js');
+      const sha = resolveWorktreeHeadSha(dir);
+      // Fallback is intentionally invalid — fails EvidencePostSchema.prHeadSha
+      // (>= 7 chars) so runEvidencePost surfaces the failure as
+      // evidence.post-failed instead of silently posting a broken URL.
+      expect(sha).toBe('HEAD');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { adviseOnPlan } from '@goose-hub/core/agent-runtime/advisor.js';
@@ -340,6 +341,9 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
   });
 
   // Step 6: evidence-post wiring (#234) — best-effort.
+  // Resolve the worktree HEAD to the real commit SHA so evidence-post pins
+  // its raw URLs to an immutable ref (#233 SHA-pinning contract).
+  const prHeadSha = resolveWorktreeHeadSha(worktreePath);
   await runEvidencePost({
     workItem,
     projectId,
@@ -348,7 +352,7 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
     appendSystemPrompt: input.evidencePostPrompt,
     outputJsonSchema: input.evidencePostJsonSchema,
     prNumber: prResult.prNumber,
-    prHeadSha: 'HEAD', // placeholder — real SHA comes from a follow-up `git rev-parse` on the worktree
+    prHeadSha,
     repoRef,
     evidenceSpecPath: implementOutput.evidenceSpecPath,
   });
@@ -475,6 +479,32 @@ ${testsList || '_no tests reported_'}
 
 Closes #${opts.workItem.externalId}
 `;
+}
+
+/**
+ * Resolves the worktree's current HEAD to a 40-char commit SHA so
+ * evidence-post can pin raw.githubusercontent.com URLs to an immutable
+ * ref (the #233 SHA-pinning contract). Falls back to `'HEAD'` only if
+ * `git rev-parse` fails — the EvidencePostSchema requires `prHeadSha.length >= 7`,
+ * which `'HEAD'` does NOT satisfy, so a fallback there will surface as
+ * a schema validation error and be caught by runEvidencePost's
+ * best-effort handler. That's intentional: a missing SHA is loud, not silent.
+ *
+ * Exported for test access — the chore-shipping path needs a real git repo
+ * to exercise the rev-parse, and isolating the call here keeps the
+ * workflow tests deps-injected for everything else.
+ */
+export function resolveWorktreeHeadSha(worktreePath: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: worktreePath,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    // Triggers a schema validation failure inside runEvidencePost,
+    // which emits evidence.post-failed and continues.
+    return 'HEAD';
+  }
 }
 
 function deriveStack(): {


### PR DESCRIPTION
## Summary

Surfaced by the M7 exit re-audit. The `fix-issue` workflow was passing the literal string `'HEAD'` to `runEvidencePost` as `prHeadSha`, silently violating the SHA-pinning contract from #233.

## The bug

`slices/fix-issue/workflow.ts` had:

```ts
prHeadSha: 'HEAD', // placeholder — real SHA comes from a follow-up `git rev-parse` on the worktree
```

`evidence-post` is supposed to pin every `raw.githubusercontent.com` URL to an immutable commit SHA so URLs don't break when the branch is deleted on merge. With `'HEAD'` as the SHA, every posted comment would have URLs like `raw.githubusercontent.com/owner/repo/HEAD/...` — which resolves to whatever HEAD currently points at, not the snapshot at PR-open time.

## The fix

- New `resolveWorktreeHeadSha(worktreePath)` helper runs `git rev-parse HEAD` against the worktree, returns the 40-char SHA.
- On failure (non-git path, etc.), falls back to `'HEAD'` — intentionally invalid per `EvidencePostSchema.prHeadSha.min(7)`. This surfaces loudly as `evidence.post-failed` instead of silently posting a broken comment.
- `afterImplement` now resolves the SHA before the `runEvidencePost` call.

## Why existing tests didn't catch it

`chore-shipping.test.ts` and the existing `slice.test.ts` use `evidenceSpecPath: null` in `makeImplementOutput()`, which short-circuits inside `runEvidencePost` before any SHA validation happens (`evidence.no-spec-declared` event, return). The bug only manifested on the path where `evidenceSpecPath` is set.

## New tests

- **Happy path:** real temp git repo (`mkdtempSync`, `git init`, `git commit --allow-empty`); asserts `resolveWorktreeHeadSha` returns a `/^[0-9a-f]{40}$/` SHA.
- **Loud-failure path:** non-git dir; asserts the `'HEAD'` fallback (which fails downstream schema validation by design).
- The fixture repo runs with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` and per-call `-c commit.gpgsign=false` so the host's commit-signing setup doesn't bleed in (the test environment had a signing hook that rejected empty commits).
- The `node:fs` vi.mock now spreads the real module so the new tests can call `mkdtempSync`/`rmSync` without losing the `readFileSync` override used elsewhere in the file.

## Test plan

- [x] `pnpm test slices/fix-issue/` — 9 tests pass (was 7 + 2 new SHA tests)
- [x] `pnpm test` — 737 / 57 files passing (was 735, +2 new tests)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [ ] Manual: real chore-shipping demo run (the M7.exit follow-up) — verify a posted evidence comment has SHA-pinned URLs that survive a branch delete

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWtsvudsztkFuNpjWj5ua6)_