### PR TITLE
M9.08: cost dashboard — per-stage cost breakdown

### DIFF
--- a/apps/server/STANDARDS.md
+++ b/apps/server/STANDARDS.md
@@ -78,14 +78,43 @@ export async function doThing(slug: string, value: string): Promise<Result<{ ok:
 
 ## Import Rules
 
-- Domain files import shared utilities from `../../shared/`.
+- Domain files import shared utilities via the `#shared/*` subpath alias —
+  e.g. `import { parseBody } from '#shared/middleware.js'`. Resolved by the
+  `imports` field in `apps/server/package.json`. Never use `'../../shared/*'`.
+- Cross-package imports use `@goose-hub/<name>/*` (e.g. `@goose-hub/core/...`).
+- Intra-domain imports stay relative (`./service.js`, `./repository.js`).
 - `server.ts` is the only file that imports from multiple domains.
-- Domains **never** import from other domains.
+- Domains **never** import from other domains. Cross-domain coordination
+  goes through `#shared/dispatch.js`.
 - `index.ts` is the entry point only — no logic, no exports.
+
+Greppable invariant for review:
+```sh
+grep -rn "from ['\"]\\.\\./\\.\\./shared" apps/server/src/   # must be 0 hits
+```
+
+## Dynamic Imports
+
+Static imports are the default. `await import(...)` is reserved for the
+following four cases — each occurrence must carry a one-line comment naming
+its case:
+
+1. **Cross-package boundary at runtime path.** Loading code that lives outside
+   any workspace package (e.g. `slices/`) and is resolved via
+   `import.meta.url` so worktree-relative paths stay correct.
+2. **Runtime-resolved path.** Loading a module whose absolute path depends on
+   user input or per-project config (e.g. each project's `project.config.ts`
+   under `target-projects/<slug>/`).
+3. **Lazy fallback for an optional dependency.** Tolerating a missing or
+   environment-gated module (rare; document the fallback inline).
+4. **Test stub injection.** A DI parameter whose default is the static import
+   and whose override is supplied dynamically by tests.
+
+If a dynamic import does not match one of these, refactor it to static.
 
 ## Body Parsing
 
-Always use `parseBody<T>()` from `../../shared/middleware.js`. Never write inline `try/catch` for JSON parsing.
+Always use `parseBody<T>()` from `#shared/middleware.js`. Never write inline `try/catch` for JSON parsing.
 
 ```ts
 const body = await parseBody<{ title: string }>(c);

--- a/apps/server/STANDARDS.md
+++ b/apps/server/STANDARDS.md
@@ -15,6 +15,7 @@ Every feature in the server MUST be placed into one of the domain folders under 
 | `projects/` | `/projects`, `/health` | No |
 | `webhooks/` | `/webhooks/**` | No |
 | `workflows/` | `/projects/:slug/tick` | No |
+| `costs/` | `/projects/:slug/costs/**`, `/projects/:slug/issues/:id/costs` | Reads only (writes from `core/cost`) |
 
 Each domain folder contains:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "imports": {
+    "#shared/*": "./src/shared/*"
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts"

--- a/apps/server/src/domains/costs/repository.ts
+++ b/apps/server/src/domains/costs/repository.ts
@@ -1,0 +1,20 @@
+import {
+  type CostRow,
+  listCostsForWorkItem as coreListCostsForWorkItem,
+  totalsByStageForProjectSince as coreTotalsByStage,
+  totalsForProjectSince as coreTotalsForProject,
+} from '@goose-hub/core/cost/repository.js';
+
+export type { CostRow, ProjectTotals, StageTotal } from '@goose-hub/core/cost/repository.js';
+
+export function listCostsForWorkItem(workItemId: string): CostRow[] {
+  return coreListCostsForWorkItem(workItemId);
+}
+
+export function totalsForProjectSince(projectId: string, sinceIso: string) {
+  return coreTotalsForProject(projectId, sinceIso);
+}
+
+export function totalsByStageForProjectSince(projectId: string, sinceIso: string) {
+  return coreTotalsByStage(projectId, sinceIso);
+}

--- a/apps/server/src/domains/costs/router.ts
+++ b/apps/server/src/domains/costs/router.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono';
+import { getProject } from '../../shared/projects.js';
+import { getCostSummary, getCostsForWorkItem } from './service.js';
+
+const router = new Hono();
+
+/** Project-level summary: week/month windows + per-stage breakdown. */
+router.get('/:slug/costs/summary', async (c) => {
+  const slug = c.req.param('slug');
+  const cfg = await getProject(slug);
+  if (cfg == null) return c.json({ error: 'project not found' }, 404);
+
+  const result = await getCostSummary(slug);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 400);
+});
+
+/** Per-task breakdown: every cost row scoped to a single work item. */
+router.get('/:slug/issues/:id/costs', async (c) => {
+  const slug = c.req.param('slug');
+  const id = c.req.param('id');
+  const cfg = await getProject(slug);
+  if (cfg == null) return c.json({ error: 'project not found' }, 404);
+
+  const repoRef = cfg.source.kind === 'github' ? cfg.source.repo : slug;
+  const workItemId = `github:${repoRef}#${id}`;
+  const result = await getCostsForWorkItem(workItemId);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 400);
+});
+
+export { router as costsRouter };

--- a/apps/server/src/domains/costs/router.ts
+++ b/apps/server/src/domains/costs/router.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { getProject } from '../../shared/projects.js';
+import { getProject } from '#shared/projects.js';
 import { getCostSummary, getCostsForWorkItem } from './service.js';
 
 const router = new Hono();

