### PR TITLE
M11.02: cross-repo dependency resolver

### DIFF
--- a/core/state-source/README.md
+++ b/core/state-source/README.md
@@ -35,6 +35,8 @@ Defines the abstraction every backend implements.
 - `DependencyResolver` caches by `(repoRef, issueNumber)` for the lifetime of the instance — the orchestrator constructs one resolver per tick to avoid N+1 GitHub calls. M11.03 will re-evaluate every tick because deps close mid-sprint.
 - `createProjectAwareTargetSource()` wires `loadProjects()` + per-project GitHub fetchers into a `FetchTargetFn` for production use. Tests inject a Map-backed adapter directly.
 
+**`null` from `FetchTargetFn` is reserved for "repo not registered."** Per-project fetchers (`ProjectIssueFetcher`) must throw `DependencyTargetFetchError` on 404 / non-OK / network errors so a fetch failure on a registered repo is not silently misclassified as `unregistered` (which would falsely trigger M11.07's needs-human escalation). The resolver propagates these errors so the orchestrator can decide whether to retry or escalate.
+
 Lifecycle (open/closed) is read straight from the GitHub issues endpoint inside the slice. `WorkItem` carries state-machine state, not GitHub-lifecycle, and the dep contract is "issue closed = dep satisfied" — keeping the API call narrow inside `core/state-source/` avoids widening the `WorkItem` shape across the codebase.
 
 ### `github-labels.ts`

--- a/core/state-source/README.md
+++ b/core/state-source/README.md
@@ -24,6 +24,19 @@ Defines the abstraction every backend implements.
 - Malformed or unrecognised lines are silently skipped — never throws
 - Consumed by M11.02 resolver and M11.03 scheduler filter
 
+### `dependency-resolver.ts`
+
+`resolveDependency(ref, ctx)` and `DependencyResolver` — turn a `DependencyRef` into a `ResolvedDep` carrying the lifecycle state of the referenced issue.
+
+- **`ResolvedDep`**: `{ ref, repoRef, issueNumber, state: 'open' | 'closed' | 'unregistered', title? }`
+- Same-repo deps (`ref.repoRef == null`) resolve against `ctx.currentRepo`.
+- Cross-repo deps resolve against the matching registered project. Unregistered repos surface `state: 'unregistered'` (M11.07 escalates these to `factory:needs-human`).
+- `closed` = dep satisfied; `open` = dep unsatisfied; `unregistered` = unresolvable.
+- `DependencyResolver` caches by `(repoRef, issueNumber)` for the lifetime of the instance — the orchestrator constructs one resolver per tick to avoid N+1 GitHub calls. M11.03 will re-evaluate every tick because deps close mid-sprint.
+- `createProjectAwareTargetSource()` wires `loadProjects()` + per-project GitHub fetchers into a `FetchTargetFn` for production use. Tests inject a Map-backed adapter directly.
+
+Lifecycle (open/closed) is read straight from the GitHub issues endpoint inside the slice. `WorkItem` carries state-machine state, not GitHub-lifecycle, and the dep contract is "issue closed = dep satisfied" — keeping the API call narrow inside `core/state-source/` avoids widening the `WorkItem` shape across the codebase.
+
 ### `github-labels.ts`
 
 `GitHubLabelsSource` — `StateSource` backed by the GitHub REST API via native `fetch`.

--- a/core/state-source/dependency-resolver.test.ts
+++ b/core/state-source/dependency-resolver.test.ts
@@ -4,7 +4,9 @@ import type { DependencyRef } from './dependency-parser.js';
 import {
   DependencyResolver,
   type DependencyTarget,
+  DependencyTargetFetchError,
   type FetchTargetFn,
+  type ProjectIssueFetcher,
   createProjectAwareTargetSource,
   resolveDependency,
 } from './dependency-resolver.js';
@@ -240,11 +242,11 @@ function makeProject(repoRef: string): ProjectConfig {
 
 describe('createProjectAwareTargetSource', () => {
   it('routes registered cross-repo lookups to the matching project fetcher', async () => {
-    const goosehubFetcher = vi.fn<FetchTargetFn>(async () => ({
+    const goosehubFetcher = vi.fn<ProjectIssueFetcher>(async () => ({
       state: 'open',
       title: 'in goose-hub',
     }));
-    const otherFetcher = vi.fn<FetchTargetFn>(async () => ({
+    const otherFetcher = vi.fn<ProjectIssueFetcher>(async () => ({
       state: 'closed',
       title: 'in other',
     }));
@@ -302,5 +304,45 @@ describe('createProjectAwareTargetSource', () => {
       issueNumber: 7,
     });
     expect(stranger).toMatchObject({ state: 'unregistered', repoRef: 'unknown/repo' });
+  });
+
+  it('propagates errors from per-project fetchers (404 on registered repo ≠ unregistered)', async () => {
+    const failingFetcher: ProjectIssueFetcher = async () => {
+      throw new DependencyTargetFetchError(
+        'shaunnez/goose-hub',
+        404,
+        404,
+        'GitHub returned 404 for shaunnez/goose-hub#404',
+      );
+    };
+
+    const fetchTarget = await createProjectAwareTargetSource({
+      projects: [makeProject('shaunnez/goose-hub')],
+      fetchTargetForProject: () => failingFetcher,
+    });
+
+    await expect(fetchTarget('shaunnez/goose-hub', 404)).rejects.toBeInstanceOf(
+      DependencyTargetFetchError,
+    );
+  });
+
+  it('resolver surfaces fetch errors as rejections, not as state: unregistered', async () => {
+    const failingFetcher: ProjectIssueFetcher = async () => {
+      throw new DependencyTargetFetchError('shaunnez/goose-hub', 404, 404, 'not found');
+    };
+
+    const fetchTarget = await createProjectAwareTargetSource({
+      projects: [makeProject('shaunnez/goose-hub')],
+      fetchTargetForProject: () => failingFetcher,
+    });
+
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    await expect(
+      resolver.resolve({ type: 'depends-on', repoRef: null, issueNumber: 404 }),
+    ).rejects.toBeInstanceOf(DependencyTargetFetchError);
   });
 });

--- a/core/state-source/dependency-resolver.test.ts
+++ b/core/state-source/dependency-resolver.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProjectConfig } from '../types.js';
+import type { DependencyRef } from './dependency-parser.js';
+import {
+  DependencyResolver,
+  type DependencyTarget,
+  type FetchTargetFn,
+  createProjectAwareTargetSource,
+  resolveDependency,
+} from './dependency-resolver.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sameRepo: DependencyRef = { type: 'depends-on', repoRef: null, issueNumber: 42 };
+const crossRepoRegistered: DependencyRef = {
+  type: 'depends-on',
+  repoRef: 'shaunnez/other-repo',
+  issueNumber: 12,
+};
+const crossRepoUnregistered: DependencyRef = {
+  type: 'depends-on',
+  repoRef: 'unknown/elsewhere',
+  issueNumber: 7,
+};
+
+function makeFetchTarget(targets: Map<string, DependencyTarget | null>): FetchTargetFn {
+  return async (repoRef, issueNumber) => {
+    const key = `${repoRef}#${issueNumber}`;
+    return targets.has(key) ? (targets.get(key) ?? null) : null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveDependency — same-repo
+// ---------------------------------------------------------------------------
+
+describe('resolveDependency — same-repo deps', () => {
+  it('resolves a same-repo open dep (ref.repoRef is null) to state: open with title', async () => {
+    const fetchTarget = makeFetchTarget(
+      new Map([['shaunnez/goose-hub#42', { state: 'open', title: 'Open Issue' }]]),
+    );
+
+    const result = await resolveDependency(sameRepo, {
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    expect(result).toEqual({
+      ref: sameRepo,
+      repoRef: 'shaunnez/goose-hub',
+      issueNumber: 42,
+      state: 'open',
+      title: 'Open Issue',
+    });
+  });
+
+  it('resolves a same-repo closed dep to state: closed', async () => {
+    const fetchTarget = makeFetchTarget(
+      new Map([['shaunnez/goose-hub#42', { state: 'closed', title: 'Done Issue' }]]),
+    );
+
+    const result = await resolveDependency(sameRepo, {
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    expect(result.state).toBe('closed');
+    expect(result.title).toBe('Done Issue');
+    expect(result.repoRef).toBe('shaunnez/goose-hub');
+  });
+
+  it('routes same-repo lookups to currentRepo, not the source map default', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'open', title: 't' }));
+    await resolveDependency(sameRepo, { currentRepo: 'foo/bar', fetchTarget });
+    expect(fetchTarget).toHaveBeenCalledWith('foo/bar', 42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDependency — cross-repo registered
+// ---------------------------------------------------------------------------
+
+describe('resolveDependency — cross-repo registered', () => {
+  it('resolves a registered cross-repo open dep', async () => {
+    const fetchTarget = makeFetchTarget(
+      new Map([['shaunnez/other-repo#12', { state: 'open', title: 'Across' }]]),
+    );
+
+    const result = await resolveDependency(crossRepoRegistered, {
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    expect(result).toEqual({
+      ref: crossRepoRegistered,
+      repoRef: 'shaunnez/other-repo',
+      issueNumber: 12,
+      state: 'open',
+      title: 'Across',
+    });
+  });
+
+  it('resolves a registered cross-repo closed dep', async () => {
+    const fetchTarget = makeFetchTarget(
+      new Map([['shaunnez/other-repo#12', { state: 'closed', title: 'Across (done)' }]]),
+    );
+
+    const result = await resolveDependency(crossRepoRegistered, {
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    expect(result.state).toBe('closed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDependency — unregistered
+// ---------------------------------------------------------------------------
+
+describe('resolveDependency — unregistered cross-repo', () => {
+  it('returns state: unregistered when fetchTarget returns null', async () => {
+    const fetchTarget: FetchTargetFn = async () => null;
+
+    const result = await resolveDependency(crossRepoUnregistered, {
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    expect(result).toEqual({
+      ref: crossRepoUnregistered,
+      repoRef: 'unknown/elsewhere',
+      issueNumber: 7,
+      state: 'unregistered',
+    });
+    expect(result.title).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DependencyResolver — per-tick caching
+// ---------------------------------------------------------------------------
+
+describe('DependencyResolver — per-tick caching', () => {
+  it('caches by (repoRef, issueNumber): repeated resolve does not re-fetch', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'open', title: 't' }));
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    await resolver.resolve(sameRepo);
+    await resolver.resolve(sameRepo);
+    await resolver.resolve({ type: 'blocks', repoRef: null, issueNumber: 42 });
+
+    expect(fetchTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not share cache across resolver instances (one resolver per tick)', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'open', title: 't' }));
+
+    const tickA = new DependencyResolver({ currentRepo: 'r/a', fetchTarget });
+    await tickA.resolve(sameRepo);
+
+    const tickB = new DependencyResolver({ currentRepo: 'r/a', fetchTarget });
+    await tickB.resolve(sameRepo);
+
+    expect(fetchTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches concurrent resolves of the same ref to a single fetch', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'open', title: 't' }));
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    await Promise.all([resolver.resolve(sameRepo), resolver.resolve(sameRepo)]);
+
+    expect(fetchTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches unregistered results too — does not retry on miss within a tick', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => null);
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    await resolver.resolve(crossRepoUnregistered);
+    await resolver.resolve(crossRepoUnregistered);
+
+    expect(fetchTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats same-repo (null repoRef) and explicit-currentRepo refs as the same cache key', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'open', title: 't' }));
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    await resolver.resolve({ type: 'depends-on', repoRef: null, issueNumber: 42 });
+    await resolver.resolve({
+      type: 'depends-on',
+      repoRef: 'shaunnez/goose-hub',
+      issueNumber: 42,
+    });
+
+    expect(fetchTarget).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createProjectAwareTargetSource — loadProjects() wiring
+// ---------------------------------------------------------------------------
+
+function makeProject(repoRef: string): ProjectConfig {
+  return {
+    id: repoRef,
+    name: repoRef,
+    slug: repoRef.replace('/', '-'),
+    source: { kind: 'github', repo: repoRef, stateMachine: 'labels' },
+    targetRepo: { cloneUrl: '', defaultBranch: 'main', localPath: '' },
+    stack: { runtime: 'node', packageManager: 'pnpm', testCommand: 'true', detectedAt: '' },
+    mode: 'supervised',
+    storage: { kind: 'local', path: '' },
+    repos: [repoRef],
+    agentConfig: {} as ProjectConfig['agentConfig'],
+    budgets: {} as ProjectConfig['budgets'],
+    governance: { immutablePaths: [] },
+    isolation: { mode: 'native' },
+    archiveAfterDays: 30,
+    visibility: 'always_visible',
+    colorStripe: '#fff',
+  };
+}
+
+describe('createProjectAwareTargetSource', () => {
+  it('routes registered cross-repo lookups to the matching project fetcher', async () => {
+    const goosehubFetcher = vi.fn<FetchTargetFn>(async () => ({
+      state: 'open',
+      title: 'in goose-hub',
+    }));
+    const otherFetcher = vi.fn<FetchTargetFn>(async () => ({
+      state: 'closed',
+      title: 'in other',
+    }));
+
+    const fetch = await createProjectAwareTargetSource({
+      projects: [makeProject('shaunnez/goose-hub'), makeProject('shaunnez/other-repo')],
+      fetchTargetForProject: (p) =>
+        p.source.repo === 'shaunnez/goose-hub' ? goosehubFetcher : otherFetcher,
+    });
+
+    const result = await fetch('shaunnez/other-repo', 99);
+
+    expect(result).toEqual({ state: 'closed', title: 'in other' });
+    expect(otherFetcher).toHaveBeenCalledWith('shaunnez/other-repo', 99);
+    expect(goosehubFetcher).not.toHaveBeenCalled();
+  });
+
+  it('returns null for repos with no registered project (drives unregistered)', async () => {
+    const fetch = await createProjectAwareTargetSource({
+      projects: [makeProject('shaunnez/goose-hub')],
+      fetchTargetForProject: () => async () => ({ state: 'open', title: 't' }),
+    });
+
+    expect(await fetch('not/registered', 1)).toBeNull();
+  });
+
+  it('end-to-end: resolver + project-aware target source surfaces unregistered for a stranger repo', async () => {
+    const fetchTarget = await createProjectAwareTargetSource({
+      projects: [makeProject('shaunnez/goose-hub')],
+      fetchTargetForProject: () => async (_, n) => ({
+        state: 'open',
+        title: `local#${n}`,
+      }),
+    });
+
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    const localOpen = await resolver.resolve({
+      type: 'depends-on',
+      repoRef: null,
+      issueNumber: 42,
+    });
+    expect(localOpen).toMatchObject({
+      state: 'open',
+      repoRef: 'shaunnez/goose-hub',
+      title: 'local#42',
+    });
+
+    const stranger = await resolver.resolve({
+      type: 'depends-on',
+      repoRef: 'unknown/repo',
+      issueNumber: 7,
+    });
+    expect(stranger).toMatchObject({ state: 'unregistered', repoRef: 'unknown/repo' });
+  });
+});

--- a/core/state-source/dependency-resolver.ts
+++ b/core/state-source/dependency-resolver.ts
@@ -26,6 +26,33 @@ export type FetchTargetFn = (
   issueNumber: number,
 ) => Promise<DependencyTarget | null>;
 
+/**
+ * Per-project fetcher used by `createProjectAwareTargetSource`.
+ *
+ * The fetcher is only invoked for repos that are registered as projects, so
+ * it must never return `null` — `null` is reserved for "repo not registered"
+ * and that decision is owned by the registry, not the fetcher. On 404 /
+ * non-OK / network error the fetcher MUST throw so the caller can distinguish
+ * "registered repo, transient or genuine fetch failure" from "no project for
+ * this repo" (which falsely triggers M11.07 needs-human escalation).
+ */
+export type ProjectIssueFetcher = (
+  repoRef: string,
+  issueNumber: number,
+) => Promise<DependencyTarget>;
+
+export class DependencyTargetFetchError extends Error {
+  constructor(
+    public readonly repoRef: string,
+    public readonly issueNumber: number,
+    public readonly status: number | null,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DependencyTargetFetchError';
+  }
+}
+
 export interface DependencyResolverContext {
   /** Repo of the issue carrying the dep. Used when `ref.repoRef` is null. */
   currentRepo: string;
@@ -98,7 +125,7 @@ export interface ProjectAwareTargetSourceOptions {
   /** Pre-loaded projects (overrides `loadProjects()`). For tests. */
   projects?: ProjectConfig[];
   /** Override per-project fetcher construction. For tests. */
-  fetchTargetForProject?: (project: ProjectConfig) => FetchTargetFn;
+  fetchTargetForProject?: (project: ProjectConfig) => ProjectIssueFetcher;
   /** GitHub token for the default fetcher. Defaults to `process.env.GITHUB_TOKEN`. */
   githubToken?: string;
 }
@@ -112,7 +139,7 @@ export async function createProjectAwareTargetSource(
   options: ProjectAwareTargetSourceOptions = {},
 ): Promise<FetchTargetFn> {
   const projects = options.projects ?? (await loadProjects());
-  const fetchers = new Map<string, FetchTargetFn>();
+  const fetchers = new Map<string, ProjectIssueFetcher>();
 
   for (const project of projects) {
     const repoRef = project.source.repo;
@@ -125,7 +152,9 @@ export async function createProjectAwareTargetSource(
 
   return async (repoRef, issueNumber) => {
     const fetcher = fetchers.get(repoRef);
-    if (fetcher == null) return null;
+    if (fetcher == null) return null; // unregistered — only path to state: 'unregistered'
+    // Registered: fetcher must return a target or throw. Errors propagate so a
+    // 404 on a registered repo is not silently misclassified as unregistered.
     return fetcher(repoRef, issueNumber);
   };
 }
@@ -137,36 +166,50 @@ export async function createProjectAwareTargetSource(
  * state-machine state. The dep contract is "issue closed = dep satisfied",
  * which is GitHub-lifecycle, so we hit the API narrowly here rather than
  * widening the `WorkItem` shape across the codebase.
+ *
+ * Throws `DependencyTargetFetchError` on 404 / non-OK / network failure so the
+ * caller can distinguish "registered repo, transient fetch failure" from
+ * "repo not registered" (which is the only path to `state: 'unregistered'`).
  */
-function defaultFetchTargetForProject(token: string): FetchTargetFn {
+function defaultFetchTargetForProject(token: string): ProjectIssueFetcher {
   return async (repoRef, issueNumber) => {
+    const url = `https://api.github.com/repos/${repoRef}/issues/${issueNumber}`;
+    let response: Response;
     try {
-      const url = `https://api.github.com/repos/${repoRef}/issues/${issueNumber}`;
-      const response = await fetch(url, {
+      response = await fetch(url, {
         headers: {
           Authorization: `Bearer ${token}`,
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
       });
-      if (response.status === 404) return null;
-      if (!response.ok) {
-        logger.warn('dependency-resolver: github fetch failed', {
-          repoRef,
-          issueNumber,
-          status: response.status,
-        });
-        return null;
-      }
-      const json = (await response.json()) as { state: 'open' | 'closed'; title: string };
-      return { state: json.state, title: json.title };
     } catch (err) {
       logger.warn('dependency-resolver: github fetch error', {
         repoRef,
         issueNumber,
         error: String(err),
       });
-      return null;
+      throw new DependencyTargetFetchError(
+        repoRef,
+        issueNumber,
+        null,
+        `Network error fetching ${repoRef}#${issueNumber}: ${String(err)}`,
+      );
     }
+    if (!response.ok) {
+      logger.warn('dependency-resolver: github fetch failed', {
+        repoRef,
+        issueNumber,
+        status: response.status,
+      });
+      throw new DependencyTargetFetchError(
+        repoRef,
+        issueNumber,
+        response.status,
+        `GitHub returned ${response.status} for ${repoRef}#${issueNumber}`,
+      );
+    }
+    const json = (await response.json()) as { state: 'open' | 'closed'; title: string };
+    return { state: json.state, title: json.title };
   };
 }

--- a/core/state-source/dependency-resolver.ts
+++ b/core/state-source/dependency-resolver.ts
@@ -1,0 +1,172 @@
+import { logger } from '../logger.js';
+import { loadProjects } from '../projects/loader.js';
+import type { ProjectConfig } from '../types.js';
+import type { DependencyRef } from './dependency-parser.js';
+
+export type DepLifecycle = 'open' | 'closed' | 'unregistered';
+
+export interface ResolvedDep {
+  /** The original ref as parsed from the issue body. */
+  ref: DependencyRef;
+  /** Owner/repo where the dep was looked up — equals `currentRepo` for same-repo refs. */
+  repoRef: string;
+  issueNumber: number;
+  state: DepLifecycle;
+  /** Issue title. Present only when `state !== 'unregistered'`. */
+  title?: string;
+}
+
+export interface DependencyTarget {
+  state: 'open' | 'closed';
+  title: string;
+}
+
+export type FetchTargetFn = (
+  repoRef: string,
+  issueNumber: number,
+) => Promise<DependencyTarget | null>;
+
+export interface DependencyResolverContext {
+  /** Repo of the issue carrying the dep. Used when `ref.repoRef` is null. */
+  currentRepo: string;
+  /**
+   * Adapter resolving `(repoRef, issueNumber) → target | null`.
+   *
+   * Returns `null` when the repo is not a registered project (drives
+   * `state: 'unregistered'`). For registered repos, returns the GitHub-issue
+   * lifecycle (`open` | `closed`) plus title.
+   *
+   * Wiring lives outside the resolver to keep it pure-unit-testable. The
+   * canonical wiring is `createProjectAwareTargetSource()`.
+   */
+  fetchTarget: FetchTargetFn;
+}
+
+/**
+ * Resolves dependency refs to their lifecycle. Caches results by
+ * `(repoRef, issueNumber)` for the lifetime of the instance — construct one
+ * resolver per orchestrator tick to satisfy "cached per tick" (M11.03 will
+ * also re-evaluate every tick because deps close mid-sprint).
+ */
+export class DependencyResolver {
+  private readonly cache = new Map<string, Promise<ResolvedDep>>();
+
+  constructor(private readonly ctx: DependencyResolverContext) {}
+
+  resolve(ref: DependencyRef): Promise<ResolvedDep> {
+    const repoRef = ref.repoRef ?? this.ctx.currentRepo;
+    const key = `${repoRef}#${ref.issueNumber}`;
+    const cached = this.cache.get(key);
+    if (cached != null) return cached;
+    const promise = this.fetchOne(ref, repoRef);
+    this.cache.set(key, promise);
+    return promise;
+  }
+
+  private async fetchOne(ref: DependencyRef, repoRef: string): Promise<ResolvedDep> {
+    const target = await this.ctx.fetchTarget(repoRef, ref.issueNumber);
+    if (target == null) {
+      return { ref, repoRef, issueNumber: ref.issueNumber, state: 'unregistered' };
+    }
+    return {
+      ref,
+      repoRef,
+      issueNumber: ref.issueNumber,
+      state: target.state,
+      title: target.title,
+    };
+  }
+}
+
+/**
+ * Resolve a single dep in one call. Equivalent to constructing a
+ * `DependencyResolver` for one ref. Use `DependencyResolver` directly when
+ * resolving many refs in one tick to benefit from caching.
+ */
+export async function resolveDependency(
+  ref: DependencyRef,
+  ctx: DependencyResolverContext,
+): Promise<ResolvedDep> {
+  return new DependencyResolver(ctx).resolve(ref);
+}
+
+// ---------------------------------------------------------------------------
+// Project-aware wiring
+// ---------------------------------------------------------------------------
+
+export interface ProjectAwareTargetSourceOptions {
+  /** Pre-loaded projects (overrides `loadProjects()`). For tests. */
+  projects?: ProjectConfig[];
+  /** Override per-project fetcher construction. For tests. */
+  fetchTargetForProject?: (project: ProjectConfig) => FetchTargetFn;
+  /** GitHub token for the default fetcher. Defaults to `process.env.GITHUB_TOKEN`. */
+  githubToken?: string;
+}
+
+/**
+ * Build a `FetchTargetFn` that consults `loadProjects()` and resolves through
+ * the matching project's GitHub source. Cross-repo refs to repos with no
+ * registered project return `null` so the resolver surfaces 'unregistered'.
+ */
+export async function createProjectAwareTargetSource(
+  options: ProjectAwareTargetSourceOptions = {},
+): Promise<FetchTargetFn> {
+  const projects = options.projects ?? (await loadProjects());
+  const fetchers = new Map<string, FetchTargetFn>();
+
+  for (const project of projects) {
+    const repoRef = project.source.repo;
+    const fetcher =
+      options.fetchTargetForProject != null
+        ? options.fetchTargetForProject(project)
+        : defaultFetchTargetForProject(options.githubToken ?? process.env.GITHUB_TOKEN ?? '');
+    fetchers.set(repoRef, fetcher);
+  }
+
+  return async (repoRef, issueNumber) => {
+    const fetcher = fetchers.get(repoRef);
+    if (fetcher == null) return null;
+    return fetcher(repoRef, issueNumber);
+  };
+}
+
+/**
+ * Default per-project fetcher: hits GitHub's issues endpoint directly.
+ *
+ * `WorkItem` does not carry GitHub-lifecycle (open/closed) — it carries
+ * state-machine state. The dep contract is "issue closed = dep satisfied",
+ * which is GitHub-lifecycle, so we hit the API narrowly here rather than
+ * widening the `WorkItem` shape across the codebase.
+ */
+function defaultFetchTargetForProject(token: string): FetchTargetFn {
+  return async (repoRef, issueNumber) => {
+    try {
+      const url = `https://api.github.com/repos/${repoRef}/issues/${issueNumber}`;
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      if (response.status === 404) return null;
+      if (!response.ok) {
+        logger.warn('dependency-resolver: github fetch failed', {
+          repoRef,
+          issueNumber,
+          status: response.status,
+        });
+        return null;
+      }
+      const json = (await response.json()) as { state: 'open' | 'closed'; title: string };
+      return { state: json.state, title: json.title };
+    } catch (err) {
+      logger.warn('dependency-resolver: github fetch error', {
+        repoRef,
+        issueNumber,
+        error: String(err),
+      });
+      return null;
+    }
+  };
+}

--- a/core/state-source/slice.test.ts
+++ b/core/state-source/slice.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseDependencies } from './dependency-parser.js';
+import {
+  DependencyResolver,
+  type FetchTargetFn,
+  resolveDependency,
+} from './dependency-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Empty / no-match cases
@@ -236,5 +241,50 @@ describe('parseDependencies — malformed input', () => {
 
   it('rejects cross-repo ref with alphanumeric suffix — owner/repo#12foo', () => {
     expect(parseDependencies('Depends on shaunnez/other-repo#12foo')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: parser → resolver
+// ---------------------------------------------------------------------------
+
+describe('slice — parser feeds resolver end-to-end', () => {
+  it('resolves all parsed deps from a real-world body, batching same-repo and cross-repo', async () => {
+    const body = [
+      'Depends on #286',
+      'Depends on shaunnez/other-repo#12',
+      'Depends on stranger/elsewhere#9',
+    ].join('\n');
+
+    const refs = parseDependencies(body);
+
+    const fetchTarget: FetchTargetFn = async (repoRef, n) => {
+      if (repoRef === 'shaunnez/goose-hub' && n === 286)
+        return { state: 'closed', title: 'parser' };
+      if (repoRef === 'shaunnez/other-repo' && n === 12) return { state: 'open', title: 'across' };
+      return null; // stranger/elsewhere — unregistered
+    };
+
+    const resolver = new DependencyResolver({
+      currentRepo: 'shaunnez/goose-hub',
+      fetchTarget,
+    });
+
+    const resolved = await Promise.all(refs.map((r) => resolver.resolve(r)));
+
+    expect(resolved).toMatchObject([
+      { state: 'closed', repoRef: 'shaunnez/goose-hub', issueNumber: 286, title: 'parser' },
+      { state: 'open', repoRef: 'shaunnez/other-repo', issueNumber: 12, title: 'across' },
+      { state: 'unregistered', repoRef: 'stranger/elsewhere', issueNumber: 9 },
+    ]);
+  });
+
+  it('resolveDependency convenience function handles a single ref', async () => {
+    const fetchTarget = vi.fn<FetchTargetFn>(async () => ({ state: 'closed', title: 't' }));
+    const result = await resolveDependency(
+      { type: 'depends-on', repoRef: null, issueNumber: 1 },
+      { currentRepo: 'shaunnez/goose-hub', fetchTarget },
+    );
+    expect(result.state).toBe('closed');
   });
 });


### PR DESCRIPTION
## Summary

Adds the M11 dependency resolver: turns parsed `DependencyRef`s into a `ResolvedDep` carrying lifecycle (`open` | `closed` | `unregistered`) plus title.

- **`DependencyResolver`** — a per-tick instance with `(repoRef, issueNumber)`-keyed caching to avoid N+1 GitHub calls.
- **`resolveDependency(ref, ctx)`** — convenience wrapper around the class.
- **`createProjectAwareTargetSource()`** — wires `loadProjects()` into the resolver: registered repos resolve through their GitHub source; unregistered cross-repo refs surface `state: 'unregistered'`.

The resolver itself is pure — it takes a `FetchTargetFn` adapter so unit tests inject Map-backed fetchers and the production wiring lives in a separate factory. Lifecycle (open/closed) is read narrowly from GitHub's issues endpoint inside the slice; `WorkItem` doesn't gain a new field.

Closes #291

## Test plan

- [x] `pnpm test core/state-source/` — 107 passed (4 files)
- [x] Unit tests cover same-repo open/closed, registered cross-repo open/closed, unregistered cross-repo
- [x] Caching tests: repeated resolve, concurrent resolve, unregistered miss caching, fresh resolver per tick
- [x] `createProjectAwareTargetSource` routes registered repos to project fetchers, returns null for unregistered
- [x] End-to-end parser → resolver test in `slice.test.ts` mixes same-repo / cross-repo / unregistered in one body
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Full suite: 1884 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_0149oz2bY2fXsuBofCfGYjYb)_