### PR TITLE
M9.XX: wire retrospective workflow into server dispatcher

### DIFF
--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -3,11 +3,13 @@ import {
   mergePR as defaultMergePR,
 } from '@goose-hub/core/connectors/github/merge-pr.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { logger } from '@goose-hub/core/logger.js';
 import { STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { isLegalTransition, legalTargets } from '@goose-hub/core/state-machine/transitions.js';
 import { cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
 import { CACHE_KEY, bustCache } from '#shared/cache.js';
+import { dispatchRetro } from '#shared/dispatch.js';
 import type { Result } from '#shared/middleware.js';
 import { getSourceForSlug } from '#shared/source.js';
 import { getRepoRef } from './internal.js';
@@ -101,6 +103,14 @@ export async function approveIssue(
 
   await source.transitionState(id, 'factory:approved', 'factory:retrospecting');
   await source.comment(id, `Approved via Goose Hub UI; PR #${prNumber} merged (${merged.sha}).`);
+
+  // Fire-and-forget the retrospective workflow. The webhook label-change
+  // handler will also dispatch retro on the factory:retrospecting label, but
+  // running it here avoids depending on webhook delivery for the post-merge
+  // path. dispatchRetro is idempotent via the in-flight guard.
+  dispatchRetro(slug, Number(id)).catch((err: unknown) => {
+    logger.error('dispatchRetro after approve failed', { slug, id, error: String(err) });
+  });
 
   return { ok: true, data: { ok: true, sha: merged.sha, prNumber } };
 }

--- a/apps/server/src/domains/workflows/retro-batch.test.ts
+++ b/apps/server/src/domains/workflows/retro-batch.test.ts
@@ -1,0 +1,223 @@
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── module mocks ──────────────────────────────────────────────────────────────
+
+const mockRun = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi
+    .fn()
+    .mockReturnValue({ personaId: 'goose-hub-self/retrospector/0', codename: 'Grey Honker' }),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/read-prompt.js', () => ({
+  readPromptWithContext: vi.fn().mockReturnValue('# mock retrospective prompt'),
+}));
+
+const mockReplay = vi.fn().mockReturnValue([]);
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: vi.fn().mockReturnValue({ id: 1, kind: 'test', payload: {}, createdAt: '' }),
+    replay: mockReplay,
+  },
+}));
+
+vi.mock('@goose-hub/core/persona/accumulate.js', () => ({
+  accumulatePersonaStats: vi.fn(),
+}));
+
+vi.mock('@goose-hub/core/db/db.js', () => ({
+  db: { insert: () => ({ values: () => ({ run: vi.fn() }) }) },
+}));
+
+const mockGetProject = vi.fn();
+vi.mock('../../shared/projects.js', () => ({ getProject: mockGetProject }));
+
+const mockGetSourceForSlug = vi.fn();
+vi.mock('../../shared/source.js', () => ({
+  getSourceForSlug: mockGetSourceForSlug,
+  isValidSlug: (s: string) => /^[a-zA-Z0-9_-]+$/.test(s),
+}));
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:shaunnez/goose-hub#42',
+    externalId: '42',
+    repoRef: 'shaunnez/goose-hub',
+    title: 'Test retrospective',
+    body: 'Retro fixture',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:retrospecting',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeMockSource(items: WorkItem[] = []): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    listOpenWork: vi.fn().mockResolvedValue(items),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn().mockResolvedValue(undefined),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn().mockResolvedValue(undefined),
+    setLabelInGroup: vi.fn().mockResolvedValue(undefined),
+    attach: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+  };
+}
+
+function makeLightRetroOutput() {
+  return {
+    summary: 'All went well.',
+    whatWorked: ['tests caught the bug'],
+    whatDidnt: [],
+    improvementCandidates: [],
+    decisionSummaries: [{ step: 'retro', summary: 'Light retro complete' }],
+  };
+}
+
+function makeDeepRetroOutput() {
+  return {
+    summary: 'QA failed; deep dive.',
+    whatWorked: [],
+    whatDidnt: ['missed an edge case'],
+    rootCauses: ['no test for empty input'],
+    improvementCandidates: [
+      { kind: 'persona-tweak', suggestionText: 'Add empty-input check to QA prompt' },
+    ],
+    decisionSummaries: [{ step: 'retro', summary: 'Deep retro complete' }],
+  };
+}
+
+function makeAgentResult(output: unknown): AgentResult {
+  return { output, decisionSummaries: [], events: [] };
+}
+
+function projectConfigWith(defaultTier: 'light' | 'deep') {
+  return {
+    agentConfig: {
+      retrospectivePolicy: { defaultTier, deepTriggers: [] },
+    },
+  };
+}
+
+const SLUG = 'goose-hub-self';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRun.mockReset();
+  mockReplay.mockReturnValue([]);
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('runRetroBatch', () => {
+  it('processes only items in factory:retrospecting and runs the workflow', async () => {
+    const retroItem = makeWorkItem({ state: 'factory:retrospecting' });
+    const otherItem = makeWorkItem({
+      id: 'github:shaunnez/goose-hub#43',
+      externalId: '43',
+      state: 'factory:needs-qa',
+    });
+    const source = makeMockSource([retroItem, otherItem]);
+    mockGetProject.mockResolvedValue(projectConfigWith('light'));
+    mockRun.mockResolvedValueOnce(makeAgentResult(makeLightRetroOutput()));
+
+    const { runRetroBatch } = await import('./retro-batch.js');
+    await runRetroBatch(SLUG, source);
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:retrospecting',
+      'factory:done',
+    );
+  });
+
+  it('runs deep retro when QA failed for the work item', async () => {
+    const retroItem = makeWorkItem({ state: 'factory:retrospecting' });
+    const source = makeMockSource([retroItem]);
+    mockGetProject.mockResolvedValue(projectConfigWith('light'));
+    mockReplay.mockReturnValue([
+      { id: 1, kind: 'qa.completed', payload: { verdict: 'fail' }, createdAt: '' },
+    ]);
+    mockRun.mockResolvedValueOnce(makeAgentResult(makeDeepRetroOutput()));
+
+    const { runRetroBatch } = await import('./retro-batch.js');
+    await runRetroBatch(SLUG, source);
+
+    // tier=deep emitted via agent.run-started; assert by inspecting the runtime call
+    const runtimeArgs = mockRun.mock.calls[0]?.[0] as { skill?: string };
+    expect(runtimeArgs.skill).toBe('retrospective-deep');
+  });
+
+  it('runs light retro when defaultTier=light and no triggers fire', async () => {
+    const retroItem = makeWorkItem({ state: 'factory:retrospecting' });
+    const source = makeMockSource([retroItem]);
+    mockGetProject.mockResolvedValue(projectConfigWith('light'));
+    mockRun.mockResolvedValueOnce(makeAgentResult(makeLightRetroOutput()));
+
+    const { runRetroBatch } = await import('./retro-batch.js');
+    await runRetroBatch(SLUG, source);
+
+    const runtimeArgs = mockRun.mock.calls[0]?.[0] as { skill?: string };
+    expect(runtimeArgs.skill).toBe('retrospective-light');
+  });
+
+  it('forces deep retro when defaultTier=deep regardless of triggers', async () => {
+    const retroItem = makeWorkItem({ state: 'factory:retrospecting' });
+    const source = makeMockSource([retroItem]);
+    mockGetProject.mockResolvedValue(projectConfigWith('deep'));
+    mockRun.mockResolvedValueOnce(makeAgentResult(makeDeepRetroOutput()));
+
+    const { runRetroBatch } = await import('./retro-batch.js');
+    await runRetroBatch(SLUG, source);
+
+    const runtimeArgs = mockRun.mock.calls[0]?.[0] as { skill?: string };
+    expect(runtimeArgs.skill).toBe('retrospective-deep');
+  });
+
+  it('transitions to factory:needs-human if the workflow throws', async () => {
+    const retroItem = makeWorkItem({ state: 'factory:retrospecting' });
+    const source = makeMockSource([retroItem]);
+    mockGetProject.mockResolvedValue(projectConfigWith('light'));
+    mockRun.mockRejectedValueOnce(new Error('runtime exploded'));
+
+    const { runRetroBatch } = await import('./retro-batch.js');
+    await runRetroBatch(SLUG, source);
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:retrospecting',
+      'factory:needs-human',
+    );
+  });
+});

