### PR TITLE
M7.XX: Bug sidebar 6

### DIFF
--- a/apps/web/e2e/issue-462.spec.ts
+++ b/apps/web/e2e/issue-462.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar header reads "Agentic OS" not "Goose Hub"', async ({ page }) => {
+  await page.goto('/');
+
+  // Expand sidebar if collapsed
+  const sidebar = page.getByTestId('sidebar');
+  await sidebar.waitFor({ state: 'visible' });
+
+  // Expand if the sidebar is collapsed (w-12 means collapsed)
+  const sidebarClass = await sidebar.getAttribute('class');
+  if (sidebarClass?.includes('w-12')) {
+    const toggle = sidebar.locator('[data-testid="sidebar-toggle"], button').first();
+    await toggle.click();
+  }
+
+  // Assert the header label
+  await expect(page.getByText('Agentic OS')).toBeVisible();
+  await expect(page.getByText('Goose Hub')).not.toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-462/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('@/state/active-project', () => ({
+  useActiveProject: () => ({
+    projects: [],
+    loading: false,
+    error: null,
+    activeSlug: 'test-project',
+    setActiveSlug: vi.fn(),
+  }),
+}));
+
+// Provide a working localStorage so Sidebar reads sidebar-collapsed = 'false' (expanded)
+const localStorageMap = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => localStorageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    localStorageMap.set(key, value);
+  },
+  removeItem: (key: string) => {
+    localStorageMap.delete(key);
+  },
+  clear: () => {
+    localStorageMap.clear();
+  },
+  get length() {
+    return localStorageMap.size;
+  },
+  key: (index: number) => [...localStorageMap.keys()][index] ?? null,
+};
+
+beforeEach(() => {
+  localStorageMap.clear();
+  localStorageMap.set('sidebar-collapsed', 'false');
+  vi.stubGlobal('localStorage', localStorageMock);
+});
+
+describe('Sidebar', () => {
+  it('displays "Agentic OS" as the header label', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeSlug="test-project" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Agentic OS')).toBeTruthy();
+  });
+
+  it('does not display "Goose Hub" as the header label', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeSlug="test-project" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Bug sidebar 6

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — change header text from 'Goose Hub' to 'Agentic OS'
- `apps/web/src/components/chrome/Sidebar.test.tsx` — unit tests asserting sidebar header text
- `apps/web/e2e/issue-462.spec.ts` — Playwright e2e spec for visual evidence

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)

Closes #462
