### PR TITLE
M7.XX: Bug sidebar new bug 3

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,37 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('@/state/active-project', () => ({
+  useActiveProject: () => ({
+    projects: [],
+    loading: false,
+    error: null,
+    activeSlug: null,
+    setActiveSlug: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  // Return 'false' for sidebar-collapsed so the header text is visible (not collapsed)
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (key === 'sidebar-collapsed' ? 'false' : null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  });
+});
+
+describe('Sidebar header label', () => {
+  it('displays "Agentic OS" not "Goose Hub"', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Agentic OS')).toBeTruthy();
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Bug sidebar new bug 3

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — change header text from Goose Hub to Agentic OS
- `apps/web/src/components/chrome/Sidebar.test.tsx` — regression test: sidebar header renders Agentic OS

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (1 cases)

Closes #452
