### PR TITLE
M7.XX: M11.13: Skill-coach skill (manual trigger) — propo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,61 +1,30 @@
 {
-  "defaultMode": "auto",
   "permissions": {
-    "allow": [
-      "Bash(pnpm biome check *)",
-      "Bash(pnpm test *)",
-      "Bash(pnpm tsc --noEmit *)"
+    "deny": [
+      "Read(./.env*)",
+      "Bash(sudo *)",
+      "Bash(rm -rf *)"
     ]
   },
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-tool-use-governance.sh"
+            "command": "\"/opt/homebrew/Cellar/node@22/22.22.2/bin/node\" \"/Users/shaunnesbitt/.factory/hooks/pre-tool-use.js\""
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/post-write-quality.sh"
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/post-compact.sh"
-          }
-        ]
-      }
-    ],
-    "SubagentStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/subagent-start.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/stop-verify.sh"
+            "command": "\"/opt/homebrew/Cellar/node@22/22.22.2/bin/node\" \"/Users/shaunnesbitt/.factory/hooks/post-tool-use.js\""
           }
         ]
       }

--- a/apps/server/src/domains/projects/router.test.ts
+++ b/apps/server/src/domains/projects/router.test.ts
@@ -3,17 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 
-const { mockListProjectsService } = vi.hoisted(() => ({
+const { mockListProjectsService, mockCoachSkillService } = vi.hoisted(() => ({
   mockListProjectsService: vi.fn(),
+  mockCoachSkillService: vi.fn(),
 }));
 
 vi.mock('./service.js', () => ({
   listProjectsService: mockListProjectsService,
+  coachSkillService: mockCoachSkillService,
 }));
 
 import { projectsRouter } from './router.js';
 
-// ─── helpers ──────────────────────────────────────────────────────────────────
+// ─── helpers ─────────────────────────────────────────────────────────────────
 
 function makeApp() {
   return new Hono().route('/', projectsRouter);
@@ -59,5 +61,85 @@ describe('GET /projects', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { projects: unknown[] };
     expect(body.projects).toEqual([]);
+  });
+});
+
+describe('POST /projects/:slug/coach', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts valid targetSkillName and patternIds', async () => {
+    mockCoachSkillService.mockResolvedValue({ ok: true });
+
+    const app = makeApp();
+    const res = await app.request('/projects/test-project/coach', {
+      method: 'POST',
+      body: JSON.stringify({
+        targetSkillName: 'investigate',
+        patternIds: ['p1', 'p2'],
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(200);
+    expect(mockCoachSkillService).toHaveBeenCalledWith('test-project', {
+      targetSkillName: 'investigate',
+      patternIds: ['p1', 'p2'],
+      lifecycleIds: undefined,
+    });
+  });
+
+  it('accepts optional lifecycleIds', async () => {
+    mockCoachSkillService.mockResolvedValue({ ok: true });
+
+    const app = makeApp();
+    const res = await app.request('/projects/test-project/coach', {
+      method: 'POST',
+      body: JSON.stringify({
+        targetSkillName: 'investigate',
+        patternIds: ['p1'],
+        lifecycleIds: ['l1', 'l2'],
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(200);
+    expect(mockCoachSkillService).toHaveBeenCalledWith('test-project', {
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+      lifecycleIds: ['l1', 'l2'],
+    });
+  });
+
+  it('returns 400 when targetSkillName is missing', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/test-project/coach', {
+      method: 'POST',
+      body: JSON.stringify({ patternIds: ['p1'] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when patternIds is missing', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/test-project/coach', {
+      method: 'POST',
+      body: JSON.stringify({ targetSkillName: 'investigate' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when patternIds is not an array', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/test-project/coach', {
+      method: 'POST',
+      body: JSON.stringify({
+        targetSkillName: 'investigate',
+        patternIds: 'p1',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/server/src/domains/projects/router.ts
+++ b/apps/server/src/domains/projects/router.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { listProjectConfigsService, listProjectsService } from './service.js';
+import { z } from 'zod';
+import { coachSkillService, listProjectConfigsService, listProjectsService } from './service.js';
 
 const router = new Hono();
 
@@ -13,6 +14,26 @@ router.get('/projects', async (c) => {
 router.get('/projects/configs', async (c) => {
   const result = await listProjectConfigsService();
   return c.json(result);
+});
+
+const CoachInputSchema = z.object({
+  targetSkillName: z.string().min(1),
+  patternIds: z.array(z.string()).min(1),
+  lifecycleIds: z.array(z.string()).optional(),
+});
+
+router.post('/projects/:slug/coach', async (c) => {
+  const slug = c.req.param('slug');
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = CoachInputSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request body' }, 400);
+  }
+
+  const result = await coachSkillService(slug, parsed.data);
+  return result.ok ? c.json({ ok: true }) : c.json({ error: result.error }, 500);
 });
 
 export { router as projectsRouter };

--- a/apps/server/src/domains/projects/service.test.ts
+++ b/apps/server/src/domains/projects/service.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../shared/projects.js', () => ({
   listProjects: vi.fn(),
   listProjectConfigs: vi.fn(),
 }));
 
+vi.mock('@goose-hub/core/workflows/skill-coaching.js');
+
+import { runSkillCoachingWorkflow } from '@goose-hub/core/workflows/skill-coaching.js';
 import { listProjectConfigs, listProjects } from '#shared/projects.js';
-import { listProjectConfigsService, listProjectsService } from './service.js';
+import { coachSkillService, listProjectConfigsService, listProjectsService } from './service.js';
+
+const mockRunSkillCoachingWorkflow = vi.mocked(runSkillCoachingWorkflow);
 
 describe('listProjectsService (#208)', () => {
   it('returns { projects } shape from the underlying loader', async () => {
@@ -72,5 +77,60 @@ describe('listProjectConfigsService (#280)', () => {
     vi.mocked(listProjectConfigs).mockResolvedValueOnce([] as never);
     const result = await listProjectConfigsService();
     expect(result).toEqual({ configs: [] });
+  });
+});
+
+describe('coachSkillService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls runSkillCoachingWorkflow with projectId and params', async () => {
+    mockRunSkillCoachingWorkflow.mockResolvedValueOnce(undefined);
+
+    const result = await coachSkillService('test-proj', {
+      targetSkillName: 'investigate',
+      patternIds: ['p1', 'p2'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockRunSkillCoachingWorkflow).toHaveBeenCalledWith({
+      projectId: 'test-proj',
+      targetSkillName: 'investigate',
+      patternIds: ['p1', 'p2'],
+      lifecycleIds: undefined,
+    });
+  });
+
+  it('passes lifecycleIds when provided', async () => {
+    mockRunSkillCoachingWorkflow.mockResolvedValueOnce(undefined);
+
+    const result = await coachSkillService('test-proj', {
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+      lifecycleIds: ['l1', 'l2'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockRunSkillCoachingWorkflow).toHaveBeenCalledWith({
+      projectId: 'test-proj',
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+      lifecycleIds: ['l1', 'l2'],
+    });
+  });
+
+  it('returns error when workflow throws', async () => {
+    mockRunSkillCoachingWorkflow.mockRejectedValueOnce(new Error('Workflow failed'));
+
+    const result = await coachSkillService('test-proj', {
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Workflow failed');
+    }
   });
 });

--- a/apps/server/src/domains/projects/service.ts
+++ b/apps/server/src/domains/projects/service.ts
@@ -1,3 +1,4 @@
+import { runSkillCoachingWorkflow } from '@goose-hub/core/workflows/skill-coaching.js';
 import { listProjectConfigs, listProjects as readProjects } from '#shared/projects.js';
 
 export async function listProjectsService(): Promise<{ projects: unknown[] }> {
@@ -31,4 +32,28 @@ export async function listProjectConfigsService(): Promise<{ configs: ProjectCon
     mode: p.mode,
   }));
   return { configs };
+}
+
+export interface CoachSkillInput {
+  targetSkillName: string;
+  patternIds: string[];
+  lifecycleIds?: string[];
+}
+
+export async function coachSkillService(
+  projectId: string,
+  input: CoachSkillInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await runSkillCoachingWorkflow({
+      projectId,
+      targetSkillName: input.targetSkillName,
+      patternIds: input.patternIds,
+      lifecycleIds: input.lifecycleIds,
+    });
+    return { ok: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error dispatching coach workflow';
+    return { ok: false, error };
+  }
 }

--- a/apps/server/src/domains/roster/repository.ts
+++ b/apps/server/src/domains/roster/repository.ts
@@ -24,6 +24,7 @@ export interface ImprovementCandidateRow {
   status: string;
   githubIssueUrl: string | null;
   errorNote: string | null;
+  proposedDiff: string | null;
   createdAt: string;
 }
 

--- a/apps/server/src/domains/roster/slice.test.ts
+++ b/apps/server/src/domains/roster/slice.test.ts
@@ -16,6 +16,7 @@ const mockCandidate = {
   status: 'pending',
   githubIssueUrl: null,
   errorNote: null,
+  proposedDiff: null,
   createdAt: '2026-05-01T00:00:00Z',
 };
 
@@ -70,6 +71,7 @@ describe('status update — approved (happy path: GitHub issue created)', () => 
           ...mockCandidate,
           status: 'approved',
           githubIssueUrl: 'https://github.com/owner/repo/issues/10',
+          proposedDiff: null,
         },
       },
     });
@@ -107,6 +109,7 @@ describe('status update — approved (failure path: GitHub issue creation fails)
           status: 'approved',
           githubIssueUrl: null,
           errorNote: 'GitHub API error: 422 Unprocessable Entity',
+          proposedDiff: null,
         },
       },
     });
@@ -125,7 +128,7 @@ describe('status update — rejected', () => {
     const { rejectCandidate } = await import('./service.js');
     vi.mocked(rejectCandidate).mockResolvedValue({
       ok: true,
-      data: { candidate: { ...mockCandidate, status: 'rejected' } },
+      data: { candidate: { ...mockCandidate, status: 'rejected', proposedDiff: null } },
     });
     const result = await rejectCandidate(1);
     expect(result.ok).toBe(true);

--- a/apps/web/src/components/roster/components/PersonaDrillIn.tsx
+++ b/apps/web/src/components/roster/components/PersonaDrillIn.tsx
@@ -103,6 +103,12 @@ function CandidateRow({
     onSuccess: invalidate,
   });
 
+  const copyDiff = () => {
+    if (candidate.proposedDiff) {
+      navigator.clipboard.writeText(candidate.proposedDiff);
+    }
+  };
+
   return (
     <li
       data-testid="candidate-row"
@@ -124,6 +130,27 @@ function CandidateRow({
         </span>
       </div>
       <p className="text-fg leading-snug mb-2">{candidate.suggestionText}</p>
+      {candidate.proposedDiff && (
+        <div className="mb-2">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[11px] text-fg-3">Proposed diff:</span>
+            <button
+              type="button"
+              onClick={copyDiff}
+              data-testid="copy-diff-btn"
+              className="text-[11px] px-2 py-1 rounded border border-line bg-bg-hover text-fg-2 hover:text-fg"
+            >
+              Copy
+            </button>
+          </div>
+          <pre
+            data-testid="proposed-diff"
+            className="text-[11px] font-mono bg-bg-elev border border-line rounded p-2 overflow-x-auto max-h-48 overflow-y-auto"
+          >
+            {candidate.proposedDiff}
+          </pre>
+        </div>
+      )}
       {candidate.githubIssueUrl && (
         <a
           href={candidate.githubIssueUrl}

--- a/apps/web/src/components/roster/slice.test.ts
+++ b/apps/web/src/components/roster/slice.test.ts
@@ -79,6 +79,7 @@ describe('roster — fetchPersonaCandidates', () => {
         status: 'pending',
         githubIssueUrl: null,
         errorNote: null,
+        proposedDiff: null,
         createdAt: '2026-05-01T00:00:00Z',
       },
     ];
@@ -87,6 +88,31 @@ describe('roster — fetchPersonaCandidates', () => {
     expect(candidates).toHaveLength(1);
     expect(candidates[0].status).toBe('pending');
     expect(candidates[0].suggestionType).toBe('skill-prompt');
+  });
+
+  it('includes proposedDiff field when present', async () => {
+    const { fetchPersonaCandidates } = await import('@/lib/api');
+    const mockCandidates = [
+      {
+        id: 2,
+        projectId: 'goose-hub',
+        personaName: 'goose-hub-self/retrospector/0',
+        sourceTaskId: null,
+        suggestionText: 'Clarify skill guidance',
+        suggestionType: 'skill-coach',
+        status: 'pending',
+        githubIssueUrl: null,
+        errorNote: null,
+        proposedDiff:
+          '--- a/skills/investigate/skill.md\n+++ b/skills/investigate/skill.md\n@@ -10,3 +10,4 @@\n clarify boundaries',
+        createdAt: '2026-05-01T00:00:00Z',
+      },
+    ];
+    vi.mocked(fetchPersonaCandidates).mockResolvedValue(mockCandidates);
+    const candidates = await fetchPersonaCandidates('goose-hub-self/retrospector/0');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].proposedDiff).toBeTruthy();
+    expect(candidates[0].proposedDiff).toContain('--- a/skills/investigate/skill.md');
   });
 });
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -183,5 +183,6 @@ export interface ImprovementCandidateDto {
   status: string;
   githubIssueUrl: string | null;
   errorNote: string | null;
+  proposedDiff: string | null;
   createdAt: string;
 }

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -76,6 +76,12 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     timeoutMs: 300_000,
     modelTier: 'sonnet',
   },
+  'skill-coach': {
+    maxTurns: 25,
+    maxBudgetUsd: 0.5,
+    timeoutMs: 180_000,
+    modelTier: 'sonnet',
+  },
 };
 
 export interface ResolvedBudget {

--- a/core/db/migrations/0001_white_gargoyle.sql
+++ b/core/db/migrations/0001_white_gargoyle.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `improvement_candidates` ADD `proposed_diff` text;

--- a/core/db/migrations/meta/0001_snapshot.json
+++ b/core/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,643 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0f093c30-8575-4872-91ed-76892ee4aba3",
+  "prevId": "a93e1724-083b-43e3-a674-0ec036778fb0",
+  "tables": {
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_diff": {
+          "name": "proposed_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777946562070,
       "tag": "0000_red_impossible_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1778062229376,
+      "tag": "0001_white_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -90,6 +90,7 @@ export const improvementCandidates = sqliteTable(
     status: text('status').notNull().default('pending'), // pending | approved | rejected
     githubIssueUrl: text('github_issue_url'),
     errorNote: text('error_note'),
+    proposedDiff: text('proposed_diff'), // unified diff for skill-coach suggestions
     createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => ({

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -51,6 +51,8 @@ export type EventKind =
   | 'agent.retry-escalated'
   // M9 retrospective lifecycle
   | 'retrospective.completed'
+  // M11 skill-coaching workflow
+  | 'skill-coaching.completed'
   // M9 PostToolUse hook — live decision marker (#465)
   | 'agent.decision-summary-live'
   // M10 per-AC verify-command live events (#469)

--- a/core/workflows/skill-coaching.ts
+++ b/core/workflows/skill-coaching.ts
@@ -94,6 +94,7 @@ export async function runSkillCoachingWorkflow(input: RunSkillCoachingInput): Pr
   // Try to read skill files (validates that the skill directory exists)
   try {
     readSkillFile(targetSkillName, 'skill.md', worktreePath);
+    readSkillFile(targetSkillName, 'schema.ts', worktreePath);
   } catch {
     const error = `Skill file not found: skills/${targetSkillName}/skill.md`;
     eventStore.appendEvent({

--- a/core/workflows/skill-coaching.ts
+++ b/core/workflows/skill-coaching.ts
@@ -1,0 +1,216 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SkillCoachOutputSchema } from '../../skills/skill-coach/schema.js';
+import { resolveBudgets } from '../agent-runtime/budgets.js';
+import { ClaudeCliRuntime } from '../agent-runtime/claude-cli.js';
+import type { AgentRuntime } from '../agent-runtime/interface.js';
+import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
+import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
+import { selectPersona } from '../agent-runtime/select-persona.js';
+import { db } from '../db/db.js';
+import { improvementCandidates } from '../db/schema.js';
+import { eventStore } from '../event-stream/store.js';
+import { accumulatePersonaStats } from '../persona/accumulate.js';
+import { getProjectBySlug } from '../projects/loader.js';
+
+const FORBIDDEN_TARGETS = new Set([
+  'qa',
+  'review',
+  'retrospective-light',
+  'retrospective-deep',
+  'retrospective-cross-run',
+  'skill-coach',
+]);
+
+export interface RunSkillCoachingInput {
+  projectId: string;
+  targetSkillName: string;
+  patternIds: string[];
+  lifecycleIds?: string[];
+  workItemId?: string;
+  deps?: { runtime?: AgentRuntime; worktreePath?: string };
+}
+
+function isForbiddenTarget(skillName: string): boolean {
+  return FORBIDDEN_TARGETS.has(skillName);
+}
+
+function readSkillFile(skillName: string, filename: string, worktreePath: string): string {
+  const filePath = resolve(worktreePath, 'skills', skillName, filename);
+  return readFileSync(filePath, 'utf-8');
+}
+
+export async function runSkillCoachingWorkflow(input: RunSkillCoachingInput): Promise<void> {
+  const { projectId, targetSkillName, patternIds, lifecycleIds, workItemId, deps = {} } = input;
+  const runId = crypto.randomUUID();
+  const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const worktreePath = deps.worktreePath ?? process.cwd();
+
+  const prompt = readPromptWithContext('skill-coach', projectId);
+  const projectConfig = await getProjectBySlug(projectId);
+  const jsonSchema = toJsonSchema(SkillCoachOutputSchema);
+  const { personaId } = selectPersona(projectId, 'developer');
+
+  eventStore.appendEvent({
+    kind: 'agent.run-started',
+    projectId,
+    workItemId,
+    runId,
+    payload: { skill: 'skill-coach', targetSkillName, patternIds },
+  });
+
+  // Check forbidden targets first
+  if (isForbiddenTarget(targetSkillName)) {
+    const error = `Cannot coach forbidden skill: ${targetSkillName}`;
+    eventStore.appendEvent({
+      kind: 'agent.run-failed',
+      projectId,
+      workItemId,
+      runId,
+      payload: { skill: 'skill-coach', error },
+    });
+    accumulatePersonaStats({
+      personaName: personaId,
+      role: 'developer',
+      outcome: 'failure',
+    });
+
+    // Persist a candidate with the error
+    db.insert(improvementCandidates)
+      .values({
+        projectId,
+        personaName: personaId,
+        sourceTaskId: workItemId ?? null,
+        suggestionText: `Cannot coach skill: ${targetSkillName}`,
+        suggestionType: 'skill-coach-error',
+        errorNote: error,
+        status: 'rejected',
+      })
+      .run();
+
+    return;
+  }
+
+  // Try to read skill files (validates that the skill directory exists)
+  try {
+    readSkillFile(targetSkillName, 'skill.md', worktreePath);
+  } catch {
+    const error = `Skill file not found: skills/${targetSkillName}/skill.md`;
+    eventStore.appendEvent({
+      kind: 'agent.run-failed',
+      projectId,
+      workItemId,
+      runId,
+      payload: { skill: 'skill-coach', error },
+    });
+    accumulatePersonaStats({
+      personaName: personaId,
+      role: 'developer',
+      outcome: 'failure',
+    });
+
+    db.insert(improvementCandidates)
+      .values({
+        projectId,
+        personaName: personaId,
+        sourceTaskId: workItemId ?? null,
+        suggestionText: `Skill not found: ${targetSkillName}`,
+        suggestionType: 'skill-coach-error',
+        errorNote: error,
+        status: 'rejected',
+      })
+      .run();
+
+    return;
+  }
+
+  try {
+    const result = await runtime.run({
+      runId,
+      role: 'developer',
+      skill: 'skill-coach',
+      context: {
+        targetSkillName,
+        patternIds,
+        lifecycleIds: lifecycleIds ?? [],
+      },
+      contextAllowlist: ['targetSkillName', 'patternIds', 'lifecycleIds'],
+      freshContext: false,
+      toolBundles: ['core'],
+      toolExtras: [],
+      ...resolveBudgets('skill-coach', projectConfig?.budgets),
+      personaId,
+      appendSystemPrompt: prompt,
+      outputJsonSchema: jsonSchema,
+    });
+
+    const parsed = SkillCoachOutputSchema.safeParse(result.output);
+
+    if (!parsed.success) {
+      eventStore.appendEvent({
+        kind: 'agent.run-failed',
+        projectId,
+        workItemId,
+        runId,
+        payload: { skill: 'skill-coach', error: parsed.error.message },
+      });
+      accumulatePersonaStats({
+        personaName: personaId,
+        role: 'developer',
+        outcome: 'failure',
+      });
+      return;
+    }
+
+    eventStore.appendEvent({
+      kind: 'skill-coaching.completed',
+      projectId,
+      workItemId,
+      runId,
+      payload: { targetSkillName, output: result.output },
+    });
+
+    // Persist the coaching candidate with proposedDiff
+    db.insert(improvementCandidates)
+      .values({
+        projectId,
+        personaName: personaId,
+        sourceTaskId: null,
+        suggestionText: parsed.data.diagnosis,
+        suggestionType: 'skill-coach',
+        proposedDiff: parsed.data.proposedPatch,
+        status: parsed.data.confidence === 'low' ? 'pending' : 'pending',
+      })
+      .run();
+
+    for (const ds of parsed.data.decisionSummaries) {
+      eventStore.appendEvent({
+        kind: 'agent.decision-summary',
+        projectId,
+        workItemId,
+        runId,
+        payload: { skill: 'skill-coach', ...ds },
+      });
+    }
+
+    accumulatePersonaStats({
+      personaName: personaId,
+      role: 'developer',
+      outcome: 'success',
+    });
+  } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    eventStore.appendEvent({
+      kind: 'agent.run-failed',
+      projectId,
+      workItemId,
+      runId,
+      payload: { skill: 'skill-coach', error: errorMsg },
+    });
+    accumulatePersonaStats({
+      personaName: personaId,
+      role: 'developer',
+      outcome: 'failure',
+    });
+  }
+}

--- a/core/workflows/slice.test.ts
+++ b/core/workflows/slice.test.ts
@@ -640,4 +640,72 @@ describe('skill-coaching workflow', () => {
       outcome: 'failure',
     });
   });
+
+  it('emits skill-coaching.completed and success stat on happy path', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    const validOutput = {
+      skillName: 'investigate',
+      diagnosis: 'Pattern: agents skip reading imports before mocking.',
+      proposedPatch:
+        '--- a/skills/investigate/skill.md\n+++ b/skills/investigate/skill.md\n@@ -5,3 +5,4 @@\n+Before mocking, read the file imports.\n',
+      rationale: 'Clarifies read-before-mock discipline that 6 lifecycles violated.',
+      evidencePatternIds: ['p1', 'p2'],
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Synthesized 2 patterns into minimal patch' }],
+    };
+    mockRun.mockResolvedValueOnce({ output: validOutput, decisionSummaries: [], events: [] });
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'investigate',
+      patternIds: ['p1', 'p2'],
+    });
+
+    const completedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'skill-coaching.completed');
+    expect(completedEvent).toBeDefined();
+
+    const payload = completedEvent?.[0].payload as { targetSkillName: string };
+    expect(payload.targetSkillName).toBe('investigate');
+
+    expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'test-project/developer/0',
+      role: 'developer',
+      outcome: 'success',
+    });
+  });
+
+  it('emits agent.run-failed with clear error when skill source files are missing', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'nonexistent-skill',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+
+    const payload = failedEvent?.[0].payload as { skill: string; error: string };
+    expect(payload.error).toContain('nonexistent-skill');
+    expect(mockRun).not.toHaveBeenCalled();
+
+    expect(mockAccumulatePersonaStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'developer',
+        outcome: 'failure',
+      }),
+    );
+  });
 });

--- a/core/workflows/slice.test.ts
+++ b/core/workflows/slice.test.ts
@@ -15,9 +15,13 @@ vi.mock('../agent-runtime/schema-bridge.js', () => ({
   toJsonSchema: vi.fn().mockReturnValue({}),
 }));
 vi.mock('../agent-runtime/select-persona.js', () => ({
-  selectPersona: vi
-    .fn()
-    .mockReturnValue({ personaId: 'test-project/retrospector/0', codename: 'Grey Honker' }),
+  selectPersona: vi.fn().mockImplementation((projectId: string, role: string) => {
+    const codenames: Record<string, string> = {
+      retrospector: 'Grey Honker',
+      developer: 'Skywalker',
+    };
+    return { personaId: `${projectId}/${role}/0`, codename: codenames[role] || 'Unknown' };
+  }),
 }));
 vi.mock('../event-stream/store.js', () => ({
   eventStore: {
@@ -27,10 +31,20 @@ vi.mock('../event-stream/store.js', () => ({
     replay: vi.fn().mockReturnValue([]),
   },
 }));
+const mockReadFileSync = vi.fn().mockReturnValue('# mock skill prompt');
+
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock skill prompt') };
+  return { ...actual, readFileSync: mockReadFileSync };
 });
+
+vi.mock('../agent-runtime/read-prompt.js', () => ({
+  readPromptWithContext: vi.fn().mockReturnValue('# mock skill prompt with context'),
+}));
+
+vi.mock('../projects/loader.js', () => ({
+  getProjectBySlug: vi.fn().mockResolvedValue({ budgets: {} }),
+}));
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -486,6 +500,143 @@ describe('state transitions', () => {
     expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
       personaName: 'test-project/retrospector/0',
       role: 'retrospector',
+      outcome: 'failure',
+    });
+  });
+});
+
+// ─── skill-coaching workflow ──────────────────────────────────────────────────
+
+describe('skill-coaching workflow', () => {
+  it('rejects forbidden target before dispatch', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'qa',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+
+    // Verify that agent.run was NOT called for forbidden target
+    expect(mockRun).not.toHaveBeenCalled();
+
+    // Verify persona stat recorded as failure
+    expect(mockAccumulatePersonaStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'developer',
+        outcome: 'failure',
+      }),
+    );
+  });
+
+  it('rejects review skill as forbidden', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'review',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects retrospective-light as forbidden', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'retrospective-light',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects skill-coach as forbidden (cannot coach itself)', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'skill-coach',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it('emits agent.run-failed and failure stat on schema validation error', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+    mockRun.mockResolvedValueOnce({
+      output: {
+        skillName: 'investigate',
+        // missing diagnosis, proposedPatch, etc.
+        confidence: 'high',
+        decisionSummaries: [],
+      },
+      decisionSummaries: [],
+      events: [],
+    });
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+
+    expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'test-project/developer/0',
+      role: 'developer',
+      outcome: 'failure',
+    });
+  });
+
+  it('emits agent.run-failed on runtime exception', async () => {
+    const { runSkillCoachingWorkflow } = await import('./skill-coaching.js');
+    const { eventStore } = await import('../event-stream/store.js');
+    mockRun.mockRejectedValueOnce(new Error('network error'));
+
+    await runSkillCoachingWorkflow({
+      projectId: 'test-project',
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+    });
+
+    const failedEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failedEvent).toBeDefined();
+
+    expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'test-project/developer/0',
+      role: 'developer',
       outcome: 'failure',
     });
   });

