### PR TITLE
M7.XX: Bug sidebar header new

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => null,
+}));
+
+afterEach(cleanup);
+
+describe('Sidebar header label', () => {
+  it('displays "Agentic OS" after expanding sidebar', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    // Default is collapsed; click expand
+    const expandBtn = screen.getByTitle('Expand sidebar');
+    fireEvent.click(expandBtn);
+    expect(screen.getByText('Agentic OS')).toBeTruthy();
+  });
+
+  it('does not display "Goose Hub" after expanding sidebar', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    const expandBtn = screen.getByTitle('Expand sidebar');
+    fireEvent.click(expandBtn);
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Bug sidebar header new

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — change header text from 'Goose Hub' to 'Agentic OS'
- `apps/web/src/components/chrome/Sidebar.test.tsx` — tests verifying header displays 'Agentic OS'

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)

Closes #450
