### PR TITLE
feat(web): surface tokens & cost on timeline cards, overview, and stage sections

### DIFF
--- a/apps/web/src/components/board/components/IssueCard.test.tsx
+++ b/apps/web/src/components/board/components/IssueCard.test.tsx
@@ -1,9 +1,11 @@
-import type { WorkItemDto } from '@/lib/types';
+import { fetchIssueCosts } from '@/lib/api';
+import type { WorkItemCostsDto, WorkItemDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IssueCard } from './IssueCard';
 
 vi.mock('@/lib/usePersonaMap', () => ({
@@ -12,7 +14,14 @@ vi.mock('@/lib/usePersonaMap', () => ({
   getPersonaLabel: () => null,
 }));
 
+vi.mock('@/lib/api', () => ({
+  fetchIssueCosts: vi.fn(),
+}));
+
 afterEach(cleanup);
+beforeEach(() => {
+  vi.mocked(fetchIssueCosts).mockReset();
+});
 
 const BASE_ITEM: WorkItemDto = {
   id: '1',
@@ -33,42 +42,84 @@ const BASE_ITEM: WorkItemDto = {
 };
 
 function renderCard(item = BASE_ITEM) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
-    <MemoryRouter>
-      <IssueCard item={item} projectSlug="goose-hub-self" />
-    </MemoryRouter>,
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <IssueCard item={item} projectSlug="goose-hub-self" />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
+}
+
+function costsResponse(rows: WorkItemCostsDto['rows'], totalUsd = 0): WorkItemCostsDto {
+  return { workItemId: 'wi-1', totalUsd, hasEstimated: false, rows };
 }
 
 describe('IssueCard', () => {
   it('renders the issue title', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard();
     expect(screen.getByText('Fix the login bug')).toBeTruthy();
   });
 
   it('renders the issue number', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard();
     expect(screen.getByText('#42')).toBeTruthy();
   });
 
   it('renders the state label', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard();
     expect(screen.getByText('in-progress')).toBeTruthy();
   });
 
   it('renders the priority pill', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard();
     // The Pill component renders "high" as text
     const pills = screen.getAllByText('high');
     expect(pills.length).toBeGreaterThan(0);
   });
 
-  it('renders the cost placeholder', () => {
+  it('renders "$—" when there are no cost rows yet', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard();
-    expect(screen.getByTestId('cost-placeholder').textContent).toBe('$—');
+    await waitFor(() => {
+      expect(screen.getByTestId('issue-card-cost').textContent).toBe('$—');
+    });
+  });
+
+  it('renders the formatted total cost when rows are present', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(
+      costsResponse(
+        [
+          {
+            runId: 'r1',
+            workItemId: 'wi-1',
+            stage: 'dev',
+            skill: 'implement',
+            modelId: 'claude-sonnet-4-6',
+            inputTokens: 800,
+            outputTokens: 400,
+            costUsd: 0.42,
+            costLabel: 'exact',
+            personaId: null,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        0.42,
+      ),
+    );
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByTestId('issue-card-cost').textContent).toBe('$0.42');
+    });
   });
 
   it('truncates long titles at 55 chars', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     const longTitle = 'A'.repeat(60);
     renderCard({ ...BASE_ITEM, title: longTitle });
     const link = screen.getByRole('link');

--- a/apps/web/src/components/board/components/IssueCard.tsx
+++ b/apps/web/src/components/board/components/IssueCard.tsx
@@ -1,9 +1,11 @@
 import { Pill } from '@/components/ui/pill';
+import { fetchIssueCosts } from '@/lib/api';
 import { cn } from '@/lib/cn';
-import { COST_PLACEHOLDER, PRIORITY_COLOR, STATE_LABEL } from '@/lib/constants';
-import type { WorkItemDto } from '@/lib/types';
+import { PRIORITY_COLOR, STATE_LABEL } from '@/lib/constants';
+import type { WorkItemCostsDto, WorkItemDto } from '@/lib/types';
 import { getPersonaInitials, usePersonaMap } from '@/lib/usePersonaMap';
-import { ageLabel } from '@/lib/utils';
+import { ageLabel, formatCost } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 
 export function IssueCard({
@@ -16,6 +18,21 @@ export function IssueCard({
   const ageStr = ageLabel(item.createdAt);
   const personaMap = usePersonaMap();
   const initials = getPersonaInitials(personaMap, item.lastPersonaId);
+
+  // Per-card fetch; TanStack Query dedupes by key so the issue detail page
+  // shares the same cache. Boards with many cards trigger N requests on mount —
+  // tracked as a follow-up to add a project-level summary endpoint.
+  const { data: costs } = useQuery<WorkItemCostsDto>({
+    queryKey: ['issue-costs', projectSlug, item.externalId],
+    queryFn: () => fetchIssueCosts(projectSlug, item.externalId),
+    staleTime: 60_000,
+  });
+  const costLabel =
+    costs == null
+      ? '—'
+      : costs.rows.length === 0
+        ? '$—'
+        : formatCost(costs.totalUsd, costs.hasEstimated ? 'estimated' : 'exact');
   return (
     <Link
       to={`/projects/${projectSlug}/items/${item.externalId}`}
@@ -63,10 +80,16 @@ export function IssueCard({
         )}
         <span
           className="ml-auto font-mono text-[10.5px] text-fg-4"
-          title="Cost tracking available in M9"
-          data-testid="cost-placeholder"
+          title={
+            costs == null
+              ? 'Loading…'
+              : costs.rows.length === 0
+                ? 'No agent runs recorded yet'
+                : `${costs.rows.length} run${costs.rows.length === 1 ? '' : 's'}`
+          }
+          data-testid="issue-card-cost"
         >
-          {COST_PLACEHOLDER}
+          {costLabel}
         </span>
       </div>
     </Link>

--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -1,16 +1,9 @@
-import { COST_PLACEHOLDER } from '@/lib/constants';
 import { sortLaneItems } from '@/lib/lanes.config';
 import { describe, expect, it } from 'vitest';
 
 // IssueCard rendering is exercised by the Playwright happy-path (#36)
 // and by board/components/IssueCard.test.tsx.
 // Here we lock the sort/ordering rule it relies on.
-
-describe('IssueCard — cost placeholder', () => {
-  it('COST_PLACEHOLDER is "$—"', () => {
-    expect(COST_PLACEHOLDER).toBe('$—');
-  });
-});
 
 describe('issue card lane ordering', () => {
   it('orders by priority desc, then issue number asc', () => {

--- a/apps/web/src/components/detail/components/CodeDiffSection.tsx
+++ b/apps/web/src/components/detail/components/CodeDiffSection.tsx
@@ -4,8 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 import { ExternalLink, FileCode } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { parseDiff } from '../lib/code-diff';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import { CodeDiffFileList } from './CodeDiffFileList';
 import { CodeDiffViewer } from './CodeDiffViewer';
+import { CostBadge } from './CostBadge';
 import { SectionEmptyState } from './SectionEmptyState';
 
 interface CodeDiffSectionProps {
@@ -30,6 +32,9 @@ export function CodeDiffSection({ projectSlug, id }: CodeDiffSectionProps) {
     queryFn: () => fetchEvents(projectSlug, id),
     staleTime: 10_000,
   });
+
+  const { byStage } = useIssueCostsBreakdown(projectSlug, id);
+  const devCost = byStage.get('dev');
 
   const prOpenedEvent = events
     ?.slice()
@@ -106,6 +111,9 @@ export function CodeDiffSection({ projectSlug, id }: CodeDiffSectionProps) {
           <span className="font-mono text-[11px] tabular-nums" style={{ color: 'var(--danger)' }}>
             −{totalDels}
           </span>
+          {devCost && (
+            <CostBadge tokens={devCost.tokens} usd={devCost.usd} label={devCost.label} size="sm" />
+          )}
         </div>
         <div className="flex items-center gap-2">
           {prUrl != null && (

--- a/apps/web/src/components/detail/components/CostBadge.test.tsx
+++ b/apps/web/src/components/detail/components/CostBadge.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CostBadge } from './CostBadge';
+
+afterEach(cleanup);
+
+describe('CostBadge', () => {
+  it('renders tokens and cost', () => {
+    render(<CostBadge tokens={1234} usd={0.12} label="exact" />);
+    const badge = screen.getByTestId('cost-badge');
+    expect(badge.textContent).toContain('1.2k');
+    expect(badge.textContent).toContain('$0.12');
+  });
+
+  it('renders the tilde prefix when label is estimated', () => {
+    render(<CostBadge tokens={500} usd={0.05} label="estimated" />);
+    expect(screen.getByTestId('cost-badge').textContent).toContain('~$0.05');
+  });
+
+  it('returns null when both tokens and usd are zero', () => {
+    const { container } = render(<CostBadge tokens={0} usd={0} label="exact" />);
+    expect(container.querySelector('[data-testid="cost-badge"]')).toBeNull();
+  });
+
+  it('renders when only one of tokens/usd is non-zero', () => {
+    render(<CostBadge tokens={42} usd={0} label="exact" />);
+    expect(screen.getByTestId('cost-badge')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/CostBadge.tsx
+++ b/apps/web/src/components/detail/components/CostBadge.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/lib/cn';
+import { formatCost, formatTokens } from '@/lib/utils';
+import { Coins } from 'lucide-react';
+
+interface CostBadgeProps {
+  tokens: number;
+  usd: number;
+  label?: 'estimated' | 'exact';
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+/**
+ * Inline pill that renders `<coins> · <tokens> · <usd>`. Returns `null` when
+ * both values are zero so unstarted runs / stages don't render `0 tok · $0`.
+ * Estimated rows render `~$x.xx` per `formatCost` and surface the qualifier in
+ * the tooltip.
+ */
+export function CostBadge({
+  tokens,
+  usd,
+  label = 'exact',
+  size = 'sm',
+  className,
+}: CostBadgeProps) {
+  if (tokens === 0 && usd === 0) return null;
+
+  const sizeClass =
+    size === 'md' ? 'h-6 px-2 gap-1.5 text-[11.5px]' : 'h-5 px-1.5 gap-1 text-[10.5px]';
+  const iconSize = size === 'md' ? 11 : 10;
+  const tokenStr = formatTokens(tokens);
+  const costStr = formatCost(usd, label);
+  const title =
+    label === 'estimated'
+      ? `${tokenStr} tokens · ${costStr} (estimated — Claude CLI rollup)`
+      : `${tokenStr} tokens · ${costStr}`;
+
+  return (
+    <span
+      data-testid="cost-badge"
+      title={title}
+      className={cn(
+        'inline-flex items-center rounded-full border border-line/70 bg-bg/40 font-mono text-fg-3',
+        sizeClass,
+        className,
+      )}
+    >
+      <Coins size={iconSize} className="opacity-70 shrink-0" />
+      <span className="tnum">{tokenStr}</span>
+      <span aria-hidden className="opacity-40">
+        ·
+      </span>
+      <span className="tnum">{costStr}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/detail/components/InvestigationSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.tsx
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 // import { Filter, RefreshCw } from 'lucide-react';
 import { Search } from 'lucide-react';
 import { useState } from 'react';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import {
   CONFIDENCE_NUM,
   READ_TOOLS,
@@ -16,6 +17,7 @@ import {
   extractInvestigationPayload,
 } from '../lib/investigation';
 import { ConfidenceBadge } from './ConfidenceBadge';
+import { CostBadge } from './CostBadge';
 import { FindingCard } from './FindingCard';
 import { SectionEmptyState } from './SectionEmptyState';
 import { StatCard } from './StatCard';
@@ -49,6 +51,9 @@ export function InvestigationSection({ projectSlug, id, itemState }: Investigati
     queryKey: ['comments', projectSlug, id],
     queryFn: () => fetchComments(projectSlug, id),
   });
+
+  const { byStage } = useIssueCostsBreakdown(projectSlug, id);
+  const investigateCost = byStage.get('investigate');
 
   const humanNotes = comments.filter((c) => c.body.startsWith('Human review notes:'));
 
@@ -136,13 +141,24 @@ export function InvestigationSection({ projectSlug, id, itemState }: Investigati
             03 · Investigation
           </div>
           <h2 className="text-[17px] font-semibold text-fg leading-snug">What was found</h2>
-          <div className="flex items-center gap-3 mt-1.5 text-[12px] text-fg-3">
+          <div className="flex items-center gap-3 mt-1.5 text-[12px] text-fg-3 flex-wrap">
             <span>
               {reads} file read{reads !== 1 ? 's' : ''} · {searches} search
               {searches !== 1 ? 'es' : ''}
             </span>
             <span className="text-fg-5">·</span>
             <ConfidenceBadge level={investigate.confidence} />
+            {investigateCost && (
+              <>
+                <span className="text-fg-5">·</span>
+                <CostBadge
+                  tokens={investigateCost.tokens}
+                  usd={investigateCost.usd}
+                  label={investigateCost.label}
+                  size="sm"
+                />
+              </>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">

--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -3,6 +3,7 @@ import { laneForState } from '@/lib/lanes.config';
 import { renderMarkdownToHtml } from '@/lib/markdown';
 import type { WorkItemDto } from '@/lib/types';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
+import { formatCost, formatTokens } from '@/lib/utils';
 import {
   Brain,
   Bug,
@@ -16,6 +17,7 @@ import {
   RotateCcw,
 } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import { SECTIONS } from '../lib/sections';
 import { CommentsSection } from './CommentsSection';
 
@@ -86,6 +88,13 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
   const blocksCount = item?.blocks?.length ?? 0;
   const lastAgentLabel = getPersonaLabel(personaMap, item?.lastPersonaId) ?? '—';
 
+  const costs = useIssueCostsBreakdown(slug, id);
+  const spentValue = costs.runCount === 0 ? '—' : formatCost(costs.total, costs.totalLabel);
+  const spentSub =
+    costs.runCount === 0
+      ? 'no runs yet'
+      : `${formatTokens(costs.totalTokens)} tokens · ${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`;
+
   const priorityColor = PRIORITY_COLOR[priority];
   const priorityBg = PRIORITY_BG[priority];
   const priorityBorder = PRIORITY_BORDER[priority];
@@ -108,7 +117,7 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
       </div>
 
       {/* Stat row */}
-      <div className="grid grid-cols-5 gap-3">
+      <div className="grid grid-cols-3 lg:grid-cols-6 gap-3">
         <StatCard label="Stage" value={lane} />
         <StatCard label="Priority" value={priority} color={priorityColor} />
         <StatCard
@@ -122,6 +131,7 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
           sub={blocksCount > 0 ? item?.blocks.map((d) => `#${d}`).join(', ') : undefined}
         />
         <StatCard label="Last agent" value={lastAgentLabel} />
+        <StatCard label="Spent" value={spentValue} sub={spentSub} />
       </div>
 
       {/* Main content grid */}

--- a/apps/web/src/components/detail/components/QASection.test.tsx
+++ b/apps/web/src/components/detail/components/QASection.test.tsx
@@ -1,16 +1,26 @@
 /** @vitest-environment jsdom */
-import { fetchEvents } from '@/lib/api';
-import type { AgentEventDto } from '@/lib/types';
+import { fetchEvents, fetchIssueCosts } from '@/lib/api';
+import type { AgentEventDto, WorkItemCostsDto } from '@/lib/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { QASection } from './QASection';
 
 afterEach(cleanup);
 
 vi.mock('@/lib/api', () => ({
   fetchEvents: vi.fn(),
+  fetchIssueCosts: vi.fn(),
 }));
+
+beforeEach(() => {
+  vi.mocked(fetchIssueCosts).mockResolvedValue({
+    workItemId: 'wi-1',
+    totalUsd: 0,
+    hasEstimated: false,
+    rows: [],
+  });
+});
 
 function render_(jsx: React.ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -111,5 +121,44 @@ describe('QASection', () => {
     expect(screen.getByText('38 / 0')).toBeTruthy();
     // Wall-time card uses the formatted duration.
     expect(screen.getByText('7.70s')).toBeTruthy();
+  });
+
+  it('renders the QA cost badge in the header when QA-stage rows exist', async () => {
+    vi.mocked(fetchEvents).mockResolvedValueOnce([
+      qaEvent({
+        verdict: 'pass',
+        overallScore: 85,
+        threshold: 70,
+        tierResults: passingTiers,
+      }),
+    ]);
+    const costs: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.05,
+      hasEstimated: false,
+      rows: [
+        {
+          runId: 'r-qa',
+          workItemId: 'wi-1',
+          stage: 'qa',
+          skill: 'qa-test',
+          modelId: 'claude-sonnet-4-6',
+          inputTokens: 600,
+          outputTokens: 200,
+          costUsd: 0.05,
+          costLabel: 'exact',
+          personaId: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costs);
+
+    render_(<QASection projectSlug="proj" id="42" />);
+    await waitFor(() => {
+      const badge = screen.getByTestId('cost-badge');
+      expect(badge.textContent).toContain('$0.05');
+      expect(badge.textContent).toContain('800');
+    });
   });
 });

--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -2,8 +2,10 @@ import { fetchEvents } from '@/lib/api';
 import type { AgentEventDto } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
 import { AlertCircle, CheckCircle, Clock, Plus, RefreshCw, XCircle } from 'lucide-react';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import { TIERS, formatWallTime } from '../lib/qa';
 import type { QaPayload } from '../lib/qa';
+import { CostBadge } from './CostBadge';
 import { QaFindingRow } from './QaFindingRow';
 import { QaTestSuiteRow } from './QaTestSuiteRow';
 import { QaTierRow } from './QaTierRow';
@@ -19,6 +21,8 @@ export function QASection({ projectSlug, id }: QASectionProps) {
     queryKey: ['events', projectSlug, id],
     queryFn: () => fetchEvents(projectSlug, id),
   });
+  const { byStage } = useIssueCostsBreakdown(projectSlug, id);
+  const qaCost = byStage.get('qa');
 
   if (isLoading) return null;
 
@@ -79,7 +83,7 @@ export function QASection({ projectSlug, id }: QASectionProps) {
         <div className="flex-1">
           <div className="text-[10.5px] uppercase tracking-wider text-fg-4 mb-1">06 · QA</div>
           <h2 className="text-[17px] font-semibold text-fg leading-snug">Verification sweep</h2>
-          <div className="flex items-center gap-2 text-[12.5px] text-fg-3 mt-1">
+          <div className="flex items-center gap-2 text-[12.5px] text-fg-3 mt-1 flex-wrap">
             <VerdictIcon size={13} style={{ color: verdictColor }} />
             <span style={{ color: verdictColor, textTransform: 'uppercase', fontWeight: 600 }}>
               {qa.verdict}
@@ -92,6 +96,12 @@ export function QASection({ projectSlug, id }: QASectionProps) {
             <span>
               {allFindings.length} {allFindings.length === 1 ? 'finding' : 'findings'}
             </span>
+            {qaCost && (
+              <>
+                <span className="text-fg-4">·</span>
+                <CostBadge tokens={qaCost.tokens} usd={qaCost.usd} label={qaCost.label} size="sm" />
+              </>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/detail/components/RetrospectiveSection.tsx
+++ b/apps/web/src/components/detail/components/RetrospectiveSection.tsx
@@ -2,6 +2,8 @@ import { fetchEvents } from '@/lib/api';
 import type { AgentEventDto } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
 import { Clock, Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { useIssueCostsBreakdown } from '../lib/costs';
+import { CostBadge } from './CostBadge';
 import { SectionEmptyState } from './SectionEmptyState';
 
 interface RetrospectiveSectionProps {
@@ -92,6 +94,8 @@ export function RetrospectiveSection({ projectSlug, id }: RetrospectiveSectionPr
     queryKey: ['events', projectSlug, id],
     queryFn: () => fetchEvents(projectSlug, id),
   });
+  const { byStage } = useIssueCostsBreakdown(projectSlug, id);
+  const retroCost = byStage.get('retrospective');
 
   if (isLoading) return null;
 
@@ -124,7 +128,7 @@ export function RetrospectiveSection({ projectSlug, id }: RetrospectiveSectionPr
   return (
     <div data-testid="retro-section" className="px-8 py-6 space-y-6">
       {/* Tier badge */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <span
           className={`text-[10px] font-medium uppercase px-2 py-0.5 rounded-full ${
             retro.tier === 'deep'
@@ -134,6 +138,14 @@ export function RetrospectiveSection({ projectSlug, id }: RetrospectiveSectionPr
         >
           {retro.tier} retro
         </span>
+        {retroCost && (
+          <CostBadge
+            tokens={retroCost.tokens}
+            usd={retroCost.usd}
+            label={retroCost.label}
+            size="sm"
+          />
+        )}
       </div>
 
       {/* Summary bullets */}

--- a/apps/web/src/components/detail/components/ReviewSection.tsx
+++ b/apps/web/src/components/detail/components/ReviewSection.tsx
@@ -2,6 +2,8 @@ import { fetchEvents } from '@/lib/api';
 import type { AgentEventDto } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
 import { AlertTriangle, Check, CheckCircle, Clock, GitPullRequest, XCircle } from 'lucide-react';
+import { useIssueCostsBreakdown } from '../lib/costs';
+import { CostBadge } from './CostBadge';
 import { SectionEmptyState } from './SectionEmptyState';
 
 interface ReviewSectionProps {
@@ -87,6 +89,8 @@ export function ReviewSection({ projectSlug, id }: ReviewSectionProps) {
     queryKey: ['events', projectSlug, id],
     queryFn: () => fetchEvents(projectSlug, id),
   });
+  const { byStage } = useIssueCostsBreakdown(projectSlug, id);
+  const reviewCost = byStage.get('review');
 
   if (isLoading) return null;
 
@@ -151,7 +155,20 @@ export function ReviewSection({ projectSlug, id }: ReviewSectionProps) {
             07 · Review
           </div>
           <h2 className="text-[20px] font-semibold tracking-tight">Pre-merge checklist</h2>
-          <div className="text-[12.5px] text-fg-3 mt-1">{hint}</div>
+          <div className="flex items-center gap-2 text-[12.5px] text-fg-3 mt-1 flex-wrap">
+            <span>{hint}</span>
+            {reviewCost && (
+              <>
+                <span className="text-fg-5">·</span>
+                <CostBadge
+                  tokens={reviewCost.tokens}
+                  usd={reviewCost.usd}
+                  label={reviewCost.label}
+                  size="sm"
+                />
+              </>
+            )}
+          </div>
         </div>
         {prUrl && (
           <div className="flex items-center gap-2 shrink-0">

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -1,14 +1,10 @@
 import { fetchMilestones, setLabel, setMilestone } from '@/lib/api';
-import {
-  COST_PLACEHOLDER,
-  PRIORITY_BG,
-  PRIORITY_BORDER,
-  PRIORITY_COLOR,
-  STATE_LABEL,
-} from '@/lib/constants';
+import { PRIORITY_BG, PRIORITY_BORDER, PRIORITY_COLOR, STATE_LABEL } from '@/lib/constants';
 import type { MilestoneDto, WorkItemDto } from '@/lib/types';
+import { formatCost, formatTokens } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import { PillSelect } from './PillSelect';
 import { TransitionButton } from './TransitionButton';
 
@@ -28,6 +24,8 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
     queryFn: () => fetchMilestones(projectSlug),
     enabled: item != null,
   });
+
+  const costs = useIssueCostsBreakdown(projectSlug, item?.externalId ?? '');
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, item?.externalId] });
@@ -100,8 +98,18 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span>opened {item?.createdAt ? new Date(item?.createdAt).toLocaleString() : ''}</span>
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span title="Cost tracking available in M9" data-testid="cost-placeholder">
-          cost <span className="font-mono">{COST_PLACEHOLDER}</span>
+        <span data-testid="task-header-cost">
+          cost{' '}
+          <span
+            className="font-mono"
+            title={
+              costs.runCount === 0
+                ? 'No agent runs recorded yet'
+                : `${formatTokens(costs.totalTokens)} tokens across ${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`
+            }
+          >
+            {costs.runCount === 0 ? '$—' : formatCost(costs.total, costs.totalLabel)}
+          </span>
         </span>
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span title="Duration tracking available in M9" data-testid="duration-placeholder">

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -1,6 +1,6 @@
 import { resumeIssue } from '@/lib/api';
 import { cn } from '@/lib/cn';
-import type { AgentEventDto } from '@/lib/types';
+import type { AgentEventDto, CostRowDto } from '@/lib/types';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
 import {
   AlertCircle,
@@ -31,6 +31,14 @@ import {
   formatSkillName,
   getPayloadStr,
 } from '../lib/timeline';
+import { CostBadge } from './CostBadge';
+
+type TimelineContext = {
+  slug: string;
+  issueId: string;
+  latestRunId: string | null;
+  runCosts?: Map<string, CostRowDto>;
+};
 
 // ─── individual event renderers ───────────────────────────────────────────────
 
@@ -1038,7 +1046,7 @@ function RunGroupWrapper({
   endedAt: string | null;
   lastEventAt: string | null;
   personaId: string | null;
-  context?: { slug: string; issueId: string; latestRunId: string | null };
+  context?: TimelineContext;
 }) {
   const personaMap = usePersonaMap();
   const [open, setOpen] = useState(true);
@@ -1081,6 +1089,9 @@ function RunGroupWrapper({
 
   const isLatestRun = context?.latestRunId === runId;
   const canResume = context != null && (isFailed || isStalled) && isLatestRun && !resumed;
+
+  const costRow = context?.runCosts?.get(runId);
+  const runTokens = costRow ? costRow.inputTokens + costRow.outputTokens : 0;
 
   const handleResume = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1155,6 +1166,14 @@ function RunGroupWrapper({
           )}
           <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
           {statusBadge}
+          {costRow && (
+            <CostBadge
+              tokens={runTokens}
+              usd={costRow.costUsd}
+              label={costRow.costLabel}
+              size="sm"
+            />
+          )}
           {metaLine}
           {canResume && (
             <button
@@ -1193,11 +1212,7 @@ function RunGroupWrapper({
 
 // ─── switch ───────────────────────────────────────────────────────────────────
 
-export function renderTimelineItem(
-  item: RenderItem,
-  idx: number,
-  context?: { slug: string; issueId: string; latestRunId: string | null },
-) {
+export function renderTimelineItem(item: RenderItem, idx: number, context?: TimelineContext) {
   if (item.kind === 'log-group') {
     return <AgentLogGroupEvent key={`log-group-${idx}`} events={item.events} />;
   }

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -2,6 +2,7 @@ import { fetchEvents } from '@/lib/api';
 import type { AgentEventDto } from '@/lib/types';
 import { Clock } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { useIssueCostsBreakdown } from '../lib/costs';
 import { EVENT_KIND_LABEL, groupEvents } from '../lib/timeline';
 import { SectionEmptyState } from './SectionEmptyState';
 import { renderTimelineItem } from './TimelineEvents';
@@ -19,6 +20,7 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const { byRun: runCosts } = useIssueCostsBreakdown(projectSlug, id);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -100,7 +102,7 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
 
   const items = groupEvents(events);
   const latestRunId = items.find((item) => item.kind === 'run-group')?.runId ?? null;
-  const context = { slug: projectSlug, issueId: id, latestRunId };
+  const context = { slug: projectSlug, issueId: id, latestRunId, runCosts };
 
   return (
     <div data-testid="timeline-section" className="px-8 py-6">

--- a/apps/web/src/components/detail/lib/costs.test.ts
+++ b/apps/web/src/components/detail/lib/costs.test.ts
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+import { fetchIssueCosts } from '@/lib/api';
+import type { CostRowDto, WorkItemCostsDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useIssueCostsBreakdown } from './costs';
+
+vi.mock('@/lib/api', () => ({
+  fetchIssueCosts: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.mocked(fetchIssueCosts).mockReset();
+});
+
+function row(partial: Partial<CostRowDto>): CostRowDto {
+  return {
+    runId: 'r1',
+    workItemId: 'wi-1',
+    stage: 'qa',
+    skill: 'qa-test',
+    modelId: 'claude-sonnet-4-6',
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd: 0.01,
+    costLabel: 'exact',
+    personaId: null,
+    createdAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useIssueCostsBreakdown', () => {
+  it('returns the empty default when id is empty (does not fetch)', () => {
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', ''), { wrapper });
+    expect(vi.mocked(fetchIssueCosts)).not.toHaveBeenCalled();
+    expect(result.current.total).toBe(0);
+    expect(result.current.runCount).toBe(0);
+    expect(result.current.byRun.size).toBe(0);
+    expect(result.current.byStage.size).toBe(0);
+  });
+
+  it('keys cost rows by runId and aggregates by stage', async () => {
+    const data: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.36,
+      hasEstimated: false,
+      rows: [
+        row({ runId: 'r-qa-1', stage: 'qa', costUsd: 0.05, inputTokens: 200, outputTokens: 100 }),
+        row({ runId: 'r-qa-2', stage: 'qa', costUsd: 0.06, inputTokens: 300, outputTokens: 100 }),
+        row({ runId: 'r-dev-1', stage: 'dev', costUsd: 0.25, inputTokens: 800, outputTokens: 400 }),
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', '42'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.runCount).toBe(3);
+    });
+
+    expect(result.current.total).toBeCloseTo(0.36, 5);
+    expect(result.current.totalTokens).toBe(200 + 100 + 300 + 100 + 800 + 400);
+    expect(result.current.byRun.get('r-dev-1')?.costUsd).toBe(0.25);
+
+    const qa = result.current.byStage.get('qa');
+    expect(qa?.runCount).toBe(2);
+    expect(qa?.usd).toBeCloseTo(0.11, 5);
+    expect(qa?.tokens).toBe(700);
+
+    const dev = result.current.byStage.get('dev');
+    expect(dev?.runCount).toBe(1);
+    expect(dev?.tokens).toBe(1200);
+  });
+
+  it("flips a stage's label to 'estimated' when any row in it is estimated", async () => {
+    const data: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.1,
+      hasEstimated: true,
+      rows: [
+        row({ runId: 'r1', stage: 'review', costLabel: 'exact', costUsd: 0.04 }),
+        row({ runId: 'r2', stage: 'review', costLabel: 'estimated', costUsd: 0.06 }),
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', '42'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.runCount).toBe(2);
+    });
+
+    expect(result.current.totalLabel).toBe('estimated');
+    expect(result.current.byStage.get('review')?.label).toBe('estimated');
+  });
+});

--- a/apps/web/src/components/detail/lib/costs.ts
+++ b/apps/web/src/components/detail/lib/costs.ts
@@ -1,0 +1,89 @@
+import { fetchIssueCosts } from '@/lib/api';
+import type { CostRowDto, WorkItemCostsDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+export type StageBreakdown = {
+  stage: CostRowDto['stage'];
+  usd: number;
+  tokens: number;
+  label: 'estimated' | 'exact';
+  runCount: number;
+};
+
+export interface IssueCostsBreakdown {
+  byRun: Map<string, CostRowDto>;
+  byStage: Map<CostRowDto['stage'], StageBreakdown>;
+  total: number;
+  totalTokens: number;
+  hasEstimated: boolean;
+  totalLabel: 'estimated' | 'exact';
+  runCount: number;
+  isLoading: boolean;
+}
+
+const EMPTY: Omit<IssueCostsBreakdown, 'isLoading'> = {
+  byRun: new Map(),
+  byStage: new Map(),
+  total: 0,
+  totalTokens: 0,
+  hasEstimated: false,
+  totalLabel: 'exact',
+  runCount: 0,
+};
+
+/**
+ * One cached fetch per work item (`['issue-costs', slug, id]`) sliced by run
+ * and by stage so timeline cards, overview, and stage sections can all read
+ * from the same query. Disabled when `id` is empty so callers can compose
+ * with not-yet-loaded work items without firing a 404.
+ */
+export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCostsBreakdown {
+  const enabled = id !== '';
+  const { data, isLoading } = useQuery<WorkItemCostsDto>({
+    queryKey: ['issue-costs', projectSlug, id],
+    queryFn: () => fetchIssueCosts(projectSlug, id),
+    enabled,
+  });
+
+  return useMemo<IssueCostsBreakdown>(() => {
+    if (data == null) return { ...EMPTY, isLoading: enabled && isLoading };
+
+    const byRun = new Map<string, CostRowDto>();
+    const byStage = new Map<CostRowDto['stage'], StageBreakdown>();
+    let totalTokens = 0;
+
+    for (const row of data.rows) {
+      byRun.set(row.runId, row);
+      const tokens = row.inputTokens + row.outputTokens;
+      totalTokens += tokens;
+
+      const existing = byStage.get(row.stage);
+      if (existing) {
+        existing.usd += row.costUsd;
+        existing.tokens += tokens;
+        existing.runCount += 1;
+        if (row.costLabel === 'estimated') existing.label = 'estimated';
+      } else {
+        byStage.set(row.stage, {
+          stage: row.stage,
+          usd: row.costUsd,
+          tokens,
+          label: row.costLabel,
+          runCount: 1,
+        });
+      }
+    }
+
+    return {
+      byRun,
+      byStage,
+      total: data.totalUsd,
+      totalTokens,
+      hasEstimated: data.hasEstimated,
+      totalLabel: data.hasEstimated ? 'estimated' : 'exact',
+      runCount: data.rows.length,
+      isLoading,
+    };
+  }, [data, isLoading, enabled]);
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -63,9 +63,6 @@ export const CODE_ACTIVE_STATES = new Set([
   'factory:done',
 ]);
 
-// Placeholder shown wherever cost data will appear once M9 wires it through.
-export const COST_PLACEHOLDER = '$—';
-
 export const GATE_STATES: Record<string, string> = {
   'factory:prd-review': 'PRD Review pending — human approval required',
   'factory:needs-review': 'Code Review pending — human approval required',


### PR DESCRIPTION
Wires the existing /api/projects/:slug/issues/:id/costs response into more
surfaces of the detail UI:

- New `useIssueCostsBreakdown` hook (`apps/web/src/components/detail/lib/costs.ts`)
  shares one cached fetch and slices rows by `runId` and by `stage`.
- New `CostBadge` component renders an inline `tokens · usd` pill, suppressing
  itself when both values are zero so unstarted runs don't show `0 tok · $0`.
- Timeline run-card headers now show per-run tokens + cost when the run has a
  cost row; live runs render no badge until they end.
- Overview gains a Spent stat card showing work-item totals and run count.
- QA, Dev (Code), Investigate, Review, and Retro section headers each show a
  badge filtered to that stage only.
- TaskHeader and IssueCard placeholders are replaced with the real work-item
  total, and the `COST_PLACEHOLDER` constant is retired.

Tests cover the new hook (aggregation by run/stage, estimated label
propagation), the badge (zero-suppression, estimated tilde), the QA stage
badge, and the IssueCard cost rendering.