--- a/apps/server/src/domains/workflows/retro-batch.ts
+++ b/apps/server/src/domains/workflows/retro-batch.ts
@@ -1,0 +1,59 @@
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { logger } from '@goose-hub/core/logger.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import type {
+  RetrospectivePolicy,
+  TriggerContext,
+} from '@goose-hub/core/workflows/retrospective.js';
+import { runRetrospectiveWorkflow } from '@goose-hub/core/workflows/retrospective.js';
+import { getProject } from '#shared/projects.js';
+import { getSourceForSlug } from '#shared/source.js';
+
+function resolvePolicy(defaultTier: 'light' | 'deep' | undefined): RetrospectivePolicy {
+  // `defaultTier: 'deep'` means run deep unconditionally. `light` (or unset)
+  // means allow auto-escalation via triggers, falling back to light otherwise.
+  return defaultTier === 'deep' ? 'always-deep' : 'auto';
+}
+
+function computeTriggers(slug: string, workItem: WorkItem): TriggerContext {
+  const events = eventStore.replay({ projectId: slug, workItemId: workItem.id });
+  const qaFailed = events.some(
+    (e) =>
+      e.kind === 'qa.completed' && (e.payload as { verdict?: string } | null)?.verdict === 'fail',
+  );
+  // firstRunInMilestone, qualityScoreDeclining, humanRequested are deferred
+  // (v1). The workflow treats undefined as falsy in selectTier.
+  return { qaFailed };
+}
+
+export async function runRetroForItem(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  slug: string,
+): Promise<void> {
+  const cfg = await getProject(slug);
+  const policy = resolvePolicy(cfg?.agentConfig.retrospectivePolicy.defaultTier);
+  const triggers = computeTriggers(slug, workItem);
+  await runRetrospectiveWorkflow({
+    workItem,
+    stateSource,
+    projectId: slug,
+    policy,
+    triggers,
+  });
+}
+
+export async function runRetroBatch(slug: string, source?: StateSource): Promise<void> {
+  logger.info('retro-batch started', { slug });
+  const stateSource = source ?? (await getSourceForSlug(slug));
+  if (stateSource == null) throw new Error(`Project not found: ${slug}`);
+
+  const allItems = await stateSource.listOpenWork();
+  const retroItems = allItems.filter((item) => item.state === 'factory:retrospecting');
+  logger.info('retro-batch items', { slug, count: retroItems.length });
+
+  for (const item of retroItems) {
+    await runRetroForItem(item, stateSource, slug);
+  }
+  logger.info('retro-batch finished', { slug, processed: retroItems.length });
+}

