### PR TITLE
test: backfill coverage for biggest gaps (89.57% → 92.77% lines)

### DIFF
--- a/apps/server/src/domains/costs/repository.test.ts
+++ b/apps/server/src/domains/costs/repository.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListCostsForWorkItem, mockTotalsForProjectSince, mockTotalsByStageForProjectSince } =
+  vi.hoisted(() => ({
+    mockListCostsForWorkItem: vi.fn(),
+    mockTotalsForProjectSince: vi.fn(),
+    mockTotalsByStageForProjectSince: vi.fn(),
+  }));
+
+vi.mock('@goose-hub/core/cost/repository.js', () => ({
+  listCostsForWorkItem: mockListCostsForWorkItem,
+  totalsForProjectSince: mockTotalsForProjectSince,
+  totalsByStageForProjectSince: mockTotalsByStageForProjectSince,
+}));
+
+import {
+  listCostsForWorkItem,
+  totalsByStageForProjectSince,
+  totalsForProjectSince,
+} from './repository.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('costs/repository wrapper', () => {
+  it('delegates listCostsForWorkItem to the core function', () => {
+    const rows = [{ runId: 'r1' }];
+    mockListCostsForWorkItem.mockReturnValue(rows);
+
+    const result = listCostsForWorkItem('github:org/repo#1');
+    expect(result).toBe(rows);
+    expect(mockListCostsForWorkItem).toHaveBeenCalledWith('github:org/repo#1');
+  });
+
+  it('delegates totalsForProjectSince to the core function', () => {
+    const totals = { totalUsd: 1.5, totalRuns: 3, hasEstimated: false };
+    mockTotalsForProjectSince.mockReturnValue(totals);
+
+    const result = totalsForProjectSince('proj', '2026-01-01T00:00:00Z');
+    expect(result).toBe(totals);
+    expect(mockTotalsForProjectSince).toHaveBeenCalledWith('proj', '2026-01-01T00:00:00Z');
+  });
+
+  it('delegates totalsByStageForProjectSince to the core function', () => {
+    const stages = [{ stage: 'qa', totalUsd: 0.5, totalRuns: 2, hasEstimated: false }];
+    mockTotalsByStageForProjectSince.mockReturnValue(stages);
+
+    const result = totalsByStageForProjectSince('proj', '2026-01-01T00:00:00Z');
+    expect(result).toBe(stages);
+    expect(mockTotalsByStageForProjectSince).toHaveBeenCalledWith('proj', '2026-01-01T00:00:00Z');
+  });
+});

--- a/apps/server/src/domains/costs/router.test.ts
+++ b/apps/server/src/domains/costs/router.test.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetCostSummary, mockGetCostsForWorkItem, mockGetProject } = vi.hoisted(() => ({
+  mockGetCostSummary: vi.fn(),
+  mockGetCostsForWorkItem: vi.fn(),
+  mockGetProject: vi.fn(),
+}));
+
+vi.mock('./service.js', () => ({
+  getCostSummary: mockGetCostSummary,
+  getCostsForWorkItem: mockGetCostsForWorkItem,
+}));
+
+vi.mock('#shared/projects.js', () => ({
+  getProject: mockGetProject,
+}));
+
+import { costsRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/', costsRouter);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /:slug/costs/summary', () => {
+  it('returns 404 when project is not configured', async () => {
+    mockGetProject.mockResolvedValue(null);
+
+    const app = makeApp();
+    const res = await app.request('/missing-slug/costs/summary');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('project not found');
+    expect(mockGetCostSummary).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with summary data on success', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'github', repo: 'org/repo' } });
+    const summary = {
+      projectId: 'goose-hub-self',
+      windows: {
+        week: { totalUsd: 1.2, totalRuns: 3, hasEstimated: false },
+        month: { totalUsd: 4.5, totalRuns: 10, hasEstimated: true },
+      },
+      byStage: [],
+    };
+    mockGetCostSummary.mockResolvedValue({ ok: true, data: summary });
+
+    const app = makeApp();
+    const res = await app.request('/goose-hub-self/costs/summary');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(summary);
+    expect(mockGetCostSummary).toHaveBeenCalledWith('goose-hub-self');
+  });
+
+  it('forwards service error status and body', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'github', repo: 'org/repo' } });
+    mockGetCostSummary.mockResolvedValue({ ok: false, error: 'oops', status: 400 });
+
+    const app = makeApp();
+    const res = await app.request('/goose-hub-self/costs/summary');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('oops');
+  });
+});
+
+describe('GET /:slug/issues/:id/costs', () => {
+  it('returns 404 when project is not configured', async () => {
+    mockGetProject.mockResolvedValue(null);
+
+    const app = makeApp();
+    const res = await app.request('/missing-slug/issues/42/costs');
+    expect(res.status).toBe(404);
+    expect(mockGetCostsForWorkItem).not.toHaveBeenCalled();
+  });
+
+  it('builds workItemId from github repo when source.kind is github', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'github', repo: 'shaunnez/goose-hub' } });
+    mockGetCostsForWorkItem.mockResolvedValue({
+      ok: true,
+      data: {
+        workItemId: 'github:shaunnez/goose-hub#42',
+        totalUsd: 0,
+        hasEstimated: false,
+        rows: [],
+      },
+    });
+
+    const app = makeApp();
+    const res = await app.request('/goose-hub-self/issues/42/costs');
+    expect(res.status).toBe(200);
+    expect(mockGetCostsForWorkItem).toHaveBeenCalledWith('github:shaunnez/goose-hub#42');
+  });
+
+  it('falls back to slug as repoRef when source.kind is not github', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'jira' } });
+    mockGetCostsForWorkItem.mockResolvedValue({
+      ok: true,
+      data: { workItemId: 'github:my-slug#7', totalUsd: 0, hasEstimated: false, rows: [] },
+    });
+
+    const app = makeApp();
+    await app.request('/my-slug/issues/7/costs');
+    expect(mockGetCostsForWorkItem).toHaveBeenCalledWith('github:my-slug#7');
+  });
+
+  it('forwards service error status and body', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'github', repo: 'org/repo' } });
+    mockGetCostsForWorkItem.mockResolvedValue({ ok: false, error: 'bad input', status: 400 });
+
+    const app = makeApp();
+    const res = await app.request('/proj/issues/9/costs');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('bad input');
+  });
+});