--- a/apps/server/src/domains/costs/service.test.ts
+++ b/apps/server/src/domains/costs/service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockTotalsForProject, mockTotalsByStage, mockListCostsForWorkItem } = vi.hoisted(() => ({
+  mockTotalsForProject: vi.fn(),
+  mockTotalsByStage: vi.fn(),
+  mockListCostsForWorkItem: vi.fn(),
+}));
+
+vi.mock('./repository.js', () => ({
+  totalsForProjectSince: mockTotalsForProject,
+  totalsByStageForProjectSince: mockTotalsByStage,
+  listCostsForWorkItem: mockListCostsForWorkItem,
+}));
+
+const { getCostSummary, getCostsForWorkItem } = await import('./service.js');
+
+describe('getCostSummary', () => {
+  it('rejects empty projectId', async () => {
+    const r = await getCostSummary('   ');
+    expect(r).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('returns week, month and per-stage totals', async () => {
+    mockTotalsForProject
+      .mockReturnValueOnce({ totalUsd: 1.2, totalRuns: 5, hasEstimated: true }) // week
+      .mockReturnValueOnce({ totalUsd: 4.5, totalRuns: 20, hasEstimated: true }); // month
+    mockTotalsByStage.mockReturnValue([
+      { stage: 'dev', totalUsd: 3.0, totalRuns: 10, hasEstimated: true },
+      { stage: 'qa', totalUsd: 1.0, totalRuns: 8, hasEstimated: false },
+    ]);
+
+    const r = await getCostSummary('goose-hub-self');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.data.windows.week.totalUsd).toBe(1.2);
+    expect(r.data.windows.month.totalUsd).toBe(4.5);
+    expect(r.data.byStage).toHaveLength(2);
+    expect(r.data.byStage[0].stage).toBe('dev');
+  });
+});
+
+describe('getCostsForWorkItem', () => {
+  it('rejects empty workItemId', async () => {
+    const r = await getCostsForWorkItem('  ');
+    expect(r).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('returns rows + total + estimated flag', async () => {
+    mockListCostsForWorkItem.mockReturnValue([
+      {
+        id: 1,
+        runId: 'r1',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:owner/repo#1',
+        stage: 'qa',
+        skill: 'qa',
+        modelId: 'claude-sonnet-4-6',
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 0.01,
+        costLabel: 'estimated',
+        personaId: null,
+        createdAt: '2026-05-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        runId: 'r2',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:owner/repo#1',
+        stage: 'review',
+        skill: 'review',
+        modelId: 'claude-sonnet-4-6',
+        inputTokens: 80,
+        outputTokens: 30,
+        costUsd: 0.005,
+        costLabel: 'exact',
+        personaId: null,
+        createdAt: '2026-05-01T00:00:00Z',
+      },
+    ]);
+    const r = await getCostsForWorkItem('github:owner/repo#1');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.data.rows).toHaveLength(2);
+    expect(r.data.totalUsd).toBeCloseTo(0.015);
+    expect(r.data.hasEstimated).toBe(true);
+  });
+});

--- a/apps/server/src/domains/costs/service.ts
+++ b/apps/server/src/domains/costs/service.ts
@@ -1,5 +1,5 @@
 import type { CostLabel, Stage } from '@goose-hub/core/cost/types.js';
-import type { Result } from '../../shared/middleware.js';
+import type { Result } from '#shared/middleware.js';
 import {
   type CostRow,
   listCostsForWorkItem,

--- a/apps/server/src/domains/costs/service.ts
+++ b/apps/server/src/domains/costs/service.ts
@@ -1,0 +1,106 @@
+import type { CostLabel, Stage } from '@goose-hub/core/cost/types.js';
+import type { Result } from '../../shared/middleware.js';
+import {
+  type CostRow,
+  listCostsForWorkItem,
+  totalsByStageForProjectSince,
+  totalsForProjectSince,
+} from './repository.js';
+
+export interface CostSummaryDto {
+  projectId: string;
+  windows: {
+    week: { totalUsd: number; totalRuns: number; hasEstimated: boolean };
+    month: { totalUsd: number; totalRuns: number; hasEstimated: boolean };
+  };
+  byStage: Array<{
+    stage: Stage;
+    totalUsd: number;
+    totalRuns: number;
+    hasEstimated: boolean;
+  }>;
+}
+
+export interface CostRowDto {
+  runId: string;
+  workItemId: string | null;
+  stage: Stage;
+  skill: string;
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costLabel: CostLabel;
+  personaId: string | null;
+  createdAt: string;
+}
+
+export interface WorkItemCostsDto {
+  workItemId: string;
+  totalUsd: number;
+  hasEstimated: boolean;
+  rows: CostRowDto[];
+}
+
+function isoDaysAgo(days: number, now: Date = new Date()): string {
+  const d = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString();
+}
+
+export async function getCostSummary(
+  projectId: string,
+  now: Date = new Date(),
+): Promise<Result<CostSummaryDto>> {
+  if (!projectId.trim()) {
+    return { ok: false, error: 'projectId is required', status: 400 };
+  }
+  const weekSince = isoDaysAgo(7, now);
+  const monthSince = isoDaysAgo(30, now);
+
+  const week = totalsForProjectSince(projectId, weekSince);
+  const month = totalsForProjectSince(projectId, monthSince);
+  const byStage = totalsByStageForProjectSince(projectId, monthSince);
+
+  return {
+    ok: true,
+    data: {
+      projectId,
+      windows: { week, month },
+      byStage,
+    },
+  };
+}
+
+export async function getCostsForWorkItem(workItemId: string): Promise<Result<WorkItemCostsDto>> {
+  if (!workItemId.trim()) {
+    return { ok: false, error: 'workItemId is required', status: 400 };
+  }
+  const rows = listCostsForWorkItem(workItemId);
+  const totalUsd = rows.reduce((s, r) => s + r.costUsd, 0);
+  const hasEstimated = rows.some((r) => r.costLabel === 'estimated');
+  return {
+    ok: true,
+    data: {
+      workItemId,
+      totalUsd,
+      hasEstimated,
+      rows: rows.map(toRowDto),
+    },
+  };
+}
+
+function toRowDto(r: CostRow): CostRowDto {
+  return {
+    runId: r.runId,
+    workItemId: r.workItemId,
+    stage: r.stage,
+    skill: r.skill,
+    modelId: r.modelId,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    costUsd: r.costUsd,
+    costLabel: r.costLabel,
+    personaId: r.personaId,
+    createdAt: r.createdAt,
+  };
+}

--- a/apps/server/src/domains/events/router.ts
+++ b/apps/server/src/domains/events/router.ts
@@ -1,6 +1,6 @@
 import { buildSseStream } from '@goose-hub/core/event-stream/sse.js';
 import { Hono } from 'hono';
-import { parseBody } from '../../shared/middleware.js';
+import { parseBody } from '#shared/middleware.js';
 import { parseSseFilter, recordToolCall } from './service.js';
 
 const router = new Hono();

--- a/apps/server/src/domains/inbox/router.ts
+++ b/apps/server/src/domains/inbox/router.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { parseBody } from '../../shared/middleware.js';
+import { parseBody } from '#shared/middleware.js';
 import { createInboxItem, deleteInboxItem, getInboxItems, promoteInboxItem } from './service.js';
 
 const router = new Hono();

--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -17,7 +17,7 @@ vi.mock('@goose-hub/core/db/db.js', () => ({
   },
 }));
 
-import { getSourceForSlug } from '../../shared/source.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
 import {
   createInboxItem,

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -2,8 +2,8 @@ import { db } from '@goose-hub/core/db/db.js';
 import { projectState } from '@goose-hub/core/db/schema.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { eq } from 'drizzle-orm';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import {
   type InboxItem,
   getInboxItem,

--- a/apps/server/src/domains/issues/diff.ts
+++ b/apps/server/src/domains/issues/diff.ts
@@ -3,8 +3,8 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug, isValidSlug } from '../../shared/source.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug, isValidSlug } from '#shared/source.js';
 import { getRepoRef } from './internal.js';
 
 /**

--- a/apps/server/src/domains/issues/fake-run.ts
+++ b/apps/server/src/domains/issues/fake-run.ts
@@ -1,6 +1,6 @@
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { getRepoRef } from './internal.js';
 
 const OUTPUT_FIXTURES: Record<string, unknown> = {

--- a/apps/server/src/domains/issues/internal.ts
+++ b/apps/server/src/domains/issues/internal.ts
@@ -1,7 +1,7 @@
 import { db } from '@goose-hub/core/db/db.js';
 import { events } from '@goose-hub/core/db/schema.js';
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
-import { getProject } from '../../shared/projects.js';
+import { getProject } from '#shared/projects.js';
 
 /**
  * Look up the canonical GitHub `owner/repo` for a project slug. Falls back to

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { parseBody } from '../../shared/middleware.js';
+import { parseBody } from '#shared/middleware.js';
 import {
   approveIssue,
   commentOnIssue,

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -51,8 +51,8 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { isLegalTransition } from '@goose-hub/core/state-machine/transitions.js';
-import { bustCache } from '../../shared/cache.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { bustCache } from '#shared/cache.js';
+import { getSourceForSlug } from '#shared/source.js';
 import {
   commentOnIssue,
   fakeRun,

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -1,7 +1,7 @@
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import { CACHE_KEY, bustCache, getCached } from '../../shared/cache.js';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { CACHE_KEY, bustCache, getCached } from '#shared/cache.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { getLastPersonaIdsByWorkItem, getRepoRef } from './internal.js';
 
 // Public surface for the issues domain. The implementation is split across

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -1,11 +1,12 @@
+import { mergePR as defaultMergePR } from '@goose-hub/core/connectors/github/merge-pr.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { isLegalTransition, legalTargets } from '@goose-hub/core/state-machine/transitions.js';
 import { cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
-import { CACHE_KEY, bustCache } from '../../shared/cache.js';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { CACHE_KEY, bustCache } from '#shared/cache.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { getRepoRef } from './internal.js';
 
 export type TransitionResult =
@@ -24,7 +25,7 @@ export async function approveIssue(
   slug: string,
   id: string,
   options: {
-    mergePRImpl?: typeof import('@goose-hub/core/connectors/github/merge-pr.js').mergePR;
+    mergePRImpl?: typeof defaultMergePR;
   } = {},
 ): Promise<Result<{ ok: true; sha: string; prNumber: number }>> {
   const source = await getSourceForSlug(slug);
@@ -52,8 +53,7 @@ export async function approveIssue(
     return { ok: false, error: 'GITHUB_TOKEN env var not set', status: 500 };
   }
 
-  const mergePR =
-    options.mergePRImpl ?? (await import('@goose-hub/core/connectors/github/merge-pr.js')).mergePR;
+  const mergePR = options.mergePRImpl ?? defaultMergePR;
 
   const merged = await mergePR({ repo: repoRef, prNumber, token });
 

--- a/apps/server/src/domains/issues/triage.ts
+++ b/apps/server/src/domains/issues/triage.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug, isValidSlug } from '../../shared/source.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug, isValidSlug } from '#shared/source.js';
 
 interface TriageEventPayload {
   triage: { type: string; priority: string };

--- a/apps/server/src/domains/milestones/router.ts
+++ b/apps/server/src/domains/milestones/router.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { parseBody } from '../../shared/middleware.js';
+import { parseBody } from '#shared/middleware.js';
 import {
   getActiveMilestone,
   listClosedMilestoneIssues,

--- a/apps/server/src/domains/milestones/service.test.ts
+++ b/apps/server/src/domains/milestones/service.test.ts
@@ -25,8 +25,8 @@ vi.mock('./repository.js', () => ({
 }));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import { bustCache } from '../../shared/cache.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { bustCache } from '#shared/cache.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { readActiveMilestone, writeActiveMilestone } from './repository.js';
 import {
   getActiveMilestone,

--- a/apps/server/src/domains/milestones/service.ts
+++ b/apps/server/src/domains/milestones/service.ts
@@ -1,7 +1,7 @@
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import { CACHE_KEY, bustCache, getCached } from '../../shared/cache.js';
-import type { Result } from '../../shared/middleware.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { CACHE_KEY, bustCache, getCached } from '#shared/cache.js';
+import type { Result } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { readActiveMilestone, writeActiveMilestone } from './repository.js';
 
 export async function getActiveMilestone(

--- a/apps/server/src/domains/projects/service.test.ts
+++ b/apps/server/src/domains/projects/service.test.ts
@@ -4,7 +4,7 @@ vi.mock('../../shared/projects.js', () => ({
   listProjects: vi.fn(),
 }));
 
-import { listProjects } from '../../shared/projects.js';
+import { listProjects } from '#shared/projects.js';
 import { listProjectsService } from './service.js';
 
 describe('listProjectsService (#208)', () => {

--- a/apps/server/src/domains/projects/service.ts
+++ b/apps/server/src/domains/projects/service.ts
@@ -1,4 +1,4 @@
-import { listProjects as readProjects } from '../../shared/projects.js';
+import { listProjects as readProjects } from '#shared/projects.js';
 
 /**
  * Returns the list of registered projects (#208). Thin shim today —

--- a/apps/server/src/domains/roster/service.ts
+++ b/apps/server/src/domains/roster/service.ts
@@ -1,5 +1,5 @@
-import type { Result } from '../../shared/middleware.js';
-import { getProject } from '../../shared/projects.js';
+import type { Result } from '#shared/middleware.js';
+import { getProject } from '#shared/projects.js';
 import type { ImprovementCandidateRow, PersonaNameRow, PersonaStat } from './repository.js';
 import {
   getCandidateById,

--- a/apps/server/src/domains/webhooks/handler.ts
+++ b/apps/server/src/domains/webhooks/handler.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { logger } from '@goose-hub/core/logger.js';
 import type { Context } from 'hono';
-import { dispatchForLabel, dispatchTriageBatch } from '../../shared/dispatch.js';
+import { dispatchForLabel, dispatchTriageBatch } from '#shared/dispatch.js';
 
 /** Map from GitHub repo full name → project slug */
 const REPO_TO_SLUG: Record<string, string> = {

--- a/apps/server/src/domains/workflows/qa-batch.ts
+++ b/apps/server/src/domains/workflows/qa-batch.ts
@@ -1,12 +1,13 @@
 import { logger } from '@goose-hub/core/logger.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { getSourceForSlug } from '#shared/source.js';
 
 export async function runQaBatch(slug: string, source?: StateSource): Promise<void> {
   logger.info('qa-batch started', { slug });
   const stateSource = source ?? (await getSourceForSlug(slug));
   if (stateSource == null) throw new Error(`Project not found: ${slug}`);
 
+  // Cross-package boundary: slices/ is not a workspace package (rule 28a).
   const { runQaWorkflow } = (await import(
     new URL('../../../../../slices/qa/workflow.js', import.meta.url).href
   )) as {

--- a/apps/server/src/domains/workflows/review-batch.ts
+++ b/apps/server/src/domains/workflows/review-batch.ts
@@ -1,12 +1,13 @@
 import { logger } from '@goose-hub/core/logger.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import { getSourceForSlug } from '../../shared/source.js';
+import { getSourceForSlug } from '#shared/source.js';
 
 export async function runReviewBatch(slug: string, source?: StateSource): Promise<void> {
   logger.info('review-batch started', { slug });
   const stateSource = source ?? (await getSourceForSlug(slug));
   if (stateSource == null) throw new Error(`Project not found: ${slug}`);
 
+  // Cross-package boundary: slices/ is not a workspace package (rule 28a).
   const { runReviewWorkflow } = (await import(
     new URL('../../../../../slices/review/workflow.js', import.meta.url).href
   )) as {

--- a/apps/server/src/domains/workflows/router.test.ts
+++ b/apps/server/src/domains/workflows/router.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 
-const mockRunTriageBatch = vi.fn().mockResolvedValue(undefined);
-const mockRunQaBatch = vi.fn().mockResolvedValue(undefined);
-const mockRunReviewBatch = vi.fn().mockResolvedValue(undefined);
+const { mockRunTriageBatch, mockRunQaBatch, mockRunReviewBatch } = vi.hoisted(() => ({
+  mockRunTriageBatch: vi.fn().mockResolvedValue(undefined),
+  mockRunQaBatch: vi.fn().mockResolvedValue(undefined),
+  mockRunReviewBatch: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('./triage-batch.js', () => ({ runTriageBatch: mockRunTriageBatch }));
 vi.mock('./qa-batch.js', () => ({ runQaBatch: mockRunQaBatch }));
@@ -15,7 +17,7 @@ vi.mock('@goose-hub/core/logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { workflowsRouter } from './router.js';
+const { workflowsRouter } = await import('./router.js');
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 

--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -1,11 +1,14 @@
 import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
+import { dispatchForIssue, dispatchQa, dispatchReview } from '#shared/dispatch.js';
+import { runQaBatch } from './qa-batch.js';
+import { runReviewBatch } from './review-batch.js';
+import { runTriageBatch } from './triage-batch.js';
 
 const router = new Hono();
 
 router.post('/:slug/tick', async (c) => {
   const slug = c.req.param('slug');
-  const { runTriageBatch } = await import('./triage-batch.js');
   runTriageBatch(slug).catch((err: unknown) => {
     logger.error('triage-batch failed', { slug, error: String(err) });
   });
@@ -14,7 +17,6 @@ router.post('/:slug/tick', async (c) => {
 
 router.post('/:slug/run-qa', async (c) => {
   const slug = c.req.param('slug');
-  const { runQaBatch } = await import('./qa-batch.js');
   runQaBatch(slug).catch((err: unknown) => {
     logger.error('qa-batch failed', { slug, error: String(err) });
   });
@@ -27,7 +29,6 @@ router.post('/:slug/run-qa/:n', async (c) => {
   if (!Number.isFinite(n)) {
     return c.json({ ok: false, error: 'invalid issue number' }, 400);
   }
-  const { dispatchQa } = await import('../../shared/dispatch.js');
   dispatchQa(slug, n).catch((err: unknown) => {
     logger.error('dispatchQa failed', { slug, n, error: String(err) });
   });
@@ -36,7 +37,6 @@ router.post('/:slug/run-qa/:n', async (c) => {
 
 router.post('/:slug/run-review', async (c) => {
   const slug = c.req.param('slug');
-  const { runReviewBatch } = await import('./review-batch.js');
   runReviewBatch(slug).catch((err: unknown) => {
     logger.error('review-batch failed', { slug, error: String(err) });
   });
@@ -49,7 +49,6 @@ router.post('/:slug/run-review/:n', async (c) => {
   if (!Number.isFinite(n)) {
     return c.json({ ok: false, error: 'invalid issue number' }, 400);
   }
-  const { dispatchReview } = await import('../../shared/dispatch.js');
   dispatchReview(slug, n).catch((err: unknown) => {
     logger.error('dispatchReview failed', { slug, n, error: String(err) });
   });
@@ -62,7 +61,6 @@ router.post('/:slug/dispatch/:n', async (c) => {
   if (!Number.isFinite(n)) {
     return c.json({ ok: false, error: 'invalid issue number' }, 400);
   }
-  const { dispatchForIssue } = await import('../../shared/dispatch.js');
   dispatchForIssue(slug, n).catch((err: unknown) => {
     logger.error('dispatchForIssue failed', { slug, n, error: String(err) });
   });

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -10,7 +10,7 @@ import { skillsRoot } from '@goose-hub/skills';
 import { RepoMatchOutputSchema } from '@goose-hub/skills/repo-match/schema.js';
 import { TriageOutputSchema } from '@goose-hub/skills/triage/schema.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
-import { getSourceForSlug, isValidSlug } from '../../shared/source.js';
+import { getSourceForSlug, isValidSlug } from '#shared/source.js';
 
 function readPrompt(skillName: string): string {
   return readFileSync(join(skillsRoot, skillName, 'prompt.md'), 'utf8');

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,7 @@
 import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { costsRouter } from './domains/costs/router.js';
 import { eventsRouter } from './domains/events/router.js';
 import { inboxRouter } from './domains/inbox/router.js';
 import { issuesRouter } from './domains/issues/router.js';
@@ -27,6 +28,7 @@ app.route('/', projectsRouter); // GET /health, GET /projects
 app.route('/projects', milestonesRouter); // GET/POST /projects/:slug/milestones/**, /active-milestone
 app.route('/projects', issuesRouter); // GET/POST /projects/:slug/issues/**
 app.route('/projects', workflowsRouter); // POST /projects/:slug/tick
+app.route('/projects', costsRouter); // GET /projects/:slug/costs/summary, /projects/:slug/issues/:id/costs
 app.route('/inbox', inboxRouter); // GET/POST /inbox/**
 app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
+import { runTriageBatch } from '../domains/workflows/triage-batch.js';
 import { getSourceForSlug } from './source.js';
 
 const _triageBatchInFlight = new Set<string>();
@@ -16,10 +17,10 @@ function issueKey(slug: string, issueNumber: number): string {
  * domains (STANDARDS.md). Webhooks, the projects router, and any other
  * caller that needs to kick off a workflow goes through these helpers.
  *
- * Implementation note: workflow modules are dynamic-imported here (one
- * indirection layer above the previous `webhooks → workflows` direct
- * import). The webhook handler now depends only on `shared/`, which is
- * domain-agnostic.
+ * Slice workflows are dynamic-imported by URL because `slices/` lives at the
+ * repo root (outside any workspace package) — see FACTORY_RULES rule 28a.
+ * Resolving them via `import.meta.url` keeps the dispatcher portable across
+ * worktrees.
  */
 
 const REPO_ROOT = join(import.meta.dirname, '../../../..');
@@ -31,8 +32,8 @@ export function dispatchTriageBatch(slug: string): Promise<void> {
     return Promise.resolve();
   }
   _triageBatchInFlight.add(slug);
-  return import('../domains/workflows/triage-batch.js')
-    .then(({ runTriageBatch }) => runTriageBatch(slug))
+  return Promise.resolve()
+    .then(() => runTriageBatch(slug))
     .catch((err: unknown) => {
       logger.error('dispatchTriageBatch failed', { slug, error: String(err) });
     })
@@ -56,6 +57,7 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
   }
   _issueInFlight.add(key);
   try {
+    // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runInvestigateWorkflow } = (await import(
       new URL('../../../../slices/investigate/workflow.js', import.meta.url).href
     )) as {
@@ -87,6 +89,7 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
   }
   _issueInFlight.add(key);
   try {
+    // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runFixIssueWorkflow } = (await import(
       new URL('../../../../slices/fix-issue/workflow.js', import.meta.url).href
     )) as {
@@ -136,6 +139,7 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
   }
   _issueInFlight.add(key);
   try {
+    // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runQaWorkflow } = (await import(
       new URL('../../../../slices/qa/workflow.js', import.meta.url).href
     )) as {
@@ -167,6 +171,7 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
   }
   _issueInFlight.add(key);
   try {
+    // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runReviewWorkflow } = (await import(
       new URL('../../../../slices/review/workflow.js', import.meta.url).href
     )) as {

--- a/apps/server/src/shared/projects.ts
+++ b/apps/server/src/shared/projects.ts
@@ -28,6 +28,7 @@ async function loadProject(slug: string): Promise<ProjectConfig | null> {
     return null;
   }
 
+  // Runtime-resolved path: each project's config lives in target-projects/<slug>/.
   const mod = (await import(pathToFileURL(file).href)) as { default: ProjectConfig };
   if (mod.default == null) {
     logger.warn('project config has no default export', { slug, file });

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,4 +1,15 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "#shared/*": ["./src/shared/*"],
+      "@goose-hub/core/*": ["../../core/*"],
+      "@goose-hub/skills": ["../../skills/index.ts"],
+      "@goose-hub/skills/*": ["../../skills/*"],
+      "@goose-hub/target-projects": ["../../target-projects/index.ts"],
+      "@goose-hub/target-projects/*": ["../../target-projects/*"]
+    }
+  },
   "include": ["src/**/*.ts"]
 }

--- a/apps/web/STANDARDS.md
+++ b/apps/web/STANDARDS.md
@@ -61,10 +61,36 @@ Leaf components with no feature-specific state or API calls belong in `component
 
 ## Import Rules
 
-- Feature components import shared code from `@/lib/*` or `@/components/ui/*`.
+- Feature components import shared code via the `@/*` path alias —
+  e.g. `@/lib/types`, `@/components/ui/Button`. Resolved by the
+  `paths` entry in `apps/web/tsconfig.json` and the matching alias
+  in `vitest.config.ts`. Never use `'../../lib/*'`.
+- Intra-feature imports stay relative (`./components/...`, `./lib/...`).
 - Types are imported from `@/lib/types` — never from `@/lib/api` for type-only imports.
 - Feature components **never** import from other feature folders.
 - Cross-feature imports are architecture violations.
+
+Greppable invariant for review:
+```sh
+grep -rn "from ['\"]\\.\\./\\.\\./lib" apps/web/src/   # must be 0 hits
+```
+
+## Dynamic Imports
+
+Static imports are the default. `await import(...)` is reserved for the
+following four cases — each occurrence must carry a one-line comment naming
+its case:
+
+1. **Cross-package boundary at runtime path.** Loading code resolved via
+   `import.meta.url` because it lives outside any workspace package.
+2. **Runtime-resolved path.** Loading a module whose path is computed from
+   user input or per-project config.
+3. **Lazy fallback for an optional dependency.** Tolerating a missing or
+   environment-gated module.
+4. **Test stub injection.** A DI parameter whose default is the static
+   import and whose override is supplied dynamically by tests.
+
+If a dynamic import does not match one of these, refactor it to static.
 
 ## Test Coverage Requirements
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter, Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { Board } from './components/board/components/Board';
 import { AppShell } from './components/chrome/AppShell';
+import { CostsPage } from './components/costs/CostsPage';
 import { DetailPage } from './components/detail/components/DetailPage';
 import { InboxList } from './components/inbox/components/InboxList';
 import { RosterPage } from './components/roster/components/RosterPage';
@@ -77,6 +78,14 @@ function RosterPageRoute() {
   );
 }
 
+function CostsPageRoute() {
+  return (
+    <AppShell breadcrumb={<span>Costs</span>}>
+      <CostsPage />
+    </AppShell>
+  );
+}
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -104,6 +113,14 @@ export function App() {
             element={
               <ProjectShell>
                 <RosterPageRoute />
+              </ProjectShell>
+            }
+          />
+          <Route
+            path="/projects/:slug/costs"
+            element={
+              <ProjectShell>
+                <CostsPageRoute />
               </ProjectShell>
             }
           />

--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -1,6 +1,6 @@
+import { COST_PLACEHOLDER } from '@/lib/constants';
+import { sortLaneItems } from '@/lib/lanes.config';
 import { describe, expect, it } from 'vitest';
-import { COST_PLACEHOLDER } from '../../lib/constants';
-import { sortLaneItems } from '../../lib/lanes.config';
 
 // IssueCard rendering is exercised by the Playwright happy-path (#36)
 // and by board/components/IssueCard.test.tsx.

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/cn';
 import {
   ChevronLeft,
   ChevronRight,
+  Coins,
   Inbox,
   KanbanSquare,
   ListChecks,
@@ -40,6 +41,12 @@ function buildItems(slug: string | undefined): SidebarItem[] {
       to: `/projects/${project}/roster`,
       label: 'Roster',
       icon: <Users size={14} />,
+      available: true,
+    },
+    {
+      to: `/projects/${project}/costs`,
+      label: 'Costs',
+      icon: <Coins size={14} />,
       available: true,
     },
     {

--- a/apps/web/src/components/costs/CostLegend.tsx
+++ b/apps/web/src/components/costs/CostLegend.tsx
@@ -1,0 +1,20 @@
+import { Info } from 'lucide-react';
+
+/**
+ * One-line legend explaining the `~$` prefix. Renders only when at least one
+ * row in scope is `'estimated'`. Spec: M9.09.
+ */
+export function CostLegend() {
+  return (
+    <div
+      data-testid="cost-legend"
+      className="inline-flex items-center gap-1.5 text-[11.5px] text-fg-3"
+    >
+      <Info size={12} />
+      <span>
+        <span className="font-mono">~$</span> = estimated (Claude CLI). Unprefixed = exact (API
+        usage metadata).
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/costs/CostsPage.tsx
+++ b/apps/web/src/components/costs/CostsPage.tsx
@@ -1,0 +1,117 @@
+import { fetchCostSummary } from '@/lib/api';
+import type { CostSummaryDto } from '@/lib/types';
+import { formatCost } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+import { Coins } from 'lucide-react';
+import { useParams } from 'react-router-dom';
+import { CostLegend } from './CostLegend';
+import { StageBar } from './StageBar';
+
+function StatTile({
+  label,
+  value,
+  sub,
+  testId,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  testId?: string;
+}) {
+  return (
+    <div data-testid={testId} className="flex-1 border border-line rounded-lg p-4 bg-bg-elev/60">
+      <div className="text-[11px] uppercase tracking-wider text-fg-4 mb-1.5">{label}</div>
+      <div className="text-[20px] font-semibold tracking-tight">{value}</div>
+      {sub != null && <div className="text-[11.5px] text-fg-3 mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+export function CostsPage() {
+  const { slug = 'goose-hub-self' } = useParams<{ slug: string }>();
+
+  const { data, isLoading, error } = useQuery<CostSummaryDto>({
+    queryKey: ['costs-summary', slug],
+    queryFn: () => fetchCostSummary(slug),
+  });
+
+  return (
+    <div data-testid="costs-page" className="h-full overflow-y-auto px-8 py-6">
+      <header className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-[15px] font-semibold flex items-center gap-2">
+            <Coins size={15} className="text-accent" />
+            Costs
+          </h1>
+          <p className="text-[12px] text-fg-3 mt-1">
+            Per-stage agent spend across the project. Updated as runs complete.
+          </p>
+        </div>
+        {data?.windows && (data.windows.week.hasEstimated || data.windows.month.hasEstimated) && (
+          <CostLegend />
+        )}
+      </header>
+
+      {isLoading && <div className="text-[13px] text-fg-3">Loading costs…</div>}
+      {error && (
+        <div className="text-[13px] text-[color:var(--danger)]">Failed to load cost summary.</div>
+      )}
+
+      {data && (
+        <>
+          <div className="flex gap-3 mb-8">
+            <StatTile
+              testId="cost-week"
+              label="This week"
+              value={formatCost(
+                data.windows.week.totalUsd,
+                data.windows.week.hasEstimated ? 'estimated' : 'exact',
+              )}
+              sub={`${data.windows.week.totalRuns} runs`}
+            />
+            <StatTile
+              testId="cost-month"
+              label="This month"
+              value={formatCost(
+                data.windows.month.totalUsd,
+                data.windows.month.hasEstimated ? 'estimated' : 'exact',
+              )}
+              sub={`${data.windows.month.totalRuns} runs`}
+            />
+          </div>
+
+          <section data-testid="stage-breakdown" className="border border-line rounded-lg p-5">
+            <h2 className="text-[11px] uppercase tracking-wider text-fg-4 mb-4">
+              Per-stage breakdown · last 30 days
+            </h2>
+            {data.byStage.length === 0 ? (
+              <div
+                data-testid="costs-empty-state"
+                className="text-center text-[13px] text-fg-3 py-8"
+              >
+                <p className="mb-1 font-medium text-fg-2">No agent runs yet</p>
+                <p>Cost rows are written as runs complete.</p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {(() => {
+                  const max = Math.max(...data.byStage.map((s) => s.totalUsd));
+                  return data.byStage.map((s) => (
+                    <StageBar
+                      key={s.stage}
+                      stage={s.stage}
+                      totalUsd={s.totalUsd}
+                      hasEstimated={s.hasEstimated}
+                      totalRuns={s.totalRuns}
+                      maxUsd={max}
+                    />
+                  ));
+                })()}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/costs/StageBar.tsx
+++ b/apps/web/src/components/costs/StageBar.tsx
@@ -1,0 +1,51 @@
+import type { CostStage } from '@/lib/types';
+import { formatCost } from '@/lib/utils';
+
+const STAGE_LABEL: Record<CostStage, string> = {
+  triage: 'Triage',
+  investigate: 'Investigate',
+  dev: 'Dev',
+  qa: 'QA',
+  review: 'Review',
+  retrospective: 'Retrospective',
+  other: 'Other',
+};
+
+interface Props {
+  stage: CostStage;
+  totalUsd: number;
+  hasEstimated: boolean;
+  totalRuns: number;
+  maxUsd: number;
+}
+
+export function StageBar({ stage, totalUsd, hasEstimated, totalRuns, maxUsd }: Props) {
+  const pct = maxUsd > 0 ? Math.max(2, (totalUsd / maxUsd) * 100) : 0;
+  return (
+    <div
+      data-testid={`stage-bar-${stage}`}
+      className="grid grid-cols-[120px_1fr_120px] items-center gap-3"
+    >
+      <span className="text-[12.5px] text-fg-2">{STAGE_LABEL[stage]}</span>
+      <div className="h-2 rounded-full bg-bg overflow-hidden">
+        <div
+          style={{
+            width: `${pct}%`,
+            background: 'var(--accent, #7c3aed)',
+            height: '100%',
+            borderRadius: 9999,
+          }}
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2 font-mono text-[12px]">
+        <span className="text-fg-2">
+          {formatCost(totalUsd, hasEstimated ? 'estimated' : 'exact')}
+        </span>
+        <span className="text-fg-4">·</span>
+        <span className="text-fg-4">
+          {totalRuns} run{totalRuns === 1 ? '' : 's'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/CostsSection.tsx
+++ b/apps/web/src/components/detail/components/CostsSection.tsx
@@ -1,0 +1,121 @@
+import { CostLegend } from '@/components/costs/CostLegend';
+import { fetchIssueCosts } from '@/lib/api';
+import type { CostRowDto, WorkItemCostsDto } from '@/lib/types';
+import { formatCost, formatTokens, timeAgo } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+import { Coins } from 'lucide-react';
+
+interface CostsSectionProps {
+  projectSlug: string;
+  id: string;
+}
+
+const STAGE_LABEL: Record<CostRowDto['stage'], string> = {
+  triage: 'Triage',
+  investigate: 'Investigate',
+  dev: 'Dev',
+  qa: 'QA',
+  review: 'Review',
+  retrospective: 'Retrospective',
+  other: 'Other',
+};
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="flex-1 border border-line rounded-lg p-3 bg-bg-elev/60">
+      <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">{label}</div>
+      <div className="text-[18px] font-semibold tracking-tight">{value}</div>
+      {sub != null && <div className="text-[11px] text-fg-3 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+export function CostsSection({ projectSlug, id }: CostsSectionProps) {
+  const { data, isLoading, error } = useQuery<WorkItemCostsDto>({
+    queryKey: ['issue-costs', projectSlug, id],
+    queryFn: () => fetchIssueCosts(projectSlug, id),
+  });
+
+  if (isLoading) return null;
+
+  if (error) {
+    return (
+      <div className="px-8 py-6 text-[13px] text-[color:var(--danger)]">Failed to load costs.</div>
+    );
+  }
+
+  if (!data || data.rows.length === 0) {
+    return (
+      <div
+        data-testid="costs-empty-state"
+        className="px-8 py-8 flex flex-col items-center justify-center gap-2 text-center"
+      >
+        <Coins size={24} className="text-fg-3 opacity-50" />
+        <p className="text-[13px] text-fg-3">No agent runs recorded for this task yet.</p>
+        <p className="text-[12px] text-fg-4">Cost rows are written as runs complete.</p>
+      </div>
+    );
+  }
+
+  const totalLabel = data.hasEstimated ? 'estimated' : 'exact';
+  const totalTokens = data.rows.reduce((s, r) => s + r.inputTokens + r.outputTokens, 0);
+
+  return (
+    <div data-testid="costs-section" className="px-8 py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider">
+          Token economics for this task
+        </h2>
+        {data.hasEstimated && <CostLegend />}
+      </div>
+
+      <div className="flex gap-3">
+        <StatTile
+          label="Spent"
+          value={formatCost(data.totalUsd, totalLabel)}
+          sub={`${data.rows.length} run${data.rows.length === 1 ? '' : 's'}`}
+        />
+        <StatTile label="Tokens" value={formatTokens(totalTokens)} sub="across all runs" />
+      </div>
+
+      <div className="border border-line rounded-lg overflow-hidden">
+        <div className="grid grid-cols-[120px_120px_140px_1fr_100px] px-4 py-2.5 border-b border-line bg-bg-elev/50 text-[10.5px] uppercase tracking-wider text-fg-4">
+          <span>Stage</span>
+          <span>Skill</span>
+          <span>Model</span>
+          <span className="text-right">Tokens</span>
+          <span className="text-right">Cost</span>
+        </div>
+        {data.rows.map((r) => (
+          <div
+            key={r.runId}
+            data-testid={`costs-row-${r.runId}`}
+            className="grid grid-cols-[120px_120px_140px_1fr_100px] px-4 py-2.5 border-t border-line items-center text-[12px]"
+          >
+            <span className="text-fg-2">{STAGE_LABEL[r.stage]}</span>
+            <span className="font-mono text-fg-3 text-[11.5px]">{r.skill}</span>
+            <span className="font-mono text-fg-3 text-[11.5px]">{r.modelId}</span>
+            <span className="text-right font-mono text-fg-2">
+              {formatTokens(r.inputTokens + r.outputTokens)}
+            </span>
+            <span className="text-right font-mono text-fg-2">
+              {formatCost(r.costUsd, r.costLabel)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-[11px] text-fg-4">
+        Most recent run: {timeAgo(data.rows[data.rows.length - 1].createdAt)}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { SECTIONS } from '../lib/sections';
 import { ApprovalGateSection } from './ApprovalGateSection';
 import { CodeDiffSection } from './CodeDiffSection';
+import { CostsSection } from './CostsSection';
 import { DeferredSurface } from './DeferredSurface';
 import { GatePendingBanner } from './GatePendingBanner';
 import { InvestigationSection } from './InvestigationSection';
@@ -247,6 +248,8 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
               <ReviewSection projectSlug={slug} id={id} />
             ) : currentSection.key === 'retrospective' ? (
               <RetrospectiveSection projectSlug={slug} id={id} />
+            ) : currentSection.key === 'costs' ? (
+              <CostsSection projectSlug={slug} id={id} />
             ) : (
               <DeferredSurface
                 surface={currentSection.label}

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -1,5 +1,5 @@
+import type { AgentEventDto } from '@/lib/types';
 import { describe, expect, it } from 'vitest';
-import type { AgentEventDto } from '../../../lib/types';
 import { groupEvents } from '../lib/timeline';
 
 function makeLogEvent(id: number): AgentEventDto {

--- a/apps/web/src/components/detail/lib/sections.ts
+++ b/apps/web/src/components/detail/lib/sections.ts
@@ -65,8 +65,7 @@ export const SECTIONS: readonly DetailSection[] = [
   {
     key: 'costs',
     label: 'Costs',
-    available: false,
-    milestone: 'M9',
+    available: true,
     description: 'Per-agent token spend, per-run cost, daily budget burn.',
   },
 ] as const;

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -1,7 +1,7 @@
+import { GATE_STATES } from '@/lib/constants';
+import { renderMarkdownToHtml } from '@/lib/markdown';
+import { LEGAL_TARGETS } from '@/lib/transitions';
 import { describe, expect, it } from 'vitest';
-import { GATE_STATES } from '../../lib/constants';
-import { renderMarkdownToHtml } from '../../lib/markdown';
-import { LEGAL_TARGETS } from '../../lib/transitions';
 import { GATE_ACTIONS } from './components/GatePendingBanner';
 import { extractPlaywrightRepro } from './lib/playwright-capture';
 import { SECTIONS } from './lib/sections';

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEventDto,
+  CostSummaryDto,
   ImprovementCandidateDto,
   InboxItemDto,
   IssueCommentDto,
@@ -11,6 +12,7 @@ import type {
   ProjectSummary,
   TransitionResult,
   TriageResultDto,
+  WorkItemCostsDto,
   WorkItemDto,
 } from './types';
 
@@ -28,6 +30,8 @@ export type {
   PersonaNameDto,
   PersonaRunDto,
   ImprovementCandidateDto,
+  CostSummaryDto,
+  WorkItemCostsDto,
 } from './types';
 
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
@@ -285,4 +289,12 @@ export async function rejectCandidateById(id: number): Promise<ImprovementCandid
     {},
   );
   return candidate;
+}
+
+export async function fetchCostSummary(slug: string): Promise<CostSummaryDto> {
+  return getJson<CostSummaryDto>(`/projects/${slug}/costs/summary`);
+}
+
+export async function fetchIssueCosts(slug: string, id: string): Promise<WorkItemCostsDto> {
+  return getJson<WorkItemCostsDto>(`/projects/${slug}/issues/${id}/costs`);
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -113,6 +113,54 @@ export interface IssueDiffDto {
   reason?: string;
 }
 
+export type CostLabel = 'estimated' | 'exact';
+
+export type CostStage =
+  | 'triage'
+  | 'investigate'
+  | 'dev'
+  | 'qa'
+  | 'review'
+  | 'retrospective'
+  | 'other';
+
+export interface CostRowDto {
+  runId: string;
+  workItemId: string | null;
+  stage: CostStage;
+  skill: string;
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costLabel: CostLabel;
+  personaId: string | null;
+  createdAt: string;
+}
+
+export interface CostWindowTotals {
+  totalUsd: number;
+  totalRuns: number;
+  hasEstimated: boolean;
+}
+
+export interface CostStageTotal extends CostWindowTotals {
+  stage: CostStage;
+}
+
+export interface CostSummaryDto {
+  projectId: string;
+  windows: { week: CostWindowTotals; month: CostWindowTotals };
+  byStage: CostStageTotal[];
+}
+
+export interface WorkItemCostsDto {
+  workItemId: string;
+  totalUsd: number;
+  hasEstimated: boolean;
+  rows: CostRowDto[];
+}
+
 export interface ImprovementCandidateDto {
   id: number;
   projectId: string;

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ageLabel, timeAgo, truncate } from './utils';
+import { ageLabel, formatCost, formatTokens, timeAgo, truncate } from './utils';
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -62,6 +62,46 @@ describe('ageLabel', () => {
   it('returns 0m for same instant', () => {
     setNow('2024-01-01T12:00:00Z');
     expect(ageLabel('2024-01-01T12:00:00Z')).toBe('0m');
+  });
+});
+
+describe('formatCost', () => {
+  it('renders exact values without qualification', () => {
+    expect(formatCost(0.42, 'exact')).toBe('$0.42');
+    expect(formatCost(1.2)).toBe('$1.20');
+  });
+
+  it('prefixes a tilde for estimated values', () => {
+    expect(formatCost(0.42, 'estimated')).toBe('~$0.42');
+  });
+
+  it('uses 4 decimals for small non-zero amounts', () => {
+    expect(formatCost(0.0042, 'estimated')).toBe('~$0.0042');
+    expect(formatCost(0.001, 'exact')).toBe('$0.0010');
+  });
+
+  it('uses 2 decimals for zero', () => {
+    expect(formatCost(0, 'estimated')).toBe('~$0.00');
+  });
+});
+
+describe('formatTokens', () => {
+  it('shows raw count under 1k', () => {
+    expect(formatTokens(0)).toBe('0');
+    expect(formatTokens(999)).toBe('999');
+  });
+
+  it('shows decimal-k under 10k', () => {
+    expect(formatTokens(1234)).toBe('1.2k');
+  });
+
+  it('shows whole-k between 10k and 1M', () => {
+    expect(formatTokens(48_000)).toBe('48k');
+    expect(formatTokens(464_000)).toBe('464k');
+  });
+
+  it('shows decimal-M for >= 1M', () => {
+    expect(formatTokens(1_300_000)).toBe('1.3M');
   });
 });
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -39,3 +39,21 @@ export function truncate(value: string, max: number): string {
   if (value.length <= max) return value;
   return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
+
+/**
+ * Formats a USD amount. When `label` is `'estimated'`, prefixes a tilde so the
+ * user knows the figure is a Claude CLI rollup rather than authoritative API
+ * metadata. See M9.09 for the labelling convention.
+ */
+export function formatCost(usd: number, label: 'estimated' | 'exact' = 'exact'): string {
+  const abs = Math.abs(usd);
+  const formatted = abs < 0.01 && abs > 0 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
+  return label === 'estimated' ? `~${formatted}` : formatted;
+}
+
+/** Formats large token counts as e.g. "1.2k", "464k", "1.3M". */
+export function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -2,6 +2,9 @@ import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { costFromCliEnvelope } from '../cost/extract.js';
+import { recordCost } from '../cost/repository.js';
+import { stageForSkill } from '../cost/skill-stage.js';
 import { eventStore } from '../event-stream/store.js';
 import { computeAllowlist } from '../tool-layer/allowlist.js';
 import { deployHooks } from '../tool-layer/pre-tool-use-hook.js';
@@ -286,11 +289,36 @@ export class ClaudeCliRuntime implements AgentRuntime {
           return;
         }
 
+        const usage = envelope ? costFromCliEnvelope(envelope) : null;
+        recordCost({
+          runId,
+          projectId,
+          workItemId,
+          stage: stageForSkill(spec.skill),
+          skill: spec.skill,
+          modelId: model,
+          inputTokens: usage?.inputTokens ?? 0,
+          outputTokens: usage?.outputTokens ?? 0,
+          costUsd: usage?.costUsd ?? 0,
+          // No CLI usage data → still 'estimated', just zeroed.
+          costLabel: usage?.costLabel ?? 'estimated',
+          personaId: personaId ?? null,
+        });
+
         eventStore.appendEvent({
           projectId,
           workItemId,
           kind: 'agent.run-completed',
-          payload: { runId, skill: spec.skill },
+          payload: {
+            runId,
+            skill: spec.skill,
+            cost: {
+              usd: usage?.costUsd ?? 0,
+              inputTokens: usage?.inputTokens ?? 0,
+              outputTokens: usage?.outputTokens ?? 0,
+              label: usage?.costLabel ?? 'estimated',
+            },
+          },
           runId,
           personaId,
         });

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -51,6 +51,9 @@ vi.mock('../event-stream/store.js', () => ({
 vi.mock('../tool-layer/allowlist.js', () => ({ computeAllowlist: vi.fn().mockReturnValue([]) }));
 vi.mock('../tool-layer/pre-tool-use-hook.js', () => ({ deployHooks: vi.fn() }));
 vi.mock('../tool-layer/sandbox.js', () => ({ writeWorkspaceSandbox: vi.fn() }));
+// Stub the cost recorder so it doesn't pull `core/db/db.ts` (which would need
+// node:fs / node:os to be fully mocked).
+vi.mock('../cost/repository.js', () => ({ recordCost: vi.fn() }));
 
 // ─── interface types ──────────────────────────────────────────────────────────
 

--- a/core/cost/README.md
+++ b/core/cost/README.md
@@ -1,0 +1,54 @@
+# core/cost
+
+Persists per-run agent cost so the UI can show:
+
+- total spend (this week, this month) at the project level
+- per-stage breakdown (Triage / Investigate / Dev / QA / Review / Retrospective)
+- per-task breakdown on the Costs tab in the detail page
+
+## Schema (`agent_run_costs`)
+
+One row per agent run, keyed on `runId`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `runId` | text, unique | Canonical workflow isolation key (FACTORY_RULES rule 7 / CONTEXT.md) |
+| `projectId` | text | Project slug (e.g. `goose-hub-self`) |
+| `workItemId` | text? | `github:owner/repo#N` — null for project-level runs |
+| `stage` | text | `triage`/`investigate`/`dev`/`qa`/`review`/`retrospective`/`other` |
+| `skill` | text | The exact skill name that ran (e.g. `retrospective-deep`) |
+| `modelId` | text | Model used (e.g. `claude-sonnet-4-6`) |
+| `inputTokens` | int | Prompt tokens |
+| `outputTokens` | int | Completion tokens |
+| `costUsd` | real | Dollar figure for this run |
+| `costLabel` | text | `'estimated'` or `'exact'` — see below |
+| `personaId` | text? | Persona that ran (e.g. `goose-hub-self/qa/0`) |
+| `createdAt` | text | ISO-8601 |
+
+The `runId` unique index means duplicate inserts (retry loops) are ignored.
+
+## How rows are populated
+
+The Claude CLI runtime calls `recordCost()` once per successful run, after
+parsing the `--output-format json` envelope. `costFromCliEnvelope()` reads
+`total_cost_usd` and `usage.{input_tokens,output_tokens}` from the envelope
+when present and returns a `CostUsage` with `costLabel: 'estimated'`. When
+the envelope has neither field we still record a zero-cost row so every run
+shows up on the dashboard — the `costLabel` is `'estimated'` and the cost
+is `0`.
+
+When a future code path talks to the Anthropic SDK directly (rather than
+spawning the CLI), it should call `costFromApiUsage()` to construct a
+`CostUsage` with `costLabel: 'exact'`. The dashboard surfaces this label
+verbatim — see M9.09 for UI rendering rules (`~$0.04` vs `$0.04`).
+
+## Stage mapping
+
+`skill-stage.ts` maps each skill name to a high-level stage. The stage is
+purely a UI grouping; the `skill` column is preserved so finer breakdowns
+remain possible from raw rows. Unknown skills land in `other`.
+
+## API surface (server)
+
+The `costs/` server domain reads from this table — it never writes. Only the
+agent runtime appends cost rows.

--- a/core/cost/extract.test.ts
+++ b/core/cost/extract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { costFromApiUsage, costFromCliEnvelope } from './extract.js';
+
+describe('costFromCliEnvelope', () => {
+  it('returns null for non-object input', () => {
+    expect(costFromCliEnvelope(null)).toBeNull();
+    expect(costFromCliEnvelope(undefined)).toBeNull();
+    expect(costFromCliEnvelope('string')).toBeNull();
+  });
+
+  it('returns null when no recognisable cost or token fields are present', () => {
+    expect(costFromCliEnvelope({ result: 'hi' })).toBeNull();
+    expect(costFromCliEnvelope({ usage: {} })).toBeNull();
+  });
+
+  it('extracts total_cost_usd and usage tokens from a CLI envelope', () => {
+    const envelope = {
+      result: '{"ok":true}',
+      total_cost_usd: 0.0421,
+      usage: { input_tokens: 1234, output_tokens: 567 },
+    };
+    expect(costFromCliEnvelope(envelope)).toEqual({
+      inputTokens: 1234,
+      outputTokens: 567,
+      costUsd: 0.0421,
+      costLabel: 'estimated',
+    });
+  });
+
+  it('handles snake_case and camelCase token fields', () => {
+    const envelope = {
+      cost_usd: 0.1,
+      usage: { inputTokens: 10, outputTokens: 20 },
+    };
+    expect(costFromCliEnvelope(envelope)).toEqual({
+      inputTokens: 10,
+      outputTokens: 20,
+      costUsd: 0.1,
+      costLabel: 'estimated',
+    });
+  });
+
+  it('returns zeros for missing token fields when only cost is present', () => {
+    expect(costFromCliEnvelope({ cost: 0.5 })).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0.5,
+      costLabel: 'estimated',
+    });
+  });
+});
+
+describe('costFromApiUsage', () => {
+  it('always tags exact', () => {
+    expect(costFromApiUsage({ inputTokens: 1, outputTokens: 2, costUsd: 0.003 })).toEqual({
+      inputTokens: 1,
+      outputTokens: 2,
+      costUsd: 0.003,
+      costLabel: 'exact',
+    });
+  });
+});

--- a/core/cost/extract.ts
+++ b/core/cost/extract.ts
@@ -1,0 +1,55 @@
+import type { CostUsage } from './types.js';
+
+/**
+ * Extracts token usage and cost from a Claude CLI `--output-format json`
+ * envelope. The CLI's envelope for a successful run includes summary fields
+ * like `total_cost_usd`, `usage`, and `num_turns` (alongside `result`).
+ *
+ * We treat this as `'estimated'` because the CLI's number is a rollup the CLI
+ * computed itself; direct API integrations (when added) can supply `'exact'`
+ * usage metadata via {@link costFromApiUsage}.
+ *
+ * Returns `null` when no recognisable usage/cost fields are present — callers
+ * fall back to a conservative zero-cost stub so a cost row is still written
+ * (we never lose the run from the dashboard).
+ */
+export function costFromCliEnvelope(envelope: unknown): CostUsage | null {
+  if (envelope == null || typeof envelope !== 'object') return null;
+  const env = envelope as Record<string, unknown>;
+
+  const cost = numericField(env, ['total_cost_usd', 'cost_usd', 'cost']);
+  const usage = (env.usage ?? {}) as Record<string, unknown>;
+  const inputTokens = numericField(usage, ['input_tokens', 'inputTokens', 'prompt_tokens']) ?? 0;
+  const outputTokens =
+    numericField(usage, ['output_tokens', 'outputTokens', 'completion_tokens']) ?? 0;
+
+  if (cost == null && inputTokens === 0 && outputTokens === 0) return null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    costUsd: cost ?? 0,
+    costLabel: 'estimated',
+  };
+}
+
+/**
+ * Builds an exact `CostUsage` from authoritative API usage metadata. Called
+ * from any future code path that talks to the Anthropic SDK directly and
+ * therefore has trusted token counts and a derived dollar figure.
+ */
+export function costFromApiUsage(input: {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}): CostUsage {
+  return { ...input, costLabel: 'exact' };
+}
+
+function numericField(obj: Record<string, unknown>, keys: string[]): number | null {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return null;
+}

--- a/core/cost/repository.test.ts
+++ b/core/cost/repository.test.ts
@@ -1,0 +1,181 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../db/db.js';
+import { agentRunCosts } from '../db/schema.js';
+import {
+  listCostsForWorkItem,
+  recordCost,
+  totalsByStageForProjectSince,
+  totalsForProjectSince,
+} from './repository.js';
+
+const PROJECT = 'test-cost-repo';
+
+beforeAll(() => {
+  db.run(sql`CREATE TABLE IF NOT EXISTS agent_run_costs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    work_item_id TEXT,
+    stage TEXT NOT NULL,
+    skill TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd REAL NOT NULL DEFAULT 0,
+    cost_label TEXT NOT NULL DEFAULT 'estimated',
+    persona_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
+  db.run(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS agent_run_costs_run_id_uniq ON agent_run_costs (run_id)`,
+  );
+});
+
+beforeEach(() => {
+  db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+afterAll(() => {
+  db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+describe('recordCost', () => {
+  it('persists a single cost row', () => {
+    recordCost({
+      runId: `run-1-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#42',
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 1000,
+      outputTokens: 500,
+      costUsd: 0.012,
+      costLabel: 'estimated',
+      personaId: 'p1',
+    });
+
+    const rows = listCostsForWorkItem('github:owner/repo#42');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: `run-1-${PROJECT}`,
+      stage: 'qa',
+      skill: 'qa',
+      costUsd: 0.012,
+      costLabel: 'estimated',
+    });
+  });
+
+  it('is idempotent on runId — duplicate insert is silently ignored', () => {
+    const runId = `run-dup-${PROJECT}`;
+    const base = {
+      runId,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#1',
+      stage: 'qa' as const,
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.001,
+      costLabel: 'estimated' as const,
+      personaId: null,
+    };
+    recordCost(base);
+    recordCost({ ...base, costUsd: 99 }); // would otherwise overwrite
+
+    const rows = listCostsForWorkItem('github:owner/repo#1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].costUsd).toBe(0.001);
+  });
+});
+
+describe('totalsForProjectSince', () => {
+  it('sums costs and flags estimated when any row is estimated', () => {
+    recordCost({
+      runId: `run-a-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: null,
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0.5,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    recordCost({
+      runId: `run-b-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: null,
+      stage: 'review',
+      skill: 'review',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0.25,
+      costLabel: 'exact',
+      personaId: null,
+    });
+
+    const totals = totalsForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(totals.totalUsd).toBeCloseTo(0.75);
+    expect(totals.totalRuns).toBe(2);
+    expect(totals.hasEstimated).toBe(true);
+  });
+
+  it('flags hasEstimated=false when every row is exact', () => {
+    recordCost({
+      runId: `run-c-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: null,
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0.5,
+      costLabel: 'exact',
+      personaId: null,
+    });
+    const totals = totalsForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(totals.hasEstimated).toBe(false);
+  });
+});
+
+describe('totalsByStageForProjectSince', () => {
+  it('groups totals by stage and orders by spend descending', () => {
+    recordCost({
+      runId: `run-s1-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: null,
+      stage: 'dev',
+      skill: 'implement',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 1.0,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    recordCost({
+      runId: `run-s2-${PROJECT}`,
+      projectId: PROJECT,
+      workItemId: null,
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0.3,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    const stages = totalsByStageForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(stages.map((s) => s.stage)).toEqual(['dev', 'qa']);
+    expect(stages[0].totalUsd).toBeCloseTo(1.0);
+    expect(stages[1].totalUsd).toBeCloseTo(0.3);
+  });
+});

--- a/core/cost/repository.ts
+++ b/core/cost/repository.ts
@@ -1,0 +1,109 @@
+import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { agentRunCosts } from '../db/schema.js';
+import type { CostLabel, CostRecord, Stage } from './types.js';
+
+export interface CostRow extends CostRecord {
+  id: number;
+  createdAt: string;
+}
+
+/**
+ * Persists a cost record for an agent run. Idempotent on `runId` — duplicate
+ * inserts are silently ignored so retry loops don't double-count.
+ */
+export function recordCost(record: CostRecord): void {
+  db.insert(agentRunCosts)
+    .values({
+      runId: record.runId,
+      projectId: record.projectId,
+      workItemId: record.workItemId,
+      stage: record.stage,
+      skill: record.skill,
+      modelId: record.modelId,
+      inputTokens: record.inputTokens,
+      outputTokens: record.outputTokens,
+      costUsd: record.costUsd,
+      costLabel: record.costLabel,
+      personaId: record.personaId,
+    })
+    .onConflictDoNothing({ target: agentRunCosts.runId })
+    .run();
+}
+
+export function listCostsForWorkItem(workItemId: string): CostRow[] {
+  const rows = db
+    .select()
+    .from(agentRunCosts)
+    .where(eq(agentRunCosts.workItemId, workItemId))
+    .orderBy(asc(agentRunCosts.createdAt))
+    .all();
+  return rows.map(toRow);
+}
+
+export interface ProjectTotals {
+  totalUsd: number;
+  totalRuns: number;
+  /** True when any contributing row was 'estimated'. UI uses this to qualify the figure. */
+  hasEstimated: boolean;
+}
+
+export interface StageTotal extends ProjectTotals {
+  stage: Stage;
+}
+
+export function totalsForProjectSince(projectId: string, sinceIso: string): ProjectTotals {
+  const [row] = db
+    .select({
+      totalUsd: sql<number>`coalesce(sum(${agentRunCosts.costUsd}), 0)`,
+      totalRuns: sql<number>`count(*)`,
+      hasEstimated: sql<number>`max(case when ${agentRunCosts.costLabel} = 'estimated' then 1 else 0 end)`,
+    })
+    .from(agentRunCosts)
+    .where(and(eq(agentRunCosts.projectId, projectId), gte(agentRunCosts.createdAt, sinceIso)))
+    .all();
+  return {
+    totalUsd: row?.totalUsd ?? 0,
+    totalRuns: row?.totalRuns ?? 0,
+    hasEstimated: (row?.hasEstimated ?? 0) === 1,
+  };
+}
+
+export function totalsByStageForProjectSince(projectId: string, sinceIso: string): StageTotal[] {
+  const rows = db
+    .select({
+      stage: agentRunCosts.stage,
+      totalUsd: sql<number>`coalesce(sum(${agentRunCosts.costUsd}), 0)`,
+      totalRuns: sql<number>`count(*)`,
+      hasEstimated: sql<number>`max(case when ${agentRunCosts.costLabel} = 'estimated' then 1 else 0 end)`,
+    })
+    .from(agentRunCosts)
+    .where(and(eq(agentRunCosts.projectId, projectId), gte(agentRunCosts.createdAt, sinceIso)))
+    .groupBy(agentRunCosts.stage)
+    .orderBy(desc(sql`sum(${agentRunCosts.costUsd})`))
+    .all();
+  return rows.map((r) => ({
+    stage: r.stage as Stage,
+    totalUsd: r.totalUsd ?? 0,
+    totalRuns: r.totalRuns ?? 0,
+    hasEstimated: (r.hasEstimated ?? 0) === 1,
+  }));
+}
+
+function toRow(r: typeof agentRunCosts.$inferSelect): CostRow {
+  return {
+    id: r.id,
+    runId: r.runId,
+    projectId: r.projectId,
+    workItemId: r.workItemId,
+    stage: r.stage as Stage,
+    skill: r.skill,
+    modelId: r.modelId,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    costUsd: r.costUsd,
+    costLabel: r.costLabel as CostLabel,
+    personaId: r.personaId,
+    createdAt: r.createdAt,
+  };
+}

--- a/core/cost/skill-stage.test.ts
+++ b/core/cost/skill-stage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { stageForSkill } from './skill-stage.js';
+
+describe('stageForSkill', () => {
+  it('maps known skills to their stage', () => {
+    expect(stageForSkill('triage')).toBe('triage');
+    expect(stageForSkill('investigate')).toBe('investigate');
+    expect(stageForSkill('implement')).toBe('dev');
+    expect(stageForSkill('fix-issue')).toBe('dev');
+    expect(stageForSkill('qa')).toBe('qa');
+    expect(stageForSkill('review')).toBe('review');
+    expect(stageForSkill('retrospective-light')).toBe('retrospective');
+    expect(stageForSkill('retrospective-deep')).toBe('retrospective');
+  });
+
+  it('returns "other" for unknown skills', () => {
+    expect(stageForSkill('something-new')).toBe('other');
+    expect(stageForSkill('')).toBe('other');
+  });
+});

--- a/core/cost/skill-stage.ts
+++ b/core/cost/skill-stage.ts
@@ -1,0 +1,24 @@
+import type { Stage } from './types.js';
+
+/**
+ * Maps a skill name to the high-level pipeline stage it belongs to.
+ * The dashboard groups costs by stage; the persisted row also records the
+ * exact `skill`, so finer breakdowns are still possible from raw data.
+ */
+const SKILL_TO_STAGE: Record<string, Stage> = {
+  triage: 'triage',
+  'triage-light': 'triage',
+  investigate: 'investigate',
+  investigation: 'investigate',
+  implement: 'dev',
+  fix: 'dev',
+  'fix-issue': 'dev',
+  qa: 'qa',
+  review: 'review',
+  'retrospective-light': 'retrospective',
+  'retrospective-deep': 'retrospective',
+};
+
+export function stageForSkill(skill: string): Stage {
+  return SKILL_TO_STAGE[skill] ?? 'other';
+}

--- a/core/cost/types.ts
+++ b/core/cost/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Cost record types — see core/cost/README.md.
+ *
+ * `costLabel` is the trust signal for the displayed number:
+ * - `'exact'`   → derived from authoritative usage metadata (e.g. direct API
+ *                  response with `usage.input_tokens` / `usage.output_tokens`).
+ * - `'estimated'` → derived from the Claude CLI's reported totals only, or a
+ *                    fallback calculation. UI must qualify these (M9.09).
+ *
+ * `stage` is the high-level pipeline phase (Triage / Investigate / Dev / QA /
+ * Review / Retrospective). `skill` is the actual skill name that ran. Stages
+ * group skills for the per-stage bar chart on the dashboard.
+ */
+export type CostLabel = 'estimated' | 'exact';
+
+export type Stage = 'triage' | 'investigate' | 'dev' | 'qa' | 'review' | 'retrospective' | 'other';
+
+export interface CostRecord {
+  runId: string;
+  projectId: string;
+  workItemId: string | null;
+  stage: Stage;
+  skill: string;
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costLabel: CostLabel;
+  personaId: string | null;
+}
+
+export interface CostUsage {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costLabel: CostLabel;
+}

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -117,3 +117,31 @@ export const personaNames = sqliteTable(
     ),
   }),
 );
+
+// One row per agent run. `runId` is unique — the same run is never recorded twice.
+// `costLabel`: 'exact' when the source provided authoritative usage metadata
+// (direct API), 'estimated' when only the Claude CLI's reported totals are
+// available. UI must surface this distinction (see M9.09).
+export const agentRunCosts = sqliteTable(
+  'agent_run_costs',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    runId: text('run_id').notNull(),
+    projectId: text('project_id').notNull(),
+    workItemId: text('work_item_id'),
+    stage: text('stage').notNull(),
+    skill: text('skill').notNull(),
+    modelId: text('model_id').notNull(),
+    inputTokens: integer('input_tokens').notNull().default(0),
+    outputTokens: integer('output_tokens').notNull().default(0),
+    costUsd: real('cost_usd').notNull().default(0),
+    costLabel: text('cost_label').notNull().default('estimated'), // estimated | exact
+    personaId: text('persona_id'),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    runIdUniq: uniqueIndex('agent_run_costs_run_id_uniq').on(t.runId),
+    projectCreatedIdx: index('agent_run_costs_project_created_idx').on(t.projectId, t.createdAt),
+    workItemIdx: index('agent_run_costs_work_item_idx').on(t.workItemId),
+  }),
+);

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -1,5 +1,6 @@
 import { resolveState } from '../state-machine/conflict-resolver.js';
 import type { StateName } from '../state-machine/states.js';
+import { isLegalTransition } from '../state-machine/transitions.js';
 import type {
   Artifact,
   CreateIssueInput,
@@ -290,7 +291,6 @@ export class GitHubLabelsSource implements StateSource {
     to: StateName,
     note?: string,
   ): Promise<void> {
-    const { isLegalTransition } = await import('../state-machine/transitions.js');
     if (!isLegalTransition(from, to)) {
       throw new Error(`Illegal transition: ${from} -> ${to}`);
     }

--- a/slices/cost-tracking/README.md
+++ b/slices/cost-tracking/README.md
@@ -1,0 +1,50 @@
+# slices/cost-tracking
+
+Per-run cost persistence and dashboard surfaces. Closes M9.08.
+
+## What it does
+
+Every Claude CLI agent run writes a row to `agent_run_costs` once the envelope
+parses. The dashboard surfaces aggregate spend per stage; the per-task Costs
+tab shows every run's row for that work item. Cost figures are tagged
+`'estimated'` (from CLI rollups) or `'exact'` (from authoritative API usage
+metadata) so the UI can qualify them — see M9.09 for the rendering rules.
+
+## Vertical surfaces touched
+
+- **DB**: `core/db/schema.ts` — `agent_run_costs` table (one row per `runId`)
+- **Core lib**: `core/cost/` — extraction (`extract.ts`), persistence
+  (`repository.ts`), skill→stage mapping (`skill-stage.ts`), shared types
+- **Runtime hook**: `core/agent-runtime/claude-cli.ts` — `recordCost()` is
+  called on the `agent.run-completed` path; the event payload also carries
+  the cost so subscribers can react
+- **Server API**: `apps/server/src/domains/costs/` — read-only endpoints
+  - `GET /projects/:slug/costs/summary` → week/month + per-stage breakdown
+  - `GET /projects/:slug/issues/:id/costs` → per-task rows
+- **Web nav + page**: `apps/web/src/components/costs/CostsPage.tsx` mounted
+  at `/projects/:slug/costs`
+- **Web detail tab**: `apps/web/src/components/detail/components/CostsSection.tsx`
+
+## Trust labels
+
+`costLabel = 'estimated'` is the default — the Claude CLI's
+`--output-format json` envelope reports a rollup, not authoritative metadata.
+The UI prefixes a tilde (`~$0.04`). When a future code path talks to the
+Anthropic SDK directly, it should construct a `CostUsage` via
+`costFromApiUsage()` to mark it `'exact'`.
+
+## Why a slice rather than horizontal layers
+
+FACTORY_RULES rule 24 — every feature ships as one slice that names every
+surface it touches. The persistence test lives in `slice.test.ts`; the
+component-level tests stay in their respective files.
+
+## Tests
+
+`slice.test.ts` covers the canonical lifecycle: envelope → extract → record →
+read via repository. Component tests:
+
+- `core/cost/extract.test.ts` — envelope parsing edge cases
+- `core/cost/skill-stage.test.ts` — skill→stage mapping
+- `core/cost/repository.test.ts` — persistence + idempotency + aggregate queries
+- `apps/server/src/domains/costs/service.test.ts` — service layer with mocked repo

--- a/slices/cost-tracking/slice.test.ts
+++ b/slices/cost-tracking/slice.test.ts
@@ -1,0 +1,142 @@
+import { costFromCliEnvelope } from '@goose-hub/core/cost/extract.js';
+import {
+  listCostsForWorkItem,
+  recordCost,
+  totalsByStageForProjectSince,
+  totalsForProjectSince,
+} from '@goose-hub/core/cost/repository.js';
+import { stageForSkill } from '@goose-hub/core/cost/skill-stage.js';
+import { db } from '@goose-hub/core/db/db.js';
+import { agentRunCosts } from '@goose-hub/core/db/schema.js';
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const PROJECT = 'cost-tracking-slice';
+
+beforeAll(() => {
+  db.run(sql`CREATE TABLE IF NOT EXISTS agent_run_costs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    work_item_id TEXT,
+    stage TEXT NOT NULL,
+    skill TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd REAL NOT NULL DEFAULT 0,
+    cost_label TEXT NOT NULL DEFAULT 'estimated',
+    persona_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
+  db.run(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS agent_run_costs_run_id_uniq ON agent_run_costs (run_id)`,
+  );
+});
+
+beforeEach(() => {
+  db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+afterAll(() => {
+  db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+describe('cost-tracking slice — end-to-end lifecycle', () => {
+  it('persists a row from a parsed Claude CLI envelope and reads it back', () => {
+    // 1. Simulate a finished CLI run.
+    const envelope = {
+      result: '{"ok":true}',
+      total_cost_usd: 0.073,
+      usage: { input_tokens: 4200, output_tokens: 1300 },
+    };
+    const usage = costFromCliEnvelope(envelope);
+    expect(usage).not.toBeNull();
+    if (!usage) return;
+
+    // 2. Persist (mirroring what claude-cli.ts does on success).
+    recordCost({
+      runId: 'slice-run-1',
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#42',
+      stage: stageForSkill('qa'),
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      costUsd: usage.costUsd,
+      costLabel: usage.costLabel,
+      personaId: 'p1',
+    });
+
+    // 3. Read back by work item — UI's per-task surface uses this path.
+    const rows = listCostsForWorkItem('github:owner/repo#42');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: 'slice-run-1',
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 4200,
+      outputTokens: 1300,
+      costLabel: 'estimated',
+    });
+    expect(rows[0].costUsd).toBeCloseTo(0.073);
+
+    // 4. Aggregate by stage — the dashboard's per-stage chart uses this.
+    const totals = totalsForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(totals.totalRuns).toBe(1);
+    expect(totals.totalUsd).toBeCloseTo(0.073);
+    expect(totals.hasEstimated).toBe(true);
+
+    const stages = totalsByStageForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(stages).toHaveLength(1);
+    expect(stages[0].stage).toBe('qa');
+    expect(stages[0].totalUsd).toBeCloseTo(0.073);
+  });
+
+  it('records a zero-cost row when the CLI envelope has no usage data', () => {
+    // No usage / no cost — we still want the run to appear on the dashboard.
+    recordCost({
+      runId: 'slice-run-2',
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#43',
+      stage: stageForSkill('triage'),
+      skill: 'triage',
+      modelId: 'claude-haiku-4-5-20251001',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+
+    const rows = listCostsForWorkItem('github:owner/repo#43');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].costUsd).toBe(0);
+    expect(rows[0].costLabel).toBe('estimated');
+  });
+
+  it('is idempotent on runId — replay does not double-count', () => {
+    const base = {
+      runId: 'slice-run-3',
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#44',
+      stage: 'dev' as const,
+      skill: 'implement',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 1000,
+      outputTokens: 500,
+      costUsd: 0.02,
+      costLabel: 'estimated' as const,
+      personaId: null,
+    };
+    recordCost(base);
+    recordCost(base);
+    recordCost({ ...base, costUsd: 999 });
+
+    const rows = listCostsForWorkItem('github:owner/repo#44');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].costUsd).toBeCloseTo(0.02);
+  });
+});

--- a/slices/cost-tracking/slice.test.ts
+++ b/slices/cost-tracking/slice.test.ts
@@ -1,4 +1,4 @@
-import { costFromCliEnvelope } from '@goose-hub/core/cost/extract.js';
+import { costFromApiUsage, costFromCliEnvelope } from '@goose-hub/core/cost/extract.js';
 import {
   listCostsForWorkItem,
   recordCost,
@@ -115,6 +115,37 @@ describe('cost-tracking slice — end-to-end lifecycle', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].costUsd).toBe(0);
     expect(rows[0].costLabel).toBe('estimated');
+  });
+
+  it('propagates the exact label end-to-end when authoritative usage metadata is supplied', () => {
+    // Direct API integration — the caller computed the dollar figure from
+    // authoritative `usage.input_tokens` / `output_tokens`, so the row must
+    // be tagged 'exact' and read back that way.
+    const usage = costFromApiUsage({ inputTokens: 800, outputTokens: 200, costUsd: 0.018 });
+    expect(usage.costLabel).toBe('exact');
+
+    recordCost({
+      runId: 'slice-run-exact',
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#99',
+      stage: stageForSkill('review'),
+      skill: 'review',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      costUsd: usage.costUsd,
+      costLabel: usage.costLabel,
+      personaId: null,
+    });
+
+    const rows = listCostsForWorkItem('github:owner/repo#99');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].costLabel).toBe('exact');
+
+    // Aggregations must reflect that the project window has at least one
+    // exact row → `hasEstimated` flips to false when the row is exact.
+    const totals = totalsForProjectSince(PROJECT, '1970-01-01T00:00:00Z');
+    expect(totals.hasEstimated).toBe(false);
   });
 
   it('is idempotent on runId — replay does not double-count', () => {

--- a/slices/fix-issue/chore-shipping.test.ts
+++ b/slices/fix-issue/chore-shipping.test.ts
@@ -37,9 +37,10 @@ vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
     .fn()
     .mockReturnValue({ personaId: 'proj/developer/0', codename: 'Grey Honker' }),
 }));
-vi.mock('node:fs', () => ({
-  readFileSync: vi.fn().mockReturnValue('# mock skill prompt'),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock skill prompt') };
+});
 vi.mock('@goose-hub/core/persona/accumulate.js', () => ({
   accumulatePersonaStats: vi.fn(),
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'apps/web/src'),
       '@goose-hub/core': path.resolve(__dirname, 'core'),
+      '#shared': path.resolve(__dirname, 'apps/server/src/shared'),
     },
   },
   test: {


### PR DESCRIPTION
Closes #266

- agent_run_costs table (one row per runId; estimated/exact label)
- core/cost/ extraction + persistence; claude-cli wires it on run-completed
- /projects/:slug/costs/summary + /:slug/issues/:id/costs read endpoints
- Costs page in main nav; Costs tab in task detail
- slices/cost-tracking/ slice with end-to-end lifecycle test

https://claude.ai/code/session_01DbgDNyDSR56AJ3dnWkQCeR