### PR TITLE
docs: ADR 0018 and M10 multi-project orchestration architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,24 @@ QA and Review are **holdouts**: each runs in a fresh agent context with no acces
 ### Standards & ADRs
 
 - `docs/standards/verification.md` — the three-tier (Structural / Functional / Regression) verification framework + 8-category code-quality rubric (≥ 70/100 threshold). Ships ahead of the M8 QA holdout.
-- `docs/adr/` — architectural decisions in chronological order. M7 added ADR 0011 (Playwright agents), 0012 (advisor wrapping + per-step typed timeouts), 0013 (GitHub connectors + fix-issue workflow shape). M8 added ADR 0014 (holdout enforcement architecture). M9 added ADR 0015 (target-projects workspace package), ADR 0016 (cost module architecture), ADR 0017 (core/workflows placement for cross-caller workflows).
+- `docs/adr/` — architectural decisions in chronological order. M7 added ADR 0011 (Playwright agents), 0012 (advisor wrapping + per-step typed timeouts), 0013 (GitHub connectors + fix-issue workflow shape). M8 added ADR 0014 (holdout enforcement architecture). M9 added ADR 0015 (target-projects workspace package), ADR 0016 (cost module architecture), ADR 0017 (core/workflows placement for cross-caller workflows). M10 added ADR 0018 (multi-project loader and per-project scheduler in core/projects/).
 
 ### Retrospective & Learning Loop (M9)
 
 - **Roster** — at `/projects/<slug>/roster`. Per-role list of personas with quality score, run count, and last-run time. Click any card to open a drill-in panel showing run history and pending improvement candidates. Approve a candidate to create a `type:improvement` Factory issue in the target repo; reject to dismiss.
 - **Cost dashboard** — at `/projects/<slug>/costs`. Weekly and monthly spend with per-stage breakdown. Figures sourced from Claude CLI are labelled `~$` (estimated); figures from direct API calls are labelled exact.
 - **Persona stats** — accumulated after every agent run across all workflow stages. `persona_stats` table holds `runs_total`, `runs_succeeded`, `runs_failed`, `avg_quality_score`, and `last_run_at` per persona/role pair.
+
+### Multi-project Orchestration (M10)
+
+Goose Hub can now drive more than one target project simultaneously. Two projects are registered under `target-projects/`: `goose-hub-self` (purple, `#7c3aed`) and `nannymudnz` (emerald, `#059669`). New projects are added by hand-creating a `target-projects/<slug>/` directory with `project.config.ts` — no code changes needed.
+
+- **Project switcher** — sidebar dropdown lists every registered project with its color stripe. Selecting a project scopes the Kanban, Roster, and Settings views immediately. Selection persists across page reload.
+- **All Projects board** — select "All Projects" in the switcher to see a single aggregated Kanban with cards from every registered project, each carrying a left-border color stripe identifying its source project.
+- **Per-project tick scheduler** — each project runs an independent `setInterval` tick loop (configurable via `tickIntervalSeconds` in `project.config.ts`, default 60 s). A crash or long-running workflow in one project never delays another project's tick.
+- **Per-project budgets** — daily token counter, per-workflow budget cap, and per-advisor budget are all keyed by project slug. Exceeding one project's daily limit blocks only that project's ticks; others continue unaffected.
+- **Per-project active milestone** — each project tracks its own `activeMilestone` independently. The Kanban for each project filters to its own milestone's issues.
+- **Cross-project Roster** — at `/projects/all/roster` (or via the project filter dropdown on the Roster page). Shows personas from all registered projects with color-stripe attribution. Filter to a single project to scope the leaderboard.
+- **Settings → Projects** — read-only display of every registered project's config (slug, source, active milestone, budget limits, color). A "Reload" button refreshes without a full page reload. Editing is file-based; the UI includes a prompt directing to `target-projects/<slug>/project.config.ts`.
+
+ADR 0018 covers the `core/projects/` loader and scheduler architecture. See `docs/adr/0018-multi-project-loader-and-scheduler.md`.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -182,7 +182,7 @@ This distinction matters: agents and future you should not underbuild durability
 
 ## 6. Repository layout
 
