### PR TITLE
docs(m9-exit): ADRs 0016–0017, retro, PLAN §6 update, README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The detail page also exposes:
 - **Code tab** (M7) — live worktree diff polled every 5 s while the dev workflow is running, plus per-step Playwright captures
 - **QA tab** (M8) — holdout QA report: overall verdict (`pass` / `fail` / `partial`), score, and per-tier (Structural / Functional / Regression) findings; populated after the QA holdout agent runs.
 - **Review tab** (M8) — holdout review verdict (`approved` / `needs-fix` / `needs-human`) and per-criterion checks; populated after the Review holdout agent runs.
+- **Retrospective tab** (M9) — light or deep retro report, populated automatically after every merge. Light tier: 3-bullet summary + obvious improvement candidates. Deep tier: full persona analysis, quality scores, decision patterns.
+- **Costs tab** (M9) — per-stage token and dollar breakdown for the issue, with `~$` prefix on estimated figures and no qualifier on exact figures.
 - **Approval gate** (M7) — when an issue reaches `factory:approved`, the gate banner shows Approve / Reject buttons (Approve merges the linked PR via the GitHub connector; Reject takes a required note and routes to `factory:needs-fix`)
 - **Markdown image rendering** in overview comments — screenshots posted by `evidence-post` from `raw.githubusercontent.com` / `github.com` / `user-images.githubusercontent.com` render inline
 