--- a/apps/server/src/domains/roster/repository.test.ts
+++ b/apps/server/src/domains/roster/repository.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSelect, mockInsert, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@goose-hub/core/db/db.js', () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+  },
+}));
+
+vi.mock('@goose-hub/core/db/schema.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goose-hub/core/db/schema.js')>();
+  return { ...actual };
+});
+
+const {
+  listPersonaNames,
+  listPersonaStats,
+  listCandidatesByPersona,
+  getCandidateById,
+  updateCandidateStatus,
+  updateCandidateGithubIssue,
+  insertCandidate,
+} = await import('./repository.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listPersonaNames', () => {
+  it('flattens projectId/role/slotIndex into a personaId', async () => {
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockResolvedValue([
+        { projectId: 'goose-hub-self', role: 'developer', slotIndex: 0, codename: 'alice' },
+        { projectId: 'goose-hub-self', role: 'qa', slotIndex: 1, codename: 'bob' },
+      ]),
+    });
+
+    const result = await listPersonaNames();
+    expect(result).toEqual([
+      { personaId: 'goose-hub-self/developer/0', codename: 'alice', role: 'developer' },
+      { personaId: 'goose-hub-self/qa/1', codename: 'bob', role: 'qa' },
+    ]);
+  });
+});
+
+describe('listPersonaStats', () => {
+  it('joins persona stats with codenames using personaName as the key', async () => {
+    const statRow = {
+      id: 1,
+      personaName: 'goose-hub-self/developer/0',
+      role: 'developer',
+      runsTotal: 5,
+      runsSucceeded: 4,
+      runsFailed: 1,
+      avgQualityScore: 0.85,
+      lastRunAt: '2026-05-01T00:00:00Z',
+    };
+    const nameRow = {
+      projectId: 'goose-hub-self',
+      role: 'developer',
+      slotIndex: 0,
+      codename: 'alice',
+    };
+
+    mockSelect
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([statRow]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockResolvedValue([nameRow]),
+      });
+
+    const result = await listPersonaStats();
+    expect(result).toHaveLength(1);
+    expect(result[0].codename).toBe('alice');
+    expect(result[0].runsTotal).toBe(5);
+  });
+
+  it('returns codename: null when no matching persona-name row exists', async () => {
+    const statRow = {
+      id: 2,
+      personaName: 'orphan/role/0',
+      role: 'role',
+      runsTotal: 0,
+      runsSucceeded: 0,
+      runsFailed: 0,
+      avgQualityScore: 0,
+      lastRunAt: '2026-05-01T00:00:00Z',
+    };
+
+    mockSelect
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([statRow]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockResolvedValue([]),
+      });
+
+    const result = await listPersonaStats();
+    expect(result[0].codename).toBeNull();
+  });
+});
+
+describe('listCandidatesByPersona', () => {
+  it('filters by personaName and the supplied status', async () => {
+    const orderBy = vi.fn().mockResolvedValue([{ id: 1, status: 'pending' }]);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({ where }),
+    });
+
+    const result = await listCandidatesByPersona('alice', 'pending');
+    expect(result).toEqual([{ id: 1, status: 'pending' }]);
+    expect(where).toHaveBeenCalled();
+  });
+
+  it('defaults the status filter to "pending"', async () => {
+    const orderBy = vi.fn().mockResolvedValue([]);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({ where }),
+    });
+
+    await listCandidatesByPersona('alice');
+    expect(where).toHaveBeenCalled();
+  });
+});
+
+describe('getCandidateById', () => {
+  it('returns the row when found', async () => {
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: 1, suggestionText: 'Add retries' }]),
+      }),
+    });
+
+    const result = await getCandidateById(1);
+    expect(result).toEqual({ id: 1, suggestionText: 'Add retries' });
+  });
+
+  it('returns null when no row is found', async () => {
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    expect(await getCandidateById(999)).toBeNull();
+  });
+});
+
+describe('updateCandidateStatus', () => {
+  it('updates the row and returns the updated record', async () => {
+    mockUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: 1, status: 'approved' }]),
+      }),
+    });
+
+    const result = await updateCandidateStatus(1, 'approved');
+    expect(result).toEqual({ id: 1, status: 'approved' });
+  });
+
+  it('returns null when the post-update read finds no row', async () => {
+    mockUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    expect(await updateCandidateStatus(404, 'rejected')).toBeNull();
+  });
+});
+
+describe('updateCandidateGithubIssue', () => {
+  it('writes the issue url + error note and returns the updated row', async () => {
+    mockUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([{ id: 5, githubIssueUrl: 'https://gh/i/9', errorNote: null }]),
+      }),
+    });
+
+    const result = await updateCandidateGithubIssue(5, 'https://gh/i/9', null);
+    expect(result?.githubIssueUrl).toBe('https://gh/i/9');
+  });
+
+  it('returns null when the row no longer exists', async () => {
+    mockUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    expect(await updateCandidateGithubIssue(999, null, 'some-error')).toBeNull();
+  });
+});
+
+describe('insertCandidate', () => {
+  it('inserts the row and returns it', async () => {
+    const inserted = {
+      id: 7,
+      projectId: 'goose-hub-self',
+      personaName: 'alice',
+      sourceTaskId: null,
+      suggestionText: 'Add retries',
+      suggestionType: 'skill-config',
+    };
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([inserted]),
+      }),
+    });
+
+    const result = await insertCandidate({
+      projectId: 'goose-hub-self',
+      personaName: 'alice',
+      sourceTaskId: null,
+      suggestionText: 'Add retries',
+      suggestionType: 'skill-config',
+    });
+    expect(result).toEqual(inserted);
+  });
+});

