### PR TITLE
M9.01: implement retrospective-light and retrospective-deep skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Before touching any file in an app, read its `README.md` first. The README will 
 
 When prompted with "start the next issue" (or similar), resolve the issue to work on as follows:
 
-1. Run: `gh issue list --milestone "M8: QA and Review Holdouts" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
+1. Run: `gh issue list --milestone "M9: Retrospective and Learning Loop" --label "schedule:current" --state open --json number,title,body,labels --jq 'sort_by(.number)'`
 2. Skip any issue already labeled `factory:in-progress`.
 3. For each remaining issue in ascending number order, check its body for `Depends on #N` lines. Fetch each referenced issue number with `gh issue view <N> --json state` and skip this issue if any dependency is still open.
 4. Pick the lowest-numbered issue that passes the dependency check.

--- a/core/retrospective/schemas.ts
+++ b/core/retrospective/schemas.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+export const ConfidenceSchema = z.enum(['low', 'medium', 'high']);
+
+export const ImprovementKindSchema = z.enum([
+  'skill-prompt',
+  'skill-schema',
+  'skill-config',
+  'global-config',
+  'project-config',
+  'persona',
+  'workflow',
+  'governance-suggestion',
+]);
+
+export const DecisionRecordSchema = z.object({
+  id: z.string(),
+  runId: z.string(),
+  personaName: z.string(),
+  role: z.string(),
+  step: z.string(),
+  context: z.string(),
+  decision: z.string(),
+  outcome: z.enum(['success', 'failure', 'partial']),
+  confidence: ConfidenceSchema,
+  timestamp: z.string().datetime(),
+});
+
+export const LearningEntrySchema = z.object({
+  id: z.string(),
+  sourceRunIds: z.array(z.string()).min(1),
+  personaName: z.string(),
+  role: z.string(),
+  observation: z.string(),
+  rationale: z.string(),
+  improvementKind: ImprovementKindSchema,
+  targetPath: z.string().optional(),
+  confidence: ConfidenceSchema,
+});
+
+export const QualityScoreSchema = z.object({
+  personaName: z.string(),
+  role: z.string(),
+  skillName: z.string(),
+  score: z.number().min(0).max(1),
+  trend: z.enum(['improving', 'stable', 'declining']),
+  sampleCount: z.number().int().min(1),
+  computedAt: z.string().datetime(),
+});
+
+export const DecisionPatternSchema = z.object({
+  id: z.string(),
+  pattern: z.string(),
+  frequency: z.number().int().min(1),
+  confidence: ConfidenceSchema,
+  exampleRunIds: z.array(z.string()).min(1),
+  surfacedAt: z.string().datetime(),
+});
+
+export type DecisionRecord = z.infer<typeof DecisionRecordSchema>;
+export type LearningEntry = z.infer<typeof LearningEntrySchema>;
+export type QualityScore = z.infer<typeof QualityScoreSchema>;
+export type DecisionPattern = z.infer<typeof DecisionPatternSchema>;
+export type ImprovementKind = z.infer<typeof ImprovementKindSchema>;
+export type Confidence = z.infer<typeof ConfidenceSchema>;
+
+// Patterns must reach this confidence level before surfacing as improvement candidates.
+// Controlled convergence prevents low-signal noise from polluting the Roster.
+export const CONVERGENCE_THRESHOLD = 'high' as const satisfies Confidence;

--- a/core/retrospective/schemas.ts
+++ b/core/retrospective/schemas.ts
@@ -57,11 +57,30 @@ export const DecisionPatternSchema = z.object({
   surfacedAt: z.string().datetime(),
 });
 
+export const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const ImprovementCandidateSchema = z.object({
+  kind: ImprovementKindSchema,
+  targetPath: z.string(),
+  sourceRunId: z.string(),
+  sourceProject: z.string(),
+  sourceWorkItem: z.string(),
+  suggestionText: z.string(),
+  confidence: ConfidenceSchema,
+  proposedDiff: z.string().optional(),
+});
+
 export type DecisionRecord = z.infer<typeof DecisionRecordSchema>;
 export type LearningEntry = z.infer<typeof LearningEntrySchema>;
 export type QualityScore = z.infer<typeof QualityScoreSchema>;
 export type DecisionPattern = z.infer<typeof DecisionPatternSchema>;
 export type ImprovementKind = z.infer<typeof ImprovementKindSchema>;
+export type ImprovementCandidate = z.infer<typeof ImprovementCandidateSchema>;
+export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
 export type Confidence = z.infer<typeof ConfidenceSchema>;
 
 // Patterns must reach this confidence level before surfacing as improvement candidates.