@@ -41,19 +43,20 @@ End-to-end workflows live in `slices/<name>/workflow.ts` and are dispatched by w
 - **`fix-issue`** (M7) — picks up `factory:dev-ready` issues, creates a worktree, runs the advisor for `priority:high|critical`, runs the implement skill (TDD-first), opens a PR via the GitHub connector, runs `evidence-post` (best-effort), transitions to `factory:needs-qa` to hand off to the QA holdout. _(M7 originally transitioned straight to `factory:approved`; M8 inserted QA + Review before the human gate.)_
 - **`qa`** (M8) — picks up `factory:needs-qa` issues, runs the QA holdout skill (lint + tests + Playwright via the project's `lintCommand` / `testCommand` / `e2eCommand`), transitions to `factory:needs-review` on pass or `factory:qa-failed` on fail (escalates to `factory:needs-human` after `maxRetries`).
 - **`review`** (M8) — picks up `factory:needs-review` issues, runs the Review holdout skill (diff vs. original issue, criteria checks), transitions to `factory:approved`, `factory:needs-fix`, or `factory:needs-human`.
+- **`retro`** (M9) — picks up `factory:retrospecting` issues (set automatically when a PR is approved), runs `retrospective-light` or `retrospective-deep` based on `retrospectivePolicy` and trigger signals (`qaFailed`, etc.), transitions to `factory:done`.
 
-Supporting slices: `holdout-boundary-test` (regression test that context enforcement fires at the runtime layer) and `retry-escalate` (counts `qa-failed` / `needs-fix` retries and escalates to `factory:needs-human` when exhausted).
+Supporting slices: `holdout-boundary-test` (regression test that context enforcement fires at the runtime layer), `retry-escalate` (counts `qa-failed` / `needs-fix` retries and escalates to `factory:needs-human` when exhausted), and `cost-tracking` (end-to-end lifecycle test for cost recording).
 
 Dev pipeline flow:
 
 ```
-dev-ready → in-progress → needs-qa → needs-review → approved → (human gate) → merged
+dev-ready → in-progress → needs-qa → needs-review → approved → (human gate) → merged → retrospecting → done
                              ↘ qa-failed / needs-fix → (retry) → needs-human
 ```
 
 ### Skills (`@goose-hub/skills`)
 
-Versioned markdown prompts + Zod schemas under `skills/<name>/`. Current set: `triage`, `repo-match`, `investigate`, `playwright-repro`, `spec-author`, `evidence-post`, `implement`, `advise-on-plan`, `qa`, `review`. Each ships with `slice.test.ts`, `eval/eval.json`, and `README.md`. Skills follow the channel-split convention from CONTEXT.md: `skill.md` is the system prompt, per-run context is rendered as XML in the user message.
+Versioned markdown prompts + Zod schemas under `skills/<name>/`. Current set: `triage`, `repo-match`, `investigate`, `playwright-repro`, `spec-author`, `evidence-post`, `implement`, `advise-on-plan`, `qa`, `review`, `retrospective-light`, `retrospective-deep`. Each ships with `slice.test.ts`, `eval/eval.json`, and `README.md`. Skills follow the channel-split convention from CONTEXT.md: `skill.md` is the system prompt, per-run context is rendered as XML in the user message.
 
 ### Holdouts (M8)
 
@@ -62,4 +65,10 @@ QA and Review are **holdouts**: each runs in a fresh agent context with no acces
 ### Standards & ADRs
 
 - `docs/standards/verification.md` — the three-tier (Structural / Functional / Regression) verification framework + 8-category code-quality rubric (≥ 70/100 threshold). Ships ahead of the M8 QA holdout.
-- `docs/adr/` — architectural decisions in chronological order. M7 added ADR 0011 (Playwright agents), 0012 (advisor wrapping + per-step typed timeouts), 0013 (GitHub connectors + fix-issue workflow shape). M8 added ADR 0014 (holdout enforcement architecture).
+- `docs/adr/` — architectural decisions in chronological order. M7 added ADR 0011 (Playwright agents), 0012 (advisor wrapping + per-step typed timeouts), 0013 (GitHub connectors + fix-issue workflow shape). M8 added ADR 0014 (holdout enforcement architecture). M9 added ADR 0015 (target-projects workspace package), ADR 0016 (cost module architecture), ADR 0017 (core/workflows placement for cross-caller workflows).
+
+### Retrospective & Learning Loop (M9)
+
+- **Roster** — at `/projects/<slug>/roster`. Per-role list of personas with quality score, run count, and last-run time. Click any card to open a drill-in panel showing run history and pending improvement candidates. Approve a candidate to create a `type:improvement` Factory issue in the target repo; reject to dismiss.
+- **Cost dashboard** — at `/projects/<slug>/costs`. Weekly and monthly spend with per-stage breakdown. Figures sourced from Claude CLI are labelled `~$` (estimated); figures from direct API calls are labelled exact.
+- **Persona stats** — accumulated after every agent run across all workflow stages. `persona_stats` table holds `runs_total`, `runs_succeeded`, `runs_failed`, `avg_quality_score`, and `last_run_at` per persona/role pair.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -272,7 +272,17 @@ goose-hub/
 │   ├── governance/                      # M4+
 │   ├── personas/                        # M6+
 │   ├── milestones/                      # M6+
-│   ├── retrospective/                   # M9+
+│   ├── retrospective/                   # M9+ (shared Zod schemas for retro skill output)
+│   │   └── schemas.ts
+│   ├── cost/                            # M9+ (see ADR 0016)
+│   │   ├── extract.ts                   # costFromCliEnvelope / costFromApiUsage
+│   │   ├── repository.ts                # recordCost / queryCosts
+│   │   ├── skill-stage.ts               # skill → stage mapping
+│   │   └── types.ts
+│   ├── persona/                         # M9+
+│   │   └── accumulate.ts                # accumulatePersonaStats — called by every workflow
+│   ├── workflows/                       # M9+ (see ADR 0017); cross-caller workflows only
+│   │   └── retrospective.ts             # runRetrospectiveWorkflow — tier selection + skill dispatch
 │   ├── bootstrap/
 │   └── connectors/
 │       └── github/                      # M7+ (#184/#186)

--- a/docs/adr/0016-cost-module-architecture.md
+++ b/docs/adr/0016-cost-module-architecture.md
@@ -1,0 +1,57 @@
+# ADR 0016: Cost Module Architecture
+
+**Status:** Accepted  
+**Date:** 2026-05-05  
+**Milestone:** M9 — Retrospective and Learning Loop
+
+## Context
+
+M9 required persisting actual or estimated agent-run costs so the UI could show per-stage breakdowns and a project-level cost dashboard. Two cost sources need to coexist:
+
+1. **Claude CLI** — emits a `total_cost_usd` field in its `--output-format json` envelope, but the number is a rollup the CLI computed internally. It cannot be independently verified, so it is labelled `'estimated'`.
+2. **Direct Anthropic API** (future) — returns authoritative `usage.input_tokens` and `usage.output_tokens` from the API response. Costs derived from this source are labelled `'exact'`.
+
+The design question was where to put extraction logic, what shape the DB row should take, and how to enforce the estimated/exact distinction throughout the stack.
+
+## Decision
+
+### 1. New `core/cost/` module — single owner of cost persistence
+
+All cost logic lives in `core/cost/`: extraction (`extract.ts`), persistence (`repository.ts`), skill-to-stage mapping (`skill-stage.ts`), and shared types (`types.ts`). No other module reimplements these functions.
+
+The `costs/` server domain only reads — it never writes. Only the agent runtime appends rows, called once per successful skill run via `recordCost()`.
+
+### 2. `CostUsage` type carries `costLabel` from the point of construction
+
+`CostUsage` is the transfer object between extraction and storage. It includes `costLabel: 'estimated' | 'exact'` as a required field. This makes the distinction impossible to lose in transit: the label is set at the moment cost data is parsed, not added as an afterthought before storage.
+
+`costFromCliEnvelope()` always returns `costLabel: 'estimated'`. `costFromApiUsage()` always returns `costLabel: 'exact'`. There is no code path that stores a cost row without a label.
+
+### 3. One row per `runId` in `agent_run_costs`
+
+The `runId` unique index means duplicate inserts (from retry loops or webhook re-deliveries) are silently ignored. Every run produces exactly one cost row, even if `costUsd` is `0` — this ensures every run appears on the dashboard regardless of whether the CLI reported a cost.
+
+### 4. `skill-stage.ts` maps skill names to UI stage buckets
+
+The `stage` column groups costs into `triage`, `investigate`, `dev`, `qa`, `review`, `retrospective`, `other`. The `skill` column is also persisted so finer-grained breakdown remains possible from raw queries. Stage is UI-only metadata; it never influences workflow logic.
+
+### 5. UI labelling convention: `~$0.04` for estimated, `$0.04` for exact
+
+Estimated costs render with a tilde prefix or `est.` badge. Exact costs render without qualification. A legend explains the distinction on first encounter. This convention is enforced in the frontend components, not in the DB schema.
+
+## Consequences
+
+**Positive:**
+- Every cost row has a verifiable provenance label; the UI cannot silently show an estimated figure as authoritative.
+- The zero-cost fallback means dashboards always reflect every run, making spend gaps visible.
+- Duplicate-insert safety via unique index requires no application-layer deduplication.
+
+**Trade-offs:**
+- CLI-sourced costs are inherently imprecise (the CLI's rollup may differ from per-model API prices). Until direct API integration is added, all production cost data will be `'estimated'`. The label is the honest acknowledgement of this.
+- `skill-stage.ts` must be updated when new skills are added. An unknown skill falls into `other` rather than failing — a deliberate soft fallback.
+
+## Alternatives Considered
+
+**Alternative A: Store costs inline on agent run events** — add cost fields to existing `agent.run-completed` event payloads. Rejected: event payloads are for observability, not persistent queries. A dedicated table supports indexed queries by project, stage, and time range without scanning the event log.
+
+**Alternative B: Infer estimated/exact from model ID** — assume Claude CLI runs are always estimated, API runs always exact, and derive the label from context rather than storing it. Rejected: too fragile as the runtime evolves. Explicit `costLabel` in `CostUsage` at construction time is unambiguous and self-documenting.

--- a/docs/adr/0017-core-workflows-placement.md
+++ b/docs/adr/0017-core-workflows-placement.md
@@ -1,0 +1,52 @@
+# ADR 0017: Placement of Cross-Slice Workflows in `core/workflows/`
+
+**Status:** Accepted  
+**Date:** 2026-05-05  
+**Milestone:** M9 — Retrospective and Learning Loop
+
+## Context
+
+Goose Hub has two locations where workflow logic can live:
+
+- **`slices/<name>/workflow.ts`** — the canonical location for a self-contained orchestration workflow that owns a specific pipeline stage and can be shipped or removed as a unit.
+- **`core/`** — shared abstractions consumed by multiple slices or apps; never deleted by removing a single feature.
+
+M9 introduced `runRetrospectiveWorkflow()`. This function is called from two places:
+
+1. `apps/server/src/domains/workflows/retro-batch.ts` (label-webhook dispatch path)
+2. `apps/server/src/domains/issues/transitions.ts` (fire-and-forget from `approveIssue`)
+
+A workflow called from two independent server code paths is not isolatable as a single slice — removing it would require coordinated changes across both callers. It also composes across the entire post-merge pipeline rather than owning a single state transition.
+
+The question was whether to put it in `slices/retrospective/` (following the existing slice pattern) or `core/workflows/` (a new subdirectory).
+
+## Decision
+
+Workflows that are **called from more than one server code path** and cannot be cleanly removed as a single slice unit live in `core/workflows/`.
+
+The first inhabitant is `core/workflows/retrospective.ts`, which exports `runRetrospectiveWorkflow()`.
+
+The rule for future workflows: start in a slice; promote to `core/workflows/` only when a second caller appears that is not the slice's own batch runner.
+
+### What `core/workflows/` is not
+
+- It is not a catch-all for "complex" workflows. Single-caller workflows belong in slices regardless of complexity.
+- It is not `core/orchestrator/workflows/`. PLAN.md §6 explicitly states workflow modules live in `slices/<name>/workflow.ts`, not under `core/orchestrator/`. The `core/workflows/` directory is a narrow exception for cross-caller modules, not the general orchestrator workflow location.
+
+## Consequences
+
+**Positive:**
+- The two callers of `runRetrospectiveWorkflow()` import from a stable core path rather than one caller importing from the other's slice (which would be a slice-to-slice import violation).
+- The naming makes the exception explicit: `core/workflows/` signals "multi-caller workflow logic" whereas `slices/*/workflow.ts` signals "single-pipeline-stage logic."
+
+**Trade-offs:**
+- `core/workflows/` is a new pattern that could attract workflows that belong in slices. The "promote only on second caller" rule is the guard against this drift.
+- PLAN.md §6 diagram must be kept current as this directory grows; it was not updated at the time of the original M9 PR (corrected in the M9 exit audit).
+
+## Alternatives Considered
+
+**Alternative A: Put the workflow in `slices/retrospective/`** — place `runRetrospectiveWorkflow` in `slices/retrospective/workflow.ts` and have `transitions.ts` import from it. Rejected: slice-to-slice imports are forbidden (FACTORY_RULES rule 24). `transitions.ts` lives in `apps/server/`, not in a slice, but having a server domain module import from a slice is an architectural inversion — the server dispatches to slices, not the reverse.
+
+**Alternative B: Inline the workflow at each call site** — duplicate the tier-selection and skill-dispatch logic in both `retro-batch.ts` and `transitions.ts`. Rejected: duplication would immediately diverge; the tier-selection logic needs a single source of truth.
+
+**Alternative C: Promote the workflow to the server shared layer** — put the logic in `apps/server/src/shared/`. Rejected: `core/` is the correct home for logic consumed across the app boundary (server today; CLI or future consumers tomorrow). `apps/server/src/shared/` is server-internal only.

--- a/docs/retros/m9.md
+++ b/docs/retros/m9.md
@@ -1,0 +1,36 @@
+# M9 Retrospective — Retrospective and Learning Loop
+
+**Closed:** 2026-05-05  
+**Issues shipped:** 9 (M9.01–M9.09, tracked as #259–#267)  
+**PRs merged:** 8 (#269, #270, #271, #272, #274, #290, #435, #478)  
+**Tests at close:** 1 612 passing, 0 failing
+
+## What worked
+
+**Scope was well-defined and shipped cleanly.** All nine issues closed. Every skill PR (#269) landed with full Zod schemas, tested round-trips, and versioned `skill.md`. The vertical-slice discipline from earlier milestones transferred naturally to the retro skills — no blank files, no stub implementations.
+
+**Persona stats are genuinely wired everywhere.** `accumulatePersonaStats()` is called in all five agent paths (triage, investigate, fix-issue, qa, review). This wasn't mandated by any single PR; each workflow owner added the call. The abstraction in `core/persona/accumulate.ts` made it a one-liner to add.
+
+**The late-wiring PR (#478) caught a real silent failure.** The retro workflow and skills existed from day two of the milestone, but no server code ever invoked them — issues landed in `factory:retrospecting` and stalled until a human moved them to `factory:done`. PR #478 identified the gap and mirrored the QA/Review dispatch pattern exactly. Having an established wiring pattern to copy meant the fix was low-risk and complete (batch runner, single-issue dispatch, router endpoints, label mapping, fire-and-forget from `approveIssue`).
+
+**The improvement candidate → Factory issue flow is complete.** Approving a candidate in the Roster creates a real GitHub issue in the target repo, labelled `type:improvement schedule:later`, with error handling if the GitHub call fails. The loop closes: retro produces candidates; human approves; new issue appears in the backlog.
+
+## What didn't work
+
+**ADRs skipped at implementation time — again.** M4, M7, M8, and now M9 all ended with the exit audit writing ADRs that should have been in the original PRs. This milestone added two new `core/` modules (`core/cost/`, `core/workflows/`) and a new placement pattern for cross-caller workflows, none of which were documented until the audit. The M4 retrospective said "write ADRs at implementation time, not in the exit audit." M9 repeated the failure.
+
+**PR #478 broke CI.** A biome format issue caused the "Lint, typecheck, test" check to fail on merge. PR #489 repaired it the same day, but this is the fourth milestone in a row where a PR merged with a red CI run. The M4 retro called for a branch protection rule; it still hasn't been enforced.
+
+**PLAN.md §6 not updated during the milestone.** Three new `core/` subdirectories (`cost/`, `persona/`, `workflows/`) shipped with no corresponding update to the repo layout diagram. Caught in the exit audit; corrected there. Same pattern as M4 and M7.
+
+**README not updated.** The README documented features through M8. Retrospective tab, Roster, Cost dashboard, and persona stats went unmentioned until the exit audit chore.
+
+## What to change for M10
+
+1. **Branch protection: require CI green before merge.** This has been recommended in three consecutive milestone retrospectives. File it as a concrete action item with a GitHub branch-protection rule, not just a note.
+
+2. **ADR-or-comment required on every `core/` PR.** The rule in `CLAUDE.md` already says this. Add an explicit check to the exit-audit checklist that names the PR number and expected ADR. If the PR modified `core/` and no ADR exists, the PR author is responsible — not the exit auditor.
+
+3. **Update PLAN.md §6 in the same commit that diverges from it.** If a PR adds a new `core/` directory or renames a module, the plan diagram update goes in the same PR. The exit audit should not be the first time the tree gets updated.
+
+4. **Run a live smoke test before the audit.** M9's headline criterion — retro auto-runs after merge, tab populates, persona stats update, candidates appear in Roster — was verified by code inspection only. A live run through the full pipeline (file issue → merge → observe retro tab) should be a human checkpoint before the audit is filed.


### PR DESCRIPTION
- ADR 0016: cost module architecture (core/cost/, CostUsage.costLabel, estimated/exact convention)
- ADR 0017: core/workflows/ placement rule for cross-caller workflows
- docs/retros/m9.md: M9 retrospective (what worked, what didn't, what to change for M10)
- PLAN.md §6: add core/cost/, core/persona/, core/workflows/ with file inventory
- README.md: document M9 features (Retrospective tab, Costs tab, retro workflow, Roster, persona stats, cost dashboard); update skills list and ADR index; extend pipeline flow diagram

https://claude.ai/code/session_01Qj7qj86AZkL8NMb9Nr2pCU