### PR TITLE
M7.XX: Bug sidebar 5

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => null,
+}));
+
+// Stub localStorage so getInitialCollapsed() returns false (expanded),
+// making the header label visible.
+const mockStorage: Record<string, string> = {};
+const localStorageStub = {
+  getItem: (key: string) => mockStorage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    mockStorage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete mockStorage[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(mockStorage)) delete mockStorage[k];
+  },
+  get length() {
+    return Object.keys(mockStorage).length;
+  },
+};
+
+describe('Sidebar header label', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageStub);
+    mockStorage['sidebar-collapsed'] = 'false';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const k of Object.keys(mockStorage)) delete mockStorage[k];
+  });
+
+  it('displays "Agentic OS" not "Goose Hub"', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeSlug={undefined} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Agentic OS')).toBeDefined();
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Bug sidebar 5

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Fix header label text per issue #460
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Test that 'Agentic OS' renders and 'Goose Hub' does not

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (1 cases)

Closes #460