--- a/apps/server/src/domains/workflows/router.test.ts
+++ b/apps/server/src/domains/workflows/router.test.ts
@@ -3,15 +3,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 
-const { mockRunTriageBatch, mockRunQaBatch, mockRunReviewBatch } = vi.hoisted(() => ({
-  mockRunTriageBatch: vi.fn().mockResolvedValue(undefined),
-  mockRunQaBatch: vi.fn().mockResolvedValue(undefined),
-  mockRunReviewBatch: vi.fn().mockResolvedValue(undefined),
-}));
+const { mockRunTriageBatch, mockRunQaBatch, mockRunReviewBatch, mockRunRetroBatch } = vi.hoisted(
+  () => ({
+    mockRunTriageBatch: vi.fn().mockResolvedValue(undefined),
+    mockRunQaBatch: vi.fn().mockResolvedValue(undefined),
+    mockRunReviewBatch: vi.fn().mockResolvedValue(undefined),
+    mockRunRetroBatch: vi.fn().mockResolvedValue(undefined),
+  }),
+);
 
 vi.mock('./triage-batch.js', () => ({ runTriageBatch: mockRunTriageBatch }));
 vi.mock('./qa-batch.js', () => ({ runQaBatch: mockRunQaBatch }));
 vi.mock('./review-batch.js', () => ({ runReviewBatch: mockRunReviewBatch }));
+vi.mock('./retro-batch.js', () => ({
+  runRetroBatch: mockRunRetroBatch,
+  runRetroForItem: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('@goose-hub/core/logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -110,6 +117,34 @@ describe('POST /projects/:slug/run-review', () => {
     mockRunReviewBatch.mockRejectedValueOnce(new Error('review error'));
     const app = makeApp();
     const res = await app.request('/projects/review-proj/run-review', { method: 'POST' });
+    expect(res.status).toBe(202);
+  });
+});
+
+describe('POST /projects/:slug/run-retro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 202 with ok:true and slug', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/run-retro', { method: 'POST' });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { ok: boolean; slug: string };
+    expect(body.ok).toBe(true);
+    expect(body.slug).toBe('goose-hub-self');
+  });
+
+  it('fires runRetroBatch asynchronously', async () => {
+    const app = makeApp();
+    await app.request('/projects/retro-proj/run-retro', { method: 'POST' });
+    await vi.waitFor(() => expect(mockRunRetroBatch).toHaveBeenCalledWith('retro-proj'));
+  });
+
+  it('still returns 202 even when runRetroBatch rejects', async () => {
+    mockRunRetroBatch.mockRejectedValueOnce(new Error('retro error'));
+    const app = makeApp();
+    const res = await app.request('/projects/retro-proj/run-retro', { method: 'POST' });
     expect(res.status).toBe(202);
   });
 });

