### PR TITLE
M11.01: Dependency parser — parseDependencies with typed DependencyRef

### DIFF
--- a/core/state-source/README.md
+++ b/core/state-source/README.md
@@ -13,6 +13,17 @@ Defines the abstraction every backend implements.
 - **`Artifact`**, **`CreateIssueInput`**, **`SourceEvent`**, **`Subscription`** — supporting types for write paths and live updates.
 - **`StateSource`** — the interface itself: `listOpenWork`, `getItem`, `listMilestones`, `getActiveMilestone`, `transitionState`, `comment`, `attach`, `createIssue`, `watchForUpdates`.
 
+### `dependency-parser.ts`
+
+`parseDependencies(body: string): DependencyRef[]` — extracts dependency declarations from an issue body into typed `DependencyRef` objects.
+
+- **`DependencyRef`**: `{ type: 'depends-on' | 'blocks', repoRef: string | null, issueNumber: number }`
+- Recognised prefixes (case-insensitive, whitespace-tolerant): `Depends on`, `Depends-on`, `deps:`, `blocked by`, `blocked-by`, `Blocks`, `Blocks:`
+- Cross-repo refs (`owner/repo#N`) populate `repoRef`; same-repo refs (`#N`) set `repoRef: null`
+- `type: 'blocks'` means the current issue blocks the referenced issue (referenced issue depends on current)
+- Malformed or unrecognised lines are silently skipped — never throws
+- Consumed by M11.02 resolver and M11.03 scheduler filter
+
 ### `github-labels.ts`
 
 `GitHubLabelsSource` — `StateSource` backed by the GitHub REST API via native `fetch`.

--- a/core/state-source/dependency-parser.ts
+++ b/core/state-source/dependency-parser.ts
@@ -1,0 +1,39 @@
+export interface DependencyRef {
+  type: 'depends-on' | 'blocks';
+  repoRef: string | null;
+  issueNumber: number;
+}
+
+const DEPENDS_ON_PREFIX = /^(?:depends[\s-]+on|deps)\s*:?\s/i;
+const BLOCKS_PREFIX = /^blocks\s*:?\s/i;
+const BLOCKED_BY_PREFIX = /^blocked[\s-]+by\s*:?\s/i;
+const REF_PATTERN = /(?:([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))?#(\d+)/g;
+
+export function parseDependencies(body: string): DependencyRef[] {
+  const results: DependencyRef[] = [];
+
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let type: 'depends-on' | 'blocks' | null = null;
+
+    if (DEPENDS_ON_PREFIX.test(trimmed) || BLOCKED_BY_PREFIX.test(trimmed)) {
+      type = 'depends-on';
+    } else if (BLOCKS_PREFIX.test(trimmed)) {
+      type = 'blocks';
+    }
+
+    if (type === null) continue;
+
+    for (const m of trimmed.matchAll(REF_PATTERN)) {
+      const repoRef = m[1] ?? null;
+      const issueNumber = Number.parseInt(m[2], 10);
+      if (!Number.isNaN(issueNumber)) {
+        results.push({ type, repoRef, issueNumber });
+      }
+    }
+  }
+
+  return results;
+}

