### PR TITLE
M9.05: Roster UI — per-role persona list with metrics and history drill-in

### DIFF
--- a/apps/server/src/domains/roster/repository.ts
+++ b/apps/server/src/domains/roster/repository.ts
@@ -1,0 +1,21 @@
+import { db } from '@goose-hub/core/db/db.js';
+import { personaStats } from '@goose-hub/core/db/schema.js';
+import { asc } from 'drizzle-orm';
+
+export interface PersonaStat {
+  id: number;
+  personaName: string;
+  role: string;
+  runsTotal: number;
+  runsSucceeded: number;
+  runsFailed: number;
+  avgQualityScore: number;
+  lastRunAt: string;
+}
+
+export async function listPersonaStats(): Promise<PersonaStat[]> {
+  return db
+    .select()
+    .from(personaStats)
+    .orderBy(asc(personaStats.role), asc(personaStats.personaName));
+}

--- a/apps/server/src/domains/roster/router.test.ts
+++ b/apps/server/src/domains/roster/router.test.ts
@@ -1,0 +1,92 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListPersonas, mockGetPersonaRuns, mockGetPersonaCandidates } = vi.hoisted(() => ({
+  mockListPersonas: vi.fn(),
+  mockGetPersonaRuns: vi.fn(),
+  mockGetPersonaCandidates: vi.fn(),
+}));
+
+vi.mock('./service.js', () => ({
+  listPersonas: mockListPersonas,
+  getPersonaRuns: mockGetPersonaRuns,
+  getPersonaCandidates: mockGetPersonaCandidates,
+}));
+
+import { rosterRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/roster', rosterRouter);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /roster', () => {
+  it('returns 200 with personas array', async () => {
+    const personas = [
+      {
+        id: 1,
+        personaName: 'alice',
+        role: 'developer',
+        runsTotal: 3,
+        runsSucceeded: 3,
+        runsFailed: 0,
+        avgQualityScore: 1.0,
+        lastRunAt: '2026-05-01T00:00:00Z',
+      },
+    ];
+    mockListPersonas.mockResolvedValue({ ok: true, data: { personas } });
+
+    const app = makeApp();
+    const res = await app.request('/roster');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { personas: unknown[] };
+    expect(body.personas).toHaveLength(1);
+  });
+
+  it('returns empty personas array when service fails', async () => {
+    mockListPersonas.mockResolvedValue({ ok: false, error: 'db error', status: 500 });
+
+    const app = makeApp();
+    const res = await app.request('/roster');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { personas: unknown[] };
+    expect(body.personas).toEqual([]);
+  });
+});
+
+describe('GET /roster/runs', () => {
+  it('returns 200 with empty runs array', async () => {
+    mockGetPersonaRuns.mockResolvedValue({ ok: true, data: { runs: [] } });
+
+    const app = makeApp();
+    const res = await app.request('/roster/runs?persona=alice');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs: unknown[] };
+    expect(body.runs).toEqual([]);
+    expect(mockGetPersonaRuns).toHaveBeenCalledWith('alice');
+  });
+
+  it('passes empty string when persona query param is absent', async () => {
+    mockGetPersonaRuns.mockResolvedValue({ ok: true, data: { runs: [] } });
+
+    const app = makeApp();
+    await app.request('/roster/runs');
+    expect(mockGetPersonaRuns).toHaveBeenCalledWith('');
+  });
+});
+
+describe('GET /roster/candidates', () => {
+  it('returns 200 with empty candidates array', async () => {
+    mockGetPersonaCandidates.mockResolvedValue({ ok: true, data: { candidates: [] } });
+
+    const app = makeApp();
+    const res = await app.request('/roster/candidates?persona=alice');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { candidates: unknown[] };
+    expect(body.candidates).toEqual([]);
+    expect(mockGetPersonaCandidates).toHaveBeenCalledWith('alice');
+  });
+});

