### PR TITLE
M7.XX: Bug sidebar 8

### DIFF
--- a/apps/web/e2e/issue-475.spec.ts
+++ b/apps/web/e2e/issue-475.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('issue-475: sidebar brand label', () => {
+  test('sidebar header reads "Agentic OS" not "Goose Hub"', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="sidebar"]');
+
+    const sidebar = page.getByTestId('sidebar');
+    await expect(sidebar).toContainText('Agentic OS');
+    await expect(sidebar).not.toContainText('Goose Hub');
+
+    await page.screenshot({ path: 'evidence/issue-475/step-1.png' });
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -129,7 +129,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Chrome is mostly React components; the slice test ensures the public files
@@ -11,6 +13,21 @@ const DEFERRED_SURFACES = [
   { label: 'Settings', milestone: 'later' },
   { label: 'Bootstrap', milestone: 'M12' },
 ];
+
+describe('chrome slice — sidebar brand label', () => {
+  const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
+
+  it('sidebar header reads "Agentic OS"', () => {
+    expect(sidebarSource).toContain('Agentic OS');
+  });
+
+  it('sidebar header does not read "Goose Hub"', () => {
+    // "Goose Hub" must not appear as the brand label in the sidebar
+    // (checking the specific label span line only — "Goose Hub" may appear in comments elsewhere)
+    const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
+  });
+});
 
 describe('chrome slice — deferred surfaces config', () => {
   it('every deferred surface has a milestone tag', () => {


### PR DESCRIPTION
## Summary

Bug sidebar 8

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — rename brand label Goose Hub → Agentic OS at line 132
- `apps/web/src/components/chrome/slice.test.ts` — add 2 contract tests asserting sidebar header text
- `apps/web/e2e/issue-475.spec.ts` — Playwright spec: navigate to /, assert sidebar reads Agentic OS

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)

Closes #475
