### PR TITLE
M9.02: retrospective workflow with tier-selection logic

### DIFF
--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -44,7 +44,9 @@ export type EventKind =
   | 'qa.completed'
   | 'review.completed'
   // M8 retry-and-escalate
-  | 'agent.retry-escalated';
+  | 'agent.retry-escalated'
+  // M9 retrospective lifecycle
+  | 'retrospective.completed';
 
 export interface AgentEvent {
   id: number;

--- a/core/workflows/README.md
+++ b/core/workflows/README.md
@@ -1,0 +1,43 @@
+# core/workflows
+
+Orchestration workflows that compose skills, persist results, and transition work-item state.
+
+## retrospective.ts
+
+Runs after every successful merge. Selects the retrospective tier (light or deep) and calls the appropriate skill.
+
+### Tier selection
+
+| Policy | Behaviour |
+|---|---|
+| `always-light` | Always runs `retrospective-light`, ignoring triggers |
+| `always-deep` | Always runs `retrospective-deep`, ignoring triggers |
+| `auto` | Light by default; deep when any trigger fires |
+
+**Auto-mode deep triggers:**
+- `firstRunInMilestone` — first issue shipped in this milestone
+- `qaFailed` — any QA failure during the run
+- `qualityScoreDeclining` — persona quality score trend is `declining`
+- `humanRequested` — human explicitly requested deep retro
+
+### What it does
+
+1. Selects tier and skill name
+2. Spawns the appropriate skill via `ClaudeCliRuntime`
+3. Emits `retrospective.completed` event with tier and full output
+4. Transitions work item `factory:retrospecting → factory:done`
+5. On error: emits `agent.run-failed`, transitions to `factory:needs-human`
+
+### Usage
+
+```ts
+import { runRetrospectiveWorkflow } from '@goose-hub/core/workflows/retrospective.js';
+
+await runRetrospectiveWorkflow({
+  workItem,
+  stateSource,
+  projectId: 'goose-hub-self',
+  policy: 'auto',
+  triggers: { qaFailed: true },
+});
+```

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DeepRetroSchema } from '../../skills/retrospective-deep/schema.js';
+import { LightRetroSchema } from '../../skills/retrospective-light/schema.js';
+import { ClaudeCliRuntime } from '../agent-runtime/claude-cli.js';
+import type { AgentRuntime } from '../agent-runtime/interface.js';
+import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
+import { selectPersona } from '../agent-runtime/select-persona.js';
+import { eventStore } from '../event-stream/store.js';
+import type { StateSource, WorkItem } from '../state-source/interface.js';
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+
+function readPrompt(skillName: string): string {
+  return readFileSync(join(REPO_ROOT, 'skills', skillName, 'skill.md'), 'utf8');
+}
+
+export type RetrospectivePolicy = 'always-light' | 'always-deep' | 'auto';
+
+export interface TriggerContext {
+  firstRunInMilestone?: boolean;
+  qaFailed?: boolean;
+  qualityScoreDeclining?: boolean;
+  humanRequested?: boolean;
+}
+
+export interface RunRetrospectiveInput {
+  workItem: WorkItem;
+  stateSource: StateSource;
+  projectId: string;
+  policy: RetrospectivePolicy;
+  triggers?: TriggerContext;
+  deps?: { runtime?: AgentRuntime };
+}
+
+function selectTier(policy: RetrospectivePolicy, triggers: TriggerContext): 'light' | 'deep' {
+  if (policy === 'always-light') return 'light';
+  if (policy === 'always-deep') return 'deep';
+  if (
+    triggers.firstRunInMilestone ||
+    triggers.qaFailed ||
+    triggers.qualityScoreDeclining ||
+    triggers.humanRequested
+  ) {
+    return 'deep';
+  }
+  return 'light';
+}
+
+export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Promise<void> {
+  const { workItem, stateSource, projectId, policy, triggers = {}, deps = {} } = input;
+  const runId = crypto.randomUUID();
+  const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const tier = selectTier(policy, triggers);
+  const skillName = tier === 'deep' ? 'retrospective-deep' : 'retrospective-light';
+  const schema = tier === 'deep' ? DeepRetroSchema : LightRetroSchema;
+  const prompt = readPrompt(skillName);
+  const jsonSchema = toJsonSchema(schema);
+  const personaId = selectPersona(projectId, 'retrospector');
+
+  eventStore.appendEvent({
+    kind: 'agent.run-started',
+    projectId,
+    workItemId: workItem.id,
+    runId,
+    payload: { skill: skillName, tier, personaId },
+  });
+
+  try {
+    const result = await runtime.run({
+      runId,
+      role: 'retrospector',
+      skill: skillName,
+      context: {
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        runSummary: { personaId, role: 'retrospector', outcome: 'success', decisionSummaries: [] },
+      },
+      contextAllowlist: ['workItem.title', 'workItem.body', 'workItem.number', 'runSummary'],
+      freshContext: false,
+      toolBundles: ['core'],
+      toolExtras: [],
+      budgets: { maxTurns: 10, maxBudgetUsd: 0.5 },
+      personaId,
+      appendSystemPrompt: prompt,
+      outputJsonSchema: jsonSchema,
+    });
+
+    eventStore.appendEvent({
+      kind: 'retrospective.completed',
+      projectId,
+      workItemId: workItem.id,
+      runId,
+      payload: { tier, output: result.output },
+    });
+
+    for (const ds of result.decisionSummaries) {
+      eventStore.appendEvent({
+        kind: 'agent.decision-summary',
+        projectId,
+        workItemId: workItem.id,
+        runId,
+        payload: { skill: skillName, ...ds },
+      });
+    }
+
+    await stateSource.transitionState(workItem.externalId, 'factory:retrospecting', 'factory:done');
+  } catch (err) {
+    eventStore.appendEvent({
+      kind: 'agent.run-failed',
+      projectId,
+      workItemId: workItem.id,
+      runId,
+      payload: { skill: skillName, error: String(err) },
+    });
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:retrospecting',
+      'factory:needs-human',
+    );
+  }
+}

