### PR TITLE
feat(inbox): add milestone picker to promote modal with active milestone auto-selection

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -124,7 +124,7 @@ describe('POST /inbox/:id/promote', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean };
     expect(body.ok).toBe(true);
-    expect(mockPromoteInboxItem).toHaveBeenCalledWith(42, 'goose-hub-self');
+    expect(mockPromoteInboxItem).toHaveBeenCalledWith(42, 'goose-hub-self', undefined);
   });
 
   it('uses default slug "goose-hub-self" when projectSlug is not provided', async () => {
@@ -136,7 +136,31 @@ describe('POST /inbox/:id/promote', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
     });
-    expect(mockPromoteInboxItem).toHaveBeenCalledWith(7, 'goose-hub-self');
+    expect(mockPromoteInboxItem).toHaveBeenCalledWith(7, 'goose-hub-self', undefined);
+  });
+
+  it('passes milestoneNumber to service when provided', async () => {
+    mockPromoteInboxItem.mockResolvedValue({ ok: true, data: { ok: true } });
+
+    const app = makeApp();
+    await app.request('/inbox/10/promote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectSlug: 'my-proj', milestoneNumber: 5 }),
+    });
+    expect(mockPromoteInboxItem).toHaveBeenCalledWith(10, 'my-proj', 5);
+  });
+
+  it('passes null milestoneNumber to service when explicitly set to null', async () => {
+    mockPromoteInboxItem.mockResolvedValue({ ok: true, data: { ok: true } });
+
+    const app = makeApp();
+    await app.request('/inbox/11/promote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectSlug: 'my-proj', milestoneNumber: null }),
+    });
+    expect(mockPromoteInboxItem).toHaveBeenCalledWith(11, 'my-proj', null);
   });
 
   it('returns 400 for non-numeric id', async () => {

--- a/apps/server/src/domains/inbox/router.ts
+++ b/apps/server/src/domains/inbox/router.ts
@@ -21,10 +21,11 @@ router.get('/', async (c) => {
 router.post('/:id/promote', async (c) => {
   const id = Number(c.req.param('id'));
   if (Number.isNaN(id)) return c.json({ error: 'invalid id' }, 400);
-  const body = await parseBody<{ projectSlug?: string }>(c);
+  const body = await parseBody<{ projectSlug?: string; milestoneNumber?: number | null }>(c);
   if (!body.ok) return body.error;
   const slug = body.data.projectSlug ?? 'goose-hub-self';
-  const result = await promoteInboxItem(id, slug);
+  const milestoneNumber = body.data.milestoneNumber;
+  const result = await promoteInboxItem(id, slug, milestoneNumber);
   return result.ok
     ? c.json(result.data)
     : c.json({ error: result.error }, result.status as 400 | 404);

--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -11,6 +11,12 @@ vi.mock('./repository.js', () => ({
   deleteInboxItem: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@goose-hub/core/db/db.js', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ all: () => [] }) }) }),
+  },
+}));
+
 import { getSourceForSlug } from '../../shared/source.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
 import { createInboxItem, getInboxItems, promoteInboxItem } from './service.js';

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -33,6 +33,7 @@ export async function getInboxItems(): Promise<Result<{ items: InboxItem[] }>> {
 export async function promoteInboxItem(
   id: number,
   projectSlug: string,
+  milestoneNumber?: number | null,
 ): Promise<Result<{ ok: true }>> {
   const item = await getInboxItem(id);
   if (item == null) return { ok: false, error: 'not found', status: 404 };
@@ -40,18 +41,24 @@ export async function promoteInboxItem(
   const source = await getSourceForSlug(projectSlug);
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
 
-  const stateRows = db
-    .select()
-    .from(projectState)
-    .where(eq(projectState.projectId, source.projectId))
-    .all();
-  const activeMilestoneNumber = stateRows[0]?.activeMilestoneNumber ?? null;
+  // Use explicit milestone from caller; fall back to project's persisted active milestone
+  let effectiveMilestoneNumber: number | null;
+  if (milestoneNumber !== undefined) {
+    effectiveMilestoneNumber = milestoneNumber;
+  } else {
+    const stateRows = db
+      .select()
+      .from(projectState)
+      .where(eq(projectState.projectId, source.projectId))
+      .all();
+    effectiveMilestoneNumber = stateRows[0]?.activeMilestoneNumber ?? null;
+  }
 
   await source.createIssue({
     title: item.title,
     body: item.body ?? '',
     type: item.type as 'feature' | 'bug' | 'chore' | 'research',
-    ...(activeMilestoneNumber != null ? { milestoneId: String(activeMilestoneNumber) } : {}),
+    ...(effectiveMilestoneNumber != null ? { milestoneId: String(effectiveMilestoneNumber) } : {}),
   });
 
   try {

--- a/apps/server/src/domains/workflows/state-flows.test.ts
+++ b/apps/server/src/domains/workflows/state-flows.test.ts
@@ -42,6 +42,10 @@ vi.mock('@goose-hub/core/connectors/github/open-pr.js', () => ({
   }),
 }));
 
+vi.mock('@goose-hub/core/persona/accumulate.js', () => ({
+  accumulatePersonaStats: vi.fn(),
+}));
+
 vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   createWorktree: vi.fn().mockReturnValue('/mock/worktree'),
   cleanupWorktree: vi.fn(),

--- a/apps/web/src/components/inbox/InboxList.tsx
+++ b/apps/web/src/components/inbox/InboxList.tsx
@@ -283,7 +283,8 @@ function PromoteModal({
               <strong>{selectedProject?.name ?? selectedSlug}</strong>
               {selectedMilestone ? (
                 <>
-                  {' '}under milestone <strong>{selectedMilestone.title}</strong>
+                  {' '}
+                  under milestone <strong>{selectedMilestone.title}</strong>
                 </>
               ) : null}
               .

--- a/apps/web/src/components/inbox/InboxList.tsx
+++ b/apps/web/src/components/inbox/InboxList.tsx
@@ -1,8 +1,8 @@
-import { fetchInboxItems, fetchProjects, promoteInboxItem } from '@/lib/api';
-import type { InboxItemDto, ProjectSummary } from '@/lib/types';
+import { fetchInboxItems, fetchMilestones, fetchProjects, promoteInboxItem } from '@/lib/api';
+import type { InboxItemDto, MilestoneDto, ProjectSummary } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ChevronDown, Inbox } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // ---------------------------------------------------------------------------
 // Two-step promote modal
@@ -19,6 +19,7 @@ function PromoteModal({
 }) {
   const [step, setStep] = useState<ModalStep>('picker');
   const [selectedSlug, setSelectedSlug] = useState<string>('');
+  const [selectedMilestoneNumber, setSelectedMilestoneNumber] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const {
@@ -30,9 +31,26 @@ function PromoteModal({
     queryFn: fetchProjects,
   });
 
+  const { data: milestones = [], isLoading: milestonesLoading } = useQuery<MilestoneDto[]>({
+    queryKey: ['milestones', selectedSlug],
+    queryFn: () => fetchMilestones(selectedSlug),
+    enabled: !!selectedSlug,
+  });
+
+  // Auto-select the first active milestone when milestones load; reset while loading
+  useEffect(() => {
+    if (!selectedSlug) return;
+    if (milestonesLoading) {
+      setSelectedMilestoneNumber(null);
+      return;
+    }
+    const active = milestones.find((m) => m.isActive);
+    setSelectedMilestoneNumber(active?.number ?? null);
+  }, [selectedSlug, milestones, milestonesLoading]);
+
   const queryClient = useQueryClient();
   const mutation = useMutation({
-    mutationFn: () => promoteInboxItem(item.id, selectedSlug),
+    mutationFn: () => promoteInboxItem(item.id, selectedSlug, selectedMilestoneNumber),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['inbox'] });
       onClose();
@@ -43,6 +61,7 @@ function PromoteModal({
   });
 
   const selectedProject = projects.find((p) => p.slug === selectedSlug);
+  const selectedMilestone = milestones.find((m) => m.number === selectedMilestoneNumber);
 
   function handlePickerNext() {
     if (!selectedSlug) return;
@@ -101,47 +120,105 @@ function PromoteModal({
             )}
 
             {!projectsLoading && !projectsError && (
-              <div style={{ position: 'relative', marginBottom: 16 }}>
-                <select
-                  aria-label="Select project"
-                  data-testid="promote-project-select"
-                  value={selectedSlug}
-                  onChange={(e) => setSelectedSlug(e.target.value)}
-                  style={{
-                    appearance: 'none',
-                    width: '100%',
-                    height: 32,
-                    paddingLeft: 12,
-                    paddingRight: 32,
-                    background: 'var(--bg)',
-                    border: '1px solid var(--line)',
-                    borderRadius: 6,
-                    fontSize: 12.5,
-                    color: 'var(--fg)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <option value="" disabled>
-                    — choose a project —
-                  </option>
-                  {projects.map((p) => (
-                    <option key={p.slug} value={p.slug}>
-                      {p.name}
+              <>
+                <div style={{ position: 'relative', marginBottom: 16 }}>
+                  <select
+                    aria-label="Select project"
+                    data-testid="promote-project-select"
+                    value={selectedSlug}
+                    onChange={(e) => setSelectedSlug(e.target.value)}
+                    style={{
+                      appearance: 'none',
+                      width: '100%',
+                      height: 32,
+                      paddingLeft: 12,
+                      paddingRight: 32,
+                      background: 'var(--bg)',
+                      border: '1px solid var(--line)',
+                      borderRadius: 6,
+                      fontSize: 12.5,
+                      color: 'var(--fg)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <option value="" disabled>
+                      — choose a project —
                     </option>
-                  ))}
-                </select>
-                <ChevronDown
-                  size={13}
-                  style={{
-                    pointerEvents: 'none',
-                    position: 'absolute',
-                    right: 8,
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    color: 'var(--fg-3)',
-                  }}
-                />
-              </div>
+                    {projects.map((p) => (
+                      <option key={p.slug} value={p.slug}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown
+                    size={13}
+                    style={{
+                      pointerEvents: 'none',
+                      position: 'absolute',
+                      right: 8,
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      color: 'var(--fg-3)',
+                    }}
+                  />
+                </div>
+
+                {selectedSlug && (
+                  <div style={{ marginBottom: 16 }}>
+                    <p style={{ margin: '0 0 6px', fontSize: 12, color: 'var(--fg-3)' }}>
+                      Milestone (optional)
+                    </p>
+                    {milestonesLoading ? (
+                      <p style={{ fontSize: 12, color: 'var(--fg-3)', margin: 0 }}>
+                        Loading milestones…
+                      </p>
+                    ) : (
+                      <div style={{ position: 'relative' }}>
+                        <select
+                          aria-label="Select milestone"
+                          data-testid="promote-milestone-select"
+                          value={selectedMilestoneNumber ?? ''}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            setSelectedMilestoneNumber(val === '' ? null : Number(val));
+                          }}
+                          style={{
+                            appearance: 'none',
+                            width: '100%',
+                            height: 32,
+                            paddingLeft: 12,
+                            paddingRight: 32,
+                            background: 'var(--bg)',
+                            border: '1px solid var(--line)',
+                            borderRadius: 6,
+                            fontSize: 12.5,
+                            color: 'var(--fg)',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          <option value="">— no milestone —</option>
+                          {milestones.map((m) => (
+                            <option key={m.number} value={m.number}>
+                              {m.title}
+                            </option>
+                          ))}
+                        </select>
+                        <ChevronDown
+                          size={13}
+                          style={{
+                            pointerEvents: 'none',
+                            position: 'absolute',
+                            right: 8,
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            color: 'var(--fg-3)',
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
             )}
 
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
@@ -203,7 +280,13 @@ function PromoteModal({
             </div>
             <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--fg-2)' }}>
               &ldquo;{item.title}&rdquo; will be created as a GitHub issue in{' '}
-              <strong>{selectedProject?.name ?? selectedSlug}</strong>.
+              <strong>{selectedProject?.name ?? selectedSlug}</strong>
+              {selectedMilestone ? (
+                <>
+                  {' '}under milestone <strong>{selectedMilestone.title}</strong>
+                </>
+              ) : null}
+              .
             </p>
             {error && (
               <p style={{ color: 'var(--danger)', fontSize: 12, marginBottom: 12 }}>{error}</p>

--- a/apps/web/src/components/inbox/InboxList.tsx
+++ b/apps/web/src/components/inbox/InboxList.tsx
@@ -31,26 +31,35 @@ function PromoteModal({
     queryFn: fetchProjects,
   });
 
-  const { data: milestones = [], isLoading: milestonesLoading } = useQuery<MilestoneDto[]>({
+  const {
+    data: milestones = [],
+    isLoading: milestonesLoading,
+    isError: milestonesError,
+    isSuccess: milestonesLoaded,
+  } = useQuery<MilestoneDto[]>({
     queryKey: ['milestones', selectedSlug],
     queryFn: () => fetchMilestones(selectedSlug),
     enabled: !!selectedSlug,
   });
 
-  // Auto-select the first active milestone when milestones load; reset while loading
+  // Reset to null while milestones are loading (or when no project selected);
+  // auto-select the first active milestone once the list arrives.
   useEffect(() => {
-    if (!selectedSlug) return;
-    if (milestonesLoading) {
+    if (!selectedSlug || !milestonesLoaded) {
       setSelectedMilestoneNumber(null);
       return;
     }
     const active = milestones.find((m) => m.isActive);
     setSelectedMilestoneNumber(active?.number ?? null);
-  }, [selectedSlug, milestones, milestonesLoading]);
+  }, [selectedSlug, milestones, milestonesLoaded]);
+
+  // Only send an explicit milestoneNumber once we have a confirmed loaded list.
+  // While loading or on error, omit it so the server falls back to its persisted active milestone.
+  const milestoneArg = milestonesLoaded && !milestonesError ? selectedMilestoneNumber : undefined;
 
   const queryClient = useQueryClient();
   const mutation = useMutation({
-    mutationFn: () => promoteInboxItem(item.id, selectedSlug, selectedMilestoneNumber),
+    mutationFn: () => promoteInboxItem(item.id, selectedSlug, milestoneArg),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['inbox'] });
       onClose();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -204,8 +204,12 @@ export async function fetchInboxItems(): Promise<InboxItemDto[]> {
   return items;
 }
 
-export async function promoteInboxItem(id: number, projectSlug = 'goose-hub-self'): Promise<void> {
-  await postJson(`/inbox/${id}/promote`, { projectSlug });
+export async function promoteInboxItem(
+  id: number,
+  projectSlug = 'goose-hub-self',
+  milestoneNumber?: number | null,
+): Promise<void> {
+  await postJson(`/inbox/${id}/promote`, { projectSlug, milestoneNumber });
 }
 
 export async function transitionState(


### PR DESCRIPTION
When promoting an inbox item, the user can now pick both the target project
and a milestone. The milestone dropdown appears after a project is selected
and auto-selects the project's current active milestone (first isActive one
if multiple exist, without erroring). The selected milestone is forwarded
through the API to the server; the server uses it directly when provided,
falling back to the project's persisted active milestone for API callers
that omit it.

https://claude.ai/code/session_01FWqXhVUBcvjGmiQXtfzrfo