### PR TITLE
M7.XX: Bug investigation page default

### DIFF
--- a/apps/web/src/components/detail/components/InvestigationSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.test.tsx
@@ -10,6 +10,9 @@ afterEach(cleanup);
 
 vi.mock('@/lib/api', () => ({
   fetchEvents: vi.fn().mockResolvedValue([]),
+  fetchComments: vi.fn().mockResolvedValue([]),
+  addComment: vi.fn(),
+  transitionState: vi.fn(),
 }));
 
 vi.mock('@/lib/markdown', () => ({
@@ -51,7 +54,26 @@ describe('InvestigationSection', () => {
   it('shows empty state when no investigation events exist', () => {
     renderSection([]);
     expect(screen.getByTestId('investigation-empty-state')).toBeTruthy();
-    expect(screen.getByText('Investigation has not run yet.')).toBeTruthy();
+  });
+
+  it('shows section header label in empty state', () => {
+    renderSection([]);
+    expect(screen.getByText('03. Investigation')).toBeTruthy();
+  });
+
+  it('shows section title in empty state', () => {
+    renderSection([]);
+    expect(screen.getByText('Findings & key files')).toBeTruthy();
+  });
+
+  it('shows "No investigation yet" heading in empty state', () => {
+    renderSection([]);
+    expect(screen.getByText('No investigation yet')).toBeTruthy();
+  });
+
+  it('shows descriptive sub-copy in empty state', () => {
+    renderSection([]);
+    expect(screen.getByTestId('investigation-empty-description')).toBeTruthy();
   });
 
   it('renders findings when investigation event is present', () => {

--- a/apps/web/src/components/detail/components/InvestigationSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.tsx
@@ -3,6 +3,7 @@ import { renderMarkdownToHtml } from '@/lib/markdown';
 import type { AgentEventDto, IssueCommentDto } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Search } from 'lucide-react';
 import { useState } from 'react';
 
 interface InvestigationSectionProps {
@@ -106,12 +107,32 @@ export function InvestigationSection({ projectSlug, id, itemState }: Investigati
 
   if (latest == null) {
     return (
-      <div
-        data-testid="investigation-empty-state"
-        className="px-8 py-8 flex flex-col items-center justify-center gap-2 text-center"
-      >
-        <p className="text-[13px] text-fg-3">Investigation has not run yet.</p>
-        <p className="text-[12px] text-fg-4">Run the investigator agent to populate this tab.</p>
+      <div data-testid="investigation-empty-state" className="px-8 py-6 flex flex-col gap-5">
+        {/* Section header */}
+        <div>
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">
+            03. Investigation
+          </div>
+          <h2 className="text-[17px] font-semibold text-fg leading-snug">
+            Findings &amp; key files
+          </h2>
+        </div>
+
+        {/* Empty body */}
+        <div className="flex flex-col items-center justify-center gap-4 py-14 rounded-lg border border-dashed border-line bg-bg-elev/20 text-center">
+          <div className="w-10 h-10 rounded-full bg-bg-elev flex items-center justify-center">
+            <Search size={20} className="text-fg-4" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-[13px] font-medium text-fg-3">No investigation yet</p>
+            <p
+              data-testid="investigation-empty-description"
+              className="text-[12px] text-fg-4 max-w-xs leading-snug"
+            >
+              The investigator agent analyses the issue and identifies key files.
+            </p>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Bug investigation page default

## Files
- `apps/web/src/components/detail/components/InvestigationSection.tsx` — Replace plain empty state with triage-style pattern
- `apps/web/src/components/detail/components/InvestigationSection.test.tsx` — Tests for new empty state structure + fix mock to include fetchComments

## Tests
- `apps/web/src/components/detail/components/InvestigationSection.test.tsx` (4 cases)

Closes #427
