### PR TITLE
M7.XX: Bug sidebar 4

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -14,6 +14,8 @@ import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { ProjectSwitcherSlot } from './slots/ProjectSwitcherSlot';
 
+export const SIDEBAR_BRAND = 'Agentic OS';
+
 interface SidebarItem {
   to: string;
   label: string;
@@ -129,7 +131,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              {SIDEBAR_BRAND}
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { SIDEBAR_BRAND } from './Sidebar';
 
 // Chrome is mostly React components; the slice test ensures the public files
 // exist and the milestone-stub configuration stays honest with the M2 plan.
@@ -11,6 +12,12 @@ const DEFERRED_SURFACES = [
   { label: 'Settings', milestone: 'later' },
   { label: 'Bootstrap', milestone: 'M12' },
 ];
+
+describe('chrome slice — sidebar brand label', () => {
+  it('sidebar header reads "Agentic OS"', () => {
+    expect(SIDEBAR_BRAND).toBe('Agentic OS');
+  });
+});
 
 describe('chrome slice — deferred surfaces config', () => {
   it('every deferred surface has a milestone tag', () => {


### PR DESCRIPTION
## Summary

Bug sidebar 4

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — export SIDEBAR_BRAND='Agentic OS'; use in header JSX
- `apps/web/src/components/chrome/slice.test.ts` — test SIDEBAR_BRAND equals 'Agentic OS'

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (1 cases)

Closes #458
