### PR TITLE
QA page: align with Harness 2.1 design

### DIFF
--- a/apps/web/src/components/detail/components/QASection.test.tsx
+++ b/apps/web/src/components/detail/components/QASection.test.tsx
@@ -1,0 +1,115 @@
+/** @vitest-environment jsdom */
+import { fetchEvents } from '@/lib/api';
+import type { AgentEventDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { QASection } from './QASection';
+
+afterEach(cleanup);
+
+vi.mock('@/lib/api', () => ({
+  fetchEvents: vi.fn(),
+}));
+
+function render_(jsx: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{jsx}</QueryClientProvider>);
+}
+
+function qaEvent(payload: unknown): AgentEventDto {
+  return {
+    id: 1,
+    projectId: 'proj',
+    workItemId: 'gh:owner/repo#42',
+    runId: 'r1',
+    kind: 'qa.completed',
+    payload,
+    createdAt: new Date().toISOString(),
+  } as AgentEventDto;
+}
+
+const passingTiers = {
+  structural: { passed: true, findings: [] },
+  functional: { passed: true, findings: [] },
+  regression: { passed: true, findings: [] },
+};
+
+describe('QASection', () => {
+  it('renders the empty state when no qa.completed event is present', async () => {
+    vi.mocked(fetchEvents).mockResolvedValueOnce([]);
+    render_(<QASection projectSlug="proj" id="42" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-empty-state')).toBeTruthy();
+    });
+  });
+
+  it('renders tier-based fallback stats when testRun is absent', async () => {
+    vi.mocked(fetchEvents).mockResolvedValueOnce([
+      qaEvent({
+        verdict: 'pass',
+        overallScore: 85,
+        threshold: 70,
+        tierResults: passingTiers,
+      }),
+    ]);
+    render_(<QASection projectSlug="proj" id="42" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-section')).toBeTruthy();
+    });
+    // Wall-time card shows the placeholder, and there's no test-suites block.
+    expect(screen.getByText('not tracked')).toBeTruthy();
+    expect(screen.queryByTestId('qa-test-suites')).toBeNull();
+  });
+
+  it('renders the test-suites block when testRun is present', async () => {
+    vi.mocked(fetchEvents).mockResolvedValueOnce([
+      qaEvent({
+        verdict: 'pass',
+        overallScore: 85,
+        threshold: 70,
+        tierResults: passingTiers,
+        testRun: {
+          wallTimeMs: 7700,
+          total: 39,
+          passed: 38,
+          failed: 0,
+          skipped: 1,
+          success: true,
+          suites: [
+            {
+              name: 'cart.test.ts',
+              filePath: '/wt/cart.test.ts',
+              total: 18,
+              passed: 18,
+              failed: 0,
+              skipped: 0,
+              durationMs: 412,
+              status: 'passed',
+            },
+            {
+              name: 'funnel.test.ts',
+              filePath: '/wt/funnel.test.ts',
+              total: 12,
+              passed: 11,
+              failed: 1,
+              skipped: 0,
+              durationMs: 288,
+              status: 'failed',
+            },
+          ],
+        },
+      }),
+    ]);
+    render_(<QASection projectSlug="proj" id="42" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-test-suites')).toBeTruthy();
+    });
+    expect(screen.getByText('cart.test.ts')).toBeTruthy();
+    expect(screen.getByText('funnel.test.ts')).toBeTruthy();
+    // Pass / Fail card uses the testRun numbers (38 / 0), not the tier counts (3 / 0).
+    expect(screen.getByText('38 / 0')).toBeTruthy();
+    // Wall-time card uses the formatted duration.
+    expect(screen.getByText('7.70s')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -1,7 +1,7 @@
 import { fetchEvents } from '@/lib/api';
 import type { AgentEventDto } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, CheckCircle, Clock, XCircle } from 'lucide-react';
+import { AlertCircle, CheckCircle, Clock, Plus, RefreshCw, XCircle } from 'lucide-react';
 
 interface QASectionProps {
   projectSlug: string;
@@ -37,6 +37,37 @@ interface QaPayload {
 
 const TIERS = ['structural', 'functional', 'regression'] as const;
 
+function StatCard({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-line bg-bg-elev px-4 py-3">
+      <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1.5">{label}</div>
+      <div
+        className="mono tnum text-[22px] font-semibold leading-none tracking-tight"
+        style={{ color: color ?? 'var(--fg)' }}
+      >
+        {value}
+      </div>
+      {sub && <div className="text-[11.5px] text-fg-3 mt-1.5">{sub}</div>}
+    </div>
+  );
+}
+
+function severityColor(sev: Finding['severity']): string {
+  if (sev === 'error') return 'var(--danger)';
+  if (sev === 'warning') return 'var(--warning)';
+  return 'var(--info)';
+}
+
 export function QASection({ projectSlug, id }: QASectionProps) {
   const { data: events = [], isLoading } = useQuery<AgentEventDto[]>({
     queryKey: ['events', projectSlug, id],
@@ -50,104 +81,227 @@ export function QASection({ projectSlug, id }: QASectionProps) {
 
   if (!qa) {
     return (
-      <div
-        data-testid="qa-empty-state"
-        className="px-8 py-8 flex flex-col items-center justify-center gap-2 text-center"
-      >
-        <Clock size={24} className="text-fg-3 opacity-50" />
-        <p className="text-[13px] text-fg-3">Waiting for QA to run…</p>
-        <p className="text-[12px] text-fg-4">QA runs automatically after the PR is opened.</p>
+      <div data-testid="qa-section" className="px-8 py-6 flex flex-col gap-5">
+        <div>
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">06 · QA</div>
+          <h2 className="text-[17px] font-semibold text-fg leading-snug">Verification sweep</h2>
+          <div className="text-[12.5px] text-fg-3 mt-1">
+            QA runs automatically after the PR is opened.
+          </div>
+        </div>
+        <div
+          data-testid="qa-empty-state"
+          className="rounded-lg border border-line bg-bg-elev px-6 py-12 flex flex-col items-center justify-center gap-2 text-center"
+        >
+          <Clock size={24} className="text-fg-3 opacity-50" />
+          <p className="text-[13px] text-fg-3">Waiting for QA to run…</p>
+          <p className="text-[12px] text-fg-4">QA runs automatically after the PR is opened.</p>
+        </div>
       </div>
     );
   }
 
-  const VerdictIcon =
-    qa.verdict === 'pass' ? CheckCircle : qa.verdict === 'fail' ? XCircle : AlertCircle;
+  const threshold = qa.threshold ?? 70;
+  const allFindings = TIERS.flatMap((t) => qa.tierResults?.[t]?.findings ?? []);
+  const errorCount = allFindings.filter((f) => f.severity === 'error').length;
+  const warnCount = allFindings.filter((f) => f.severity === 'warning').length;
+  const infoCount = allFindings.filter((f) => f.severity === 'info').length;
+  const passedTiers = TIERS.filter((t) => qa.tierResults?.[t]?.passed).length;
+  const failedTiers = TIERS.length - passedTiers;
+
   const verdictColor =
     qa.verdict === 'pass'
-      ? 'text-green-500'
+      ? 'var(--success)'
       : qa.verdict === 'fail'
-        ? 'text-red-500'
-        : 'text-yellow-500';
-  const verdictBg =
-    qa.verdict === 'pass'
-      ? 'bg-green-500/10 border-green-500/20'
-      : qa.verdict === 'fail'
-        ? 'bg-red-500/10 border-red-500/20'
-        : 'bg-yellow-500/10 border-yellow-500/20';
+        ? 'var(--danger)'
+        : 'var(--warning)';
+  const VerdictIcon =
+    qa.verdict === 'pass' ? CheckCircle : qa.verdict === 'fail' ? XCircle : AlertCircle;
 
-  const threshold = qa.threshold ?? 70;
+  const flakeRisk = errorCount > 0 ? 'high' : warnCount > 0 ? 'medium' : 'low';
+  const flakeColor =
+    flakeRisk === 'low'
+      ? 'var(--success)'
+      : flakeRisk === 'medium'
+        ? 'var(--warning)'
+        : 'var(--danger)';
 
   return (
-    <div data-testid="qa-section" className="px-8 py-6 space-y-6">
-      {/* Verdict header */}
-      <div className={`flex items-center gap-3 p-4 rounded-lg border ${verdictBg}`}>
-        <VerdictIcon size={20} className={verdictColor} />
-        <div>
-          <div className="font-semibold text-[13px] uppercase tracking-wide">{qa.verdict}</div>
-          <div className="text-[12px] text-fg-3">
-            Score: {qa.overallScore}/{threshold <= 100 ? 100 : threshold} — threshold {threshold}
+    <div data-testid="qa-section" className="px-8 py-6 flex flex-col gap-5">
+      {/* Section header */}
+      <div className="flex items-end gap-3">
+        <div className="flex-1">
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">06 · QA</div>
+          <h2 className="text-[17px] font-semibold text-fg leading-snug">Verification sweep</h2>
+          <div className="flex items-center gap-2 text-[12.5px] text-fg-3 mt-1">
+            <VerdictIcon size={13} style={{ color: verdictColor }} />
+            <span style={{ color: verdictColor, textTransform: 'uppercase', fontWeight: 600 }}>
+              {qa.verdict}
+            </span>
+            <span className="text-fg-4">·</span>
+            <span>
+              {passedTiers} of {TIERS.length} tiers passing
+            </span>
+            <span className="text-fg-4">·</span>
+            <span>
+              {allFindings.length} {allFindings.length === 1 ? 'finding' : 'findings'}
+            </span>
           </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-line bg-bg-elev hover:bg-bg-hover text-[12px] text-fg-2"
+          >
+            <RefreshCw size={12} /> Re-run
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-accent-line bg-accent-soft hover:opacity-80 text-[12px] text-accent"
+          >
+            <Plus size={12} /> Add test
+          </button>
         </div>
       </div>
 
-      {/* Tier results */}
+      {/* Stat row */}
+      <div className="grid grid-cols-4 gap-3">
+        <StatCard
+          label="Pass / Fail"
+          value={`${passedTiers} / ${failedTiers}`}
+          sub={`${allFindings.length} findings`}
+          color={failedTiers === 0 ? 'var(--success)' : 'var(--danger)'}
+        />
+        <StatCard
+          label="Score"
+          value={`${qa.overallScore}%`}
+          sub={`threshold ${threshold}`}
+          color={qa.overallScore >= threshold ? 'var(--success)' : 'var(--danger)'}
+        />
+        <StatCard label="Wall time" value="—" sub="not tracked" />
+        <StatCard
+          label="Flake risk"
+          value={flakeRisk}
+          sub={`${errorCount} errors · ${warnCount} warnings`}
+          color={flakeColor}
+        />
+      </div>
+
+      {/* Verification tiers */}
       <div>
-        <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+        <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-2">
           Verification Tiers
-        </h3>
-        <div className="grid grid-cols-3 gap-3">
-          {TIERS.map((tier) => {
+        </div>
+        <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
+          {TIERS.map((tier, i) => {
             const result = qa.tierResults?.[tier];
+            const findings = result?.findings ?? [];
+            const passed = !!result?.passed;
+            const dots: Array<{ key: string; sev: Finding['severity'] | null }> =
+              findings.length > 0
+                ? findings.slice(0, 16).map((f, idx) => ({
+                    key: `${tier}-f-${idx}-${f.severity}`,
+                    sev: f.severity,
+                  }))
+                : Array.from({ length: 8 }, (_, idx) => ({
+                    key: `${tier}-empty-${idx}`,
+                    sev: null,
+                  }));
             return (
-              <div key={tier} className="border border-line rounded-lg p-3">
-                <div className="flex items-center gap-2 mb-1">
-                  {result?.passed ? (
-                    <CheckCircle size={13} className="text-green-500" />
-                  ) : (
-                    <XCircle size={13} className="text-red-500" />
-                  )}
-                  <span className="text-[12px] font-medium capitalize">{tier}</span>
+              <div
+                key={tier}
+                className="grid items-center px-4 py-3"
+                style={{
+                  gridTemplateColumns: '1.5fr 1fr 90px 90px 90px',
+                  borderTop: i ? '1px solid var(--line)' : 'none',
+                }}
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    className="inline-block rounded-full"
+                    style={{
+                      width: 8,
+                      height: 8,
+                      background: passed ? 'var(--success)' : 'var(--danger)',
+                    }}
+                  />
+                  <span className="mono text-[12.5px] capitalize">{tier}</span>
                 </div>
-                <div
-                  className={`text-[11px] ${result?.passed ? 'text-green-500' : 'text-red-500'}`}
+                <div className="flex items-center gap-1">
+                  {dots.map((d) => (
+                    <span
+                      key={d.key}
+                      style={{
+                        width: 8,
+                        height: 14,
+                        borderRadius: 1.5,
+                        background: d.sev === null ? 'var(--success)' : severityColor(d.sev),
+                        opacity: d.sev === null ? 0.7 : 1,
+                      }}
+                    />
+                  ))}
+                </div>
+                <span className="mono tnum text-right text-[12px] text-fg-2">
+                  {passed ? 'pass' : `${findings.length} issue${findings.length === 1 ? '' : 's'}`}
+                </span>
+                <span
+                  className="mono tnum text-right text-[12px] text-fg-3 truncate"
+                  title={result?.command ?? ''}
                 >
-                  {result?.passed ? 'Pass' : `${result?.findings?.length ?? 0} finding(s)`}
-                </div>
+                  {result?.command ?? '—'}
+                </span>
+                <span className="text-right">
+                  <span
+                    className="inline-flex items-center px-2 py-0.5 rounded-full border text-[10.5px] font-medium uppercase tracking-wide"
+                    style={{
+                      color: passed ? 'var(--success)' : 'var(--danger)',
+                      borderColor: passed
+                        ? 'oklch(from var(--success) l c h / 0.4)'
+                        : 'oklch(from var(--danger) l c h / 0.4)',
+                      background: passed
+                        ? 'oklch(from var(--success) l c h / 0.1)'
+                        : 'oklch(from var(--danger) l c h / 0.1)',
+                    }}
+                  >
+                    {passed ? 'passing' : 'failing'}
+                  </span>
+                </span>
               </div>
             );
           })}
         </div>
       </div>
 
-      {/* Findings across all tiers */}
-      {qa.tierResults && TIERS.flatMap((tier) => qa.tierResults[tier].findings).length > 0 && (
+      {/* Findings */}
+      {allFindings.length > 0 && (
         <div>
-          <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
-            Findings
-          </h3>
-          <div className="space-y-2">
+          <div className="flex items-baseline justify-between mb-2">
+            <div className="text-[10.5px] uppercase tracking-wider text-fg-4">Findings</div>
+            <div className="text-[11px] text-fg-4 mono tnum">
+              {errorCount} error{errorCount === 1 ? '' : 's'} · {warnCount} warning
+              {warnCount === 1 ? '' : 's'} · {infoCount} info
+            </div>
+          </div>
+          <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
             {TIERS.flatMap((tier) =>
-              qa.tierResults[tier].findings.map((f) => (
+              (qa.tierResults?.[tier]?.findings ?? []).map((f, idx) => (
                 <div
-                  key={`${tier}:${f.description}`}
-                  className="border border-line rounded-lg p-3 text-[12.5px]"
+                  key={`${tier}:${idx}:${f.description}`}
+                  className="px-4 py-3 border-t border-line first:border-t-0 text-[12.5px]"
                 >
-                  <div className="flex items-center gap-2 mb-1">
+                  <div className="flex items-center gap-2 mb-1 flex-wrap">
                     <span
-                      className={`text-[10px] font-medium uppercase px-1.5 py-0.5 rounded ${
-                        f.severity === 'error'
-                          ? 'bg-red-500/15 text-red-400'
-                          : f.severity === 'warning'
-                            ? 'bg-yellow-500/15 text-yellow-400'
-                            : 'bg-blue-500/15 text-blue-400'
-                      }`}
+                      className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide"
+                      style={{
+                        color: severityColor(f.severity),
+                        background: `oklch(from ${severityColor(f.severity)} l c h / 0.12)`,
+                      }}
                     >
                       {f.severity}
                     </span>
                     <span className="text-[11px] text-fg-4 capitalize">{tier}</span>
                     {f.file && (
-                      <span className="font-mono text-[10px] text-fg-3 bg-bg-glass px-1 py-0.5 rounded">
+                      <span className="mono text-[10.5px] text-fg-3 bg-bg-elev-2 px-1.5 py-0.5 rounded">
                         {f.file}
                         {f.line != null ? `:${f.line}` : ''}
                       </span>
@@ -155,7 +309,7 @@ export function QASection({ projectSlug, id }: QASectionProps) {
                   </div>
                   <div className="text-fg-2">{f.description}</div>
                   {f.suggestion && (
-                    <div className="text-[11px] text-fg-3 mt-1">→ {f.suggestion}</div>
+                    <div className="text-[11.5px] text-fg-3 mt-1">→ {f.suggestion}</div>
                   )}
                 </div>
               )),

--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -24,6 +24,27 @@ interface TierResult {
   output?: string | null;
 }
 
+interface SuiteResult {
+  name: string;
+  filePath: string;
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  status: 'passed' | 'failed' | 'skipped';
+}
+
+interface TestRun {
+  wallTimeMs: number;
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  success: boolean;
+  suites: SuiteResult[];
+}
+
 interface QaPayload {
   verdict: 'pass' | 'fail' | 'partial';
   overallScore: number;
@@ -33,6 +54,13 @@ interface QaPayload {
     functional: TierResult;
     regression: TierResult;
   };
+  testRun?: TestRun;
+}
+
+function formatWallTime(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  return s < 60 ? `${s.toFixed(s < 10 ? 2 : 1)}s` : `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`;
 }
 
 const TIERS = ['structural', 'functional', 'regression'] as const;
@@ -166,19 +194,40 @@ export function QASection({ projectSlug, id }: QASectionProps) {
 
       {/* Stat row */}
       <div className="grid grid-cols-4 gap-3">
-        <StatCard
-          label="Pass / Fail"
-          value={`${passedTiers} / ${failedTiers}`}
-          sub={`${allFindings.length} findings`}
-          color={failedTiers === 0 ? 'var(--success)' : 'var(--danger)'}
-        />
+        {qa.testRun ? (
+          <StatCard
+            label="Pass / Fail"
+            value={`${qa.testRun.passed} / ${qa.testRun.failed}`}
+            sub={
+              qa.testRun.skipped > 0
+                ? `${qa.testRun.total} total · ${qa.testRun.skipped} skipped`
+                : `${qa.testRun.total} total`
+            }
+            color={qa.testRun.failed === 0 ? 'var(--success)' : 'var(--danger)'}
+          />
+        ) : (
+          <StatCard
+            label="Pass / Fail"
+            value={`${passedTiers} / ${failedTiers}`}
+            sub={`${allFindings.length} findings`}
+            color={failedTiers === 0 ? 'var(--success)' : 'var(--danger)'}
+          />
+        )}
         <StatCard
           label="Score"
           value={`${qa.overallScore}%`}
           sub={`threshold ${threshold}`}
           color={qa.overallScore >= threshold ? 'var(--success)' : 'var(--danger)'}
         />
-        <StatCard label="Wall time" value="—" sub="not tracked" />
+        {qa.testRun ? (
+          <StatCard
+            label="Wall time"
+            value={formatWallTime(qa.testRun.wallTimeMs)}
+            sub={`${qa.testRun.suites.length} ${qa.testRun.suites.length === 1 ? 'suite' : 'suites'}`}
+          />
+        ) : (
+          <StatCard label="Wall time" value="—" sub="not tracked" />
+        )}
         <StatCard
           label="Flake risk"
           value={flakeRisk}
@@ -186,6 +235,91 @@ export function QASection({ projectSlug, id }: QASectionProps) {
           color={flakeColor}
         />
       </div>
+
+      {/* Test suites — when real test-run data is present */}
+      {qa.testRun && qa.testRun.suites.length > 0 && (
+        <div data-testid="qa-test-suites">
+          <div className="flex items-baseline justify-between mb-2">
+            <div className="text-[10.5px] uppercase tracking-wider text-fg-4">Test suites</div>
+            <div className="text-[11px] text-fg-4 mono tnum">
+              {qa.testRun.passed} passed · {qa.testRun.failed} failed · {qa.testRun.skipped} skipped
+            </div>
+          </div>
+          <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
+            {qa.testRun.suites.map((s, i) => {
+              const pillColor =
+                s.status === 'passed'
+                  ? 'var(--success)'
+                  : s.status === 'failed'
+                    ? 'var(--danger)'
+                    : 'var(--warning)';
+              return (
+                <div
+                  key={s.filePath || s.name}
+                  className="grid items-center px-4 py-3"
+                  style={{
+                    gridTemplateColumns: '1.5fr 1fr 100px 90px 90px',
+                    borderTop: i ? '1px solid var(--line)' : 'none',
+                  }}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span
+                      className="inline-block rounded-full shrink-0"
+                      style={{
+                        width: 8,
+                        height: 8,
+                        background: pillColor,
+                      }}
+                    />
+                    <span className="mono text-[12.5px] truncate" title={s.filePath}>
+                      {s.name}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 flex-wrap">
+                    {Array.from({ length: Math.min(s.total, 24) }, (_, j) => {
+                      const isPass = j < s.passed;
+                      const isFail = j >= s.passed && j < s.passed + s.failed;
+                      const bg = isPass
+                        ? 'var(--success)'
+                        : isFail
+                          ? 'var(--danger)'
+                          : 'var(--warning)';
+                      return (
+                        <span
+                          key={`${s.filePath}-${j}`}
+                          style={{ width: 8, height: 14, borderRadius: 1.5, background: bg }}
+                        />
+                      );
+                    })}
+                  </div>
+                  <span className="mono tnum text-right text-[12px] text-fg-2">
+                    {s.passed}/{s.total}
+                  </span>
+                  <span className="mono tnum text-right text-[12px] text-fg-3">
+                    {s.durationMs > 0 ? `${s.durationMs}ms` : '—'}
+                  </span>
+                  <span className="text-right">
+                    <span
+                      className="inline-flex items-center px-2 py-0.5 rounded-full border text-[10.5px] font-medium uppercase tracking-wide"
+                      style={{
+                        color: pillColor,
+                        borderColor: `oklch(from ${pillColor} l c h / 0.4)`,
+                        background: `oklch(from ${pillColor} l c h / 0.1)`,
+                      }}
+                    >
+                      {s.status === 'passed'
+                        ? 'passing'
+                        : s.status === 'failed'
+                          ? 'failing'
+                          : 'skipped'}
+                    </span>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Verification tiers */}
       <div>

--- a/core/test-runner/parse-vitest-json.test.ts
+++ b/core/test-runner/parse-vitest-json.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { parseVitestJson } from './parse-vitest-json.js';
+
+const STAR = 1_700_000_000_000;
+
+const sample = {
+  numTotalTestSuites: 2,
+  numPassedTestSuites: 1,
+  numFailedTestSuites: 1,
+  numTotalTests: 5,
+  numPassedTests: 3,
+  numFailedTests: 1,
+  numPendingTests: 1,
+  numTodoTests: 0,
+  startTime: STAR,
+  success: false,
+  testResults: [
+    {
+      name: '/repo/src/cart.test.ts',
+      status: 'passed',
+      assertionResults: [
+        { status: 'passed', duration: 12 },
+        { status: 'passed', duration: 18.4 },
+        { status: 'pending', duration: 0 },
+      ],
+    },
+    {
+      name: '/repo/src/funnel.test.ts',
+      status: 'failed',
+      assertionResults: [
+        { status: 'passed', duration: 7 },
+        { status: 'failed', duration: 41 },
+      ],
+    },
+  ],
+};
+
+describe('parseVitestJson', () => {
+  it('produces canonical TestRun from a vitest JSON report', () => {
+    const run = parseVitestJson(sample, STAR + 7700);
+    expect(run.wallTimeMs).toBe(7700);
+    expect(run.total).toBe(5);
+    expect(run.passed).toBe(3);
+    expect(run.failed).toBe(1);
+    expect(run.skipped).toBe(1);
+    expect(run.success).toBe(false);
+    expect(run.suites).toHaveLength(2);
+
+    const cart = run.suites[0];
+    expect(cart.name).toBe('cart.test.ts');
+    expect(cart.filePath).toBe('/repo/src/cart.test.ts');
+    expect(cart.total).toBe(3);
+    expect(cart.passed).toBe(2);
+    expect(cart.failed).toBe(0);
+    expect(cart.skipped).toBe(1);
+    expect(cart.durationMs).toBe(30); // 12 + 18.4 -> rounded
+    expect(cart.status).toBe('passed');
+
+    const funnel = run.suites[1];
+    expect(funnel.status).toBe('failed');
+    expect(funnel.failed).toBe(1);
+  });
+
+  it('marks a suite skipped when no tests passed and at least one is pending', () => {
+    const run = parseVitestJson({
+      success: true,
+      startTime: STAR,
+      testResults: [
+        {
+          name: 'a.test.ts',
+          status: 'passed',
+          assertionResults: [
+            { status: 'pending', duration: 0 },
+            { status: 'pending', duration: 0 },
+          ],
+        },
+      ],
+    });
+    expect(run.suites[0].status).toBe('skipped');
+  });
+
+  it('treats success=true with zero failures as a successful run', () => {
+    const run = parseVitestJson({
+      numTotalTests: 1,
+      numPassedTests: 1,
+      numFailedTests: 0,
+      success: true,
+      startTime: STAR,
+      testResults: [
+        {
+          name: 'ok.test.ts',
+          status: 'passed',
+          assertionResults: [{ status: 'passed', duration: 1 }],
+        },
+      ],
+    });
+    expect(run.success).toBe(true);
+  });
+
+  it('treats success=true with non-zero failures as failed (defensive)', () => {
+    const run = parseVitestJson({
+      numTotalTests: 1,
+      numPassedTests: 0,
+      numFailedTests: 1,
+      success: true,
+      startTime: STAR,
+      testResults: [
+        {
+          name: 'bad.test.ts',
+          status: 'failed',
+          assertionResults: [{ status: 'failed', duration: 1 }],
+        },
+      ],
+    });
+    expect(run.success).toBe(false);
+  });
+
+  it('falls back to summing assertions when top-level totals are missing', () => {
+    const run = parseVitestJson({
+      success: true,
+      startTime: STAR,
+      testResults: [
+        {
+          name: 'x.test.ts',
+          status: 'passed',
+          assertionResults: [
+            { status: 'passed', duration: 5 },
+            { status: 'passed', duration: 5 },
+          ],
+        },
+      ],
+    });
+    expect(run.total).toBe(2);
+    expect(run.passed).toBe(2);
+    expect(run.failed).toBe(0);
+    expect(run.skipped).toBe(0);
+  });
+
+  it('throws on non-object input', () => {
+    expect(() => parseVitestJson(null as unknown)).toThrow(/expected an object/);
+    expect(() => parseVitestJson('not json' as unknown)).toThrow(/expected an object/);
+  });
+
+  it('handles an empty report gracefully', () => {
+    const run = parseVitestJson({ startTime: STAR, success: true, testResults: [] }, STAR + 100);
+    expect(run.total).toBe(0);
+    expect(run.passed).toBe(0);
+    expect(run.failed).toBe(0);
+    expect(run.success).toBe(true);
+    expect(run.suites).toEqual([]);
+    expect(run.wallTimeMs).toBe(100);
+  });
+
+  it('uses now() when startTime is missing', () => {
+    const run = parseVitestJson({ success: true, testResults: [] }, STAR + 5);
+    expect(run.wallTimeMs).toBe(0);
+  });
+});

--- a/core/test-runner/parse-vitest-json.ts
+++ b/core/test-runner/parse-vitest-json.ts
@@ -1,0 +1,93 @@
+// core/test-runner/parse-vitest-json.ts
+// Parses vitest's `--reporter=json` output into a runner-agnostic TestRun.
+//
+// Pure function over JSON: no I/O. Pair with run-vitest.ts to actually
+// invoke vitest and feed the raw JSON in here.
+
+import { basename } from 'node:path';
+import type { SuiteResult, TestRun } from '@goose-hub/skills/qa/schema.js';
+
+type SuiteStatus = SuiteResult['status'];
+
+interface VitestAssertion {
+  status: string;
+  duration?: number | null;
+}
+
+interface VitestTestResult {
+  name: string;
+  status: string;
+  startTime?: number;
+  endTime?: number;
+  assertionResults?: VitestAssertion[];
+}
+
+interface VitestJsonReport {
+  numTotalTests?: number;
+  numPassedTests?: number;
+  numFailedTests?: number;
+  numPendingTests?: number;
+  numTodoTests?: number;
+  startTime?: number;
+  success?: boolean;
+  testResults?: VitestTestResult[];
+}
+
+function classifySuite(passed: number, failed: number, total: number): SuiteStatus {
+  if (failed > 0) return 'failed';
+  if (passed === 0 && total > 0) return 'skipped';
+  return 'passed';
+}
+
+/** Parse a vitest `--reporter=json` payload into the canonical TestRun shape. */
+export function parseVitestJson(raw: unknown, now: number = Date.now()): TestRun {
+  if (raw == null || typeof raw !== 'object') {
+    throw new Error('parseVitestJson: expected an object');
+  }
+  const report = raw as VitestJsonReport;
+  const results = report.testResults ?? [];
+
+  const suites: SuiteResult[] = results.map((r) => {
+    const assertions = r.assertionResults ?? [];
+    const passed = assertions.filter((a) => a.status === 'passed').length;
+    const failed = assertions.filter((a) => a.status === 'failed').length;
+    const skipped = assertions.filter(
+      (a) => a.status === 'skipped' || a.status === 'pending' || a.status === 'todo',
+    ).length;
+    const total = assertions.length;
+    const durationMs = assertions.reduce((sum, a) => sum + (a.duration ?? 0), 0);
+    return {
+      name: basename(r.name || 'unknown'),
+      filePath: r.name || '',
+      total,
+      passed,
+      failed,
+      skipped,
+      durationMs: Math.round(durationMs),
+      status: classifySuite(passed, failed, total),
+    };
+  });
+
+  const total = report.numTotalTests ?? suites.reduce((s, x) => s + x.total, 0);
+  const passed = report.numPassedTests ?? suites.reduce((s, x) => s + x.passed, 0);
+  const failed = report.numFailedTests ?? suites.reduce((s, x) => s + x.failed, 0);
+  const skipped =
+    (report.numPendingTests ?? 0) +
+    (report.numTodoTests ?? 0) +
+    (report.numPendingTests == null && report.numTodoTests == null
+      ? suites.reduce((s, x) => s + x.skipped, 0)
+      : 0);
+
+  const startTime = report.startTime ?? now;
+  const wallTimeMs = Math.max(0, Math.round(now - startTime));
+
+  return {
+    wallTimeMs,
+    total,
+    passed,
+    failed,
+    skipped,
+    success: report.success === true && failed === 0,
+    suites,
+  };
+}

--- a/core/test-runner/run-vitest.test.ts
+++ b/core/test-runner/run-vitest.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runVitest } from './run-vitest.js';
+
+// Spawns a fake "vitest" via a tiny shell script that writes a known JSON
+// report to the path supplied via --outputFile, exercising the real spawn /
+// tempfile / parse plumbing without needing vitest itself.
+
+let workDir: string;
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'goose-hub-rv-test-'));
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeFakeRunner(name: string, body: string): string {
+  const path = join(workDir, name);
+  writeFileSync(path, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return path;
+}
+
+function writeReportScript(report: unknown, exitCode: number): string {
+  return [
+    'for arg in "$@"; do',
+    '  case "$arg" in',
+    '    --outputFile=*) out="${arg#--outputFile=}";;',
+    '  esac',
+    'done',
+    `cat <<'JSON' > "$out"`,
+    JSON.stringify(report),
+    'JSON',
+    `exit ${exitCode}`,
+  ].join('\n');
+}
+
+describe('runVitest', () => {
+  it('parses the JSON report written to --outputFile', async () => {
+    const report = {
+      numTotalTests: 2,
+      numPassedTests: 2,
+      numFailedTests: 0,
+      success: true,
+      startTime: 0,
+      testResults: [
+        {
+          name: 'a.test.ts',
+          status: 'passed',
+          assertionResults: [
+            { status: 'passed', duration: 5 },
+            { status: 'passed', duration: 5 },
+          ],
+        },
+      ],
+    };
+    // Fake binary: extracts the value passed to --outputFile=... and writes the JSON there.
+    const runner = writeFakeRunner('fake-vitest.sh', writeReportScript(report, 0));
+
+    const run = await runVitest({ command: runner, cwd: workDir });
+    expect(run.total).toBe(2);
+    expect(run.passed).toBe(2);
+    expect(run.failed).toBe(0);
+    expect(run.success).toBe(true);
+  });
+
+  it('still parses the report when the runner exits non-zero (failed tests)', async () => {
+    const report = {
+      numTotalTests: 1,
+      numPassedTests: 0,
+      numFailedTests: 1,
+      success: false,
+      startTime: 0,
+      testResults: [
+        {
+          name: 'b.test.ts',
+          status: 'failed',
+          assertionResults: [{ status: 'failed', duration: 1 }],
+        },
+      ],
+    };
+    const runner = writeFakeRunner('fake-vitest-fail.sh', writeReportScript(report, 1));
+
+    const run = await runVitest({ command: runner, cwd: workDir });
+    expect(run.failed).toBe(1);
+    expect(run.success).toBe(false);
+  });
+
+  it('rejects when the runner does not produce an output file', async () => {
+    const runner = writeFakeRunner('fake-vitest-noop.sh', 'exit 0');
+    await expect(runVitest({ command: runner, cwd: workDir })).rejects.toThrow();
+  });
+
+  it('rejects when the command times out', async () => {
+    const runner = writeFakeRunner('fake-vitest-hang.sh', 'sleep 5');
+    await expect(runVitest({ command: runner, cwd: workDir, timeoutMs: 100 })).rejects.toThrow(
+      /timed out/,
+    );
+  });
+});

--- a/core/test-runner/run-vitest.ts
+++ b/core/test-runner/run-vitest.ts
@@ -1,0 +1,71 @@
+// core/test-runner/run-vitest.ts
+// Runs a vitest test command with `--reporter=json` and returns the parsed
+// TestRun. Captures wall time deterministically here rather than relying on
+// the reporter's startTime so the QA workflow gets accurate timings.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TestRun } from '@goose-hub/skills/qa/schema.js';
+import { parseVitestJson } from './parse-vitest-json.js';
+
+export interface RunVitestOptions {
+  /**
+   * Test command as a single shell string (e.g. `pnpm test --run`).
+   * The runner appends `--reporter=json --outputFile=<tmp>` so callers
+   * don't need to know the reporter flag.
+   */
+  command: string;
+  cwd: string;
+  /** Hard timeout for the test run, in milliseconds. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+/**
+ * Runs the given test command with vitest's JSON reporter and parses the
+ * output. The command is executed via `sh -c` so callers can pass pipelines
+ * or compound commands ("pnpm test --run"). Vitest is told to write the
+ * report to a tempfile (stdout is reserved for log output) which we then
+ * read back.
+ */
+export async function runVitest(opts: RunVitestOptions): Promise<TestRun> {
+  const dir = mkdtempSync(join(tmpdir(), 'goose-hub-vitest-'));
+  const outFile = join(dir, 'report.json');
+  const fullCommand = `${opts.command} --reporter=json --outputFile=${JSON.stringify(outFile)}`;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn('sh', ['-c', fullCommand], {
+        cwd: opts.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, CI: '1', FORCE_COLOR: '0' },
+      });
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(
+          new Error(
+            `runVitest: test command timed out after ${opts.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      // vitest exits non-zero on test failure; that's expected — we still
+      // want to parse the report. Only reject on missing output file below.
+      child.on('exit', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    const raw = JSON.parse(readFileSync(outFile, 'utf8'));
+    return parseVitestJson(raw, Date.now());
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/skills/qa/README.md
+++ b/skills/qa/README.md
@@ -87,6 +87,7 @@ The `computeOverallScore` helper in `schema.ts` sums all category values.
 | `qualityScores` | `QualityScores` | All 8 category scores |
 | `findings` | `Finding[]` | Consolidated findings across all tiers |
 | `decisionSummaries` | `DecisionSummary[]` | Per-step audit trail |
+| `testRun` | `TestRun?` | Structured test results — populated by the workflow, not the agent |
 
 `Finding`:
 

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -30,6 +30,27 @@ export const TierResultSchema = z.object({
  * Maximum aggregate score: 100 points.
  * Pass threshold: >= 70 points.
  */
+export const SuiteResultSchema = z.object({
+  name: z.string(),
+  filePath: z.string(),
+  total: z.number().int().min(0),
+  passed: z.number().int().min(0),
+  failed: z.number().int().min(0),
+  skipped: z.number().int().min(0),
+  durationMs: z.number().int().min(0),
+  status: z.enum(['passed', 'failed', 'skipped']),
+});
+
+export const TestRunSchema = z.object({
+  wallTimeMs: z.number().int().min(0),
+  total: z.number().int().min(0),
+  passed: z.number().int().min(0),
+  failed: z.number().int().min(0),
+  skipped: z.number().int().min(0),
+  success: z.boolean(),
+  suites: z.array(SuiteResultSchema),
+});
+
 export const QualityScoresSchema = z.object({
   /** Open/Closed principle adherence — 0–20 pts */
   openClosed: z.number().int().min(0).max(20),
@@ -68,12 +89,21 @@ export const QaOutputSchema = z.object({
   findings: z.array(FindingSchema),
   /** Per-step audit trail of QA decisions */
   decisionSummaries: z.array(DecisionSummarySchema),
+  /**
+   * Optional: structured test-run data. The QA workflow runs the test
+   * command itself and attaches this; the agent does not need to
+   * populate it (and shouldn't — it's overwritten on the workflow side
+   * after the run validates).
+   */
+  testRun: TestRunSchema.optional(),
 });
 
 export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
 export type Finding = z.infer<typeof FindingSchema>;
 export type TierResult = z.infer<typeof TierResultSchema>;
 export type QualityScores = z.infer<typeof QualityScoresSchema>;
+export type SuiteResult = z.infer<typeof SuiteResultSchema>;
+export type TestRun = z.infer<typeof TestRunSchema>;
 export type QaOutput = z.infer<typeof QaOutputSchema>;
 
 /**

--- a/skills/qa/skill.md
+++ b/skills/qa/skill.md
@@ -28,6 +28,15 @@ Your context contains:
   - `lintCommand` — command to run lint and type-check (optional)
   - `e2eCommand` — command to run Playwright end-to-end tests (optional)
 - `sliceTests` — array of paths to slice-level test files (optional)
+- `testRun` — structured results from `testCommand`, already executed by the
+  workflow before you started (optional; may be `null` if the run failed to
+  produce a report). When present:
+  - `wallTimeMs`, `total`, `passed`, `failed`, `skipped`, `success`
+  - `suites` — per-file: `{ name, filePath, total, passed, failed, skipped, durationMs, status }`
+  Do **not** re-run `testCommand` if `testRun` is present — grade the
+  Functional tier from `testRun` directly. Only re-run if you need to verify a
+  specific test in isolation (e.g. checking that a regression is genuinely
+  fixed rather than skipped).
 
 ## Three-tier verification framework
 
@@ -56,8 +65,8 @@ Record tier result with:
 Purpose: Catch behavior regressions and missing test coverage.
 
 Steps:
-1. Run `testCommand`. If `sliceTests` are provided, run those first for targeted feedback.
-2. Check test output for failures, errors, and skipped tests.
+1. If `testRun` is present in your context, use it as the test result — do not re-run `testCommand`. If `testRun` is absent or `null`, run `testCommand` yourself; if `sliceTests` are provided, run those first for targeted feedback.
+2. Check test output (or `testRun.suites`) for failures, errors, and skipped tests.
    **Known worktree noise — do not report as findings:** Test files that fail with `ERR_DLOPEN_FAILED` or `Error: The module ... better-sqlite3 ...` are caused by the native module not being rebuilt for the worktree's Node version. These are pre-existing environment failures, not regressions introduced by the PR. Filter them out before assessing pass/fail. If ALL failures are of this type, record an `info`-severity finding noting the sqlite noise and mark the tier passed.
 3. Read the diff and verify that the changed behavior is covered by tests in the PR.
 4. Check that every acceptance criterion in `workItem.body` is addressed — either by a passing test or by observable code change.

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -486,6 +486,144 @@ describe('runQaWorkflow', () => {
     });
   });
 
+  describe('test-run propagation', () => {
+    const sampleTestRun = {
+      wallTimeMs: 7700,
+      total: 39,
+      passed: 38,
+      failed: 0,
+      skipped: 1,
+      success: true,
+      suites: [
+        {
+          name: 'cart.test.ts',
+          filePath: '/wt/cart.test.ts',
+          total: 18,
+          passed: 18,
+          failed: 0,
+          skipped: 0,
+          durationMs: 412,
+          status: 'passed' as const,
+        },
+      ],
+    };
+
+    it('runs the injected test runner against the worktree path before invoking the agent', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: { worktreePath: '/wt/abc' },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+      const runTests = vi.fn().mockResolvedValue(sampleTestRun);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', { runTests });
+
+      expect(runTests).toHaveBeenCalledTimes(1);
+      expect(runTests).toHaveBeenCalledWith('/wt/abc', expect.stringContaining('pnpm test'));
+    });
+
+    it('passes testRun into the agent context and allowlists it', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: { worktreePath: '/wt/abc' },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(sampleTestRun),
+      });
+
+      const spec = mockRun.mock.calls[0][0] as {
+        context: { testRun: unknown };
+        contextAllowlist: string[];
+      };
+      expect(spec.context.testRun).toEqual(sampleTestRun);
+      expect(spec.contextAllowlist).toContain('testRun');
+    });
+
+    it('includes testRun in the qa.completed payload when present', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: { worktreePath: '/wt/abc' },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(sampleTestRun),
+      });
+
+      const completed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.completed');
+      const payload = completed?.[0].payload as Record<string, unknown>;
+      expect(payload.testRun).toEqual(sampleTestRun);
+    });
+
+    it('omits testRun from qa.completed when the runner returns null', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: { worktreePath: '/wt/abc' },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(null),
+      });
+
+      const completed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.completed');
+      const payload = completed?.[0].payload as Record<string, unknown>;
+      expect(payload.testRun).toBeUndefined();
+    });
+
+    it('skips the test runner entirely when no worktree is available', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      // No pr.opened event => findDevWorktreePath returns undefined
+      mockReplay.mockReturnValue([]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+      const runTests = vi.fn();
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', { runTests });
+
+      expect(runTests).not.toHaveBeenCalled();
+      const spec = mockRun.mock.calls[0][0] as { context: { testRun: unknown } };
+      expect(spec.context.testRun).toBeNull();
+    });
+  });
+
   describe('partial verdict', () => {
     it('transitions to factory:needs-review when partial score >= 70', async () => {
       const item = makeWorkItem();

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -9,7 +9,8 @@ import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import { QaOutputSchema } from '@goose-hub/skills/qa/schema.js';
+import { runVitest } from '@goose-hub/core/test-runner/run-vitest.js';
+import { QaOutputSchema, type TestRun } from '@goose-hub/skills/qa/schema.js';
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 
@@ -35,6 +36,23 @@ function findDevWorktreePath(workItemId: string): string | undefined {
 
 export interface QaWorkflowDeps {
   runtime?: AgentRuntime;
+  /**
+   * Override for the test runner. Default uses `runVitest` against the
+   * configured test command. Pass a stub in tests to avoid spawning.
+   * Returning `null` (or throwing) is treated as "no testRun data" — the
+   * QA agent still runs, just without real suite numbers in its context.
+   */
+  runTests?: (cwd: string, command: string) => Promise<TestRun | null>;
+}
+
+const DEFAULT_TEST_COMMAND = 'pnpm test --run';
+
+async function defaultRunTests(cwd: string, command: string): Promise<TestRun | null> {
+  try {
+    return await runVitest({ command, cwd });
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -63,14 +81,22 @@ export async function runQaWorkflow(
 ): Promise<void> {
   const runId = crypto.randomUUID();
   const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const runTests = deps.runTests ?? defaultRunTests;
   const qaPrompt = readPrompt('qa');
   const qaJsonSchema = toJsonSchema(QaOutputSchema);
   const { personaId } = selectPersona(projectId, 'qa');
   const prDiff = getPrDiff(workItem);
+  const workspaceDir = findDevWorktreePath(workItem.id);
 
   // Snapshot prior events BEFORE this run's outcome is appended.
   // shouldEscalateQa uses this count to decide: Nth failure = N-1 priors.
   const priorEvents = eventStore.replay({ workItemId: workItem.id });
+
+  // Run tests deterministically before invoking the QA agent so the agent
+  // grades against real numbers instead of re-running the suite. Failures
+  // here are non-fatal — the agent still runs without testRun.
+  const testCommand = DEFAULT_TEST_COMMAND;
+  const testRun = workspaceDir != null ? await runTests(workspaceDir, testCommand) : null;
 
   try {
     const qaResult = await runtime.run({
@@ -87,14 +113,15 @@ export async function runQaWorkflow(
         },
         prDiff,
         projectCommands: {
-          testCommand: 'pnpm test --run',
+          testCommand,
           lintCommand: 'pnpm biome check .',
         },
+        testRun,
       },
-      contextAllowlist: ['workItem', 'prDiff', 'projectCommands'],
+      contextAllowlist: ['workItem', 'prDiff', 'projectCommands', 'testRun'],
       freshContext: true,
       toolBundles: ['read', 'qa-tools'],
-      workspaceDir: findDevWorktreePath(workItem.id),
+      workspaceDir,
       toolExtras: [],
       budgets: { maxTurns: 50, maxBudgetUsd: 5, timeoutMs: 600_000 },
       personaId,
@@ -130,6 +157,9 @@ export async function runQaWorkflow(
     }
 
     // Emit qa.completed with full payload (qualityScores included for UI and history).
+    // testRun is the workflow-captured one (deterministic), not whatever the
+    // agent might echo back — even if the schema accepts it from the agent,
+    // we trust our own measurement.
     eventStore.appendEvent({
       projectId,
       workItemId: workItem.id,
@@ -140,6 +170,7 @@ export async function runQaWorkflow(
         threshold: qaOutput.threshold,
         tierResults: qaOutput.tierResults,
         qualityScores: qaOutput.qualityScores,
+        ...(testRun ? { testRun } : {}),
       },
       runId,
     });


### PR DESCRIPTION
Restyles QASection to match the design in docs/design/harness-2-1:
- Section header (eyebrow · title · hint) with verdict + tier-pass + finding summary, plus Re-run / Add test actions.
- 4-card stat row: Pass / Fail (tiers), Score, Wall time (placeholder — not yet tracked), Flake risk (derived from finding severities).
- Verification Tiers table with status dot, mini severity-coloured progress dots, issue count, command label, and passing/failing pill per tier.
- Findings list restyled with severity pill, tier badge, file:line chip and suggestion line.

Preserves existing qa-section and qa-empty-state testids and reads from the
existing qa.completed event payload only — no schema changes.