--- a/apps/server/src/domains/workflows/qa-batch.test.ts
+++ b/apps/server/src/domains/workflows/qa-batch.test.ts
@@ -1,0 +1,95 @@
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRunQaWorkflow } = vi.hoisted(() => ({ mockRunQaWorkflow: vi.fn() }));
+const { mockGetSourceForSlug } = vi.hoisted(() => ({ mockGetSourceForSlug: vi.fn() }));
+
+vi.mock('#shared/source.js', () => ({ getSourceForSlug: mockGetSourceForSlug }));
+
+// Cross-package import via URL — intercept the dynamic import.
+vi.mock(new URL('../../../../../slices/qa/workflow.js', import.meta.url).href, () => ({
+  runQaWorkflow: mockRunQaWorkflow,
+}));
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:org/repo#1',
+    externalId: '1',
+    repoRef: 'org/repo',
+    title: 'Test',
+    body: '',
+    type: 'bug',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:needs-qa',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeMockSource(items: WorkItem[]): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    listOpenWork: vi.fn().mockResolvedValue(items),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn(),
+    forceState: vi.fn(),
+    comment: vi.fn(),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn(),
+    setLabelInGroup: vi.fn(),
+    attach: vi.fn(),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runQaBatch', () => {
+  it('throws "Project not found" when no source can be resolved', async () => {
+    mockGetSourceForSlug.mockResolvedValue(null);
+    const { runQaBatch } = await import('./qa-batch.js');
+    await expect(runQaBatch('missing-slug')).rejects.toThrow(/Project not found: missing-slug/);
+    expect(mockRunQaWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('uses the explicit source argument when provided (skips getSourceForSlug)', async () => {
+    const source = makeMockSource([]);
+    const { runQaBatch } = await import('./qa-batch.js');
+    await runQaBatch('any-slug', source);
+    expect(mockGetSourceForSlug).not.toHaveBeenCalled();
+  });
+
+  it('only runs the workflow on items in factory:needs-qa state', async () => {
+    const items = [
+      makeWorkItem({ externalId: '1', state: 'factory:needs-qa' }),
+      makeWorkItem({ externalId: '2', state: 'factory:in-progress' }),
+      makeWorkItem({ externalId: '3', state: 'factory:needs-qa' }),
+    ];
+    const source = makeMockSource(items);
+    const { runQaBatch } = await import('./qa-batch.js');
+    await runQaBatch('goose-hub-self', source);
+    expect(mockRunQaWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to slug when item.repoRef is missing', async () => {
+    const item = makeWorkItem({ repoRef: undefined });
+    const source = makeMockSource([item]);
+    const { runQaBatch } = await import('./qa-batch.js');
+    await runQaBatch('fallback-slug', source);
+    expect(mockRunQaWorkflow).toHaveBeenCalledWith(item, source, source.projectId, 'fallback-slug');
+  });
+});

--- a/apps/server/src/domains/workflows/review-batch.test.ts
+++ b/apps/server/src/domains/workflows/review-batch.test.ts
@@ -1,0 +1,99 @@
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRunReviewWorkflow } = vi.hoisted(() => ({ mockRunReviewWorkflow: vi.fn() }));
+const { mockGetSourceForSlug } = vi.hoisted(() => ({ mockGetSourceForSlug: vi.fn() }));
+
+vi.mock('#shared/source.js', () => ({ getSourceForSlug: mockGetSourceForSlug }));
+
+vi.mock(new URL('../../../../../slices/review/workflow.js', import.meta.url).href, () => ({
+  runReviewWorkflow: mockRunReviewWorkflow,
+}));
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'github:org/repo#1',
+    externalId: '1',
+    repoRef: 'org/repo',
+    title: 'Test',
+    body: '',
+    type: 'bug',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:needs-review',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeMockSource(items: WorkItem[]): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    listOpenWork: vi.fn().mockResolvedValue(items),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+    listWorkByMilestone: vi.fn().mockResolvedValue([]),
+    getItem: vi.fn(),
+    listMilestones: vi.fn().mockResolvedValue([]),
+    getActiveMilestone: vi.fn().mockResolvedValue(null),
+    transitionState: vi.fn(),
+    forceState: vi.fn(),
+    comment: vi.fn(),
+    listComments: vi.fn().mockResolvedValue([]),
+    setMilestone: vi.fn(),
+    setLabelInGroup: vi.fn(),
+    attach: vi.fn(),
+    createIssue: vi.fn(),
+    watchForUpdates: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runReviewBatch', () => {
+  it('throws "Project not found" when no source can be resolved', async () => {
+    mockGetSourceForSlug.mockResolvedValue(null);
+    const { runReviewBatch } = await import('./review-batch.js');
+    await expect(runReviewBatch('missing-slug')).rejects.toThrow(/Project not found: missing-slug/);
+    expect(mockRunReviewWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('uses the explicit source argument when provided', async () => {
+    const source = makeMockSource([]);
+    const { runReviewBatch } = await import('./review-batch.js');
+    await runReviewBatch('any-slug', source);
+    expect(mockGetSourceForSlug).not.toHaveBeenCalled();
+  });
+
+  it('only runs the workflow on items in factory:needs-review state', async () => {
+    const items = [
+      makeWorkItem({ externalId: '1', state: 'factory:needs-review' }),
+      makeWorkItem({ externalId: '2', state: 'factory:needs-qa' }),
+      makeWorkItem({ externalId: '3', state: 'factory:needs-review' }),
+    ];
+    const source = makeMockSource(items);
+    const { runReviewBatch } = await import('./review-batch.js');
+    await runReviewBatch('goose-hub-self', source);
+    expect(mockRunReviewWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to slug when item.repoRef is missing', async () => {
+    const item = makeWorkItem({ repoRef: undefined });
+    const source = makeMockSource([item]);
+    const { runReviewBatch } = await import('./review-batch.js');
+    await runReviewBatch('fallback-slug', source);
+    expect(mockRunReviewWorkflow).toHaveBeenCalledWith(
+      item,
+      source,
+      source.projectId,
+      'fallback-slug',
+    );
+  });
+});

--- a/apps/web/e2e/issue-522.spec.ts
+++ b/apps/web/e2e/issue-522.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test('Kanban board milestone text truncates properly without overflow', async ({ page }) => {
   // Mock the API endpoints to return test data with long milestone names
-  await page.route('**/api/projects/*/issues', route =>
+  await page.route('**/api/projects/*/issues', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -31,7 +31,7 @@ test('Kanban board milestone text truncates properly without overflow', async ({
     }),
   );
 
-  await page.route('**/api/projects/*/issues/*/timeline*', route =>
+  await page.route('**/api/projects/*/issues/*/timeline*', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -50,7 +50,7 @@ test('Kanban board milestone text truncates properly without overflow', async ({
   expect(isVisible).toBe(true);
 
   // Get computed styles to verify truncation is applied
-  const computedStyle = await milestoneBadge.evaluate(el => {
+  const computedStyle = await milestoneBadge.evaluate((el) => {
     const style = window.getComputedStyle(el);
     return {
       overflow: style.overflow,
@@ -74,9 +74,7 @@ test('Kanban board milestone text truncates properly without overflow', async ({
   if (cardBounds && badgeBounds) {
     // Badge should be within card bounds (with small margin for padding)
     expect(badgeBounds.x).toBeGreaterThanOrEqual(cardBounds.x);
-    expect(badgeBounds.x + badgeBounds.width).toBeLessThanOrEqual(
-      cardBounds.x + cardBounds.width,
-    );
+    expect(badgeBounds.x + badgeBounds.width).toBeLessThanOrEqual(cardBounds.x + cardBounds.width);
   }
 
   // Take a screenshot as visual evidence

--- a/apps/web/src/components/detail/lib/investigation.test.ts
+++ b/apps/web/src/components/detail/lib/investigation.test.ts
@@ -1,0 +1,108 @@
+import type { AgentEventDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import {
+  CONFIDENCE_COLOR,
+  CONFIDENCE_NUM,
+  READ_TOOLS,
+  SEARCH_TOOLS,
+  SEV_LABEL,
+  SEV_VAR,
+  countToolCalls,
+  decisionLabel,
+  extractInvestigationPayload,
+} from './investigation';
+
+function event(partial: Partial<AgentEventDto>): AgentEventDto {
+  return {
+    id: 1,
+    projectId: 'proj',
+    workItemId: 'wi-1',
+    runId: null,
+    personaId: null,
+    kind: 'agent.tool-call',
+    payload: {},
+    createdAt: new Date().toISOString(),
+    ...partial,
+  } as AgentEventDto;
+}
+
+describe('decisionLabel', () => {
+  it('returns kind when present', () => {
+    expect(decisionLabel({ kind: 'PLAN', summary: 's' })).toBe('PLAN');
+  });
+
+  it('falls back to step when only step is set (legacy pre-#466)', () => {
+    expect(decisionLabel({ step: 'INVESTIGATE', summary: 's' })).toBe('INVESTIGATE');
+  });
+
+  it('returns empty string when neither kind nor step is set', () => {
+    expect(decisionLabel({ summary: 's' })).toBe('');
+  });
+
+  it('prefers kind over step when both are set', () => {
+    expect(decisionLabel({ kind: 'A', step: 'B', summary: 's' })).toBe('A');
+  });
+});
+
+describe('extractInvestigationPayload', () => {
+  it('returns null when payload is null', () => {
+    expect(extractInvestigationPayload(event({ payload: null }))).toBeNull();
+  });
+
+  it('returns null when "investigate" key is missing', () => {
+    expect(extractInvestigationPayload(event({ payload: { other: true } }))).toBeNull();
+  });
+
+  it('returns the payload when "investigate" key is present', () => {
+    const investigate = {
+      findings: 'x',
+      keyFiles: [],
+      confidence: 'high' as const,
+      openQuestions: [],
+      decisionSummaries: [],
+    };
+    const result = extractInvestigationPayload(event({ payload: { investigate } }));
+    expect(result).toEqual({ investigate });
+  });
+});
+
+describe('countToolCalls', () => {
+  it('counts only events whose kind is agent.tool-call', () => {
+    const events: AgentEventDto[] = [
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Read' } }),
+      event({ kind: 'agent.run-started', payload: { tool_name: 'Read' } }),
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Read' } }),
+    ];
+    expect(countToolCalls(events, READ_TOOLS)).toBe(2);
+  });
+
+  it('ignores tool-call events whose tool_name is not in the supplied set', () => {
+    const events: AgentEventDto[] = [
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Bash' } }),
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Grep' } }),
+    ];
+    expect(countToolCalls(events, READ_TOOLS)).toBe(0);
+    expect(countToolCalls(events, SEARCH_TOOLS)).toBe(1);
+  });
+
+  it('ignores tool-call events with no tool_name', () => {
+    const events: AgentEventDto[] = [
+      event({ kind: 'agent.tool-call', payload: {} }),
+      event({ kind: 'agent.tool-call', payload: null }),
+    ];
+    expect(countToolCalls(events, READ_TOOLS)).toBe(0);
+  });
+});
+
+describe('investigation constants', () => {
+  it('exposes confidence colour, number, and severity maps for high/medium/low', () => {
+    for (const k of ['high', 'medium', 'low'] as const) {
+      expect(CONFIDENCE_COLOR[k]).toBeDefined();
+      expect(typeof CONFIDENCE_NUM[k]).toBe('number');
+      expect(SEV_VAR[k]).toMatch(/^var\(--/);
+      expect(SEV_LABEL[k]).toBeDefined();
+    }
+    expect(CONFIDENCE_NUM.high).toBeGreaterThan(CONFIDENCE_NUM.medium);
+    expect(CONFIDENCE_NUM.medium).toBeGreaterThan(CONFIDENCE_NUM.low);
+  });
+});

--- a/apps/web/src/components/detail/lib/qa.test.ts
+++ b/apps/web/src/components/detail/lib/qa.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { TIERS, formatWallTime, severityColor } from './qa';
+
+describe('formatWallTime', () => {
+  it('shows milliseconds for sub-second durations', () => {
+    expect(formatWallTime(0)).toBe('0ms');
+    expect(formatWallTime(999)).toBe('999ms');
+  });
+
+  it('shows two decimals for sub-10s durations', () => {
+    expect(formatWallTime(1000)).toBe('1.00s');
+    expect(formatWallTime(9499)).toBe('9.50s');
+  });
+
+  it('shows one decimal for 10s..59s durations', () => {
+    expect(formatWallTime(10_000)).toBe('10.0s');
+    expect(formatWallTime(59_900)).toBe('59.9s');
+  });
+
+  it('shows minutes-and-seconds for 60s+ durations', () => {
+    expect(formatWallTime(60_000)).toBe('1m 0s');
+    expect(formatWallTime(125_000)).toBe('2m 5s');
+  });
+});
+
+describe('severityColor', () => {
+  it('returns the danger colour for "error"', () => {
+    expect(severityColor('error')).toBe('var(--danger)');
+  });
+
+  it('returns the warning colour for "warning"', () => {
+    expect(severityColor('warning')).toBe('var(--warning)');
+  });
+
+  it('returns the info colour for "info"', () => {
+    expect(severityColor('info')).toBe('var(--info)');
+  });
+});
+
+describe('TIERS', () => {
+  it('exposes the canonical three-tier order', () => {
+    expect(TIERS).toEqual(['structural', 'functional', 'regression']);
+  });
+});

--- a/apps/web/src/components/detail/lib/retrospective.test.ts
+++ b/apps/web/src/components/detail/lib/retrospective.test.ts
@@ -1,0 +1,64 @@
+import { AlertCircle, CheckCircle, XCircle } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+import { CONFIDENCE_COLOR, outcomeMeta, scoreGrade } from './retrospective';
+
+describe('scoreGrade', () => {
+  it('returns "Excellent" for scores >= 0.9', () => {
+    expect(scoreGrade(0.9)).toEqual({ label: 'Excellent', color: 'var(--success)' });
+    expect(scoreGrade(1.0)).toEqual({ label: 'Excellent', color: 'var(--success)' });
+  });
+
+  it('returns "Strong" for scores in [0.8, 0.9)', () => {
+    expect(scoreGrade(0.8)).toEqual({ label: 'Strong', color: 'var(--success)' });
+    expect(scoreGrade(0.89)).toEqual({ label: 'Strong', color: 'var(--success)' });
+  });
+
+  it('returns "Solid" for scores in [0.7, 0.8)', () => {
+    expect(scoreGrade(0.7)).toEqual({ label: 'Solid', color: 'var(--accent)' });
+    expect(scoreGrade(0.79)).toEqual({ label: 'Solid', color: 'var(--accent)' });
+  });
+
+  it('returns "Mixed" for scores in [0.6, 0.7)', () => {
+    expect(scoreGrade(0.6)).toEqual({ label: 'Mixed', color: 'var(--warning)' });
+    expect(scoreGrade(0.69)).toEqual({ label: 'Mixed', color: 'var(--warning)' });
+  });
+
+  it('returns "Concerning" for scores below 0.6', () => {
+    expect(scoreGrade(0.59)).toEqual({ label: 'Concerning', color: 'var(--danger)' });
+    expect(scoreGrade(0)).toEqual({ label: 'Concerning', color: 'var(--danger)' });
+  });
+});
+
+describe('outcomeMeta', () => {
+  it('maps "success" to CheckCircle + success colour', () => {
+    expect(outcomeMeta('success')).toEqual({
+      icon: CheckCircle,
+      color: 'var(--success)',
+      label: 'Success',
+    });
+  });
+
+  it('maps "failure" to XCircle + danger colour', () => {
+    expect(outcomeMeta('failure')).toEqual({
+      icon: XCircle,
+      color: 'var(--danger)',
+      label: 'Failure',
+    });
+  });
+
+  it('maps "partial" to AlertCircle + warning colour', () => {
+    expect(outcomeMeta('partial')).toEqual({
+      icon: AlertCircle,
+      color: 'var(--warning)',
+      label: 'Partial',
+    });
+  });
+});
+
+describe('CONFIDENCE_COLOR', () => {
+  it('exposes a colour class for every confidence level', () => {
+    expect(CONFIDENCE_COLOR.high).toContain('green');
+    expect(CONFIDENCE_COLOR.medium).toContain('yellow');
+    expect(CONFIDENCE_COLOR.low).toContain('blue');
+  });
+});

--- a/apps/web/src/components/inbox/lib/promote.test.ts
+++ b/apps/web/src/components/inbox/lib/promote.test.ts
@@ -1,0 +1,44 @@
+import type { MilestoneDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import { resolveActiveMilestone } from './promote';
+
+function milestone(partial: Partial<MilestoneDto>): MilestoneDto {
+  return {
+    id: partial.id ?? 'M0',
+    title: partial.title ?? 'Milestone',
+    number: partial.number ?? 0,
+    isActive: partial.isActive ?? false,
+    ...partial,
+  };
+}
+
+describe('resolveActiveMilestone', () => {
+  it('returns null when the list is empty', () => {
+    expect(resolveActiveMilestone([])).toBeNull();
+  });
+
+  it('returns null when no milestone is active', () => {
+    const result = resolveActiveMilestone([
+      milestone({ number: 1, isActive: false }),
+      milestone({ number: 2, isActive: false }),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns the number of the active milestone', () => {
+    const result = resolveActiveMilestone([
+      milestone({ number: 1, isActive: false }),
+      milestone({ number: 9, isActive: true }),
+      milestone({ number: 10, isActive: false }),
+    ]);
+    expect(result).toBe(9);
+  });
+
+  it('returns the first active milestone when several are flagged active', () => {
+    const result = resolveActiveMilestone([
+      milestone({ number: 3, isActive: true }),
+      milestone({ number: 4, isActive: true }),
+    ]);
+    expect(result).toBe(3);
+  });
+});

--- a/core/agent-runtime/mock-outputs.test.ts
+++ b/core/agent-runtime/mock-outputs.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSpec } from './interface.js';
+import { resolveMockOutput } from './mock-outputs.js';
+
+function makeSpec(overrides: Partial<AgentSpec> & { skill: string }): AgentSpec {
+  return {
+    runId: 'run-1',
+    role: 'triager',
+    context: {},
+    contextAllowlist: [],
+    freshContext: false,
+    toolBundles: [],
+    toolExtras: [],
+    budgets: { maxTurns: 1, maxBudgetUsd: 0.01 },
+    personaId: 'mock/triager/0',
+    ...overrides,
+  } as AgentSpec;
+}
+
+describe('resolveMockOutput — triage', () => {
+  it('passes through bug/research/feature workItem.type', () => {
+    for (const incoming of ['bug', 'research', 'feature'] as const) {
+      const result = resolveMockOutput(
+        makeSpec({ skill: 'triage', context: { workItem: { type: incoming } } }),
+      );
+      const out = result.output as { type: string };
+      expect(out.type).toBe(incoming);
+    }
+  });
+
+  it('falls back to "chore" when type is unknown or absent', () => {
+    const unknown = resolveMockOutput(
+      makeSpec({ skill: 'triage', context: { workItem: { type: 'gibberish' } } }),
+    );
+    expect((unknown.output as { type: string }).type).toBe('chore');
+
+    const missingWorkItem = resolveMockOutput(makeSpec({ skill: 'triage', context: {} }));
+    expect((missingWorkItem.output as { type: string }).type).toBe('chore');
+  });
+
+  it('emits a PLAN decision summary that mirrors the resolved type', () => {
+    const r = resolveMockOutput(
+      makeSpec({ skill: 'triage', context: { workItem: { type: 'bug' } } }),
+    );
+    expect(r.decisionSummaries).toHaveLength(1);
+    expect(r.decisionSummaries[0]).toMatchObject({
+      kind: 'PLAN',
+      summary: 'Classified as bug for e2e',
+    });
+  });
+});
+
+describe('resolveMockOutput — repo-match', () => {
+  it('returns a single shaunnez/goose-hub candidate at confidence 95', () => {
+    const r = resolveMockOutput(makeSpec({ skill: 'repo-match' }));
+    const out = r.output as { candidates: Array<{ repo: string; confidence: number }> };
+    expect(out.candidates).toHaveLength(1);
+    expect(out.candidates[0].repo).toBe('shaunnez/goose-hub');
+    expect(out.candidates[0].confidence).toBe(95);
+  });
+});
+
+describe('resolveMockOutput — implement', () => {
+  it('returns a deterministic implement plan with a mock PR url', () => {
+    const r = resolveMockOutput(makeSpec({ skill: 'implement' }));
+    const out = r.output as { prUrl: string; confidence: string; filesWritten: unknown[] };
+    expect(out.prUrl).toBe('https://github.com/shaunnez/goose-hub/pull/999');
+    expect(out.confidence).toBe('high');
+    expect(out.filesWritten).toHaveLength(1);
+  });
+});
+
+describe('resolveMockOutput — investigate', () => {
+  it('returns a high-confidence findings stub', () => {
+    const r = resolveMockOutput(makeSpec({ skill: 'investigate' }));
+    const out = r.output as { confidence: string; findings: string };
+    expect(out.confidence).toBe('high');
+    expect(out.findings).toBe('E2E mock findings');
+  });
+});
+
+describe('resolveMockOutput — qa', () => {
+  it('returns a passing functional verdict', () => {
+    const r = resolveMockOutput(makeSpec({ skill: 'qa' }));
+    const out = r.output as { verdict: string; tier: string };
+    expect(out.verdict).toBe('pass');
+    expect(out.tier).toBe('functional');
+  });
+});
+
+describe('resolveMockOutput — review', () => {
+  it('returns an "approved" verdict with no feedback', () => {
+    const r = resolveMockOutput(makeSpec({ skill: 'review' }));
+    const out = r.output as { verdict: string; feedback: string | null };
+    expect(out.verdict).toBe('approved');
+    expect(out.feedback).toBeNull();
+  });
+});
+
+describe('resolveMockOutput — unknown skill', () => {
+  it('throws when no preset matches', () => {
+    expect(() => resolveMockOutput(makeSpec({ skill: 'made-up-skill' }))).toThrow(
+      /no preset for skill "made-up-skill"/,
+    );
+  });
+});

--- a/core/agent-runtime/schema-bridge.test.ts
+++ b/core/agent-runtime/schema-bridge.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { toJsonSchema } from './schema-bridge.js';
+
+describe('toJsonSchema', () => {
+  it('converts a Zod schema to JSON Schema', () => {
+    const schema = z.object({ name: z.string(), count: z.number() });
+    const result = toJsonSchema(schema);
+    expect(result).toMatchObject({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        count: { type: 'number' },
+      },
+    });
+  });
+
+  it('returns an empty schema and warns when conversion throws', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A schema-shaped object that intentionally trips toJSONSchema by missing
+    // the internal _zod metadata it relies on.
+    const broken = {} as unknown as Parameters<typeof toJsonSchema>[0];
+
+    const result = toJsonSchema(broken);
+
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0][0])).toContain('schema-bridge');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/core/event-stream/store.test.ts
+++ b/core/event-stream/store.test.ts
@@ -461,10 +461,6 @@ describe('eventStore.closeOrphanedRuns', () => {
     db.delete(events).where(sql`project_id = ${ORPHAN_PROJECT}`).run();
   });
 
-  it('returns 0 when there are no run-started events at all', () => {
-    expect(eventStore.closeOrphanedRuns()).toBe(0);
-  });
-
   it('closes a run that started but never completed by emitting agent.run-failed', () => {
     const runId = 'orphan-run-1';
     eventStore.appendEvent({

--- a/core/event-stream/store.test.ts
+++ b/core/event-stream/store.test.ts
@@ -441,3 +441,112 @@ describe('EventStore — replay branch coverage', () => {
     errorSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// closeOrphanedRuns — startup recovery for crash-mid-run scenarios
+// ---------------------------------------------------------------------------
+
+describe('eventStore.closeOrphanedRuns', () => {
+  const ORPHAN_PROJECT = 'test-event-store-orphan';
+
+  beforeAll(() => {
+    db.delete(events).where(sql`project_id = ${ORPHAN_PROJECT}`).run();
+  });
+
+  afterEach(() => {
+    db.delete(events).where(sql`project_id = ${ORPHAN_PROJECT}`).run();
+  });
+
+  afterAll(() => {
+    db.delete(events).where(sql`project_id = ${ORPHAN_PROJECT}`).run();
+  });
+
+  it('returns 0 when there are no run-started events at all', () => {
+    expect(eventStore.closeOrphanedRuns()).toBe(0);
+  });
+
+  it('closes a run that started but never completed by emitting agent.run-failed', () => {
+    const runId = 'orphan-run-1';
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      workItemId: 'github:org/repo#1',
+      kind: 'agent.run-started',
+      payload: { skill: 'echo-test' },
+      runId,
+    });
+
+    const closed = eventStore.closeOrphanedRuns();
+    expect(closed).toBeGreaterThanOrEqual(1);
+
+    const replay = eventStore.replay({ projectId: ORPHAN_PROJECT, runId });
+    const failed = replay.find((e) => e.kind === 'agent.run-failed');
+    expect(failed).toBeDefined();
+    const payload = failed?.payload as { orphaned?: boolean; error?: string };
+    expect(payload.orphaned).toBe(true);
+    expect(payload.error).toMatch(/orphaned/i);
+  });
+
+  it('does not re-close a run that already has a run-completed event', () => {
+    const runId = 'completed-run-1';
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-started',
+      payload: {},
+      runId,
+    });
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-completed',
+      payload: {},
+      runId,
+    });
+
+    eventStore.closeOrphanedRuns();
+    const replay = eventStore.replay({ projectId: ORPHAN_PROJECT, runId });
+    const failedCount = replay.filter((e) => e.kind === 'agent.run-failed').length;
+    expect(failedCount).toBe(0);
+  });
+
+  it('does not re-close a run that already has a run-failed event', () => {
+    const runId = 'failed-run-1';
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-started',
+      payload: {},
+      runId,
+    });
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-failed',
+      payload: { error: 'first failure' },
+      runId,
+    });
+
+    eventStore.closeOrphanedRuns();
+    const replay = eventStore.replay({ projectId: ORPHAN_PROJECT, runId });
+    const failed = replay.filter((e) => e.kind === 'agent.run-failed');
+    // Still exactly one — closeOrphanedRuns must not have appended a synthetic one.
+    expect(failed).toHaveLength(1);
+    expect((failed[0].payload as { error: string }).error).toBe('first failure');
+  });
+
+  it('only emits a single synthetic failure even when a run has multiple started events', () => {
+    const runId = 'multi-start-run';
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-started',
+      payload: { attempt: 1 },
+      runId,
+    });
+    eventStore.appendEvent({
+      projectId: ORPHAN_PROJECT,
+      kind: 'agent.run-started',
+      payload: { attempt: 2 },
+      runId,
+    });
+
+    eventStore.closeOrphanedRuns();
+    const replay = eventStore.replay({ projectId: ORPHAN_PROJECT, runId });
+    expect(replay.filter((e) => e.kind === 'agent.run-failed')).toHaveLength(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         '**/vitest.config.ts',
         '**/vite.config.ts',
         '**/playwright.config.ts',
+        '**/playwright-*.config.ts',
         '**/tailwind.config.ts',
         '**/*.d.ts',
         // One-time migration/setup scripts — not unit-testable


### PR DESCRIPTION
## Summary

Adds 11 new test files (+78 tests) targeting the lowest-coverage files identified in the coverage sweep.

| Metric | Before | After | Threshold |
|---|---|---|---|
| Statements | 89.57 | **92.77** | 90 ✅ |
| Branches | 87.50 | **89.01** | 90 ❌ (0.99 short) |
| Functions | 90.18 | **94.47** | 90 ✅ |
| Lines | 89.57 | **92.77** | 90 ✅ |

### Files moved out of the gap list

| File | Before | After |
|---|---|---|
| `apps/web/src/components/inbox/lib/promote.ts` | 0% | 100% |
| `apps/web/src/components/detail/lib/retrospective.ts` | 0% | 100% |
| `core/agent-runtime/mock-outputs.ts` | 1.19% | 100% |
| `apps/server/src/domains/roster/repository.ts` lines | 3.84% | 100% |
| `apps/server/src/domains/costs/router.ts` | 28.57% | 100% |
| `apps/server/src/domains/costs/repository.ts` | 40% | 100% |
| `core/agent-runtime/schema-bridge.ts` | 50% | 100% |
| `core/event-stream/store.ts` lines | 71.54% | 100% (extended `closeOrphanedRuns` coverage) |
| `apps/server/src/domains/workflows/{qa,review}-batch.ts` branches | 40% | 88% |
| `apps/web/src/components/detail/lib/investigation.ts` branches | 30% | 97% |
| `apps/web/src/components/detail/lib/qa.ts` branches | 50% | 100% |

Also updates `vitest.config.ts` so the coverage exclude pattern matches `playwright-*.config.ts` (caught the orphan `playwright-e2e-pipeline.config.ts` showing 0%).

### Files still below 70% lines

Three remaining, all infrastructure that's intentionally e2e-tested rather than unit-tested:
- `apps/server/src/shared/dispatch.ts` — 38.64% (subprocess dispatchers + dynamic slice imports)
- `apps/server/src/domains/inbox/enhance.ts` — 16.94% (wraps `ClaudeCliRuntime` subprocess)
- `skills/bug-enhance/skill.config.ts` — 0% (config module, not unit-testable)

## Test plan

- [x] `pnpm test` — 1869 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm coverage` — lines/statements/functions over 90% threshold; branches at 89.01% (0.99% short of 90)

https://claude.ai/code/session_01FBw5zNXihfqV4pvBeEXCAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBw5zNXihfqV4pvBeEXCAt)_