### PR TITLE
M7.XX: Bug sidebar header new

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -1,3 +1,5 @@
+export const SIDEBAR_HEADER_LABEL = 'Agentic OS';
+
 import { cn } from '@/lib/cn';
 import {
   ChevronLeft,
@@ -129,7 +131,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              {SIDEBAR_HEADER_LABEL}
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { SIDEBAR_HEADER_LABEL } from './Sidebar';
 
 // Chrome is mostly React components; the slice test ensures the public files
 // exist and the milestone-stub configuration stays honest with the M2 plan.
@@ -36,5 +37,9 @@ describe('chrome slice — deferred surfaces config', () => {
     const storedFalse = 'false';
     const collapsed = storedFalse !== 'false';
     expect(collapsed).toBe(false);
+  });
+
+  it('sidebar header label is "Agentic OS"', () => {
+    expect(SIDEBAR_HEADER_LABEL).toBe('Agentic OS');
   });
 });


### PR DESCRIPTION
## Summary

Bug sidebar header new

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — export SIDEBAR_HEADER_LABEL = 'Agentic OS', use in JSX
- `apps/web/src/components/chrome/slice.test.ts` — contract test asserting sidebar header label is 'Agentic OS'

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (1 cases)

Closes #450