--- a/core/state-source/dependency-parser.ts
+++ b/core/state-source/dependency-parser.ts
@@ -7,7 +7,7 @@ export interface DependencyRef {
 const DEPENDS_ON_PREFIX = /^(?:depends[\s-]+on|deps)\s*:?\s/i;
 const BLOCKS_PREFIX = /^blocks\s*:?\s/i;
 const BLOCKED_BY_PREFIX = /^blocked[\s-]+by\s*:?\s/i;
-const REF_PATTERN = /(?:([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))?#(\d+)/g;
+const REF_PATTERN = /(?:([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))?#(\d+)(?!\w)/g;
 
 export function parseDependencies(body: string): DependencyRef[] {
   const results: DependencyRef[] = [];

--- a/core/state-source/slice.test.ts
+++ b/core/state-source/slice.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import { parseDependencies } from './dependency-parser.js';
+
+// ---------------------------------------------------------------------------
+// Empty / no-match cases
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — empty / no-match', () => {
+  it('returns empty array for empty body', () => {
+    expect(parseDependencies('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only body', () => {
+    expect(parseDependencies('   \n\n\t')).toEqual([]);
+  });
+
+  it('ignores lines without a recognised prefix', () => {
+    expect(parseDependencies('This issue is related to #5 but not a dep')).toEqual([]);
+  });
+
+  it('ignores a bare #N reference with no prefix', () => {
+    expect(parseDependencies('See #42 for context')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Depends-on variants
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — depends-on variants', () => {
+  it('parses "Depends on #N" (no colon)', () => {
+    expect(parseDependencies('Depends on #42')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 42 },
+    ]);
+  });
+
+  it('parses "Depends on: #N" (with colon)', () => {
+    expect(parseDependencies('Depends on: #42')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 42 },
+    ]);
+  });
+
+  it('parses "Depends-on #N" (hyphen variant)', () => {
+    expect(parseDependencies('Depends-on #7')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 7 },
+    ]);
+  });
+
+  it('parses "deps: #N"', () => {
+    expect(parseDependencies('deps: #15')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 15 },
+    ]);
+  });
+
+  it('parses "blocked by #N"', () => {
+    expect(parseDependencies('blocked by #8')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 8 },
+    ]);
+  });
+
+  it('parses "blocked-by #N" (hyphen variant)', () => {
+    expect(parseDependencies('blocked-by #8')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 8 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blocks variants
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — blocks variants', () => {
+  it('parses "Blocks #N" as blocks type', () => {
+    expect(parseDependencies('Blocks #3')).toEqual([
+      { type: 'blocks', repoRef: null, issueNumber: 3 },
+    ]);
+  });
+
+  it('parses "Blocks: #N" (with colon)', () => {
+    expect(parseDependencies('Blocks: #3')).toEqual([
+      { type: 'blocks', repoRef: null, issueNumber: 3 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-repo form
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — cross-repo form', () => {
+  it('parses "Depends on owner/repo#N"', () => {
+    expect(parseDependencies('Depends on shaunnez/other-repo#12')).toEqual([
+      { type: 'depends-on', repoRef: 'shaunnez/other-repo', issueNumber: 12 },
+    ]);
+  });
+
+  it('parses "Blocks owner/repo#N"', () => {
+    expect(parseDependencies('Blocks shaunnez/some-repo#99')).toEqual([
+      { type: 'blocks', repoRef: 'shaunnez/some-repo', issueNumber: 99 },
+    ]);
+  });
+
+  it('mixes same-repo and cross-repo refs on one line', () => {
+    expect(parseDependencies('Depends on shaunnez/other-repo#12, #3')).toEqual([
+      { type: 'depends-on', repoRef: 'shaunnez/other-repo', issueNumber: 12 },
+      { type: 'depends-on', repoRef: null, issueNumber: 3 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case insensitivity
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — case insensitive', () => {
+  it('handles all-caps DEPENDS ON', () => {
+    expect(parseDependencies('DEPENDS ON #5')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 5 },
+    ]);
+  });
+
+  it('handles all-caps BLOCKS', () => {
+    expect(parseDependencies('BLOCKS #10')).toEqual([
+      { type: 'blocks', repoRef: null, issueNumber: 10 },
+    ]);
+  });
+
+  it('handles all-caps DEPS', () => {
+    expect(parseDependencies('DEPS: #5')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 5 },
+    ]);
+  });
+
+  it('handles mixed case Blocked By', () => {
+    expect(parseDependencies('Blocked By #4')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 4 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace tolerance
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — whitespace tolerance', () => {
+  it('handles leading whitespace on dep lines', () => {
+    expect(parseDependencies('  Depends on #9')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 9 },
+    ]);
+  });
+
+  it('handles trailing whitespace on dep lines', () => {
+    expect(parseDependencies('Depends on #9   ')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 9 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple deps
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — multiple deps', () => {
+  it('parses multiple dep lines across a full body', () => {
+    const body = ['Some description.', '', 'Depends on #1', 'Depends on #2', 'Blocks #3'].join(
+      '\n',
+    );
+    expect(parseDependencies(body)).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 1 },
+      { type: 'depends-on', repoRef: null, issueNumber: 2 },
+      { type: 'blocks', repoRef: null, issueNumber: 3 },
+    ]);
+  });
+
+  it('parses multiple refs on a single line', () => {
+    expect(parseDependencies('Depends on #1, #2, #3')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 1 },
+      { type: 'depends-on', repoRef: null, issueNumber: 2 },
+      { type: 'depends-on', repoRef: null, issueNumber: 3 },
+    ]);
+  });
+
+  it('handles mixed types and cross-repo in a real-world body', () => {
+    const body = [
+      '## Context',
+      '',
+      'This issue depends on the parser and the resolver.',
+      '',
+      '## Depends on',
+      '',
+      '- #286',
+      '- #291',
+    ].join('\n');
+
+    // The "## Depends on" heading line has no ref, and the "- #286" lines
+    // don't start with a recognised prefix — this is deliberate: the parser
+    // only reads lines that start with the prefix.  The section-header style
+    // is handled by the resolver/scheduler consuming WorkItem.dependsOn.
+    expect(parseDependencies(body)).toEqual([]);
+  });
+
+  it('handles the actual GitHub issue body format with prefix on each line', () => {
+    const body = ['## Depends on', '', 'Depends on #286', 'Depends on #291'].join('\n');
+    expect(parseDependencies(body)).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 286 },
+      { type: 'depends-on', repoRef: null, issueNumber: 291 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed / no-crash guarantees
+// ---------------------------------------------------------------------------
+
+describe('parseDependencies — malformed input', () => {
+  it('silently skips lines with prefix but no valid ref', () => {
+    expect(parseDependencies('Depends on nothing')).toEqual([]);
+  });
+
+  it('silently skips lines with prefix and malformed ref (letters only)', () => {
+    expect(parseDependencies('Depends on #abc')).toEqual([]);
+  });
+
+  it('does not crash on a body with only newlines', () => {
+    expect(parseDependencies('\n\n\n')).toEqual([]);
+  });
+
+  it('does not include NaN issue numbers', () => {
+    const result = parseDependencies('Depends on #');
+    expect(result).toEqual([]);
+  });
+});

--- a/core/state-source/slice.test.ts
+++ b/core/state-source/slice.test.ts
@@ -229,4 +229,12 @@ describe('parseDependencies — malformed input', () => {
     const result = parseDependencies('Depends on #');
     expect(result).toEqual([]);
   });
+
+  it('rejects alphanumeric suffixes — #123abc must not match as 123', () => {
+    expect(parseDependencies('Depends on #123abc')).toEqual([]);
+  });
+
+  it('rejects cross-repo ref with alphanumeric suffix — owner/repo#12foo', () => {
+    expect(parseDependencies('Depends on shaunnez/other-repo#12foo')).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #286

Adds `core/state-source/dependency-parser.ts` — the M11 foundation for dependency-aware scheduling.

## What ships

- `parseDependencies(body: string): DependencyRef[]` exported from `core/state-source/dependency-parser.ts`
- `DependencyRef`: `{ type: 'depends-on' | 'blocks', repoRef: string | null, issueNumber: number }`
- All required variants recognised (case-insensitive, whitespace-tolerant): `Depends on #N`, `Depends on owner/repo#N`, `Depends-on`, `deps:`, `blocked by`, `Blocks #N`, `Blocks:`
- Cross-repo refs populate `repoRef`; same-repo refs set `repoRef: null`
- Malformed or unrecognised lines silently skipped — never throws
- 29 tests in `core/state-source/slice.test.ts` covering all variants, cross-repo, mixed-case, whitespace, multiple deps, malformed input
- `core/state-source/README.md` updated to document the new module

## What's next

M11.02 (#291) adds the resolver that calls `parseDependencies` and resolves each `DependencyRef` to `open | closed | unregistered` state.

https://claude.ai/code/session_013kwubhDsDsTyRBPnxQtFJm

---
_Generated by [Claude Code](https://claude.ai/code/session_013kwubhDsDsTyRBPnxQtFJm)_