### PR TITLE
fix: resolve agent-context by project slug, not project id

### DIFF
--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -182,7 +182,7 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
       runQaWorkflow: (
         item: unknown,
         source: unknown,
-        projectId: string,
+        projectSlug: string,
         targetRepo: string,
       ) => Promise<unknown>;
     };
@@ -192,7 +192,7 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
       return;
     }
     const item = await source.getItem(issueNumber.toString());
-    await runQaWorkflow(item, source, source.projectId, item.repoRef ?? slug);
+    await runQaWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
     _issueInFlight.delete(key);
   }
@@ -214,7 +214,7 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
       runReviewWorkflow: (
         item: unknown,
         source: unknown,
-        projectId: string,
+        projectSlug: string,
         targetRepo: string,
       ) => Promise<unknown>;
     };
@@ -224,7 +224,7 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
       return;
     }
     const item = await source.getItem(issueNumber.toString());
-    await runReviewWorkflow(item, source, source.projectId, item.repoRef ?? slug);
+    await runReviewWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
     _issueInFlight.delete(key);
   }

--- a/core/agent-runtime/read-prompt.ts
+++ b/core/agent-runtime/read-prompt.ts
@@ -7,20 +7,20 @@ const DEFAULT_REPO_ROOT = join(import.meta.dirname, '../..');
  * Reads a skill's base prompt and optionally appends project-specific context.
  *
  * Looks for base prompt at: skills/<skillName>/skill.md