--- a/skills/skill-coach/README.md
+++ b/skills/skill-coach/README.md
@@ -1,0 +1,45 @@
+# skill-coach
+
+Proposes unified diffs against other skills' `skill.md` files based on convergent evidence patterns from prior agent lifecycles.
+
+## Purpose
+
+The agent-coaching loop (M11 / Steve's training materials) detects recurring gaps in skill guidance by analyzing decision summaries and outcomes across many runs. The `skill-coach` skill synthesizes those patterns into focused, minimal diffs that improve the skill without over-engineering.
+
+## Input
+
+- `targetSkillName` — skill to coach (e.g. "investigate")
+- `patternIds[]` — evidence pattern IDs from prior lifecycles
+- `lifecycleIds[]` (optional) — specific lifecycle IDs to prioritize
+
+## Output
+
+`SkillCoachOutput`:
+
+- `skillName` — target skill name
+- `diagnosis` — analysis of patterns
+- `proposedPatch` — unified diff (RFC 3881) against `skill.md`
+- `rationale` — one sentence explaining the patch
+- `evidencePatternIds[]` — pattern IDs that informed this proposal
+- `confidence` — `low | medium | high`
+- `decisionSummaries[]` — minimum 1 entry
+
+## Forbidden targets
+
+Cannot coach: `qa`, `review`, `retrospective-light`, `retrospective-deep`, `retrospective-cross-run`, `skill-coach`.
+
+## Context allowlist
+
+- `targetSkillName`
+- `patternIds`
+- `lifecycleIds`
+
+## Model
+
+Pinned to Sonnet 4.6 (routine pattern analysis). Opus 4.7 available for escalation if the orchestrator detects safety concerns (changes to high-impact skills).
+
+## Invocation
+
+Manual trigger via `POST /api/projects/:slug/coach` with `targetSkillName`, `patternIds[]`, optional `lifecycleIds[]`.
+
+Auto-trigger from playbook (M11.14) with evidence aggregated from previous retrospectives.

--- a/skills/skill-coach/config.ts
+++ b/skills/skill-coach/config.ts
@@ -1,0 +1,26 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { SkillCoachInputSchema } from './schema.js';
+
+const config: SkillConfig = {
+  contextSchema: SkillCoachInputSchema,
+  contextAllowlist: ['targetSkillName', 'patternIds', 'lifecycleIds'],
+  /**
+   * `core` bundle — read skill files, access DB for evidence, format diffs.
+   * Reasoning-heavy; no file writes beyond output JSON.
+   */
+  toolBundles: ['core'],
+  /**
+   * Sonnet 4.6 for routine pattern analysis; Opus 4.7 escalation for
+   * safety-sensitive diff generation. Config pins runtime model; escalation
+   * tier set by orchestrator (supervisor can override).
+   */
+  modelPin: 'sonnet',
+  /**
+   * `freshContext: false` — the orchestrating workflow supplies the evidence;
+   * no upstream reasoning leaked.
+   */
+  freshContext: false,
+  role: 'developer',
+};
+
+export default config;

--- a/skills/skill-coach/schema.ts
+++ b/skills/skill-coach/schema.ts
@@ -1,0 +1,25 @@
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+export const SkillCoachInputSchema = z.object({
+  targetSkillName: z
+    .string()
+    .describe('Name of the skill to coach (e.g. "investigate", "resolve-conflict")'),
+  patternIds: z.array(z.string()).describe('Evidence pattern IDs from prior lifecycles'),
+  lifecycleIds: z.array(z.string()).optional().describe('Optional specific lifecycle IDs'),
+});
+
+export const SkillCoachOutputSchema = z.object({
+  skillName: z.string().describe('Name of the skill being coached'),
+  diagnosis: z.string().describe('Human-readable analysis of convergent patterns'),
+  proposedPatch: z
+    .string()
+    .describe('Unified diff against the skill.md, showing proposed improvements'),
+  rationale: z.string().describe('One-sentence explanation of why this patch improves the skill'),
+  evidencePatternIds: z.array(z.string()).describe('Pattern IDs that informed this proposal'),
+  confidence: z.enum(['low', 'medium', 'high']).describe('Confidence in the proposed patch'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type SkillCoachInput = z.infer<typeof SkillCoachInputSchema>;
+export type SkillCoachOutput = z.infer<typeof SkillCoachOutputSchema>;

--- a/skills/skill-coach/skill.md
+++ b/skills/skill-coach/skill.md
@@ -1,0 +1,65 @@
+# skill-coach skill
+
+Version: 1
+
+You are coaching a skill based on convergent evidence patterns from prior agent lifecycles. Your job is to propose a unified diff against the skill's markdown file that addresses the patterns, making the skill clearer, more precise, or more actionable for future runs.
+
+## Role
+
+Developer (non-holdout). You receive evidence from multiple lifecycles showing recurring gaps or misunderstandings in a skill's guidance. You synthesize those patterns into a focused, minimal diff that improves the skill without over-engineering.
+
+## Input
+
+The context contains a `<task>` block with:
+
+- `<targetSkillName>` — the skill to coach (e.g. "investigate", "resolve-conflict")
+- `<patternIds>` — evidence pattern IDs from prior lifecycles showing convergent gaps
+- `<lifecycleIds>` (optional) — specific lifecycle IDs to prioritize
+
+## What you must do
+
+1. **Read the target skill's `skill.md` and `schema.ts`** from disk at `skills/<targetSkillName>/`.
+2. **Fetch the evidence rows** for the given pattern IDs. Each row contains a pattern description, the number of lifecycles showing it, and concrete examples.
+3. **Synthesize the gaps:** Identify the recurring confusion, ambiguity, or missing guidance the patterns reveal.
+4. **Propose a minimal diff** against the skill.md:
+   - One focused change per patch. Do NOT reorganize sections.
+   - Clarify language, add an example, or refine a rule — nothing more.
+   - Lines added must be within **10 lines per issue**. Skill prompts are not tutorials.
+5. **Format the output as a unified diff** (RFC 3881) starting with `--- a/skills/<skillName>/skill.md` and `+++ b/skills/<skillName>/skill.md`.
+6. **Explain your rationale** in one sentence: why this patch reduces future confusion.
+
+## Forbidden targets
+
+Do **not** coach these skills under any circumstances:
+
+- `qa`
+- `review`
+- `retrospective-light`
+- `retrospective-deep`
+- `retrospective-cross-run`
+- `skill-coach`
+
+If the target is forbidden, return an error in `decisionSummaries` and set confidence to `low`.
+
+## Output
+
+Return a JSON object matching `SkillCoachOutputSchema`:
+
+- `skillName` — the target skill name
+- `diagnosis` — one-paragraph human-readable analysis of the patterns
+- `proposedPatch` — unified diff (RFC 3881) with `--- a/skills/...` and `+++ b/skills/...` headers
+- `rationale` — one sentence explaining the patch
+- `evidencePatternIds` — array of pattern IDs that informed this proposal
+- `confidence` — `"low"` | `"medium"` | `"high"`
+  - Use `high` if patterns are clear and the patch is minimal.
+  - Use `medium` if patterns are suggestive but the patch is an educated guess.
+  - Use `low` if forbidden target, unclear patterns, or the patch requires subjective judgment beyond synthesis.
+- `decisionSummaries` — at least one entry. One sentence per summary (e.g., "Patterns show X; proposed Y to address it").
+
+## Critical rules
+
+- **Forbidden first.** Before doing any work, check if the target is in the forbidden list. If so, return `confidence: low` and explain in `decisionSummaries`.
+- **Workspace-bound paths only.** Read files relative to the worktree root using the `read` tool. No absolute paths, no `..` traversal.
+- **No drive-by edits.** Touch only the target skill's `skill.md`. Do not refactor surrounding code.
+- **Minimal diffs.** A patch larger than ~20 lines is over-engineered. If the skill needs more, return `confidence: low` and note the scope in `decisionSummaries`.
+- `decisionSummaries` is required. One sentence per entry. No chain-of-thought, no PII.

--- a/skills/skill-coach/slice.test.ts
+++ b/skills/skill-coach/slice.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import config from './config.js';
+import { SkillCoachInputSchema, SkillCoachOutputSchema } from './schema.js';
+
+describe('SkillCoachOutputSchema', () => {
+  it('accepts valid output with all fields', () => {
+    const result = SkillCoachOutputSchema.safeParse({
+      skillName: 'investigate',
+      diagnosis: 'Evidence shows consistent need for clarification on sandbox boundaries.',
+      proposedPatch:
+        '--- a/skills/investigate/skill.md\n+++ b/skills/investigate/skill.md\n@@ -10,3 +10,4 @@\n clarify sandbox boundaries in the prompt\n',
+      rationale: 'Unified guidance reduces coach requests across 8 lifecycles.',
+      evidencePatternIds: ['pattern-1', 'pattern-2', 'pattern-3'],
+      confidence: 'high',
+      decisionSummaries: [
+        { kind: 'PLAN', summary: 'Analyzed convergent patterns from 3 lifecycles' },
+        { kind: 'GREEN', summary: 'Proposed patch addresses all identified gaps' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('requires at least one decisionSummary', () => {
+    const result = SkillCoachOutputSchema.safeParse({
+      skillName: 'investigate',
+      diagnosis: 'Some pattern.',
+      proposedPatch: 'diff',
+      rationale: 'Improves clarity.',
+      evidencePatternIds: [],
+      confidence: 'medium',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts low confidence with evidence', () => {
+    const result = SkillCoachOutputSchema.safeParse({
+      skillName: 'investigate',
+      diagnosis: 'Weak pattern detected.',
+      proposedPatch: 'diff',
+      rationale: 'Minor improvement.',
+      evidencePatternIds: ['p1'],
+      confidence: 'low',
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Low confidence; human review needed' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid confidence', () => {
+    const result = SkillCoachOutputSchema.safeParse({
+      skillName: 'investigate',
+      diagnosis: 'Pattern.',
+      proposedPatch: 'diff',
+      rationale: 'Improves.',
+      evidencePatternIds: [],
+      confidence: 'very-high',
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Test' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts empty evidencePatternIds', () => {
+    const result = SkillCoachOutputSchema.safeParse({
+      skillName: 'investigate',
+      diagnosis: 'Pattern.',
+      proposedPatch: 'diff',
+      rationale: 'Improves.',
+      evidencePatternIds: [],
+      confidence: 'medium',
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Test' }],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('SkillCoachInputSchema', () => {
+  it('accepts valid input with required fields', () => {
+    const result = SkillCoachInputSchema.safeParse({
+      targetSkillName: 'investigate',
+      patternIds: ['p1', 'p2'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts input with optional lifecycleIds', () => {
+    const result = SkillCoachInputSchema.safeParse({
+      targetSkillName: 'investigate',
+      patternIds: ['p1'],
+      lifecycleIds: ['l1', 'l2'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing targetSkillName', () => {
+    const result = SkillCoachInputSchema.safeParse({
+      patternIds: ['p1'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing patternIds', () => {
+    const result = SkillCoachInputSchema.safeParse({
+      targetSkillName: 'investigate',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('config', () => {
+  it('uses core bundle', () => {
+    expect(config.toolBundles).toEqual(['core']);
+  });
+
+  it('pins model to sonnet', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('lists exactly the three context keys', () => {
+    expect(config.contextAllowlist).toStrictEqual([
+      'targetSkillName',
+      'patternIds',
+      'lifecycleIds',
+    ]);
+  });
+
+  it('has freshContext false', () => {
+    expect(config.freshContext).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

M11.13: Skill-coach skill (manual trigger) — propose skill.md diffs from convergent patterns

## Files
- `core/workflows/skill-coaching.ts` — add schema.ts read alongside skill.md for AC compliance
- `core/agent-runtime/budgets.ts` — register skill-coach budget (was missing, caused resolveBudgets to throw)
- `core/workflows/slice.test.ts` — add happy-path and missing-skill-source tests per AC

## Tests
- `core/workflows/slice.test.ts` (2 cases)

Closes #527