-This reflects the actual layout as of M2. Future directories are annotated with the milestone that introduces them.
+This reflects the actual layout as of M10. Future directories are annotated with the milestone that introduces them.
 
 ```
 goose-hub/
@@ -196,10 +196,15 @@ goose-hub/
 ├── biome.json
 ├── .github/
 │   └── workflows/                       # CI YAML — allowed, expected
-├── target-projects/                     # config + governance per project
-│   └── goose-hub-self/
+├── target-projects/                     # config + governance per project (@goose-hub/target-projects, see ADR 0015)
+│   ├── index.ts                         # exports targetProjectsRoot path anchor
+│   ├── goose-hub-self/
+│   │   ├── MISSION.md
+│   │   ├── FACTORY_RULES.md
+│   │   ├── project.config.ts
+│   │   └── personas/
+│   └── nannymudnz/                      # M10: second registered project (color #059669)
 │       ├── MISSION.md
-│       ├── FACTORY_RULES.md
 │       ├── project.config.ts
 │       └── personas/
 ├── skills/                              # composable skill packages (M5+, @goose-hub/skills workspace pkg)
@@ -244,13 +249,11 @@ goose-hub/
 │   │   ├── schema.ts
 │   │   ├── db.ts
 │   │   └── migrate.ts
-│   ├── orchestrator/                    # M5+
-│   │   ├── tick.ts
-│   │   ├── locks.ts
-│   │   └── scheduler.ts
-│   │                                    # NOTE: workflow modules live in /slices/<name>/workflow.ts,
-│   │                                    # NOT under core/orchestrator/workflows/. The orchestrator
-│   │                                    # tick dispatches to slice workflows via apps/server/src/shared/dispatch.ts.
+│   ├── projects/                        # M10+ (see ADR 0018); multi-project loader + per-project scheduler
+│   │   ├── loader.ts                    # loadProjects() / getProjectBySlug() — reads target-projects/*/project.config.ts
+│   │   └── scheduler.ts                 # startPerProjectScheduler() — one independent setInterval per project
+│   │                                    # NOTE: per-project locking and workflow dispatch live in
+│   │                                    # apps/server/src/shared/dispatch.ts, not here.
 │   ├── agent-runtime/                   # M4+
 │   │   ├── interface.ts
 │   │   ├── claude-cli.ts
@@ -268,10 +271,8 @@ goose-hub/
 │   │   ├── secret-redaction.ts
 │   │   └── pre-tool-use-hook.ts
 │   ├── workspaces/                      # M4+
-│   ├── budgets/                         # M4+
-│   ├── governance/                      # M4+
-│   ├── personas/                        # M6+
-│   ├── milestones/                      # M6+
+│   ├── persona/                         # M9+ (singular — accumulatePersonaStats)
+│   │   └── accumulate.ts                # accumulatePersonaStats — called by every workflow
 │   ├── retrospective/                   # M9+ (shared Zod schemas for retro skill output)
 │   │   └── schemas.ts
 │   ├── cost/                            # M9+ (see ADR 0016)
@@ -279,11 +280,8 @@ goose-hub/
 │   │   ├── repository.ts                # recordCost / queryCosts
 │   │   ├── skill-stage.ts               # skill → stage mapping
 │   │   └── types.ts
-│   ├── persona/                         # M9+
-│   │   └── accumulate.ts                # accumulatePersonaStats — called by every workflow
 │   ├── workflows/                       # M9+ (see ADR 0017); cross-caller workflows only
 │   │   └── retrospective.ts             # runRetrospectiveWorkflow — tier selection + skill dispatch
-│   ├── bootstrap/
 │   └── connectors/
 │       └── github/                      # M7+ (#184/#186)
 │           ├── open-pr.ts

--- a/docs/adr/0018-multi-project-loader-and-scheduler.md
+++ b/docs/adr/0018-multi-project-loader-and-scheduler.md
@@ -1,0 +1,58 @@
+# ADR 0018: Multi-project Loader and Per-project Scheduler in `core/projects/`
+
+**Status:** Accepted  
+**Date:** 2026-05-05  
+**Milestone:** M10 — Multi-project Orchestration
+
+## Context
+
+M10 makes Goose Hub capable of driving more than one target project simultaneously. Two new runtime concerns emerged:
+
+1. **Project discovery** — at startup, enumerate every `target-projects/*/project.config.ts` and return typed `ProjectConfig[]`. Callers include the tick scheduler, the HTTP projects endpoint, the budget checker, and the CLI `status` command.
+
+2. **Per-project tick scheduling** — each registered project needs an independent orchestrator tick loop. A crash or long-running workflow in project A must not delay project B's tick.
+
+PLAN §6 had sketched these responsibilities under a `core/orchestrator/` directory (with `tick.ts`, `locks.ts`, `scheduler.ts`). That directory was never built: the dispatch/lock logic landed in `apps/server/src/shared/dispatch.ts` and the actual tick driver lived in `apps/server/src/index.ts`. The "orchestrator" concept fragmented across server-layer concerns, leaving no appropriate home in `core/`.
+
+## Decision
+
+### 1. `core/projects/` as the new module
+
+A new `core/projects/` module holds two files:
+
+- **`loader.ts`** — `loadProjects()` and `getProjectBySlug()`. Reads all `target-projects/*/project.config.ts` files at startup. Design choices:
+  - Uses `import()` (dynamic) to load each TypeScript config via `tsx`/`ts-node` resolution at runtime.
+  - Process-lifetime in-memory cache per directory path — configs don't change while the server is running; hot-reload is not required (restart is sufficient, per M10 scope).
+  - Missing or malformed configs log a warning and are skipped; startup is not aborted.
+  - Duplicate slug detection throws `DuplicateSlugError` eagerly, preventing silent misconfiguration.
+  - `DEFAULT_PROJECTS_ROOT` is resolved relative to the compiled module's `__dirname` so the loader works regardless of the working directory the server is launched from.
+
+- **`scheduler.ts`** — `startPerProjectScheduler()`. Spawns one `setInterval` per project. Design choices:
+  - Error isolation: each tick call is wrapped in `.catch()`; a throw in project A's tick never cancels project B's timer.
+  - Interval is per-project configurable via `ProjectConfig.tickIntervalSeconds` (default 60 s).
+  - Returns a `ProjectScheduler` handle with a `stop()` method for clean shutdown and test teardown.
+  - Per-project *locking* is intentionally not in the scheduler — it stays in `apps/server/src/shared/dispatch.ts` per-slug in-flight sets. The scheduler only drives timing; dispatch handles concurrency.
+
+### 2. `core/orchestrator/` is not built
+
+The previously planned `core/orchestrator/` (with `tick.ts`, `locks.ts`, `scheduler.ts`) was never built. PLAN §6 is updated to remove it and replace it with `core/projects/`. The responsibilities are:
+
+| Concern | Actual home |
+|---|---|
+| Per-project tick timing | `core/projects/scheduler.ts` |
+| Per-project locking | `apps/server/src/shared/dispatch.ts` (per-slug in-flight Set) |
+| Workflow dispatch | `apps/server/src/shared/dispatch.ts` |
+| Project config access | `apps/server/src/shared/projects.ts` (thin wrapper over `core/projects/loader.ts`) |
+
+### 3. Why `core/` and not `apps/server/src/shared/`
+
+`loadProjects()` is consumed by the CLI (`goose status` reads config to format output) as well as the server. Putting it in `apps/server/src/shared/` would require the CLI to import from the server package, violating the workspace boundary. `core/` is the shared layer both apps import from.
+
+`startPerProjectScheduler()` is only called from `apps/server/src/index.ts`, but placing it in `core/` keeps the scheduler logic independently testable without importing the Hono server stack.
+
+## Consequences
+
+- `apps/server/src/shared/projects.ts` becomes a thin delegation wrapper — `listProjects()` calls `loadProjects()`, `getProject()` calls `getProjectBySlug()`. No business logic lives there.
+- Adding a new project is a file-system operation (`target-projects/<slug>/project.config.ts`), not a code change. The loader discovers it on next restart.
+- The M10 exit criterion (two independent lifecycles) is enabled: each project gets its own tick interval and its budget/lock state is keyed by slug throughout the server.
+- M12 (project bootstrap workflow) will extend this by writing new `project.config.ts` files programmatically, but the loader shape does not change.


### PR DESCRIPTION
## Summary

This PR documents the architectural decisions and repository layout for M10 multi-project orchestration. It introduces ADR 0018, which specifies the design of `core/projects/` (a new module for project discovery and per-project scheduling) and updates the PLAN.md repository layout to reflect the actual M10 structure.

## Key Changes

- **New ADR 0018** (`docs/adr/0018-multi-project-loader-and-scheduler.md`):
  - Establishes `core/projects/` as the home for multi-project concerns (not the previously planned `core/orchestrator/`)
  - Specifies `loader.ts`: dynamic TypeScript config loading, in-memory caching, duplicate slug detection, and graceful error handling
  - Specifies `scheduler.ts`: per-project independent `setInterval` loops with error isolation and configurable tick intervals
  - Clarifies responsibility boundaries: scheduler handles timing, `apps/server/src/shared/dispatch.ts` handles per-slug locking and workflow dispatch
  - Justifies `core/` placement: shared by both server and CLI, respecting workspace boundaries

- **Updated PLAN.md** (`docs/PLAN.md`):
  - Advances repository layout snapshot from M2 to M10
  - Replaces the unbuilt `core/orchestrator/` directory with `core/projects/` (loader.ts, scheduler.ts)
  - Adds `target-projects/nannymudnz/` as the second registered project example
  - Adds `target-projects/index.ts` as a path anchor export
  - Reorganizes `core/` module listing to reflect actual M9–M10 structure (persona, retrospective, cost, workflows modules)
  - Removes obsolete bootstrap directory reference

- **Updated README.md** (`README.md`):
  - Adds M10 section documenting multi-project orchestration features (project switcher, all-projects board, per-project tick scheduler, per-project budgets, per-project milestones, cross-project roster, settings UI)
  - References ADR 0018 for architectural details
  - Updates ADR summary to include ADR 0018

## Notable Details

- ADR 0018 explicitly documents why the previously planned `core/orchestrator/` was never built and how responsibilities map to actual homes in the codebase
- The design prioritizes error isolation (per-project tick crashes don't affect other projects) and independent lifecycle management
- Configuration is file-based discovery; no code changes required to add a new project
- The scheduler is intentionally thin; concurrency control remains in the dispatch layer

https://claude.ai/code/session_01JyT1uzfMEEdWmxZRadhTzg