### PR TITLE
M7.XX: Milestone list 2

### DIFF
--- a/apps/server/src/domains/milestones/service.test.ts
+++ b/apps/server/src/domains/milestones/service.test.ts
@@ -110,9 +110,49 @@ describe('listMilestones', () => {
   });
 
   it('returns milestones list', async () => {
-    mockSource.listMilestones.mockResolvedValueOnce([{ number: 1 }, { number: 2 }]);
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 1, title: 'M1: State Machine' },
+      { number: 2, title: 'M2: Chrome' },
+    ]);
     const result = await listMilestones('my-proj');
-    expect(result).toEqual({ ok: true, data: { milestones: [{ number: 1 }, { number: 2 }] } });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        milestones: [
+          { number: 1, title: 'M1: State Machine' },
+          { number: 2, title: 'M2: Chrome' },
+        ],
+      },
+    });
+  });
+
+  it('filters out non-M-prefixed milestones (e.g. E2E)', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 10, title: 'M1: State Machine' },
+      { number: 20, title: 'E2E: End-to-End Tests' },
+      { number: 30, title: 'M3: Inbox' },
+      { number: 40, title: 'Internal Tooling' },
+    ]);
+    const result = await listMilestones('my-proj');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const titles = (result.data.milestones as Array<{ title: string }>).map((m) => m.title);
+    expect(titles).toEqual(['M1: State Machine', 'M3: Inbox']);
+    expect(titles).not.toContain('E2E: End-to-End Tests');
+    expect(titles).not.toContain('Internal Tooling');
+  });
+
+  it('sorts milestones numerically by M-number ascending', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 30, title: 'M10: Analytics' },
+      { number: 10, title: 'M2: Chrome' },
+      { number: 20, title: 'M1: State Machine' },
+    ]);
+    const result = await listMilestones('my-proj');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const titles = (result.data.milestones as Array<{ title: string }>).map((m) => m.title);
+    expect(titles).toEqual(['M1: State Machine', 'M2: Chrome', 'M10: Analytics']);
   });
 });
 

--- a/apps/server/src/domains/milestones/service.ts
+++ b/apps/server/src/domains/milestones/service.ts
@@ -39,12 +39,20 @@ export async function setActiveMilestone(
   return { ok: true, data: { ok: true, milestoneNumber } };
 }
 
+const MILESTONE_TITLE_RE = /^M(\d+)/;
+
+function extractMilestoneOrder(title: string): number {
+  const m = MILESTONE_TITLE_RE.exec(title);
+  return m != null ? Number.parseInt(m[1], 10) : Number.MAX_SAFE_INTEGER;
+}
+
 export async function listMilestones(slug: string): Promise<Result<{ milestones: unknown[] }>> {
   const source = await getSourceForSlug(slug);
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
-  const milestones = await getCached(CACHE_KEY.milestones(slug), 60_000, () =>
-    source.listMilestones(),
-  );
+  const raw = await getCached(CACHE_KEY.milestones(slug), 60_000, () => source.listMilestones());
+  const milestones = (raw as Array<{ title: string }>)
+    .filter((m) => MILESTONE_TITLE_RE.test(m.title))
+    .sort((a, b) => extractMilestoneOrder(a.title) - extractMilestoneOrder(b.title));
   return { ok: true, data: { milestones } };
 }
 


### PR DESCRIPTION
## Summary

Milestone list 2

## Files
- `apps/server/src/domains/milestones/service.ts` — add filter (M\d+ titles only) and numeric sort by M-number to listMilestones
- `apps/server/src/domains/milestones/service.test.ts` — 2 new failing tests covering filter and sort behavior

## Tests
- `apps/server/src/domains/milestones/service.test.ts` (2 cases)

Closes #412
