### PR TITLE
feat(agent-runtime): label-aware MOCK_AGENTS triage mock

### DIFF
--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -87,7 +87,11 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       runId,
       role: 'triager',
       skill: 'triage',
-      context: { projectId, workItemId, workItem: { title: item.title, body: item.body } },
+      context: {
+        projectId,
+        workItemId,
+        workItem: { title: item.title, body: item.body, type: item.type },
+      },
       contextAllowlist: ['workItem'],
       freshContext: false,
       toolBundles: [],

--- a/apps/web/e2e/pipeline/state-flow.spec.ts
+++ b/apps/web/e2e/pipeline/state-flow.spec.ts
@@ -1,0 +1,201 @@
+import { expect, test } from '@playwright/test';
+
+const REPO = 'shaunnez/goose-hub';
+const PROJECT_SLUG = 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+const MILESTONE_TITLE = '[E2E Pipeline] Tests';
+const TOKEN = process.env.GITHUB_TOKEN ?? '';
+
+async function gh(path: string, method = 'GET', body?: unknown) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`GitHub ${method} ${path} → ${res.status}`);
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`POST ${path} → ${res.status}`);
+  return res;
+}
+
+test.describe('Pipeline e2e (MOCK_AGENTS=true)', () => {
+  test.skip(!TOKEN, 'GITHUB_TOKEN is required.');
+
+  let milestoneNumber: number;
+  let choreIssueNumber: number | undefined;
+  let bugIssueNumber: number | undefined;
+
+  test.beforeAll(async () => {
+    const all = (await gh(`/repos/${REPO}/milestones?state=all&per_page=100`)) as unknown as Array<{
+      number: number;
+      title: string;
+      state: string;
+    }>;
+    let ms = all.find((m) => m.title === MILESTONE_TITLE);
+    if (!ms) {
+      ms = (await gh(`/repos/${REPO}/milestones`, 'POST', {
+        title: MILESTONE_TITLE,
+        state: 'open',
+        description: 'Automated E2E pipeline fixture — do not use for real issues.',
+      })) as { number: number; title: string; state: string };
+    } else if (ms.state === 'closed') {
+      await gh(`/repos/${REPO}/milestones/${ms.number}`, 'PATCH', { state: 'open' });
+    }
+    milestoneNumber = ms.number;
+
+    await postServer(`/projects/${PROJECT_SLUG}/active-milestone`, { milestoneNumber });
+  });
+
+  test.afterAll(async () => {
+    if (choreIssueNumber) {
+      try {
+        await gh(`/repos/${REPO}/issues/${choreIssueNumber}`, 'PATCH', { state: 'closed' });
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (bugIssueNumber) {
+      try {
+        await gh(`/repos/${REPO}/issues/${bugIssueNumber}`, 'PATCH', { state: 'closed' });
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (milestoneNumber) {
+      try {
+        await gh(`/repos/${REPO}/milestones/${milestoneNumber}`, 'PATCH', { state: 'closed' });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  test('chore pipeline: inbox capture → factory:approved', async ({ page }) => {
+    test.setTimeout(180_000);
+    const choreTitle = `[E2E Pipeline] Chore ${Date.now()}`;
+
+    // 1. Capture an inbox idea via the top-bar button.
+    await page.goto(`/projects/${PROJECT_SLUG}`);
+    await page.getByTestId('capture-button').click();
+    await page.getByTestId('capture-title-input').fill(choreTitle);
+    await page.getByTestId('capture-submit').click();
+
+    // 2. Confirm capture modal closed, then go to inbox.
+    await expect(page.getByTestId('capture-title-input')).not.toBeVisible({ timeout: 10_000 });
+    await page.goto(`/projects/${PROJECT_SLUG}/inbox`);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({ timeout: 15_000 });
+
+    // 3. Promote the captured item to a real GitHub issue.
+    const inboxRow = page.getByTestId('inbox-item').filter({ hasText: choreTitle }).first();
+    await expect(inboxRow).toBeVisible({ timeout: 10_000 });
+    await inboxRow.getByTestId('promote-button').click();
+
+    await page.getByTestId('promote-project-select').selectOption(PROJECT_SLUG);
+    await page.getByTestId('promote-next').click();
+    await page.getByTestId('promote-confirm').click();
+
+    // 4. Inbox item disappears once promoted.
+    await expect(page.getByTestId('inbox-item').filter({ hasText: choreTitle })).not.toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 5. Find the freshly created issue on the board.
+    await page.goto(`/projects/${PROJECT_SLUG}`);
+    const milestoneSelector = page.locator('select[data-testid="milestone-selector"]');
+    await expect(milestoneSelector).toBeVisible({ timeout: 15_000 });
+    await milestoneSelector.selectOption({ value: String(milestoneNumber) });
+
+    const cards = page.getByTestId('issue-card');
+    const card = cards.filter({ hasText: choreTitle }).first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    const cardNumberAttr = await card.getAttribute('data-issue-number');
+    if (!cardNumberAttr) throw new Error('issue-card missing data-issue-number');
+    choreIssueNumber = Number(cardNumberAttr);
+
+    // 6. Open the detail page; switch to Timeline.
+    await card.click();
+    await expect(page.getByTestId('detail-page')).toBeVisible({ timeout: 15_000 });
+    await page.getByRole('link', { name: 'Timeline' }).click();
+    await expect(page.getByTestId('timeline-section')).toBeVisible({ timeout: 10_000 });
+
+    // 7. Kick off the triage batch. With MOCK_AGENTS=true the mock honours type:chore
+    //    and routes the issue: triaging → accepted → dev-ready. The dev-ready label
+    //    triggers the webhook dispatch into runFixIssueWorkflow, which then lands at
+    //    needs-qa. This step relies on GitHub webhooks reaching the local server.
+    await postServer(`/projects/${PROJECT_SLUG}/tick`);
+
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // 8. Drive QA and review via their batch endpoints (no auto-chain for these).
+    await postServer(`/projects/${PROJECT_SLUG}/run-qa`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    await postServer(`/projects/${PROJECT_SLUG}/run-review`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+
+    // 9. Spot-check the timeline shows the agent + PR events the mocks produce.
+    await expect(page.locator('[data-event-kind="agent.triage-complete"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-event-kind="agent.implement-complete"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-event-kind="pr.opened"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('bug pipeline: triaging → factory:investigation-complete', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create the bug issue directly so triage sees type:bug already on it.
+    const issue = (await gh(`/repos/${REPO}/issues`, 'POST', {
+      title: `[E2E Pipeline] Bug ${Date.now()}`,
+      body: 'Automated e2e fixture — safe to close.',
+      milestone: milestoneNumber,
+      labels: [
+        'factory:triaging',
+        'priority:medium',
+        'type:bug',
+        'schedule:current',
+        'mode:supervised',
+        'exec:serial',
+      ],
+    })) as { number: number };
+    bugIssueNumber = issue.number;
+
+    // 2. Open the detail page; switch to Timeline.
+    await page.goto(`/projects/${PROJECT_SLUG}/items/${bugIssueNumber}`);
+    await expect(page.getByTestId('detail-page')).toBeVisible({ timeout: 15_000 });
+    await page.getByRole('link', { name: 'Timeline' }).click();
+    await expect(page.getByTestId('timeline-section')).toBeVisible({ timeout: 10_000 });
+
+    // 3. Trigger triage. The label-aware mock returns type:bug, so triage routes
+    //    triaging → accepted → investigating. The investigating label then auto-
+    //    dispatches the investigate workflow → investigation-complete.
+    await postServer(`/projects/${PROJECT_SLUG}/tick`);
+
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:investigation-complete', { timeout: 90_000 });
+
+    await expect(page.locator('[data-event-kind="agent.triage-complete"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.locator('[data-event-kind="agent.investigation-complete"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:pipeline": "playwright test --config playwright-e2e-pipeline.config.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.6",

--- a/apps/web/playwright-e2e-pipeline.config.ts
+++ b/apps/web/playwright-e2e-pipeline.config.ts
@@ -1,0 +1,43 @@
+import { resolve } from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+
+config({ path: resolve(import.meta.dirname, '../../.env') });
+
+const PORT = Number(process.env.WEB_PORT ?? 5173);
+
+export default defineConfig({
+  testDir: './e2e/pipeline',
+  timeout: 120_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer:
+    process.env.SKIP_WEBSERVER === '1'
+      ? undefined
+      : [
+          {
+            command: 'pnpm --filter @goose-hub/server start',
+            port: 3001,
+            reuseExistingServer: !process.env.CI,
+            timeout: 30_000,
+            env: {
+              GITHUB_TOKEN: process.env.GITHUB_TOKEN ?? '',
+              MOCK_AGENTS: 'true',
+              MOCK_OPEN_PR: 'true',
+            },
+          },
+          {
+            command: `pnpm dev --port ${PORT}`,
+            port: PORT,
+            reuseExistingServer: !process.env.CI,
+            timeout: 30_000,
+          },
+        ],
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -19,6 +19,7 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         <span className="grow" />
         <button
           type="button"
+          data-testid="capture-button"
           onClick={() => setShowCapture(true)}
           title="Capture an idea or task"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"

--- a/apps/web/src/components/inbox/CaptureModal.tsx
+++ b/apps/web/src/components/inbox/CaptureModal.tsx
@@ -96,6 +96,7 @@ export function CaptureModal({ open, onClose }: CaptureModalProps) {
           </label>
           <input
             id="capture-title"
+            data-testid="capture-title-input"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -196,6 +197,7 @@ export function CaptureModal({ open, onClose }: CaptureModalProps) {
             </button>
             <button
               type="submit"
+              data-testid="capture-submit"
               disabled={submitting}
               style={{
                 padding: '5px 14px',

--- a/apps/web/src/components/inbox/InboxList.tsx
+++ b/apps/web/src/components/inbox/InboxList.tsx
@@ -106,6 +106,7 @@ function PromoteModal({
               <div style={{ position: 'relative', marginBottom: 16 }}>
                 <select
                   aria-label="Select project"
+                  data-testid="promote-project-select"
                   value={selectedSlug}
                   onChange={(e) => setSelectedSlug(e.target.value)}
                   style={{
@@ -162,6 +163,7 @@ function PromoteModal({
               </button>
               <button
                 type="button"
+                data-testid="promote-next"
                 onClick={handlePickerNext}
                 disabled={!selectedSlug}
                 style={{
@@ -225,6 +227,7 @@ function PromoteModal({
               </button>
               <button
                 type="button"
+                data-testid="promote-confirm"
                 onClick={() => mutation.mutate()}
                 disabled={mutation.isPending}
                 style={{
@@ -278,6 +281,8 @@ export function InboxList() {
         {items.map((item) => (
           <li
             key={item.id}
+            data-testid="inbox-item"
+            data-inbox-id={item.id}
             className="flex items-center gap-4 rounded-md border border-line bg-bg-elev/60 px-4 py-3"
           >
             <div className="flex-1 min-w-0">
@@ -293,6 +298,7 @@ export function InboxList() {
             </div>
             <button
               type="button"
+              data-testid="promote-button"
               onClick={() => setPromoting(item)}
               className="h-7 px-3 rounded-md border border-line text-[12px] text-fg-2 hover:text-fg hover:bg-bg-hover shrink-0"
             >

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -17,5 +17,11 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src", "vite.config.ts", "playwright.config.ts", "e2e"]
+  "include": [
+    "src",
+    "vite.config.ts",
+    "playwright.config.ts",
+    "playwright-e2e-pipeline.config.ts",
+    "e2e"
+  ]
 }

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -2,18 +2,25 @@ import type { AgentResult, AgentSpec } from './interface.js';
 
 export function resolveMockOutput(spec: AgentSpec): AgentResult {
   switch (spec.skill) {
-    case 'triage':
+    case 'triage': {
+      const workItem = (spec.context?.workItem ?? {}) as { type?: string };
+      const incoming = workItem.type;
+      const type =
+        incoming === 'bug' || incoming === 'research' || incoming === 'feature'
+          ? incoming
+          : 'chore';
       return {
         output: {
-          type: 'chore',
+          type,
           priority: 'p3',
           labels: [],
           reasoning: 'e2e fixture',
-          decisionSummaries: [{ step: 'classify', summary: 'Classified as chore for e2e' }],
+          decisionSummaries: [{ step: 'classify', summary: `Classified as ${type} for e2e` }],
         },
-        decisionSummaries: [{ step: 'classify', summary: 'Classified as chore for e2e' }],
+        decisionSummaries: [{ step: 'classify', summary: `Classified as ${type} for e2e` }],
         events: [],
       };
+    }
 
     case 'repo-match':
       return {


### PR DESCRIPTION
Pass workItem.type through the triage AgentSpec context so the MOCK_AGENTS
preset can honour an existing type:bug / type:research label instead of
always returning chore. Required by the bug pipeline e2e scenario.