### PR TITLE
fix: flip comment order to newest-first with user toggle

### DIFF
--- a/apps/web/src/components/detail/components/CommentsSection.test.tsx
+++ b/apps/web/src/components/detail/components/CommentsSection.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react';
-import { cleanup } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CommentsSection } from './CommentsSection';
 
@@ -26,18 +25,19 @@ vi.mock('./CommentComposer', () => ({
   CommentComposer: () => <div data-testid="comment-composer-mock">composer</div>,
 }));
 
+// API returns comments oldest-first: bob (2h ago) then alice (1h ago)
 const MOCK_COMMENTS = [
   {
     id: 1,
     body: '**Hello**',
-    authorLogin: 'alice',
-    createdAt: new Date(Date.now() - 3600000).toISOString(),
+    authorLogin: 'bob',
+    createdAt: new Date(Date.now() - 7200000).toISOString(),
   },
   {
     id: 2,
     body: 'World',
-    authorLogin: 'bob',
-    createdAt: new Date(Date.now() - 7200000).toISOString(),
+    authorLogin: 'alice',
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
   },
 ];
 
@@ -77,5 +77,40 @@ describe('CommentsSection', () => {
   it('shows no count when comments array is empty', () => {
     renderSection([]);
     expect(screen.queryByText(/\(\d+\)/)).toBeNull();
+  });
+
+  it('defaults to newest-first order', () => {
+    renderSection();
+    const authors = screen.getAllByText(/alice|bob/).map((el) => el.textContent);
+    // bob is older, alice is newer — newest first means alice before bob
+    expect(authors[0]).toBe('alice');
+    expect(authors[1]).toBe('bob');
+  });
+
+  it('shows the sort toggle when there are multiple comments', () => {
+    renderSection();
+    expect(screen.getByTestId('sort-order-toggle')).toBeTruthy();
+  });
+
+  it('hides the sort toggle when there is only one comment', () => {
+    renderSection([MOCK_COMMENTS[0]]);
+    expect(screen.queryByTestId('sort-order-toggle')).toBeNull();
+  });
+
+  it('reverses order when the toggle is clicked', () => {
+    renderSection();
+    fireEvent.click(screen.getByTestId('sort-order-toggle'));
+    const authors = screen.getAllByText(/alice|bob/).map((el) => el.textContent);
+    // oldest first: bob before alice
+    expect(authors[0]).toBe('bob');
+    expect(authors[1]).toBe('alice');
+  });
+
+  it('toggles label between "Oldest first" and "Newest first"', () => {
+    renderSection();
+    const toggle = screen.getByTestId('sort-order-toggle');
+    expect(toggle.textContent).toBe('Oldest first');
+    fireEvent.click(toggle);
+    expect(toggle.textContent).toBe('Newest first');
   });
 });

--- a/apps/web/src/components/detail/components/CommentsSection.tsx
+++ b/apps/web/src/components/detail/components/CommentsSection.tsx
@@ -3,6 +3,7 @@ import { renderMarkdownToHtml } from '@/lib/markdown';
 import type { IssueCommentDto } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { CommentComposer } from './CommentComposer';
 
 interface CommentsSectionProps {
@@ -12,16 +13,32 @@ interface CommentsSectionProps {
 }
 
 export function CommentsSection({ projectSlug, id, externalId }: CommentsSectionProps) {
+  const [newestFirst, setNewestFirst] = useState(true);
+
   const { data: comments = [], isLoading } = useQuery<IssueCommentDto[]>({
     queryKey: ['comments', projectSlug, id],
     queryFn: () => fetchComments(projectSlug, id),
   });
 
+  const sorted = newestFirst ? [...comments].reverse() : [...comments];
+
   return (
     <div className="mt-8" data-testid="comments-section">
-      <h2 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-4">
-        Comments {comments.length > 0 && <span className="text-fg-4">({comments.length})</span>}
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider">
+          Comments {comments.length > 0 && <span className="text-fg-4">({comments.length})</span>}
+        </h2>
+        {comments.length > 1 && (
+          <button
+            type="button"
+            onClick={() => setNewestFirst((v) => !v)}
+            className="text-[11px] text-fg-4 hover:text-fg-2 transition-colors"
+            data-testid="sort-order-toggle"
+          >
+            {newestFirst ? 'Oldest first' : 'Newest first'}
+          </button>
+        )}
+      </div>
 
       {isLoading ? (
         <p className="text-[12.5px] text-fg-4">Loading…</p>
@@ -32,7 +49,7 @@ export function CommentsSection({ projectSlug, id, externalId }: CommentsSection
           )}
 
           <div className="flex flex-col gap-4">
-            {comments.map((c) => (
+            {sorted.map((c) => (
               <div key={c.id} className="relative pl-8">
                 <div className="absolute left-[5px] top-[13px] w-[13px] h-[13px] rounded-full border border-line-2 bg-bg-elev" />
                 <div className="rounded-md border border-line overflow-hidden">


### PR DESCRIPTION
Comments now default to newest-first (reversed from GitHub's oldest-first API
response). A toggle button appears when there are multiple comments, letting
the user switch between newest-first and oldest-first views.

https://claude.ai/code/session_01PLrLPNNZtiMPRnAHouVrqX