### PR TITLE
M7.XX: bug: review skill emits empty criteriaChecks[] des

### DIFF
--- a/skills/review/skill.md
+++ b/skills/review/skill.md
@@ -209,6 +209,8 @@ Bad summaries:
 
 Return a JSON object conforming exactly to this structure.
 
+**`criteriaChecks` MUST contain one entry per acceptance criterion extracted in Step 1.** Do not leave this array empty if you found criteria. `criteriaChecks: []` is never valid when the issue contains acceptance criteria — it signals that criteria were not checked and will cause the review to be rejected by the orchestrator. Every criterion you listed in Step 1 must appear here with a `met`, `unmet`, or `unclear` status.
+
 For `approved` or `needs-fix`:
 
 ```json
@@ -272,3 +274,4 @@ For `needs-human` (escalationReason is REQUIRED):
 - If a criterion appears trivially met, still document why — "README.md present with all required sections on lines 1–45."
 - The QA verdict is context, not directive. A QA `pass` does not guarantee your `approved`.
 - **Optional fields must be OMITTED, not null.** When a finding has no specific source location, omit `file` and `line` entirely — never write `"file": null` or `"line": null`. Same applies to `escalationReason` on non-`needs-human` verdicts — omit it entirely.
+- **`criteriaChecks` must have one entry per criterion from Step 1.** `criteriaChecks: []` is never valid when criteria exist — populate it from your Step 3 verification before returning.

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import config, { ReviewContextSchema } from './config.js';
 import { CriterionCheckSchema, ReviewFindingSchema, ReviewOutputSchema } from './schema.js';
@@ -288,6 +290,22 @@ describe('confidence range validation', () => {
   it('rejects confidence below 0.0', () => {
     const result = ReviewOutputSchema.safeParse(makeApprovedOutput({ confidence: -0.1 }));
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── skill.md — criteriaChecks output requirement ────────────────────────────
+
+describe('skill.md — criteriaChecks population requirement', () => {
+  const skillMd = readFileSync(join(import.meta.dirname, 'skill.md'), 'utf-8');
+
+  it('output format section explicitly requires one entry per criterion', () => {
+    // Must contain language stating criteriaChecks needs one entry per criterion
+    expect(skillMd).toMatch(/criteriaChecks.*one entry per/s);
+  });
+
+  it('warns that empty criteriaChecks array is never valid when criteria exist', () => {
+    // Must contain a warning that criteriaChecks: [] is never valid
+    expect(skillMd).toMatch(/criteriaChecks.*\[\].*never valid|criteriaChecks: \[\].*never valid/s);
   });
 });
 


### PR DESCRIPTION
## Summary

bug: review skill emits empty criteriaChecks[] despite checking criteria

## Files
- `skills/review/slice.test.ts` — 2 new tests asserting skill.md contains explicit criteriaChecks requirement
- `skills/review/skill.md` — Add explicit criteriaChecks population requirement to output format section and Important reminders

## Tests
- `skills/review/slice.test.ts` (2 cases)

Closes #456
