### PR TITLE
feat(db): replace drizzle-kit push with generate+migrate workflow

### DIFF
--- a/core/db/README.md
+++ b/core/db/README.md
@@ -18,11 +18,15 @@ Drizzle table definitions. Three tables ship in M1; more land in later milestone
 
 ### `db.ts`
 
-Exports the singleton `db` Drizzle handle bound to `better-sqlite3`. Importing it ensures `~/.factory/data/` exists.
+Exports the singleton `db` Drizzle handle bound to `better-sqlite3`. Importing it ensures `~/.factory/data/` exists and applies any pending migrations from `core/db/migrations/` (tracked in `__drizzle_migrations`).
 
 ### `migrate.ts`
 
-Programmatic entry point that touches the DB so the file is created. Schema migrations are applied via `pnpm db:migrate` (drizzle-kit push).
+Programmatic entry point that touches the DB so the file is created. Migrations auto-apply on import via `db.ts`. To author a new migration after a schema change: `pnpm db:generate`. To apply manually: `pnpm db:migrate`.
+
+### `migrations/`
+
+Generated SQL migration files (committed to git). Drizzle compares the schema snapshot in `meta/` against `schema.ts` to produce additive `ALTER TABLE` statements rather than `drizzle-kit push`'s drop-and-recreate behaviour.
 
 ## Consumers
 

--- a/core/db/db.ts
+++ b/core/db/db.ts
@@ -1,15 +1,19 @@
 import { mkdirSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import * as schema from './schema.js';
 
 const dbPath = path.join(os.homedir(), '.factory', 'data', 'factory.db');
-const dbDir = path.dirname(dbPath);
-
-mkdirSync(dbDir, { recursive: true });
+mkdirSync(path.dirname(dbPath), { recursive: true });
 
 const sqlite = new Database(dbPath);
-
 export const db = drizzle(sqlite, { schema });
+
+// Apply any pending migrations on startup. Safe to call repeatedly —
+// drizzle tracks applied migrations in __drizzle_migrations.
+const migrationsFolder = path.join(path.dirname(fileURLToPath(import.meta.url)), 'migrations');
+migrate(db, { migrationsFolder });

--- a/core/db/migrate.ts
+++ b/core/db/migrate.ts
@@ -1,5 +1,7 @@
 import { db } from './db.js';
 
 // Programmatic entry point: ensures ~/.factory/data/ exists and the DB file is
-// created. Table creation is handled by `pnpm db:migrate` (drizzle-kit push).
+// created. Migrations are applied automatically by db.ts on import via migrate().
+// To create a new migration after a schema change: pnpm db:generate
+// To apply manually: pnpm db:migrate
 console.log('DB ready at', db);

--- a/core/db/migrations/0000_red_impossible_man.sql
+++ b/core/db/migrations/0000_red_impossible_man.sql
@@ -1,0 +1,97 @@
+CREATE TABLE `agent_run_costs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`run_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`work_item_id` text,
+	`stage` text NOT NULL,
+	`skill` text NOT NULL,
+	`model_id` text NOT NULL,
+	`input_tokens` integer DEFAULT 0 NOT NULL,
+	`output_tokens` integer DEFAULT 0 NOT NULL,
+	`cost_usd` real DEFAULT 0 NOT NULL,
+	`cost_label` text DEFAULT 'estimated' NOT NULL,
+	`persona_id` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `agent_run_costs_run_id_uniq` ON `agent_run_costs` (`run_id`);--> statement-breakpoint
+CREATE INDEX `agent_run_costs_project_created_idx` ON `agent_run_costs` (`project_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `agent_run_costs_work_item_idx` ON `agent_run_costs` (`work_item_id`);--> statement-breakpoint
+CREATE TABLE `events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` text NOT NULL,
+	`work_item_id` text,
+	`kind` text NOT NULL,
+	`payload` text NOT NULL,
+	`run_id` text,
+	`persona_id` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `events_project_created_idx` ON `events` (`project_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `governance_audit` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`pr_url` text NOT NULL,
+	`project_id` text NOT NULL,
+	`ok` integer NOT NULL,
+	`violations` text NOT NULL,
+	`checked_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `improvement_candidates` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`persona_name` text NOT NULL,
+	`source_task_id` text,
+	`suggestion_text` text NOT NULL,
+	`suggestion_type` text NOT NULL,
+	`project_id` text DEFAULT '' NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`github_issue_url` text,
+	`error_note` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `improvement_candidates_persona_status_idx` ON `improvement_candidates` (`persona_name`,`status`);--> statement-breakpoint
+CREATE TABLE `inbox_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`title` text NOT NULL,
+	`body` text DEFAULT '' NOT NULL,
+	`type` text DEFAULT 'feature' NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `persona_names` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` text NOT NULL,
+	`role` text NOT NULL,
+	`slot_index` integer NOT NULL,
+	`codename` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `persona_names_slot_uniq` ON `persona_names` (`project_id`,`role`,`slot_index`);--> statement-breakpoint
+CREATE TABLE `persona_routing` (
+	`project_id` text NOT NULL,
+	`role` text NOT NULL,
+	`last_index` integer DEFAULT 0 NOT NULL,
+	PRIMARY KEY(`project_id`, `role`)
+);
+--> statement-breakpoint
+CREATE TABLE `persona_stats` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`persona_name` text NOT NULL,
+	`role` text NOT NULL,
+	`runs_total` integer DEFAULT 0 NOT NULL,
+	`runs_succeeded` integer DEFAULT 0 NOT NULL,
+	`runs_failed` integer DEFAULT 0 NOT NULL,
+	`avg_quality_score` real DEFAULT 1 NOT NULL,
+	`last_run_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `persona_stats_persona_role_uniq` ON `persona_stats` (`persona_name`,`role`);--> statement-breakpoint
+CREATE TABLE `project_state` (
+	`project_id` text PRIMARY KEY NOT NULL,
+	`active_milestone_number` integer,
+	`active_milestone_set_at` text,
+	`active_milestone_set_by` text,
+	`last_tick_at` text
+);

--- a/core/db/migrations/meta/0000_snapshot.json
+++ b/core/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,636 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a93e1724-083b-43e3-a674-0ec036778fb0",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1777946562070,
+      "tag": "0000_red_impossible_man",
+      "breakpoints": true
+    }
+  ]
+}

