### PR TITLE
M7.XX: Collapse expand all

### DIFF
--- a/apps/web/e2e/issue-509.spec.ts
+++ b/apps/web/e2e/issue-509.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test('issue-509: expand all and collapse all buttons appear on timeline with run groups', async ({
+  page,
+}) => {
+  // Navigate to an issue detail page that has a timeline section.
+  // The detail page is at /:slug/:id.
+  await page.goto('/');
+  await page.waitForSelector('[data-testid="timeline-section"]', { timeout: 10000 }).catch(() => {
+    // No timeline on root — navigate to any detail page if available.
+  });
+
+  // Find an issue card and navigate to its detail page.
+  const issueCard = page.locator('[data-testid="issue-card"]').first();
+  if ((await issueCard.count()) > 0) {
+    await issueCard.click();
+    await page.waitForSelector('[data-testid="timeline-section"]', { timeout: 10000 }).catch(() => {});
+  }
+
+  await page.screenshot({ path: 'evidence/issue-509/step-1.png' });
+
+  // Check for expand/collapse buttons if run groups are present.
+  const expandBtn = page.locator('[data-testid="timeline-expand-all"]');
+  const collapseBtn = page.locator('[data-testid="timeline-collapse-all"]');
+
+  if ((await expandBtn.count()) > 0) {
+    // Collapse all — all run group details should close.
+    await collapseBtn.click();
+    const details = page.locator('[data-run-id]').first();
+    await expect(details).not.toHaveAttribute('open');
+    await page.screenshot({ path: 'evidence/issue-509/step-2-collapsed.png' });
+
+    // Expand all — all run group details should open.
+    await expandBtn.click();
+    await expect(details).toHaveAttribute('open');
+    await page.screenshot({ path: 'evidence/issue-509/step-3-expanded.png' });
+  } else {
+    // No run groups on this page — buttons correctly not rendered.
+    expect(await expandBtn.count()).toBe(0);
+    expect(await collapseBtn.count()).toBe(0);
+  }
+});

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -38,6 +38,7 @@ type TimelineContext = {
   issueId: string;
   latestRunId: string | null;
   runCosts?: Map<string, CostRowDto>;
+  expandSignal?: { open: boolean; seq: number };
 };
 
 // ─── individual event renderers ───────────────────────────────────────────────