--- a/apps/server/src/domains/roster/router.ts
+++ b/apps/server/src/domains/roster/router.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono';
+import { getPersonaCandidates, getPersonaRuns, listPersonas } from './service.js';
+
+const router = new Hono();
+
+router.get('/', async (c) => {
+  const result = await listPersonas();
+  return result.ok ? c.json(result.data) : c.json({ personas: [] });
+});
+
+router.get('/runs', async (c) => {
+  const persona = c.req.query('persona') ?? '';
+  const result = await getPersonaRuns(persona);
+  return result.ok ? c.json(result.data) : c.json({ runs: [] });
+});
+
+router.get('/candidates', async (c) => {
+  const persona = c.req.query('persona') ?? '';
+  const result = await getPersonaCandidates(persona);
+  return result.ok ? c.json(result.data) : c.json({ candidates: [] });
+});
+
+export { router as rosterRouter };

--- a/apps/server/src/domains/roster/service.test.ts
+++ b/apps/server/src/domains/roster/service.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStats = [
+  {
+    id: 1,
+    personaName: 'alice',
+    role: 'developer',
+    runsTotal: 5,
+    runsSucceeded: 4,
+    runsFailed: 1,
+    avgQualityScore: 0.85,
+    lastRunAt: '2026-05-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    personaName: 'bob',
+    role: 'qa',
+    runsTotal: 3,
+    runsSucceeded: 3,
+    runsFailed: 0,
+    avgQualityScore: 1.0,
+    lastRunAt: '2026-05-02T00:00:00Z',
+  },
+];
+
+const { mockListPersonaStats } = vi.hoisted(() => ({
+  mockListPersonaStats: vi.fn(),
+}));
+
+vi.mock('./repository.js', () => ({
+  listPersonaStats: mockListPersonaStats,
+}));
+
+import { getPersonaCandidates, getPersonaRuns, listPersonas } from './service.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listPersonas', () => {
+  it('returns all persona stats from the DB', async () => {
+    mockListPersonaStats.mockResolvedValue(mockStats);
+    const result = await listPersonas();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.personas).toHaveLength(2);
+      expect(result.data.personas[0].personaName).toBe('alice');
+      expect(result.data.personas[1].role).toBe('qa');
+    }
+  });
+
+  it('returns empty array when no personas exist', async () => {
+    mockListPersonaStats.mockResolvedValue([]);
+    const result = await listPersonas();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.personas).toHaveLength(0);
+    }
+  });
+});
+
+describe('getPersonaRuns', () => {
+  it('returns empty run history (no per-run table yet)', async () => {
+    const result = await getPersonaRuns('alice');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.runs).toEqual([]);
+    }
+  });
+
+  it('accepts any persona name without error', async () => {
+    const result = await getPersonaRuns('unknown-persona');
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('getPersonaCandidates', () => {
+  it('returns empty candidates list (table created in #264)', async () => {
+    const result = await getPersonaCandidates('alice');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.candidates).toEqual([]);
+    }
+  });
+
+  it('accepts any persona name without error', async () => {
+    const result = await getPersonaCandidates('unknown-persona');
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/server/src/domains/roster/service.ts
+++ b/apps/server/src/domains/roster/service.ts
@@ -1,0 +1,40 @@
+import type { Result } from '../../shared/middleware.js';
+import type { PersonaStat } from './repository.js';
+import { listPersonaStats } from './repository.js';
+
+export interface PersonaRunDto {
+  runId: string;
+  workItemId: string | null;
+  outcome: string;
+  qualityScore: number;
+  createdAt: string;
+}
+
+export interface ImprovementCandidateDto {
+  id: number;
+  personaName: string;
+  sourceTaskId: string | null;
+  suggestionText: string;
+  suggestionType: string;
+  status: string;
+  createdAt: string;
+}
+
+export async function listPersonas(): Promise<Result<{ personas: PersonaStat[] }>> {
+  const personas = await listPersonaStats();
+  return { ok: true, data: { personas } };
+}
+
+export async function getPersonaRuns(
+  _personaName: string,
+): Promise<Result<{ runs: PersonaRunDto[] }>> {
+  // Per-run history table is added in a future issue; return empty for now.
+  return { ok: true, data: { runs: [] } };
+}
+
+export async function getPersonaCandidates(
+  _personaName: string,
+): Promise<Result<{ candidates: ImprovementCandidateDto[] }>> {
+  // improvement_candidates table is created in #264; return empty for now.
+  return { ok: true, data: { candidates: [] } };
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -6,6 +6,7 @@ import { inboxRouter } from './domains/inbox/router.js';
 import { issuesRouter } from './domains/issues/router.js';
 import { milestonesRouter } from './domains/milestones/router.js';
 import { projectsRouter } from './domains/projects/router.js';
+import { rosterRouter } from './domains/roster/router.js';
 import { webhooksRouter } from './domains/webhooks/router.js';
 import { workflowsRouter } from './domains/workflows/router.js';
 
@@ -27,6 +28,7 @@ app.route('/projects', milestonesRouter); // GET/POST /projects/:slug/milestones
 app.route('/projects', issuesRouter); // GET/POST /projects/:slug/issues/**
 app.route('/projects', workflowsRouter); // POST /projects/:slug/tick
 app.route('/inbox', inboxRouter); // GET/POST /inbox/**
+app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events
 app.route('/webhooks', webhooksRouter); // POST /webhooks/github
 

--- a/apps/web/e2e/m9-roster.spec.ts
+++ b/apps/web/e2e/m9-roster.spec.ts
@@ -1,0 +1,118 @@
+import { type Route, expect, test } from '@playwright/test';
+
+/**
+ * M9 Roster UI (#263).
+ *
+ * Verifies the Roster page loads, shows personas grouped by role,
+ * and the drill-in panel opens with run history and candidate sections.
+ * All API requests are intercepted.
+ */
+test.describe('M9 Roster UI', () => {
+  const slug = 'goose-hub-self';
+
+  const mockPersonas = [
+    {
+      id: 1,
+      personaName: 'alice',
+      role: 'developer',
+      runsTotal: 5,
+      runsSucceeded: 4,
+      runsFailed: 1,
+      avgQualityScore: 0.85,
+      lastRunAt: new Date(Date.now() - 3_600_000).toISOString(),
+    },
+    {
+      id: 2,
+      personaName: 'bob',
+      role: 'qa',
+      runsTotal: 3,
+      runsSucceeded: 3,
+      runsFailed: 0,
+      avgQualityScore: 1.0,
+      lastRunAt: new Date(Date.now() - 7_200_000).toISOString(),
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/projects', (route: Route) =>
+      route.fulfill({
+        json: { projects: [{ slug, name: 'Goose Hub (self)', color: '#6366f1' }] },
+      }),
+    );
+
+    await page.route('**/projects/goose-hub-self/active-milestone', (route: Route) =>
+      route.fulfill({ json: { milestoneNumber: null, source: 'github-default' } }),
+    );
+
+    await page.route(`**/projects/${slug}/issues`, (route: Route) =>
+      route.fulfill({ json: { items: [] } }),
+    );
+
+    await page.route('**/roster', (route: Route) =>
+      route.fulfill({ json: { personas: mockPersonas } }),
+    );
+
+    await page.route('**/roster/runs**', (route: Route) => route.fulfill({ json: { runs: [] } }));
+
+    await page.route('**/roster/candidates**', (route: Route) =>
+      route.fulfill({ json: { candidates: [] } }),
+    );
+  });
+
+  test('Roster page is accessible from sidebar nav', async ({ page }) => {
+    await page.goto(`/projects/${slug}`);
+
+    const rosterLink = page.getByRole('link', { name: /roster/i });
+    await expect(rosterLink).toBeVisible();
+    await rosterLink.click();
+
+    await expect(page).toHaveURL(`/projects/${slug}/roster`);
+    await expect(page.getByTestId('roster-page')).toBeVisible();
+  });
+
+  test('persona cards are visible grouped by role', async ({ page }) => {
+    await page.goto(`/projects/${slug}/roster`);
+
+    await expect(page.getByTestId('roster-page')).toBeVisible();
+
+    const cards = page.getByTestId('persona-card');
+    await expect(cards).toHaveCount(2);
+
+    await expect(page.getByText('alice')).toBeVisible();
+    await expect(page.getByText('bob')).toBeVisible();
+    await expect(page.getByText('developer')).toBeVisible();
+    await expect(page.getByText('qa')).toBeVisible();
+  });
+
+  test('drill-in panel opens when clicking a persona card', async ({ page }) => {
+    await page.goto(`/projects/${slug}/roster`);
+
+    await page.getByTestId('persona-card').first().click();
+
+    await expect(page.getByTestId('persona-drill-in')).toBeVisible();
+  });
+
+  test('drill-in shows run history empty state when no runs exist', async ({ page }) => {
+    await page.goto(`/projects/${slug}/roster`);
+
+    await page.getByTestId('persona-card').first().click();
+
+    await expect(page.getByTestId('runs-empty-state')).toBeVisible();
+  });
+
+  test('drill-in shows empty state when no candidates exist', async ({ page }) => {
+    await page.goto(`/projects/${slug}/roster`);
+
+    await page.getByTestId('persona-card').first().click();
+
+    await expect(page.getByTestId('candidates-empty-state')).toBeVisible();
+  });
+
+  test('empty state shown when roster has no personas', async ({ page }) => {
+    await page.route('**/roster', (route: Route) => route.fulfill({ json: { personas: [] } }));
+
+    await page.goto(`/projects/${slug}/roster`);
+
+    await expect(page.getByTestId('roster-empty-state')).toBeVisible();
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Board } from './components/board/components/Board';
 import { AppShell } from './components/chrome/AppShell';
 import { DetailPage } from './components/detail/components/DetailPage';
 import { InboxList } from './components/inbox/InboxList';
+import { RosterPage } from './components/roster/components/RosterPage';
 import { ActiveMilestoneProvider } from './state/active-milestone';
 import { ActiveProjectProvider } from './state/active-project';
 import { LaneVisibilityProvider } from './state/lane-visibility';
@@ -68,6 +69,14 @@ function InboxPage() {
   );
 }
 
+function RosterPageRoute() {
+  return (
+    <AppShell breadcrumb={<span>Roster</span>}>
+      <RosterPage />
+    </AppShell>
+  );
+}
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -87,6 +96,14 @@ export function App() {
             element={
               <ProjectShell>
                 <InboxPage />
+              </ProjectShell>
+            }
+          />
+          <Route
+            path="/projects/:slug/roster"
+            element={
+              <ProjectShell>
+                <RosterPageRoute />
               </ProjectShell>
             }
           />

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -31,8 +31,7 @@ function buildItems(slug: string | undefined): SidebarItem[] {
       to: `/projects/${project}/roster`,
       label: 'Roster',
       icon: <Users size={14} />,
-      available: false,
-      milestone: 'M5',
+      available: true,
     },
     {
       to: `/projects/${project}/milestones`,

--- a/apps/web/src/components/roster/README.md
+++ b/apps/web/src/components/roster/README.md
@@ -1,0 +1,24 @@
+# roster
+
+Roster page — per-role persona list with metrics and history drill-in.
+
+## Route
+
+`/projects/:slug/roster`
+
+## Components
+
+- `RosterPage` — main page; fetches all personas, groups by role, renders `PersonaCard` grid
+- `PersonaDrillIn` — right-side panel with quality stats, run history, and improvement candidates
+
+## Data
+
+- `GET /roster` — all personas with aggregate stats (from `persona_stats` table)
+- `GET /roster/runs?persona=<name>` — per-run history (empty until per-run table is added)
+- `GET /roster/candidates?persona=<name>` — improvement candidates (empty until #264)
+
+## Empty states
+
+- No personas: "No personas yet — stats accumulate as agent runs complete"
+- No run history: "No run history recorded yet"
+- No candidates: "No improvement candidates yet"

--- a/apps/web/src/components/roster/components/PersonaDrillIn.tsx
+++ b/apps/web/src/components/roster/components/PersonaDrillIn.tsx
@@ -1,0 +1,178 @@
+import { fetchPersonaCandidates, fetchPersonaRuns } from '@/lib/api';
+import type { ImprovementCandidateDto, PersonaRunDto, PersonaStatDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { X } from 'lucide-react';
+
+interface PersonaDrillInProps {
+  persona: PersonaStatDto;
+  onClose: () => void;
+}
+
+function qualityBar(score: number) {
+  const pct = Math.round(score * 100);
+  const color =
+    pct >= 80
+      ? 'var(--success, #22c55e)'
+      : pct >= 50
+        ? 'var(--warning, #f59e0b)'
+        : 'var(--danger, #ef4444)';
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 rounded-full bg-bg overflow-hidden">
+        <div style={{ width: `${pct}%`, background: color, height: '100%', borderRadius: 9999 }} />
+      </div>
+      <span className="text-[11px] font-mono text-fg-3 w-8 text-right">{pct}%</span>
+    </div>
+  );
+}
+
+function RunHistory({ personaName }: { personaName: string }) {
+  const { data: runs = [], isLoading } = useQuery<PersonaRunDto[]>({
+    queryKey: ['persona-runs', personaName],
+    queryFn: () => fetchPersonaRuns(personaName),
+  });
+
+  if (isLoading) {
+    return <div className="text-[12px] text-fg-4 py-4">Loading run history…</div>;
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div
+        data-testid="runs-empty-state"
+        className="text-[12px] text-fg-4 py-4 text-center border border-dashed border-line rounded-md"
+      >
+        No run history recorded yet
+      </div>
+    );
+  }
+
+  return (
+    <ol className="flex flex-col gap-1.5">
+      {runs.map((run) => (
+        <li
+          key={run.runId}
+          className="flex items-center gap-3 px-3 py-2 rounded-md border border-line bg-bg text-[12px]"
+        >
+          <span
+            className="shrink-0 px-1.5 py-0.5 rounded text-[10.5px] uppercase font-mono"
+            style={{
+              background:
+                run.outcome === 'success'
+                  ? 'var(--success-soft, #dcfce7)'
+                  : 'var(--danger-soft, #fee2e2)',
+              color:
+                run.outcome === 'success' ? 'var(--success, #15803d)' : 'var(--danger, #dc2626)',
+            }}
+          >
+            {run.outcome}
+          </span>
+          <span className="flex-1 text-fg-3 truncate">{run.workItemId ?? '—'}</span>
+          <span className="text-fg-4 font-mono shrink-0">
+            {Math.round(run.qualityScore * 100)}%
+          </span>
+          <span className="text-fg-4 shrink-0">{new Date(run.createdAt).toLocaleDateString()}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function CandidatesList({ personaName }: { personaName: string }) {
+  const { data: candidates = [], isLoading } = useQuery<ImprovementCandidateDto[]>({
+    queryKey: ['persona-candidates', personaName],
+    queryFn: () => fetchPersonaCandidates(personaName),
+  });
+
+  if (isLoading) {
+    return <div className="text-[12px] text-fg-4 py-4">Loading candidates…</div>;
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <div
+        data-testid="candidates-empty-state"
+        className="text-[12px] text-fg-4 py-4 text-center border border-dashed border-line rounded-md"
+      >
+        No improvement candidates yet
+      </div>
+    );
+  }
+
+  return (
+    <ol className="flex flex-col gap-1.5">
+      {candidates.map((c) => (
+        <li key={c.id} className="px-3 py-2 rounded-md border border-line bg-bg text-[12px]">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="px-1.5 py-0.5 rounded text-[10.5px] uppercase font-mono bg-bg-elev text-fg-3 border border-line">
+              {c.suggestionType}
+            </span>
+            <span
+              className="px-1.5 py-0.5 rounded text-[10.5px] uppercase font-mono"
+              style={{
+                background:
+                  c.status === 'pending' ? 'var(--warning-soft, #fef3c7)' : 'var(--bg-elev)',
+                color: c.status === 'pending' ? 'var(--warning, #92400e)' : 'var(--fg-3)',
+              }}
+            >
+              {c.status}
+            </span>
+          </div>
+          <p className="text-fg leading-snug">{c.suggestionText}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function PersonaDrillIn({ persona, onClose }: PersonaDrillInProps) {
+  return (
+    <aside
+      data-testid="persona-drill-in"
+      className="w-[360px] shrink-0 flex flex-col border-l border-line bg-bg-elev overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-line">
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] font-semibold text-fg truncate">{persona.personaName}</div>
+          <div className="text-[11px] text-fg-3 capitalize">{persona.role}</div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close panel"
+          className="p-1 rounded hover:bg-bg-hover text-fg-4 hover:text-fg"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-5">
+        {/* Stats summary */}
+        <section>
+          <h3 className="text-[11px] uppercase tracking-wider text-fg-4 mb-2">Quality</h3>
+          {qualityBar(persona.avgQualityScore)}
+          <div className="flex gap-4 mt-2 text-[11.5px] text-fg-3">
+            <span>{persona.runsTotal} total</span>
+            <span className="text-[color:var(--success,#22c55e)]">{persona.runsSucceeded} ok</span>
+            <span className="text-[color:var(--danger,#ef4444)]">{persona.runsFailed} failed</span>
+          </div>
+        </section>
+
+        {/* Run history */}
+        <section>
+          <h3 className="text-[11px] uppercase tracking-wider text-fg-4 mb-2">Run History</h3>
+          <RunHistory personaName={persona.personaName} />
+        </section>
+
+        {/* Improvement candidates */}
+        <section>
+          <h3 className="text-[11px] uppercase tracking-wider text-fg-4 mb-2">
+            Improvement Candidates
+          </h3>
+          <CandidatesList personaName={persona.personaName} />
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/roster/components/RosterPage.tsx
+++ b/apps/web/src/components/roster/components/RosterPage.tsx
@@ -1,0 +1,151 @@
+import { fetchRoster } from '@/lib/api';
+import type { PersonaStatDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { PersonaDrillIn } from './PersonaDrillIn';
+
+function qualityColor(score: number): string {
+  if (score >= 0.8) return 'var(--success, #22c55e)';
+  if (score >= 0.5) return 'var(--warning, #f59e0b)';
+  return 'var(--danger, #ef4444)';
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function PersonaCard({
+  persona,
+  isSelected,
+  onClick,
+}: {
+  persona: PersonaStatDto;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="persona-card"
+      onClick={onClick}
+      className={[
+        'w-full text-left px-3 py-3 rounded-md border transition-colors',
+        isSelected
+          ? 'border-accent bg-accent-soft'
+          : 'border-line bg-bg-elev/60 hover:bg-bg-elev hover:border-line',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <span className="text-[12.5px] font-medium text-fg truncate">{persona.personaName}</span>
+        <span
+          className="text-[11px] font-mono shrink-0"
+          style={{ color: qualityColor(persona.avgQualityScore) }}
+        >
+          {Math.round(persona.avgQualityScore * 100)}%
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-fg-4">
+        <span>{persona.runsTotal} runs</span>
+        <span>·</span>
+        <span>{timeAgo(persona.lastRunAt)}</span>
+      </div>
+    </button>
+  );
+}
+
+function RoleGroup({
+  role,
+  personas,
+  selectedPersona,
+  onSelect,
+}: {
+  role: string;
+  personas: PersonaStatDto[];
+  selectedPersona: PersonaStatDto | null;
+  onSelect: (p: PersonaStatDto) => void;
+}) {
+  return (
+    <section>
+      <h2 className="text-[11px] uppercase tracking-wider text-fg-4 px-1 mb-2 capitalize">
+        {role}
+      </h2>
+      <div className="flex flex-col gap-1.5">
+        {personas.map((p) => (
+          <PersonaCard
+            key={p.id}
+            persona={p}
+            isSelected={selectedPersona?.id === p.id}
+            onClick={() => onSelect(p)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function RosterPage() {
+  const [selectedPersona, setSelectedPersona] = useState<PersonaStatDto | null>(null);
+
+  const {
+    data: personas = [],
+    isLoading,
+    error,
+  } = useQuery<PersonaStatDto[]>({
+    queryKey: ['roster'],
+    queryFn: fetchRoster,
+  });
+
+  const grouped: Record<string, PersonaStatDto[]> = {};
+  for (const p of personas) {
+    if (!grouped[p.role]) grouped[p.role] = [];
+    grouped[p.role].push(p);
+  }
+
+  const roles = Object.keys(grouped).sort();
+
+  return (
+    <div data-testid="roster-page" className="flex h-full overflow-hidden">
+      {/* Main list */}
+      <div className="flex-1 overflow-y-auto px-8 py-6">
+        <h1 className="text-[15px] font-semibold mb-6">Roster</h1>
+
+        {isLoading && <div className="text-fg-3 text-[13px]">Loading personas…</div>}
+
+        {error && (
+          <div className="text-[color:var(--danger)] text-[13px]">Failed to load roster.</div>
+        )}
+
+        {!isLoading && !error && personas.length === 0 && (
+          <div data-testid="roster-empty-state" className="text-center text-fg-3 text-[13px] py-16">
+            <p className="mb-2 font-medium text-fg-2">No personas yet</p>
+            <p>Persona stats accumulate as agent runs complete.</p>
+          </div>
+        )}
+
+        {!isLoading && !error && roles.length > 0 && (
+          <div className="flex flex-col gap-8 max-w-[600px]">
+            {roles.map((role) => (
+              <RoleGroup
+                key={role}
+                role={role}
+                personas={grouped[role]}
+                selectedPersona={selectedPersona}
+                onSelect={setSelectedPersona}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Drill-in panel */}
+      {selectedPersona && (
+        <PersonaDrillIn persona={selectedPersona} onClose={() => setSelectedPersona(null)} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/slice.test.ts
+++ b/apps/web/src/components/roster/slice.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockPersonas = [
+  {
+    id: 1,
+    personaName: 'alice',
+    role: 'developer',
+    runsTotal: 5,
+    runsSucceeded: 4,
+    runsFailed: 1,
+    avgQualityScore: 0.85,
+    lastRunAt: '2026-05-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    personaName: 'bob',
+    role: 'qa',
+    runsTotal: 3,
+    runsSucceeded: 3,
+    runsFailed: 0,
+    avgQualityScore: 1.0,
+    lastRunAt: '2026-05-02T00:00:00Z',
+  },
+];
+
+describe('roster — fetchRoster', () => {
+  it('resolves to a PersonaStatDto array', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockPersonas);
+    vi.doMock('@/lib/api', () => ({
+      fetchRoster: mockFetch,
+      fetchPersonaRuns: vi.fn(),
+      fetchPersonaCandidates: vi.fn(),
+    }));
+    const { fetchRoster } = await import('@/lib/api');
+    vi.mocked(fetchRoster).mockResolvedValue(mockPersonas);
+    const personas = await fetchRoster();
+    expect(personas).toHaveLength(2);
+    expect(personas[0].personaName).toBe('alice');
+    expect(personas[1].role).toBe('qa');
+  });
+
+  it('returns empty array when no personas exist', async () => {
+    const { fetchRoster } = await import('@/lib/api');
+    vi.mocked(fetchRoster).mockResolvedValue([]);
+    const personas = await fetchRoster();
+    expect(personas).toEqual([]);
+  });
+});
+
+describe('roster — fetchPersonaRuns', () => {
+  it('resolves to an empty array when no run history exists', async () => {
+    const { fetchPersonaRuns } = await import('@/lib/api');
+    vi.mocked(fetchPersonaRuns).mockResolvedValue([]);
+    const runs = await fetchPersonaRuns('alice');
+    expect(runs).toEqual([]);
+  });
+});
+
+describe('roster — fetchPersonaCandidates', () => {
+  it('resolves to an empty array when no candidates exist', async () => {
+    const { fetchPersonaCandidates } = await import('@/lib/api');
+    vi.mocked(fetchPersonaCandidates).mockResolvedValue([]);
+    const candidates = await fetchPersonaCandidates('alice');
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe('roster — grouping by role', () => {
+  it('groups personas into distinct roles', () => {
+    const grouped: Record<string, typeof mockPersonas> = {};
+    for (const p of mockPersonas) {
+      if (!grouped[p.role]) grouped[p.role] = [];
+      grouped[p.role].push(p);
+    }
+    expect(Object.keys(grouped)).toContain('developer');
+    expect(Object.keys(grouped)).toContain('qa');
+    expect(grouped.developer).toHaveLength(1);
+    expect(grouped.developer[0].personaName).toBe('alice');
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,11 @@
 import type {
   AgentEventDto,
+  ImprovementCandidateDto,
   InboxItemDto,
   IssueCommentDto,
   MilestoneDto,
+  PersonaRunDto,
+  PersonaStatDto,
   ProjectSummary,
   TransitionResult,
   TriageResultDto,
@@ -18,6 +21,9 @@ export type {
   TransitionResult,
   InboxItemDto,
   TriageResultDto,
+  PersonaStatDto,
+  PersonaRunDto,
+  ImprovementCandidateDto,
 } from './types';
 
 async function getJson<T>(path: string): Promise<T> {
@@ -215,4 +221,25 @@ export async function transitionState(
   });
   const data = (await res.json().catch(() => ({}))) as TransitionResult;
   return { status: res.status, data };
+}
+
+export async function fetchRoster(): Promise<PersonaStatDto[]> {
+  const { personas } = await getJson<{ personas: PersonaStatDto[] }>('/roster');
+  return personas;
+}
+
+export async function fetchPersonaRuns(personaName: string): Promise<PersonaRunDto[]> {
+  const { runs } = await getJson<{ runs: PersonaRunDto[] }>(
+    `/roster/runs?persona=${encodeURIComponent(personaName)}`,
+  );
+  return runs;
+}
+
+export async function fetchPersonaCandidates(
+  personaName: string,
+): Promise<ImprovementCandidateDto[]> {
+  const { candidates } = await getJson<{ candidates: ImprovementCandidateDto[] }>(
+    `/roster/candidates?persona=${encodeURIComponent(personaName)}`,
+  );
+  return candidates;
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -78,3 +78,32 @@ export interface InboxItemDto {
   type: string;
   createdAt: string;
 }
+
+export interface PersonaStatDto {
+  id: number;
+  personaName: string;
+  role: string;
+  runsTotal: number;
+  runsSucceeded: number;
+  runsFailed: number;
+  avgQualityScore: number;
+  lastRunAt: string;
+}
+
+export interface PersonaRunDto {
+  runId: string;
+  workItemId: string | null;
+  outcome: string;
+  qualityScore: number;
+  createdAt: string;
+}
+
+export interface ImprovementCandidateDto {
+  id: number;
+  personaName: string;
+  sourceTaskId: string | null;
+  suggestionText: string;
+  suggestionType: string;
+  status: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- Adds `GET /roster`, `GET /roster/runs`, `GET /roster/candidates` server endpoints backed by the `persona_stats` table
- Roster page at `/projects/:slug/roster` showing personas grouped by role with quality score, run count, and last-run time
- Click-to-open drill-in panel (360px) with quality bar, run history, and improvement candidates sections
- Empty states for no personas, no run history, and no candidates
- Sidebar "Roster" nav item enabled

## What's deferred

- Per-run history table (no table exists yet — endpoint returns `[]`, UI shows empty state)
- Improvement candidates (table created in #264 — endpoint returns `[]`, UI shows empty state)

## Test plan

- [ ] 11 new server unit tests (service + router) — all pass
- [ ] 4 new frontend slice tests — all pass  
- [ ] 6 Playwright e2e tests in `e2e/m9-roster.spec.ts` covering nav access, persona cards, drill-in, and empty states
- [ ] TypeScript clean (`tsc --noEmit`)
- [ ] Biome lint clean

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)