### PR TITLE
fix(governance): block agent writes to .claude/settings.json and hooks

### DIFF
--- a/.claude/hooks/pre-tool-use-governance.sh
+++ b/.claude/hooks/pre-tool-use-governance.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Blocks writes to existing governance files (MISSION.md, FACTORY_RULES.md).
-# These files are immutable per FACTORY_RULES once created. New project bootstrap
-# is allowed to create them — the gate only blocks modification of existing files.
+# Blocks writes to governance files and Claude Code config files.
+# MISSION.md and FACTORY_RULES.md are immutable once created; creation is
+# allowed during new project bootstrap but modification is never allowed.
+# .claude/settings.json and .claude/hooks/* are always blocked — agents must
+# not self-modify their own permissions or hooks configuration.
 
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
@@ -17,6 +19,11 @@ if echo "$FILE" | grep -qE '(MISSION\.md|FACTORY_RULES\.md)$'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Governance file is immutable per FACTORY_RULES. Cannot modify an existing MISSION.md or FACTORY_RULES.md."}}'
     exit 0
   fi
+fi
+
+if echo "$FILE" | grep -qE '\.claude/settings\.json$|\.claude/hooks/'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Claude Code configuration files (.claude/settings.json, .claude/hooks/*) are protected. Agents cannot modify their own permissions or hooks."}}'
+  exit 0
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- Extends `pre-tool-use-governance.sh` to deny any `Edit` or `Write` tool call targeting `.claude/settings.json` or `.claude/hooks/*`
- Agents can no longer self-modify their own permissions or hook configuration
- Existing MISSION.md / FACTORY_RULES.md protection is unchanged

## Context

PR #523 showed a dev agent rewriting `.claude/settings.json` while working on an unrelated UI task (Kanban card truncation). It stripped the governance hook, removed the allowlist, and committed machine-local absolute paths (`/opt/homebrew/...`, `/Users/shaunnesbitt/...`). The governance hook was supposed to prevent exactly this — but `.claude/settings.json` wasn't in its blocklist.

## What changed

`pre-tool-use-governance.sh` now has a second guard that matches paths ending in `.claude/settings.json` or containing `.claude/hooks/` and returns a hard deny with a clear reason message.

## What to do with PR #523

The settings.json changes in that PR should be reverted before merge. The pill truncation fix itself (`pill.tsx`, `IssueCard.test.tsx`, `issue-522.spec.ts`) is fine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFkSbnEhZgwQF3ztSyGTPA)_