@@ -1110,6 +1111,13 @@ function RunGroupWrapper({
   const [resuming, setResuming] = useState(false);
   const [resumed, setResumed] = useState(false);
   const isLive = endedAt == null;
+
+  const expandSignal = context?.expandSignal;
+  useEffect(() => {
+    if (expandSignal != null) {
+      setOpen(expandSignal.open);
+    }
+  }, [expandSignal]);
 
   useEffect(() => {
     if (!isLive) return;

--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -1,0 +1,143 @@
+/** @vitest-environment jsdom */
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RenderItem } from '../lib/timeline';
+import { renderTimelineItem } from './TimelineEvents';
+
+vi.mock('@/lib/usePersonaMap', () => ({
+  usePersonaMap: () => ({}),
+  getPersonaLabel: () => null,
+}));
+vi.mock('@/lib/api', () => ({
+  resumeIssue: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+function makeRunGroupItem(runId = 'run-test'): RenderItem {
+  const now = new Date().toISOString();
+  return {
+    kind: 'run-group',
+    runId,
+    skill: 'implement',
+    startedAt: now,
+    endedAt: now,
+    lastEventAt: now,
+    personaId: null,
+    items: [
+      {
+        kind: 'event',
+        event: {
+          id: 1,
+          projectId: 'proj',
+          workItemId: 'wi-1',
+          kind: 'agent.run-started',
+          payload: { skill: 'implement' },
+          runId,
+          createdAt: now,
+        },
+      },
+      {
+        kind: 'event',
+        event: {
+          id: 2,
+          projectId: 'proj',
+          workItemId: 'wi-1',
+          kind: 'agent.run-completed',
+          payload: {},
+          runId,
+          createdAt: now,
+        },
+      },
+    ],
+  };
+}
+
+const baseCtx = { slug: 'p', issueId: '1', latestRunId: null };
+
+describe('Timeline expand/collapse all (#509)', () => {
+  it('RunGroupWrapper starts open by default', () => {
+    const item = makeRunGroupItem();
+    const { container } = render(<ol>{renderTimelineItem(item, 0, baseCtx)}</ol>);
+    const details = container.querySelector('details');
+    expect(details?.open).toBe(true);
+  });
+
+  it('RunGroupWrapper closes when expandSignal has open: false', () => {
+    const item = makeRunGroupItem();
+    const { container, rerender } = render(<ol>{renderTimelineItem(item, 0, baseCtx)}</ol>);
+
+    rerender(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: false, seq: 1 },
+        })}
+      </ol>,
+    );
+
+    const details = container.querySelector('details');
+    expect(details?.open).toBe(false);
+  });
+
+  it('RunGroupWrapper opens when expandSignal has open: true after being closed', () => {
+    const item = makeRunGroupItem();
+    const { container, rerender } = render(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: false, seq: 1 },
+        })}
+      </ol>,
+    );
+
+    rerender(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: true, seq: 2 },
+        })}
+      </ol>,
+    );
+
+    const details = container.querySelector('details');
+    expect(details?.open).toBe(true);
+  });
+
+  it('seq increment with same open direction applies the signal again', () => {
+    const item = makeRunGroupItem();
+    // Start collapsed via signal seq:1
+    const { container, rerender } = render(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: false, seq: 1 },
+        })}
+      </ol>,
+    );
+    expect(container.querySelector('details')?.open).toBe(false);
+
+    // expand via seq:2
+    rerender(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: true, seq: 2 },
+        })}
+      </ol>,
+    );
+    expect(container.querySelector('details')?.open).toBe(true);
+
+    // collapse again via seq:3
+    rerender(
+      <ol>
+        {renderTimelineItem(item, 0, {
+          ...baseCtx,
+          expandSignal: { open: false, seq: 3 },
+        })}
+      </ol>,
+    );
+    expect(container.querySelector('details')?.open).toBe(false);
+  });
+});

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -19,6 +19,9 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
   const [events, setEvents] = useState<AgentEventDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandSignal, setExpandSignal] = useState<{ open: boolean; seq: number } | undefined>(
+    undefined,
+  );
   const eventSourceRef = useRef<EventSource | null>(null);
   const { byRun: runCosts } = useIssueCostsBreakdown(projectSlug, id);
 
@@ -102,10 +105,36 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
 
   const items = groupEvents(events);
   const latestRunId = items.find((item) => item.kind === 'run-group')?.runId ?? null;
-  const context = { slug: projectSlug, issueId: id, latestRunId, runCosts };
+  const hasRunGroups = items.some((item) => item.kind === 'run-group');
+  const context = { slug: projectSlug, issueId: id, latestRunId, runCosts, expandSignal };
+
+  const handleExpandAll = () =>
+    setExpandSignal((prev) => ({ open: true, seq: (prev?.seq ?? 0) + 1 }));
+  const handleCollapseAll = () =>
+    setExpandSignal((prev) => ({ open: false, seq: (prev?.seq ?? 0) + 1 }));
 
   return (
     <div data-testid="timeline-section" className="px-8 py-6">
+      {hasRunGroups && (
+        <div className="flex justify-end gap-3 mb-3">
+          <button
+            type="button"
+            data-testid="timeline-expand-all"
+            onClick={handleExpandAll}
+            className="text-[11px] text-fg-4 hover:text-fg-2 transition-colors"
+          >
+            Expand all
+          </button>
+          <button
+            type="button"
+            data-testid="timeline-collapse-all"
+            onClick={handleCollapseAll}
+            className="text-[11px] text-fg-4 hover:text-fg-2 transition-colors"
+          >
+            Collapse all
+          </button>
+        </div>
+      )}
       <ol className="flex flex-col gap-3">
         {items.map((item, idx) => renderTimelineItem(item, idx, context))}
       </ol>


### PR DESCRIPTION
## Summary

Collapse expand all

## Files
- `apps/web/src/components/detail/components/TimelineEvents.tsx` — Add expandSignal to TimelineContext; sync RunGroupWrapper open state via useEffect
- `apps/web/src/components/detail/components/TimelineSection.tsx` — Add expandSignal state, expand/collapse all button handlers, and subtle button UI above run groups
- `apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx` — 4 tests covering default open state and expand/collapse signal behavior
- `apps/web/e2e/issue-509.spec.ts` — Playwright spec navigates to timeline, clicks collapse/expand, screenshots evidence

## Tests
- `apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx` (4 cases)

Closes #509