--- a/core/db/smoke.test.ts
+++ b/core/db/smoke.test.ts
@@ -1,6 +1,9 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { events, governanceAudit, personaNames, projectState } from './schema.js';
 
@@ -127,5 +130,27 @@ describe('core/db smoke', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].codename).toBe('Grey Honker');
     expect(rows[0].slotIndex).toBe(0);
+  });
+});
+
+describe('drizzle migrations', () => {
+  it('__drizzle_migrations table exists after migrate runs against a fresh DB', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite);
+    const migrationsFolder = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'migrations',
+    );
+    migrate(db, { migrationsFolder });
+
+    const trackingRows = sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='__drizzle_migrations'")
+      .all();
+    expect(trackingRows).toHaveLength(1);
+
+    const tableRows = sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='persona_names'")
+      .all();
+    expect(tableRows).toHaveLength(1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "coverage": "vitest run --coverage",
     "test:e2e": "pnpm --filter @goose-hub/web test:e2e",
     "install-labels": "tsx scripts/install-labels.ts",
-    "db:migrate": "drizzle-kit push --config=drizzle.config.ts",
+    "db:generate": "drizzle-kit generate --config=drizzle.config.ts",
+    "db:migrate": "drizzle-kit migrate --config=drizzle.config.ts",
     "cleanup-worktrees": "bash scripts/cleanup-worktrees.sh",
     "backfill:persona-names": "tsx scripts/backfill-persona-names.ts"
   },


### PR DESCRIPTION
Replaces drizzle-kit push (which silently drops and recreates tables on
schema diff, wiping persona_names codenames) with explicit SQL migration
files. Adds the baseline migration snapshot, wires migrate() into db.ts
so pending migrations auto-apply on import, and exposes pnpm db:generate
for authoring new migrations alongside the renamed pnpm db:migrate
(drizzle-kit migrate).

Adds a smoke test that applies the migrations folder to a fresh
in-memory DB and verifies __drizzle_migrations plus expected tables.