### PR TITLE
M8: QA and Review Holdouts

### DIFF
--- a/apps/server/src/domains/workflows/qa-batch.ts
+++ b/apps/server/src/domains/workflows/qa-batch.ts
@@ -1,12 +1,22 @@
 import { logger } from '@goose-hub/core/logger.js';
-import type { StateSource } from '@goose-hub/core/state-source/interface.js';
-import { runQaWorkflow } from '../../../../slices/qa/workflow.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { getSourceForSlug } from '../../shared/source.js';
 
 export async function runQaBatch(slug: string, source?: StateSource): Promise<void> {
   logger.info('qa-batch started', { slug });
   const stateSource = source ?? (await getSourceForSlug(slug));
   if (stateSource == null) throw new Error(`Project not found: ${slug}`);
+
+  const { runQaWorkflow } = (await import(
+    new URL('../../../../slices/qa/workflow.js', import.meta.url).href
+  )) as {
+    runQaWorkflow: (
+      item: WorkItem,
+      source: StateSource,
+      projectId: string,
+      repo: string,
+    ) => Promise<void>;
+  };
 
   const allItems = await stateSource.listOpenWork();
   const qaItems = allItems.filter((item) => item.state === 'factory:needs-qa');

--- a/apps/server/src/domains/workflows/qa-batch.ts
+++ b/apps/server/src/domains/workflows/qa-batch.ts
@@ -1,0 +1,19 @@
+import { logger } from '@goose-hub/core/logger.js';
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+import { runQaWorkflow } from '../../../../slices/qa/workflow.js';
+import { getSourceForSlug } from '../../shared/source.js';
+
+export async function runQaBatch(slug: string, source?: StateSource): Promise<void> {
+  logger.info('qa-batch started', { slug });
+  const stateSource = source ?? (await getSourceForSlug(slug));
+  if (stateSource == null) throw new Error(`Project not found: ${slug}`);
+
+  const allItems = await stateSource.listOpenWork();
+  const qaItems = allItems.filter((item) => item.state === 'factory:needs-qa');
+  logger.info('qa-batch items', { slug, count: qaItems.length });
+
+  for (const item of qaItems) {
+    await runQaWorkflow(item, stateSource, stateSource.projectId, item.repoRef ?? slug);
+  }
+  logger.info('qa-batch finished', { slug, processed: qaItems.length });
+}

--- a/apps/server/src/domains/workflows/review-batch.ts
+++ b/apps/server/src/domains/workflows/review-batch.ts
@@ -1,12 +1,22 @@
 import { logger } from '@goose-hub/core/logger.js';
-import type { StateSource } from '@goose-hub/core/state-source/interface.js';
-import { runReviewWorkflow } from '../../../../slices/review/workflow.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { getSourceForSlug } from '../../shared/source.js';
 
 export async function runReviewBatch(slug: string, source?: StateSource): Promise<void> {
   logger.info('review-batch started', { slug });
   const stateSource = source ?? (await getSourceForSlug(slug));
   if (stateSource == null) throw new Error(`Project not found: ${slug}`);
+
+  const { runReviewWorkflow } = (await import(
+    new URL('../../../../slices/review/workflow.js', import.meta.url).href
+  )) as {
+    runReviewWorkflow: (
+      item: WorkItem,
+      source: StateSource,
+      projectId: string,
+      repo: string,
+    ) => Promise<void>;
+  };
 
   const allItems = await stateSource.listOpenWork();
   const reviewItems = allItems.filter((item) => item.state === 'factory:needs-review');

--- a/apps/server/src/domains/workflows/review-batch.ts
+++ b/apps/server/src/domains/workflows/review-batch.ts
@@ -1,0 +1,19 @@
+import { logger } from '@goose-hub/core/logger.js';
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+import { runReviewWorkflow } from '../../../../slices/review/workflow.js';
+import { getSourceForSlug } from '../../shared/source.js';
+
+export async function runReviewBatch(slug: string, source?: StateSource): Promise<void> {
+  logger.info('review-batch started', { slug });
+  const stateSource = source ?? (await getSourceForSlug(slug));
+  if (stateSource == null) throw new Error(`Project not found: ${slug}`);
+
+  const allItems = await stateSource.listOpenWork();
+  const reviewItems = allItems.filter((item) => item.state === 'factory:needs-review');
+  logger.info('review-batch items', { slug, count: reviewItems.length });
+
+  for (const item of reviewItems) {
+    await runReviewWorkflow(item, stateSource, stateSource.projectId, item.repoRef ?? slug);
+  }
+  logger.info('review-batch finished', { slug, processed: reviewItems.length });
+}

--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -12,4 +12,13 @@ router.post('/:slug/tick', async (c) => {
   return c.json({ ok: true, slug }, 202);
 });
 
+router.post('/:slug/run-qa', async (c) => {
+  const slug = c.req.param('slug');
+  const { runQaBatch } = await import('./qa-batch.js');
+  runQaBatch(slug).catch((err: unknown) => {
+    logger.error('qa-batch failed', { slug, error: String(err) });
+  });
+  return c.json({ ok: true, slug }, 202);
+});
+
 export { router as workflowsRouter };

--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -21,4 +21,13 @@ router.post('/:slug/run-qa', async (c) => {
   return c.json({ ok: true, slug }, 202);
 });
 
+router.post('/:slug/run-review', async (c) => {
+  const slug = c.req.param('slug');
+  const { runReviewBatch } = await import('./review-batch.js');
+  runReviewBatch(slug).catch((err: unknown) => {
+    logger.error('review-batch failed', { slug, error: String(err) });
+  });
+  return c.json({ ok: true, slug }, 202);
+});
+
 export { router as workflowsRouter };

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -15,6 +15,8 @@ import { InvestigationSection } from './InvestigationSection';
 import { LeftRail } from './LeftRail';
 import { OverviewSection } from './OverviewSection';
 import { PlaywrightCaptureSection } from './PlaywrightCaptureSection';
+import { QASection } from './QASection';
+import { ReviewSection } from './ReviewSection';
 import { RightRail } from './RightRail';
 import { TaskHeader } from './TaskHeader';
 import { TimelineSection } from './TimelineSection';
@@ -223,6 +225,10 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
                 <CodeDiffSection projectSlug={slug} id={id} />
                 <PlaywrightCaptureSection projectSlug={slug} id={id} itemType={item?.type ?? ''} />
               </div>
+            ) : currentSection.key === 'qa' ? (
+              <QASection projectSlug={slug} id={id} />
+            ) : currentSection.key === 'review' ? (
+              <ReviewSection projectSlug={slug} id={id} />
             ) : (
               <DeferredSurface
                 surface={currentSection.label}

--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -1,0 +1,168 @@
+import { fetchEvents } from '@/lib/api';
+import type { AgentEventDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, CheckCircle, Clock, XCircle } from 'lucide-react';
+
+interface QASectionProps {
+  projectSlug: string;
+  id: string;
+}
+
+interface Finding {
+  tier: 'structural' | 'functional' | 'regression';
+  severity: 'error' | 'warning' | 'info';
+  file?: string;
+  line?: number;
+  description: string;
+  suggestion?: string;
+}
+
+interface TierResult {
+  passed: boolean;
+  findings: Finding[];
+  command?: string;
+  output?: string;
+}
+
+interface QaPayload {
+  verdict: 'pass' | 'fail' | 'partial';
+  overallScore: number;
+  threshold?: number;
+  tierResults: {
+    structural: TierResult;
+    functional: TierResult;
+    regression: TierResult;
+  };
+}
+
+const TIERS = ['structural', 'functional', 'regression'] as const;
+
+export function QASection({ projectSlug, id }: QASectionProps) {
+  const { data: events = [], isLoading } = useQuery<AgentEventDto[]>({
+    queryKey: ['events', projectSlug, id],
+    queryFn: () => fetchEvents(projectSlug, id),
+  });
+
+  if (isLoading) return null;
+
+  const qaEvent = [...events].reverse().find((e) => e.kind === 'qa.completed');
+  const qa = qaEvent?.payload as QaPayload | undefined;
+
+  if (!qa) {
+    return (
+      <div
+        data-testid="qa-empty-state"
+        className="px-8 py-8 flex flex-col items-center justify-center gap-2 text-center"
+      >
+        <Clock size={24} className="text-fg-3 opacity-50" />
+        <p className="text-[13px] text-fg-3">Waiting for QA to run…</p>
+        <p className="text-[12px] text-fg-4">QA runs automatically after the PR is opened.</p>
+      </div>
+    );
+  }
+
+  const VerdictIcon =
+    qa.verdict === 'pass' ? CheckCircle : qa.verdict === 'fail' ? XCircle : AlertCircle;
+  const verdictColor =
+    qa.verdict === 'pass'
+      ? 'text-green-500'
+      : qa.verdict === 'fail'
+        ? 'text-red-500'
+        : 'text-yellow-500';
+  const verdictBg =
+    qa.verdict === 'pass'
+      ? 'bg-green-500/10 border-green-500/20'
+      : qa.verdict === 'fail'
+        ? 'bg-red-500/10 border-red-500/20'
+        : 'bg-yellow-500/10 border-yellow-500/20';
+
+  const threshold = qa.threshold ?? 70;
+
+  return (
+    <div data-testid="qa-section" className="px-8 py-6 space-y-6">
+      {/* Verdict header */}
+      <div className={`flex items-center gap-3 p-4 rounded-lg border ${verdictBg}`}>
+        <VerdictIcon size={20} className={verdictColor} />
+        <div>
+          <div className="font-semibold text-[13px] uppercase tracking-wide">{qa.verdict}</div>
+          <div className="text-[12px] text-fg-3">
+            Score: {qa.overallScore}/{threshold <= 100 ? 100 : threshold} — threshold {threshold}
+          </div>
+        </div>
+      </div>
+
+      {/* Tier results */}
+      <div>
+        <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+          Verification Tiers
+        </h3>
+        <div className="grid grid-cols-3 gap-3">
+          {TIERS.map((tier) => {
+            const result = qa.tierResults?.[tier];
+            return (
+              <div key={tier} className="border border-line rounded-lg p-3">
+                <div className="flex items-center gap-2 mb-1">
+                  {result?.passed ? (
+                    <CheckCircle size={13} className="text-green-500" />
+                  ) : (
+                    <XCircle size={13} className="text-red-500" />
+                  )}
+                  <span className="text-[12px] font-medium capitalize">{tier}</span>
+                </div>
+                <div
+                  className={`text-[11px] ${result?.passed ? 'text-green-500' : 'text-red-500'}`}
+                >
+                  {result?.passed ? 'Pass' : `${result?.findings?.length ?? 0} finding(s)`}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Findings across all tiers */}
+      {qa.tierResults && TIERS.flatMap((tier) => qa.tierResults[tier].findings).length > 0 && (
+        <div>
+          <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+            Findings
+          </h3>
+          <div className="space-y-2">
+            {TIERS.flatMap((tier) =>
+              qa.tierResults[tier].findings.map((f) => (
+                <div
+                  key={`${tier}:${f.description}`}
+                  className="border border-line rounded-lg p-3 text-[12.5px]"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span
+                      className={`text-[10px] font-medium uppercase px-1.5 py-0.5 rounded ${
+                        f.severity === 'error'
+                          ? 'bg-red-500/15 text-red-400'
+                          : f.severity === 'warning'
+                            ? 'bg-yellow-500/15 text-yellow-400'
+                            : 'bg-blue-500/15 text-blue-400'
+                      }`}
+                    >
+                      {f.severity}
+                    </span>
+                    <span className="text-[11px] text-fg-4 capitalize">{tier}</span>
+                    {f.file && (
+                      <span className="font-mono text-[10px] text-fg-3 bg-bg-glass px-1 py-0.5 rounded">
+                        {f.file}
+                        {f.line != null ? `:${f.line}` : ''}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-fg-2">{f.description}</div>
+                  {f.suggestion && (
+                    <div className="text-[11px] text-fg-3 mt-1">→ {f.suggestion}</div>
+                  )}
+                </div>
+              )),
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/ReviewSection.tsx
+++ b/apps/web/src/components/detail/components/ReviewSection.tsx
@@ -1,0 +1,167 @@
+import { fetchEvents } from '@/lib/api';
+import type { AgentEventDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle, Clock, XCircle } from 'lucide-react';
+
+interface ReviewSectionProps {
+  projectSlug: string;
+  id: string;
+}
+
+interface CriterionCheck {
+  criterion: string;
+  status: 'met' | 'unmet' | 'unclear';
+  notes?: string;
+}
+
+interface ReviewFinding {
+  criterion?: string;
+  severity: 'blocker' | 'major' | 'minor';
+  description: string;
+  suggestion?: string;
+  file?: string;
+  line?: number;
+}
+
+type ReviewVerdict = 'approved' | 'needs-fix' | 'needs-human';
+
+interface ReviewPayload {
+  verdict: ReviewVerdict;
+  confidence: number;
+  criteriaChecks: CriterionCheck[];
+  findings: ReviewFinding[];
+  escalationReason?: string;
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  blocker: 'bg-red-500/15 text-red-400',
+  major: 'bg-orange-500/15 text-orange-400',
+  minor: 'bg-gray-500/15 text-gray-400',
+};
+
+export function ReviewSection({ projectSlug, id }: ReviewSectionProps) {
+  const { data: events = [], isLoading } = useQuery<AgentEventDto[]>({
+    queryKey: ['events', projectSlug, id],
+    queryFn: () => fetchEvents(projectSlug, id),
+  });
+
+  if (isLoading) return null;
+
+  const reviewEvent = [...events].reverse().find((e) => e.kind === 'review.completed');
+  const review = reviewEvent?.payload as ReviewPayload | undefined;
+
+  if (!review) {
+    return (
+      <div
+        data-testid="review-empty-state"
+        className="px-8 py-8 flex flex-col items-center justify-center gap-2 text-center"
+      >
+        <Clock size={24} className="text-fg-3 opacity-50" />
+        <p className="text-[13px] text-fg-3">Waiting for Review to run…</p>
+        <p className="text-[12px] text-fg-4">Review runs automatically after QA passes.</p>
+      </div>
+    );
+  }
+
+  const VerdictIcon =
+    review.verdict === 'approved'
+      ? CheckCircle
+      : review.verdict === 'needs-fix'
+        ? XCircle
+        : AlertTriangle;
+  const verdictColor =
+    review.verdict === 'approved'
+      ? 'text-green-500'
+      : review.verdict === 'needs-fix'
+        ? 'text-orange-500'
+        : 'text-red-500';
+  const verdictBg =
+    review.verdict === 'approved'
+      ? 'bg-green-500/10 border-green-500/20'
+      : review.verdict === 'needs-fix'
+        ? 'bg-orange-500/10 border-orange-500/20'
+        : 'bg-red-500/10 border-red-500/20';
+
+  return (
+    <div data-testid="review-section" className="px-8 py-6 space-y-6">
+      {/* Verdict header */}
+      <div className={`flex items-center gap-3 p-4 rounded-lg border ${verdictBg}`}>
+        <VerdictIcon size={20} className={verdictColor} />
+        <div>
+          <div className="font-semibold text-[13px] uppercase tracking-wide">
+            {review.verdict.replace(/-/g, ' ')}
+          </div>
+          <div className="text-[12px] text-fg-3">
+            Confidence: {Math.round(review.confidence * 100)}%
+          </div>
+        </div>
+      </div>
+
+      {/* Escalation reason (needs-human only) */}
+      {review.escalationReason && (
+        <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-[12.5px] text-fg-2">
+          <span className="font-medium text-red-400">Escalation: </span>
+          {review.escalationReason}
+        </div>
+      )}
+
+      {/* Acceptance criteria checks */}
+      {review.criteriaChecks.length > 0 && (
+        <div>
+          <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+            Acceptance Criteria
+          </h3>
+          <div className="space-y-2">
+            {review.criteriaChecks.map((check) => (
+              <div key={check.criterion} className="flex items-start gap-2.5 text-[12.5px]">
+                {check.status === 'met' ? (
+                  <CheckCircle size={14} className="text-green-500 mt-0.5 shrink-0" />
+                ) : check.status === 'unmet' ? (
+                  <XCircle size={14} className="text-red-500 mt-0.5 shrink-0" />
+                ) : (
+                  <AlertTriangle size={14} className="text-yellow-500 mt-0.5 shrink-0" />
+                )}
+                <div className="min-w-0">
+                  <span className={check.status === 'unmet' ? 'text-fg' : 'text-fg-2'}>
+                    {check.criterion}
+                  </span>
+                  {check.notes && <p className="text-[11px] text-fg-3 mt-0.5">{check.notes}</p>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Findings */}
+      {review.findings.length > 0 && (
+        <div>
+          <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+            Findings
+          </h3>
+          <div className="space-y-2">
+            {review.findings.map((f) => (
+              <div key={f.description} className="border border-line rounded-lg p-3 text-[12.5px]">
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    className={`text-[10px] font-medium uppercase px-1.5 py-0.5 rounded ${SEVERITY_COLOR[f.severity] ?? 'bg-gray-500/15 text-gray-400'}`}
+                  >
+                    {f.severity}
+                  </span>
+                  {f.file && (
+                    <span className="font-mono text-[10px] text-fg-3 bg-bg-glass px-1 py-0.5 rounded">
+                      {f.file}
+                      {f.line != null ? `:${f.line}` : ''}
+                    </span>
+                  )}
+                </div>
+                <div className="text-fg-2">{f.description}</div>
+                {f.suggestion && <div className="text-[11px] text-fg-3 mt-1">→ {f.suggestion}</div>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/lib/sections.ts
+++ b/apps/web/src/components/detail/lib/sections.ts
@@ -39,15 +39,13 @@ export const SECTIONS: readonly DetailSection[] = [
   {
     key: 'qa',
     label: 'QA',
-    available: false,
-    milestone: 'M8',
+    available: true,
     description: 'Holdout QA report — outcome assessed against the original issue.',
   },
   {
     key: 'review',
     label: 'Review',
-    available: false,
-    milestone: 'M8',
+    available: true,
     description: 'Holdout review verdict, requested changes.',
   },
   { key: 'timeline', label: 'Timeline', available: true },

--- a/core/agent-runtime/context-assembly.ts
+++ b/core/agent-runtime/context-assembly.ts
@@ -1,8 +1,14 @@
+import { eventStore } from '../event-stream/store.js';
 import type { AgentSpec } from './interface.js';
 
 export interface SpawnContext {
   contextXml: string;
 }
+
+// Holdout roles that enforce strict context isolation
+const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
+// Keys managed by the runtime itself — not user-injected, so not violations
+const SYSTEM_KEYS = new Set(['projectId', 'workItemId']);
 
 /**
  * Centralised context injection point. All ambient injection routes through here.
@@ -12,6 +18,9 @@ export interface SpawnContext {
  * `spec.personaId` is accepted here and will be used to load persona history in M9+.
  * For now, the non-fresh path is a no-op stub.
  *
+ * For holdout roles (qa, reviewer), any context key that is not in contextAllowlist and
+ * is not a system-internal key (projectId, workItemId) triggers a tool.violation event.
+ *
  * ESLint rule: any access to event-stream or persona-history from core/agent-runtime/
  * outside this file should be flagged (enforced manually until ESLint plugin is wired).
  */
@@ -20,17 +29,45 @@ export function assembleSpawnContext(spec: AgentSpec): SpawnContext {
   // At M6, persona history loading is a stub — the field is wired into AgentSpec
   // so the runtime can record persona attribution in events without injecting history.
   void spec.personaId; // consumed in M9 persona history injection
-  const base = renderManifest(spec.context, spec.contextAllowlist);
-  if (spec.freshContext) return base;
+  const { contextXml, disallowedKeys } = renderManifest(spec.context, spec.contextAllowlist);
+
+  // Emit tool.violation for disallowed keys on holdout roles
+  if (HOLDOUT_ROLES.has(spec.role) && disallowedKeys.length > 0) {
+    for (const key of disallowedKeys) {
+      eventStore.appendEvent({
+        projectId: typeof spec.context.projectId === 'string' ? spec.context.projectId : 'unknown',
+        workItemId:
+          typeof spec.context.workItemId === 'string' ? spec.context.workItemId : undefined,
+        kind: 'tool.violation',
+        payload: { role: spec.role, disallowedKey: key, runId: spec.runId },
+        runId: spec.runId,
+      });
+    }
+  }
+
+  if (spec.freshContext) return { contextXml };
   // Non-fresh ambient injection (event stream, persona history) deferred to M9+
-  return base;
+  return { contextXml };
 }
 
-function renderManifest(context: Record<string, unknown>, allowlist: string[]): SpawnContext {
-  const filtered =
-    allowlist.length === 0
-      ? {}
-      : Object.fromEntries(Object.entries(context).filter(([k]) => allowlist.includes(k)));
+function renderManifest(
+  context: Record<string, unknown>,
+  allowlist: string[],
+): { contextXml: string; disallowedKeys: string[] } {
+  const disallowedKeys: string[] = [];
+  const filtered: Record<string, unknown> = {};
+
+  if (allowlist.length === 0) {
+    // empty allowlist = nothing passes; no user keys to flag as violations
+  } else {
+    for (const [k, v] of Object.entries(context)) {
+      if (allowlist.includes(k)) {
+        filtered[k] = v;
+      } else if (!SYSTEM_KEYS.has(k)) {
+        disallowedKeys.push(k);
+      }
+    }
+  }
 
   const inner = Object.entries(filtered)
     .map(([k, v]) => {
@@ -40,7 +77,7 @@ function renderManifest(context: Record<string, unknown>, allowlist: string[]): 
     .join('\n');
 
   const contextXml = inner.length > 0 ? `<task>\n${inner}\n</task>` : '<task></task>';
-  return { contextXml };
+  return { contextXml, disallowedKeys };
 }
 
 function escapeXml(s: string): string {

--- a/core/agent-runtime/fallback.test.ts
+++ b/core/agent-runtime/fallback.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HoldoutFallbackForbiddenError, withFallback } from './fallback.js';
+import type { AgentRuntime, AgentSpec } from './interface.js';
+
+function makeSpec(role: string, modelOverride?: string): AgentSpec {
+  return {
+    runId: 'test-run',
+    role: role as AgentSpec['role'],
+    skill: 'test',
+    context: { projectId: 'p', workItemId: 'w' },
+    contextAllowlist: ['workItem'],
+    freshContext: role === 'qa' || role === 'reviewer',
+    toolBundles: [],
+    toolExtras: [],
+    budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: `p/${role}/0`,
+    ...(modelOverride ? { modelOverride } : {}),
+  };
+}
+
+function makeRuntime(run: AgentRuntime['run']): AgentRuntime {
+  return { run };
+}
+
+describe('withFallback — holdout enforcement', () => {
+  it('throws HoldoutFallbackForbiddenError when qa primary fails', async () => {
+    const failingRuntime = makeRuntime(vi.fn().mockRejectedValue(new Error('API error')));
+    const wrapped = withFallback(failingRuntime, { allowDownTier: true, maxAttempts: 2 });
+    await expect(wrapped.run(makeSpec('qa', 'claude-sonnet-4-6'))).rejects.toThrow(
+      HoldoutFallbackForbiddenError,
+    );
+  });
+
+  it('throws HoldoutFallbackForbiddenError when reviewer primary fails', async () => {
+    const failingRuntime = makeRuntime(vi.fn().mockRejectedValue(new Error('Rate limit')));
+    const wrapped = withFallback(failingRuntime, { allowDownTier: true, maxAttempts: 2 });
+    await expect(wrapped.run(makeSpec('reviewer', 'claude-sonnet-4-6'))).rejects.toThrow(
+      HoldoutFallbackForbiddenError,
+    );
+  });
+
+  it('HoldoutFallbackForbiddenError message mentions the role', async () => {
+    const failingRuntime = makeRuntime(vi.fn().mockRejectedValue(new Error('error')));
+    const wrapped = withFallback(failingRuntime, { allowDownTier: true, maxAttempts: 2 });
+    try {
+      await wrapped.run(makeSpec('qa', 'claude-sonnet-4-6'));
+    } catch (e) {
+      expect(e).toBeInstanceOf(HoldoutFallbackForbiddenError);
+      expect((e as Error).message).toContain('qa');
+    }
+  });
+
+  it('non-holdout role with opus model: falls back to sonnet on error', async () => {
+    const failingRuntime = makeRuntime(
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error('error'))
+        .mockResolvedValue({ output: {}, decisionSummaries: [], events: [] }),
+    );
+    const wrapped = withFallback(failingRuntime, { allowDownTier: true, maxAttempts: 2 });
+    const result = await wrapped.run(makeSpec('developer', 'claude-opus-4-7'));
+    expect(result).toBeDefined();
+    // Second call should use a lower-tier model
+    expect(vi.mocked(failingRuntime.run)).toHaveBeenCalledTimes(2);
+  });
+
+  it('holdout primary succeeds: returns result normally', async () => {
+    const successRuntime = makeRuntime(
+      vi.fn().mockResolvedValue({ output: {}, decisionSummaries: [], events: [] }),
+    );
+    const wrapped = withFallback(successRuntime, { allowDownTier: true, maxAttempts: 2 });
+    const result = await wrapped.run(makeSpec('qa', 'claude-sonnet-4-6'));
+    expect(result).toBeDefined();
+    expect(vi.mocked(successRuntime.run)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/core/agent-runtime/fallback.ts
+++ b/core/agent-runtime/fallback.ts
@@ -1,4 +1,6 @@
+export { HoldoutFallbackForbiddenError } from './interface.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
+import { HoldoutFallbackForbiddenError } from './interface.js';
 import { modelsAtOrAboveTier, tierOf } from './models.js';
 
 export interface FallbackPolicy {
@@ -22,8 +24,17 @@ export function withFallback(runtime: AgentRuntime, policy: FallbackPolicy): Age
       const priority = (spec.context.priority as string | undefined) ?? 'medium';
       const isCriticalOrHigh = CRITICAL_PRIORITIES.has(priority);
 
-      // Holdout and critical/high: no fallback
-      if (isHoldout || isCriticalOrHigh || !policy.allowDownTier) {
+      // Holdout roles: no fallback — catch primary failure and surface as typed error
+      if (isHoldout) {
+        try {
+          return await runtime.run(spec);
+        } catch {
+          throw new HoldoutFallbackForbiddenError(spec.role);
+        }
+      }
+
+      // Critical/high priority or policy disallows down-tier: no fallback
+      if (isCriticalOrHigh || !policy.allowDownTier) {
         return runtime.run(spec);
       }
 

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -64,3 +64,12 @@ export interface SkillConfig {
   role?: Role;
   contextAllowlist?: string[];
 }
+
+export class HoldoutFallbackForbiddenError extends Error {
+  constructor(role: string) {
+    super(
+      `Fallback is forbidden for holdout role '${role}' — escalate to factory:needs-human instead`,
+    );
+    this.name = 'HoldoutFallbackForbiddenError';
+  }
+}

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -6,6 +6,7 @@ import { eventStore } from '../event-stream/store.js';
 import { ClaudeCliRuntime, resolveMcpConfigPath } from './claude-cli.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import { withFallback } from './fallback.js';
+import { HoldoutFallbackForbiddenError } from './interface.js';
 import type { AgentResult, AgentRuntime, AgentSpec, DecisionSummary } from './interface.js';
 import {
   MODELS,
@@ -456,11 +457,11 @@ describe('withFallback', () => {
     expect((result.output as { ok: boolean }).ok).toBe(true);
   });
 
-  it('holdout role: does not retry on failure', async () => {
+  it('holdout role: does not retry on failure — throws HoldoutFallbackForbiddenError', async () => {
     const runtime = makeRuntime(true);
     const wrapped = withFallback(runtime, { allowDownTier: true, maxAttempts: 2 });
     const qaSpec = makeSpec({ role: 'qa' });
-    await expect(wrapped.run(qaSpec)).rejects.toThrow('Model unavailable');
+    await expect(wrapped.run(qaSpec)).rejects.toThrow(HoldoutFallbackForbiddenError);
     expect(vi.mocked(runtime.run)).toHaveBeenCalledTimes(1);
   });
 

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -255,6 +255,111 @@ describe('assembleSpawnContext', () => {
   });
 });
 
+// ─── holdout enforcement (tool.violation events) ──────────────────────────────
+
+describe('assembleSpawnContext — holdout enforcement', () => {
+  const makeHoldoutSpec = (overrides: Partial<AgentSpec> = {}): AgentSpec => ({
+    runId: 'holdout-run-01',
+    role: 'qa',
+    skill: 'qa-test',
+    context: {
+      projectId: 'proj-abc',
+      workItemId: 'item-42',
+      message: 'allowed',
+      secret: 'tok_injected',
+      implementationReasoning: 'should not pass through',
+    },
+    contextAllowlist: ['message'],
+    freshContext: true,
+    toolBundles: [],
+    toolExtras: [],
+    budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: 'proj-abc/qa/0',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disallowed keys are absent from the rendered XML', () => {
+    const { contextXml } = assembleSpawnContext(makeHoldoutSpec());
+    expect(contextXml).not.toContain('secret');
+    expect(contextXml).not.toContain('tok_injected');
+    expect(contextXml).not.toContain('implementationReasoning');
+  });
+
+  it('allowed keys remain in the rendered XML', () => {
+    const { contextXml } = assembleSpawnContext(makeHoldoutSpec());
+    expect(contextXml).toContain('message');
+    expect(contextXml).toContain('allowed');
+  });
+
+  it('emits tool.violation for each disallowed key on a qa holdout role', () => {
+    assembleSpawnContext(makeHoldoutSpec());
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    // 'secret' and 'implementationReasoning' are disallowed; projectId/workItemId are system keys
+    expect(violations).toHaveLength(2);
+    const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
+    expect(keys).toContain('secret');
+    expect(keys).toContain('implementationReasoning');
+  });
+
+  it('emits tool.violation with correct role and runId in payload', () => {
+    assembleSpawnContext(makeHoldoutSpec());
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    for (const [e] of violations) {
+      const payload = e.payload as { role: string; runId: string };
+      expect(payload.role).toBe('qa');
+      expect(payload.runId).toBe('holdout-run-01');
+    }
+  });
+
+  it('emits tool.violation on reviewer role too', () => {
+    assembleSpawnContext(makeHoldoutSpec({ role: 'reviewer' }));
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    expect(violations.length).toBeGreaterThan(0);
+    const [e] = violations[0];
+    expect((e.payload as { role: string }).role).toBe('reviewer');
+  });
+
+  it('does NOT emit tool.violation for a non-holdout (developer) role', () => {
+    assembleSpawnContext(makeHoldoutSpec({ role: 'developer' }));
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    expect(violations).toHaveLength(0);
+  });
+
+  it('does NOT flag system keys (projectId, workItemId) as violations', () => {
+    assembleSpawnContext(makeHoldoutSpec());
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
+    expect(keys).not.toContain('projectId');
+    expect(keys).not.toContain('workItemId');
+  });
+
+  it('emits no violations when all non-system keys are allowlisted', () => {
+    const spec = makeHoldoutSpec({
+      context: { projectId: 'proj-abc', workItemId: 'item-42', message: 'allowed' },
+      contextAllowlist: ['message'],
+    });
+    assembleSpawnContext(spec);
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    expect(violations).toHaveLength(0);
+  });
+});
+
 // ─── output validator ─────────────────────────────────────────────────────────
 
 describe('validateOutput', () => {

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -39,7 +39,12 @@ export type EventKind =
   | 'gate.rejected'
   | 'pr.merged'
   // M8 holdout enforcement — context injection boundary violations
-  | 'tool.violation';
+  | 'tool.violation'
+  // M8 QA/Review lifecycle events
+  | 'qa.completed'
+  | 'review.completed'
+  // M8 retry-and-escalate
+  | 'agent.retry-escalated';
 
 export interface AgentEvent {
   id: number;

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -162,7 +162,6 @@ class EventStore {
         const shape = `${e?.name ?? 'Error'}: ${e?.message ?? '<no message>'}`;
         if (!seenErrorShapes.has(shape)) {
           seenErrorShapes.add(shape);
-          // biome-ignore lint/suspicious/noConsole: subscriber-error reporting is intentional
           console.error(`[event-stream] subscriber threw (logged once): ${shape}`);
         }
       }

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -37,7 +37,9 @@ export type EventKind =
   // M7 approval gate (#186)
   | 'gate.approved'
   | 'gate.rejected'
-  | 'pr.merged';
+  | 'pr.merged'
+  // M8 holdout enforcement — context injection boundary violations
+  | 'tool.violation';
 
 export interface AgentEvent {
   id: number;

--- a/core/retry/retry-counter.ts
+++ b/core/retry/retry-counter.ts
@@ -1,31 +1,43 @@
 // core/retry/retry-counter.ts
 // Tracks retry counts using events already in the event store.
 // No new DB table needed — counts domain events per work item.
+//
+// Semantics: call these functions with events collected BEFORE the current
+// run's outcome is appended. That way count reflects prior failures only,
+// and escalation triggers on the (maxRetries+1)th failure:
+//   maxRetries=2 → escalate on 3rd failure (2 qa-failed cycles, then needs-human)
 
 export const DEFAULT_MAX_RETRIES = 2;
 
 type EventLike = { kind: string; payload: string | unknown };
 
+type QaPayload = { verdict?: string; overallScore?: number };
+
 /**
- * Counts how many times QA has failed for a work item.
- * Uses qa.completed events with non-pass verdict as the signal.
+ * Counts prior QA failures for a work item.
+ * A failure is: verdict === 'fail', OR verdict === 'partial' with overallScore < 70
+ * (mirrors the pass logic in slices/qa/workflow.ts).
+ * Call with events collected BEFORE the current qa.completed is appended.
  */
 export function getQaRetryCount(events: EventLike[]): number {
   return events.filter((e) => {
     if (e.kind !== 'qa.completed') return false;
-    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
-    return (payload as { verdict?: string }).verdict !== 'pass';
+    const p = (typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload) as QaPayload;
+    return p.verdict === 'fail' || (p.verdict === 'partial' && (p.overallScore ?? 0) < 70);
   }).length;
 }
 
 /**
- * Counts how many times Review has requested fixes for a work item.
+ * Counts prior Review fix-requests for a work item.
+ * Call with events collected BEFORE the current review.completed is appended.
  */
 export function getReviewRetryCount(events: EventLike[]): number {
   return events.filter((e) => {
     if (e.kind !== 'review.completed') return false;
-    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
-    return (payload as { verdict?: string }).verdict === 'needs-fix';
+    const p = (typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload) as {
+      verdict?: string;
+    };
+    return p.verdict === 'needs-fix';
   }).length;
 }
 

--- a/core/retry/retry-counter.ts
+++ b/core/retry/retry-counter.ts
@@ -1,0 +1,41 @@
+// core/retry/retry-counter.ts
+// Tracks retry counts using events already in the event store.
+// No new DB table needed — counts domain events per work item.
+
+export const DEFAULT_MAX_RETRIES = 2;
+
+type EventLike = { kind: string; payload: string | unknown };
+
+/**
+ * Counts how many times QA has failed for a work item.
+ * Uses qa.completed events with non-pass verdict as the signal.
+ */
+export function getQaRetryCount(events: EventLike[]): number {
+  return events.filter((e) => {
+    if (e.kind !== 'qa.completed') return false;
+    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+    return (payload as { verdict?: string }).verdict !== 'pass';
+  }).length;
+}
+
+/**
+ * Counts how many times Review has requested fixes for a work item.
+ */
+export function getReviewRetryCount(events: EventLike[]): number {
+  return events.filter((e) => {
+    if (e.kind !== 'review.completed') return false;
+    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+    return (payload as { verdict?: string }).verdict === 'needs-fix';
+  }).length;
+}
+
+export function shouldEscalateQa(events: EventLike[], maxRetries = DEFAULT_MAX_RETRIES): boolean {
+  return getQaRetryCount(events) >= maxRetries;
+}
+
+export function shouldEscalateReview(
+  events: EventLike[],
+  maxRetries = DEFAULT_MAX_RETRIES,
+): boolean {
+  return getReviewRetryCount(events) >= maxRetries;
+}

--- a/core/state-machine/transitions.ts
+++ b/core/state-machine/transitions.ts
@@ -20,8 +20,8 @@ const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
   'factory:investigation-complete': ['factory:dev-ready'],
   'factory:dev-ready': ['factory:in-progress'],
   'factory:in-progress': ['factory:needs-qa'],
-  'factory:needs-qa': ['factory:qa-failed', 'factory:needs-review'],
-  'factory:qa-failed': ['factory:needs-fix'],
+  'factory:needs-qa': ['factory:qa-failed', 'factory:needs-review', 'factory:needs-human'],
+  'factory:qa-failed': ['factory:needs-fix', 'factory:needs-human'],
   // needs-review → rejected covers the "human explicitly cancelled" case from section 9.2
   'factory:needs-review': [
     'factory:needs-fix',

--- a/docs/adr/0014-m8-holdout-enforcement-architecture.md
+++ b/docs/adr/0014-m8-holdout-enforcement-architecture.md
@@ -1,0 +1,68 @@
+# ADR 0014: M8 Holdout Enforcement Architecture
+
+**Status:** Accepted  
+**Date:** 2026-05-03  
+**Milestone:** M8 — QA and Review Holdouts
+
+## Context
+
+M8 adds QA and Reviewer agents that are "holdouts" — they must never see implementation reasoning, developer decision summaries, investigation findings, or advisor feedback. This is a hard requirement (FACTORY_RULES rules 1, 20, 23). The question was how to enforce this at the runtime layer rather than by convention.
+
+Three sub-decisions were required:
+
+1. Where to gate context injection
+2. How to signal a violation without silently swallowing it
+3. What to do when a holdout primary model fails
+
+## Decision
+
+### 1. Centralised context gateway in `context-assembly.ts`
+
+All context injection routes through `assembleSpawnContext()` in `core/agent-runtime/context-assembly.ts`. This is the single point where `spec.context` is filtered against `spec.contextAllowlist` before being rendered into XML and passed to Claude.
+
+`HOLDOUT_ROLES = new Set(['qa', 'reviewer'])` is the source of truth for which roles enforce strict context isolation.
+
+`SYSTEM_KEYS = new Set(['projectId', 'workItemId'])` exempts runtime-managed keys from violation detection — they are always present in `spec.context` by convention and never considered user-injected.
+
+Any key in `spec.context` that is (a) not in `spec.contextAllowlist` and (b) not a `SYSTEM_KEY` is a disallowed key.
+
+### 2. `tool.violation` event per disallowed key on holdout roles
+
+When a disallowed key is detected on a holdout role, `assembleSpawnContext` emits a `tool.violation` event to the event store for each disallowed key. The event payload carries `role`, `disallowedKey`, and `runId`.
+
+Non-holdout roles do NOT emit violations — disallowed keys are silently omitted. This matches the existing pre-M8 behaviour and avoids noise for normal developer runs where partial context is routine.
+
+The violation event is the observable signal for the M8 exit criterion: "explicit attempt to inject Dev decision-summaries into QA/Reviewer fails at the runtime layer with `tool.violation` event."
+
+### 3. `HoldoutFallbackForbiddenError` — typed escalation on holdout primary failure
+
+FACTORY_RULES rule 23: fallback is forbidden on holdouts. If the primary model for a QA or Reviewer run fails (rate limit, timeout, API error), `withFallback()` in `core/agent-runtime/fallback.ts` now catches the error and re-throws `HoldoutFallbackForbiddenError(role)` — a named, typed error. The workflow's catch block can detect this specific error class and transition to `factory:needs-human` with a clear signal.
+
+Before M8, holdout failures propagated as untyped errors. The typed error makes the failure mode explicit and testable.
+
+### 4. Retry counter in `core/retry/` — no new DB table
+
+Retry counts are derived from the existing event stream: count `qa.completed` events with non-pass verdict for QA retries; count `review.completed` events with `needs-fix` verdict for review retries. `DEFAULT_MAX_RETRIES = 2`. When the count meets or exceeds `maxRetries`, the workflow escalates to `factory:needs-human` and emits `agent.retry-escalated`.
+
+This module lives in `core/retry/retry-counter.ts` (not in any slice) so both `slices/qa/` and `slices/review/` can import it without violating FACTORY_RULES rule 24 (slices never import from other slices).
+
+## Consequences
+
+**Positive:**
+- Holdout enforcement is enforced at a single gateway, not distributed across every skill and workflow.
+- Violations are observable and auditable via `tool.violation` events.
+- The typed error class makes the "no fallback on holdouts" constraint verifiable in tests.
+- Retry escalation reuses the event stream as state rather than adding a new DB table, staying consistent with the stateless-orchestrator model.
+
+**Trade-offs:**
+- `assembleSpawnContext` now has a side-effect (emitting events). This is a deliberate exception to the render-only contract — the side-effect is the enforcement signal, not a data mutation.
+- The retry counter includes the current run's event in its count (the just-appended `qa.completed` fires before the count check). This means: with `maxRetries=2`, the second consecutive failure triggers escalation. This is the intended behaviour (first fail → retry; second fail → escalate) and is documented in `slices/retry-escalate/README.md`.
+- `getQaVerdict` in `slices/review/workflow.ts` returns `undefined` for M8 scope. The Reviewer does not receive QA context as corroborating signal. A follow-up issue should be filed for M9 to read `qa.completed` from the event store.
+
+## Alternatives Considered
+
+**Alternative A: Enforce at the CC spawn layer** — reject the spawn call itself if disallowed keys are present. Rejected: too late in the pipeline; the rendering layer is the correct gate since it is the only place all context is assembled.
+
+**Alternative B: Compile-time enforcement only** — use TypeScript's conditional type on `AgentSpec<R>` to prevent building a spec with disallowed keys. Rejected: insufficient alone — runtime callers can pass `as any` or the wrong role. Runtime enforcement is required in addition to compile-time checks.
+
+**Alternative C: New DB table for retry counts** — add `retry_counters(workItemId, stage, count)`. Rejected: the event stream already records every outcome. Reading from it avoids schema drift and keeps retry logic consistent with the event-sourcing model.

--- a/skills/qa/README.md
+++ b/skills/qa/README.md
@@ -1,0 +1,119 @@
+# skills/qa
+
+QA holdout skill. Runs independent three-tier verification of a PR against the original issue acceptance criteria, then produces a structured quality verdict.
+
+## Holdout discipline
+
+The QA agent is a **holdout** role. This means:
+
+1. `freshContext: true` — the agent starts with no memory of prior sessions
+2. `contextAllowlist` restricts what it can see — it never receives developer decision summaries or investigator findings
+3. It must independently verify the PR without knowledge of why the developer made the choices they did
+
+The contextAllowlist contains: `workItem`, `prDiff`, `projectCommands`, `sliceTests`.
+It explicitly excludes: `devDecisionSummaries`, `investigationFindings`.
+
+This is enforced at the orchestrator level. Any attempt to pass developer reasoning to the QA agent constitutes a violation of the holdout rule.
+
+## Role
+
+`qa` — sonnet-tier model. Verification is structured and repeatable; it does not require opus-level reasoning.
+
+## Three-tier verification framework
+
+The QA agent runs three tiers in sequence. Each tier has a defined purpose and produces a `TierResult`.
+
+| Tier | Purpose | Commands |
+|------|---------|----------|
+| Structural | Lint, type-check, schema regressions | `lintCommand` (if provided) |
+| Functional | Unit + integration tests, acceptance criteria | `testCommand` |
+| Regression | E2E, UX regressions | `e2eCommand` (if provided) |
+
+A tier failure records all findings but does not stop execution. All three tiers always run (unless the environment is broken).
+
+## 8-category quality scoring
+
+The QA agent scores code quality across 8 categories from Steve's training materials:
+
+| Category | Max pts | What it measures |
+|----------|---------|-----------------|
+| openClosed | 20 | Open/Closed Principle adherence |
+| conceptCount | 15 | Number of distinct concepts introduced |
+| timeToCapability | 15 | How quickly a developer can use the code |
+| complecting | 15 | Mixing of unrelated concerns |
+| loc | 10 | Conciseness (fewer lines = better, when clear) |
+| coupling | 10 | Dependency strength between modules |
+| gallsLaw | 10 | Incremental evolution vs big-bang complexity |
+| cyclomaticComplexity | 5 | Branching count in functions |
+| **Total** | **100** | |
+
+Pass threshold: **aggregate >= 70/100**
+
+The `computeOverallScore` helper in `schema.ts` sums all category values.
+
+## Verdict rules
+
+| Verdict | Conditions |
+|---------|-----------|
+| `pass` | No error findings; all criteria met; score >= 70; tiers 1 and 2 passed |
+| `fail` | Any error finding; or any criterion not met; or score < 70; or tier 1 failed |
+| `partial` | Tier 1 passed but tier 2 failed; or warnings present with score >= 70; or e2e skipped with UI changes |
+
+## Inputs
+
+`contextSchema` (`QaContextSchema`) requires:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workItem.title` | `string` | Issue title |
+| `workItem.body` | `string` | Issue body with acceptance criteria |
+| `workItem.number` | `number` | Issue number |
+| `prDiff` | `string` | Complete git diff of the PR |
+| `projectCommands.testCommand` | `string` | Command to run tests |
+| `projectCommands.lintCommand` | `string?` | Command to run lint (optional) |
+| `projectCommands.e2eCommand` | `string?` | Command to run e2e tests (optional) |
+| `sliceTests` | `string[]?` | Paths to slice test files (optional) |
+
+## Outputs
+
+`QaOutputSchema`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `verdict` | `"pass" \| "fail" \| "partial"` | Overall QA verdict |
+| `overallScore` | `integer 0–100` | Sum of all quality scores |
+| `threshold` | `integer` | Pass threshold (default: 70) |
+| `tierResults` | `object` | Per-tier results (structural, functional, regression) |
+| `qualityScores` | `QualityScores` | All 8 category scores |
+| `findings` | `Finding[]` | Consolidated findings across all tiers |
+| `decisionSummaries` | `DecisionSummary[]` | Per-step audit trail |
+
+`Finding`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tier` | `"structural" \| "functional" \| "regression"` | Which tier found this |
+| `severity` | `"error" \| "warning" \| "info"` | How serious |
+| `file` | `string?` | Relevant file path |
+| `line` | `integer?` | Relevant line number |
+| `description` | `string` | What was found |
+| `suggestion` | `string?` | Suggested fix |
+
+## On-failure behavior
+
+When the QA verdict is `fail`:
+1. The orchestrator picks up the `QaOutput` from the agent result
+2. All `error`-severity findings are surfaced in the PR review comment
+3. The issue transitions back to `factory:in-progress` for the developer to address
+4. The developer does NOT see `decisionSummaries` from the QA run (holdout preserved on retry)
+
+When the QA verdict is `partial`:
+1. The orchestrator surfaces `warning`-severity findings as review comments
+2. The PR may proceed to the Reviewer agent if the criteria and score conditions are met
+3. The Reviewer can choose to accept or require further changes
+
+## Decision-summary pattern
+
+The QA agent emits `[decision] <one sentence>` lines during verification. These are stored as `agent.decision-summary` events and are NOT forwarded to the Reviewer agent (maintaining the reviewer holdout).
+
+Standard steps: `issue-read`, `diff-read`, `structural-check`, `functional-check`, `regression-check`, `criteria-check`, `quality-score`, `verdict`.

--- a/skills/qa/config.ts
+++ b/skills/qa/config.ts
@@ -1,0 +1,81 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Context keys provided to the QA holdout agent, formatted as structured XML.
+ *
+ * HOLDOUT DISCIPLINE: The QA agent must never receive developer reasoning.
+ * The contextAllowlist explicitly excludes:
+ * - devDecisionSummaries (developer implementation decisions)
+ * - investigationFindings (root cause analysis from the investigator)
+ *
+ * The QA agent only sees what a fresh external reviewer would see:
+ * the original issue, the diff, and the commands needed to verify it.
+ *
+ *   <task>
+ *     <work_item>
+ *       <title>...</title>
+ *       <body>...</body>
+ *       <number>...</number>
+ *     </work_item>
+ *     <pr_diff>...</pr_diff>
+ *     <project_commands>
+ *       <test_command>...</test_command>
+ *       <lint_command>...</lint_command>
+ *       <e2e_command>...</e2e_command>
+ *     </project_commands>
+ *     <slice_tests>
+ *       <path>...</path>
+ *     </slice_tests>
+ *   </task>
+ */
+export const QaContextSchema = z.object({
+  /** The original GitHub issue — acceptance criteria and requirements */
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  /** The git diff of the PR being reviewed — what was actually changed */
+  prDiff: z.string(),
+  /** Shell commands to run verification — project-specific */
+  projectCommands: z.object({
+    testCommand: z.string(),
+    lintCommand: z.string().optional(),
+    e2eCommand: z.string().optional(),
+  }),
+  /** Paths to slice-level test files for targeted test runs */
+  sliceTests: z.array(z.string()).optional(),
+});
+
+const config: SkillConfig = {
+  contextSchema: QaContextSchema,
+  /**
+   * Tool bundles:
+   * - 'read'     — read source files to understand what changed
+   * - 'shell'    — run lint, tests, and e2e commands
+   * - 'validate' — validate JSON output against the skill schema
+   */
+  toolBundles: ['read', 'shell', 'validate'],
+  /**
+   * Model pin: QA uses sonnet-tier.
+   * Verification is structured and repeatable — doesn't require opus-level reasoning.
+   */
+  modelPin: 'sonnet',
+  /**
+   * freshContext: true — REQUIRED for all holdout roles.
+   * The QA agent starts with a clean slate: no memory of developer decisions,
+   * no investigation findings, no implementation reasoning.
+   * This is the core holdout discipline.
+   */
+  freshContext: true,
+  role: 'qa',
+  /**
+   * contextAllowlist — what the QA agent is permitted to see.
+   * Explicitly EXCLUDED: devDecisionSummaries, investigationFindings.
+   * The QA agent must independently verify, not rubber-stamp developer reasoning.
+   */
+  contextAllowlist: ['workItem', 'prDiff', 'projectCommands', 'sliceTests'],
+};
+
+export default config;

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const FindingSchema = z.object({
+  tier: z.enum(['structural', 'functional', 'regression']),
+  severity: z.enum(['error', 'warning', 'info']),
+  file: z.string().optional(),
+  line: z.number().int().optional(),
+  description: z.string(),
+  suggestion: z.string().optional(),
+});
+
+export const TierResultSchema = z.object({
+  passed: z.boolean(),
+  findings: z.array(FindingSchema),
+  command: z.string().optional(),
+  output: z.string().optional(),
+});
+
+/**
+ * 8-category code quality rubric (from Steve's training materials).
+ * Maximum aggregate score: 100 points.
+ * Pass threshold: >= 70 points.
+ */
+export const QualityScoresSchema = z.object({
+  /** Open/Closed principle adherence — 0–20 pts */
+  openClosed: z.number().int().min(0).max(20),
+  /** Number of distinct concepts introduced — 0–15 pts */
+  conceptCount: z.number().int().min(0).max(15),
+  /** Time-to-capability: how quickly a developer can use the code — 0–15 pts */
+  timeToCapability: z.number().int().min(0).max(15),
+  /** Complecting: mixing unrelated concerns — 0–15 pts */
+  complecting: z.number().int().min(0).max(15),
+  /** Lines of code: conciseness — 0–10 pts */
+  loc: z.number().int().min(0).max(10),
+  /** Coupling: dependency strength between modules — 0–10 pts */
+  coupling: z.number().int().min(0).max(10),
+  /** Gall's Law: avoidance of big-bang complexity — 0–10 pts */
+  gallsLaw: z.number().int().min(0).max(10),
+  /** Cyclomatic complexity: branching count — 0–5 pts */
+  cyclomaticComplexity: z.number().int().min(0).max(5),
+});
+
+export const QaOutputSchema = z.object({
+  /** Overall QA verdict for the PR */
+  verdict: z.enum(['pass', 'fail', 'partial']),
+  /** Aggregate quality score (0–100) computed from qualityScores */
+  overallScore: z.number().int().min(0).max(100),
+  /** Passing threshold — default 70 */
+  threshold: z.number().int().default(70),
+  /** Results from each of the three verification tiers */
+  tierResults: z.object({
+    structural: TierResultSchema,
+    functional: TierResultSchema,
+    regression: TierResultSchema,
+  }),
+  /** 8-category quality scores */
+  qualityScores: QualityScoresSchema,
+  /** All findings aggregated across tiers */
+  findings: z.array(FindingSchema),
+  /** Per-step audit trail of QA decisions */
+  decisionSummaries: z.array(DecisionSummarySchema),
+});
+
+export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
+export type Finding = z.infer<typeof FindingSchema>;
+export type TierResult = z.infer<typeof TierResultSchema>;
+export type QualityScores = z.infer<typeof QualityScoresSchema>;
+export type QaOutput = z.infer<typeof QaOutputSchema>;
+
+/**
+ * Compute the aggregate quality score by summing all 8 category scores.
+ * The maximum possible score is 100 (20+15+15+15+10+10+10+5).
+ * The pass threshold is 70.
+ */
+export function computeOverallScore(scores: z.infer<typeof QualityScoresSchema>): number {
+  return Object.values(scores).reduce((a, b) => a + b, 0);
+}

--- a/skills/qa/skill.md
+++ b/skills/qa/skill.md
@@ -1,0 +1,297 @@
+# qa skill
+
+You are a QA holdout agent. You operate with **fresh context** — you have no memory of developer decisions, implementation reasoning, or investigator findings. You are an independent verifier. Your job is to confirm that the PR satisfies the original acceptance criteria and meets the project's quality bar.
+
+You are NOT a rubber stamp. You must run the verification commands yourself, read the diff, and form your own independent judgement. If you are uncertain about something, record it as a finding.
+
+## Holdout discipline
+
+You will never speculate about developer intent. You do not have access to:
+- Developer decision summaries
+- Implementation notes or reasoning
+- Investigator findings
+- Any context outside what is explicitly provided to you
+
+If you find yourself reasoning about "why the developer did X", stop. Your job is to verify what was done against what the issue required. Intent is irrelevant — outcome is everything.
+
+## Input
+
+Your context contains:
+
+- `workItem` — the original GitHub issue
+  - `title` — the issue title
+  - `body` — the full issue body, including acceptance criteria
+  - `number` — the issue number
+- `prDiff` — the complete git diff of the PR being reviewed
+- `projectCommands` — shell commands to run
+  - `testCommand` — command to run unit and integration tests
+  - `lintCommand` — command to run lint and type-check (optional)
+  - `e2eCommand` — command to run Playwright end-to-end tests (optional)
+- `sliceTests` — array of paths to slice-level test files (optional)
+
+## Three-tier verification framework
+
+Run the tiers in order. If a tier fails, record all findings from that tier and continue to the next tier. Do not stop early unless the environment is broken.
+
+### Tier 1 — Structural
+
+Purpose: Catch schema regressions, type errors, and lint violations.
+
+Steps:
+1. If `lintCommand` is provided, run it. Record any errors or warnings.
+2. Check that every changed TypeScript file (from the diff) type-checks correctly.
+3. If the PR introduces or modifies Zod schemas, verify that the schema exports are valid and correctly typed.
+4. Look for obvious anti-patterns in the diff: inline prompts instead of skill.md files, imports between slices, missing `README.md` or `slice.test.ts` for new slices.
+
+Emit: `[decision] Structural tier <passed|failed>: <one-sentence summary>`
+
+Record tier result with:
+- `passed`: true if no errors found, false otherwise
+- `findings`: list of all structural issues
+- `command`: the lint command actually run (if any)
+- `output`: the command output (truncated to relevant lines if very long)
+
+### Tier 2 — Functional
+
+Purpose: Catch behavior regressions and missing test coverage.
+
+Steps:
+1. Run `testCommand`. If `sliceTests` are provided, run those first for targeted feedback.
+2. Check test output for failures, errors, and skipped tests.
+3. Read the diff and verify that the changed behavior is covered by tests in the PR.
+4. Check that every acceptance criterion in `workItem.body` is addressed — either by a passing test or by observable code change.
+5. Verify that new functions, schemas, or modules have corresponding tests.
+
+Emit: `[decision] Functional tier <passed|failed>: <one-sentence summary>`
+
+Record tier result with:
+- `passed`: true if all tests pass and coverage is adequate
+- `findings`: list of functional issues (test failures, missing coverage)
+- `command`: the test command run
+- `output`: relevant test output (failures only, truncated if long)
+
+### Tier 3 — Regression
+
+Purpose: Catch UX regressions that only appear in end-to-end flows.
+
+Steps:
+1. If `e2eCommand` is provided, run it and record results.
+2. Read the diff and identify any UI surface changes (component changes, route changes, API changes visible to the frontend).
+3. If no e2e command is provided, assess whether the changes affect any UI flow. If they do, record a warning-severity finding.
+4. Check that any new UI paths introduced by the PR are reachable and render correctly (if e2e tests cover them).
+
+Emit: `[decision] Regression tier <passed|failed|skipped>: <one-sentence summary>`
+
+Record tier result with:
+- `passed`: true if all e2e tests pass or no regressions are possible
+- `findings`: list of regression issues
+- `command`: the e2e command run (if any)
+- `output`: relevant e2e output (failures only)
+
+## Acceptance criteria check
+
+After running all tiers, systematically go through each acceptance criterion in `workItem.body`.
+
+For each criterion marked `[ ]` (checkbox syntax):
+1. Read the relevant changed files from the diff.
+2. Determine whether the criterion is satisfied by the code changes.
+3. If satisfied, note it in your decision summaries.
+4. If not satisfied, record an `error`-severity finding in the functional tier.
+
+Do not assume a criterion is satisfied just because the test passes. Read the code.
+
+## 8-category quality scoring rubric
+
+Score each category independently. Be honest — low scores are informative, not punitive.
+
+### openClosed (0–20 pts)
+
+Does the code follow the Open/Closed Principle? New behavior should be added by extension, not by modifying existing stable interfaces.
+
+- 18–20: New behavior added via extension. No modification to existing stable interfaces.
+- 12–17: Minor modifications to stable interfaces that are clearly necessary and well-scoped.
+- 6–11: Significant interface modifications. Breaking changes not justified by the issue.
+- 0–5: Pervasive modification of existing interfaces. Closed code forced open without justification.
+
+### conceptCount (0–15 pts)
+
+How many distinct concepts does the PR introduce? Fewer is better. Each new abstraction has a carrying cost.
+
+- 13–15: 1–2 new concepts. Reuses existing patterns heavily.
+- 9–12: 3–4 new concepts. All clearly necessary.
+- 5–8: 5–6 new concepts. Some feel unnecessary or duplicative.
+- 0–4: 7+ new concepts. Code would require significant time to understand.
+
+### timeToCapability (0–15 pts)
+
+How quickly can a developer who reads this code use it productively? Consider: naming clarity, documentation, self-evident structure.
+
+- 13–15: A developer could use this in under 5 minutes. Names are clear, README is complete.
+- 9–12: 5–15 minutes to get up to speed. Minor naming issues or gaps in docs.
+- 5–8: 15–30 minutes. Requires reading the implementation to understand how to use it.
+- 0–4: 30+ minutes. Requires context that isn't present in the code or docs.
+
+### complecting (0–15 pts)
+
+Does the code avoid mixing unrelated concerns? Complecting is combining things that should be separate.
+
+- 13–15: No complecting. Each module has one clear responsibility.
+- 9–12: Minor complecting. One or two places where responsibilities blur.
+- 5–8: Moderate complecting. Logic from two domains in the same file/function.
+- 0–4: Heavy complecting. Multiple unrelated concerns tangled together.
+
+### loc (0–10 pts)
+
+Are the changes as concise as they could be without sacrificing clarity?
+
+- 9–10: Minimum necessary code. No padding, no dead code, no unnecessary abstractions.
+- 7–8: Slightly verbose but nothing egregious.
+- 4–6: Noticeable verbosity. Could be shorter without losing clarity.
+- 0–3: Significantly more code than necessary.
+
+### coupling (0–10 pts)
+
+How tightly is the new code coupled to other modules? Loose coupling is better.
+
+- 9–10: Depends only on stable interfaces (`core/` public APIs, standard lib). No cross-slice imports.
+- 7–8: Minor coupling to semi-stable internals. No cross-slice violations.
+- 4–6: Moderate coupling. Some imports that create fragile dependencies.
+- 0–3: Strong coupling. Cross-slice imports, direct internal dependencies, or import cycles.
+
+### gallsLaw (0–10 pts)
+
+Does the PR avoid introducing a complex system from scratch? Complex working systems evolve from simple working systems (Gall's Law).
+
+- 9–10: Builds incrementally on existing working code. Small, evolutionary change.
+- 7–8: Mostly incremental. One larger addition that is well-contained.
+- 4–6: Some big-bang elements. New subsystem introduced without a simpler predecessor.
+- 0–3: Significant new complexity introduced without incremental foundation.
+
+### cyclomaticComplexity (0–5 pts)
+
+Are functions and methods simple? Low cyclomatic complexity means fewer branches, easier testing.
+
+- 5: All functions have cyclomatic complexity ≤ 5. No deeply nested conditionals.
+- 4: Mostly simple. One or two functions with complexity 6–8.
+- 2–3: Some complex functions. Complexity 9–12 in places.
+- 0–1: Functions with complexity > 12. Hard to test exhaustively.
+
+## Verdict rules
+
+Set `verdict` based on the following rules, in order:
+
+1. **fail** — if any of the following are true:
+   - Any `error`-severity finding exists in any tier
+   - Any acceptance criterion from `workItem.body` is not satisfied
+   - `overallScore < threshold` (default threshold: 70)
+   - Tier 1 (structural) failed
+
+2. **partial** — if any of the following are true (and none of the fail conditions):
+   - Tier 2 (functional) failed but Tier 1 passed
+   - `overallScore >= threshold` but there are `warning`-severity findings
+   - Some acceptance criteria satisfied but not all (and no `error` findings)
+   - E2e tests skipped due to missing `e2eCommand` but UI changes detected
+
+3. **pass** — all of the following are true:
+   - No `error`-severity findings in any tier
+   - All acceptance criteria in `workItem.body` are satisfied
+   - `overallScore >= threshold`
+   - Tier 1 and Tier 2 both passed
+
+## Decision-summary pattern
+
+After each major step, emit a line in your text turn:
+
+```
+[decision] <one sentence summary>
+```
+
+These lines are parsed by the orchestrator and stored as `agent.decision-summary` events. Keep each to a single sentence. Do not include raw output, credentials, or implementation reasoning.
+
+Standard steps to emit decisions for:
+
+| Step | When to emit |
+|------|-------------|
+| `issue-read` | After reading and understanding the issue and acceptance criteria |
+| `diff-read` | After reading and understanding the PR diff |
+| `structural-check` | After running lint/typecheck |
+| `functional-check` | After running tests |
+| `regression-check` | After running e2e or assessing regression risk |
+| `criteria-check` | After verifying acceptance criteria against code |
+| `quality-score` | After completing the 8-category scoring |
+| `verdict` | After setting the final verdict |
+
+Examples of good QA decision summaries:
+- `[decision] Read issue #239: QA holdout skill with 3-tier verification and 8-cat scoring`
+- `[decision] Structural tier passed: biome check and tsc clean`
+- `[decision] Functional tier passed: all 34 tests pass including slice.test.ts`
+- `[decision] Regression tier skipped: no e2eCommand provided, no UI changes in diff`
+- `[decision] All 6 acceptance criteria satisfied by code and tests`
+- `[decision] Quality score: 82/100 — verdict: pass`
+
+Bad summaries:
+- More than one sentence
+- Raw test output or file contents
+- Anything mentioning developer intent or reasoning
+
+## Output format
+
+Return a JSON object conforming exactly to this structure:
+
+```json
+{
+  "verdict": "pass | fail | partial",
+  "overallScore": 0,
+  "threshold": 70,
+  "tierResults": {
+    "structural": {
+      "passed": true,
+      "findings": [],
+      "command": "pnpm biome check .",
+      "output": "Checked 42 files. No errors found."
+    },
+    "functional": {
+      "passed": true,
+      "findings": [],
+      "command": "pnpm test --run",
+      "output": "34 tests passed"
+    },
+    "regression": {
+      "passed": true,
+      "findings": [],
+      "command": null,
+      "output": null
+    }
+  },
+  "qualityScores": {
+    "openClosed": 0,
+    "conceptCount": 0,
+    "timeToCapability": 0,
+    "complecting": 0,
+    "loc": 0,
+    "coupling": 0,
+    "gallsLaw": 0,
+    "cyclomaticComplexity": 0
+  },
+  "findings": [],
+  "decisionSummaries": [
+    { "step": "issue-read", "summary": "<one sentence>", "evidence": "<optional>" }
+  ]
+}
+```
+
+`findings` must contain ALL findings across all tiers — not just the ones in `tierResults`. This is the consolidated list used by the reviewer.
+
+`overallScore` must equal the sum of all `qualityScores` values. Do not estimate — compute it.
+
+`decisionSummaries` must have at least one entry per major verification step.
+
+## Important reminders
+
+- You are a holdout. You do not have — and must not seek — developer reasoning.
+- Run the commands. Do not assume tests pass. Do not assume lint is clean.
+- Read the diff. Do not assume the code does what the commit message says.
+- Check acceptance criteria one by one. Do not assume they are all met.
+- Score quality honestly. A score of 65 with a clear explanation is more useful than an inflated 80.
+- The threshold is 70. A score of 70 is a pass. A score of 69 is a fail on quality alone.
+- If you cannot run a command (e.g., the shell is unavailable), record it as an `info`-severity finding and proceed to the next step.

--- a/skills/qa/slice.test.ts
+++ b/skills/qa/slice.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config, { QaContextSchema } from './config.js';
+import {
+  FindingSchema,
+  QaOutputSchema,
+  QualityScoresSchema,
+  TierResultSchema,
+  computeOverallScore,
+} from './schema.js';
+
+// ─── Helper: minimal valid QaOutput ─────────────────────────────────────────
+
+function makeValidScores() {
+  return {
+    openClosed: 15,
+    conceptCount: 10,
+    timeToCapability: 10,
+    complecting: 10,
+    loc: 8,
+    coupling: 8,
+    gallsLaw: 8,
+    cyclomaticComplexity: 4,
+  };
+}
+
+function makeValidTierResult() {
+  return { passed: true, findings: [] };
+}
+
+function makeValidOutput(overrides = {}) {
+  return {
+    verdict: 'pass',
+    overallScore: 73,
+    tierResults: {
+      structural: makeValidTierResult(),
+      functional: makeValidTierResult(),
+      regression: makeValidTierResult(),
+    },
+    qualityScores: makeValidScores(),
+    findings: [],
+    decisionSummaries: [{ step: 'structural-check', summary: 'All lint and type-check passed' }],
+    ...overrides,
+  };
+}
+
+// ─── QaOutputSchema ──────────────────────────────────────────────────────────
+
+describe('QaOutputSchema', () => {
+  it('accepts a valid pass result', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ verdict: 'pass' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid fail result', () => {
+    const result = QaOutputSchema.safeParse(
+      makeValidOutput({
+        verdict: 'fail',
+        overallScore: 45,
+        findings: [
+          {
+            tier: 'structural',
+            severity: 'error',
+            description: 'TypeScript error: Type "string" is not assignable to type "number"',
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid partial result', () => {
+    const result = QaOutputSchema.safeParse(
+      makeValidOutput({
+        verdict: 'partial',
+        overallScore: 65,
+        tierResults: {
+          structural: { passed: true, findings: [] },
+          functional: {
+            passed: false,
+            findings: [{ tier: 'functional', severity: 'error', description: 'Test failed' }],
+          },
+          regression: { passed: false, findings: [] },
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid verdict', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ verdict: 'unknown' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing verdict', () => {
+    const { verdict: _v, ...rest } = makeValidOutput();
+    const result = QaOutputSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects overallScore above 100', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ overallScore: 101 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects overallScore below 0', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ overallScore: -1 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects overallScore that is not an integer', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ overallScore: 72.5 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing tierResults', () => {
+    const { tierResults: _t, ...rest } = makeValidOutput();
+    const result = QaOutputSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing qualityScores', () => {
+    const { qualityScores: _q, ...rest } = makeValidOutput();
+    const result = QaOutputSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults threshold to 70 when not provided', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.threshold).toBe(70);
+    }
+  });
+
+  it('accepts explicit threshold value', () => {
+    const result = QaOutputSchema.safeParse(makeValidOutput({ threshold: 80 }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.threshold).toBe(80);
+    }
+  });
+
+  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(QaOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).toHaveProperty('properties');
+  });
+});
+
+// ─── FindingSchema ───────────────────────────────────────────────────────────
+
+describe('FindingSchema', () => {
+  it('accepts a minimal structural finding', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'structural',
+      severity: 'error',
+      description: 'Biome lint error: missing semicolon',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a functional finding with optional fields', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'functional',
+      severity: 'warning',
+      file: 'src/core/something.ts',
+      line: 42,
+      description: 'Test assertion failed',
+      suggestion: 'Check the return value of computeX()',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a regression finding', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'regression',
+      severity: 'info',
+      description: 'Playwright test skipped due to flaky selector',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid tier', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'performance',
+      severity: 'error',
+      description: 'Some issue',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid severity', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'structural',
+      severity: 'critical',
+      description: 'Some issue',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing description', () => {
+    const result = FindingSchema.safeParse({ tier: 'structural', severity: 'error' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── TierResultSchema ────────────────────────────────────────────────────────
+
+describe('TierResultSchema', () => {
+  it('accepts a passing tier with no findings', () => {
+    const result = TierResultSchema.safeParse({ passed: true, findings: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a failing tier with findings and optional command/output', () => {
+    const result = TierResultSchema.safeParse({
+      passed: false,
+      findings: [{ tier: 'structural', severity: 'error', description: 'lint error' }],
+      command: 'pnpm biome check .',
+      output: 'error: missing semicolon',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing passed field', () => {
+    const result = TierResultSchema.safeParse({ findings: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing findings field', () => {
+    const result = TierResultSchema.safeParse({ passed: true });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── QualityScoresSchema ─────────────────────────────────────────────────────
+
+describe('QualityScoresSchema', () => {
+  it('accepts all max values', () => {
+    const result = QualityScoresSchema.safeParse({
+      openClosed: 20,
+      conceptCount: 15,
+      timeToCapability: 15,
+      complecting: 15,
+      loc: 10,
+      coupling: 10,
+      gallsLaw: 10,
+      cyclomaticComplexity: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all zero values', () => {
+    const result = QualityScoresSchema.safeParse({
+      openClosed: 0,
+      conceptCount: 0,
+      timeToCapability: 0,
+      complecting: 0,
+      loc: 0,
+      coupling: 0,
+      gallsLaw: 0,
+      cyclomaticComplexity: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects openClosed above 20', () => {
+    const result = QualityScoresSchema.safeParse({ ...makeValidScores(), openClosed: 21 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects conceptCount above 15', () => {
+    const result = QualityScoresSchema.safeParse({ ...makeValidScores(), conceptCount: 16 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects cyclomaticComplexity above 5', () => {
+    const result = QualityScoresSchema.safeParse({ ...makeValidScores(), cyclomaticComplexity: 6 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative values', () => {
+    const result = QualityScoresSchema.safeParse({ ...makeValidScores(), loc: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer values', () => {
+    const result = QualityScoresSchema.safeParse({ ...makeValidScores(), coupling: 7.5 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing field', () => {
+    const { gallsLaw: _g, ...rest } = makeValidScores();
+    const result = QualityScoresSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── computeOverallScore ─────────────────────────────────────────────────────
+
+describe('computeOverallScore', () => {
+  it('returns 100 for all maximum scores', () => {
+    const scores = {
+      openClosed: 20,
+      conceptCount: 15,
+      timeToCapability: 15,
+      complecting: 15,
+      loc: 10,
+      coupling: 10,
+      gallsLaw: 10,
+      cyclomaticComplexity: 5,
+    };
+    expect(computeOverallScore(scores)).toBe(100);
+  });
+
+  it('returns 0 for all zero scores', () => {
+    const scores = {
+      openClosed: 0,
+      conceptCount: 0,
+      timeToCapability: 0,
+      complecting: 0,
+      loc: 0,
+      coupling: 0,
+      gallsLaw: 0,
+      cyclomaticComplexity: 0,
+    };
+    expect(computeOverallScore(scores)).toBe(0);
+  });
+
+  it('sums all category scores correctly', () => {
+    const scores = makeValidScores();
+    // 15 + 10 + 10 + 10 + 8 + 8 + 8 + 4 = 73
+    expect(computeOverallScore(scores)).toBe(73);
+  });
+
+  it('returns a score at the pass threshold (70)', () => {
+    const scores = {
+      openClosed: 14,
+      conceptCount: 10,
+      timeToCapability: 10,
+      complecting: 10,
+      loc: 8,
+      coupling: 8,
+      gallsLaw: 8,
+      cyclomaticComplexity: 2,
+    };
+    expect(computeOverallScore(scores)).toBe(70);
+  });
+
+  it('returns a score below the pass threshold (69)', () => {
+    const scores = {
+      openClosed: 13,
+      conceptCount: 10,
+      timeToCapability: 10,
+      complecting: 10,
+      loc: 8,
+      coupling: 8,
+      gallsLaw: 8,
+      cyclomaticComplexity: 2,
+    };
+    expect(computeOverallScore(scores)).toBe(69);
+  });
+});
+
+// ─── QA skill config ─────────────────────────────────────────────────────────
+
+describe('qa skill config', () => {
+  it('has role qa', () => {
+    expect(config.role).toBe('qa');
+  });
+
+  it('has freshContext: true (holdout requirement)', () => {
+    expect(config.freshContext).toBe(true);
+  });
+
+  it('has shell toolBundle for running commands', () => {
+    expect(config.toolBundles).toContain('shell');
+  });
+
+  it('contextAllowlist contains workItem', () => {
+    expect(config.contextAllowlist).toContain('workItem');
+  });
+
+  it('contextAllowlist contains prDiff', () => {
+    expect(config.contextAllowlist).toContain('prDiff');
+  });
+
+  it('contextAllowlist contains projectCommands', () => {
+    expect(config.contextAllowlist).toContain('projectCommands');
+  });
+
+  it('contextAllowlist does NOT contain devDecisionSummaries', () => {
+    expect(config.contextAllowlist).not.toContain('devDecisionSummaries');
+  });
+
+  it('contextAllowlist does NOT contain investigationFindings', () => {
+    expect(config.contextAllowlist).not.toContain('investigationFindings');
+  });
+
+  it('contextSchema validates required workItem, prDiff and projectCommands', () => {
+    const valid = QaContextSchema.safeParse({
+      workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.', number: 42 },
+      prDiff: 'diff --git a/src/foo.ts b/src/foo.ts\n...',
+      projectCommands: { testCommand: 'pnpm test --run', lintCommand: 'pnpm biome check .' },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema accepts optional sliceTests', () => {
+    const valid = QaContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+      prDiff: 'diff output here',
+      projectCommands: { testCommand: 'pnpm test --run' },
+      sliceTests: ['skills/qa/slice.test.ts'],
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem', () => {
+    const invalid = QaContextSchema.safeParse({
+      prDiff: 'diff output',
+      projectCommands: { testCommand: 'pnpm test --run' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing prDiff', () => {
+    const invalid = QaContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+      projectCommands: { testCommand: 'pnpm test --run' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing projectCommands', () => {
+    const invalid = QaContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+      prDiff: 'diff output',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing workItem.number', () => {
+    const invalid = QaContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body' },
+      prDiff: 'diff output',
+      projectCommands: { testCommand: 'pnpm test --run' },
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/skills/review/README.md
+++ b/skills/review/README.md
@@ -1,0 +1,126 @@
+# skills/review
+
+The **Review holdout skill** is the final gate before a PR is approved. It runs after QA passes and independently verifies that the PR satisfies every acceptance criterion in the original GitHub issue.
+
+## Purpose
+
+Review exists to enforce acceptance criteria — not code quality (that's QA's job). It answers one question: **does this PR do what the issue asked?**
+
+Review is a holdout agent. It runs with `freshContext: true` and has no access to developer reasoning, implementation decisions, or investigation findings. It only sees:
+
+1. The original issue (`workItem`)
+2. The PR diff (`prDiff`)
+3. The QA verdict for context (`qaVerdict`, optional)
+
+This isolation is deliberate. The Review agent must form its own independent judgement, not validate the developer's self-assessment.
+
+## Holdout discipline
+
+Review and QA are the two holdout roles in the Factory workflow. Holdout means:
+
+- The agent starts every run with a clean slate (no conversation history)
+- The `contextAllowlist` explicitly excludes developer decision summaries and investigation findings
+- The agent cannot be told "the developer said X" — it must verify from the artifact (the diff) alone
+
+Violating holdout discipline — passing developer reasoning into the Review context — defeats the purpose of the review stage. The orchestrator enforces `contextAllowlist` at the AgentSpec level.
+
+## Verdict table
+
+| Verdict | When it triggers | Action |
+|---------|-----------------|--------|
+| `approved` | All criteria `met`, no blockers, confidence ≥ 0.7 | PR is ready to merge |
+| `needs-fix` | Any criterion `unmet`, confidence ≥ 0.5, issue is fixable | Developer addresses findings and re-submits |
+| `needs-human` | Confidence < 0.5 on any unclear criterion, OR security/architecture concern, OR ambiguous spec | Human reviewer steps in to decide |
+
+The reviewer never produces `approved` by default. It is a positive assertion that requires all criteria to be explicitly verified as `met`.
+
+## Context allowlist
+
+The following keys are permitted in the Review agent's context:
+
+| Key | Description |
+|-----|-------------|
+| `workItem` | Original GitHub issue: title, body (with checkboxes), number |
+| `prDiff` | Complete git diff of the PR |
+| `qaVerdict` | QA outcome (verdict + overallScore) — context only, not directive |
+
+The following keys are **explicitly excluded** and must never be added:
+
+| Key | Why excluded |
+|-----|-------------|
+| `devDecisionSummaries` | Developer reasoning — holdout discipline |
+| `investigationFindings` | Root-cause analysis — holdout discipline |
+| `implementationNotes` | Any form of developer intent — holdout discipline |
+
+## Acceptance criteria verification
+
+The Review agent parses every `- [ ]` checkbox from `workItem.body` and verifies each one independently against the diff. Pre-checked `- [x]` boxes are also verified — the agent does not trust that the developer checked them correctly.
+
+For each criterion, the agent records a `CriterionCheck`:
+
+```typescript
+{
+  criterion: string;       // the criterion text
+  status: 'met' | 'unmet' | 'unclear';
+  notes?: string;          // optional evidence or explanation
+}
+```
+
+**All criteria must be checked.** The agent never skips a criterion, even if it seems obviously satisfied.
+
+## Finding severities
+
+| Severity | Meaning | Effect on verdict |
+|----------|---------|------------------|
+| `blocker` | Must fix — criterion unmet or structural violation | Forces `needs-fix` or `needs-human` |
+| `major` | Should fix — meaningful risk or ambiguity | May force `needs-human` if confidence drops |
+| `minor` | Nice to fix — low-impact quality improvement | Does not block `approved` |
+
+Review findings use different severity labels from QA findings (`blocker/major/minor` vs. QA's `error/warning/info`). This distinction is intentional — Review is about acceptance criteria, QA is about code quality.
+
+## Escalation policy
+
+`needs-human` is triggered when the Review agent cannot make a confident decision. Common escalation triggers:
+
+1. **Low confidence** — confidence falls below 0.5 on any unmet or unclear criterion
+2. **Ambiguous spec** — the issue body does not clearly define what "done" looks like
+3. **Security concern** — credentials in diff, overly permissive access, sensitive data exposure
+4. **Architectural concern** — change contradicts `FACTORY_RULES.md` or `CONTEXT.md` in a way that requires human judgement
+5. **Scope concern** — the diff appears to do more (or less) than the issue specifies
+
+When `needs-human` is returned, the `escalationReason` field is **mandatory** and must contain a clear, actionable description of what question the human reviewer needs to answer. An empty or vague `escalationReason` is a schema validation failure.
+
+## Schema
+
+Output is validated against `ReviewOutputSchema` in `schema.ts`. The schema uses a Zod `discriminatedUnion` on `verdict` so that `needs-human` structurally requires `escalationReason` — the other two verdicts do not have this field.
+
+```typescript
+import { ReviewOutputSchema, type ReviewOutput } from './schema.js';
+```
+
+## Config
+
+```typescript
+import config, { ReviewContextSchema } from './config.js';
+// config.freshContext === true
+// config.role === 'reviewer'
+// config.contextAllowlist === ['workItem', 'prDiff', 'qaVerdict']
+```
+
+## Tests
+
+Run the slice tests:
+
+```bash
+pnpm test --run skills/review/slice.test.ts
+```
+
+Tests cover:
+- All three verdicts (`approved`, `needs-fix`, `needs-human`)
+- `needs-human` without `escalationReason` is rejected
+- `criteriaChecks` status enum validation (`met`, `unmet`, `unclear`)
+- `findings` severity enum validation (`blocker`, `major`, `minor`)
+- `confidence` range validation (0.0–1.0)
+- Config: `freshContext: true`, `role: 'reviewer'`
+- Config `contextAllowlist` inclusions and exclusions
+- Context schema validation (required and optional fields)

--- a/skills/review/config.ts
+++ b/skills/review/config.ts
@@ -1,0 +1,78 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Context keys provided to the Review holdout agent, formatted as structured XML.
+ *
+ * HOLDOUT DISCIPLINE: The Review agent must never receive developer reasoning.
+ * The contextAllowlist explicitly excludes:
+ * - devDecisionSummaries (developer implementation decisions)
+ * - investigationFindings (root cause analysis from the investigator)
+ *
+ * The Review agent only sees what a fresh external reviewer would see:
+ * the original issue, the diff, and the QA verdict for context.
+ *
+ *   <task>
+ *     <work_item>
+ *       <title>...</title>
+ *       <body>...</body>
+ *       <number>...</number>
+ *     </work_item>
+ *     <pr_diff>...</pr_diff>
+ *     <qa_verdict>
+ *       <verdict>pass|fail|partial</verdict>
+ *       <overall_score>82</overall_score>
+ *     </qa_verdict>
+ *   </task>
+ */
+export const ReviewContextSchema = z.object({
+  /** The original GitHub issue — acceptance criteria and requirements */
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  /** The git diff of the PR being reviewed — what was actually changed */
+  prDiff: z.string(),
+  /**
+   * QA verdict from the prior QA holdout run — used as signal, not directive.
+   * The reviewer forms its own independent judgement. QA verdict is context only.
+   */
+  qaVerdict: z
+    .object({
+      verdict: z.enum(['pass', 'fail', 'partial']),
+      overallScore: z.number(),
+    })
+    .optional(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ReviewContextSchema,
+  /**
+   * Tool bundles:
+   * - 'read'     — read source files to understand what changed
+   * - 'validate' — validate JSON output against the skill schema
+   */
+  toolBundles: ['read', 'validate'],
+  /**
+   * Model pin: Review uses sonnet-tier.
+   * Criteria checking is structured and systematic — doesn't require opus-level reasoning.
+   */
+  modelPin: 'sonnet',
+  /**
+   * freshContext: true — REQUIRED for all holdout roles.
+   * The Review agent starts with a clean slate: no memory of developer decisions,
+   * no investigation findings, no implementation reasoning.
+   * This is the core holdout discipline.
+   */
+  freshContext: true,
+  role: 'reviewer',
+  /**
+   * contextAllowlist — what the Review agent is permitted to see.
+   * Explicitly EXCLUDED: devDecisionSummaries, investigationFindings.
+   * The Review agent must independently verify criteria, not rubber-stamp developer reasoning.
+   */
+  contextAllowlist: ['workItem', 'prDiff', 'qaVerdict'],
+};
+
+export default config;

--- a/skills/review/schema.ts
+++ b/skills/review/schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const CriterionCheckSchema = z.object({
+  criterion: z.string(),
+  status: z.enum(['met', 'unmet', 'unclear']),
+  notes: z.string().optional(),
+});
+
+export const ReviewFindingSchema = z.object({
+  criterion: z.string().optional(),
+  severity: z.enum(['blocker', 'major', 'minor']),
+  description: z.string(),
+  suggestion: z.string().optional(),
+  file: z.string().optional(),
+  line: z.number().int().optional(),
+});
+
+/**
+ * Discriminated union on `verdict` so that `needs-human` REQUIRES
+ * `escalationReason` — the other two verdicts do not have this field.
+ */
+export const ReviewOutputSchema = z.discriminatedUnion('verdict', [
+  z.object({
+    verdict: z.literal('approved'),
+    confidence: z.number().min(0).max(1),
+    criteriaChecks: z.array(CriterionCheckSchema),
+    findings: z.array(ReviewFindingSchema),
+    decisionSummaries: z.array(DecisionSummarySchema),
+  }),
+  z.object({
+    verdict: z.literal('needs-fix'),
+    confidence: z.number().min(0).max(1),
+    criteriaChecks: z.array(CriterionCheckSchema),
+    findings: z.array(ReviewFindingSchema),
+    decisionSummaries: z.array(DecisionSummarySchema),
+  }),
+  z.object({
+    verdict: z.literal('needs-human'),
+    confidence: z.number().min(0).max(1),
+    criteriaChecks: z.array(CriterionCheckSchema),
+    findings: z.array(ReviewFindingSchema),
+    decisionSummaries: z.array(DecisionSummarySchema),
+    escalationReason: z.string().min(1),
+  }),
+]);
+
+export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
+export type CriterionCheck = z.infer<typeof CriterionCheckSchema>;
+export type ReviewFinding = z.infer<typeof ReviewFindingSchema>;
+export type ReviewOutput = z.infer<typeof ReviewOutputSchema>;

--- a/skills/review/skill.md
+++ b/skills/review/skill.md
@@ -1,0 +1,273 @@
+# review skill
+
+You are a **Review holdout agent**. You operate with **fresh context** — you have never seen developer decisions, implementation reasoning, investigator findings, or any information beyond what is explicitly provided to you in this session. You are an independent reviewer of the final product, not a collaborator with the development team.
+
+You are NOT a rubber stamp. Your job is to read the PR diff against the original acceptance criteria and deliver an honest, structured verdict. Your independence is the entire point of your existence in this workflow.
+
+## Holdout discipline
+
+You will never speculate about developer intent. You do not have access to — and must not request:
+- Developer decision summaries
+- Implementation notes or reasoning
+- Investigator findings
+- QA internal notes beyond the verdict and score
+- Any context outside what is explicitly provided to you
+
+If you find yourself reasoning about "why the developer did X", stop. You verify **what was done** against **what the issue required**. Intent is irrelevant — outcome is everything.
+
+The QA verdict (`qaVerdict`) is provided as context only. Do not rubber-stamp a `pass` QA verdict as your `approved`. Your review is independent. QA verifies code quality and test coverage. You verify that the original acceptance criteria are satisfied by the delivered code.
+
+## Input
+
+Your context contains:
+
+- `workItem` — the original GitHub issue
+  - `title` — the issue title
+  - `body` — the full issue body, including acceptance criteria as `- [ ]` checkboxes
+  - `number` — the issue number
+- `prDiff` — the complete git diff of the PR being reviewed
+- `qaVerdict` _(optional)_ — the result of the prior QA holdout run
+  - `verdict` — `pass`, `fail`, or `partial`
+  - `overallScore` — aggregate quality score (0–100)
+
+## Step 1 — Parse the acceptance criteria
+
+Read `workItem.body` carefully. Find every acceptance criterion marked with a checkbox:
+
+```
+- [ ] Criterion text here
+- [x] Already-checked criterion (still verify it)
+```
+
+Extract ALL criteria — both unchecked `[ ]` and pre-checked `[x]`. Pre-checked boxes may have been checked by the developer; your job is to independently verify they are actually satisfied.
+
+List the criteria you found. Emit a decision summary:
+
+```
+[decision] Read issue #<number>: found <N> acceptance criteria to verify
+```
+
+If no checkboxes are found, look for numbered lists, bullet points prefixed with "must", "should", or "acceptance criteria" section headers. If truly no criteria are identifiable, record a `needs-human` verdict with `escalationReason: "No acceptance criteria found in workItem.body — cannot verify"`.
+
+## Step 2 — Read the PR diff
+
+Read `prDiff` in full. Understand:
+
+1. What files were added, modified, or deleted
+2. What new exports, functions, schemas, or types were introduced
+3. What existing code was changed and how
+4. Whether any `README.md`, `slice.test.ts`, or `skill.md` files are present (required for new slices)
+
+Emit:
+
+```
+[decision] Read PR diff: <N> files changed — <brief description of main change>
+```
+
+Do not rely on the commit message to understand what changed. Read the diff itself.
+
+## Step 3 — Verify each acceptance criterion
+
+For every criterion identified in Step 1, do the following:
+
+1. Find the relevant section of the diff that would satisfy this criterion
+2. Read the changed code carefully — do not assume it does what it says
+3. Determine one of three statuses:
+   - **met** — the diff clearly addresses and satisfies the criterion
+   - **unmet** — the criterion is not satisfied by the diff (may be partially addressed)
+   - **unclear** — you cannot determine from the diff alone whether the criterion is satisfied
+
+Record a `CriterionCheck` for every criterion.
+
+**Never skip a criterion.** Partial coverage is still unmet. "Close enough" is not met.
+
+Examples of each status:
+
+- `met`: The issue requires a Zod schema export named `ReviewOutputSchema` and the diff adds exactly that, with correct types.
+- `unmet`: The issue requires a `README.md` but no README changes appear in the diff.
+- `unclear`: The issue requires "no breaking changes to existing API" but the diff changes an interface; you cannot verify downstream impact from the diff alone.
+
+Emit after verifying all criteria:
+
+```
+[decision] Criteria check: <N> met, <N> unmet, <N> unclear
+```
+
+## Step 4 — Record findings
+
+For each problem you identify — whether or not it maps to a specific criterion — record a `ReviewFinding`. Use the following severity levels:
+
+### blocker (must fix before approval)
+
+Use `blocker` when:
+- An acceptance criterion is `unmet`
+- A required file is missing (e.g., `slice.test.ts`, `README.md` for a new slice, `skill.md` for a new skill)
+- A cross-slice import violation is present (slices must not import from other slices)
+- An inline prompt is found in TypeScript code (prompts must live in `skill.md` files)
+- An ESM import is missing the `.js` extension in TypeScript source
+- A Zod schema output does not match the specified structure in the issue
+
+### major (should fix, affects usability or correctness)
+
+Use `major` when:
+- A criterion is `unclear` and the ambiguity creates meaningful risk
+- Public API naming diverges from what the issue specified without obvious justification
+- A test exists but does not cover the acceptance criterion it claims to cover
+- A `README.md` is present but missing key sections (purpose, usage, context allowlist)
+- Security-adjacent concerns (credentials in code, overly broad permissions)
+
+### minor (nice to fix, low impact)
+
+Use `minor` when:
+- Code style is inconsistent but does not affect correctness
+- A doc comment is misleading or incomplete
+- A test helper could be simpler or more readable
+- An optional field would improve usability but is not required by the issue
+
+## Step 5 — Determine the verdict
+
+Set `verdict` using the following rules, evaluated in order:
+
+### needs-human
+
+Escalate to `needs-human` when **any** of the following are true:
+
+- Your `confidence` on any `unmet` or `unclear` criterion is below **0.5**
+- The issue body is ambiguous enough that you cannot determine what was required
+- A security concern is present (credentials, overly permissive access controls, sensitive data exposure)
+- An architectural concern is present that contradicts `FACTORY_RULES.md` or `CONTEXT.md` in a way that requires human judgement
+- The diff is too large or complex to review with confidence in one pass
+
+When `needs-human`, you MUST populate `escalationReason` — a clear, one-paragraph explanation of exactly why human review is required and what question needs to be answered. An empty `escalationReason` is not permitted.
+
+### needs-fix
+
+Use `needs-fix` when **any** criterion is `unmet` AND you are confident (`confidence >= 0.5`) about what needs to change. This means:
+
+- There are `blocker` findings
+- The developer can clearly address the findings without architectural decisions
+- No security or governance escalation is needed
+
+### approved
+
+Use `approved` only when **all** of the following are true:
+
+- Every criterion has status `met`
+- No `blocker` findings exist
+- `confidence >= 0.7` overall
+- No security or architectural escalation triggers apply
+
+`approved` means you are confident the work satisfies all acceptance criteria. It is not a "good enough" verdict — it is a positive assertion.
+
+## Step 6 — Set confidence
+
+`confidence` is a decimal from 0.0 to 1.0 representing how certain you are in your verdict.
+
+| Range | Meaning |
+|-------|---------|
+| 0.9–1.0 | Highly certain — all criteria are clearly addressed by the diff |
+| 0.7–0.89 | Confident — minor ambiguity exists but does not affect the verdict |
+| 0.5–0.69 | Moderate — meaningful uncertainty, leaning toward a verdict |
+| 0.0–0.49 | Low — you cannot confidently determine the outcome from the diff |
+
+If `confidence < 0.5` and any criterion is `unmet` or `unclear`, use `needs-human`.
+
+## Decision-summary pattern
+
+After each major step, emit a line in your text turn:
+
+```
+[decision] <one sentence summary>
+```
+
+These lines are parsed by the orchestrator and stored as `agent.decision-summary` events. Keep each to a single sentence. Do not include raw output, credentials, or implementation reasoning.
+
+Standard steps to emit decisions for:
+
+| Step | When to emit |
+|------|-------------|
+| `issue-read` | After parsing the issue and listing acceptance criteria |
+| `diff-read` | After reading and understanding the PR diff |
+| `criteria-check` | After verifying all acceptance criteria |
+| `findings-summary` | After recording all findings |
+| `verdict` | After setting the final verdict and confidence |
+
+Examples of good Review decision summaries:
+- `[decision] Read issue #240: found 6 acceptance criteria to verify`
+- `[decision] Read PR diff: 5 files changed — new skills/review/ directory with schema, config, tests, skill.md, README`
+- `[decision] Criteria check: 5 met, 1 unmet, 0 unclear`
+- `[decision] 1 blocker finding: README.md missing required escalation policy section`
+- `[decision] Verdict: needs-fix, confidence: 0.85 — README gap is clear and fixable`
+
+Bad summaries:
+- More than one sentence
+- Raw file contents or diff excerpts
+- Anything mentioning developer intent or reasoning
+- "I think" or "probably" — state facts about the diff, not speculation
+
+## Output format
+
+Return a JSON object conforming exactly to this structure.
+
+For `approved` or `needs-fix`:
+
+```json
+{
+  "verdict": "approved",
+  "confidence": 0.92,
+  "criteriaChecks": [
+    {
+      "criterion": "ReviewOutputSchema is exported from schema.ts",
+      "status": "met",
+      "notes": "Exported on line 47 of skills/review/schema.ts"
+    }
+  ],
+  "findings": [],
+  "decisionSummaries": [
+    { "step": "issue-read", "summary": "Read issue #240: found 5 acceptance criteria" },
+    { "step": "diff-read", "summary": "Read PR diff: 5 files changed in skills/review/" },
+    { "step": "criteria-check", "summary": "All 5 criteria met: schema, config, tests, skill.md, README present" },
+    { "step": "verdict", "summary": "Verdict: approved, confidence 0.92 — all criteria met, no blockers" }
+  ]
+}
+```
+
+For `needs-human` (escalationReason is REQUIRED):
+
+```json
+{
+  "verdict": "needs-human",
+  "confidence": 0.35,
+  "criteriaChecks": [
+    {
+      "criterion": "No breaking changes to existing public API",
+      "status": "unclear",
+      "notes": "Interface changed but downstream impact cannot be assessed from diff alone"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "major",
+      "description": "Interface AgentSpec changed in core/agent-runtime/interface.ts — cannot verify downstream safety",
+      "file": "core/agent-runtime/interface.ts"
+    }
+  ],
+  "decisionSummaries": [
+    { "step": "issue-read", "summary": "Read issue #240: 3 criteria found" },
+    { "step": "criteria-check", "summary": "Criteria check: 2 met, 0 unmet, 1 unclear" },
+    { "step": "verdict", "summary": "Verdict: needs-human — confidence 0.35 on unclear criterion, architectural risk" }
+  ],
+  "escalationReason": "The criterion 'no breaking changes' cannot be verified from the diff. The AgentSpec interface in core/agent-runtime/interface.ts has been modified. Downstream consumers are outside the diff scope. A human reviewer with broader codebase knowledge must confirm this change is safe."
+}
+```
+
+## Important reminders
+
+- You are a holdout. You do not have — and must not seek — developer reasoning.
+- Read the diff. Do not assume the code does what the commit message says.
+- Check EVERY acceptance criterion. Never skip one, even if it seems obviously met.
+- `approved` is a positive assertion, not a default. It requires all criteria `met`.
+- `needs-human` requires a non-empty `escalationReason`. No exceptions.
+- `confidence` is your honest assessment, not what you wish it were.
+- If a criterion appears trivially met, still document why — "README.md present with all required sections on lines 1–45."
+- The QA verdict is context, not directive. A QA `pass` does not guarantee your `approved`.

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from 'vitest';
+import config, { ReviewContextSchema } from './config.js';
+import { CriterionCheckSchema, ReviewFindingSchema, ReviewOutputSchema } from './schema.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeApprovedOutput(overrides = {}) {
+  return {
+    verdict: 'approved',
+    confidence: 0.9,
+    criteriaChecks: [{ criterion: 'Schema exports are valid', status: 'met' }],
+    findings: [],
+    decisionSummaries: [{ step: 'issue-read', summary: 'Issue #42 parsed: 1 criterion found' }],
+    ...overrides,
+  };
+}
+
+function makeNeedsFixOutput(overrides = {}) {
+  return {
+    verdict: 'needs-fix',
+    confidence: 0.65,
+    criteriaChecks: [
+      { criterion: 'All tests pass', status: 'unmet', notes: 'slice.test.ts is missing' },
+    ],
+    findings: [
+      { severity: 'blocker', description: 'Missing slice.test.ts required by FACTORY_RULES' },
+    ],
+    decisionSummaries: [
+      { step: 'criteria-check', summary: 'Criterion unmet: slice.test.ts absent' },
+    ],
+    ...overrides,
+  };
+}
+
+function makeNeedsHumanOutput(overrides = {}) {
+  return {
+    verdict: 'needs-human',
+    confidence: 0.3,
+    criteriaChecks: [{ criterion: 'Architecture is sound', status: 'unclear' }],
+    findings: [
+      {
+        severity: 'major',
+        description: 'Ambiguous architectural decision requires human judgement',
+      },
+    ],
+    decisionSummaries: [
+      { step: 'verdict', summary: 'Escalating: confidence below 0.5 on unclear criterion' },
+    ],
+    escalationReason:
+      'Confidence below 0.5: cannot determine if architectural constraint is satisfied without human input',
+    ...overrides,
+  };
+}
+
+// ─── ReviewOutputSchema — approved ───────────────────────────────────────────
+
+describe('ReviewOutputSchema — approved verdict', () => {
+  it('accepts a valid approved result', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepted approved result carries all required fields', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.verdict).toBe('approved');
+      expect(result.data.confidence).toBe(0.9);
+      expect(result.data.criteriaChecks).toHaveLength(1);
+      expect(result.data.findings).toHaveLength(0);
+      expect(result.data.decisionSummaries).toHaveLength(1);
+    }
+  });
+
+  it('approved result does NOT require escalationReason', () => {
+    const output = makeApprovedOutput();
+    expect('escalationReason' in output).toBe(false);
+    const result = ReviewOutputSchema.safeParse(output);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── ReviewOutputSchema — needs-fix ──────────────────────────────────────────
+
+describe('ReviewOutputSchema — needs-fix verdict', () => {
+  it('accepts a valid needs-fix result', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsFixOutput());
+    expect(result.success).toBe(true);
+  });
+
+  it('needs-fix result carries criteriaChecks with unmet status', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsFixOutput());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.verdict).toBe('needs-fix');
+      expect(result.data.criteriaChecks[0].status).toBe('unmet');
+    }
+  });
+
+  it('needs-fix result does NOT require escalationReason', () => {
+    const output = makeNeedsFixOutput();
+    expect('escalationReason' in output).toBe(false);
+    const result = ReviewOutputSchema.safeParse(output);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── ReviewOutputSchema — needs-human ────────────────────────────────────────
+
+describe('ReviewOutputSchema — needs-human verdict', () => {
+  it('accepts a valid needs-human result WITH escalationReason', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput());
+    expect(result.success).toBe(true);
+  });
+
+  it('needs-human without escalationReason is REJECTED', () => {
+    const { escalationReason: _e, ...withoutEscalation } = makeNeedsHumanOutput();
+    const result = ReviewOutputSchema.safeParse(withoutEscalation);
+    expect(result.success).toBe(false);
+  });
+
+  it('needs-human with empty escalationReason is REJECTED', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput({ escalationReason: '' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('needs-human with whitespace-only escalationReason passes min(1) check', () => {
+    // min(1) means at least 1 character; a space technically passes
+    // This tests the literal schema constraint, not business logic
+    const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput({ escalationReason: ' ' }));
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── ReviewOutputSchema — verdict validation ──────────────────────────────────
+
+describe('ReviewOutputSchema — verdict validation', () => {
+  it('rejects an unknown verdict', () => {
+    const result = ReviewOutputSchema.safeParse({
+      ...makeApprovedOutput(),
+      verdict: 'rejected',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing verdict', () => {
+    const { verdict: _v, ...rest } = makeApprovedOutput();
+    const result = ReviewOutputSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── CriterionCheckSchema ─────────────────────────────────────────────────────
+
+describe('CriterionCheckSchema', () => {
+  it('accepts status: met', () => {
+    const result = CriterionCheckSchema.safeParse({
+      criterion: 'All tests pass',
+      status: 'met',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts status: unmet', () => {
+    const result = CriterionCheckSchema.safeParse({
+      criterion: 'README.md is present',
+      status: 'unmet',
+      notes: 'File not found in diff',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts status: unclear', () => {
+    const result = CriterionCheckSchema.safeParse({
+      criterion: 'No breaking changes',
+      status: 'unclear',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid status', () => {
+    const result = CriterionCheckSchema.safeParse({
+      criterion: 'Something',
+      status: 'pending',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing criterion', () => {
+    const result = CriterionCheckSchema.safeParse({ status: 'met' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing status', () => {
+    const result = CriterionCheckSchema.safeParse({ criterion: 'Something' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── ReviewFindingSchema ──────────────────────────────────────────────────────
+
+describe('ReviewFindingSchema', () => {
+  it('accepts a blocker finding', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'blocker',
+      description: 'Acceptance criterion unmet: slice.test.ts missing',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a major finding with optional fields', () => {
+    const result = ReviewFindingSchema.safeParse({
+      criterion: 'No inline prompts in code',
+      severity: 'major',
+      description: 'Prompt found inline in src/agent.ts',
+      suggestion: 'Move to skills/myskill/skill.md',
+      file: 'src/agent.ts',
+      line: 37,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a minor finding', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'minor',
+      description: 'JSDoc comment could be more descriptive',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid severity', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'critical',
+      description: 'Something very bad',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects severity: error (QA enum, not Review enum)', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'error',
+      description: 'A QA-style severity that is invalid for Review',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects severity: warning (QA enum, not Review enum)', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'warning',
+      description: 'A QA-style severity that is invalid for Review',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing description', () => {
+    const result = ReviewFindingSchema.safeParse({ severity: 'blocker' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer line number', () => {
+    const result = ReviewFindingSchema.safeParse({
+      severity: 'minor',
+      description: 'Indentation issue',
+      line: 3.5,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── confidence range validation ──────────────────────────────────────────────
+
+describe('confidence range validation', () => {
+  it('accepts confidence at 0.0 (minimum)', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput({ confidence: 0.0 }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts confidence at 1.0 (maximum)', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput({ confidence: 1.0 }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects confidence above 1.0', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput({ confidence: 1.1 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects confidence below 0.0', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput({ confidence: -0.1 }));
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Review skill config ──────────────────────────────────────────────────────
+
+describe('review skill config', () => {
+  it('has freshContext: true (holdout requirement)', () => {
+    expect(config.freshContext).toBe(true);
+  });
+
+  it('has role: reviewer', () => {
+    expect(config.role).toBe('reviewer');
+  });
+
+  it('contextAllowlist contains workItem', () => {
+    expect(config.contextAllowlist).toContain('workItem');
+  });
+
+  it('contextAllowlist contains prDiff', () => {
+    expect(config.contextAllowlist).toContain('prDiff');
+  });
+
+  it('contextAllowlist contains qaVerdict', () => {
+    expect(config.contextAllowlist).toContain('qaVerdict');
+  });
+
+  it('contextAllowlist does NOT contain devDecisionSummaries', () => {
+    expect(config.contextAllowlist).not.toContain('devDecisionSummaries');
+  });
+
+  it('contextAllowlist does NOT contain investigationFindings', () => {
+    expect(config.contextAllowlist).not.toContain('investigationFindings');
+  });
+
+  it('contextSchema validates required workItem and prDiff', () => {
+    const valid = ReviewContextSchema.safeParse({
+      workItem: {
+        title: 'Add review skill',
+        body: '- [ ] schema defined\n- [ ] tests pass',
+        number: 240,
+      },
+      prDiff: 'diff --git a/skills/review/schema.ts b/skills/review/schema.ts\n...',
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema accepts optional qaVerdict', () => {
+    const valid = ReviewContextSchema.safeParse({
+      workItem: { title: 'Add review skill', body: '- [ ] schema defined', number: 240 },
+      prDiff: 'diff output here',
+      qaVerdict: { verdict: 'pass', overallScore: 82 },
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it('contextSchema rejects missing workItem', () => {
+    const invalid = ReviewContextSchema.safeParse({
+      prDiff: 'diff output',
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects missing prDiff', () => {
+    const invalid = ReviewContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it('contextSchema rejects invalid qaVerdict verdict value', () => {
+    const invalid = ReviewContextSchema.safeParse({
+      workItem: { title: 'title', body: 'body', number: 1 },
+      prDiff: 'diff output',
+      qaVerdict: { verdict: 'approved', overallScore: 82 },
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/slices/fix-issue/chore-shipping.test.ts
+++ b/slices/fix-issue/chore-shipping.test.ts
@@ -115,7 +115,7 @@ describe('chore-shipping end-to-end (#187)', () => {
     process.env.GITHUB_TOKEN = undefined;
   });
 
-  it('ships a chore: dev-ready → in-progress → PR open → approved → done', async () => {
+  it('ships a chore: dev-ready → in-progress → PR open → needs-qa → done', async () => {
     const item = makeChoreItem();
     const source = makeStateSource();
 
@@ -193,10 +193,10 @@ describe('chore-shipping end-to-end (#187)', () => {
     // ── Acceptance: state transitions in order ────────────────────────────
     const transitions = vi.mocked(source.transitionState).mock.calls;
     expect(transitions[0]).toEqual(['9999', 'factory:dev-ready', 'factory:in-progress']);
-    expect(transitions[1]).toEqual(['9999', 'factory:in-progress', 'factory:approved']);
+    expect(transitions[1]).toEqual(['9999', 'factory:in-progress', 'factory:needs-qa']);
 
     // ── Step 8: human approves at the gate; PR merges; issue closes ──────
-    // The workflow leaves the issue in factory:approved with a recorded
+    // The workflow leaves the issue in factory:needs-qa with a recorded
     // pr.opened payload (asserted above). The ApprovalGateSection UI test
     // (apps/web/src/components/.../ApprovalGateSection.test.tsx) covers
     // the click-Approve → POST /approve flow. The approveIssue / rejectIssue

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -108,6 +108,9 @@ describe('runFixIssueWorkflow (#183)', () => {
     const adviseOnPlanImpl = vi.fn();
     const createWorktreeImpl = vi.fn().mockReturnValue('/work/wt');
     const cleanupWorktreeImpl = vi.fn();
+    const resolveWorktreeHeadShaImpl = vi
+      .fn()
+      .mockReturnValue('abc1234567890abcdef1234567890abcdef1234');
 
     const { runFixIssueWorkflow } = await import('./workflow.js');
     await runFixIssueWorkflow(item, source, 'proj', '/repo', {
@@ -116,6 +119,7 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl,
       createWorktreeImpl,
       cleanupWorktreeImpl,
+      resolveWorktreeHeadShaImpl,
     });
 
     expect(createWorktreeImpl).toHaveBeenCalledWith('/repo', expect.any(String));
@@ -175,6 +179,9 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl,
       createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
       cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
     });
 
     expect(adviseOnPlanImpl).toHaveBeenCalledTimes(1);
@@ -218,6 +225,9 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl,
       createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
       cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
     });
 
     expect(runMock).toHaveBeenCalledTimes(2);
@@ -252,6 +262,9 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl,
       createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
       cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
     });
 
     expect(openPRImpl).not.toHaveBeenCalled();
@@ -274,6 +287,9 @@ describe('runFixIssueWorkflow (#183)', () => {
     };
     const openPRImpl = vi.fn();
     const cleanupWorktreeImpl = vi.fn();
+    const resolveWorktreeHeadShaImpl = vi
+      .fn()
+      .mockReturnValue('abc1234567890abcdef1234567890abcdef1234');
 
     const { runFixIssueWorkflow } = await import('./workflow.js');
     await runFixIssueWorkflow(item, source, 'proj', '/repo', {
@@ -282,6 +298,7 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl: vi.fn(),
       createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
       cleanupWorktreeImpl,
+      resolveWorktreeHeadShaImpl,
     });
 
     expect(openPRImpl).not.toHaveBeenCalled();
@@ -328,6 +345,9 @@ describe('runFixIssueWorkflow (#183)', () => {
       adviseOnPlanImpl: vi.fn(),
       createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
       cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
     });
 
     const decisionEvents = vi

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -87,7 +87,7 @@ describe('runFixIssueWorkflow (#183)', () => {
     process.env.GITHUB_TOKEN = undefined;
   });
 
-  it('happy path (priority:medium, no advisor): worktree → in-progress → implement → PR → approved', async () => {
+  it('happy path (priority:medium, no advisor): worktree → in-progress → implement → PR → needs-qa', async () => {
     const item = makeWorkItem({ priority: 'medium' });
     const source = makeStateSource();
 
@@ -136,7 +136,7 @@ describe('runFixIssueWorkflow (#183)', () => {
     expect(source.transitionState).toHaveBeenLastCalledWith(
       '42',
       'factory:in-progress',
-      'factory:approved',
+      'factory:needs-qa',
     );
     expect(cleanupWorktreeImpl).toHaveBeenCalled();
     // pr.opened event recorded

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -34,6 +34,8 @@ export interface FixIssueDeps {
   createWorktreeImpl?: typeof createWorktree;
   /** Override cleanupWorktree (used by tests). */
   cleanupWorktreeImpl?: typeof cleanupWorktree;
+  /** Override resolveWorktreeHeadSha (used by tests to avoid real git subprocess). */
+  resolveWorktreeHeadShaImpl?: typeof resolveWorktreeHeadSha;
 }
 
 /**
@@ -68,6 +70,7 @@ export async function runFixIssueWorkflow(
   const advisorFn = deps.adviseOnPlanImpl ?? adviseOnPlan;
   const createWtFn = deps.createWorktreeImpl ?? createWorktree;
   const cleanupWtFn = deps.cleanupWorktreeImpl ?? cleanupWorktree;
+  const resolveHeadShaFn = deps.resolveWorktreeHeadShaImpl ?? resolveWorktreeHeadSha;
 
   const implementPrompt = readPrompt('implement');
   const implementJsonSchema = toJsonSchema(ImplementSchema);
@@ -149,6 +152,7 @@ export async function runFixIssueWorkflow(
           runtime,
           evidencePostPrompt,
           evidencePostJsonSchema,
+          resolveHeadShaFn,
         });
         return;
       }
@@ -181,6 +185,7 @@ export async function runFixIssueWorkflow(
       runtime,
       evidencePostPrompt,
       evidencePostJsonSchema,
+      resolveHeadShaFn,
     });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -285,6 +290,7 @@ interface AfterImplementInput {
   runtime: AgentRuntime;
   evidencePostPrompt: string;
   evidencePostJsonSchema: Record<string, unknown>;
+  resolveHeadShaFn: typeof resolveWorktreeHeadSha;
 }
 
 async function afterImplement(input: AfterImplementInput): Promise<void> {
@@ -343,7 +349,7 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
   // Step 6: evidence-post wiring (#234) — best-effort.
   // Resolve the worktree HEAD to the real commit SHA so evidence-post pins
   // its raw URLs to an immutable ref (#233 SHA-pinning contract).
-  const prHeadSha = resolveWorktreeHeadSha(worktreePath);
+  const prHeadSha = input.resolveHeadShaFn(worktreePath);
   await runEvidencePost({
     workItem,
     projectId,

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -357,9 +357,8 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
     evidenceSpecPath: implementOutput.evidenceSpecPath,
   });
 
-  // Step 7: transition to factory:approved (M7 path; M8 will insert
-  // factory:needs-qa → factory:needs-review before this).
-  await stateSource.transitionState(workItem.externalId, 'factory:in-progress', 'factory:approved');
+  // Step 7: M8 path — route through QA before approval (factory:in-progress → factory:needs-qa)
+  await stateSource.transitionState(workItem.externalId, 'factory:in-progress', 'factory:needs-qa');
 }
 
 interface RunEvidencePostInput {

--- a/slices/holdout-boundary-test/README.md
+++ b/slices/holdout-boundary-test/README.md
@@ -1,0 +1,25 @@
+# slices/holdout-boundary-test/
+
+Verification slice for M8 exit criteria: deliberate context injection attempts on holdout roles (QA, Reviewer) must fail at the runtime layer.
+
+## What this tests
+
+- Disallowed keys are absent from the rendered XML context passed to Claude
+- `tool.violation` events are emitted for each disallowed key on a holdout role
+- Non-holdout roles do NOT emit violations (silent filter only)
+- System keys (`projectId`, `workItemId`) are exempted from violation detection
+- `runId` is correctly attributed in violation events
+
+## Why this exists
+
+FACTORY_RULES rule 1: QA and Review never see implementation reasoning. The holdout boundary
+test is the formal proof that this property holds at the runtime layer, not just by convention.
+Referenced directly in the M8 exit criteria (PLAN.md §28 M8).
+
+## Running
+
+```bash
+pnpm test --run slices/holdout-boundary-test/slice.test.ts
+```
+
+No live Claude API required — tests the context assembly layer only.

--- a/slices/holdout-boundary-test/slice.test.ts
+++ b/slices/holdout-boundary-test/slice.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock eventStore before importing assembleSpawnContext
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
@@ -8,18 +8,23 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 }));
 
 import { assembleSpawnContext } from '@goose-hub/core/agent-runtime/context-assembly.js';
+import type { AgentSpec } from '@goose-hub/core/agent-runtime/interface.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 
 const mockAppendEvent = vi.mocked(eventStore.appendEvent);
 
-function makeHoldoutSpec(role: 'qa' | 'reviewer', context: Record<string, unknown>, allowlist: string[]) {
+function makeHoldoutSpec(
+  role: 'qa' | 'reviewer',
+  context: Record<string, unknown>,
+  allowlist: string[],
+): AgentSpec {
   return {
     runId: `boundary-test-${crypto.randomUUID()}`,
     role,
     skill: role,
     context: { projectId: 'test-project', workItemId: 'test-item', ...context },
     contextAllowlist: allowlist,
-    freshContext: true as const,
+    freshContext: true,
     toolBundles: [],
     toolExtras: [],
     budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
@@ -34,65 +39,78 @@ describe('Holdout boundary test — deliberate injection attempts', () => {
 
   describe('QA role — devDecisionSummaries injection attempt', () => {
     it('devDecisionSummaries is absent from rendered XML', () => {
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'test' },
-        devDecisionSummaries: ['SECRET: developer chose approach X because of Y constraint'],
-      }, ['workItem']);
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'test' },
+          devDecisionSummaries: ['SECRET: developer chose approach X because of Y constraint'],
+        },
+        ['workItem'],
+      );
 
-      const { contextXml } = assembleSpawnContext(spec as any);
+      const { contextXml } = assembleSpawnContext(spec);
       expect(contextXml).not.toContain('devDecisionSummaries');
       expect(contextXml).not.toContain('SECRET');
       expect(contextXml).not.toContain('developer chose approach');
     });
 
     it('devDecisionSummaries injection emits tool.violation event', () => {
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'test' },
-        devDecisionSummaries: ['secret reasoning'],
-      }, ['workItem']);
-
-      assembleSpawnContext(spec as any);
-
-      const violations = mockAppendEvent.mock.calls.filter(
-        ([e]) => e.kind === 'tool.violation'
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'test' },
+          devDecisionSummaries: ['secret reasoning'],
+        },
+        ['workItem'],
       );
+
+      assembleSpawnContext(spec);
+
+      const violations = mockAppendEvent.mock.calls.filter(([e]) => e.kind === 'tool.violation');
       expect(violations.length).toBeGreaterThanOrEqual(1);
-      const violationPayloads = violations.map(([e]) => e.payload as { disallowedKey: string; role: string });
+      const violationPayloads = violations.map(
+        ([e]) => e.payload as { disallowedKey: string; role: string },
+      );
       expect(violationPayloads.some((p) => p.disallowedKey === 'devDecisionSummaries')).toBe(true);
       expect(violationPayloads.every((p) => p.role === 'qa')).toBe(true);
     });
 
     it('runId is included in tool.violation event payload', () => {
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'test' },
-        investigationFindings: 'leaked reasoning',
-      }, ['workItem']);
-
-      assembleSpawnContext(spec as any);
-
-      const violation = mockAppendEvent.mock.calls.find(
-        ([e]) => e.kind === 'tool.violation'
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'test' },
+          investigationFindings: 'leaked reasoning',
+        },
+        ['workItem'],
       );
+
+      assembleSpawnContext(spec);
+
+      const violation = mockAppendEvent.mock.calls.find(([e]) => e.kind === 'tool.violation');
       expect(violation).toBeDefined();
-      expect((violation![0].payload as { runId: string }).runId).toBe(spec.runId);
+      const payload = violation?.[0].payload as { runId: string } | undefined;
+      expect(payload?.runId).toBe(spec.runId);
     });
   });
 
   describe('QA role — multiple disallowed keys', () => {
     it('emits one tool.violation event per disallowed key', () => {
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'test' },
-        devDecisionSummaries: ['secret 1'],
-        investigationFindings: { keyFile: 'auth.ts' },
-        advisorFeedback: 'internal advisor thoughts',
-      }, ['workItem']);
-
-      assembleSpawnContext(spec as any);
-
-      const violations = mockAppendEvent.mock.calls.filter(
-        ([e]) => e.kind === 'tool.violation'
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'test' },
+          devDecisionSummaries: ['secret 1'],
+          investigationFindings: { keyFile: 'auth.ts' },
+          advisorFeedback: 'internal advisor thoughts',
+        },
+        ['workItem'],
       );
-      expect(violations.length).toBe(3); // one per disallowed key
+
+      assembleSpawnContext(spec);
+
+      const violations = mockAppendEvent.mock.calls.filter(([e]) => e.kind === 'tool.violation');
+      expect(violations.length).toBe(3);
       const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
       expect(keys).toContain('devDecisionSummaries');
       expect(keys).toContain('investigationFindings');
@@ -100,13 +118,17 @@ describe('Holdout boundary test — deliberate injection attempts', () => {
     });
 
     it('allowed keys ARE present in XML', () => {
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'my test issue' },
-        prDiff: '+foo bar',
-        devDecisionSummaries: ['should not appear'],
-      }, ['workItem', 'prDiff']);
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'my test issue' },
+          prDiff: '+foo bar',
+          devDecisionSummaries: ['should not appear'],
+        },
+        ['workItem', 'prDiff'],
+      );
 
-      const { contextXml } = assembleSpawnContext(spec as any);
+      const { contextXml } = assembleSpawnContext(spec);
       expect(contextXml).toContain('workItem');
       expect(contextXml).toContain('prDiff');
       expect(contextXml).not.toContain('devDecisionSummaries');
@@ -115,36 +137,44 @@ describe('Holdout boundary test — deliberate injection attempts', () => {
 
   describe('Reviewer role — injection attempt', () => {
     it('devDecisionSummaries absent from Reviewer XML', () => {
-      const spec = makeHoldoutSpec('reviewer', {
-        workItem: { title: 'test' },
-        prDiff: '+foo',
-        devDecisionSummaries: ['SECRET reviewer should not see this'],
-      }, ['workItem', 'prDiff', 'qaVerdict']);
+      const spec = makeHoldoutSpec(
+        'reviewer',
+        {
+          workItem: { title: 'test' },
+          prDiff: '+foo',
+          devDecisionSummaries: ['SECRET reviewer should not see this'],
+        },
+        ['workItem', 'prDiff', 'qaVerdict'],
+      );
 
-      const { contextXml } = assembleSpawnContext(spec as any);
+      const { contextXml } = assembleSpawnContext(spec);
       expect(contextXml).not.toContain('devDecisionSummaries');
       expect(contextXml).not.toContain('SECRET reviewer should not see this');
     });
 
     it('Reviewer injection emits tool.violation with role: reviewer', () => {
-      const spec = makeHoldoutSpec('reviewer', {
-        workItem: { title: 'test' },
-        devDecisionSummaries: ['reasoning'],
-      }, ['workItem', 'qaVerdict']);
-
-      assembleSpawnContext(spec as any);
-
-      const violations = mockAppendEvent.mock.calls.filter(
-        ([e]) => e.kind === 'tool.violation'
+      const spec = makeHoldoutSpec(
+        'reviewer',
+        {
+          workItem: { title: 'test' },
+          devDecisionSummaries: ['reasoning'],
+        },
+        ['workItem', 'qaVerdict'],
       );
+
+      assembleSpawnContext(spec);
+
+      const violations = mockAppendEvent.mock.calls.filter(([e]) => e.kind === 'tool.violation');
       expect(violations.length).toBeGreaterThanOrEqual(1);
-      expect(violations.every(([e]) => (e.payload as { role: string }).role === 'reviewer')).toBe(true);
+      expect(violations.every(([e]) => (e.payload as { role: string }).role === 'reviewer')).toBe(
+        true,
+      );
     });
   });
 
   describe('Non-holdout role — NO violation events', () => {
     it('developer role with unlisted keys does NOT emit tool.violation', () => {
-      const spec = {
+      const spec: AgentSpec = {
         runId: 'dev-test',
         role: 'developer',
         skill: 'implement',
@@ -163,28 +193,26 @@ describe('Holdout boundary test — deliberate injection attempts', () => {
         personaId: 'test-project/developer/0',
       };
 
-      assembleSpawnContext(spec as any);
+      assembleSpawnContext(spec);
 
-      const violations = mockAppendEvent.mock.calls.filter(
-        ([e]) => e.kind === 'tool.violation'
-      );
+      const violations = mockAppendEvent.mock.calls.filter(([e]) => e.kind === 'tool.violation');
       expect(violations.length).toBe(0);
     });
   });
 
   describe('System keys — exempted from violation detection', () => {
     it('projectId and workItemId are NOT flagged as violations on holdout roles', () => {
-      // projectId and workItemId are always in context but may not be in allowlist
-      const spec = makeHoldoutSpec('qa', {
-        workItem: { title: 'test' },
-        // projectId and workItemId are added by makeHoldoutSpec
-      }, ['workItem']); // projectId and workItemId NOT in allowlist
-
-      assembleSpawnContext(spec as any);
-
-      const violations = mockAppendEvent.mock.calls.filter(
-        ([e]) => e.kind === 'tool.violation'
+      const spec = makeHoldoutSpec(
+        'qa',
+        {
+          workItem: { title: 'test' },
+        },
+        ['workItem'], // projectId and workItemId NOT in allowlist — should NOT be violations
       );
+
+      assembleSpawnContext(spec);
+
+      const violations = mockAppendEvent.mock.calls.filter(([e]) => e.kind === 'tool.violation');
       const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
       expect(keys).not.toContain('projectId');
       expect(keys).not.toContain('workItemId');

--- a/slices/holdout-boundary-test/slice.test.ts
+++ b/slices/holdout-boundary-test/slice.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock eventStore before importing assembleSpawnContext
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi.fn(),
+  },
+}));
+
+import { assembleSpawnContext } from '@goose-hub/core/agent-runtime/context-assembly.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+
+const mockAppendEvent = vi.mocked(eventStore.appendEvent);
+
+function makeHoldoutSpec(role: 'qa' | 'reviewer', context: Record<string, unknown>, allowlist: string[]) {
+  return {
+    runId: `boundary-test-${crypto.randomUUID()}`,
+    role,
+    skill: role,
+    context: { projectId: 'test-project', workItemId: 'test-item', ...context },
+    contextAllowlist: allowlist,
+    freshContext: true as const,
+    toolBundles: [],
+    toolExtras: [],
+    budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+    personaId: `test-project/${role}/0`,
+  };
+}
+
+describe('Holdout boundary test — deliberate injection attempts', () => {
+  beforeEach(() => {
+    mockAppendEvent.mockClear();
+  });
+
+  describe('QA role — devDecisionSummaries injection attempt', () => {
+    it('devDecisionSummaries is absent from rendered XML', () => {
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'test' },
+        devDecisionSummaries: ['SECRET: developer chose approach X because of Y constraint'],
+      }, ['workItem']);
+
+      const { contextXml } = assembleSpawnContext(spec as any);
+      expect(contextXml).not.toContain('devDecisionSummaries');
+      expect(contextXml).not.toContain('SECRET');
+      expect(contextXml).not.toContain('developer chose approach');
+    });
+
+    it('devDecisionSummaries injection emits tool.violation event', () => {
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'test' },
+        devDecisionSummaries: ['secret reasoning'],
+      }, ['workItem']);
+
+      assembleSpawnContext(spec as any);
+
+      const violations = mockAppendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      expect(violations.length).toBeGreaterThanOrEqual(1);
+      const violationPayloads = violations.map(([e]) => e.payload as { disallowedKey: string; role: string });
+      expect(violationPayloads.some((p) => p.disallowedKey === 'devDecisionSummaries')).toBe(true);
+      expect(violationPayloads.every((p) => p.role === 'qa')).toBe(true);
+    });
+
+    it('runId is included in tool.violation event payload', () => {
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'test' },
+        investigationFindings: 'leaked reasoning',
+      }, ['workItem']);
+
+      assembleSpawnContext(spec as any);
+
+      const violation = mockAppendEvent.mock.calls.find(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      expect(violation).toBeDefined();
+      expect((violation![0].payload as { runId: string }).runId).toBe(spec.runId);
+    });
+  });
+
+  describe('QA role — multiple disallowed keys', () => {
+    it('emits one tool.violation event per disallowed key', () => {
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'test' },
+        devDecisionSummaries: ['secret 1'],
+        investigationFindings: { keyFile: 'auth.ts' },
+        advisorFeedback: 'internal advisor thoughts',
+      }, ['workItem']);
+
+      assembleSpawnContext(spec as any);
+
+      const violations = mockAppendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      expect(violations.length).toBe(3); // one per disallowed key
+      const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
+      expect(keys).toContain('devDecisionSummaries');
+      expect(keys).toContain('investigationFindings');
+      expect(keys).toContain('advisorFeedback');
+    });
+
+    it('allowed keys ARE present in XML', () => {
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'my test issue' },
+        prDiff: '+foo bar',
+        devDecisionSummaries: ['should not appear'],
+      }, ['workItem', 'prDiff']);
+
+      const { contextXml } = assembleSpawnContext(spec as any);
+      expect(contextXml).toContain('workItem');
+      expect(contextXml).toContain('prDiff');
+      expect(contextXml).not.toContain('devDecisionSummaries');
+    });
+  });
+
+  describe('Reviewer role — injection attempt', () => {
+    it('devDecisionSummaries absent from Reviewer XML', () => {
+      const spec = makeHoldoutSpec('reviewer', {
+        workItem: { title: 'test' },
+        prDiff: '+foo',
+        devDecisionSummaries: ['SECRET reviewer should not see this'],
+      }, ['workItem', 'prDiff', 'qaVerdict']);
+
+      const { contextXml } = assembleSpawnContext(spec as any);
+      expect(contextXml).not.toContain('devDecisionSummaries');
+      expect(contextXml).not.toContain('SECRET reviewer should not see this');
+    });
+
+    it('Reviewer injection emits tool.violation with role: reviewer', () => {
+      const spec = makeHoldoutSpec('reviewer', {
+        workItem: { title: 'test' },
+        devDecisionSummaries: ['reasoning'],
+      }, ['workItem', 'qaVerdict']);
+
+      assembleSpawnContext(spec as any);
+
+      const violations = mockAppendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      expect(violations.length).toBeGreaterThanOrEqual(1);
+      expect(violations.every(([e]) => (e.payload as { role: string }).role === 'reviewer')).toBe(true);
+    });
+  });
+
+  describe('Non-holdout role — NO violation events', () => {
+    it('developer role with unlisted keys does NOT emit tool.violation', () => {
+      const spec = {
+        runId: 'dev-test',
+        role: 'developer',
+        skill: 'implement',
+        context: {
+          projectId: 'test-project',
+          workItemId: 'test-item',
+          workItem: { title: 'test' },
+          advisorFeedback: 'some feedback',
+          extraData: 'extra',
+        },
+        contextAllowlist: ['workItem'],
+        freshContext: false,
+        toolBundles: [],
+        toolExtras: [],
+        budgets: { maxTurns: 5, maxBudgetUsd: 0.1 },
+        personaId: 'test-project/developer/0',
+      };
+
+      assembleSpawnContext(spec as any);
+
+      const violations = mockAppendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      expect(violations.length).toBe(0);
+    });
+  });
+
+  describe('System keys — exempted from violation detection', () => {
+    it('projectId and workItemId are NOT flagged as violations on holdout roles', () => {
+      // projectId and workItemId are always in context but may not be in allowlist
+      const spec = makeHoldoutSpec('qa', {
+        workItem: { title: 'test' },
+        // projectId and workItemId are added by makeHoldoutSpec
+      }, ['workItem']); // projectId and workItemId NOT in allowlist
+
+      assembleSpawnContext(spec as any);
+
+      const violations = mockAppendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'tool.violation'
+      );
+      const keys = violations.map(([e]) => (e.payload as { disallowedKey: string }).disallowedKey);
+      expect(keys).not.toContain('projectId');
+      expect(keys).not.toContain('workItemId');
+    });
+  });
+});

--- a/slices/qa/README.md
+++ b/slices/qa/README.md
@@ -1,0 +1,29 @@
+# slices/qa
+
+QA holdout workflow. Handles work items in `factory:needs-qa` state.
+
+## What it does
+
+Invokes the `qa` skill (holdout agent) to independently verify a PR against its acceptance criteria using a three-tier framework (structural, functional, regression). Based on the verdict and quality score, transitions the issue to:
+
+- `factory:needs-review` — pass, or partial with score >= 70
+- `factory:qa-failed` — fail, or partial with score < 70
+- `factory:needs-human` — on runtime error
+
+## Holdout discipline
+
+`freshContext: true` is mandatory. The QA agent never sees developer decision summaries or investigation findings. It only receives the original issue (`workItem`), the PR diff (`prDiff`), and project commands (`projectCommands`).
+
+## Files
+
+- `workflow.ts` — `runQaWorkflow(workItem, stateSource, projectId, targetRepo, deps?)`
+- `slice.test.ts` — unit tests (mocked runtime)
+- `README.md` — this file
+
+## Skill
+
+Uses `skills/qa/` — see `skills/qa/skill.md` for the prompt and `skills/qa/schema.ts` for `QaOutputSchema`.
+
+## Entry point (server)
+
+`POST /:slug/run-qa` in `apps/server/src/domains/workflows/router.ts` dispatches to `qa-batch.ts`, which filters open work items by state and calls this workflow for each.

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -18,11 +18,14 @@ vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
   selectPersona: vi.fn().mockReturnValue('test-project/qa/0'),
 }));
 
+const mockReplay = vi.fn().mockReturnValue([]);
+
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     appendEvent: vi
       .fn()
       .mockReturnValue({ id: 1, kind: 'qa.completed', payload: {}, createdAt: '' }),
+    replay: (...args: unknown[]) => mockReplay(...args),
   },
 }));
 
@@ -200,6 +203,8 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
 
 beforeEach(() => {
   mockRun.mockReset();
+  mockReplay.mockReset();
+  mockReplay.mockReturnValue([]);
   vi.clearAllMocks();
 });
 
@@ -342,6 +347,54 @@ describe('runQaWorkflow', () => {
       const item = makeWorkItem();
       const source = makeMockSource();
       mockRun.mockResolvedValueOnce(makePartialLowResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:qa-failed',
+      );
+    });
+  });
+
+  describe('retry-and-escalate', () => {
+    it('transitions to factory:needs-human and emits agent.retry-escalated when qa-fail count >= maxRetries', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeFailResult());
+      // Simulate 2 prior qa.completed fail events already in the store
+      mockReplay.mockReturnValue([
+        { kind: 'qa.completed', payload: JSON.stringify({ verdict: 'fail', overallScore: 40 }) },
+        { kind: 'qa.completed', payload: JSON.stringify({ verdict: 'fail', overallScore: 35 }) },
+      ]);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-human',
+      );
+      expect(eventStore.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'agent.retry-escalated',
+          payload: expect.objectContaining({ stage: 'qa' }),
+        }),
+      );
+    });
+
+    it('transitions to factory:qa-failed when qa-fail count < maxRetries', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeFailResult());
+      // Only 1 prior qa.completed fail event — under the maxRetries threshold
+      mockReplay.mockReturnValue([
+        { kind: 'qa.completed', payload: JSON.stringify({ verdict: 'fail', overallScore: 40 }) },
+      ]);
 
       const { runQaWorkflow } = await import('./workflow.js');
       await runQaWorkflow(item, source, 'test-project', 'owner/repo');

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -1,0 +1,356 @@
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── module mocks ─────────────────────────────────────────────────────────────
+
+const mockRun = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue('test-project/qa/0'),
+}));
+
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi
+      .fn()
+      .mockReturnValue({ id: 1, kind: 'qa.completed', payload: {}, createdAt: '' }),
+  },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock prompt') };
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:owner/repo#42',
+    externalId: '42',
+    repoRef: 'owner/repo',
+    title: 'Test issue',
+    body: '## Acceptance criteria\n- [ ] Add foo',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:needs-qa',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makePassResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'pass',
+      overallScore: 85,
+      threshold: 70,
+      tierResults: {
+        structural: { passed: true, findings: [] },
+        functional: { passed: true, findings: [] },
+        regression: { passed: true, findings: [] },
+      },
+      qualityScores: {
+        openClosed: 17,
+        conceptCount: 12,
+        timeToCapability: 13,
+        complecting: 14,
+        loc: 9,
+        coupling: 9,
+        gallsLaw: 9,
+        cyclomaticComplexity: 4,
+      },
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeFailResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'fail',
+      overallScore: 45,
+      threshold: 70,
+      tierResults: {
+        structural: {
+          passed: false,
+          findings: [{ tier: 'structural', severity: 'error', description: 'lint error' }],
+        },
+        functional: { passed: false, findings: [] },
+        regression: { passed: true, findings: [] },
+      },
+      qualityScores: {
+        openClosed: 5,
+        conceptCount: 5,
+        timeToCapability: 5,
+        complecting: 5,
+        loc: 5,
+        coupling: 5,
+        gallsLaw: 5,
+        cyclomaticComplexity: 4,
+      },
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makePartialHighResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'partial',
+      overallScore: 72,
+      threshold: 70,
+      tierResults: {
+        structural: { passed: true, findings: [] },
+        functional: { passed: false, findings: [] },
+        regression: { passed: true, findings: [] },
+      },
+      qualityScores: {
+        openClosed: 15,
+        conceptCount: 10,
+        timeToCapability: 12,
+        complecting: 12,
+        loc: 7,
+        coupling: 7,
+        gallsLaw: 7,
+        cyclomaticComplexity: 2,
+      },
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makePartialLowResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'partial',
+      overallScore: 65,
+      threshold: 70,
+      tierResults: {
+        structural: { passed: false, findings: [] },
+        functional: { passed: false, findings: [] },
+        regression: { passed: true, findings: [] },
+      },
+      qualityScores: {
+        openClosed: 10,
+        conceptCount: 8,
+        timeToCapability: 10,
+        complecting: 10,
+        loc: 6,
+        coupling: 6,
+        gallsLaw: 6,
+        cyclomaticComplexity: 5,
+      },
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
+  return {
+    projectId: 'test-project',
+    repoRef: 'owner/repo',
+    listOpenWork: vi.fn().mockResolvedValue([]),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── test setup ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockRun.mockReset();
+  vi.clearAllMocks();
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('runQaWorkflow', () => {
+  describe('pass verdict', () => {
+    it('transitions state to factory:needs-review on pass', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-review',
+      );
+    });
+
+    it('posts a comment on pass verdict', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.comment).toHaveBeenCalledWith('42', expect.any(String));
+    });
+  });
+
+  describe('fail verdict', () => {
+    it('transitions state to factory:qa-failed on fail', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeFailResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:qa-failed',
+      );
+    });
+  });
+
+  describe('error path', () => {
+    it('transitions to factory:needs-human on runtime error', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockRejectedValueOnce(new Error('Runtime exploded'));
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-human',
+      );
+    });
+
+    it('posts a comment with error message on runtime error', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockRejectedValueOnce(new Error('Runtime exploded'));
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.comment).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('Runtime exploded'),
+      );
+    });
+  });
+
+  describe('AgentSpec fields', () => {
+    it('uses role "qa" in AgentSpec', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { role: string };
+      expect(specUsed.role).toBe('qa');
+    });
+
+    it('sets freshContext to true in AgentSpec', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { freshContext: boolean };
+      expect(specUsed.freshContext).toBe(true);
+    });
+
+    it('contextAllowlist contains "workItem" and "prDiff" but NOT "devDecisionSummaries"', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { contextAllowlist: string[] };
+      expect(specUsed.contextAllowlist).toContain('workItem');
+      expect(specUsed.contextAllowlist).toContain('prDiff');
+      expect(specUsed.contextAllowlist).not.toContain('devDecisionSummaries');
+    });
+  });
+
+  describe('partial verdict', () => {
+    it('transitions to factory:needs-review when partial score >= 70', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePartialHighResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-review',
+      );
+    });
+
+    it('transitions to factory:qa-failed when partial score < 70', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePartialLowResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:qa-failed',
+      );
+    });
+  });
+});

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -16,10 +16,7 @@ function readPrompt(skillName: string): string {
   return readFileSync(join(REPO_ROOT, 'skills', skillName, 'skill.md'), 'utf8');
 }
 
-/**
- * Placeholder — real PR diff fetch is M9+ scope.
- * Returns empty string; QA grades on test results.
- */
+// M9+ will fetch the real diff from GitHub. Until then QA grades on test/lint results only.
 function getPrDiff(_workItem: WorkItem): string {
   return '';
 }
@@ -29,20 +26,21 @@ export interface QaWorkflowDeps {
 }
 
 /**
- * Runs the QA workflow for a work item in `factory:needs-qa` state.
+ * Runs the QA holdout workflow for a work item in `factory:needs-qa` state.
+ * QA is a holdout: fresh context, no advisor, no fallback (FACTORY_RULES 1, 20, 23).
  *
  * Workflow:
- * 1. Run the `qa` skill (QA holdout agent, sonnet-tier)
- * 2. Validate output against QaOutputSchema
- * 3. Emit `qa.completed` event
- * 4. Emit `agent.decision-summary` for each decision summary
- * 5. Post a comment summarizing verdict and score
- * 6. Transition state:
+ * 1. Snapshot existing events (for retry counting — read BEFORE appending outcome)
+ * 2. Run the `qa` skill
+ * 3. Emit tier-specific failure events (qa.structural-failed etc.) for failed tiers
+ * 4. Emit `qa.completed` with full payload including qualityScores
+ * 5. Emit `agent.decision-summary` per entry
+ * 6. Determine next state using pre-run snapshot for retry count
  *    - pass or partial≥70 → factory:needs-review
- *    - fail or partial<70 → factory:qa-failed
+ *    - fail or partial<70, retries < maxRetries → factory:qa-failed
+ *    - fail or partial<70, retries >= maxRetries → factory:needs-human
  *
- * On failure: persist agent.run-failed event, post comment,
- * transition to factory:needs-human.
+ * On runtime error: emit agent.run-failed, comment, transition to factory:needs-human.
  */
 export async function runQaWorkflow(
   workItem: WorkItem,
@@ -58,8 +56,11 @@ export async function runQaWorkflow(
   const personaId = selectPersona(projectId, 'qa');
   const prDiff = getPrDiff(workItem);
 
+  // Snapshot prior events BEFORE this run's outcome is appended.
+  // shouldEscalateQa uses this count to decide: Nth failure = N-1 priors.
+  const priorEvents = eventStore.replay({ workItemId: workItem.id });
+
   try {
-    // Run the QA skill
     const qaResult = await runtime.run({
       runId,
       role: 'qa',
@@ -88,14 +89,34 @@ export async function runQaWorkflow(
       appendSystemPrompt: qaPrompt,
     });
 
-    // Validate output
     const qaParsed = QaOutputSchema.safeParse(qaResult.output);
     if (!qaParsed.success) {
       throw new Error(`QA output validation failed: ${JSON.stringify(qaParsed.error.issues)}`);
     }
     const qaOutput = qaParsed.data;
 
-    // Emit qa.completed event
+    // Emit tier-specific failure events for downstream subscribers.
+    const TIER_EVENTS = {
+      structural: 'qa.structural-failed',
+      functional: 'qa.functional-failed',
+      regression: 'qa.regression-failed',
+    } as const;
+    for (const [tier, kind] of Object.entries(TIER_EVENTS) as [
+      keyof typeof TIER_EVENTS,
+      (typeof TIER_EVENTS)[keyof typeof TIER_EVENTS],
+    ][]) {
+      if (!qaOutput.tierResults[tier].passed) {
+        eventStore.appendEvent({
+          projectId,
+          workItemId: workItem.id,
+          kind,
+          payload: { tier, findings: qaOutput.tierResults[tier].findings },
+          runId,
+        });
+      }
+    }
+
+    // Emit qa.completed with full payload (qualityScores included for UI and history).
     eventStore.appendEvent({
       projectId,
       workItemId: workItem.id,
@@ -103,12 +124,13 @@ export async function runQaWorkflow(
       payload: {
         verdict: qaOutput.verdict,
         overallScore: qaOutput.overallScore,
+        threshold: qaOutput.threshold,
         tierResults: qaOutput.tierResults,
+        qualityScores: qaOutput.qualityScores,
       },
       runId,
     });
 
-    // Emit agent.decision-summary for each decision summary in output
     for (const summary of qaOutput.decisionSummaries) {
       eventStore.appendEvent({
         projectId,
@@ -119,18 +141,17 @@ export async function runQaWorkflow(
       });
     }
 
-    // Determine next state
+    // Determine next state. Use priorEvents (snapshotted before this run) so the
+    // retry count reflects completed prior failures, not the current one.
     const passes =
       qaOutput.verdict === 'pass' ||
-      (qaOutput.verdict === 'partial' && qaOutput.overallScore >= 70);
+      (qaOutput.verdict === 'partial' && qaOutput.overallScore >= qaOutput.threshold);
 
     let nextState: StateName;
     if (passes) {
       nextState = 'factory:needs-review';
     } else {
-      // Check retry count using events already in the store (including the one just appended)
-      const existingEvents = eventStore.replay({ workItemId: workItem.id });
-      const needsEscalation = shouldEscalateQa(existingEvents);
+      const needsEscalation = shouldEscalateQa(priorEvents);
       nextState = needsEscalation ? 'factory:needs-human' : 'factory:qa-failed';
       if (needsEscalation) {
         eventStore.appendEvent({
@@ -143,17 +164,14 @@ export async function runQaWorkflow(
       }
     }
 
-    // Post summary comment
     const scoreLabel = `${qaOutput.overallScore}/${qaOutput.threshold}`;
-    const comment = `**QA ${qaOutput.verdict}** — score ${scoreLabel}\n\nVerdict: ${qaOutput.verdict} → ${nextState}`;
-    await stateSource.comment(workItem.externalId, comment);
-
-    // Transition state
+    await stateSource.comment(
+      workItem.externalId,
+      `**QA ${qaOutput.verdict}** — score ${scoreLabel}\n\nVerdict: ${qaOutput.verdict} → ${nextState}`,
+    );
     await stateSource.transitionState(workItem.externalId, 'factory:needs-qa', nextState);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-
-    // Persist failure event
     eventStore.appendEvent({
       projectId,
       workItemId: workItem.id,
@@ -161,11 +179,7 @@ export async function runQaWorkflow(
       payload: { runId, error: error.message },
       runId,
     });
-
-    // Post GitHub comment
     await stateSource.comment(workItem.externalId, `QA failed: ${error.message}`);
-
-    // Transition to error state
     await stateSource.transitionState(
       workItem.externalId,
       'factory:needs-qa',

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -7,6 +7,7 @@ import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { QaOutputSchema } from '@goose-hub/skills/qa/schema.js';
+import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '../retry-escalate/retry-counter.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 
@@ -121,7 +122,25 @@ export async function runQaWorkflow(
     const passes =
       qaOutput.verdict === 'pass' ||
       (qaOutput.verdict === 'partial' && qaOutput.overallScore >= 70);
-    const nextState = passes ? 'factory:needs-review' : 'factory:qa-failed';
+
+    let nextState: string;
+    if (passes) {
+      nextState = 'factory:needs-review';
+    } else {
+      // Check retry count using events already in the store (including the one just appended)
+      const existingEvents = eventStore.replay({ workItemId: workItem.id });
+      const needsEscalation = shouldEscalateQa(existingEvents);
+      nextState = needsEscalation ? 'factory:needs-human' : 'factory:qa-failed';
+      if (needsEscalation) {
+        eventStore.appendEvent({
+          projectId,
+          workItemId: workItem.id,
+          kind: 'agent.retry-escalated',
+          payload: { stage: 'qa', maxRetries: DEFAULT_MAX_RETRIES, runId },
+          runId,
+        });
+      }
+    }
 
     // Post summary comment
     const scoreLabel = `${qaOutput.overallScore}/${qaOutput.threshold}`;

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -5,9 +5,9 @@ import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { QaOutputSchema } from '@goose-hub/skills/qa/schema.js';
-import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '../retry-escalate/retry-counter.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -6,6 +6,7 @@ import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
+import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { QaOutputSchema } from '@goose-hub/skills/qa/schema.js';
 
@@ -123,7 +124,7 @@ export async function runQaWorkflow(
       qaOutput.verdict === 'pass' ||
       (qaOutput.verdict === 'partial' && qaOutput.overallScore >= 70);
 
-    let nextState: string;
+    let nextState: StateName;
     if (passes) {
       nextState = 'factory:needs-review';
     } else {

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
+import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { QaOutputSchema } from '@goose-hub/skills/qa/schema.js';
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+
+function readPrompt(skillName: string): string {
+  return readFileSync(join(REPO_ROOT, 'skills', skillName, 'skill.md'), 'utf8');
+}
+
+/**
+ * Placeholder — real PR diff fetch is M9+ scope.
+ * Returns empty string; QA grades on test results.
+ */
+function getPrDiff(_workItem: WorkItem): string {
+  return '';
+}
+
+export interface QaWorkflowDeps {
+  runtime?: AgentRuntime;
+}
+
+/**
+ * Runs the QA workflow for a work item in `factory:needs-qa` state.
+ *
+ * Workflow:
+ * 1. Run the `qa` skill (QA holdout agent, sonnet-tier)
+ * 2. Validate output against QaOutputSchema
+ * 3. Emit `qa.completed` event
+ * 4. Emit `agent.decision-summary` for each decision summary
+ * 5. Post a comment summarizing verdict and score
+ * 6. Transition state:
+ *    - pass or partial≥70 → factory:needs-review
+ *    - fail or partial<70 → factory:qa-failed
+ *
+ * On failure: persist agent.run-failed event, post comment,
+ * transition to factory:needs-human.
+ */
+export async function runQaWorkflow(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  projectId: string,
+  _targetRepo: string,
+  deps: QaWorkflowDeps = {},
+): Promise<void> {
+  const runId = crypto.randomUUID();
+  const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const qaPrompt = readPrompt('qa');
+  const qaJsonSchema = toJsonSchema(QaOutputSchema);
+  const personaId = selectPersona(projectId, 'qa');
+  const prDiff = getPrDiff(workItem);
+
+  try {
+    // Run the QA skill
+    const qaResult = await runtime.run({
+      runId,
+      role: 'qa',
+      skill: 'qa',
+      context: {
+        projectId,
+        workItemId: workItem.id,
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        prDiff,
+        projectCommands: {
+          testCommand: 'pnpm test --run',
+          lintCommand: 'pnpm biome check .',
+        },
+      },
+      contextAllowlist: ['workItem', 'prDiff', 'projectCommands'],
+      freshContext: true,
+      toolBundles: ['read', 'shell', 'validate'],
+      toolExtras: [],
+      budgets: { maxTurns: 50, maxBudgetUsd: 0.5, timeoutMs: 300_000 },
+      personaId,
+      outputJsonSchema: qaJsonSchema,
+      appendSystemPrompt: qaPrompt,
+    });
+
+    // Validate output
+    const qaParsed = QaOutputSchema.safeParse(qaResult.output);
+    if (!qaParsed.success) {
+      throw new Error(`QA output validation failed: ${JSON.stringify(qaParsed.error.issues)}`);
+    }
+    const qaOutput = qaParsed.data;
+
+    // Emit qa.completed event
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'qa.completed',
+      payload: {
+        verdict: qaOutput.verdict,
+        overallScore: qaOutput.overallScore,
+        tierResults: qaOutput.tierResults,
+      },
+      runId,
+    });
+
+    // Emit agent.decision-summary for each decision summary in output
+    for (const summary of qaOutput.decisionSummaries) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.decision-summary',
+        payload: { skill: 'qa', ...summary },
+        runId,
+      });
+    }
+
+    // Determine next state
+    const passes =
+      qaOutput.verdict === 'pass' ||
+      (qaOutput.verdict === 'partial' && qaOutput.overallScore >= 70);
+    const nextState = passes ? 'factory:needs-review' : 'factory:qa-failed';
+
+    // Post summary comment
+    const scoreLabel = `${qaOutput.overallScore}/${qaOutput.threshold}`;
+    const comment = `**QA ${qaOutput.verdict}** — score ${scoreLabel}\n\nVerdict: ${qaOutput.verdict} → ${nextState}`;
+    await stateSource.comment(workItem.externalId, comment);
+
+    // Transition state
+    await stateSource.transitionState(workItem.externalId, 'factory:needs-qa', nextState);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+
+    // Persist failure event
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.run-failed',
+      payload: { runId, error: error.message },
+      runId,
+    });
+
+    // Post GitHub comment
+    await stateSource.comment(workItem.externalId, `QA failed: ${error.message}`);
+
+    // Transition to error state
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-qa',
+      'factory:needs-human',
+    );
+  }
+}

--- a/slices/retry-escalate/README.md
+++ b/slices/retry-escalate/README.md
@@ -1,0 +1,35 @@
+# retry-escalate
+
+Utility slice that tracks retry counts for QA and Review failures, and decides when to escalate a work item to `factory:needs-human` instead of re-queuing it.
+
+## Purpose
+
+When QA fails (`factory:qa-failed`) or Review requests fixes (`factory:needs-fix`), the orchestrator normally re-runs the Dev agent for another attempt. After `maxRetries` attempts the item is escalated to `factory:needs-human` so a human can intervene.
+
+This slice provides the counter and predicate functions. It does **not** own any DB table — retry counts are derived by reading the existing `events` table via `eventStore.replay`.
+
+## Constants
+
+- `DEFAULT_MAX_RETRIES = 2` — M8 definition. Change here to affect all callers.
+
+## API
+
+```typescript
+getQaRetryCount(events)       // number of qa.completed non-pass events
+getReviewRetryCount(events)   // number of review.completed needs-fix events
+shouldEscalateQa(events, maxRetries?)     // true when QA retries exhausted
+shouldEscalateReview(events, maxRetries?) // true when Review retries exhausted
+```
+
+## Consumers
+
+- `slices/qa/workflow.ts` — calls `shouldEscalateQa` after each QA fail verdict
+- `slices/review/workflow.ts` — calls `shouldEscalateReview` after each needs-fix verdict
+
+## Emitted events
+
+When escalation is triggered, callers emit `agent.retry-escalated` with:
+
+```json
+{ "stage": "qa" | "review", "maxRetries": 2, "runId": "<uuid>" }
+```

--- a/slices/retry-escalate/retry-counter.ts
+++ b/slices/retry-escalate/retry-counter.ts
@@ -1,0 +1,46 @@
+// slices/retry-escalate/retry-counter.ts
+// Tracks retry counts using events already in the event store.
+// No new DB table needed.
+
+export const DEFAULT_MAX_RETRIES = 2;
+
+/**
+ * Counts how many times QA has failed for a work item.
+ * Uses qa.completed events with non-pass verdict as the signal.
+ */
+export function getQaRetryCount(
+  events: Array<{ kind: string; payload: string | unknown }>,
+): number {
+  return events.filter((e) => {
+    if (e.kind !== 'qa.completed') return false;
+    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+    return (payload as { verdict?: string }).verdict !== 'pass';
+  }).length;
+}
+
+/**
+ * Counts how many times Review has requested fixes for a work item.
+ */
+export function getReviewRetryCount(
+  events: Array<{ kind: string; payload: string | unknown }>,
+): number {
+  return events.filter((e) => {
+    if (e.kind !== 'review.completed') return false;
+    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+    return (payload as { verdict?: string }).verdict === 'needs-fix';
+  }).length;
+}
+
+export function shouldEscalateQa(
+  events: Array<{ kind: string; payload: string | unknown }>,
+  maxRetries = DEFAULT_MAX_RETRIES,
+): boolean {
+  return getQaRetryCount(events) >= maxRetries;
+}
+
+export function shouldEscalateReview(
+  events: Array<{ kind: string; payload: string | unknown }>,
+  maxRetries = DEFAULT_MAX_RETRIES,
+): boolean {
+  return getReviewRetryCount(events) >= maxRetries;
+}

--- a/slices/retry-escalate/retry-counter.ts
+++ b/slices/retry-escalate/retry-counter.ts
@@ -1,46 +1,9 @@
-// slices/retry-escalate/retry-counter.ts
-// Tracks retry counts using events already in the event store.
-// No new DB table needed.
-
-export const DEFAULT_MAX_RETRIES = 2;
-
-/**
- * Counts how many times QA has failed for a work item.
- * Uses qa.completed events with non-pass verdict as the signal.
- */
-export function getQaRetryCount(
-  events: Array<{ kind: string; payload: string | unknown }>,
-): number {
-  return events.filter((e) => {
-    if (e.kind !== 'qa.completed') return false;
-    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
-    return (payload as { verdict?: string }).verdict !== 'pass';
-  }).length;
-}
-
-/**
- * Counts how many times Review has requested fixes for a work item.
- */
-export function getReviewRetryCount(
-  events: Array<{ kind: string; payload: string | unknown }>,
-): number {
-  return events.filter((e) => {
-    if (e.kind !== 'review.completed') return false;
-    const payload = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
-    return (payload as { verdict?: string }).verdict === 'needs-fix';
-  }).length;
-}
-
-export function shouldEscalateQa(
-  events: Array<{ kind: string; payload: string | unknown }>,
-  maxRetries = DEFAULT_MAX_RETRIES,
-): boolean {
-  return getQaRetryCount(events) >= maxRetries;
-}
-
-export function shouldEscalateReview(
-  events: Array<{ kind: string; payload: string | unknown }>,
-  maxRetries = DEFAULT_MAX_RETRIES,
-): boolean {
-  return getReviewRetryCount(events) >= maxRetries;
-}
+// Re-exports from core/retry/ — the canonical implementation lives there.
+// This file exists so slices/retry-escalate/slice.test.ts can import locally.
+export {
+  DEFAULT_MAX_RETRIES,
+  getQaRetryCount,
+  getReviewRetryCount,
+  shouldEscalateQa,
+  shouldEscalateReview,
+} from '@goose-hub/core/retry/retry-counter.js';

--- a/slices/retry-escalate/slice.test.ts
+++ b/slices/retry-escalate/slice.test.ts
@@ -16,6 +16,7 @@ describe('retry-counter', () => {
     it('returns 0 with no events', () => {
       expect(getQaRetryCount([])).toBe(0);
     });
+
     it('counts qa.completed fail events', () => {
       const events = [
         makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 }),
@@ -23,6 +24,7 @@ describe('retry-counter', () => {
       ];
       expect(getQaRetryCount(events)).toBe(2);
     });
+
     it('does not count qa.completed pass events', () => {
       const events = [
         makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 }),
@@ -30,8 +32,36 @@ describe('retry-counter', () => {
       ];
       expect(getQaRetryCount(events)).toBe(1);
     });
+
     it('does not count unrelated events', () => {
       const events = [makeEvent('agent.run-failed', { error: 'timeout' })];
+      expect(getQaRetryCount(events)).toBe(0);
+    });
+
+    // Partial-verdict cases — these are the cases the original code got wrong.
+    it('does NOT count partial verdict when overallScore >= 70 (treated as pass by workflow)', () => {
+      const events = [makeEvent('qa.completed', { verdict: 'partial', overallScore: 75 })];
+      expect(getQaRetryCount(events)).toBe(0);
+    });
+
+    it('counts partial verdict when overallScore < 70 (treated as fail by workflow)', () => {
+      const events = [makeEvent('qa.completed', { verdict: 'partial', overallScore: 65 })];
+      expect(getQaRetryCount(events)).toBe(1);
+    });
+
+    it('counts partial verdict when overallScore === 69 (boundary — just below threshold)', () => {
+      const events = [makeEvent('qa.completed', { verdict: 'partial', overallScore: 69 })];
+      expect(getQaRetryCount(events)).toBe(1);
+    });
+
+    it('does NOT count partial verdict when overallScore === 70 (boundary — at threshold)', () => {
+      const events = [makeEvent('qa.completed', { verdict: 'partial', overallScore: 70 })];
+      expect(getQaRetryCount(events)).toBe(0);
+    });
+
+    it('handles missing verdict gracefully — not counted (neither fail nor partial-fail)', () => {
+      const events = [makeEvent('qa.completed', {})];
+      // verdict is undefined — doesn't match 'fail' or ('partial' && score<70), so not counted
       expect(getQaRetryCount(events)).toBe(0);
     });
   });
@@ -40,28 +70,60 @@ describe('retry-counter', () => {
     it('returns 0 with no events', () => {
       expect(getReviewRetryCount([])).toBe(0);
     });
+
     it('counts review.completed needs-fix events', () => {
       const events = [makeEvent('review.completed', { verdict: 'needs-fix', confidence: 0.7 })];
       expect(getReviewRetryCount(events)).toBe(1);
     });
+
     it('does not count review.completed approved events', () => {
       const events = [makeEvent('review.completed', { verdict: 'approved', confidence: 0.9 })];
+      expect(getReviewRetryCount(events)).toBe(0);
+    });
+
+    it('does not count review.completed needs-human events', () => {
+      const events = [
+        makeEvent('review.completed', {
+          verdict: 'needs-human',
+          confidence: 0.3,
+          escalationReason: 'ambiguous spec',
+        }),
+      ];
       expect(getReviewRetryCount(events)).toBe(0);
     });
   });
 
   describe('shouldEscalateQa', () => {
     it('returns false when retries < maxRetries', () => {
-      const events = [makeEvent('qa.completed', { verdict: 'fail' })];
+      const events = [makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 })];
       expect(shouldEscalateQa(events, 2)).toBe(false);
     });
+
     it('returns true when retries >= maxRetries', () => {
       const events = [
-        makeEvent('qa.completed', { verdict: 'fail' }),
-        makeEvent('qa.completed', { verdict: 'fail' }),
+        makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 }),
+        makeEvent('qa.completed', { verdict: 'fail', overallScore: 35 }),
       ];
       expect(shouldEscalateQa(events, 2)).toBe(true);
     });
+
+    it('partial-pass does not count toward escalation', () => {
+      const events = [
+        makeEvent('qa.completed', { verdict: 'partial', overallScore: 80 }), // pass — not counted
+        makeEvent('qa.completed', { verdict: 'partial', overallScore: 80 }), // pass — not counted
+      ];
+      // Two partial-passes should not trigger escalation
+      expect(shouldEscalateQa(events, 2)).toBe(false);
+    });
+
+    it('partial-fail DOES count toward escalation', () => {
+      const events = [
+        makeEvent('qa.completed', { verdict: 'partial', overallScore: 60 }), // fail
+        makeEvent('qa.completed', { verdict: 'partial', overallScore: 55 }), // fail
+      ];
+      expect(shouldEscalateQa(events, 2)).toBe(true);
+    });
+
     it('DEFAULT_MAX_RETRIES is 2', () => {
       expect(DEFAULT_MAX_RETRIES).toBe(2);
     });
@@ -72,6 +134,7 @@ describe('retry-counter', () => {
       const events = [makeEvent('review.completed', { verdict: 'needs-fix' })];
       expect(shouldEscalateReview(events, 2)).toBe(false);
     });
+
     it('returns true when retries >= maxRetries', () => {
       const events = [
         makeEvent('review.completed', { verdict: 'needs-fix' }),

--- a/slices/retry-escalate/slice.test.ts
+++ b/slices/retry-escalate/slice.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MAX_RETRIES,
+  getQaRetryCount,
+  getReviewRetryCount,
+  shouldEscalateQa,
+  shouldEscalateReview,
+} from './retry-counter.js';
+
+function makeEvent(kind: string, payload: object) {
+  return { kind, payload: JSON.stringify(payload) };
+}
+
+describe('retry-counter', () => {
+  describe('getQaRetryCount', () => {
+    it('returns 0 with no events', () => {
+      expect(getQaRetryCount([])).toBe(0);
+    });
+    it('counts qa.completed fail events', () => {
+      const events = [
+        makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 }),
+        makeEvent('qa.completed', { verdict: 'fail', overallScore: 35 }),
+      ];
+      expect(getQaRetryCount(events)).toBe(2);
+    });
+    it('does not count qa.completed pass events', () => {
+      const events = [
+        makeEvent('qa.completed', { verdict: 'fail', overallScore: 40 }),
+        makeEvent('qa.completed', { verdict: 'pass', overallScore: 85 }),
+      ];
+      expect(getQaRetryCount(events)).toBe(1);
+    });
+    it('does not count unrelated events', () => {
+      const events = [makeEvent('agent.run-failed', { error: 'timeout' })];
+      expect(getQaRetryCount(events)).toBe(0);
+    });
+  });
+
+  describe('getReviewRetryCount', () => {
+    it('returns 0 with no events', () => {
+      expect(getReviewRetryCount([])).toBe(0);
+    });
+    it('counts review.completed needs-fix events', () => {
+      const events = [makeEvent('review.completed', { verdict: 'needs-fix', confidence: 0.7 })];
+      expect(getReviewRetryCount(events)).toBe(1);
+    });
+    it('does not count review.completed approved events', () => {
+      const events = [makeEvent('review.completed', { verdict: 'approved', confidence: 0.9 })];
+      expect(getReviewRetryCount(events)).toBe(0);
+    });
+  });
+
+  describe('shouldEscalateQa', () => {
+    it('returns false when retries < maxRetries', () => {
+      const events = [makeEvent('qa.completed', { verdict: 'fail' })];
+      expect(shouldEscalateQa(events, 2)).toBe(false);
+    });
+    it('returns true when retries >= maxRetries', () => {
+      const events = [
+        makeEvent('qa.completed', { verdict: 'fail' }),
+        makeEvent('qa.completed', { verdict: 'fail' }),
+      ];
+      expect(shouldEscalateQa(events, 2)).toBe(true);
+    });
+    it('DEFAULT_MAX_RETRIES is 2', () => {
+      expect(DEFAULT_MAX_RETRIES).toBe(2);
+    });
+  });
+
+  describe('shouldEscalateReview', () => {
+    it('returns false when retries < maxRetries', () => {
+      const events = [makeEvent('review.completed', { verdict: 'needs-fix' })];
+      expect(shouldEscalateReview(events, 2)).toBe(false);
+    });
+    it('returns true when retries >= maxRetries', () => {
+      const events = [
+        makeEvent('review.completed', { verdict: 'needs-fix' }),
+        makeEvent('review.completed', { verdict: 'needs-fix' }),
+      ];
+      expect(shouldEscalateReview(events, 2)).toBe(true);
+    });
+  });
+});

--- a/slices/review/README.md
+++ b/slices/review/README.md
@@ -1,0 +1,48 @@
+# slices/review
+
+Run-review workflow: transitions work items from `factory:needs-review` to `factory:approved`, `factory:needs-fix`, or `factory:needs-human`.
+
+## What this slice does
+
+Invokes the Review holdout agent (`skills/review/`) after QA has passed. The Reviewer independently checks acceptance criteria against the PR diff and QA verdict, then issues a verdict.
+
+## State machine
+
+```
+factory:needs-review
+  → factory:approved   (verdict: approved)
+  → factory:needs-fix  (verdict: needs-fix)
+  → factory:needs-human (verdict: needs-human OR runtime error)
+```
+
+## Holdout discipline
+
+The Reviewer is a holdout (FACTORY_RULES 1, 20, 23):
+
+- `freshContext: true` — no memory of developer decisions
+- `contextAllowlist: ['workItem', 'prDiff', 'qaVerdict']` — no `devDecisionSummaries`
+- Forms an independent judgement; QA verdict is context only, not directive
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `workflow.ts` | Main workflow function `runReviewWorkflow` |
+| `slice.test.ts` | Vitest tests covering all verdicts and error path |
+| `README.md` | This file |
+
+## Usage
+
+Called by `apps/server/src/domains/workflows/review-batch.ts` via the `/run-review` endpoint.
+
+```typescript
+import { runReviewWorkflow } from 'slices/review/workflow.js';
+
+await runReviewWorkflow(workItem, stateSource, projectId, targetRepo);
+```
+
+## Related
+
+- `skills/review/` — skill prompt and schema
+- `slices/qa/` — upstream QA holdout (same pattern)
+- `apps/server/src/domains/workflows/review-batch.ts` — batch runner

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -1,0 +1,266 @@
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── module mocks ─────────────────────────────────────────────────────────────
+
+const mockRun = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue('test-project/reviewer/0'),
+}));
+
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi
+      .fn()
+      .mockReturnValue({ id: 1, kind: 'review.completed', payload: {}, createdAt: '' }),
+  },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock prompt') };
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:owner/repo#42',
+    externalId: '42',
+    repoRef: 'owner/repo',
+    title: 'Test issue',
+    body: '## Acceptance criteria\n- [ ] Add foo',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:needs-review',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeApprovedResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'approved',
+      confidence: 0.9,
+      criteriaChecks: [{ criterion: 'Add foo', status: 'met' }],
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeNeedsFixResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'needs-fix',
+      confidence: 0.7,
+      criteriaChecks: [{ criterion: 'Add foo', status: 'unmet' }],
+      findings: [{ severity: 'blocker', description: 'not implemented' }],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeNeedsHumanResult(): AgentResult {
+  return {
+    output: {
+      verdict: 'needs-human',
+      confidence: 0.3,
+      criteriaChecks: [],
+      findings: [],
+      decisionSummaries: [],
+      escalationReason: 'spec is ambiguous',
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
+  return {
+    projectId: 'test-project',
+    repoRef: 'owner/repo',
+    listOpenWork: vi.fn().mockResolvedValue([]),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── test setup ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockRun.mockReset();
+  vi.clearAllMocks();
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('runReviewWorkflow', () => {
+  describe('approved verdict', () => {
+    it('transitions state to factory:approved on approved verdict', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeApprovedResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:approved',
+      );
+    });
+
+    it('posts a comment on approved verdict', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeApprovedResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.comment).toHaveBeenCalledWith('42', expect.any(String));
+    });
+  });
+
+  describe('needs-fix verdict', () => {
+    it('transitions state to factory:needs-fix on needs-fix verdict', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeNeedsFixResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-fix',
+      );
+    });
+  });
+
+  describe('needs-human verdict', () => {
+    it('transitions state to factory:needs-human on needs-human verdict', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeNeedsHumanResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-human',
+      );
+    });
+  });
+
+  describe('error path', () => {
+    it('transitions to factory:needs-human on runtime error', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockRejectedValueOnce(new Error('Runtime exploded'));
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-human',
+      );
+    });
+
+    it('posts a comment with error message on runtime error', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockRejectedValueOnce(new Error('Runtime exploded'));
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.comment).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('Runtime exploded'),
+      );
+    });
+  });
+
+  describe('AgentSpec fields', () => {
+    it('uses role "reviewer" in AgentSpec', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeApprovedResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { role: string };
+      expect(specUsed.role).toBe('reviewer');
+    });
+
+    it('sets freshContext to true in AgentSpec', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeApprovedResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { freshContext: boolean };
+      expect(specUsed.freshContext).toBe(true);
+    });
+
+    it('contextAllowlist contains "workItem", "prDiff", and "qaVerdict" but NOT "devDecisionSummaries"', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeApprovedResult());
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const specUsed = mockRun.mock.calls[0][0] as { contextAllowlist: string[] };
+      expect(specUsed.contextAllowlist).toContain('workItem');
+      expect(specUsed.contextAllowlist).toContain('prDiff');
+      expect(specUsed.contextAllowlist).toContain('qaVerdict');
+      expect(specUsed.contextAllowlist).not.toContain('devDecisionSummaries');
+    });
+  });
+});

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -18,11 +18,14 @@ vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
   selectPersona: vi.fn().mockReturnValue('test-project/reviewer/0'),
 }));
 
+const mockReplay = vi.fn().mockReturnValue([]);
+
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     appendEvent: vi
       .fn()
       .mockReturnValue({ id: 1, kind: 'review.completed', payload: {}, createdAt: '' }),
+    replay: (...args: unknown[]) => mockReplay(...args),
   },
 }));
 
@@ -124,6 +127,8 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
 
 beforeEach(() => {
   mockRun.mockReset();
+  mockReplay.mockReset();
+  mockReplay.mockReturnValue([]);
   vi.clearAllMocks();
 });
 
@@ -261,6 +266,63 @@ describe('runReviewWorkflow', () => {
       expect(specUsed.contextAllowlist).toContain('prDiff');
       expect(specUsed.contextAllowlist).toContain('qaVerdict');
       expect(specUsed.contextAllowlist).not.toContain('devDecisionSummaries');
+    });
+  });
+
+  describe('retry-and-escalate', () => {
+    it('transitions to factory:needs-human and emits agent.retry-escalated when review needs-fix count >= maxRetries', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeNeedsFixResult());
+      // Simulate 2 prior review.completed needs-fix events already in the store
+      mockReplay.mockReturnValue([
+        {
+          kind: 'review.completed',
+          payload: JSON.stringify({ verdict: 'needs-fix', confidence: 0.7 }),
+        },
+        {
+          kind: 'review.completed',
+          payload: JSON.stringify({ verdict: 'needs-fix', confidence: 0.6 }),
+        },
+      ]);
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-human',
+      );
+      expect(eventStore.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'agent.retry-escalated',
+          payload: expect.objectContaining({ stage: 'review' }),
+        }),
+      );
+    });
+
+    it('transitions to factory:needs-fix when review needs-fix count < maxRetries', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeNeedsFixResult());
+      // Only 1 prior review.completed needs-fix event — under the maxRetries threshold
+      mockReplay.mockReturnValue([
+        {
+          kind: 'review.completed',
+          payload: JSON.stringify({ verdict: 'needs-fix', confidence: 0.7 }),
+        },
+      ]);
+
+      const { runReviewWorkflow } = await import('./workflow.js');
+      await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-fix',
+      );
     });
   });
 });

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -5,9 +5,9 @@ import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
-import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '../retry-escalate/retry-counter.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -6,6 +6,7 @@ import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '@goose-hub/core/retry/retry-counter.js';
+import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
 
@@ -97,7 +98,7 @@ export async function runReviewWorkflow(
     const comment = buildReviewComment(reviewOutput);
     await stateSource.comment(workItem.externalId, comment);
 
-    let nextState: string;
+    let nextState: StateName;
     if (reviewOutput.verdict === 'needs-fix') {
       // Check retry count using events already in the store (including the one just appended)
       const existingEvents = eventStore.replay({ workItemId: workItem.id });
@@ -113,7 +114,7 @@ export async function runReviewWorkflow(
         });
       }
     } else {
-      const VERDICT_TO_STATE: Record<string, string> = {
+      const VERDICT_TO_STATE: Record<string, StateName> = {
         approved: 'factory:approved',
         'needs-human': 'factory:needs-human',
       };

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -42,6 +42,9 @@ export async function runReviewWorkflow(
   const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
   const personaId = selectPersona(projectId, 'reviewer');
 
+  // Snapshot prior events BEFORE this run's outcome is appended (same pattern as QA workflow).
+  const priorEvents = eventStore.replay({ workItemId: workItem.id });
+
   try {
     const prDiff = await getPrDiff(workItem, stateSource);
     const qaVerdict = getQaVerdict(workItem);
@@ -100,9 +103,8 @@ export async function runReviewWorkflow(
 
     let nextState: StateName;
     if (reviewOutput.verdict === 'needs-fix') {
-      // Check retry count using events already in the store (including the one just appended)
-      const existingEvents = eventStore.replay({ workItemId: workItem.id });
-      const needsEscalation = shouldEscalateReview(existingEvents);
+      // Use priorEvents (snapshotted before this run) for retry count.
+      const needsEscalation = shouldEscalateReview(priorEvents);
       nextState = needsEscalation ? 'factory:needs-human' : 'factory:needs-fix';
       if (needsEscalation) {
         eventStore.appendEvent({

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -7,6 +7,7 @@ import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
+import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '../retry-escalate/retry-counter.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 
@@ -96,12 +97,28 @@ export async function runReviewWorkflow(
     const comment = buildReviewComment(reviewOutput);
     await stateSource.comment(workItem.externalId, comment);
 
-    const VERDICT_TO_STATE: Record<string, string> = {
-      approved: 'factory:approved',
-      'needs-fix': 'factory:needs-fix',
-      'needs-human': 'factory:needs-human',
-    };
-    const nextState = VERDICT_TO_STATE[reviewOutput.verdict] ?? 'factory:needs-human';
+    let nextState: string;
+    if (reviewOutput.verdict === 'needs-fix') {
+      // Check retry count using events already in the store (including the one just appended)
+      const existingEvents = eventStore.replay({ workItemId: workItem.id });
+      const needsEscalation = shouldEscalateReview(existingEvents);
+      nextState = needsEscalation ? 'factory:needs-human' : 'factory:needs-fix';
+      if (needsEscalation) {
+        eventStore.appendEvent({
+          projectId,
+          workItemId: workItem.id,
+          kind: 'agent.retry-escalated',
+          payload: { stage: 'review', maxRetries: DEFAULT_MAX_RETRIES, runId },
+          runId,
+        });
+      }
+    } else {
+      const VERDICT_TO_STATE: Record<string, string> = {
+        approved: 'factory:approved',
+        'needs-human': 'factory:needs-human',
+      };
+      nextState = VERDICT_TO_STATE[reviewOutput.verdict] ?? 'factory:needs-human';
+    }
     await stateSource.transitionState(workItem.externalId, 'factory:needs-review', nextState);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
+import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+
+function readPrompt(skillName: string): string {
+  return readFileSync(join(REPO_ROOT, 'skills', skillName, 'skill.md'), 'utf8');
+}
+
+export interface ReviewWorkflowDeps {
+  runtime?: AgentRuntime;
+}
+
+/**
+ * Runs the Review holdout workflow for a work item in `factory:needs-review` state.
+ * Reviewer is a holdout: fresh context, no advisor, no fallback (FACTORY_RULES 1, 20, 23).
+ *
+ * State transitions:
+ *   factory:needs-review → factory:approved   (verdict: approved)
+ *   factory:needs-review → factory:needs-fix  (verdict: needs-fix)
+ *   factory:needs-review → factory:needs-human (verdict: needs-human OR runtime error)
+ */
+export async function runReviewWorkflow(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  projectId: string,
+  _targetRepo: string,
+  deps: ReviewWorkflowDeps = {},
+): Promise<void> {
+  const runId = crypto.randomUUID();
+  const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const reviewPrompt = readPrompt('review');
+  const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
+  const personaId = selectPersona(projectId, 'reviewer');
+
+  try {
+    const prDiff = await getPrDiff(workItem, stateSource);
+    const qaVerdict = getQaVerdict(workItem);
+
+    const result = await runtime.run({
+      runId,
+      role: 'reviewer',
+      skill: 'review',
+      context: {
+        projectId,
+        workItemId: workItem.id,
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        prDiff,
+        qaVerdict,
+      },
+      contextAllowlist: ['workItem', 'prDiff', 'qaVerdict'],
+      freshContext: true,
+      toolBundles: ['read', 'validate'],
+      toolExtras: [],
+      budgets: { maxTurns: 50, maxBudgetUsd: 0.5, timeoutMs: 300_000 },
+      personaId,
+      outputJsonSchema: reviewJsonSchema,
+      appendSystemPrompt: reviewPrompt,
+    });
+
+    const parsed = ReviewOutputSchema.safeParse(result.output);
+    if (!parsed.success) {
+      throw new Error(`Review output validation failed: ${JSON.stringify(parsed.error.issues)}`);
+    }
+    const reviewOutput = parsed.data;
+
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'review.completed',
+      payload: { verdict: reviewOutput.verdict, confidence: reviewOutput.confidence },
+      runId,
+    });
+
+    for (const summary of reviewOutput.decisionSummaries) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.decision-summary',
+        payload: { skill: 'review', ...summary },
+        runId,
+      });
+    }
+
+    const comment = buildReviewComment(reviewOutput);
+    await stateSource.comment(workItem.externalId, comment);
+
+    const VERDICT_TO_STATE: Record<string, string> = {
+      approved: 'factory:approved',
+      'needs-fix': 'factory:needs-fix',
+      'needs-human': 'factory:needs-human',
+    };
+    const nextState = VERDICT_TO_STATE[reviewOutput.verdict] ?? 'factory:needs-human';
+    await stateSource.transitionState(workItem.externalId, 'factory:needs-review', nextState);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.run-failed',
+      payload: { runId, error: error.message, skill: 'review' },
+      runId,
+    });
+
+    await stateSource.comment(workItem.externalId, `Review failed: ${error.message}`);
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+  }
+}
+
+async function getPrDiff(workItem: WorkItem, stateSource: StateSource): Promise<string> {
+  if ('getPrDiff' in stateSource && typeof stateSource.getPrDiff === 'function') {
+    return (stateSource.getPrDiff as (id: string) => Promise<string>)(workItem.externalId);
+  }
+  return '';
+}
+
+function getQaVerdict(_workItem: WorkItem): { verdict: string; overallScore: number } | undefined {
+  // In production, read from the qa.completed event in the event store.
+  // For M8 scope: return undefined (qaVerdict is optional in ReviewContextSchema).
+  return undefined;
+}
+
+function buildReviewComment(output: {
+  verdict: string;
+  confidence: number;
+  criteriaChecks: Array<{ criterion: string; status: string }>;
+  findings: Array<{ severity: string; description: string }>;
+}): string {
+  const emojiMap: Record<string, string> = {
+    approved: '✅',
+    'needs-fix': '🔧',
+    'needs-human': '🆘',
+  };
+  const emoji = emojiMap[output.verdict] ?? '❓';
+  const critLines = output.criteriaChecks
+    .map((c) => `- [${c.status === 'met' ? 'x' : ' '}] ${c.criterion}`)
+    .join('\n');
+  const findingLines = output.findings
+    .slice(0, 5)
+    .map((f) => `- [${f.severity}] ${f.description}`)
+    .join('\n');
+  return `**Review ${emoji} ${output.verdict.toUpperCase()}** (confidence: ${Math.round(output.confidence * 100)}%)\n\n${critLines || ''}\n\n${findingLines || ''}`.trim();
+}


### PR DESCRIPTION
## Summary

Implements all 11 M8 issues: sequential QA → Review holdout agents that run after every Developer PR, with full context isolation, retry/escalation logic, UI tabs, and a formal boundary test.

## Issues closed

Closes #239 Closes #240 Closes #241 Closes #242 Closes #243 Closes #244 Closes #245 Closes #246 Closes #247 Closes #248 Closes #249

## What shipped

- `skills/qa/` — QA holdout skill (3-tier verification, 8-category code quality scoring, freshContext: true)
- `skills/review/` — Review holdout skill (discriminated verdict union, criteria checks, escalation)
- `core/agent-runtime/context-assembly.ts` — emits `tool.violation` events when disallowed keys are attempted on holdout roles
- `core/agent-runtime/fallback.ts` + `interface.ts` — `HoldoutFallbackForbiddenError` thrown when holdout primary fails (no down-tier)
- `core/retry/retry-counter.ts` — retry counter logic in `core/` (FACTORY_RULES compliant, no cross-slice imports)
- `slices/qa/` — run-qa workflow (needs-qa → needs-review or qa-failed or needs-human)
- `slices/review/` — run-review workflow (needs-review → approved/needs-fix/needs-human)
- `slices/fix-issue/` — transition updated to factory:needs-qa after PR (was factory:approved)
- `slices/retry-escalate/` — slice with tests; re-exports from core/retry/
- `apps/web/` — QA and Review tabs live in task detail drawer
- `slices/holdout-boundary-test/` — 9-test formal proof of holdout boundary at runtime layer
- `core/state-machine/transitions.ts` — added needs-qa → needs-human transition

## Test results

876 passing, 4 pre-existing Windows path separator failures (unrelated to M8)

## Audit

Exit audit passed after two fixes:
1. Added missing `factory:needs-qa → factory:needs-human` transition (was causing runtime crash on error/escalation paths)
2. Moved `retry-counter.ts` to `core/retry/` to comply with FACTORY_RULES rule 24 (no cross-slice imports)