### PR TITLE
M7.XX: No way to delete inbox items

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -3,16 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 
-const { mockCreateInboxItem, mockGetInboxItems, mockPromoteInboxItem } = vi.hoisted(() => ({
-  mockCreateInboxItem: vi.fn(),
-  mockGetInboxItems: vi.fn(),
-  mockPromoteInboxItem: vi.fn(),
-}));
+const { mockCreateInboxItem, mockGetInboxItems, mockPromoteInboxItem, mockDeleteInboxItem } =
+  vi.hoisted(() => ({
+    mockCreateInboxItem: vi.fn(),
+    mockGetInboxItems: vi.fn(),
+    mockPromoteInboxItem: vi.fn(),
+    mockDeleteInboxItem: vi.fn(),
+  }));
 
 vi.mock('./service.js', () => ({
   createInboxItem: mockCreateInboxItem,
   getInboxItems: mockGetInboxItems,
   promoteInboxItem: mockPromoteInboxItem,
+  deleteInboxItem: mockDeleteInboxItem,
 }));
 
 vi.mock('@goose-hub/core/logger.js', () => ({
@@ -211,5 +214,41 @@ describe('POST /inbox/:id/promote', () => {
       body: JSON.stringify({ projectSlug: 'unknown-slug' }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /inbox/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 on success', async () => {
+    mockDeleteInboxItem.mockResolvedValue({ ok: true, data: { ok: true } });
+
+    const app = makeApp();
+    const res = await app.request('/inbox/7', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(mockDeleteInboxItem).toHaveBeenCalledWith(7);
+  });
+
+  it('returns 400 for non-numeric id', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox/not-a-number', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid id');
+    expect(mockDeleteInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when item not found', async () => {
+    mockDeleteInboxItem.mockResolvedValue({ ok: false, error: 'not found', status: 404 });
+
+    const app = makeApp();
+    const res = await app.request('/inbox/999', { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('not found');
   });
 });

--- a/apps/server/src/domains/inbox/router.ts
+++ b/apps/server/src/domains/inbox/router.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { parseBody } from '../../shared/middleware.js';
-import { createInboxItem, getInboxItems, promoteInboxItem } from './service.js';
+import { createInboxItem, deleteInboxItem, getInboxItems, promoteInboxItem } from './service.js';
 
 const router = new Hono();
 
@@ -29,6 +29,13 @@ router.post('/:id/promote', async (c) => {
   return result.ok
     ? c.json(result.data)
     : c.json({ error: result.error }, result.status as 400 | 404);
+});
+
+router.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({ error: 'invalid id' }, 400);
+  const result = await deleteInboxItem(id);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
 });
 
 export { router as inboxRouter };

--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -19,7 +19,12 @@ vi.mock('@goose-hub/core/db/db.js', () => ({
 
 import { getSourceForSlug } from '../../shared/source.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
-import { createInboxItem, getInboxItems, promoteInboxItem } from './service.js';
+import {
+  createInboxItem,
+  deleteInboxItem as deleteInboxItemService,
+  getInboxItems,
+  promoteInboxItem,
+} from './service.js';
 
 const mockItem = { id: 1, title: 'Fix bug', body: '', type: 'bug', createdAt: '2026-05-01' };
 const mockSource = { createIssue: vi.fn().mockResolvedValue(undefined) };
@@ -127,5 +132,22 @@ describe('promoteInboxItem', () => {
     vi.mocked(getInboxItem).mockResolvedValueOnce(itemWithNullBody);
     await promoteInboxItem(3, 'my-proj');
     expect(mockSource.createIssue).toHaveBeenCalledWith(expect.objectContaining({ body: '' }));
+  });
+});
+
+describe('deleteInboxItem (service)', () => {
+  it('returns 404 when item not found', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce(null);
+    const result = await deleteInboxItemService(999);
+    expect(result).toEqual({ ok: false, error: 'not found', status: 404 });
+    expect(deleteInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:true and calls repository delete when item exists', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce(mockItem);
+    vi.mocked(deleteInboxItem).mockResolvedValueOnce(undefined);
+    const result = await deleteInboxItemService(1);
+    expect(result).toEqual({ ok: true, data: { ok: true } });
+    expect(deleteInboxItem).toHaveBeenCalledWith(1);
   });
 });

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -6,10 +6,10 @@ import type { Result } from '../../shared/middleware.js';
 import { getSourceForSlug } from '../../shared/source.js';
 import {
   type InboxItem,
-  deleteInboxItem,
   getInboxItem,
   insertInboxItem,
   listInboxItems,
+  deleteInboxItem as repoDeleteInboxItem,
 } from './repository.js';
 
 const VALID_TYPES = ['feature', 'bug', 'chore', 'research'] as const;
@@ -62,7 +62,7 @@ export async function promoteInboxItem(
   });
 
   try {
-    await deleteInboxItem(id);
+    await repoDeleteInboxItem(id);
   } catch (err) {
     logger.error('inbox promotion: GitHub issue created but inbox delete failed', {
       id,
@@ -70,5 +70,12 @@ export async function promoteInboxItem(
     });
   }
 
+  return { ok: true, data: { ok: true } };
+}
+
+export async function deleteInboxItem(id: number): Promise<Result<{ ok: true }>> {
+  const item = await getInboxItem(id);
+  if (item == null) return { ok: false, error: 'not found', status: 404 };
+  await repoDeleteInboxItem(id);
   return { ok: true, data: { ok: true } };
 }

--- a/apps/web/src/components/inbox/InboxList.tsx
+++ b/apps/web/src/components/inbox/InboxList.tsx
@@ -1,7 +1,13 @@
-import { fetchInboxItems, fetchMilestones, fetchProjects, promoteInboxItem } from '@/lib/api';
+import {
+  deleteInboxItem,
+  fetchInboxItems,
+  fetchMilestones,
+  fetchProjects,
+  promoteInboxItem,
+} from '@/lib/api';
 import type { InboxItemDto, MilestoneDto, ProjectSummary } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, ChevronDown, Inbox } from 'lucide-react';
+import { ArrowLeft, ChevronDown, Inbox, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 // ---------------------------------------------------------------------------
@@ -349,9 +355,11 @@ function PromoteModal({
 function InboxDetail({
   item,
   onPromote,
+  onDelete,
 }: {
   item: InboxItemDto;
   onPromote: (item: InboxItemDto) => void;
+  onDelete: (item: InboxItemDto) => void;
 }) {
   return (
     <div className="flex flex-col h-full overflow-y-auto px-8 py-6">
@@ -371,14 +379,25 @@ function InboxDetail({
             </span>
           </div>
         </div>
-        <button
-          type="button"
-          data-testid="promote-button"
-          onClick={() => onPromote(item)}
-          className="shrink-0 h-8 px-4 rounded-md border border-line text-[12px] text-fg-2 hover:text-fg hover:bg-bg-hover"
-        >
-          Promote
-        </button>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            data-testid="promote-button"
+            onClick={() => onPromote(item)}
+            className="h-8 px-4 rounded-md border border-line text-[12px] text-fg-2 hover:text-fg hover:bg-bg-hover"
+          >
+            Promote
+          </button>
+          <button
+            type="button"
+            data-testid="delete-button"
+            onClick={() => onDelete(item)}
+            aria-label="Delete inbox item"
+            className="h-8 w-8 flex items-center justify-center rounded-md border border-line text-fg-3 hover:text-danger hover:border-danger/50 hover:bg-danger/5"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
       </div>
 
       <div className="border-t border-line pt-6">
@@ -426,6 +445,20 @@ export function InboxList() {
     queryKey: ['inbox'],
     queryFn: fetchInboxItems,
   });
+
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteInboxItem(id),
+    onSuccess: () => {
+      setSelectedId(null);
+      void queryClient.invalidateQueries({ queryKey: ['inbox'] });
+    },
+  });
+
+  function handleDelete(item: InboxItemDto) {
+    if (!window.confirm(`Delete "${item.title}"? This cannot be undone.`)) return;
+    deleteMutation.mutate(item.id);
+  }
 
   if (isLoading) return <div className="px-8 py-10 text-fg-3">Loading inbox…</div>;
   if (error)
@@ -482,7 +515,7 @@ export function InboxList() {
 
       {/* Right panel — detail */}
       <div className="flex-1 min-w-0 min-h-0 bg-bg-elev/30">
-        <InboxDetail item={selectedItem} onPromote={setPromoting} />
+        <InboxDetail item={selectedItem} onPromote={setPromoting} onDelete={handleDelete} />
       </div>
 
       {promoting && <PromoteModal item={promoting} onClose={() => setPromoting(null)} />}

--- a/apps/web/src/components/inbox/slice.test.ts
+++ b/apps/web/src/components/inbox/slice.test.ts
@@ -34,6 +34,21 @@ describe('inbox promote — promoteInboxItem', () => {
   });
 });
 
+describe('inbox delete — deleteInboxItem', () => {
+  it('calls DELETE /inbox/:id', async () => {
+    const mockDelete = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('@/lib/api', () => ({
+      deleteInboxItem: mockDelete,
+      fetchInboxItems: vi.fn(),
+      promoteInboxItem: vi.fn(),
+    }));
+    const { deleteInboxItem } = await import('@/lib/api');
+    vi.mocked(deleteInboxItem).mockResolvedValue(undefined);
+    await deleteInboxItem(42);
+    expect(deleteInboxItem).toHaveBeenCalledWith(42);
+  });
+});
+
 describe('inbox promote — project picker', () => {
   it('fetchProjects returns all configured projects', async () => {
     const twoProjects = [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -214,6 +214,17 @@ export async function promoteInboxItem(
   await postJson(`/inbox/${id}/promote`, { projectSlug, milestoneNumber });
 }
 
+export async function deleteInboxItem(id: number): Promise<void> {
+  const res = await fetch(`/api/inbox/${id}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`DELETE /inbox/${id} failed: ${res.status} ${res.statusText} ${text}`);
+  }
+}
+
 export async function transitionState(
   slug: string,
   id: string,


### PR DESCRIPTION
## Summary

No way to delete inbox items

## Files
- `apps/server/src/domains/inbox/service.ts` — add deleteInboxItem service fn; alias repo import
- `apps/server/src/domains/inbox/router.ts` — add DELETE /:id route
- `apps/server/src/domains/inbox/router.test.ts` — tests for DELETE /inbox/:id
- `apps/server/src/domains/inbox/service.test.ts` — tests for deleteInboxItem service
- `apps/web/src/lib/api.ts` — add deleteInboxItem client function
- `apps/web/src/components/inbox/InboxList.tsx` — delete button + mutation in InboxDetail
- `apps/web/src/components/inbox/slice.test.ts` — test for deleteInboxItem API fn

## Tests
- `apps/server/src/domains/inbox/router.test.ts` (3 cases)
- `apps/server/src/domains/inbox/service.test.ts` (2 cases)
- `apps/web/src/components/inbox/slice.test.ts` (1 cases)

Closes #422