--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -1,7 +1,8 @@
 import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
-import { dispatchForIssue, dispatchQa, dispatchReview } from '#shared/dispatch.js';
+import { dispatchForIssue, dispatchQa, dispatchRetro, dispatchReview } from '#shared/dispatch.js';
 import { runQaBatch } from './qa-batch.js';
+import { runRetroBatch } from './retro-batch.js';
 import { runReviewBatch } from './review-batch.js';
 import { runTriageBatch } from './triage-batch.js';
 
@@ -51,6 +52,26 @@ router.post('/:slug/run-review/:n', async (c) => {
   }
   dispatchReview(slug, n).catch((err: unknown) => {
     logger.error('dispatchReview failed', { slug, n, error: String(err) });
+  });
+  return c.json({ ok: true, slug, issueNumber: n }, 202);
+});
+
+router.post('/:slug/run-retro', async (c) => {
+  const slug = c.req.param('slug');
+  runRetroBatch(slug).catch((err: unknown) => {
+    logger.error('retro-batch failed', { slug, error: String(err) });
+  });
+  return c.json({ ok: true, slug }, 202);
+});
+
+router.post('/:slug/run-retro/:n', async (c) => {
+  const slug = c.req.param('slug');
+  const n = Number(c.req.param('n'));
+  if (!Number.isFinite(n)) {
+    return c.json({ ok: false, error: 'invalid issue number' }, 400);
+  }
+  dispatchRetro(slug, n).catch((err: unknown) => {
+    logger.error('dispatchRetro failed', { slug, n, error: String(err) });
   });
   return c.json({ ok: true, slug, issueNumber: n }, 202);
 });

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
+import { runRetroForItem } from '../domains/workflows/retro-batch.js';
 import { runTriageBatch } from '../domains/workflows/triage-batch.js';
 import { getSourceForSlug } from './source.js';
 
@@ -230,6 +231,27 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
   }
 }
 
+/** Run the retrospective workflow for a single issue. Drops duplicate triggers for the same issue. */
+export async function dispatchRetro(slug: string, issueNumber: number): Promise<void> {
+  const key = issueKey(slug, issueNumber);
+  if (_issueInFlight.has(key)) {
+    logger.warn('dispatchRetro: already in-flight, dropping duplicate', { slug, issueNumber });
+    return;
+  }
+  _issueInFlight.add(key);
+  try {
+    const source = await getSourceForSlug(slug);
+    if (source == null) {
+      logger.error('dispatchRetro: no source for slug', { slug });
+      return;
+    }
+    const item = await source.getItem(issueNumber.toString());
+    await runRetroForItem(item, source, slug);
+  } finally {
+    _issueInFlight.delete(key);
+  }
+}
+
 /**
  * Auto-transition from investigation-complete based on confidence.
  * Low confidence → gate-pending (human review required).
@@ -336,6 +358,10 @@ export async function dispatchForLabel(
     await dispatchResolveConflict(slug, issueNumber);
     return;
   }
+  if (labelName === 'factory:retrospecting') {
+    await dispatchRetro(slug, issueNumber);
+    return;
+  }
   logger.info('dispatchForLabel: no workflow for label', { slug, labelName });
 }
 
@@ -369,6 +395,7 @@ const RESUME_WORKFLOWS: Partial<Record<StateName, ResumeEntry>> = {
     dispatch: dispatchResolveConflict,
   },
   'factory:investigating': { targetState: 'factory:investigating', dispatch: dispatchInvestigate },
+  'factory:retrospecting': { targetState: 'factory:retrospecting', dispatch: dispatchRetro },
 };
 
 /**


### PR DESCRIPTION
The retrospective workflow (core/workflows/retrospective.ts) and skills
were shipped in M9.01–M9.02 but no server code ever invoked them. Issues
landed in factory:retrospecting and stalled until a human moved them to
factory:done — so the Retrospective tab stayed empty and the Roster
never received improvement candidates.

Mirror the QA / Review server wiring: per-item helper, batch runner,
single-issue dispatch, router endpoints, label mapping, resume entry,
and a fire-and-forget kick from approveIssue.

https://claude.ai/code/session_01JdbKBTX5x5C4uEh1FAM2q7