### PR TITLE
M11.12: cross-run retrospective skill + playbook writer + gate thresholds

### DIFF
--- a/apps/server/src/domains/playbooks/repository.ts
+++ b/apps/server/src/domains/playbooks/repository.ts
@@ -1,6 +1,6 @@
 import { db } from '@goose-hub/core/db/db.js';
 import { playbooks } from '@goose-hub/core/db/schema.js';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 
 export interface PlaybookRow {
   id: number;
@@ -21,7 +21,14 @@ export async function listPlaybooksForProject(projectId: string): Promise<Playbo
     .all();
 }
 
-export async function getPlaybookById(id: number): Promise<PlaybookRow | null> {
-  const rows = await db.select().from(playbooks).where(eq(playbooks.id, id)).all();
+export async function getPlaybookByIdForProject(
+  projectId: string,
+  id: number,
+): Promise<PlaybookRow | null> {
+  const rows = await db
+    .select()
+    .from(playbooks)
+    .where(and(eq(playbooks.projectId, projectId), eq(playbooks.id, id)))
+    .all();
   return rows[0] ?? null;
 }

--- a/apps/server/src/domains/playbooks/repository.ts
+++ b/apps/server/src/domains/playbooks/repository.ts
@@ -1,0 +1,27 @@
+import { db } from '@goose-hub/core/db/db.js';
+import { playbooks } from '@goose-hub/core/db/schema.js';
+import { desc, eq } from 'drizzle-orm';
+
+export interface PlaybookRow {
+  id: number;
+  projectId: string;
+  windowStartAt: string;
+  windowEndAt: string;
+  lifecycleCount: number;
+  manifest: string;
+  createdAt: string;
+}
+
+export async function listPlaybooksForProject(projectId: string): Promise<PlaybookRow[]> {
+  return db
+    .select()
+    .from(playbooks)
+    .where(eq(playbooks.projectId, projectId))
+    .orderBy(desc(playbooks.createdAt))
+    .all();
+}
+
+export async function getPlaybookById(id: number): Promise<PlaybookRow | null> {
+  const rows = await db.select().from(playbooks).where(eq(playbooks.id, id)).all();
+  return rows[0] ?? null;
+}

--- a/apps/server/src/domains/playbooks/router.test.ts
+++ b/apps/server/src/domains/playbooks/router.test.ts
@@ -1,0 +1,149 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListPlaybooks, mockGetPlaybook, mockCreatePlaybook } = vi.hoisted(() => ({
+  mockListPlaybooks: vi.fn(),
+  mockGetPlaybook: vi.fn(),
+  mockCreatePlaybook: vi.fn(),
+}));
+
+vi.mock('./service.js', () => ({
+  listPlaybooks: mockListPlaybooks,
+  getPlaybook: mockGetPlaybook,
+  createPlaybook: mockCreatePlaybook,
+}));
+
+vi.mock('@goose-hub/core/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { playbooksRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/projects', playbooksRouter);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /projects/:slug/playbooks', () => {
+  it('returns playbook summaries', async () => {
+    mockListPlaybooks.mockResolvedValue({
+      ok: true,
+      data: { playbooks: [{ id: 1, projectId: 'p', lifecycleCount: 5 }] },
+    });
+    const res = await makeApp().request('/projects/p/playbooks');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { playbooks: unknown[] };
+    expect(body.playbooks).toHaveLength(1);
+  });
+
+  it('falls back to empty array on service failure', async () => {
+    mockListPlaybooks.mockResolvedValue({ ok: false, error: 'oops', status: 500 });
+    const res = await makeApp().request('/projects/p/playbooks');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { playbooks: unknown[] };
+    expect(body.playbooks).toEqual([]);
+  });
+});
+
+describe('GET /projects/:slug/playbooks/:id', () => {
+  it('404s when playbook missing', async () => {
+    mockGetPlaybook.mockResolvedValue({ ok: false, error: 'playbook not found', status: 404 });
+    const res = await makeApp().request('/projects/p/playbooks/9999');
+    expect(res.status).toBe(404);
+  });
+
+  it('400s when id is not a number', async () => {
+    const res = await makeApp().request('/projects/p/playbooks/abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns the playbook detail', async () => {
+    mockGetPlaybook.mockResolvedValue({
+      ok: true,
+      data: { playbook: { id: 1, manifest: { lifecycleCount: 3 } } },
+    });
+    const res = await makeApp().request('/projects/p/playbooks/1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /projects/:slug/playbooks', () => {
+  it('returns 400 for invalid JSON body', async () => {
+    const res = await makeApp().request('/projects/p/playbooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+    expect(res.status).toBe(400);
+    expect(mockCreatePlaybook).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when service rejects with input error', async () => {
+    mockCreatePlaybook.mockResolvedValue({
+      ok: false,
+      error: 'exactly one of windowSize or dateRange must be supplied',
+      status: 400,
+    });
+    const res = await makeApp().request('/projects/p/playbooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards windowSize to the service', async () => {
+    mockCreatePlaybook.mockResolvedValue({
+      ok: true,
+      data: { playbookId: 7, lifecycleCount: 4 },
+    });
+    const res = await makeApp().request('/projects/goose-hub-self/playbooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ windowSize: 5 }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockCreatePlaybook).toHaveBeenCalledWith(
+      'goose-hub-self',
+      expect.objectContaining({ windowSize: 5 }),
+    );
+  });
+
+  it('forwards a complete dateRange to the service', async () => {
+    mockCreatePlaybook.mockResolvedValue({
+      ok: true,
+      data: { playbookId: 7, lifecycleCount: 4 },
+    });
+    await makeApp().request('/projects/p/playbooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+      }),
+    });
+    expect(mockCreatePlaybook).toHaveBeenCalledWith(
+      'p',
+      expect.objectContaining({
+        dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+      }),
+    );
+  });
+
+  it('drops partial dateRange (missing endAt) so the workflow input validator rejects it', async () => {
+    mockCreatePlaybook.mockResolvedValue({
+      ok: false,
+      error: 'exactly one of windowSize or dateRange must be supplied',
+      status: 400,
+    });
+    await makeApp().request('/projects/p/playbooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dateRange: { startAt: '2026-04-01T00:00:00Z' } }),
+    });
+    const callArg = mockCreatePlaybook.mock.calls[0][1];
+    expect(callArg.dateRange).toBeUndefined();
+  });
+});

--- a/apps/server/src/domains/playbooks/router.test.ts
+++ b/apps/server/src/domains/playbooks/router.test.ts
@@ -60,13 +60,21 @@ describe('GET /projects/:slug/playbooks/:id', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns the playbook detail', async () => {
+  it('passes the slug to the service so lookups are scoped per project', async () => {
     mockGetPlaybook.mockResolvedValue({
       ok: true,
       data: { playbook: { id: 1, manifest: { lifecycleCount: 3 } } },
     });
-    const res = await makeApp().request('/projects/p/playbooks/1');
+    const res = await makeApp().request('/projects/project-a/playbooks/1');
     expect(res.status).toBe(200);
+    expect(mockGetPlaybook).toHaveBeenCalledWith('project-a', 1);
+  });
+
+  it('404s when the slug does not match the playbook owner (cross-project leak prevention)', async () => {
+    mockGetPlaybook.mockResolvedValue({ ok: false, error: 'playbook not found', status: 404 });
+    const res = await makeApp().request('/projects/project-b/playbooks/1');
+    expect(res.status).toBe(404);
+    expect(mockGetPlaybook).toHaveBeenCalledWith('project-b', 1);
   });
 });
 

--- a/apps/server/src/domains/playbooks/router.ts
+++ b/apps/server/src/domains/playbooks/router.ts
@@ -12,9 +12,10 @@ router.get('/:slug/playbooks', async (c) => {
 });
 
 router.get('/:slug/playbooks/:id', async (c) => {
+  const slug = c.req.param('slug');
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
-  const result = await getPlaybook(id);
+  const result = await getPlaybook(slug, id);
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
 });
 

--- a/apps/server/src/domains/playbooks/router.ts
+++ b/apps/server/src/domains/playbooks/router.ts
@@ -1,0 +1,49 @@
+import { logger } from '@goose-hub/core/logger.js';
+import { Hono } from 'hono';
+import { parseBody } from '#shared/middleware.js';
+import { createPlaybook, getPlaybook, listPlaybooks } from './service.js';
+
+const router = new Hono();
+
+router.get('/:slug/playbooks', async (c) => {
+  const slug = c.req.param('slug');
+  const result = await listPlaybooks(slug);
+  return result.ok ? c.json(result.data) : c.json({ playbooks: [] });
+});
+
+router.get('/:slug/playbooks/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+  const result = await getPlaybook(id);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
+});
+
+router.post('/:slug/playbooks', async (c) => {
+  const slug = c.req.param('slug');
+  const body = await parseBody<{
+    windowSize?: number;
+    dateRange?: { startAt?: string; endAt?: string };
+  }>(c);
+  if (!body.ok) return body.error;
+
+  const dateRange =
+    body.data.dateRange?.startAt != null && body.data.dateRange.endAt != null
+      ? { startAt: body.data.dateRange.startAt, endAt: body.data.dateRange.endAt }
+      : undefined;
+
+  try {
+    const result = await createPlaybook(slug, {
+      windowSize: body.data.windowSize,
+      dateRange,
+    });
+    if (!result.ok) {
+      return c.json({ error: result.error }, result.status as 400 | 500);
+    }
+    return c.json(result.data, 201);
+  } catch (err) {
+    logger.error('createPlaybook failed', { slug, error: String(err) });
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+export { router as playbooksRouter };

--- a/apps/server/src/domains/playbooks/service.ts
+++ b/apps/server/src/domains/playbooks/service.ts
@@ -3,7 +3,11 @@ import {
   runCrossRunRetroWorkflow,
 } from '@goose-hub/core/workflows/cross-run-retro.js';
 import type { Result } from '#shared/middleware.js';
-import { type PlaybookRow, getPlaybookById, listPlaybooksForProject } from './repository.js';
+import {
+  type PlaybookRow,
+  getPlaybookByIdForProject,
+  listPlaybooksForProject,
+} from './repository.js';
 
 export interface PlaybookSummaryDto {
   id: number;
@@ -56,8 +60,11 @@ export async function listPlaybooks(
   return { ok: true, data: { playbooks: rows.map(toSummary) } };
 }
 
-export async function getPlaybook(id: number): Promise<Result<{ playbook: PlaybookDetailDto }>> {
-  const row = await getPlaybookById(id);
+export async function getPlaybook(
+  projectId: string,
+  id: number,
+): Promise<Result<{ playbook: PlaybookDetailDto }>> {
+  const row = await getPlaybookByIdForProject(projectId, id);
   if (!row) return { ok: false, error: 'playbook not found', status: 404 };
   const manifest = parseManifest(row.manifest);
   return {

--- a/apps/server/src/domains/playbooks/service.ts
+++ b/apps/server/src/domains/playbooks/service.ts
@@ -1,0 +1,102 @@
+import {
+  CrossRunRetroInputError,
+  runCrossRunRetroWorkflow,
+} from '@goose-hub/core/workflows/cross-run-retro.js';
+import type { Result } from '#shared/middleware.js';
+import { type PlaybookRow, getPlaybookById, listPlaybooksForProject } from './repository.js';
+
+export interface PlaybookSummaryDto {
+  id: number;
+  projectId: string;
+  windowStartAt: string;
+  windowEndAt: string;
+  lifecycleCount: number;
+  topPatternCount: number;
+  topCandidateCount: number;
+  createdAt: string;
+}
+
+export interface PlaybookDetailDto extends PlaybookSummaryDto {
+  manifest: unknown;
+}
+
+interface ManifestShape {
+  topPatterns?: unknown[];
+  improvementCandidates?: unknown[];
+}
+
+function parseManifest(raw: string): ManifestShape {
+  try {
+    return JSON.parse(raw) as ManifestShape;
+  } catch {
+    return {};
+  }
+}
+
+function toSummary(row: PlaybookRow): PlaybookSummaryDto {
+  const manifest = parseManifest(row.manifest);
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    windowStartAt: row.windowStartAt,
+    windowEndAt: row.windowEndAt,
+    lifecycleCount: row.lifecycleCount,
+    topPatternCount: Array.isArray(manifest.topPatterns) ? manifest.topPatterns.length : 0,
+    topCandidateCount: Array.isArray(manifest.improvementCandidates)
+      ? manifest.improvementCandidates.length
+      : 0,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function listPlaybooks(
+  projectId: string,
+): Promise<Result<{ playbooks: PlaybookSummaryDto[] }>> {
+  const rows = await listPlaybooksForProject(projectId);
+  return { ok: true, data: { playbooks: rows.map(toSummary) } };
+}
+
+export async function getPlaybook(id: number): Promise<Result<{ playbook: PlaybookDetailDto }>> {
+  const row = await getPlaybookById(id);
+  if (!row) return { ok: false, error: 'playbook not found', status: 404 };
+  const manifest = parseManifest(row.manifest);
+  return {
+    ok: true,
+    data: {
+      playbook: {
+        ...toSummary(row),
+        manifest,
+      },
+    },
+  };
+}
+
+export interface CreatePlaybookInput {
+  windowSize?: number;
+  dateRange?: { startAt: string; endAt: string };
+}
+
+export async function createPlaybook(
+  projectId: string,
+  input: CreatePlaybookInput,
+): Promise<Result<{ playbookId: number; lifecycleCount: number }>> {
+  try {
+    const result = await runCrossRunRetroWorkflow({
+      projectId,
+      windowSize: input.windowSize,
+      dateRange: input.dateRange,
+    });
+    if (!result.ok) {
+      return { ok: false, error: result.error, status: 500 };
+    }
+    return {
+      ok: true,
+      data: { playbookId: result.playbookId, lifecycleCount: result.lifecycleCount },
+    };
+  } catch (err) {
+    if (err instanceof CrossRunRetroInputError) {
+      return { ok: false, error: err.message, status: 400 };
+    }
+    return { ok: false, error: String(err), status: 500 };
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -6,6 +6,7 @@ import { eventsRouter } from './domains/events/router.js';
 import { inboxRouter } from './domains/inbox/router.js';
 import { issuesRouter } from './domains/issues/router.js';
 import { milestonesRouter } from './domains/milestones/router.js';
+import { playbooksRouter } from './domains/playbooks/router.js';
 import { projectsRouter } from './domains/projects/router.js';
 import { rosterRouter } from './domains/roster/router.js';
 import { webhooksRouter } from './domains/webhooks/router.js';
@@ -29,6 +30,7 @@ app.route('/projects', milestonesRouter); // GET/POST /projects/:slug/milestones
 app.route('/projects', issuesRouter); // GET/POST /projects/:slug/issues/**
 app.route('/projects', workflowsRouter); // POST /projects/:slug/tick
 app.route('/projects', costsRouter); // GET /projects/:slug/costs/summary, /projects/:slug/issues/:id/costs
+app.route('/projects', playbooksRouter); // GET/POST /projects/:slug/playbooks (M11.12)
 app.route('/inbox', inboxRouter); // GET/POST /inbox/**
 app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events

--- a/apps/web/src/components/roster/README.md
+++ b/apps/web/src/components/roster/README.md
@@ -36,3 +36,11 @@ invalidation.
 - No personas: "No personas yet — stats accumulate as agent runs complete"
 - No run history: "No run history recorded yet"
 - No candidates: "No improvement candidates yet"
+
+## Playbooks tab (M11.12)
+
+A second tab on the roster page lists cross-run retrospective `PlaybookManifest` artifacts produced by `core/workflows/cross-run-retro.ts`. Each card shows the window dates, lifecycle count, and pattern/candidate counts; selecting a card opens a drill-in panel with the full manifest (summary, top patterns, improvement candidates, gate thresholds, cost baselines).
+
+- `GET /projects/:slug/playbooks` — playbook summaries for the current project
+- `GET /projects/:slug/playbooks/:id` — full manifest detail
+- `POST /projects/:slug/playbooks` — manual trigger; body is one of `{ windowSize: N }` or `{ dateRange: { startAt, endAt } }`

--- a/apps/web/src/components/roster/components/PlaybooksTab.tsx
+++ b/apps/web/src/components/roster/components/PlaybooksTab.tsx
@@ -1,0 +1,286 @@
+import { fetchPlaybook, fetchPlaybooks } from '@/lib/api';
+import type { PlaybookDetailDto, PlaybookManifestDto, PlaybookSummaryDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+interface PlaybooksTabProps {
+  projectSlug: string;
+}
+
+export function PlaybooksTab({ projectSlug }: PlaybooksTabProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const {
+    data: playbooks = [],
+    isLoading,
+    error,
+  } = useQuery<PlaybookSummaryDto[]>({
+    queryKey: ['playbooks', projectSlug],
+    queryFn: () => fetchPlaybooks(projectSlug),
+  });
+
+  return (
+    <div data-testid="playbooks-tab" className="flex h-full overflow-hidden">
+      <div className="flex-1 overflow-y-auto px-8 py-6">
+        <div className="flex items-baseline justify-between mb-3">
+          <h1 className="text-[15px] font-semibold">Playbooks</h1>
+          <span className="text-[11.5px] text-fg-3">
+            Cross-run retrospective manifests (M11.12)
+          </span>
+        </div>
+
+        {isLoading && <div className="text-fg-3 text-[13px]">Loading playbooks…</div>}
+
+        {error && (
+          <div className="text-[color:var(--danger)] text-[13px]">Failed to load playbooks.</div>
+        )}
+
+        {!isLoading && !error && playbooks.length === 0 && (
+          <div
+            data-testid="playbooks-empty-state"
+            className="text-center text-fg-3 text-[13px] py-16"
+          >
+            <p className="mb-2 font-medium text-fg-2">No playbooks yet</p>
+            <p>
+              Trigger a cross-run retrospective with{' '}
+              <code className="font-mono">POST /api/projects/{projectSlug}/playbooks</code>.
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !error && playbooks.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            {playbooks.map((p) => (
+              <PlaybookCard
+                key={p.id}
+                playbook={p}
+                isSelected={selectedId === p.id}
+                onClick={() => setSelectedId(p.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selectedId != null && (
+        <PlaybookDrillIn
+          projectSlug={projectSlug}
+          playbookId={selectedId}
+          onClose={() => setSelectedId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface PlaybookCardProps {
+  playbook: PlaybookSummaryDto;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function PlaybookCard({ playbook, isSelected, onClick }: PlaybookCardProps) {
+  return (
+    <button
+      type="button"
+      data-testid="playbook-card"
+      onClick={onClick}
+      className={[
+        'w-full text-left px-3 py-3 rounded-md border transition-colors',
+        isSelected
+          ? 'border-accent bg-accent-soft'
+          : 'border-line bg-bg-elev/60 hover:bg-bg-elev hover:border-line',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <span className="text-[12.5px] font-medium text-fg truncate">
+          {formatDate(playbook.windowStartAt)} → {formatDate(playbook.windowEndAt)}
+        </span>
+        <span className="text-[11px] font-mono shrink-0 text-fg-2">#{playbook.id}</span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-fg-2">
+        <span>{playbook.lifecycleCount} lifecycles</span>
+        <span>·</span>
+        <span>{playbook.topPatternCount} patterns</span>
+        <span>·</span>
+        <span>{playbook.topCandidateCount} candidates</span>
+      </div>
+    </button>
+  );
+}
+
+interface PlaybookDrillInProps {
+  projectSlug: string;
+  playbookId: number;
+  onClose: () => void;
+}
+
+function PlaybookDrillIn({ projectSlug, playbookId, onClose }: PlaybookDrillInProps) {
+  const { data: detail, isLoading } = useQuery<PlaybookDetailDto>({
+    queryKey: ['playbook-detail', projectSlug, playbookId],
+    queryFn: () => fetchPlaybook(projectSlug, playbookId),
+  });
+
+  return (
+    <aside
+      data-testid="playbook-drill-in"
+      className="w-[420px] shrink-0 border-l border-line bg-bg-elev overflow-y-auto px-5 py-5"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-[14px] font-semibold">Playbook #{playbookId}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-fg-2 hover:text-fg text-[12px]"
+          aria-label="Close playbook detail"
+        >
+          Close
+        </button>
+      </div>
+      {isLoading && <div className="text-fg-3 text-[13px]">Loading…</div>}
+      {detail && <PlaybookManifestView manifest={detail.manifest} />}
+    </aside>
+  );
+}
+
+function PlaybookManifestView({ manifest }: { manifest: PlaybookManifestDto }) {
+  return (
+    <div className="flex flex-col gap-5 text-[12.5px] text-fg-2">
+      <Section title="Summary">
+        <Row label="Went well">{manifest.summary.wentWell}</Row>
+        <Row label="Did not">{manifest.summary.didNotGoWell}</Row>
+        <Row label="Takeaway">{manifest.summary.architecturalTakeaway}</Row>
+      </Section>
+
+      <Section title={`Top patterns (${manifest.topPatterns.length})`}>
+        {manifest.topPatterns.length === 0 ? (
+          <p className="text-fg-3">No patterns surfaced.</p>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {manifest.topPatterns.map((p) => (
+              <li key={p.patternId} className="border border-line rounded p-2">
+                <div className="font-mono text-[11px] text-fg-3">{p.patternId}</div>
+                <div className="text-fg">{p.pattern}</div>
+                <div className="text-[11px] text-fg-3">
+                  {p.occurrenceCount}× · consistency {(p.consistencyScore * 100).toFixed(0)}%
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section title={`Improvement candidates (${manifest.improvementCandidates.length})`}>
+        {manifest.improvementCandidates.length === 0 ? (
+          <p className="text-fg-3">No candidates surfaced.</p>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {manifest.improvementCandidates.map((c, idx) => (
+              <li key={`${c.targetPath}-${idx}`} className="border border-line rounded p-2">
+                <div className="font-mono text-[11px] text-fg-3">
+                  {c.kind} · {c.targetPath}
+                </div>
+                <div className="text-fg">{c.suggestionText}</div>
+                {c.evidence && (
+                  <div className="text-[11px] text-fg-3 mt-1">Evidence: {c.evidence}</div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section title="Gate thresholds">
+        {manifest.gateThresholds.length === 0 ? (
+          <p className="text-fg-3">No gate samples in window.</p>
+        ) : (
+          <table className="w-full text-[11.5px] font-mono">
+            <thead className="text-fg-3">
+              <tr>
+                <th className="text-left">Gate</th>
+                <th className="text-right">Mean</th>
+                <th className="text-right">Min</th>
+                <th className="text-right">Max</th>
+                <th className="text-right">σ</th>
+                <th className="text-right">N</th>
+              </tr>
+            </thead>
+            <tbody>
+              {manifest.gateThresholds.map((g) => (
+                <tr key={g.gate}>
+                  <td>{g.gate}</td>
+                  <td className="text-right">{g.mean.toFixed(2)}</td>
+                  <td className="text-right">{g.min.toFixed(2)}</td>
+                  <td className="text-right">{g.max.toFixed(2)}</td>
+                  <td className="text-right">{g.stdDev.toFixed(2)}</td>
+                  <td className="text-right">{g.sampleCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Section>
+
+      <Section title="Cost baselines">
+        {manifest.costBaselines.length === 0 ? (
+          <p className="text-fg-3">No cost samples in window.</p>
+        ) : (
+          <table className="w-full text-[11.5px] font-mono">
+            <thead className="text-fg-3">
+              <tr>
+                <th className="text-left">Role/Skill</th>
+                <th className="text-right">Mean</th>
+                <th className="text-right">P50</th>
+                <th className="text-right">P95</th>
+                <th className="text-right">N</th>
+              </tr>
+            </thead>
+            <tbody>
+              {manifest.costBaselines.map((c) => (
+                <tr key={`${c.role}::${c.skill}`}>
+                  <td>
+                    {c.role}/{c.skill}
+                  </td>
+                  <td className="text-right">{formatUsd(c.mean)}</td>
+                  <td className="text-right">{formatUsd(c.p50)}</td>
+                  <td className="text-right">{formatUsd(c.p95)}</td>
+                  <td className="text-right">{c.sampleCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="text-[11px] uppercase tracking-wider text-fg-2 mb-2">{title}</h3>
+      <div className="flex flex-col gap-1.5">{children}</div>
+    </section>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[11px] uppercase tracking-wider text-fg-3">{label}</div>
+      <div className="text-fg">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/components/RosterPage.tsx
+++ b/apps/web/src/components/roster/components/RosterPage.tsx
@@ -3,7 +3,9 @@ import type { PersonaStatDto, ProjectConfigDto } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { PersonaDrillIn } from './PersonaDrillIn';
+import { PlaybooksTab } from './PlaybooksTab';
 
 // Extracts the project slug from a persona name in the format "<slug>/<role>/<index>"
 export function personaProjectSlug(personaName: string): string {
@@ -121,6 +123,9 @@ function RoleGroup({
 }
 
 export function RosterPage() {
+  const params = useParams<{ slug?: string }>();
+  const projectSlug = params.slug ?? 'goose-hub-self';
+  const [activeTab, setActiveTab] = useState<'personas' | 'playbooks'>('personas');
   const [selectedPersona, setSelectedPersona] = useState<PersonaStatDto | null>(null);
   const [projectScope, setProjectScope] = useState<'all' | string>('all');
 
@@ -154,86 +159,157 @@ export function RosterPage() {
 
   const roles = Object.keys(grouped).sort();
 
-  return (
-    <div data-testid="roster-page" className="flex h-full overflow-hidden">
-      {/* Main list */}
-      <div className="flex-1 overflow-y-auto px-8 py-6">
-        <h1 className="text-[15px] font-semibold mb-3">Roster</h1>
+  if (activeTab === 'playbooks') {
+    return (
+      <div data-testid="roster-page" className="flex flex-col h-full overflow-hidden">
+        <RosterTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <PlaybooksTab projectSlug={projectSlug} />
+        </div>
+      </div>
+    );
+  }
 
-        {/* Project filter */}
-        {projectConfigs.length > 0 && (
-          <div className="flex items-center gap-1.5 mb-5 flex-wrap" data-testid="project-filter">
-            <button
-              type="button"
-              data-testid="filter-all"
-              onClick={() => setProjectScope('all')}
-              className={[
-                'px-2.5 py-1 rounded-full text-[11.5px] font-medium transition-colors border',
-                projectScope === 'all'
-                  ? 'bg-accent-soft text-fg border-accent'
-                  : 'text-fg-3 hover:text-fg hover:bg-bg-hover border-transparent',
-              ].join(' ')}
-            >
-              All Projects
-            </button>
-            {projectConfigs.map((cfg) => (
+  return (
+    <div data-testid="roster-page" className="flex flex-col h-full overflow-hidden">
+      <RosterTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="flex-1 min-h-0 flex overflow-hidden">
+        {/* Main list */}
+        <div className="flex-1 overflow-y-auto px-8 py-6">
+          <h1 className="text-[15px] font-semibold mb-3">Roster</h1>
+
+          {/* Project filter */}
+          {projectConfigs.length > 0 && (
+            <div className="flex items-center gap-1.5 mb-5 flex-wrap" data-testid="project-filter">
               <button
-                key={cfg.slug}
                 type="button"
-                data-testid={`filter-${cfg.slug}`}
-                onClick={() => setProjectScope(cfg.slug)}
+                data-testid="filter-all"
+                onClick={() => setProjectScope('all')}
                 className={[
-                  'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-medium transition-colors border',
-                  projectScope === cfg.slug
+                  'px-2.5 py-1 rounded-full text-[11.5px] font-medium transition-colors border',
+                  projectScope === 'all'
                     ? 'bg-accent-soft text-fg border-accent'
                     : 'text-fg-3 hover:text-fg hover:bg-bg-hover border-transparent',
                 ].join(' ')}
               >
-                <span
-                  className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
-                  style={{ background: cfg.colorStripe }}
-                />
-                {cfg.name}
+                All Projects
               </button>
-            ))}
-          </div>
-        )}
+              {projectConfigs.map((cfg) => (
+                <button
+                  key={cfg.slug}
+                  type="button"
+                  data-testid={`filter-${cfg.slug}`}
+                  onClick={() => setProjectScope(cfg.slug)}
+                  className={[
+                    'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-medium transition-colors border',
+                    projectScope === cfg.slug
+                      ? 'bg-accent-soft text-fg border-accent'
+                      : 'text-fg-3 hover:text-fg hover:bg-bg-hover border-transparent',
+                  ].join(' ')}
+                >
+                  <span
+                    className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                    style={{ background: cfg.colorStripe }}
+                  />
+                  {cfg.name}
+                </button>
+              ))}
+            </div>
+          )}
 
-        {isLoading && <div className="text-fg-3 text-[13px]">Loading personas…</div>}
+          {isLoading && <div className="text-fg-3 text-[13px]">Loading personas…</div>}
 
-        {error && (
-          <div className="text-[color:var(--danger)] text-[13px]">Failed to load roster.</div>
-        )}
+          {error && (
+            <div className="text-[color:var(--danger)] text-[13px]">Failed to load roster.</div>
+          )}
 
-        {!isLoading && !error && filteredPersonas.length === 0 && (
-          <div data-testid="roster-empty-state" className="text-center text-fg-3 text-[13px] py-16">
-            <p className="mb-2 font-medium text-fg-2">No personas yet</p>
-            <p>Persona stats accumulate as agent runs complete.</p>
-          </div>
-        )}
+          {!isLoading && !error && filteredPersonas.length === 0 && (
+            <div
+              data-testid="roster-empty-state"
+              className="text-center text-fg-3 text-[13px] py-16"
+            >
+              <p className="mb-2 font-medium text-fg-2">No personas yet</p>
+              <p>Persona stats accumulate as agent runs complete.</p>
+            </div>
+          )}
 
-        {!isLoading && !error && roles.length > 0 && (
-          <div className="flex flex-col gap-8">
-            {roles.map((role) => (
-              <RoleGroup
-                key={role}
-                role={role}
-                personas={grouped[role]}
-                selectedPersona={selectedPersona}
-                onSelect={setSelectedPersona}
-                colorMap={colorMap}
-                nameMap={nameMap}
-                showProjectBadge={projectScope === 'all' && projectConfigs.length > 1}
-              />
-            ))}
-          </div>
+          {!isLoading && !error && roles.length > 0 && (
+            <div className="flex flex-col gap-8">
+              {roles.map((role) => (
+                <RoleGroup
+                  key={role}
+                  role={role}
+                  personas={grouped[role]}
+                  selectedPersona={selectedPersona}
+                  onSelect={setSelectedPersona}
+                  colorMap={colorMap}
+                  nameMap={nameMap}
+                  showProjectBadge={projectScope === 'all' && projectConfigs.length > 1}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Drill-in panel */}
+        {selectedPersona && (
+          <PersonaDrillIn persona={selectedPersona} onClose={() => setSelectedPersona(null)} />
         )}
       </div>
-
-      {/* Drill-in panel */}
-      {selectedPersona && (
-        <PersonaDrillIn persona={selectedPersona} onClose={() => setSelectedPersona(null)} />
-      )}
     </div>
+  );
+}
+
+interface RosterTabBarProps {
+  activeTab: 'personas' | 'playbooks';
+  onTabChange: (tab: 'personas' | 'playbooks') => void;
+}
+
+function RosterTabBar({ activeTab, onTabChange }: RosterTabBarProps) {
+  return (
+    <div className="flex items-center gap-1 px-8 pt-5 border-b border-line">
+      <TabButton
+        testId="tab-personas"
+        active={activeTab === 'personas'}
+        onClick={() => onTabChange('personas')}
+      >
+        Personas
+      </TabButton>
+      <TabButton
+        testId="tab-playbooks"
+        active={activeTab === 'playbooks'}
+        onClick={() => onTabChange('playbooks')}
+      >
+        Playbooks
+      </TabButton>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  testId,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      className={[
+        'px-3 py-2 text-[12.5px] border-b-2 -mb-px transition-colors',
+        active
+          ? 'border-accent text-fg'
+          : 'border-transparent text-fg-2 hover:text-fg hover:border-line',
+      ].join(' ')}
+    >
+      {children}
+    </button>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   PersonaNameDto,
   PersonaRunDto,
   PersonaStatDto,
+  PlaybookDetailDto,
+  PlaybookSummaryDto,
   ProjectConfigDto,
   ProjectSummary,
   TransitionResult,
@@ -34,6 +36,8 @@ export type {
   ImprovementCandidateDto,
   CostSummaryDto,
   WorkItemCostsDto,
+  PlaybookSummaryDto,
+  PlaybookDetailDto,
 } from './types';
 
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
@@ -320,4 +324,28 @@ export async function fetchCostSummary(slug: string): Promise<CostSummaryDto> {
 
 export async function fetchIssueCosts(slug: string, id: string): Promise<WorkItemCostsDto> {
   return getJson<WorkItemCostsDto>(`/projects/${slug}/issues/${id}/costs`);
+}
+
+export async function fetchPlaybooks(slug: string): Promise<PlaybookSummaryDto[]> {
+  const { playbooks } = await getJson<{ playbooks: PlaybookSummaryDto[] }>(
+    `/projects/${slug}/playbooks`,
+  );
+  return playbooks;
+}
+
+export async function fetchPlaybook(slug: string, id: number): Promise<PlaybookDetailDto> {
+  const { playbook } = await getJson<{ playbook: PlaybookDetailDto }>(
+    `/projects/${slug}/playbooks/${id}`,
+  );
+  return playbook;
+}
+
+export async function createPlaybook(
+  slug: string,
+  body: { windowSize?: number; dateRange?: { startAt: string; endAt: string } },
+): Promise<{ playbookId: number; lifecycleCount: number }> {
+  return postJson<{ playbookId: number; lifecycleCount: number }>(
+    `/projects/${slug}/playbooks`,
+    body,
+  );
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -185,3 +185,68 @@ export interface ImprovementCandidateDto {
   errorNote: string | null;
   createdAt: string;
 }
+
+export interface PlaybookSummaryDto {
+  id: number;
+  projectId: string;
+  windowStartAt: string;
+  windowEndAt: string;
+  lifecycleCount: number;
+  topPatternCount: number;
+  topCandidateCount: number;
+  createdAt: string;
+}
+
+export interface PlaybookManifestDto {
+  outcome: string;
+  workItemNumber: number;
+  windowStartAt: string;
+  windowEndAt: string;
+  lifecycleCount: number;
+  summary: { wentWell: string; didNotGoWell: string; architecturalTakeaway: string };
+  aggregatedLearnings: Array<{
+    observation: string;
+    rationale: string;
+    improvementKind: string;
+    targetPath?: string;
+    confidence: string;
+  }>;
+  topPatterns: Array<{
+    patternId: string;
+    pattern: string;
+    occurrenceCount: number;
+    consistencyScore: number;
+    role?: string;
+    kind?: string;
+    exampleWorkItemIds: string[];
+  }>;
+  gateThresholds: Array<{
+    gate: 'qa' | 'review';
+    mean: number;
+    min: number;
+    max: number;
+    stdDev: number;
+    sampleCount: number;
+  }>;
+  costBaselines: Array<{
+    role: string;
+    skill: string;
+    mean: number;
+    p50: number;
+    p95: number;
+    sampleCount: number;
+  }>;
+  improvementCandidates: Array<{
+    kind: string;
+    targetPath: string;
+    suggestionText: string;
+    confidence: string;
+    evidence?: string;
+    proposedDiff?: string;
+  }>;
+  decisionSummaries: Array<{ kind: string; summary: string; evidence?: string }>;
+}
+
+export interface PlaybookDetailDto extends PlaybookSummaryDto {
+  manifest: PlaybookManifestDto;
+}

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -76,6 +76,14 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     timeoutMs: 300_000,
     modelTier: 'sonnet',
   },
+  // Cross-run retro reasons over a window of lifecycles (M11.12). Larger
+  // context window than per-merge retros, so a higher turn/budget cap.
+  'retrospective-cross-run': {
+    maxTurns: 40,
+    maxBudgetUsd: 1.0,
+    timeoutMs: 420_000,
+    modelTier: 'sonnet',
+  },
 };
 
 export interface ResolvedBudget {

--- a/core/db/migrations/0002_nervous_lucky_pierre.sql
+++ b/core/db/migrations/0002_nervous_lucky_pierre.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `playbooks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` text NOT NULL,
+	`window_start_at` text NOT NULL,
+	`window_end_at` text NOT NULL,
+	`lifecycle_count` integer DEFAULT 0 NOT NULL,
+	`manifest` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `playbooks_project_created_idx` ON `playbooks` (`project_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `playbooks_project_window_idx` ON `playbooks` (`project_id`,`window_start_at`,`window_end_at`);

--- a/core/db/migrations/meta/0002_snapshot.json
+++ b/core/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,911 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "167f0a25-c41b-4d60-a08b-9b9e4f6d8a5f",
+  "prevId": "9904ddc5-e044-4780-91d7-e252ba1db058",
+  "tables": {
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "archived_lifecycles": {
+      "name": "archived_lifecycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_summaries": {
+          "name": "decision_summaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "learning_entries": {
+          "name": "learning_entries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "quality_scores": {
+          "name": "quality_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "costs_usd": {
+          "name": "costs_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "run_ids": {
+          "name": "run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "archived_lifecycles_project_work_item_idx": {
+          "name": "archived_lifecycles_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "archived_lifecycles_project_closed_idx": {
+          "name": "archived_lifecycles_project_closed_idx",
+          "columns": [
+            "project_id",
+            "closed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_patterns": {
+      "name": "decision_patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_summary": {
+          "name": "action_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_summary": {
+          "name": "reason_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consistency_score": {
+          "name": "consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "example_work_item_ids": {
+          "name": "example_work_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "decision_patterns_project_kind_role_uniq": {
+          "name": "decision_patterns_project_kind_role_uniq",
+          "columns": [
+            "project_id",
+            "kind",
+            "role"
+          ],
+          "isUnique": true
+        },
+        "decision_patterns_project_idx": {
+          "name": "decision_patterns_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playbooks": {
+      "name": "playbooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_count": {
+          "name": "lifecycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "playbooks_project_created_idx": {
+          "name": "playbooks_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "playbooks_project_window_idx": {
+          "name": "playbooks_project_window_idx",
+          "columns": [
+            "project_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778065774445,
       "tag": "0001_parallel_morg",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1778098267923,
+      "tag": "0002_nervous_lucky_pierre",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -164,6 +164,27 @@ export const decisionPatterns = sqliteTable(
   }),
 );
 
+export const playbooks = sqliteTable(
+  'playbooks',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    projectId: text('project_id').notNull(),
+    windowStartAt: text('window_start_at').notNull(),
+    windowEndAt: text('window_end_at').notNull(),
+    lifecycleCount: integer('lifecycle_count').notNull().default(0),
+    manifest: text('manifest').notNull(),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    projectCreatedIdx: index('playbooks_project_created_idx').on(t.projectId, t.createdAt),
+    projectWindowIdx: index('playbooks_project_window_idx').on(
+      t.projectId,
+      t.windowStartAt,
+      t.windowEndAt,
+    ),
+  }),
+);
+
 // One row per agent run. `runId` is unique — the same run is never recorded twice.
 // `costLabel`: 'exact' when the source provided authoritative usage metadata
 // (direct API), 'estimated' when only the Claude CLI's reported totals are

--- a/core/learning/playbook-stats.test.ts
+++ b/core/learning/playbook-stats.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const FLUENT = ['select', 'from', 'where'] as const;
+  const mockDb: Record<string, unknown> = {};
+  for (const method of FLUENT) {
+    mockDb[method] = vi.fn().mockReturnValue(mockDb);
+  }
+  mockDb.all = vi.fn().mockReturnValue([]);
+  return { mockDb: mockDb as Record<string, ReturnType<typeof vi.fn>> };
+});
+
+vi.mock('../db/db.js', () => ({ db: mockDb }));
+vi.mock('../db/schema.js', () => ({
+  archivedLifecycles: {
+    projectId: 'project_id',
+    closedAt: 'closed_at',
+  },
+  events: {
+    projectId: 'project_id',
+    createdAt: 'created_at',
+  },
+  agentRunCosts: {
+    projectId: 'project_id',
+    createdAt: 'created_at',
+    stage: 'stage',
+    skill: 'skill',
+    costUsd: 'cost_usd',
+  },
+}));
+
+function reset() {
+  vi.clearAllMocks();
+  mockDb.select = vi.fn().mockReturnValue(mockDb);
+  mockDb.from = vi.fn().mockReturnValue(mockDb);
+  mockDb.where = vi.fn().mockReturnValue(mockDb);
+  mockDb.all = vi.fn().mockReturnValue([]);
+}
+
+import {
+  computeCostBaselines,
+  computeGateThresholds,
+  computePercentile,
+  computeStats,
+} from './playbook-stats.js';
+
+describe('computeStats', () => {
+  it('returns zeros for empty array', () => {
+    expect(computeStats([])).toEqual({ mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 });
+  });
+
+  it('handles single sample (stdDev = 0)', () => {
+    expect(computeStats([42])).toEqual({
+      mean: 42,
+      min: 42,
+      max: 42,
+      stdDev: 0,
+      sampleCount: 1,
+    });
+  });
+
+  it('computes mean / min / max / stdDev for multi-sample', () => {
+    const result = computeStats([60, 70, 80, 90, 100]);
+    expect(result.mean).toBe(80);
+    expect(result.min).toBe(60);
+    expect(result.max).toBe(100);
+    expect(result.sampleCount).toBe(5);
+    // population stdDev of [60,70,80,90,100] = sqrt(200) ≈ 14.142
+    expect(result.stdDev).toBeCloseTo(Math.sqrt(200), 5);
+  });
+
+  it('handles all-zero samples', () => {
+    expect(computeStats([0, 0, 0])).toEqual({
+      mean: 0,
+      min: 0,
+      max: 0,
+      stdDev: 0,
+      sampleCount: 3,
+    });
+  });
+});
+
+describe('computePercentile', () => {
+  it('returns 0 for empty array', () => {
+    expect(computePercentile([], 0.5)).toBe(0);
+  });
+
+  it('returns the only sample for size 1', () => {
+    expect(computePercentile([7], 0.95)).toBe(7);
+  });
+
+  it('p50 of [1,2,3,4,5] = 3', () => {
+    expect(computePercentile([1, 2, 3, 4, 5], 0.5)).toBe(3);
+  });
+
+  it('p95 of 20 samples is at the high end', () => {
+    const samples = Array.from({ length: 20 }, (_, i) => i + 1);
+    const p95 = computePercentile(samples, 0.95);
+    expect(p95).toBeGreaterThanOrEqual(samples[18]);
+    expect(p95).toBeLessThanOrEqual(samples[19]);
+  });
+
+  it('handles unsorted input by sorting internally', () => {
+    expect(computePercentile([5, 1, 3, 2, 4], 0.5)).toBe(3);
+  });
+});
+
+describe('computeGateThresholds', () => {
+  beforeEach(reset);
+
+  it('returns zeroed entries for both gates when no events match', () => {
+    mockDb.all = vi.fn().mockReturnValue([]);
+    const result = computeGateThresholds({
+      projectId: 'p',
+      windowStartAt: '2026-04-01T00:00:00Z',
+      windowEndAt: '2026-05-01T00:00:00Z',
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.gate)).toEqual(['qa', 'review']);
+    expect(result[0].sampleCount).toBe(0);
+  });
+
+  it('aggregates qa overallScore and review confidence into per-gate stats', () => {
+    mockDb.all = vi.fn().mockReturnValue([
+      { kind: 'qa.completed', payload: JSON.stringify({ overallScore: 70 }) },
+      { kind: 'qa.completed', payload: JSON.stringify({ overallScore: 80 }) },
+      { kind: 'qa.completed', payload: JSON.stringify({ overallScore: 90 }) },
+      { kind: 'review.completed', payload: JSON.stringify({ confidence: 0.8 }) },
+      { kind: 'review.completed', payload: JSON.stringify({ confidence: 0.9 }) },
+      { kind: 'agent.run-completed', payload: JSON.stringify({ ok: true }) }, // ignored
+    ]);
+    const result = computeGateThresholds({
+      projectId: 'p',
+      windowStartAt: '2026-04-01T00:00:00Z',
+      windowEndAt: '2026-05-01T00:00:00Z',
+    });
+    const qa = result.find((r) => r.gate === 'qa');
+    const review = result.find((r) => r.gate === 'review');
+    expect(qa?.mean).toBe(80);
+    expect(qa?.min).toBe(70);
+    expect(qa?.max).toBe(90);
+    expect(qa?.sampleCount).toBe(3);
+    expect(review?.mean).toBeCloseTo(0.85, 5);
+    expect(review?.sampleCount).toBe(2);
+  });
+
+  it('tolerates malformed payloads without crashing', () => {
+    mockDb.all = vi.fn().mockReturnValue([
+      { kind: 'qa.completed', payload: 'not-json' },
+      { kind: 'qa.completed', payload: JSON.stringify({}) },
+      { kind: 'qa.completed', payload: JSON.stringify({ overallScore: 60 }) },
+    ]);
+    const result = computeGateThresholds({
+      projectId: 'p',
+      windowStartAt: '2026-04-01T00:00:00Z',
+      windowEndAt: '2026-05-01T00:00:00Z',
+    });
+    const qa = result.find((r) => r.gate === 'qa');
+    expect(qa?.sampleCount).toBe(1);
+    expect(qa?.mean).toBe(60);
+  });
+});
+
+describe('computeCostBaselines', () => {
+  beforeEach(reset);
+
+  it('returns empty array when no costs match', () => {
+    mockDb.all = vi.fn().mockReturnValue([]);
+    expect(
+      computeCostBaselines({
+        projectId: 'p',
+        windowStartAt: '2026-04-01T00:00:00Z',
+        windowEndAt: '2026-05-01T00:00:00Z',
+      }),
+    ).toEqual([]);
+  });
+
+  it('groups by (role, skill) and computes mean / p50 / p95', () => {
+    mockDb.all = vi.fn().mockReturnValue([
+      { stage: 'developer', skill: 'implement', costUsd: 0.1 },
+      { stage: 'developer', skill: 'implement', costUsd: 0.2 },
+      { stage: 'developer', skill: 'implement', costUsd: 0.3 },
+      { stage: 'developer', skill: 'implement', costUsd: 0.4 },
+      { stage: 'developer', skill: 'implement', costUsd: 0.5 },
+      { stage: 'qa', skill: 'qa', costUsd: 1.0 },
+    ]);
+    const result = computeCostBaselines({
+      projectId: 'p',
+      windowStartAt: '2026-04-01T00:00:00Z',
+      windowEndAt: '2026-05-01T00:00:00Z',
+    });
+    expect(result).toHaveLength(2);
+    const dev = result.find((r) => r.role === 'developer' && r.skill === 'implement');
+    const qa = result.find((r) => r.role === 'qa' && r.skill === 'qa');
+    expect(dev?.mean).toBeCloseTo(0.3, 5);
+    expect(dev?.p50).toBeCloseTo(0.3, 5);
+    expect(dev?.p95).toBeCloseTo(0.48, 2);
+    expect(dev?.sampleCount).toBe(5);
+    expect(qa?.mean).toBe(1.0);
+    expect(qa?.sampleCount).toBe(1);
+  });
+
+  it('produces deterministic ordering by role+skill', () => {
+    mockDb.all = vi.fn().mockReturnValue([
+      { stage: 'qa', skill: 'qa', costUsd: 1.0 },
+      { stage: 'developer', skill: 'implement', costUsd: 0.1 },
+      { stage: 'reviewer', skill: 'review', costUsd: 0.05 },
+    ]);
+    const result = computeCostBaselines({
+      projectId: 'p',
+      windowStartAt: '2026-04-01T00:00:00Z',
+      windowEndAt: '2026-05-01T00:00:00Z',
+    });
+    expect(result.map((r) => `${r.role}::${r.skill}`)).toEqual([
+      'developer::implement',
+      'qa::qa',
+      'reviewer::review',
+    ]);
+  });
+});

--- a/core/learning/playbook-stats.ts
+++ b/core/learning/playbook-stats.ts
@@ -1,0 +1,206 @@
+import { type SQL, and, eq, gte, lte } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { events, agentRunCosts, archivedLifecycles } from '../db/schema.js';
+
+export interface GateThreshold {
+  gate: 'qa' | 'review';
+  mean: number;
+  min: number;
+  max: number;
+  stdDev: number;
+  sampleCount: number;
+}
+
+export interface CostBaseline {
+  role: string;
+  skill: string;
+  mean: number;
+  p50: number;
+  p95: number;
+  sampleCount: number;
+}
+
+export interface ArchivedLifecycleRow {
+  id: number;
+  projectId: string;
+  workItemId: string;
+  closedAt: string;
+  decisionSummaries: string;
+  learningEntries: string;
+  qualityScores: string;
+  costsUsd: number;
+  runIds: string;
+}
+
+export interface WindowQuery {
+  projectId: string;
+  windowStartAt: string;
+  windowEndAt: string;
+}
+
+export function computeStats(samples: number[]): {
+  mean: number;
+  min: number;
+  max: number;
+  stdDev: number;
+  sampleCount: number;
+} {
+  if (samples.length === 0) {
+    return { mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 };
+  }
+  const n = samples.length;
+  const sum = samples.reduce((a, b) => a + b, 0);
+  const mean = sum / n;
+  let min = samples[0] ?? 0;
+  let max = samples[0] ?? 0;
+  for (const s of samples) {
+    if (s < min) min = s;
+    if (s > max) max = s;
+  }
+  if (n === 1) {
+    return { mean, min, max, stdDev: 0, sampleCount: 1 };
+  }
+  const variance = samples.reduce((acc, s) => acc + (s - mean) ** 2, 0) / n;
+  const stdDev = Math.sqrt(variance);
+  return { mean, min, max, stdDev, sampleCount: n };
+}
+
+export function computePercentile(samples: number[], p: number): number {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = p * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo] ?? 0;
+  const loVal = sorted[lo] ?? 0;
+  const hiVal = sorted[hi] ?? 0;
+  return loVal + (hiVal - loVal) * (rank - lo);
+}
+
+export interface PayloadEnvelope {
+  overallScore?: number;
+  confidence?: number;
+  verdict?: string;
+}
+
+function parsePayload(raw: unknown): PayloadEnvelope {
+  if (raw == null) return {};
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as PayloadEnvelope;
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === 'object') {
+    return raw as PayloadEnvelope;
+  }
+  return {};
+}
+
+function whereWindow(query: WindowQuery): SQL {
+  return and(
+    eq(events.projectId, query.projectId),
+    gte(events.createdAt, query.windowStartAt),
+    lte(events.createdAt, query.windowEndAt),
+  ) as SQL;
+}
+
+/**
+ * Per-gate `mean / min / max / stdDev` of scores within the window.
+ *
+ * QA score: `overallScore` (0–100) from `qa.completed` events.
+ * Review score: `confidence` (0–1) from `review.completed` events. Confidence is
+ * the only numeric proxy for review quality — verdict alone isn't comparable.
+ */
+export function computeGateThresholds(query: WindowQuery): GateThreshold[] {
+  const rows = db.select().from(events).where(whereWindow(query)).all();
+
+  const qaScores: number[] = [];
+  const reviewScores: number[] = [];
+
+  for (const row of rows) {
+    const payload = parsePayload(row.payload);
+    if (row.kind === 'qa.completed' && typeof payload.overallScore === 'number') {
+      qaScores.push(payload.overallScore);
+    } else if (row.kind === 'review.completed' && typeof payload.confidence === 'number') {
+      reviewScores.push(payload.confidence);
+    }
+  }
+
+  return [
+    { gate: 'qa', ...computeStats(qaScores) },
+    { gate: 'review', ...computeStats(reviewScores) },
+  ];
+}
+
+/**
+ * Per `(role, skill)` `mean / p50 / p95` cost in USD within the window.
+ *
+ * Reads from `agent_run_costs`. The `stage` column is the role (developer, qa,
+ * reviewer, retrospector, …); the `skill` column is the skill key.
+ */
+export function computeCostBaselines(query: WindowQuery): CostBaseline[] {
+  const rows = db
+    .select({
+      stage: agentRunCosts.stage,
+      skill: agentRunCosts.skill,
+      costUsd: agentRunCosts.costUsd,
+    })
+    .from(agentRunCosts)
+    .where(
+      and(
+        eq(agentRunCosts.projectId, query.projectId),
+        gte(agentRunCosts.createdAt, query.windowStartAt),
+        lte(agentRunCosts.createdAt, query.windowEndAt),
+      ),
+    )
+    .all();
+
+  const groups = new Map<string, { role: string; skill: string; costs: number[] }>();
+  for (const row of rows) {
+    const key = `${row.stage}::${row.skill}`;
+    const existing = groups.get(key);
+    if (existing == null) {
+      groups.set(key, { role: row.stage, skill: row.skill, costs: [row.costUsd] });
+    } else {
+      existing.costs.push(row.costUsd);
+    }
+  }
+
+  const out: CostBaseline[] = [];
+  for (const group of groups.values()) {
+    const stats = computeStats(group.costs);
+    out.push({
+      role: group.role,
+      skill: group.skill,
+      mean: stats.mean,
+      p50: computePercentile(group.costs, 0.5),
+      p95: computePercentile(group.costs, 0.95),
+      sampleCount: stats.sampleCount,
+    });
+  }
+
+  // Stable sort for deterministic output
+  out.sort((a, b) => (a.role + a.skill).localeCompare(b.role + b.skill));
+  return out;
+}
+
+/**
+ * Fetch archived lifecycles inside the window. Window bounds are inclusive on
+ * `closedAt`. Used by the cross-run retro workflow as the input universe for
+ * the skill, gate-threshold computation, and cost-baseline computation.
+ */
+export function fetchLifecyclesInWindow(query: WindowQuery): ArchivedLifecycleRow[] {
+  return db
+    .select()
+    .from(archivedLifecycles)
+    .where(
+      and(
+        eq(archivedLifecycles.projectId, query.projectId),
+        gte(archivedLifecycles.closedAt, query.windowStartAt),
+        lte(archivedLifecycles.closedAt, query.windowEndAt),
+      ),
+    )
+    .all();
+}

--- a/core/workflows/cross-run-retro.test.ts
+++ b/core/workflows/cross-run-retro.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRun = vi.fn();
+const mockAppendEvent = vi.fn().mockReturnValue({ id: 1 });
+const mockComputeGateThresholds = vi.fn();
+const mockComputeCostBaselines = vi.fn();
+const mockFetchLifecyclesInWindow = vi.fn();
+const mockGetProjectBySlug = vi.fn().mockResolvedValue(null);
+const mockSelectPersona = vi
+  .fn()
+  .mockReturnValue({ personaId: 'test-project/retrospector/0', codename: 'Tester' });
+
+const { mockDb } = vi.hoisted(() => {
+  const FLUENT = ['select', 'from', 'where', 'insert', 'values', 'returning'] as const;
+  const mockDb: Record<string, unknown> = {};
+  for (const method of FLUENT) {
+    mockDb[method] = vi.fn().mockReturnValue(mockDb);
+  }
+  mockDb.all = vi.fn().mockReturnValue([]);
+  mockDb.run = vi.fn();
+  return { mockDb: mockDb as Record<string, ReturnType<typeof vi.fn>> };
+});
+
+vi.mock('../db/db.js', () => ({ db: mockDb }));
+vi.mock('../db/schema.js', () => ({
+  archivedLifecycles: { projectId: 'project_id', closedAt: 'closed_at' },
+  decisionPatterns: { projectId: 'project_id' },
+  playbooks: { id: 'id' },
+}));
+vi.mock('../agent-runtime/claude-cli.js', () => ({
+  ClaudeCliRuntime: vi.fn().mockImplementation(() => ({ run: mockRun })),
+}));
+vi.mock('../agent-runtime/schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../agent-runtime/select-persona.js', () => ({
+  selectPersona: (...args: unknown[]) => mockSelectPersona(...args),
+}));
+vi.mock('../agent-runtime/read-prompt.js', () => ({
+  readPromptWithContext: vi.fn().mockReturnValue('# mock cross-run prompt'),
+}));
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: (...args: unknown[]) => mockAppendEvent(...args),
+    replay: vi.fn().mockReturnValue([]),
+  },
+}));
+vi.mock('../learning/playbook-stats.js', () => ({
+  computeGateThresholds: (...args: unknown[]) => mockComputeGateThresholds(...args),
+  computeCostBaselines: (...args: unknown[]) => mockComputeCostBaselines(...args),
+  fetchLifecyclesInWindow: (...args: unknown[]) => mockFetchLifecyclesInWindow(...args),
+}));
+vi.mock('../projects/loader.js', () => ({
+  getProjectBySlug: (...args: unknown[]) => mockGetProjectBySlug(...args),
+}));
+
+import {
+  CrossRunRetroInputError,
+  resolveWindow,
+  runCrossRunRetroWorkflow,
+} from './cross-run-retro.js';
+
+function makeManifestOutput(overrides: Record<string, unknown> = {}) {
+  return {
+    output: {
+      outcome: 'success',
+      workItemNumber: 0,
+      windowStartAt: '2026-04-01T00:00:00.000Z',
+      windowEndAt: '2026-05-01T00:00:00.000Z',
+      lifecycleCount: 2,
+      summary: {
+        wentWell: 'TDD discipline',
+        didNotGoWell: 'Out-of-scope edits',
+        architecturalTakeaway: 'Formalize ACs',
+      },
+      aggregatedLearnings: [],
+      topPatterns: [],
+      gateThresholds: [],
+      costBaselines: [],
+      improvementCandidates: [],
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Cross-run retro complete' }],
+      ...overrides,
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+beforeEach(() => {
+  mockRun.mockReset();
+  mockAppendEvent.mockClear();
+  mockComputeGateThresholds.mockReset().mockReturnValue([]);
+  mockComputeCostBaselines.mockReset().mockReturnValue([]);
+  mockFetchLifecyclesInWindow.mockReset().mockReturnValue([]);
+  mockSelectPersona.mockClear();
+  for (const method of ['select', 'from', 'where', 'insert', 'values', 'returning']) {
+    mockDb[method] = vi.fn().mockReturnValue(mockDb);
+  }
+  mockDb.all = vi.fn().mockReturnValue([]);
+  mockDb.run = vi.fn();
+});
+
+describe('resolveWindow', () => {
+  it('throws when neither windowSize nor dateRange supplied', () => {
+    expect(() => resolveWindow({ projectId: 'p' })).toThrow(CrossRunRetroInputError);
+  });
+
+  it('throws when both windowSize and dateRange supplied', () => {
+    expect(() =>
+      resolveWindow({
+        projectId: 'p',
+        windowSize: 5,
+        dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+      }),
+    ).toThrow(CrossRunRetroInputError);
+  });
+
+  it('echoes dateRange verbatim', () => {
+    const w = resolveWindow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+    expect(w).toEqual({ startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' });
+  });
+
+  it('rejects inverted dateRange', () => {
+    expect(() =>
+      resolveWindow({
+        projectId: 'p',
+        dateRange: { startAt: '2026-05-01T00:00:00Z', endAt: '2026-04-01T00:00:00Z' },
+      }),
+    ).toThrow(CrossRunRetroInputError);
+  });
+
+  it('rejects non-positive windowSize', () => {
+    expect(() => resolveWindow({ projectId: 'p', windowSize: 0 })).toThrow(CrossRunRetroInputError);
+    expect(() => resolveWindow({ projectId: 'p', windowSize: -1 })).toThrow(
+      CrossRunRetroInputError,
+    );
+  });
+
+  it('windowSize on empty archive collapses to (now, now)', () => {
+    mockDb.all = vi.fn().mockReturnValue([]);
+    const now = new Date('2026-05-06T00:00:00.000Z');
+    const w = resolveWindow({ projectId: 'p', windowSize: 5, deps: { now: () => now } });
+    expect(w.startAt).toBe(now.toISOString());
+    expect(w.endAt).toBe(now.toISOString());
+  });
+
+  it('windowSize selects Nth most recent closedAt as startAt', () => {
+    mockDb.all = vi
+      .fn()
+      .mockReturnValue([
+        { closedAt: '2026-05-01T00:00:00Z' },
+        { closedAt: '2026-04-29T00:00:00Z' },
+        { closedAt: '2026-04-27T00:00:00Z' },
+        { closedAt: '2026-04-25T00:00:00Z' },
+        { closedAt: '2026-04-23T00:00:00Z' },
+      ]);
+    const now = new Date('2026-05-06T00:00:00.000Z');
+    const w = resolveWindow({ projectId: 'p', windowSize: 3, deps: { now: () => now } });
+    // 3rd most recent = 2026-04-27
+    expect(w.startAt).toBe('2026-04-27T00:00:00Z');
+    expect(w.endAt).toBe(now.toISOString());
+  });
+
+  it('windowSize > available falls back to oldest closedAt', () => {
+    mockDb.all = vi.fn().mockReturnValue([{ closedAt: '2026-05-01T00:00:00Z' }]);
+    const now = new Date('2026-05-06T00:00:00.000Z');
+    const w = resolveWindow({ projectId: 'p', windowSize: 99, deps: { now: () => now } });
+    expect(w.startAt).toBe('2026-05-01T00:00:00Z');
+  });
+});
+
+describe('runCrossRunRetroWorkflow', () => {
+  it('happy path: persists playbook with manifest + emits retrospective.completed', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([
+      {
+        id: 1,
+        projectId: 'p',
+        workItemId: 'github:o/r#1',
+        closedAt: '2026-04-15T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0.5,
+        runIds: '[]',
+      },
+      {
+        id: 2,
+        projectId: 'p',
+        workItemId: 'github:o/r#2',
+        closedAt: '2026-04-20T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0.6,
+        runIds: '[]',
+      },
+    ]);
+    mockComputeGateThresholds.mockReturnValue([]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockDb.all = vi.fn().mockReturnValue([{ id: 42 }]);
+    mockRun.mockResolvedValueOnce(makeManifestOutput({ lifecycleCount: 2 }));
+
+    const result = await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.playbookId).toBe(42);
+    expect(result.lifecycleCount).toBe(2);
+    expect(result.windowStartAt).toBe('2026-04-01T00:00:00Z');
+    expect(result.windowEndAt).toBe('2026-05-01T00:00:00Z');
+
+    const events = mockAppendEvent.mock.calls.map((c) => c[0]);
+    expect(events.some((e) => e.kind === 'agent.run-started')).toBe(true);
+    expect(events.some((e) => e.kind === 'retrospective.completed')).toBe(true);
+  });
+
+  it('empty archive case: still produces a playbook over an empty window', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([]);
+    mockComputeGateThresholds.mockReturnValue([
+      { gate: 'qa', mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 },
+      { gate: 'review', mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 },
+    ]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockDb.all = vi.fn().mockReturnValue([{ id: 7 }]);
+    mockRun.mockResolvedValueOnce(
+      makeManifestOutput({
+        lifecycleCount: 0,
+        gateThresholds: [
+          { gate: 'qa', mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 },
+          { gate: 'review', mean: 0, min: 0, max: 0, stdDev: 0, sampleCount: 0 },
+        ],
+      }),
+    );
+
+    const result = await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.lifecycleCount).toBe(0);
+  });
+
+  it('window edge case: single lifecycle and no patterns still validates', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([
+      {
+        id: 1,
+        projectId: 'p',
+        workItemId: 'github:o/r#1',
+        closedAt: '2026-04-15T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0.5,
+        runIds: '[]',
+      },
+    ]);
+    mockComputeGateThresholds.mockReturnValue([]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockDb.all = vi.fn().mockReturnValue([{ id: 99 }]);
+    mockRun.mockResolvedValueOnce(makeManifestOutput({ lifecycleCount: 1 }));
+
+    const result = await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns failure + emits agent.run-failed when output fails schema validation', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([]);
+    mockComputeGateThresholds.mockReturnValue([]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockRun.mockResolvedValueOnce({
+      output: { outcome: 'success' /* missing required fields */ },
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+
+    expect(result.ok).toBe(false);
+    const events = mockAppendEvent.mock.calls.map((c) => c[0]);
+    expect(events.some((e) => e.kind === 'agent.run-failed')).toBe(true);
+  });
+
+  it('returns failure + emits agent.run-failed when runtime throws', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([]);
+    mockComputeGateThresholds.mockReturnValue([]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockRun.mockRejectedValueOnce(new Error('timeout'));
+
+    const result = await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('timeout');
+  });
+
+  it('passes precomputed gate thresholds + cost baselines into the skill context', async () => {
+    mockFetchLifecyclesInWindow.mockReturnValue([]);
+    mockComputeGateThresholds.mockReturnValue([
+      { gate: 'qa', mean: 80, min: 70, max: 90, stdDev: 5, sampleCount: 5 },
+    ]);
+    mockComputeCostBaselines.mockReturnValue([
+      { role: 'developer', skill: 'implement', mean: 0.4, p50: 0.4, p95: 0.7, sampleCount: 5 },
+    ]);
+    mockDb.all = vi.fn().mockReturnValue([{ id: 1 }]);
+    mockRun.mockResolvedValueOnce(makeManifestOutput());
+
+    await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+    });
+
+    const spec = mockRun.mock.calls[0][0] as {
+      context: {
+        precomputedGateThresholds: unknown[];
+        precomputedCostBaselines: unknown[];
+      };
+    };
+    expect(spec.context.precomputedGateThresholds).toHaveLength(1);
+    expect(spec.context.precomputedCostBaselines).toHaveLength(1);
+  });
+});

--- a/core/workflows/cross-run-retro.ts
+++ b/core/workflows/cross-run-retro.ts
@@ -1,0 +1,301 @@
+import { eq } from 'drizzle-orm';
+import {
+  type CrossRunRetroOutput,
+  CrossRunRetroOutputSchema,
+} from '../../skills/retrospective-cross-run/schema.js';
+import { resolveBudgets } from '../agent-runtime/budgets.js';
+import { ClaudeCliRuntime } from '../agent-runtime/claude-cli.js';
+import type { AgentRuntime } from '../agent-runtime/interface.js';
+import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
+import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
+import { selectPersona } from '../agent-runtime/select-persona.js';
+import { db } from '../db/db.js';
+import { archivedLifecycles, decisionPatterns, playbooks } from '../db/schema.js';
+import { eventStore } from '../event-stream/store.js';
+import {
+  computeCostBaselines,
+  computeGateThresholds,
+  fetchLifecyclesInWindow,
+} from '../learning/playbook-stats.js';
+import { getProjectBySlug } from '../projects/loader.js';
+
+export interface DateRange {
+  startAt: string;
+  endAt: string;
+}
+
+export interface CrossRunRetroInput {
+  projectId: string;
+  /** Most recent N lifecycles (closedAt-ordered desc). Mutually exclusive with `dateRange`. */
+  windowSize?: number;
+  /** Inclusive ISO8601 bounds. Mutually exclusive with `windowSize`. */
+  dateRange?: DateRange;
+  deps?: { runtime?: AgentRuntime; now?: () => Date };
+}
+
+export interface CrossRunRetroResult {
+  ok: true;
+  playbookId: number;
+  windowStartAt: string;
+  windowEndAt: string;
+  lifecycleCount: number;
+  manifest: CrossRunRetroOutput;
+}
+
+export interface CrossRunRetroFailure {
+  ok: false;
+  error: string;
+}
+
+export type CrossRunRetroOutcome = CrossRunRetroResult | CrossRunRetroFailure;
+
+export class CrossRunRetroInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CrossRunRetroInputError';
+  }
+}
+
+/**
+ * Resolve the inclusive `(startAt, endAt)` window. Behaviour:
+ *   - dateRange  → echoed verbatim
+ *   - windowSize → endAt = now; startAt = closedAt of the Nth most recent
+ *                  lifecycle. If fewer than N exist, startAt = oldest closedAt.
+ *                  If zero lifecycles exist, the window collapses to (now, now)
+ *                  (empty window — the workflow still runs and produces an
+ *                  empty-window playbook).
+ */
+export function resolveWindow(input: CrossRunRetroInput): { startAt: string; endAt: string } {
+  const hasWindowSize = input.windowSize != null;
+  const hasDateRange = input.dateRange != null;
+  if (hasWindowSize === hasDateRange) {
+    throw new CrossRunRetroInputError('exactly one of windowSize or dateRange must be supplied');
+  }
+
+  if (hasDateRange) {
+    const range = input.dateRange as DateRange;
+    if (!range.startAt || !range.endAt) {
+      throw new CrossRunRetroInputError('dateRange.startAt and dateRange.endAt are required');
+    }
+    if (range.startAt > range.endAt) {
+      throw new CrossRunRetroInputError('dateRange.startAt must be <= dateRange.endAt');
+    }
+    return { startAt: range.startAt, endAt: range.endAt };
+  }
+
+  const size = input.windowSize as number;
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new CrossRunRetroInputError('windowSize must be a positive integer');
+  }
+
+  const now = (input.deps?.now ?? (() => new Date()))();
+  const endAt = now.toISOString();
+
+  const rows = db
+    .select({ closedAt: archivedLifecycles.closedAt })
+    .from(archivedLifecycles)
+    .where(eq(archivedLifecycles.projectId, input.projectId))
+    .all();
+
+  if (rows.length === 0) {
+    return { startAt: endAt, endAt };
+  }
+
+  const closedAts = rows.map((r) => r.closedAt).sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+  const startAt = closedAts[Math.min(size, closedAts.length) - 1] ?? endAt;
+  return { startAt, endAt };
+}
+
+function loadMinedPatterns(projectId: string) {
+  return db
+    .select()
+    .from(decisionPatterns)
+    .where(eq(decisionPatterns.projectId, projectId))
+    .all()
+    .map((p) => ({
+      patternId: `${p.kind}::${p.role}`,
+      pattern: p.actionSummary,
+      occurrenceCount: p.occurrenceCount,
+      consistencyScore: p.consistencyScore,
+      role: p.role,
+      kind: p.kind,
+      exampleWorkItemIds: safeParseJsonStringArray(p.exampleWorkItemIds),
+    }));
+}
+
+function safeParseJsonStringArray(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeParseJsonUnknownArray(raw: string): unknown[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Cross-run retrospective workflow (M11.12). Fetches archived lifecycles +
+ * mined patterns + computed gate thresholds and cost baselines, dispatches the
+ * `retrospective-cross-run` skill, and persists the validated output as a new
+ * `playbooks` row. The per-merge `retrospective-deep` skill is unaffected.
+ */
+export async function runCrossRunRetroWorkflow(
+  input: CrossRunRetroInput,
+): Promise<CrossRunRetroOutcome> {
+  const window = resolveWindow(input);
+  const projectId = input.projectId;
+  const runId = crypto.randomUUID();
+  const runtime = input.deps?.runtime ?? new ClaudeCliRuntime();
+
+  const lifecycles = fetchLifecyclesInWindow({
+    projectId,
+    windowStartAt: window.startAt,
+    windowEndAt: window.endAt,
+  });
+
+  const minedPatterns = loadMinedPatterns(projectId);
+  const gateThresholds = computeGateThresholds({
+    projectId,
+    windowStartAt: window.startAt,
+    windowEndAt: window.endAt,
+  });
+  const costBaselines = computeCostBaselines({
+    projectId,
+    windowStartAt: window.startAt,
+    windowEndAt: window.endAt,
+  });
+
+  const skillName = 'retrospective-cross-run';
+  const prompt = readPromptWithContext(skillName, projectId);
+  const projectConfig = await getProjectBySlug(projectId);
+  const jsonSchema = toJsonSchema(CrossRunRetroOutputSchema);
+  const { personaId } = selectPersona(projectId, 'retrospector');
+
+  eventStore.appendEvent({
+    kind: 'agent.run-started',
+    projectId,
+    runId,
+    payload: {
+      skill: skillName,
+      tier: 'cross-run',
+      personaId,
+      windowStartAt: window.startAt,
+      windowEndAt: window.endAt,
+      lifecycleCount: lifecycles.length,
+    },
+  });
+
+  const archivedForSkill = lifecycles.map((row) => ({
+    workItemId: row.workItemId,
+    closedAt: row.closedAt,
+    decisionSummaries: safeParseJsonUnknownArray(row.decisionSummaries),
+    learningEntries: safeParseJsonUnknownArray(row.learningEntries),
+    qualityScores: safeParseJsonUnknownArray(row.qualityScores),
+    costsUsd: row.costsUsd,
+  }));
+
+  try {
+    const result = await runtime.run({
+      runId,
+      role: 'retrospector',
+      skill: skillName,
+      context: {
+        projectId,
+        windowStartAt: window.startAt,
+        windowEndAt: window.endAt,
+        lifecycleCount: lifecycles.length,
+        archivedLifecycles: archivedForSkill,
+        minedPatterns,
+        precomputedGateThresholds: gateThresholds,
+        precomputedCostBaselines: costBaselines,
+        priorAggregatedLearnings: [],
+      },
+      contextAllowlist: [
+        'projectId',
+        'windowStartAt',
+        'windowEndAt',
+        'lifecycleCount',
+        'archivedLifecycles',
+        'minedPatterns',
+        'precomputedGateThresholds',
+        'precomputedCostBaselines',
+        'priorAggregatedLearnings',
+      ],
+      freshContext: false,
+      toolBundles: ['core'],
+      toolExtras: [],
+      ...resolveBudgets(skillName, projectConfig?.budgets),
+      personaId,
+      appendSystemPrompt: prompt,
+      outputJsonSchema: jsonSchema,
+    });
+
+    const parsed = CrossRunRetroOutputSchema.safeParse(result.output);
+    if (!parsed.success) {
+      eventStore.appendEvent({
+        kind: 'agent.run-failed',
+        projectId,
+        runId,
+        payload: { skill: skillName, error: parsed.error.message },
+      });
+      return { ok: false, error: parsed.error.message };
+    }
+
+    const manifest = parsed.data;
+
+    const inserted = db
+      .insert(playbooks)
+      .values({
+        projectId,
+        windowStartAt: window.startAt,
+        windowEndAt: window.endAt,
+        lifecycleCount: lifecycles.length,
+        manifest: JSON.stringify(manifest),
+      })
+      .returning({ id: playbooks.id })
+      .all();
+
+    const playbookId = inserted[0]?.id ?? -1;
+
+    for (const ds of manifest.decisionSummaries) {
+      eventStore.appendEvent({
+        kind: 'agent.decision-summary',
+        projectId,
+        runId,
+        payload: { skill: skillName, ...ds },
+      });
+    }
+
+    eventStore.appendEvent({
+      kind: 'retrospective.completed',
+      projectId,
+      runId,
+      payload: { tier: 'cross-run', playbookId, manifest },
+    });
+
+    return {
+      ok: true,
+      playbookId,
+      windowStartAt: window.startAt,
+      windowEndAt: window.endAt,
+      lifecycleCount: lifecycles.length,
+      manifest,
+    };
+  } catch (err) {
+    eventStore.appendEvent({
+      kind: 'agent.run-failed',
+      projectId,
+      runId,
+      payload: { skill: skillName, error: String(err) },
+    });
+    return { ok: false, error: String(err) };
+  }
+}

--- a/skills/retrospective-cross-run/README.md
+++ b/skills/retrospective-cross-run/README.md
@@ -1,0 +1,48 @@
+# retrospective-cross-run
+
+Cross-run retrospective skill (M11.12). Produces a `PlaybookManifest` over a window of archived lifecycles.
+
+This is the **analytical path** counterpart to the per-merge `retrospective-deep` skill, not a replacement. The per-merge retro keeps emitting per-run output (the fast path); the cross-run retro consumes many of those.
+
+## When it runs
+
+Triggered on demand by `POST /api/projects/:slug/playbooks` with one of:
+
+- `windowSize` (integer, number of most recent lifecycles to consider), or
+- `dateRange` (`{ startAt, endAt }`, ISO8601 inclusive bounds)
+
+The workflow (`core/workflows/cross-run-retro.ts`) fetches archived lifecycles + mined patterns + computed gate thresholds and cost baselines, dispatches the skill, then persists the validated output as a new `playbooks` row.
+
+## Output schema
+
+Defined in `schema.ts`. Extends `RetroOutputBaseSchema` from `core/retrospective/schemas.ts` with:
+
+| Field | Type | Description |
+|---|---|---|
+| `windowStartAt` | `string` (ISO8601) | Window lower bound |
+| `windowEndAt` | `string` (ISO8601) | Window upper bound |
+| `lifecycleCount` | `integer` | Number of archived lifecycles in the window |
+| `aggregatedLearnings` | `LearningEntry[]` | Cross-run learnings (recurring observations) |
+| `topPatterns` | `CrossRunPattern[]` | Highest-signal mined patterns (`consistencyScore` + `occurrenceCount`) |
+| `gateThresholds` | `GateThreshold[]` | Per-gate `mean / min / max / stdDev` for `qa` and `review` |
+| `costBaselines` | `CostBaseline[]` | Per `(role, skill)` `mean / p50 / p95` cost in USD |
+| `improvementCandidates` | `ImprovementCandidate[]` | Reuses the existing schema; `evidence` **must** cite a `patternId` when `kind ∈ {skill-prompt, skill-schema, skill-config}` |
+
+## Storage
+
+Validated output is persisted to the `playbooks` table:
+
+- `id` — autoincrement
+- `projectId`
+- `windowStartAt`, `windowEndAt`
+- `lifecycleCount`
+- `manifest` — JSON-encoded `CrossRunRetroOutput`
+- `createdAt`
+
+## Skill config
+
+`skill.config.ts` — Role: `retrospector`. Not a holdout. Pinned to `sonnet` (structured analysis, not coding).
+
+## Prompt file
+
+`prompt.md` — appended to system prompt via `readPromptWithContext()`. Inline prompts in code fail review.

--- a/skills/retrospective-cross-run/prompt.md
+++ b/skills/retrospective-cross-run/prompt.md
@@ -1,0 +1,104 @@
+# retrospective-cross-run skill
+
+You are a Retrospector agent producing a cross-run `PlaybookManifest` over a window of archived lifecycles. Output the canonical "what we got better at across many runs" artifact — the input to skill-coach.
+
+This is the **analytical-path** counterpart to the per-merge `retrospective-deep` skill, not a replacement.
+
+## Input
+
+The context contains:
+
+- `<project_id>` — the project slug
+- `<window_start_at>`, `<window_end_at>` — ISO8601 bounds of the analysis window
+- `<lifecycle_count>` — total archived lifecycles in the window
+- `<archived_lifecycles>` — array of `{ workItemId, closedAt, decisionSummaries[], learningEntries[], qualityScores[], costsUsd }`
+- `<mined_patterns>` — pre-mined decision patterns. Each carries a `patternId`, `pattern` description, `occurrenceCount`, `consistencyScore`, optional `role` / `kind`, and `exampleWorkItemIds[]`
+- `<precomputed_gate_thresholds>` — numerical thresholds for gates `qa` and `review` (mean/min/max/stdDev). **Echo verbatim.**
+- `<precomputed_cost_baselines>` — numerical baselines per `(role, skill)` (mean/p50/p95). **Echo verbatim.**
+- `<prior_aggregated_learnings>` — learnings carried from earlier playbooks in the same project (may be empty)
+
+## Process
+
+### Step 1 — Read the window
+
+Identify the window bounds and how many lifecycles it covers.
+
+Emit: `[decision] READ: Cross-run retro for <projectId> over <lifecycleCount> lifecycles between <windowStartAt> and <windowEndAt>`
+
+### Step 2 — Write the summary
+
+Produce a `summary` object with three concrete strings:
+
+- `wentWell` — the most consistent positive across the window (one sentence)
+- `didNotGoWell` — the most concerning recurring failure mode (one sentence)
+- `architecturalTakeaway` — the single architectural insight you would carry into the next milestone
+
+If there is no meaningful signal (e.g. `lifecycleCount === 0`), still emit non-empty strings explaining the empty window.
+
+### Step 3 — Aggregated learnings
+
+Merge `learningEntries` from each lifecycle plus `priorAggregatedLearnings` into a deduplicated list. For each learning:
+
+- `observation` — the cross-run observation
+- `rationale` — why it matters across many runs (not a single run)
+- `improvementKind` — must be one of the `ImprovementKindSchema` enum values
+- `targetPath` (optional) — file path if obvious
+- `confidence` — `low | medium | high`
+
+Only keep learnings that recur across ≥2 lifecycles. Single-lifecycle learnings stay in their per-run retro.
+
+### Step 4 — Top patterns
+
+Select up to 10 highest-signal patterns from `<mined_patterns>`. For each, populate:
+
+- `patternId` — copied verbatim
+- `pattern` — copied verbatim
+- `occurrenceCount` — integer
+- `consistencyScore` — number in 0..1
+- `role` / `kind` (optional) — copied verbatim
+- `exampleWorkItemIds` — copied verbatim (may be empty)
+
+Rank by `consistencyScore × log(1 + occurrenceCount)`.
+
+### Step 5 — Gate thresholds (echo)
+
+Echo `<precomputed_gate_thresholds>` verbatim into `gateThresholds[]`. Do **not** invent or reshape numbers — these are computed by the workflow. If absent or empty, emit `[]`.
+
+### Step 6 — Cost baselines (echo)
+
+Echo `<precomputed_cost_baselines>` verbatim into `costBaselines[]`. Same rule as gate thresholds — do not recompute.
+
+### Step 7 — Improvement candidates
+
+Surface candidates only where `confidence: "high"`. A candidate must:
+
+- Be actionable (specific file)
+- Cite at least one `patternId` from `topPatterns[]` in its `evidence` field when `kind ∈ {skill-prompt, skill-schema, skill-config}`. Use the form `pattern:<patternId>` or include `<patternId>` so the cross-run evidence is traceable.
+- Not be a `governance-suggestion` (those go to the human queue separately)
+
+Populate **only** these fields per candidate:
+
+- `kind` — required, from `ImprovementKindSchema`
+- `targetPath` — required
+- `suggestionText` — required
+- `confidence` — required
+- `evidence` — required for skill-* kinds; must reference a `patternId`
+- `proposedDiff` (optional) — fenced diff if obvious
+
+### Step 8 — Decision summaries
+
+Include at least one decision summary with `kind: "VERDICT"` summarising the playbook's bottom line.
+
+## Output
+
+Return JSON conforming to `CrossRunRetroOutputSchema`. No free-text outside the schema fields. Required top-level fields:
+
+- `outcome` — `success | failure | partial`
+- `workItemNumber` — integer (use `0` for cross-run; this is a window-level analysis, not per-issue)
+- `windowStartAt` / `windowEndAt` — ISO8601 strings echoing the input
+- `lifecycleCount` — integer echoing the input
+- `summary` — `{ wentWell, didNotGoWell, architecturalTakeaway }`
+- `aggregatedLearnings[]`, `topPatterns[]`, `gateThresholds[]`, `costBaselines[]`, `improvementCandidates[]` — arrays (any may be empty)
+- `decisionSummaries[]` — at least one VERDICT
+
+[decision] VERDICT: Cross-run playbook complete: <one sentence on the headline finding>

--- a/skills/retrospective-cross-run/schema.ts
+++ b/skills/retrospective-cross-run/schema.ts
@@ -1,0 +1,71 @@
+import {
+  ImprovementCandidateSchema as BaseImprovementCandidateSchema,
+  LearningEntrySchema,
+  RetroOutputBaseSchema,
+} from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+export const GateNameSchema = z.enum(['qa', 'review']);
+
+export const GateThresholdSchema = z.object({
+  gate: GateNameSchema,
+  mean: z.number(),
+  min: z.number(),
+  max: z.number(),
+  stdDev: z.number().min(0),
+  sampleCount: z.number().int().min(0),
+});
+
+export const CostBaselineSchema = z.object({
+  role: z.string().min(1),
+  skill: z.string().min(1),
+  mean: z.number().min(0),
+  p50: z.number().min(0),
+  p95: z.number().min(0),
+  sampleCount: z.number().int().min(0),
+});
+
+export const CrossRunPatternSchema = z.object({
+  patternId: z.string().min(1),
+  pattern: z.string().min(1),
+  occurrenceCount: z.number().int().min(1),
+  consistencyScore: z.number().min(0).max(1),
+  role: z.string().optional(),
+  kind: z.string().optional(),
+  exampleWorkItemIds: z.array(z.string()).default([]),
+});
+
+const PATTERN_BACKED_KINDS = new Set(['skill-prompt', 'skill-schema', 'skill-config']);
+
+const ImprovementCandidateRequiringEvidence = BaseImprovementCandidateSchema.superRefine(
+  (candidate, ctx) => {
+    if (!PATTERN_BACKED_KINDS.has(candidate.kind)) return;
+    const evidence = candidate.evidence ?? '';
+    if (!/(^|[^a-zA-Z])pattern[:#-]?[\w-]+/i.test(evidence)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['evidence'],
+        message:
+          'evidence must cite at least one pattern id (e.g. "pattern:foo-bar") when kind is skill-prompt, skill-schema, or skill-config',
+      });
+    }
+  },
+);
+
+export const CrossRunRetroOutputSchema = RetroOutputBaseSchema.extend({
+  windowStartAt: z.string().min(1),
+  windowEndAt: z.string().min(1),
+  lifecycleCount: z.number().int().min(0),
+  aggregatedLearnings: z.array(LearningEntrySchema),
+  topPatterns: z.array(CrossRunPatternSchema),
+  gateThresholds: z.array(GateThresholdSchema),
+  costBaselines: z.array(CostBaselineSchema),
+  improvementCandidates: z.array(ImprovementCandidateRequiringEvidence),
+});
+
+export type CrossRunRetroOutput = z.infer<typeof CrossRunRetroOutputSchema>;
+export type GateThreshold = z.infer<typeof GateThresholdSchema>;
+export type CostBaseline = z.infer<typeof CostBaselineSchema>;
+export type CrossRunPattern = z.infer<typeof CrossRunPatternSchema>;
+export { LearningEntrySchema };
+export type AggregatedLearning = z.infer<typeof LearningEntrySchema>;

--- a/skills/retrospective-cross-run/skill.config.ts
+++ b/skills/retrospective-cross-run/skill.config.ts
@@ -1,0 +1,58 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+import {
+  CostBaselineSchema,
+  CrossRunPatternSchema,
+  GateThresholdSchema,
+  LearningEntrySchema,
+} from './schema.js';
+
+export const CrossRunRetroContextSchema = z.object({
+  projectId: z.string().min(1),
+  windowStartAt: z.string().min(1),
+  windowEndAt: z.string().min(1),
+  lifecycleCount: z.number().int().min(0),
+  archivedLifecycles: z
+    .array(
+      z.object({
+        workItemId: z.string(),
+        closedAt: z.string(),
+        decisionSummaries: z.array(z.unknown()).default([]),
+        learningEntries: z.array(z.unknown()).default([]),
+        qualityScores: z.array(z.unknown()).default([]),
+        costsUsd: z.number().default(0),
+      }),
+    )
+    .describe('All archived lifecycles in the requested window'),
+  minedPatterns: z
+    .array(CrossRunPatternSchema)
+    .describe('Pre-mined decision patterns from core/learning/mine.ts'),
+  precomputedGateThresholds: z
+    .array(GateThresholdSchema)
+    .describe('Numerically-computed gate thresholds (mean/min/max/stdDev) for qa and review'),
+  precomputedCostBaselines: z
+    .array(CostBaselineSchema)
+    .describe('Numerically-computed cost baselines (mean/p50/p95) per (role, skill)'),
+  priorAggregatedLearnings: z.array(LearningEntrySchema).default([]),
+});
+
+const config: SkillConfig = {
+  contextSchema: CrossRunRetroContextSchema,
+  contextAllowlist: [
+    'projectId',
+    'windowStartAt',
+    'windowEndAt',
+    'lifecycleCount',
+    'archivedLifecycles',
+    'minedPatterns',
+    'precomputedGateThresholds',
+    'precomputedCostBaselines',
+    'priorAggregatedLearnings',
+  ],
+  toolBundles: ['core'],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'retrospector',
+};
+
+export default config;

--- a/skills/retrospective-cross-run/slice.test.ts
+++ b/skills/retrospective-cross-run/slice.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import { toJSONSchema } from 'zod';
+import {
+  CostBaselineSchema,
+  CrossRunPatternSchema,
+  CrossRunRetroOutputSchema,
+  GateThresholdSchema,
+} from './schema.js';
+import config from './skill.config.js';
+
+const baseValid = {
+  outcome: 'success' as const,
+  workItemNumber: 0,
+  windowStartAt: '2026-04-01T00:00:00Z',
+  windowEndAt: '2026-05-01T00:00:00Z',
+  lifecycleCount: 12,
+  summary: {
+    wentWell: 'TDD discipline held across 11/12 lifecycles',
+    didNotGoWell: 'Out-of-scope settings.json edits recurred in 3 runs',
+    architecturalTakeaway: 'Reviewer AC inference is consistent — formalize it as a workflow step',
+  },
+  aggregatedLearnings: [
+    {
+      observation: 'Reviewers independently infer ACs from prose when no checkboxes exist',
+      rationale: 'Inference cost is paid 4× per merge; codifying ACs would amortise it',
+      improvementKind: 'workflow' as const,
+      confidence: 'high' as const,
+    },
+  ],
+  topPatterns: [
+    {
+      patternId: 'PLAN::developer',
+      pattern: 'Developer writes tests before any implementation',
+      occurrenceCount: 11,
+      consistencyScore: 0.92,
+      role: 'developer',
+      kind: 'PLAN',
+      exampleWorkItemIds: ['github:owner/repo#501', 'github:owner/repo#502'],
+    },
+  ],
+  gateThresholds: [
+    {
+      gate: 'qa' as const,
+      mean: 82.4,
+      min: 70,
+      max: 95,
+      stdDev: 6.8,
+      sampleCount: 12,
+    },
+    {
+      gate: 'review' as const,
+      mean: 88.1,
+      min: 78,
+      max: 96,
+      stdDev: 5.2,
+      sampleCount: 12,
+    },
+  ],
+  costBaselines: [
+    {
+      role: 'developer',
+      skill: 'implement',
+      mean: 0.42,
+      p50: 0.38,
+      p95: 0.71,
+      sampleCount: 12,
+    },
+  ],
+  improvementCandidates: [
+    {
+      kind: 'skill-prompt' as const,
+      targetPath: 'skills/implement/prompt.md',
+      suggestionText: 'Add explicit reminder to write slice.test.ts first',
+      confidence: 'high' as const,
+      evidence: 'pattern:PLAN::developer recurred 11/12 times',
+    },
+  ],
+  decisionSummaries: [
+    {
+      kind: 'VERDICT' as const,
+      summary: 'Cross-run playbook: TDD strong, formalize ACs',
+    },
+  ],
+};
+
+describe('CrossRunRetroOutputSchema', () => {
+  it('accepts a fully-populated valid manifest', () => {
+    expect(CrossRunRetroOutputSchema.safeParse(baseValid).success).toBe(true);
+  });
+
+  it('accepts empty aggregatedLearnings, topPatterns, gateThresholds, costBaselines', () => {
+    expect(
+      CrossRunRetroOutputSchema.safeParse({
+        ...baseValid,
+        aggregatedLearnings: [],
+        topPatterns: [],
+        gateThresholds: [],
+        costBaselines: [],
+        improvementCandidates: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts lifecycleCount of 0 (empty window)', () => {
+    expect(CrossRunRetroOutputSchema.safeParse({ ...baseValid, lifecycleCount: 0 }).success).toBe(
+      true,
+    );
+  });
+
+  it('rejects skill-prompt candidate without evidence citing a pattern id', () => {
+    const result = CrossRunRetroOutputSchema.safeParse({
+      ...baseValid,
+      improvementCandidates: [
+        {
+          kind: 'skill-prompt' as const,
+          targetPath: 'skills/implement/prompt.md',
+          suggestionText: 'Add explicit reminder to write slice.test.ts first',
+          confidence: 'high' as const,
+          evidence: 'general observation, no specific pattern',
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects skill-schema candidate with missing evidence', () => {
+    const result = CrossRunRetroOutputSchema.safeParse({
+      ...baseValid,
+      improvementCandidates: [
+        {
+          kind: 'skill-schema' as const,
+          targetPath: 'skills/implement/schema.ts',
+          suggestionText: 'Add fooBar field',
+          confidence: 'high' as const,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts skill-config candidate when evidence cites a pattern id', () => {
+    const result = CrossRunRetroOutputSchema.safeParse({
+      ...baseValid,
+      improvementCandidates: [
+        {
+          kind: 'skill-config' as const,
+          targetPath: 'skills/implement/skill.config.ts',
+          suggestionText: 'Increase maxTurns budget',
+          confidence: 'high' as const,
+          evidence: 'pattern:RETRY::developer recurs 4× per window',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts workflow candidate without pattern id evidence (rule only applies to skill-* kinds)', () => {
+    const result = CrossRunRetroOutputSchema.safeParse({
+      ...baseValid,
+      improvementCandidates: [
+        {
+          kind: 'workflow' as const,
+          targetPath: 'docs/PLAN.md',
+          suggestionText: 'Document AC checklist requirement',
+          confidence: 'high' as const,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty windowStartAt', () => {
+    expect(CrossRunRetroOutputSchema.safeParse({ ...baseValid, windowStartAt: '' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    expect(
+      CrossRunRetroOutputSchema.safeParse({ ...baseValid, decisionSummaries: [] }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown gate name', () => {
+    expect(
+      CrossRunRetroOutputSchema.safeParse({
+        ...baseValid,
+        gateThresholds: [{ ...baseValid.gateThresholds[0], gate: 'lint' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects negative stdDev', () => {
+    expect(
+      CrossRunRetroOutputSchema.safeParse({
+        ...baseValid,
+        gateThresholds: [{ ...baseValid.gateThresholds[0], stdDev: -1 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects consistencyScore outside [0, 1]', () => {
+    expect(
+      CrossRunRetroOutputSchema.safeParse({
+        ...baseValid,
+        topPatterns: [{ ...baseValid.topPatterns[0], consistencyScore: 1.4 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('zod toJSONSchema roundtrip produces a valid JSON Schema object', () => {
+    const jsonSchema = toJSONSchema(CrossRunRetroOutputSchema);
+    expect(typeof jsonSchema).toBe('object');
+    expect(jsonSchema).not.toBeNull();
+  });
+});
+
+describe('GateThresholdSchema', () => {
+  it('accepts all-zero thresholds (empty window)', () => {
+    expect(
+      GateThresholdSchema.safeParse({
+        gate: 'qa',
+        mean: 0,
+        min: 0,
+        max: 0,
+        stdDev: 0,
+        sampleCount: 0,
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('CostBaselineSchema', () => {
+  it('rejects negative mean cost', () => {
+    expect(
+      CostBaselineSchema.safeParse({
+        role: 'developer',
+        skill: 'implement',
+        mean: -0.1,
+        p50: 0.5,
+        p95: 0.9,
+        sampleCount: 4,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('CrossRunPatternSchema', () => {
+  it('requires patternId and pattern strings', () => {
+    expect(
+      CrossRunPatternSchema.safeParse({
+        patternId: 'p1',
+        pattern: '',
+        occurrenceCount: 1,
+        consistencyScore: 0.5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('retrospective-cross-run skill config', () => {
+  it('has role retrospector', () => {
+    expect(config.role).toBe('retrospector');
+  });
+
+  it('is pinned to sonnet (structured analysis, not coding)', () => {
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('is not a holdout (cross-run retro reads archived run history)', () => {
+    expect(config.freshContext).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

M11.12 — adds the analytical-path counterpart to the per-merge `retrospective-deep` skill. A retrospector reasons over a window of archived lifecycles and produces a `PlaybookManifest`: aggregated learnings, mined decision patterns, gate thresholds, cost baselines.

The per-merge `retrospective-deep` is unchanged — it keeps emitting per-run output. This skill consumes many of those.

## Files

- `skills/retrospective-cross-run/` — new skill with `prompt.md`, `schema.ts` (`CrossRunRetroOutputSchema` extends `RetroOutputBaseSchema`), `skill.config.ts`, `README.md`, `slice.test.ts`
- `core/retrospective/schemas.ts` reused via `LearningEntrySchema` + `ImprovementCandidateSchema`; cross-run schema enforces `evidence` cite a `patternId` when `kind ∈ {skill-prompt, skill-schema, skill-config}`
- `core/workflows/cross-run-retro.ts` — workflow takes `{ projectId, windowSize | dateRange }`, fetches archived lifecycles + mined patterns, dispatches the skill, persists validated manifest as a `playbooks` row
- `core/learning/playbook-stats.ts` — `computeGateThresholds()` (mean/min/max/stdDev for `qa.overallScore` + `review.confidence`), `computeCostBaselines()` (mean/p50/p95 per `(role, skill)` from `agent_run_costs`), `fetchLifecyclesInWindow()`
- `core/db/schema.ts` + migration `0002_nervous_lucky_pierre.sql` — `playbooks` table (`projectId`, `windowStartAt`, `windowEndAt`, `lifecycleCount`, `manifest` JSON, `createdAt`)
- `core/agent-runtime/budgets.ts` — registers `retrospective-cross-run` budget (sonnet, 40 turns, $1, 7min)
- `apps/server/src/domains/playbooks/{repository,service,router}.ts` — `GET/POST /api/projects/:slug/playbooks` + `GET /api/projects/:slug/playbooks/:id`
- `apps/web/src/components/roster/components/PlaybooksTab.tsx` + `RosterPage.tsx` tabs — new "Playbooks" tab with drill-in to manifest detail
- `apps/web/src/lib/{api,types}.ts` — `fetchPlaybooks`, `fetchPlaybook`, `createPlaybook` + `PlaybookSummaryDto` / `PlaybookDetailDto`

## Tests

New tests (58 total, all passing):

- `skills/retrospective-cross-run/slice.test.ts` — 19 cases: schema happy path, empty arrays, evidence-cites-pattern enforcement for skill-* kinds, edge cases on gate/cost/pattern schemas
- `core/learning/playbook-stats.test.ts` — 15 cases: `computeStats` (empty/single/multi), `computePercentile`, `computeGateThresholds` aggregation + payload tolerance, `computeCostBaselines` grouping + ordering
- `core/workflows/cross-run-retro.test.ts` — 14 cases: `resolveWindow` (windowSize / dateRange / empty archive / inverted range / invalid sizes), workflow happy path, empty archive, single-lifecycle edge case, schema-validation failure path, runtime-throws path, context shape
- `apps/server/src/domains/playbooks/router.test.ts` — 10 cases: GET/POST routing, 400 on invalid body, 404 on missing playbook, partial dateRange handling

Full suite: 1962 tests pass, lint + typecheck clean.

## Test plan

- [ ] Run `pnpm lint && pnpm typecheck && pnpm test` locally
- [ ] Hit `POST /api/projects/goose-hub-self/playbooks` with `{ windowSize: 5 }` against a project with archived lifecycles
- [ ] Hit `POST /api/projects/goose-hub-self/playbooks` with `{ dateRange: { startAt, endAt } }`
- [ ] Confirm `playbooks` table row + emitted `retrospective.completed` event
- [ ] Open `/projects/goose-hub-self/roster`, switch to **Playbooks** tab, drill into the manifest

Closes #526


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvMx4A5985wXWkiEGtt3KQ)_