### PR TITLE
M7.XX: Bug Triage Page

### DIFF
--- a/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { fetchTriageResult, setRepoOverride } from '@/lib/api';
+import type { TriageResultDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TriageResultsSection } from './TriageResultsSection';
+
+afterEach(cleanup);
+
+vi.mock('@/lib/api', () => ({
+  fetchTriageResult: vi.fn(),
+  setRepoOverride: vi.fn(),
+}));
+
+const TRIAGE_DATA: TriageResultDto = {
+  priority: 'high',
+  type: 'bug',
+  candidates: [
+    {
+      repo: 'shaunnez/goose-hub',
+      confidence: 85,
+      tier: 1,
+      evidence: 'Keyword match in src/lib/',
+    },
+  ],
+  overrideRepo: null,
+};
+
+function renderSection(slug = 'proj', id = '42') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <TriageResultsSection projectSlug={slug} id={id} />
+    </QueryClientProvider>,
+  );
+  return qc;
+}
+
+describe('TriageResultsSection — empty state', () => {
+  it('renders empty state when fetch returns null', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
+    renderSection();
+    const el = await screen.findByTestId('triage-empty-state');
+    expect(el).toBeTruthy();
+  });
+
+  it('shows "No triage result yet" heading in empty state', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
+    renderSection();
+    await screen.findByTestId('triage-empty-state');
+    expect(screen.getByText('No triage result yet')).toBeTruthy();
+  });
+
+  it('shows section header in empty state', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
+    renderSection();
+    await screen.findByTestId('triage-empty-state');
+    expect(screen.getByText('Repo candidates & classification')).toBeTruthy();
+  });
+
+  it('shows descriptive sub-copy in empty state', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
+    renderSection();
+    await screen.findByTestId('triage-empty-state');
+    expect(screen.getByTestId('triage-empty-description')).toBeTruthy();
+  });
+});
+
+describe('TriageResultsSection — with data', () => {
+  it('renders triage section when data is present', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(TRIAGE_DATA);
+    renderSection();
+    const el = await screen.findByTestId('triage-results-section');
+    expect(el).toBeTruthy();
+  });
+
+  it('does not render empty state when data is present', async () => {
+    vi.mocked(fetchTriageResult).mockResolvedValueOnce(TRIAGE_DATA);
+    renderSection();
+    await screen.findByTestId('triage-results-section');
+    expect(screen.queryByTestId('triage-empty-state')).toBeNull();
+  });
+});

--- a/apps/web/src/components/detail/components/TriageResultsSection.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.tsx
@@ -2,7 +2,7 @@ import { fetchTriageResult, setRepoOverride } from '@/lib/api';
 import { PRIORITY_BG, PRIORITY_BORDER, PRIORITY_COLOR } from '@/lib/constants';
 import type { TriageResultDto } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, Folder, Plus } from 'lucide-react';
+import { Check, Folder, Plus, ScanSearch } from 'lucide-react';
 import { useState } from 'react';
 
 interface TriageResultsSectionProps {
@@ -54,7 +54,35 @@ export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionPr
     );
   }
 
-  if (data == null) return null;
+  if (data == null) {
+    return (
+      <div data-testid="triage-empty-state" className="px-8 py-6 flex flex-col gap-5">
+        {/* Section header */}
+        <div>
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">02. Triage</div>
+          <h2 className="text-[17px] font-semibold text-fg leading-snug">
+            Repo candidates &amp; classification
+          </h2>
+        </div>
+
+        {/* Empty body */}
+        <div className="flex flex-col items-center justify-center gap-4 py-14 rounded-lg border border-dashed border-line bg-bg-elev/20 text-center">
+          <div className="w-10 h-10 rounded-full bg-bg-elev flex items-center justify-center">
+            <ScanSearch size={20} className="text-fg-4" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-[13px] font-medium text-fg-3">No triage result yet</p>
+            <p
+              data-testid="triage-empty-description"
+              className="text-[12px] text-fg-4 max-w-xs leading-snug"
+            >
+              The triager agent classifies this issue and identifies candidate repositories.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const triage: TriageResultDto = data;
   const pickedRepo = triage.overrideRepo ?? triage.candidates[0]?.repo;


### PR DESCRIPTION
## Summary

Bug Triage Page

## Files
- `apps/web/src/components/detail/components/TriageResultsSection.tsx` — replaced null return with designed empty state
- `apps/web/src/components/detail/components/TriageResultsSection.test.tsx` — new test file covering empty state and data paths

## Tests
- `apps/web/src/components/detail/components/TriageResultsSection.test.tsx` (6 cases)

Closes #420
