### PR TITLE
M7.XX: Bug sidebar 7

### DIFF
--- a/apps/web/e2e/issue-470.spec.ts
+++ b/apps/web/e2e/issue-470.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('issue-470: sidebar header reads "Agentic OS"', () => {
+  test('sidebar header label is "Agentic OS"', async ({ page }) => {
+    await page.goto('/');
+    // Wait for sidebar to be present
+    await page.waitForSelector('[data-testid="sidebar"]');
+
+    // Expand sidebar if collapsed (look for the expand button)
+    const expandBtn = page.getByTitle('Expand sidebar');
+    if (await expandBtn.isVisible()) {
+      await expandBtn.click();
+    }
+
+    // Wait for the header text to appear
+    await page.waitForSelector('text=Agentic OS');
+
+    await expect(page.getByText('Agentic OS')).toBeVisible();
+    await expect(page.getByText('Goose Hub')).not.toBeVisible();
+
+    await page.screenshot({ path: 'evidence/issue-470/step-1.png' });
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+// Mock ProjectSwitcherSlot — it calls useActiveProject which needs a running server
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher-mock" />,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Sidebar header label', () => {
+  it('displays "Agentic OS" after expanding the sidebar', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    // Sidebar starts collapsed — expand it (toggle wraps localStorage in try-catch)
+    fireEvent.click(screen.getByTitle('Expand sidebar'));
+    expect(screen.getByText('Agentic OS')).toBeTruthy();
+  });
+
+  it('does NOT display "Goose Hub" after expanding the sidebar', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByTitle('Expand sidebar'));
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Bug sidebar 7

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Change sidebar header text from 'Goose Hub' to 'Agentic OS' at line 132
- `apps/web/src/components/chrome/Sidebar.test.tsx` — New jsdom render test verifying 'Agentic OS' header label
- `apps/web/e2e/issue-470.spec.ts` — Playwright e2e spec asserting sidebar header text and capturing screenshot

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)

Closes #470
