### PR TITLE
M7.XX: Goose hub logo issue 2

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher-mock" />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderSidebar() {
+  render(
+    <MemoryRouter>
+      <Sidebar activeSlug="goose-hub-self" />
+    </MemoryRouter>,
+  );
+}
+
+function stubStorage(value: string | null) {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn().mockReturnValue(value),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  });
+}
+
+describe('Sidebar logo', () => {
+  describe('when collapsed (localStorage key absent)', () => {
+    beforeEach(() => {
+      stubStorage(null);
+    });
+
+    it('shows the G letter badge', () => {
+      renderSidebar();
+      expect(screen.getByTestId('logo-g-badge').textContent).toBe('G');
+    });
+
+    it('does not show full brand name', () => {
+      renderSidebar();
+      expect(screen.queryByText('Goose Hub')).toBeNull();
+    });
+  });
+
+  describe('when expanded (sidebar-collapsed = "false")', () => {
+    beforeEach(() => {
+      stubStorage('false');
+    });
+
+    it('shows the full brand name', () => {
+      renderSidebar();
+      expect(screen.getByText('Goose Hub')).toBeTruthy();
+    });
+
+    it('does not show the G badge', () => {
+      renderSidebar();
+      expect(screen.queryByTestId('logo-g-badge')).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -117,10 +117,12 @@ export function Sidebar({ activeSlug }: SidebarProps) {
       >
         {collapsed ? (
           <span
-            aria-hidden
-            className="inline-block w-1.5 h-4 rounded-sm"
+            data-testid="logo-g-badge"
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md text-white text-[13px] font-bold select-none"
             style={{ background: '#7c3aed' }}
-          />
+          >
+            G
+          </span>
         ) : (
           <div className="flex items-center gap-2">
             <span


### PR DESCRIPTION
## Summary

Goose hub logo issue 2

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — replace collapsed logo from purple bar to G badge
- `apps/web/src/components/chrome/Sidebar.test.tsx` — tests for collapsed and expanded logo states

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (4 cases)

Closes #445