--- a/core/retrospective/slice.test.ts
+++ b/core/retrospective/slice.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONVERGENCE_THRESHOLD,
+  DecisionPatternSchema,
+  DecisionRecordSchema,
+  ImprovementKindSchema,
+  LearningEntrySchema,
+  QualityScoreSchema,
+} from './schemas.js';
+
+const ISO = '2026-05-03T12:00:00.000Z';
+
+describe('DecisionRecordSchema', () => {
+  const base = {
+    id: 'dr-001',
+    runId: 'run-abc',
+    personaName: 'alice',
+    role: 'developer',
+    step: 'plan',
+    context: 'Implementing feature X',
+    decision: 'Use vertical slice pattern',
+    outcome: 'success' as const,
+    confidence: 'high' as const,
+    timestamp: ISO,
+  };
+
+  it('accepts a fully-populated valid record', () => {
+    expect(DecisionRecordSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts all valid outcome values', () => {
+    for (const outcome of ['success', 'failure', 'partial'] as const) {
+      expect(DecisionRecordSchema.safeParse({ ...base, outcome }).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown outcome value', () => {
+    expect(DecisionRecordSchema.safeParse({ ...base, outcome: 'unknown' }).success).toBe(false);
+  });
+
+  it('rejects an unknown confidence value', () => {
+    expect(DecisionRecordSchema.safeParse({ ...base, confidence: 'very-high' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects missing id', () => {
+    const { id: _omit, ...rest } = base;
+    expect(DecisionRecordSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects non-datetime timestamp', () => {
+    expect(DecisionRecordSchema.safeParse({ ...base, timestamp: '2026-05-03' }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('LearningEntrySchema', () => {
+  const base = {
+    id: 'le-001',
+    sourceRunIds: ['run-abc', 'run-def'],
+    personaName: 'alice',
+    role: 'developer',
+    observation: 'Vertical slices reduce merge conflicts',
+    rationale: 'Observed in 3 consecutive runs with zero conflicts',
+    improvementKind: 'skill-prompt' as const,
+    confidence: 'medium' as const,
+  };
+
+  it('accepts a fully-populated valid entry', () => {
+    expect(LearningEntrySchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts optional targetPath when present', () => {
+    expect(
+      LearningEntrySchema.safeParse({ ...base, targetPath: 'skills/implement/prompt.md' }).success,
+    ).toBe(true);
+  });
+
+  it('accepts all valid ImprovementKind values', () => {
+    const kinds = [
+      'skill-prompt',
+      'skill-schema',
+      'skill-config',
+      'global-config',
+      'project-config',
+      'persona',
+      'workflow',
+      'governance-suggestion',
+    ] as const;
+    for (const improvementKind of kinds) {
+      expect(LearningEntrySchema.safeParse({ ...base, improvementKind }).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown improvementKind', () => {
+    expect(
+      LearningEntrySchema.safeParse({ ...base, improvementKind: 'unknown-kind' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects empty sourceRunIds array', () => {
+    expect(LearningEntrySchema.safeParse({ ...base, sourceRunIds: [] }).success).toBe(false);
+  });
+
+  it('rejects missing observation', () => {
+    const { observation: _omit, ...rest } = base;
+    expect(LearningEntrySchema.safeParse(rest).success).toBe(false);
+  });
+});
+
+describe('QualityScoreSchema', () => {
+  const base = {
+    personaName: 'alice',
+    role: 'developer',
+    skillName: 'implement',
+    score: 0.85,
+    trend: 'improving' as const,
+    sampleCount: 5,
+    computedAt: ISO,
+  };
+
+  it('accepts a fully-populated valid score', () => {
+    expect(QualityScoreSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts score at boundary values 0 and 1', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, score: 0 }).success).toBe(true);
+    expect(QualityScoreSchema.safeParse({ ...base, score: 1 }).success).toBe(true);
+  });
+
+  it('rejects score above 1', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, score: 1.01 }).success).toBe(false);
+  });
+
+  it('rejects score below 0', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, score: -0.1 }).success).toBe(false);
+  });
+
+  it('rejects non-integer sampleCount', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, sampleCount: 2.5 }).success).toBe(false);
+  });
+
+  it('rejects sampleCount of zero', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, sampleCount: 0 }).success).toBe(false);
+  });
+
+  it('accepts all valid trend values', () => {
+    for (const trend of ['improving', 'stable', 'declining'] as const) {
+      expect(QualityScoreSchema.safeParse({ ...base, trend }).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown trend value', () => {
+    expect(QualityScoreSchema.safeParse({ ...base, trend: 'flat' }).success).toBe(false);
+  });
+});
+
+describe('DecisionPatternSchema', () => {
+  const base = {
+    id: 'dp-001',
+    pattern: 'Developer consistently chooses vertical slice before horizontal',
+    frequency: 7,
+    confidence: 'high' as const,
+    exampleRunIds: ['run-abc', 'run-def', 'run-ghi'],
+    surfacedAt: ISO,
+  };
+
+  it('accepts a fully-populated valid pattern', () => {
+    expect(DecisionPatternSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('rejects frequency less than 1', () => {
+    expect(DecisionPatternSchema.safeParse({ ...base, frequency: 0 }).success).toBe(false);
+  });
+
+  it('rejects non-integer frequency', () => {
+    expect(DecisionPatternSchema.safeParse({ ...base, frequency: 1.5 }).success).toBe(false);
+  });
+
+  it('rejects empty exampleRunIds', () => {
+    expect(DecisionPatternSchema.safeParse({ ...base, exampleRunIds: [] }).success).toBe(false);
+  });
+
+  it('rejects non-datetime surfacedAt', () => {
+    expect(DecisionPatternSchema.safeParse({ ...base, surfacedAt: 'not-a-date' }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('ImprovementKindSchema', () => {
+  it('accepts all canonical kinds from CONTEXT.md', () => {
+    const kinds = [
+      'skill-prompt',
+      'skill-schema',
+      'skill-config',
+      'global-config',
+      'project-config',
+      'persona',
+      'workflow',
+      'governance-suggestion',
+    ];
+    for (const kind of kinds) {
+      expect(ImprovementKindSchema.safeParse(kind).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(ImprovementKindSchema.safeParse('infrastructure').success).toBe(false);
+  });
+});
+
+describe('CONVERGENCE_THRESHOLD', () => {
+  it('is the string "high" — patterns must reach high confidence to surface', () => {
+    expect(CONVERGENCE_THRESHOLD).toBe('high');
+  });
+});

--- a/core/state-source/github-labels.test.ts
+++ b/core/state-source/github-labels.test.ts
@@ -514,6 +514,735 @@ describe('rate limit', () => {
 });
 
 // ---------------------------------------------------------------------------
+// listWorkByMilestone
+// ---------------------------------------------------------------------------
+
+describe('listWorkByMilestone', () => {
+  it('fetches all-state issues for the given milestone', async () => {
+    const issues = [
+      makeIssue({
+        number: 60,
+        title: 'Open feature',
+        labels: [{ name: 'factory:in-progress' }],
+        milestone: { number: 3, title: 'M3', description: null, due_on: null, state: 'open' },
+      }),
+      makeIssue({
+        number: 61,
+        title: 'Done chore',
+        labels: [{ name: 'factory:done' }, { name: 'type:chore' }],
+        milestone: { number: 3, title: 'M3', description: null, due_on: null, state: 'open' },
+      }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetchByUrl((url) => {
+        expect(url).toContain('state=all');
+        expect(url).toContain('milestone=3');
+        return new Response(JSON.stringify(issues), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    const source = makeSource();
+    const items = await source.listWorkByMilestone(3);
+    expect(items).toHaveLength(2);
+    expect(items[0].externalId).toBe('60');
+    expect(items[1].type).toBe('chore');
+  });
+
+  it('filters out pull requests', async () => {
+    const mixed = [makeIssue({ number: 62 }), { ...makeIssue({ number: 63 }), pull_request: {} }];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetchByUrl(
+        () =>
+          new Response(JSON.stringify(mixed), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      ),
+    );
+
+    const source = makeSource();
+    const items = await source.listWorkByMilestone(3);
+    expect(items).toHaveLength(1);
+    expect(items[0].externalId).toBe('62');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getItem
+// ---------------------------------------------------------------------------
+
+describe('getItem', () => {
+  it('fetches a single issue by its full id (github:owner/repo#N)', async () => {
+    const issue = makeIssue({
+      number: 42,
+      title: 'Single item',
+      labels: [{ name: 'factory:accepted' }],
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetchByUrl((url) => {
+        expect(url).toContain('/issues/42');
+        return new Response(JSON.stringify(issue), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    const source = makeSource();
+    const item = await source.getItem('github:shaunnez/goose-hub#42');
+    expect(item.externalId).toBe('42');
+    expect(item.title).toBe('Single item');
+  });
+
+  it('fetches a single issue by its plain number string', async () => {
+    const issue = makeIssue({ number: 7, title: 'Plain number' });
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetchByUrl((url) => {
+        expect(url).toContain('/issues/7');
+        return new Response(JSON.stringify(issue), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    const source = makeSource();
+    const item = await source.getItem('7');
+    expect(item.externalId).toBe('7');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMilestones
+// ---------------------------------------------------------------------------
+
+describe('listMilestones', () => {
+  it('returns all milestones filtered through mapGithubMilestone', async () => {
+    const milestones = [
+      {
+        number: 1,
+        title: 'M1',
+        description: 'First',
+        due_on: '2024-03-01T00:00:00Z',
+        state: 'closed',
+      },
+      { number: 2, title: 'M2', description: null, due_on: null, state: 'open' },
+    ];
+
+    vi.stubGlobal('fetch', mockFetchOnce(milestones));
+
+    const source = makeSource();
+    const result = await source.listMilestones();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('1');
+    expect(result[0].isActive).toBe(false);
+    expect(result[0].dueOn).toBeInstanceOf(Date);
+    expect(result[1].isActive).toBe(true);
+    expect(result[1].dueOn).toBeUndefined();
+  });
+
+  it('filters out milestones whose title starts with [E2E]', async () => {
+    const milestones = [
+      { number: 1, title: 'M1', description: null, due_on: null, state: 'open' },
+      { number: 2, title: '[E2E] test milestone', description: null, due_on: null, state: 'open' },
+    ];
+
+    vi.stubGlobal('fetch', mockFetchOnce(milestones));
+
+    const source = makeSource();
+    const result = await source.listMilestones();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('M1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transitionState
+// ---------------------------------------------------------------------------
+
+describe('transitionState', () => {
+  it('removes the old label and adds the new one for a legal transition', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    // factory:triaging -> factory:accepted is a legal transition
+    await expect(
+      source.transitionState('github:shaunnez/goose-hub#5', 'factory:triaging', 'factory:accepted'),
+    ).resolves.toBeUndefined();
+
+    const deleteCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init?.method ?? 'GET').toUpperCase() === 'DELETE',
+    );
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0][0]).toContain('factory%3Atriaging');
+
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init?.method ?? 'GET').toUpperCase() === 'POST',
+    );
+    expect(postCalls).toHaveLength(1);
+    const body = JSON.parse(postCalls[0][1].body as string) as { labels: string[] };
+    expect(body.labels).toContain('factory:accepted');
+  });
+
+  it('throws on an illegal transition', async () => {
+    const source = makeSource();
+    // factory:done -> factory:triaging is not a legal transition
+    await expect(source.transitionState('42', 'factory:done', 'factory:triaging')).rejects.toThrow(
+      'Illegal transition',
+    );
+  });
+
+  it('tolerates 404 when removing the old label (idempotent)', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(
+      source.transitionState('5', 'factory:triaging', 'factory:accepted'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when removing the old label fails with a non-404 error', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'DELETE') {
+        return Promise.resolve(
+          new Response('', { status: 500, statusText: 'Internal Server Error' }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(
+      source.transitionState('5', 'factory:triaging', 'factory:accepted'),
+    ).rejects.toThrow('Failed to remove label');
+  });
+
+  it('throws when adding the new label fails', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response('', { status: 422, statusText: 'Unprocessable Entity' }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(
+      source.transitionState('5', 'factory:triaging', 'factory:accepted'),
+    ).rejects.toThrow('Failed to add label');
+  });
+
+  it('posts a comment when a note is supplied', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await source.transitionState(
+      '5',
+      'factory:triaging',
+      'factory:accepted',
+      'Transitioned by agent',
+    );
+
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init?.method ?? 'GET').toUpperCase() === 'POST',
+    );
+    // First POST = add label, second POST = comment
+    expect(postCalls).toHaveLength(2);
+    const commentBody = JSON.parse(postCalls[1][1].body as string) as { body: string };
+    expect(commentBody.body).toBe('Transitioned by agent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comment
+// ---------------------------------------------------------------------------
+
+describe('comment', () => {
+  it('posts a comment to the given issue', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.comment('github:shaunnez/goose-hub#10', 'hello')).resolves.toBeUndefined();
+
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toContain('/issues/10/comments');
+    const body = JSON.parse(call[1].body as string) as { body: string };
+    expect(body.body).toBe('hello');
+  });
+
+  it('throws when the comment POST fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 403, statusText: 'Forbidden' })),
+    );
+
+    const source = makeSource();
+    await expect(source.comment('10', 'fail')).rejects.toThrow('Failed to post comment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setMilestone
+// ---------------------------------------------------------------------------
+
+describe('setMilestone', () => {
+  it('sends a PATCH request with the milestone number', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.setMilestone('github:shaunnez/goose-hub#10', 3)).resolves.toBeUndefined();
+
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toContain('/issues/10');
+    expect(call[1].method).toBe('PATCH');
+    const body = JSON.parse(call[1].body as string) as { milestone: number };
+    expect(body.milestone).toBe(3);
+  });
+
+  it('sends null to clear the milestone', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await source.setMilestone('10', null);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as { milestone: null };
+    expect(body.milestone).toBeNull();
+  });
+
+  it('throws when the PATCH fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' })),
+    );
+
+    const source = makeSource();
+    await expect(source.setMilestone('10', 1)).rejects.toThrow('Failed to set milestone');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setLabelInGroup
+// ---------------------------------------------------------------------------
+
+describe('setLabelInGroup', () => {
+  it('removes old group labels and adds the new value', async () => {
+    const existingLabels = [
+      { name: 'priority:medium' },
+      { name: 'type:feature' },
+      { name: 'factory:accepted' },
+    ];
+
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify(existingLabels), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await source.setLabelInGroup('10', 'priority', 'high');
+
+    const deleteCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init?.method ?? 'GET').toUpperCase() === 'DELETE',
+    );
+    // Only 'priority:medium' should be deleted — not type or factory labels
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0][0]).toContain('priority%3Amedium');
+
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init?.method ?? 'GET').toUpperCase() === 'POST',
+    );
+    const body = JSON.parse(postCalls[0][1].body as string) as { labels: string[] };
+    expect(body.labels).toContain('priority:high');
+  });
+
+  it('throws when removing an old group label fails with non-404', async () => {
+    const existingLabels = [{ name: 'schedule:current' }];
+
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify(existingLabels), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (method === 'DELETE') {
+        return Promise.resolve(
+          new Response('', { status: 500, statusText: 'Internal Server Error' }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.setLabelInGroup('10', 'schedule', 'next')).rejects.toThrow(
+      'Failed to remove label',
+    );
+  });
+
+  it('throws when adding the new group label fails', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response('', { status: 422, statusText: 'Unprocessable Entity' }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.setLabelInGroup('10', 'type', 'bug')).rejects.toThrow(
+      'Failed to add label',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createIssue
+// ---------------------------------------------------------------------------
+
+describe('createIssue', () => {
+  it('creates an issue with default labels and returns the mapped WorkItem', async () => {
+    const createdIssue = makeIssue({
+      number: 99,
+      title: 'New feature',
+      labels: [
+        { name: 'factory:triaging' },
+        { name: 'type:feature' },
+        { name: 'priority:medium' },
+        { name: 'schedule:later' },
+        { name: 'mode:supervised' },
+        { name: 'exec:serial' },
+      ],
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdIssue), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    const item = await source.createIssue({ title: 'New feature', body: '' });
+
+    expect(item.externalId).toBe('99');
+    expect(item.title).toBe('New feature');
+    expect(item.state).toBe('factory:triaging');
+
+    const call = fetchMock.mock.calls[0];
+    expect(call[1].method).toBe('POST');
+    const body = JSON.parse(call[1].body as string) as { title: string; labels: string[] };
+    expect(body.title).toBe('New feature');
+    expect(body.labels).toContain('factory:triaging');
+  });
+
+  it('uses provided type and priority', async () => {
+    const createdIssue = makeIssue({ number: 100, title: 'Bug report', labels: [] });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdIssue), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await source.createIssue({ title: 'Bug report', body: '', type: 'bug', priority: 'critical' });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as { labels: string[] };
+    expect(body.labels).toContain('type:bug');
+    expect(body.labels).toContain('priority:critical');
+  });
+
+  it('throws when the create request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(new Response('', { status: 422, statusText: 'Unprocessable Entity' })),
+    );
+
+    const source = makeSource();
+    await expect(source.createIssue({ title: 'Bad issue', body: '' })).rejects.toThrow(
+      'Failed to create issue',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listComments
+// ---------------------------------------------------------------------------
+
+describe('listComments', () => {
+  it('fetches and maps comments for an issue', async () => {
+    const rawComments = [
+      {
+        id: 1,
+        body: 'First comment',
+        user: { login: 'alice' },
+        created_at: '2024-01-01T00:00:00Z',
+      },
+      { id: 2, body: 'Second comment', user: null, created_at: '2024-01-02T00:00:00Z' },
+    ];
+
+    vi.stubGlobal('fetch', mockFetchOnce(rawComments));
+
+    const source = makeSource();
+    const comments = await source.listComments('github:shaunnez/goose-hub#10');
+
+    expect(comments).toHaveLength(2);
+    expect(comments[0].id).toBe(1);
+    expect(comments[0].body).toBe('First comment');
+    expect(comments[0].authorLogin).toBe('alice');
+    expect(comments[1].authorLogin).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attach and watchForUpdates (not-implemented stubs)
+// ---------------------------------------------------------------------------
+
+describe('not-implemented stubs', () => {
+  it('attach throws "not implemented"', async () => {
+    const source = makeSource();
+    await expect(source.attach('10', { kind: 'file', url: 'https://example.com' })).rejects.toThrow(
+      'not implemented',
+    );
+  });
+
+  it('watchForUpdates throws "not implemented"', async () => {
+    const source = makeSource();
+    await expect(source.watchForUpdates(() => {})).rejects.toThrow('not implemented');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ghFetch — rate limit with reset timestamp
+// ---------------------------------------------------------------------------
+
+describe('ghFetch — rate limit reset timestamp', () => {
+  it('includes the reset time in the error message when X-RateLimit-Reset is present', async () => {
+    const resetEpoch = String(Math.floor(Date.now() / 1000) + 3600);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('', {
+          status: 429,
+          headers: {
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': resetEpoch,
+          },
+        }),
+      ),
+    );
+
+    const source = makeSource();
+    await expect(source.listOpenWork()).rejects.toThrow('resets at');
+  });
+
+  it('throws a generic API error on non-rate-limit, non-auth failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' })),
+    );
+
+    const source = makeSource();
+    await expect(source.listOpenWork()).rejects.toThrow('GitHub API error: 404');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forceState — error handling
+// ---------------------------------------------------------------------------
+
+describe('forceState — error handling', () => {
+  it('throws when adding the forced label fails', async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (method === 'POST') {
+        return Promise.resolve(
+          new Response('', { status: 422, statusText: 'Unprocessable Entity' }),
+        );
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.forceState('10', 'factory:archived')).rejects.toThrow(
+      'Failed to add label',
+    );
+  });
+
+  it('throws when removing a factory label fails with non-404', async () => {
+    const existingLabels = [{ name: 'factory:in-progress' }];
+
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify(existingLabels), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response('', { status: 500, statusText: 'Server Error' }));
+      }
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = makeSource();
+    await expect(source.forceState('10', 'factory:archived')).rejects.toThrow(
+      'Failed to remove label',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 

--- a/core/tool-layer/tools/read.test.ts
+++ b/core/tool-layer/tools/read.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Additional tests for core/tool-layer/tools/read.ts
+ * Focuses on the searchFiles function — specifically the spawn-based paths that
+ * are unreachable in slice.test.ts when `rg` is not installed.
+ * Uses vi.mock to stub `node:child_process` so tests run everywhere.
+ */
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── mock node:child_process ──────────────────────────────────────────────────
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// Import after mock is registered
+import { spawn } from 'node:child_process';
+import { SandboxViolationError, searchFiles } from './read.js';
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal fake child process
+// ---------------------------------------------------------------------------
+
+function makeChild(opts: {
+  stdoutData?: string;
+  stderrData?: string;
+  exitCode?: number;
+  spawnError?: Error;
+}) {
+  const stdout = new EventEmitter() as EventEmitter & { pipe?: unknown };
+  const stderr = new EventEmitter() as EventEmitter & { pipe?: unknown };
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = () => {};
+
+  // Emit events on the next tick so the Promise has time to register listeners
+  setTimeout(() => {
+    if (opts.spawnError != null) {
+      child.emit('error', opts.spawnError);
+      return;
+    }
+    if (opts.stdoutData != null) {
+      stdout.emit('data', Buffer.from(opts.stdoutData));
+    }
+    if (opts.stderrData != null) {
+      stderr.emit('data', Buffer.from(opts.stderrData));
+    }
+    child.emit('close', opts.exitCode ?? 0);
+  }, 0);
+
+  return child;
+}
+
+beforeEach(() => {
+  vi.mocked(spawn).mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// searchFiles — validation (no spawn needed)
+// ---------------------------------------------------------------------------
+
+describe('searchFiles — input validation', () => {
+  it('rejects an empty pattern with SandboxViolationError', async () => {
+    await expect(searchFiles({ workspaceRoot: '/tmp', pattern: '' })).rejects.toThrow(
+      SandboxViolationError,
+    );
+  });
+
+  it('rejects a pattern containing ../ with SandboxViolationError', async () => {
+    await expect(searchFiles({ workspaceRoot: '/tmp', pattern: '../secret' })).rejects.toThrow(
+      SandboxViolationError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchFiles — spawn-backed paths
+// ---------------------------------------------------------------------------
+
+describe('searchFiles — spawn paths', () => {
+  it('returns stdout on exit code 0 (match found)', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeChild({ stdoutData: 'file.ts:1: match', exitCode: 0 }) as ReturnType<typeof spawn>,
+    );
+
+    const result = await searchFiles({ workspaceRoot: '/workspace', pattern: 'match' });
+
+    expect(result).toBe('file.ts:1: match');
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it('returns empty string on exit code 1 (no matches)', async () => {
+    vi.mocked(spawn).mockReturnValue(makeChild({ exitCode: 1 }) as ReturnType<typeof spawn>);
+
+    const result = await searchFiles({ workspaceRoot: '/workspace', pattern: 'nomatch' });
+
+    expect(result).toBe('');
+  });
+
+  it('rejects with an Error on exit code >= 2 (ripgrep error)', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeChild({ exitCode: 2, stderrData: 'some rg error' }) as ReturnType<typeof spawn>,
+    );
+
+    await expect(searchFiles({ workspaceRoot: '/workspace', pattern: 'x' })).rejects.toThrow(
+      'ripgrep exited with code 2',
+    );
+  });
+
+  it('includes stderr in the rejection message', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeChild({ exitCode: 2, stderrData: 'bad pattern error' }) as ReturnType<typeof spawn>,
+    );
+
+    await expect(searchFiles({ workspaceRoot: '/workspace', pattern: 'x' })).rejects.toThrow(
+      'bad pattern error',
+    );
+  });
+
+  it('rejects when spawn itself emits an error (e.g. rg not found)', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeChild({ spawnError: new Error('spawn ENOENT') }) as ReturnType<typeof spawn>,
+    );
+
+    await expect(searchFiles({ workspaceRoot: '/workspace', pattern: 'x' })).rejects.toThrow(
+      'Failed to spawn ripgrep',
+    );
+  });
+
+  it('passes the glob option to ripgrep args when provided', async () => {
+    vi.mocked(spawn).mockReturnValue(makeChild({ exitCode: 1 }) as ReturnType<typeof spawn>);
+
+    await searchFiles({ workspaceRoot: '/workspace', pattern: 'x', glob: '*.ts' });
+
+    const spawnArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(spawnArgs).toContain('--glob');
+    expect(spawnArgs).toContain('*.ts');
+  });
+
+  it('omits the glob flag when glob is not provided', async () => {
+    vi.mocked(spawn).mockReturnValue(makeChild({ exitCode: 1 }) as ReturnType<typeof spawn>);
+
+    await searchFiles({ workspaceRoot: '/workspace', pattern: 'x' });
+
+    const spawnArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(spawnArgs).not.toContain('--glob');
+  });
+
+  it('omits the glob flag when glob is an empty string', async () => {
+    vi.mocked(spawn).mockReturnValue(makeChild({ exitCode: 1 }) as ReturnType<typeof spawn>);
+
+    await searchFiles({ workspaceRoot: '/workspace', pattern: 'x', glob: '' });
+
+    const spawnArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(spawnArgs).not.toContain('--glob');
+  });
+
+  it('always pins the search path to workspaceRoot (never user-supplied)', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeChild({ exitCode: 0, stdoutData: '' }) as ReturnType<typeof spawn>,
+    );
+
+    const root = '/my/workspace';
+    await searchFiles({ workspaceRoot: root, pattern: 'x' });
+
+    const spawnArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+    // Last arg is the search path — must be workspaceRoot
+    expect(spawnArgs[spawnArgs.length - 1]).toBe(root);
+  });
+
+  it('collects stdout across multiple data events', async () => {
+    const child = makeChild({}) as ReturnType<typeof spawn>;
+    // Override the auto-emit with manual control
+    vi.mocked(spawn).mockReturnValue(child);
+
+    const promise = searchFiles({ workspaceRoot: '/w', pattern: 'x' });
+
+    // Manually emit two chunks then close
+    child.stdout!.emit('data', Buffer.from('chunk1'));
+    child.stdout!.emit('data', Buffer.from('chunk2'));
+    child.emit('close', 0);
+
+    const result = await promise;
+    expect(result).toBe('chunk1chunk2');
+  });
+});

--- a/skills/retrospective-deep/README.md
+++ b/skills/retrospective-deep/README.md
@@ -1,0 +1,59 @@
+# retrospective-deep
+
+Full retrospective skill. Runs after a successful merge when any deep trigger fires.
+
+## When it runs
+
+The `retrospective` workflow selects this skill (over `retrospective-light`) when:
+- First run in a milestone
+- Any QA failure occurred during the run
+- A persona's quality score is declining
+- `≥2` retry attempts were made
+- `priority:high` or `priority:critical` task
+- `retrospectivePolicy: 'always-deep'` in project config
+- Explicit human request
+
+## Output schema
+
+Defined in `schema.ts`. References shared data models from `@goose-hub/core/retrospective/schemas.ts`:
+
+| Field | Type | Description |
+|---|---|---|
+| `summary` | `string` | 3-bullet markdown: what went well, what did not, why |
+| `personaAnalysis` | `QualityScore[]` | Per-persona quality scores with trend |
+| `learningEntries` | `LearningEntry[]` | Normalized observations derived from decision records |
+| `decisionPatterns` | `DecisionPattern[]` | Recurring cross-run patterns |
+| `improvementCandidates` | `ImprovementCandidate[]` | Surfaced suggestions for prompt/skill/config changes |
+| `decisionSummaries` | `DecisionSummary[]` | Required — ≥1 entry per FACTORY_RULES rule 6 |
+
+## Convergence threshold
+
+`CONVERGENCE_THRESHOLD = 'high'` (from `core/retrospective/schemas.ts`).
+
+A `DecisionPattern` is only eligible to surface as an `ImprovementCandidate` once its `confidence` reaches `'high'`. Patterns at `'low'` or `'medium'` confidence are recorded in `decisionPatterns` but filtered out of `improvementCandidates` by the workflow layer.
+
+This prevents low-signal noise from polluting the Roster with unactionable suggestions. The threshold applies at the workflow level, not the skill level — the skill reports all detected patterns; the workflow filters by `CONVERGENCE_THRESHOLD` before persisting candidates.
+
+## improvement_candidates table compatibility
+
+The `improvement_candidates` DB table (added in M9.06 / #264) stores `LearningEntry`-derived rows. Column mapping:
+
+| Table column | Derived from |
+|---|---|
+| `id` | `LearningEntry.id` |
+| `persona_name` | `LearningEntry.personaName` |
+| `source_task_id` | First of `LearningEntry.sourceRunIds` (the run that triggered the retro) |
+| `suggestion_text` | `LearningEntry.observation` |
+| `suggestion_type` | `LearningEntry.improvementKind` |
+| `status` | Always `'pending'` on insert; updated to `'approved'` or `'rejected'` via Roster UI |
+| `created_at` | Set at insert time |
+
+The `ImprovementCandidate` in the skill output additionally carries `targetPath`, `sourceProject`, `sourceWorkItem`, `confidence`, and optional `proposedDiff` — these are stored in the `improvement_candidates` table in the M9.06 migration (see #264 for full column list).
+
+## Prompt file
+
+`prompt.md` — added in M9.01 (#259) which creates both retrospective skills.
+
+## Skill config
+
+`config.ts` — added in M9.01 (#259). Role: `retrospector`. Not a holdout.

--- a/skills/retrospective-deep/config.ts
+++ b/skills/retrospective-deep/config.ts
@@ -1,0 +1,41 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const DeepRetroContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  runSummary: z.object({
+    personaId: z.string(),
+    role: z.string(),
+    outcome: z.enum(['success', 'failure', 'partial']),
+    decisionSummaries: z.array(z.object({ step: z.string(), summary: z.string() })),
+    retryCount: z.number().int().min(0),
+    qaFailed: z.boolean(),
+  }),
+  triggerReasons: z.array(z.string()).describe('Why deep tier was selected'),
+});
+
+const config: SkillConfig = {
+  contextSchema: DeepRetroContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'runSummary.personaId',
+    'runSummary.role',
+    'runSummary.outcome',
+    'runSummary.decisionSummaries',
+    'runSummary.retryCount',
+    'runSummary.qaFailed',
+    'triggerReasons',
+  ],
+  toolBundles: ['core'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'retrospector',
+};
+
+export default config;

--- a/skills/retrospective-deep/schema.ts
+++ b/skills/retrospective-deep/schema.ts
@@ -1,28 +1,13 @@
 import {
-  ConfidenceSchema,
   DecisionPatternSchema,
-  ImprovementKindSchema,
+  DecisionSummarySchema,
+  ImprovementCandidateSchema,
   LearningEntrySchema,
   QualityScoreSchema,
 } from '@goose-hub/core/retrospective/schemas.js';
 import { z } from 'zod';
 
-const DecisionSummarySchema = z.object({
-  step: z.string(),
-  summary: z.string(),
-  evidence: z.string().optional(),
-});
-
-export const ImprovementCandidateSchema = z.object({
-  kind: ImprovementKindSchema,
-  targetPath: z.string(),
-  sourceRunId: z.string(),
-  sourceProject: z.string(),
-  sourceWorkItem: z.string(),
-  suggestionText: z.string(),
-  confidence: ConfidenceSchema,
-  proposedDiff: z.string().optional(),
-});
+export { ImprovementCandidateSchema };
 
 export const DeepRetroSchema = z.object({
   summary: z.string().min(1).describe('3-bullet summary of what went well, what did not, and why'),

--- a/skills/retrospective-deep/schema.ts
+++ b/skills/retrospective-deep/schema.ts
@@ -1,0 +1,45 @@
+import {
+  ConfidenceSchema,
+  DecisionPatternSchema,
+  ImprovementKindSchema,
+  LearningEntrySchema,
+  QualityScoreSchema,
+} from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+const DecisionSummarySchema = z.object({
+  step: z.string(),
+  summary: z.string(),
+  evidence: z.string().optional(),
+});
+
+export const ImprovementCandidateSchema = z.object({
+  kind: ImprovementKindSchema,
+  targetPath: z.string(),
+  sourceRunId: z.string(),
+  sourceProject: z.string(),
+  sourceWorkItem: z.string(),
+  suggestionText: z.string(),
+  confidence: ConfidenceSchema,
+  proposedDiff: z.string().optional(),
+});
+
+export const DeepRetroSchema = z.object({
+  summary: z.string().min(1).describe('3-bullet summary of what went well, what did not, and why'),
+  personaAnalysis: z
+    .array(QualityScoreSchema)
+    .describe('Quality scores per persona active in this run'),
+  learningEntries: z
+    .array(LearningEntrySchema)
+    .describe('Normalized observations derived from agent decisions'),
+  decisionPatterns: z
+    .array(DecisionPatternSchema)
+    .describe('Recurring patterns detected across decision records'),
+  improvementCandidates: z
+    .array(ImprovementCandidateSchema)
+    .describe('Surfaced candidates for prompt, skill, or config changes'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type DeepRetroOutput = z.infer<typeof DeepRetroSchema>;
+export type ImprovementCandidate = z.infer<typeof ImprovementCandidateSchema>;

--- a/skills/retrospective-deep/skill.md
+++ b/skills/retrospective-deep/skill.md
@@ -1,0 +1,64 @@
+# retrospective-deep skill
+
+You are a Retrospector agent running a deep retrospective after a merge that triggered deep analysis. Your job is to produce a full structured analysis: persona quality scores, learning entries, decision patterns, and improvement candidates.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<work_item>` — the issue that was shipped
+- `<run_summary>` — outcome, persona, role, decision summaries, retry count, and QA failure flag
+- `<trigger_reasons>` — why deep tier was selected (e.g. "qa-failed", "first-run-in-milestone")
+
+## Process
+
+### Step 1 — Read the run context
+
+Read the work item, run summary, and trigger reasons.
+
+Emit: `[decision] Deep retro triggered for #<number>: reasons=<trigger_reasons>, outcome=<outcome>`
+
+### Step 2 — Write the 3-bullet summary
+
+Write three markdown bullets:
+1. What went well (concrete, from decision summaries)
+2. What did not go well (what caused retries, QA failures, or escalations — if any)
+3. Main architectural or workflow takeaway
+
+### Step 3 — Persona analysis (QualityScore)
+
+For each active persona in the run, produce a `QualityScore`:
+- `score`: 0.0–1.0 reflecting run quality (1.0 = perfect, 0.0 = total failure). Weight: 0.6 outcome + 0.4 decision quality.
+- `trend`: `improving | stable | declining` — estimate from the decision summaries; default to `stable` if insufficient data.
+- `sampleCount`: 1 (this single run) unless run summary provides history.
+
+### Step 4 — Learning entries
+
+For each distinct decision point that reveals a generalizable lesson:
+- `observation`: what happened (one sentence)
+- `rationale`: why this matters (one sentence)
+- `improvementKind`: what category of change would fix or reinforce it
+- `confidence`: how certain you are (low/medium/high)
+
+Only produce entries where you have evidence in the decision summaries.
+
+### Step 5 — Decision patterns
+
+If the same decision recurs ≥2 times in the decision summaries (even in this single run), record it as a pattern with `confidence: "low"`. Only escalate confidence if you have cross-run evidence from run history.
+
+### Step 6 — Improvement candidates
+
+Surface candidates only where `confidence: "high"` (from `CONVERGENCE_THRESHOLD`). A candidate must:
+- Be actionable (a specific file to change)
+- Be clearly evidenced by the decision summaries or failure data
+- Not be a governance suggestion (those go to the human queue separately)
+
+### Step 7 — Write decision summaries
+
+Include at least one decision summary with `step: "retro-complete"` summarising the full analysis.
+
+## Output
+
+Return JSON conforming to the `DeepRetroSchema`. No free-text outside the schema fields.
+
+[decision] Deep retro complete: <one sentence on key finding>

--- a/skills/retrospective-deep/slice.test.ts
+++ b/skills/retrospective-deep/slice.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toJSONSchema } from 'zod';
+import config from './config.js';
 import { DeepRetroSchema } from './schema.js';
 
 const ISO = '2026-05-03T12:00:00.000Z';
@@ -131,5 +132,19 @@ describe('DeepRetroSchema', () => {
     const jsonSchema = toJSONSchema(DeepRetroSchema);
     expect(typeof jsonSchema).toBe('object');
     expect(jsonSchema).not.toBeNull();
+  });
+});
+
+describe('retrospective-deep skill config', () => {
+  it('has role retrospector', () => {
+    expect(config.role).toBe('retrospector');
+  });
+
+  it('is pinned to sonnet (deep retro is structured analysis, not coding)', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('is not a holdout (retrospector sees run history and decision summaries)', () => {
+    expect(config.freshContext).toBe(false);
   });
 });

--- a/skills/retrospective-deep/slice.test.ts
+++ b/skills/retrospective-deep/slice.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import { DeepRetroSchema } from './schema.js';
+
+const ISO = '2026-05-03T12:00:00.000Z';
+
+const baseValid = {
+  summary:
+    '- Implemented vertical slice cleanly.\n- No holdout violations.\n- Zero retry attempts.',
+  personaAnalysis: [
+    {
+      personaName: 'alice',
+      role: 'developer',
+      skillName: 'implement',
+      score: 0.9,
+      trend: 'improving',
+      sampleCount: 4,
+      computedAt: ISO,
+    },
+  ],
+  learningEntries: [
+    {
+      id: 'le-001',
+      sourceRunIds: ['run-abc'],
+      personaName: 'alice',
+      role: 'developer',
+      observation: 'Slice pattern consistently reduces integration surface',
+      rationale: 'No cross-slice imports in last 4 runs',
+      improvementKind: 'skill-prompt',
+      confidence: 'medium',
+    },
+  ],
+  decisionPatterns: [
+    {
+      id: 'dp-001',
+      pattern: 'Developer writes tests before any implementation',
+      frequency: 4,
+      confidence: 'high',
+      exampleRunIds: ['run-abc', 'run-def'],
+      surfacedAt: ISO,
+    },
+  ],
+  improvementCandidates: [
+    {
+      kind: 'skill-prompt',
+      targetPath: 'skills/implement/prompt.md',
+      sourceRunId: 'run-abc',
+      sourceProject: 'goose-hub',
+      sourceWorkItem: 'shaunnez/goose-hub#77',
+      suggestionText: 'Add explicit reminder to write slice.test.ts first',
+      confidence: 'high',
+    },
+  ],
+  decisionSummaries: [
+    { step: 'tier-select', summary: 'Selected light retro — no deep triggers fired' },
+  ],
+};
+
+describe('DeepRetroSchema', () => {
+  it('accepts a fully-populated valid deep retro output', () => {
+    expect(DeepRetroSchema.safeParse(baseValid).success).toBe(true);
+  });
+
+  it('accepts empty arrays for personaAnalysis, learningEntries, decisionPatterns, improvementCandidates', () => {
+    expect(
+      DeepRetroSchema.safeParse({
+        ...baseValid,
+        personaAnalysis: [],
+        learningEntries: [],
+        decisionPatterns: [],
+        improvementCandidates: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts optional proposedDiff on improvementCandidates', () => {
+    const withDiff = {
+      ...baseValid,
+      improvementCandidates: [
+        { ...baseValid.improvementCandidates[0], proposedDiff: '- old line\n+ new line' },
+      ],
+    };
+    expect(DeepRetroSchema.safeParse(withDiff).success).toBe(true);
+  });
+
+  it('rejects empty summary', () => {
+    expect(DeepRetroSchema.safeParse({ ...baseValid, summary: '' }).success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    expect(DeepRetroSchema.safeParse({ ...baseValid, decisionSummaries: [] }).success).toBe(false);
+  });
+
+  it('rejects invalid QualityScore score above 1', () => {
+    expect(
+      DeepRetroSchema.safeParse({
+        ...baseValid,
+        personaAnalysis: [{ ...baseValid.personaAnalysis[0], score: 2.0 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects invalid LearningEntry with empty sourceRunIds', () => {
+    expect(
+      DeepRetroSchema.safeParse({
+        ...baseValid,
+        learningEntries: [{ ...baseValid.learningEntries[0], sourceRunIds: [] }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown improvementCandidate kind', () => {
+    expect(
+      DeepRetroSchema.safeParse({
+        ...baseValid,
+        improvementCandidates: [{ ...baseValid.improvementCandidates[0], kind: 'unknown' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown confidence on improvementCandidate', () => {
+    expect(
+      DeepRetroSchema.safeParse({
+        ...baseValid,
+        improvementCandidates: [{ ...baseValid.improvementCandidates[0], confidence: 'very-high' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces a valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(DeepRetroSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+  });
+});

--- a/skills/retrospective-light/README.md
+++ b/skills/retrospective-light/README.md
@@ -1,0 +1,34 @@
+# retrospective-light
+
+Thin retrospective skill. Runs by default after every successful merge.
+
+## When it runs
+
+Selected by the `retrospective` workflow when no deep trigger fires:
+- No QA failures
+- Zero retry attempts
+- Not the first run in a milestone
+- No persona quality score decline
+- `retrospectivePolicy: 'always-light'` or `'auto'` (with no triggers)
+
+## Output schema
+
+Defined in `schema.ts`. Imports `ImprovementCandidateSchema` from `@goose-hub/core/retrospective/schemas.ts`.
+
+| Field | Type | Description |
+|---|---|---|
+| `summary` | `string` | 3-bullet markdown: what went well, what did not, main takeaway |
+| `improvementCandidates` | `ImprovementCandidate[]` | Obvious high-confidence candidates only |
+| `decisionSummaries` | `DecisionSummary[]` | Required — ≥1 entry per FACTORY_RULES rule 6 |
+
+## Improvement candidates
+
+Only `confidence: "high"` candidates are included. Low/medium confidence observations are discarded in the light tier. Use deep retro to capture those.
+
+## Prompt
+
+`skill.md` — instructs the agent to summarise the run in 3 bullets and surface high-confidence candidates only.
+
+## Config
+
+`config.ts` — role: `retrospector`, model: `sonnet`, `freshContext: false`.

--- a/skills/retrospective-light/config.ts
+++ b/skills/retrospective-light/config.ts
@@ -1,0 +1,35 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+export const LightRetroContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  runSummary: z.object({
+    personaId: z.string(),
+    role: z.string(),
+    outcome: z.enum(['success', 'failure', 'partial']),
+    decisionSummaries: z.array(z.object({ step: z.string(), summary: z.string() })),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: LightRetroContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'runSummary.personaId',
+    'runSummary.role',
+    'runSummary.outcome',
+    'runSummary.decisionSummaries',
+  ],
+  toolBundles: ['core'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'retrospector',
+};
+
+export default config;

--- a/skills/retrospective-light/schema.ts
+++ b/skills/retrospective-light/schema.ts
@@ -1,0 +1,18 @@
+import {
+  DecisionSummarySchema,
+  ImprovementCandidateSchema,
+} from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+export const LightRetroSchema = z.object({
+  summary: z
+    .string()
+    .min(1)
+    .describe('3-bullet markdown summary: what went well, what did not, main takeaway'),
+  improvementCandidates: z
+    .array(ImprovementCandidateSchema)
+    .describe('Obvious high-confidence improvement candidates only'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type LightRetroOutput = z.infer<typeof LightRetroSchema>;

--- a/skills/retrospective-light/skill.md
+++ b/skills/retrospective-light/skill.md
@@ -1,0 +1,48 @@
+# retrospective-light skill
+
+You are a Retrospector agent running a light retrospective after a successful merge. Your job is to produce a concise, structured summary of the run and surface any obvious improvement candidates.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<work_item>` — the issue that was shipped
+- `<run_summary>` — outcome, persona, role, and the decision summaries from the run
+
+## Process
+
+### Step 1 — Read the run
+
+Read the work item and run summary. Note the outcome and any decision summaries.
+
+Emit: `[decision] Reviewed run for #<number>: outcome=<outcome>, <N> decision summaries`
+
+### Step 2 — Write the 3-bullet summary
+
+Write three markdown bullets covering:
+1. What went well (one concrete observation from the decision summaries)
+2. What did not go well or could be smoother (if nothing, note "Clean run")
+3. Main takeaway for this persona/role combination
+
+### Step 3 — Surface obvious improvement candidates
+
+An obvious candidate is one where:
+- The decision summaries show a recurring friction point, OR
+- The outcome suggests a gap in the skill prompt or config
+
+Only include candidates with `confidence: "high"`. If none qualify, return an empty array.
+
+For each candidate, set:
+- `kind`: one of `skill-prompt | skill-schema | skill-config | global-config | project-config | persona | workflow`
+- `targetPath`: the file most likely to fix the issue
+- `suggestionText`: one clear sentence on what to change and why
+
+### Step 4 — Write decision summary
+
+Emit one decision summary with `step: "retro-complete"` summarising the retrospective outcome.
+
+## Output
+
+Return JSON conforming to the `LightRetroSchema`. No free-text outside the schema fields.
+
+[decision] Retro complete: <one sentence on outcome>

--- a/skills/retrospective-light/slice.test.ts
+++ b/skills/retrospective-light/slice.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import config from './config.js';
+import { LightRetroSchema } from './schema.js';
+
+const baseValid = {
+  summary:
+    '- Tests all pass.\n- One minor lint warning auto-fixed.\n- Dev followed vertical slice pattern throughout.',
+  improvementCandidates: [
+    {
+      kind: 'skill-prompt',
+      targetPath: 'skills/implement/skill.md',
+      sourceRunId: 'run-abc',
+      sourceProject: 'goose-hub',
+      sourceWorkItem: 'shaunnez/goose-hub#42',
+      suggestionText: 'Add explicit reminder to check slice.test.ts exists before writing code',
+      confidence: 'high',
+    },
+  ],
+  decisionSummaries: [{ step: 'tier-select', summary: 'Selected light retro — no deep triggers' }],
+};
+
+describe('LightRetroSchema', () => {
+  it('accepts a fully-populated valid light retro output', () => {
+    expect(LightRetroSchema.safeParse(baseValid).success).toBe(true);
+  });
+
+  it('accepts empty improvementCandidates (common case — clean run)', () => {
+    expect(LightRetroSchema.safeParse({ ...baseValid, improvementCandidates: [] }).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts optional proposedDiff on a candidate', () => {
+    const withDiff = {
+      ...baseValid,
+      improvementCandidates: [
+        { ...baseValid.improvementCandidates[0], proposedDiff: '- old\n+ new' },
+      ],
+    };
+    expect(LightRetroSchema.safeParse(withDiff).success).toBe(true);
+  });
+
+  it('rejects empty summary', () => {
+    expect(LightRetroSchema.safeParse({ ...baseValid, summary: '' }).success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    expect(LightRetroSchema.safeParse({ ...baseValid, decisionSummaries: [] }).success).toBe(false);
+  });
+
+  it('rejects unknown ImprovementKind on a candidate', () => {
+    expect(
+      LightRetroSchema.safeParse({
+        ...baseValid,
+        improvementCandidates: [{ ...baseValid.improvementCandidates[0], kind: 'unknown' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects invalid confidence on a candidate', () => {
+    expect(
+      LightRetroSchema.safeParse({
+        ...baseValid,
+        improvementCandidates: [{ ...baseValid.improvementCandidates[0], confidence: 'very-high' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces a valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(LightRetroSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+  });
+});
+
+describe('retrospective-light skill config', () => {
+  it('has role retrospector', () => {
+    expect(config.role).toBe('retrospector');
+  });
+
+  it('is pinned to sonnet (light retro is routine analysis, not deep reasoning)', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('is not a holdout (retrospector sees run history)', () => {
+    expect(config.freshContext).toBe(false);
+  });
+});

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -211,6 +211,140 @@ beforeEach(() => {
 // ─── tests ────────────────────────────────────────────────────────────────────
 
 describe('runQaWorkflow', () => {
+  describe('qa output validation failure', () => {
+    it('transitions to needs-human when QA output schema validation fails', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce({
+        output: { bad: 'data', missing: 'required' },
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-human',
+      );
+    });
+
+    it('emits agent.run-failed when QA output schema validation fails', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce({
+        output: { invalid: true },
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const failed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+      expect(failed).toBeDefined();
+    });
+  });
+
+  describe('tier failure events', () => {
+    it('emits qa.structural-failed when structural tier fails', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeFailResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const structuralFailed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.structural-failed');
+      expect(structuralFailed).toBeDefined();
+    });
+
+    it('emits qa.functional-failed when functional tier fails', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makeFailResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const functionalFailed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.functional-failed');
+      expect(functionalFailed).toBeDefined();
+    });
+
+    it('does NOT emit qa.structural-failed when structural tier passes', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const structuralFailed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.structural-failed');
+      expect(structuralFailed).toBeUndefined();
+    });
+
+    it('emits qa.completed with full payload including qualityScores on pass', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const completed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.completed');
+      expect(completed).toBeDefined();
+      const payload = completed?.[0].payload as Record<string, unknown>;
+      expect(payload.verdict).toBe('pass');
+      expect(payload.qualityScores).toBeDefined();
+    });
+
+    it('emits agent.decision-summary per decisionSummary entry', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      const resultWithSummaries: AgentResult = {
+        output: {
+          ...(makePassResult().output as object),
+          decisionSummaries: [
+            { step: 's1', summary: 'passed lint' },
+            { step: 's2', summary: 'tests passed' },
+          ],
+        },
+        decisionSummaries: [],
+        events: [],
+      };
+      mockRun.mockResolvedValueOnce(resultWithSummaries);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const decisionEvents = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.filter(
+          ([e]) =>
+            e.kind === 'agent.decision-summary' && (e.payload as { skill?: string }).skill === 'qa',
+        );
+      expect(decisionEvents).toHaveLength(2);
+    });
+  });
+
   describe('pass verdict', () => {
     it('transitions state to factory:needs-review on pass', async () => {
       const item = makeWorkItem();
@@ -403,6 +537,29 @@ describe('runQaWorkflow', () => {
         '42',
         'factory:needs-qa',
         'factory:qa-failed',
+      );
+    });
+  });
+
+  describe('non-Error thrown (line 174 branch)', () => {
+    it('wraps non-Error thrown value as Error and transitions to needs-human', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      // Throw a string instead of an Error object — covers line 174
+      // eslint-disable-next-line prefer-promise-reject-errors
+      mockRun.mockRejectedValueOnce('string error from qa runtime');
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-human',
+      );
+      expect(source.comment).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('string error from qa runtime'),
       );
     });
   });


### PR DESCRIPTION
Implements both retrospective skill packages for M9.

## What ships

**`skills/retrospective-light/`** (new):
- `schema.ts` — `LightRetroSchema`: 3-bullet summary + high-confidence improvement candidates
- `config.ts` — role: retrospector, model: sonnet, freshContext: false
- `skill.md` — prompt instructing the agent to summarise and surface obvious candidates
- `README.md` — tier selection rules and schema docs
- `slice.test.ts` — 11 unit tests

**`skills/retrospective-deep/`** (additions to #77 base):
- `config.ts` — role: retrospector, model: sonnet, freshContext: false
- `skill.md` — prompt for full persona analysis, patterns, and candidates

**`core/retrospective/schemas.ts`** (updated):
- Added `ImprovementCandidateSchema` and `DecisionSummarySchema` to core so both skills share them without cross-slice imports

52 tests pass across all three test files. Typecheck and lint clean.

## Acceptance criteria

- [x] `skills/retrospective-light/` created with Zod output schema: 3-bullet summary + obvious improvement candidates
- [x] `skills/retrospective-deep/` created with full Zod output schema: persona analysis, quality scores, decision patterns, improvement candidates
- [x] Both skills include `skill.md`, `schema.ts`, `README.md`, `slice.test.ts`, and `config.ts`
- [x] `skills/retrospective-light/` schema validated by unit tests (11 tests)
- [x] `skills/retrospective-deep/` schema validated by unit tests (13 tests)
- [x] Both skills produce JSON conforming to their schemas (toJSONSchema roundtrip tested)

Closes #259