--- a/core/workflows/slice.test.ts
+++ b/core/workflows/slice.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── module mocks ─────────────────────────────────────────────────────────────
+
+const mockRun = vi.fn();
+
+vi.mock('../agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+vi.mock('../agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue('test-project/retrospector/0'),
+}));
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi
+      .fn()
+      .mockReturnValue({ id: 1, kind: 'retrospective.completed', payload: {}, createdAt: '' }),
+    replay: vi.fn().mockReturnValue([]),
+  },
+}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock skill prompt') };
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+import type { StateSource, WorkItem } from '../state-source/interface.js';
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:owner/repo#42',
+    externalId: '42',
+    repoRef: 'owner/repo',
+    title: 'Shipped feature',
+    body: 'body',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:retrospecting',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeSource(overrides: Partial<StateSource> = {}): StateSource {
+  return {
+    projectId: 'test-project',
+    repoRef: 'owner/repo',
+    listOpenWork: vi.fn().mockResolvedValue([]),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeLightResult() {
+  return {
+    output: {
+      summary: '- All good.\n- No issues.\n- Keep it up.',
+      improvementCandidates: [],
+      decisionSummaries: [{ step: 'retro-complete', summary: 'Clean run' }],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeDeepResult() {
+  return {
+    output: {
+      summary: '- Good.\n- QA failed once.\n- Adjust prompt.',
+      personaAnalysis: [],
+      learningEntries: [],
+      decisionPatterns: [],
+      improvementCandidates: [],
+      decisionSummaries: [{ step: 'retro-complete', summary: 'Deep retro complete' }],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+beforeEach(() => {
+  mockRun.mockReset();
+  vi.clearAllMocks();
+});
+
+// ─── tier selection ───────────────────────────────────────────────────────────
+
+describe('tier selection', () => {
+  it('always-light policy runs retrospective-light regardless of triggers', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeLightResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'always-light',
+      triggers: { qaFailed: true, firstRunInMilestone: true },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-light');
+  });
+
+  it('always-deep policy runs retrospective-deep regardless of triggers', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'always-deep',
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-deep');
+  });
+
+  it('auto + no triggers → retrospective-light', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeLightResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'auto',
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-light');
+  });
+
+  it('auto + qaFailed → retrospective-deep', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'auto',
+      triggers: { qaFailed: true },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-deep');
+  });
+
+  it('auto + firstRunInMilestone → retrospective-deep', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'auto',
+      triggers: { firstRunInMilestone: true },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-deep');
+  });
+
+  it('auto + qualityScoreDeclining → retrospective-deep', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'auto',
+      triggers: { qualityScoreDeclining: true },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-deep');
+  });
+
+  it('auto + humanRequested → retrospective-deep', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'auto',
+      triggers: { humanRequested: true },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as { skill: string };
+    expect(spec.skill).toBe('retrospective-deep');
+  });
+});
+
+// ─── state transitions ────────────────────────────────────────────────────────
+
+describe('state transitions', () => {
+  it('transitions to factory:done after successful retro', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    const source = makeSource();
+    mockRun.mockResolvedValueOnce(makeLightResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: source,
+      projectId: 'test-project',
+      policy: 'always-light',
+    });
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:retrospecting',
+      'factory:done',
+    );
+  });
+
+  it('emits retrospective.completed event with tier info', async () => {
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    const { eventStore } = await import('../event-stream/store.js');
+    mockRun.mockResolvedValueOnce(makeLightResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'always-light',
+    });
+
+    const retroEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'retrospective.completed');
+    expect(retroEvent).toBeDefined();
+    const payload = retroEvent![0].payload as { tier: string };
+    expect(payload.tier).toBe('light');
+  });
+});


### PR DESCRIPTION
Implements the retrospective workflow that runs after every successful merge.

## What ships

- `core/workflows/retrospective.ts` — `runRetrospectiveWorkflow()` selecting `retrospective-light` or `retrospective-deep` based on policy and trigger signals
- `core/workflows/slice.test.ts` — 9 unit tests covering all policies and trigger combinations
- `core/workflows/README.md` — tier-selection table and usage example
- `core/event-stream/store.ts` — adds `'retrospective.completed'` to `EventKind`

## Acceptance criteria

- [x] `core/workflows/retrospective.ts` created as a vertical slice
- [x] Tier selection reads `retrospectivePolicy`: always-light, always-deep, auto
- [x] Auto mode triggers deep on: firstRunInMilestone, qaFailed, qualityScoreDeclining, humanRequested
- [x] Workflow calls appropriate skill and persists result (retrospective.completed event)
- [x] `slice.test.ts` covers light path, deep path, and each auto-trigger condition
- [x] `README.md` documents tier-selection logic

Closes #260