### PR TITLE
chore: fix biome import-sort violation in CaptureModal.test.tsx

### DIFF
--- a/apps/web/src/components/inbox/CaptureModal.test.tsx
+++ b/apps/web/src/components/inbox/CaptureModal.test.tsx
@@ -1,7 +1,7 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 /** @vitest-environment jsdom */
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CaptureModal } from './CaptureModal';
 

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -286,6 +286,28 @@ export class ClaudeCliRuntime implements AgentRuntime {
           return;
         }
 
+        // Surface non-empty stderr even on successful runs. The Claude CLI
+        // forwards MCP server stderr (startup banners, registration warnings,
+        // failed --strict-mcp-config diagnostics) here. Without this, an agent
+        // can run with a silently-broken MCP server, return a free-text
+        // apology, and leave operators with no signal in the event stream.
+        const stderrTrimmed = stderr.trim();
+        if (stderrTrimmed.length > 0) {
+          eventStore.appendEvent({
+            projectId,
+            workItemId,
+            kind: 'agent.log',
+            payload: {
+              runId,
+              skill: spec.skill,
+              stream: 'stderr',
+              text: stderrTrimmed.slice(0, 4000),
+            },
+            runId,
+            personaId,
+          });
+        }
+
         eventStore.appendEvent({
           projectId,
           workItemId,

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -1,6 +1,13 @@
 import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Skip the playwright-test MCP pre-flight subprocess in workflow.ts — same
+// convention claude-cli.ts uses to bypass real spawns under tests.
+process.env.MOCK_AGENTS = 'true';
+afterAll(() => {
+  process.env.MOCK_AGENTS = undefined;
+});
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -13,8 +14,67 @@ import { PlaywrightReproSchema } from '@goose-hub/skills/playwright-repro/schema
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
 
+/**
+ * The Claude CLI subprocess is spawned with a minimal PATH (see
+ * core/agent-runtime/claude-cli.ts). Mirror that PATH here so the pre-flight
+ * detects the same `pnpm`/`playwright` resolution failures the spawn would hit.
+ */
+const MINIMAL_PATH =
+  process.platform === 'darwin'
+    ? '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin'
+    : '/usr/local/bin:/usr/bin:/bin';
+
 function readPrompt(skillName: string): string {
   return readFileSync(join(REPO_ROOT, 'skills', skillName, 'skill.md'), 'utf8');
+}
+
+/**
+ * Spawns the playwright-test MCP server briefly to confirm it can start in the
+ * environment the Claude CLI subprocess will use. Resolves with `{ ok: true }`
+ * if the process is still alive after `probeMs` (the server is long-running and
+ * never exits on its own), or with `{ ok: false, error }` if it exits early or
+ * fails to spawn at all (missing pnpm, missing playwright, missing browsers).
+ */
+async function preflightPlaywrightMcp(
+  probeMs = 3000,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return new Promise((resolve) => {
+    let stderr = '';
+    let resolved = false;
+    const finish = (result: { ok: true } | { ok: false; error: string }) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already dead */
+      }
+      resolve(result);
+    };
+
+    const child = spawn(
+      'pnpm',
+      ['--filter', '@goose-hub/web', 'exec', 'playwright', 'run-test-mcp-server', '--headless'],
+      {
+        cwd: REPO_ROOT,
+        env: { HOME: homedir(), PATH: MINIMAL_PATH },
+        shell: false,
+        stdio: ['ignore', 'ignore', 'pipe'],
+      },
+    );
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (err) => finish({ ok: false, error: `spawn failed: ${err.message}` }));
+    child.on('exit', (code) =>
+      finish({
+        ok: false,
+        error: `MCP server exited early with code ${code}: ${stderr.slice(0, 500).trim() || '(no stderr)'}`,
+      }),
+    );
+    setTimeout(() => finish({ ok: true }), probeMs);
+  });
 }
 
 /**
@@ -88,68 +148,123 @@ export async function runInvestigateWorkflow(
       const { personaId: playwrightPersonaId } = selectPersona(projectId, 'investigator');
       const playwrightRunId = crypto.randomUUID();
 
-      // Write a runtime MCP config that invokes playwright via pnpm from the
-      // actual repo root (where node_modules exist). The worktree is isolated
-      // from node_modules, so npx/direct invocation fails there.
-      const playwrightMcpConfigPath = join(
-        homedir(),
-        '.factory',
-        'workspaces',
-        `${playwrightRunId}-mcp.json`,
-      );
-      writeFileSync(
-        playwrightMcpConfigPath,
-        JSON.stringify({
-          mcpServers: {
-            'playwright-test': {
-              command: 'pnpm',
-              args: [
-                '--filter',
-                '@goose-hub/web',
-                'exec',
-                'playwright',
-                'run-test-mcp-server',
-                '--headless',
-              ],
-              cwd: REPO_ROOT,
-            },
+      // Pre-flight: confirm the MCP server can actually start before spawning
+      // an agent that has only browser_* tools and no fallback. Skipped under
+      // MOCK_AGENTS=true to match the runtime bypass in claude-cli.ts.
+      const preflight =
+        process.env.MOCK_AGENTS === 'true' ? { ok: true as const } : await preflightPlaywrightMcp();
+      if (!preflight.ok) {
+        eventStore.appendEvent({
+          projectId,
+          workItemId: workItem.id,
+          kind: 'agent.run-failed',
+          payload: {
+            runId: playwrightRunId,
+            skill: 'playwright-repro',
+            error: `playwright-test MCP server pre-flight failed: ${preflight.error}`,
           },
-        }),
-      );
-
-      try {
-        const playwrightResult = await runtime.run({
           runId: playwrightRunId,
-          role: 'investigator',
-          skill: 'playwright-repro',
-          workspaceDir: worktreePath,
-          context: {
+        });
+      } else {
+        // Write a runtime MCP config that invokes playwright via pnpm from the
+        // actual repo root (where node_modules exist). The worktree is isolated
+        // from node_modules, so npx/direct invocation fails there.
+        const playwrightMcpConfigPath = join(
+          homedir(),
+          '.factory',
+          'workspaces',
+          `${playwrightRunId}-mcp.json`,
+        );
+        writeFileSync(
+          playwrightMcpConfigPath,
+          JSON.stringify({
+            mcpServers: {
+              'playwright-test': {
+                command: 'pnpm',
+                args: [
+                  '--filter',
+                  '@goose-hub/web',
+                  'exec',
+                  'playwright',
+                  'run-test-mcp-server',
+                  '--headless',
+                ],
+                cwd: REPO_ROOT,
+              },
+            },
+          }),
+        );
+
+        try {
+          const playwrightResult = await runtime.run({
+            runId: playwrightRunId,
+            role: 'investigator',
+            skill: 'playwright-repro',
+            workspaceDir: worktreePath,
+            context: {
+              projectId,
+              workItemId: workItem.id,
+              workItem: {
+                title: workItem.title,
+                body: workItem.body,
+                reproSteps: workItem.body,
+              },
+              appUrl: 'http://localhost:5173',
+            },
+            contextAllowlist: ['workItem', 'appUrl'],
+            freshContext: false,
+            toolBundles: ['playwright-mcp'],
+            toolExtras: [],
+            budgets: { maxTurns: 25, maxBudgetUsd: 5, timeoutMs: 120_000 },
+            personaId: playwrightPersonaId,
+            mcpConfigPath: playwrightMcpConfigPath,
+            outputJsonSchema: playwrightReproJsonSchema,
+            appendSystemPrompt: playwrightReproPrompt,
+          });
+
+          const reproparsed = PlaywrightReproSchema.safeParse(playwrightResult.output);
+          if (reproparsed.success) {
+            reproOutput = reproparsed.data;
+          } else {
+            // Most common cause: agent ran but the MCP server never registered
+            // its tools, so the agent returned a free-text "I cannot do this"
+            // instead of a schema-conforming JSON object. Capture a preview so
+            // the actual agent output is visible in the event stream.
+            const preview =
+              typeof playwrightResult.output === 'string'
+                ? playwrightResult.output.slice(0, 800)
+                : JSON.stringify(playwrightResult.output).slice(0, 800);
+            eventStore.appendEvent({
+              projectId,
+              workItemId: workItem.id,
+              kind: 'agent.run-failed',
+              payload: {
+                runId: playwrightRunId,
+                skill: 'playwright-repro',
+                error: `Output validation failed: ${JSON.stringify(reproparsed.error.issues)}`,
+                outputPreview: preview,
+              },
+              runId: playwrightRunId,
+            });
+          }
+        } catch (err) {
+          // playwright-repro failure is non-fatal — investigate findings are
+          // persisted regardless. But never silent: emit the actual error so
+          // operators can diagnose MCP startup, --strict-mcp-config rejections,
+          // missing browsers, etc.
+          const error = err instanceof Error ? err : new Error(String(err));
+          eventStore.appendEvent({
             projectId,
             workItemId: workItem.id,
-            workItem: {
-              title: workItem.title,
-              body: workItem.body,
-              reproSteps: workItem.body,
+            kind: 'agent.run-failed',
+            payload: {
+              runId: playwrightRunId,
+              skill: 'playwright-repro',
+              error: error.message,
             },
-            appUrl: 'http://localhost:5173',
-          },
-          contextAllowlist: ['workItem', 'appUrl'],
-          freshContext: false,
-          toolBundles: ['playwright-mcp'],
-          toolExtras: [],
-          budgets: { maxTurns: 25, maxBudgetUsd: 5, timeoutMs: 120_000 },
-          personaId: playwrightPersonaId,
-          mcpConfigPath: playwrightMcpConfigPath,
-          outputJsonSchema: playwrightReproJsonSchema,
-          appendSystemPrompt: playwrightReproPrompt,
-        });
-
-        const reproparsed = PlaywrightReproSchema.safeParse(playwrightResult.output);
-        if (reproparsed.success) {
-          reproOutput = reproparsed.data;
+            runId: playwrightRunId,
+          });
         }
-      } catch {
-        // playwright-repro failure is non-fatal — investigate findings are persisted regardless
       }
     }
 


### PR DESCRIPTION
Pre-existing lint failure surfaced by running pnpm lint. Auto-fixed by biome.
Split out so the playwright-repro diagnostics commit stays scoped.