- * Looks for project context at: target-projects/<projectId>/agent-context/<skillName>.md
+ * Looks for project context at: target-projects/<projectSlug>/agent-context/<skillName>.md
  *
  * The optional repoRoot parameter exists for testing — production callers omit it.
  */
 export function readPromptWithContext(
   skillName: string,
-  projectId: string,
+  projectSlug: string,
   repoRoot: string = DEFAULT_REPO_ROOT,
 ): string {
   const basePrompt = readFileSync(join(repoRoot, 'skills', skillName, 'skill.md'), 'utf8');
   const contextPath = join(
     repoRoot,
     'target-projects',
-    projectId,
+    projectSlug,
     'agent-context',
     `${skillName}.md`,
   );

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -68,16 +68,16 @@ async function defaultRunTests(cwd: string, command: string): Promise<TestRun | 
 export async function runQaWorkflow(
   workItem: WorkItem,
   stateSource: StateSource,
-  projectId: string,
+  projectSlug: string,
   _targetRepo: string,
   deps: QaWorkflowDeps = {},
 ): Promise<void> {
   const runId = crypto.randomUUID();
   const runtime = deps.runtime ?? new ClaudeCliRuntime();
   const runTests = deps.runTests ?? defaultRunTests;
-  const qaPrompt = readPromptWithContext('qa', projectId);
+  const qaPrompt = readPromptWithContext('qa', projectSlug);
   const qaJsonSchema = toJsonSchema(QaOutputSchema);
-  const { personaId } = selectPersona(projectId, 'qa');
+  const { personaId } = selectPersona(projectSlug, 'qa');
   const prDiff = getPrDiff(workItem);
   const workspaceDir = findDevWorktreePath(workItem.id);
 
@@ -97,7 +97,7 @@ export async function runQaWorkflow(
       role: 'qa',
       skill: 'qa',
       context: {
-        projectId,
+        projectId: projectSlug,
         workItemId: workItem.id,
         workItem: {
           title: workItem.title,
@@ -140,7 +140,7 @@ export async function runQaWorkflow(
     ][]) {
       if (!qaOutput.tierResults[tier].passed) {
         eventStore.appendEvent({
-          projectId,
+          projectId: projectSlug,
           workItemId: workItem.id,
           kind,
           payload: { tier, findings: qaOutput.tierResults[tier].findings },
@@ -154,7 +154,7 @@ export async function runQaWorkflow(
     // agent might echo back — even if the schema accepts it from the agent,
     // we trust our own measurement.
     eventStore.appendEvent({
-      projectId,
+      projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'qa.completed',
       payload: {
@@ -170,7 +170,7 @@ export async function runQaWorkflow(
 
     for (const summary of qaOutput.decisionSummaries) {
       eventStore.appendEvent({
-        projectId,
+        projectId: projectSlug,
         workItemId: workItem.id,
         kind: 'agent.decision-summary',
         payload: { skill: 'qa', ...summary },
@@ -192,7 +192,7 @@ export async function runQaWorkflow(
       nextState = needsEscalation ? 'factory:needs-human' : 'factory:qa-failed';
       if (needsEscalation) {
         eventStore.appendEvent({
-          projectId,
+          projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'agent.retry-escalated',
           payload: { stage: 'qa', maxRetries: DEFAULT_MAX_RETRIES, runId },
@@ -217,7 +217,7 @@ export async function runQaWorkflow(
     accumulatePersonaStats({ personaName: personaId, role: 'qa', outcome: 'failure' });
     const error = err instanceof Error ? err : new Error(String(err));
     eventStore.appendEvent({
-      projectId,
+      projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
       payload: { runId, error: error.message },

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -27,15 +27,15 @@ export interface ReviewWorkflowDeps {
 export async function runReviewWorkflow(
   workItem: WorkItem,
   stateSource: StateSource,
-  projectId: string,
+  projectSlug: string,
   _targetRepo: string,
   deps: ReviewWorkflowDeps = {},
 ): Promise<void> {
   const runId = crypto.randomUUID();
   const runtime = deps.runtime ?? new ClaudeCliRuntime();
-  const reviewPrompt = readPromptWithContext('review', projectId);
+  const reviewPrompt = readPromptWithContext('review', projectSlug);
   const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
-  const { personaId } = selectPersona(projectId, 'reviewer');
+  const { personaId } = selectPersona(projectSlug, 'reviewer');
 
   // Snapshot prior events BEFORE this run's outcome is appended (same pattern as QA workflow).
   const priorEvents = eventStore.replay({ workItemId: workItem.id });
@@ -49,7 +49,7 @@ export async function runReviewWorkflow(
       role: 'reviewer',
       skill: 'review',
       context: {
-        projectId,
+        projectId: projectSlug,
         workItemId: workItem.id,
         workItem: {
           title: workItem.title,
@@ -76,7 +76,7 @@ export async function runReviewWorkflow(
     const reviewOutput = parsed.data;
 
     eventStore.appendEvent({
-      projectId,
+      projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'review.completed',
       payload: { verdict: reviewOutput.verdict, confidence: reviewOutput.confidence },
@@ -85,7 +85,7 @@ export async function runReviewWorkflow(
 
     for (const summary of reviewOutput.decisionSummaries) {
       eventStore.appendEvent({
-        projectId,
+        projectId: projectSlug,
         workItemId: workItem.id,
         kind: 'agent.decision-summary',
         payload: { skill: 'review', ...summary },
@@ -103,7 +103,7 @@ export async function runReviewWorkflow(
       nextState = needsEscalation ? 'factory:needs-human' : 'factory:needs-fix';
       if (needsEscalation) {
         eventStore.appendEvent({
-          projectId,
+          projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'agent.retry-escalated',
           payload: { stage: 'review', maxRetries: DEFAULT_MAX_RETRIES, runId },
@@ -129,7 +129,7 @@ export async function runReviewWorkflow(
     const error = err instanceof Error ? err : new Error(String(err));
 
     eventStore.appendEvent({
-      projectId,
+      projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
       payload: { runId, error: error.message, skill: 'review' },


### PR DESCRIPTION
readPromptWithContext was building the path using the projectId field
(cfg.id) but target-projects directories are keyed by slug (cfg.slug).
dispatchQa and dispatchReview were passing source.projectId instead of
slug, causing agent-context files to silently go missing for any project
where id !== slug. dispatchInvestigate and dispatchFixIssue already
passed slug correctly.

https://claude.ai/code/session_01RkRnuzYLgqgG5xbKwzwNjv