### PR TITLE
fix(qa): accept null file/line on findings to prevent validation failures

### DIFF
--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -11,8 +11,8 @@ interface QASectionProps {
 interface Finding {
   tier: 'structural' | 'functional' | 'regression';
   severity: 'error' | 'warning' | 'info';
-  file?: string;
-  line?: number;
+  file?: string | null;
+  line?: number | null;
   description: string;
   suggestion?: string;
 }
@@ -20,8 +20,8 @@ interface Finding {
 interface TierResult {
   passed: boolean;
   findings: Finding[];
-  command?: string;
-  output?: string;
+  command?: string | null;
+  output?: string | null;
 }
 
 interface QaPayload {

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -12,8 +12,8 @@ export const FindingSchema = z.object({
     .transform((s) => s.toLowerCase())
     .pipe(z.enum(['structural', 'functional', 'regression'])),
   severity: z.enum(['error', 'warning', 'info']),
-  file: z.string().optional(),
-  line: z.number().int().optional(),
+  file: z.string().nullable().optional(),
+  line: z.number().int().nullable().optional(),
   description: z.string(),
   suggestion: z.string().optional(),
 });

--- a/skills/qa/skill.md
+++ b/skills/qa/skill.md
@@ -260,9 +260,7 @@ Return a JSON object conforming exactly to this structure:
     },
     "regression": {
       "passed": true,
-      "findings": [],
-      "command": null,
-      "output": null
+      "findings": []
     }
   },
   "qualityScores": {
@@ -290,6 +288,8 @@ Return a JSON object conforming exactly to this structure:
 `overallScore` must equal the sum of all `qualityScores` values. Do not estimate — compute it.
 
 `decisionSummaries` must have at least one entry per major verification step.
+
+Optional fields without a value should be OMITTED, not set to `null`. In particular, when a finding does not pertain to a specific source location, omit `file` and `line` entirely — do not write `"file": null` or `"line": null`. The same applies to `command` and `output` on tier results when no command was run.
 
 ## Important reminders
 

--- a/skills/qa/slice.test.ts
+++ b/skills/qa/slice.test.ts
@@ -204,6 +204,17 @@ describe('FindingSchema', () => {
     const result = FindingSchema.safeParse({ tier: 'structural', severity: 'error' });
     expect(result.success).toBe(false);
   });
+
+  it('accepts null file and null line for findings without a source location', () => {
+    const result = FindingSchema.safeParse({
+      tier: 'functional',
+      severity: 'warning',
+      file: null,
+      line: null,
+      description: 'Acceptance criterion 3 not covered by any test',
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 // ─── TierResultSchema ────────────────────────────────────────────────────────


### PR DESCRIPTION
QA agent runs were aborting with "QA output validation failed" because the
LLM emits "file": null and "line": null for findings without a source
location. The Zod schema only accepted undefined (.optional()), not null.

- Make file/line on FindingSchema .nullable().optional() to match the
  existing command/output pattern on TierResultSchema.
- Drop the "command": null, "output": null example from skill.md and add a
  reminder to omit optional fields rather than set them to null.
- Update QASection.tsx Finding/TierResult types to allow null on those
  fields (the runtime null-checks were already correct).
- Add a slice.test.ts case covering null file/line on FindingSchema.

https://claude.ai/code/session_01UhkhNKzLM6fxRwtEDD1cLa