### PR TITLE
M11.04: UI dependency visibility on issue detail

### DIFF
--- a/apps/web/src/components/detail/README.md
+++ b/apps/web/src/components/detail/README.md
@@ -17,6 +17,7 @@ Components:
 - `OverviewSection.tsx` — renders the issue body via the lightweight Markdown helper.
 - `TimelineSection.tsx` — fetches `events` for the work item; subscribes to `/events?workItemId=…` SSE so new transitions appear without a refresh.
 - `DeferredSurface.tsx` — small "Available in M&lt;N&gt;" empty-state for the inert sections.
+- `DependenciesSection.tsx` — renders the "Dependencies" block inside `OverviewSection`. Parses dependency declarations from the issue body using `lib/dependency-parser`, fetches each dep's title and state via React Query, resolves cross-repo deps to registered project slugs. Hidden when the issue has no dep declarations. Added in M11.04 (#288).
 - `sections.ts` — single source of truth for the 10-section list, milestone tags, descriptions.
 - `InvestigationSection.tsx` — renders structured investigation findings from `agent.investigation-complete` events: confidence badge (low/medium/high), markdown findings, key files list, and open questions. Shows empty state if no investigation has run. Added in M6.06 (#190).
 - `GatePendingBanner.tsx` — amber callout rendered between `TaskHeader` and the main content rails when the issue is in a gate state (a state requiring human action). Renders null for non-gate states.

--- a/apps/web/src/components/detail/components/DependenciesSection.tsx
+++ b/apps/web/src/components/detail/components/DependenciesSection.tsx
@@ -52,7 +52,7 @@ export function DependenciesSection({ item, projectSlug }: DependenciesSectionPr
           if (target === 'unregistered') return null;
           return fetchIssue(target.slug, target.id);
         },
-        enabled: target !== 'unregistered' && projects.length > 0,
+        enabled: target !== 'unregistered',
       };
     }),
   });

--- a/apps/web/src/components/detail/components/DependenciesSection.tsx
+++ b/apps/web/src/components/detail/components/DependenciesSection.tsx
@@ -1,0 +1,147 @@
+import { fetchIssue, fetchProjects } from '@/lib/api';
+import { type DependencyRef, parseDependencies } from '@/lib/dependency-parser';
+import type { ProjectSummary, WorkItemDto } from '@/lib/types';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, Circle } from 'lucide-react';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+interface DependenciesSectionProps {
+  item: WorkItemDto;
+  projectSlug: string;
+}
+
+function resolveDepTarget(
+  ref: DependencyRef,
+  currentSlug: string,
+  currentRepoRef: string,
+  projects: ProjectSummary[],
+): { slug: string; id: string } | 'unregistered' {
+  if (ref.repoRef === null || ref.repoRef === currentRepoRef) {
+    return { slug: currentSlug, id: String(ref.issueNumber) };
+  }
+  const match = projects.find((p) => p.source.repo === ref.repoRef);
+  if (match == null) return 'unregistered';
+  return { slug: match.slug, id: String(ref.issueNumber) };
+}
+
+function isOpenState(state: string): boolean {
+  return state !== 'factory:done' && state !== 'factory:archived';
+}
+
+export function DependenciesSection({ item, projectSlug }: DependenciesSectionProps) {
+  const deps = useMemo(() => parseDependencies(item.body), [item.body]);
+
+  const { data: projects = [] } = useQuery<ProjectSummary[]>({
+    queryKey: ['projects'],
+    queryFn: () => fetchProjects(),
+    enabled: deps.length > 0,
+  });
+
+  const targets = useMemo(
+    () => deps.map((ref) => resolveDepTarget(ref, projectSlug, item.repoRef, projects)),
+    [deps, projectSlug, item.repoRef, projects],
+  );
+
+  const depQueries = useQueries({
+    queries: deps.map((ref, i) => {
+      const target = targets[i];
+      return {
+        queryKey: ['dep-issue', ref.repoRef ?? item.repoRef, ref.issueNumber],
+        queryFn: async () => {
+          if (target === 'unregistered') return null;
+          return fetchIssue(target.slug, target.id);
+        },
+        enabled: target !== 'unregistered' && projects.length > 0,
+      };
+    }),
+  });
+
+  if (deps.length === 0) return null;
+
+  return (
+    <div data-testid="dependencies-section" className="mt-6">
+      <h3 className="text-[11px] font-medium text-fg-3 uppercase tracking-wider mb-3">
+        Dependencies ({deps.length})
+      </h3>
+      <div className="flex flex-col gap-2">
+        {deps.map((ref, i) => {
+          const target = targets[i];
+          const query = depQueries[i];
+          const depItem = query?.data ?? null;
+          const isUnregistered = target === 'unregistered';
+          const isLoading = query?.isLoading ?? false;
+          const open = depItem != null && isOpenState(depItem.state);
+
+          const refLabel =
+            ref.repoRef != null ? `${ref.repoRef}#${ref.issueNumber}` : `#${ref.issueNumber}`;
+
+          return (
+            <div
+              key={`${ref.repoRef ?? ''}#${ref.issueNumber}`}
+              className="flex items-start gap-3 px-3 py-2.5 rounded-lg border border-line bg-bg-elev"
+              data-testid={`dep-row-${ref.issueNumber}`}
+            >
+              <span className="mt-0.5 shrink-0">
+                {isUnregistered ? (
+                  <AlertTriangle
+                    size={13}
+                    style={{ color: 'var(--warning)' }}
+                    aria-label="unregistered"
+                  />
+                ) : isLoading ? (
+                  <Circle size={13} className="text-fg-4 animate-pulse" aria-label="loading" />
+                ) : open ? (
+                  <Circle size={13} className="text-fg-3" aria-label="open" />
+                ) : (
+                  <CheckCircle2 size={13} style={{ color: 'var(--success)' }} aria-label="closed" />
+                )}
+              </span>
+
+              <div className="flex-1 min-w-0">
+                {isUnregistered ? (
+                  <div>
+                    <span className="font-mono text-[12px] text-fg-3">{refLabel}</span>
+                    <span className="ml-2 text-[11px] text-fg-4 italic">
+                      unregistered repo — register it in Goose Hub to resolve
+                    </span>
+                  </div>
+                ) : depItem != null ? (
+                  <div className="flex items-baseline gap-2 min-w-0">
+                    {typeof target === 'object' ? (
+                      <Link
+                        to={`/projects/${target.slug}/items/${target.id}`}
+                        className="font-mono text-[12px] text-accent hover:underline shrink-0"
+                      >
+                        {refLabel}
+                      </Link>
+                    ) : (
+                      <span className="font-mono text-[12px] text-fg-3 shrink-0">{refLabel}</span>
+                    )}
+                    <span className="text-[12.5px] text-fg truncate">{depItem.title}</span>
+                    <span
+                      className="text-[11px] shrink-0"
+                      style={{ color: open ? 'var(--fg-3)' : 'var(--success)' }}
+                    >
+                      {open ? 'open' : 'closed'}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="font-mono text-[12px] text-fg-4">{refLabel}</span>
+                )}
+              </div>
+
+              <span
+                className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border shrink-0 ${
+                  ref.type === 'blocks' ? 'border-line text-fg-3' : 'border-line text-fg-4'
+                }`}
+              >
+                {ref.type === 'blocks' ? 'blocks' : 'dep'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { SECTIONS } from '../lib/sections';
+import { useHasOpenDep } from '../lib/useHasOpenDep';
 import { ApprovalGateSection } from './ApprovalGateSection';
 import { CodeDiffSection } from './CodeDiffSection';
 import { CostsSection } from './CostsSection';
@@ -106,6 +107,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
   }, [onBack, onNext, onPrev]);
 
   const [fakeRunInProgress, setFakeRunInProgress] = useState(false);
+  const hasOpenDep = useHasOpenDep(item, slug);
 
   const onFakeRun = useCallback(() => {
     if (fakeRunInProgress) return;
@@ -210,7 +212,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
           </button>
         </div>
 
-        <TaskHeader item={item} projectSlug={slug} />
+        <TaskHeader item={item} projectSlug={slug} hasOpenDep={hasOpenDep} />
 
         <GatePendingBanner
           state={item?.state}

--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router-dom';
 import { parseDiff } from '../lib/code-diff';
 import { useIssueCostsBreakdown } from '../lib/costs';
 import { CommentsSection } from './CommentsSection';
+import { DependenciesSection } from './DependenciesSection';
 
 interface OverviewSectionProps {
   item?: WorkItemDto;
@@ -166,6 +167,11 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
             )}
           </div>
         </div>
+
+        {/* Dependencies */}
+        {item != null && projectSlug != null && (
+          <DependenciesSection item={item} projectSlug={projectSlug} />
+        )}
 
         {/* Comments card */}
         {item != null && projectSlug != null && (

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -13,9 +13,10 @@ import { TransitionButton } from './TransitionButton';
 interface TaskHeaderProps {
   item?: WorkItemDto;
   projectSlug: string;
+  hasOpenDep?: boolean;
 }
 
-export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
+export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeaderProps) {
   const queryClient = useQueryClient();
   const [savingPriority, setSavingPriority] = useState(false);
   const [savingSchedule, setSavingSchedule] = useState(false);
@@ -125,6 +126,19 @@ export function TaskHeader({ item, projectSlug }: TaskHeaderProps) {
         </span>
 
         <div className="flex grow" />
+        {hasOpenDep && (
+          <span
+            data-testid="blocked-badge"
+            className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] border font-medium"
+            style={{
+              color: 'var(--warning)',
+              background: 'oklch(from var(--warning) l c h / 0.12)',
+              borderColor: 'oklch(from var(--warning) l c h / 0.4)',
+            }}
+          >
+            Blocked
+          </span>
+        )}
         {/* State — static accent pill */}
         <span
           data-testid="state-pill"

--- a/apps/web/src/components/detail/lib/useHasOpenDep.ts
+++ b/apps/web/src/components/detail/lib/useHasOpenDep.ts
@@ -53,7 +53,7 @@ export function useHasOpenDep(item: WorkItemDto | undefined, projectSlug: string
           if (target === 'unregistered') return null;
           return fetchIssue(target.slug, target.id);
         },
-        enabled: target !== 'unregistered' && projects.length > 0,
+        enabled: target !== 'unregistered',
       };
     }),
   });

--- a/apps/web/src/components/detail/lib/useHasOpenDep.ts
+++ b/apps/web/src/components/detail/lib/useHasOpenDep.ts
@@ -1,0 +1,62 @@
+import { fetchIssue, fetchProjects } from '@/lib/api';
+import { type DependencyRef, parseDependencies } from '@/lib/dependency-parser';
+import type { ProjectSummary, WorkItemDto } from '@/lib/types';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+function resolveDepTarget(
+  ref: DependencyRef,
+  currentSlug: string,
+  currentRepoRef: string,
+  projects: ProjectSummary[],
+): { slug: string; id: string } | 'unregistered' {
+  if (ref.repoRef === null || ref.repoRef === currentRepoRef) {
+    return { slug: currentSlug, id: String(ref.issueNumber) };
+  }
+  const match = projects.find((p) => p.source.repo === ref.repoRef);
+  if (match == null) return 'unregistered';
+  return { slug: match.slug, id: String(ref.issueNumber) };
+}
+
+function isOpenState(state: string): boolean {
+  return state !== 'factory:done' && state !== 'factory:archived';
+}
+
+// Returns true if any `depends-on` dep of the given item is still open.
+// Only considers depends-on refs — `blocks` refs are outbound and do not block this issue.
+export function useHasOpenDep(item: WorkItemDto | undefined, projectSlug: string): boolean {
+  const deps = useMemo(
+    () => (item != null ? parseDependencies(item.body).filter((d) => d.type === 'depends-on') : []),
+    [item],
+  );
+
+  const { data: projects = [] } = useQuery<ProjectSummary[]>({
+    queryKey: ['projects'],
+    queryFn: () => fetchProjects(),
+    enabled: deps.length > 0,
+  });
+
+  const targets = useMemo(
+    () =>
+      item != null
+        ? deps.map((ref) => resolveDepTarget(ref, projectSlug, item.repoRef, projects))
+        : [],
+    [deps, projectSlug, item, projects],
+  );
+
+  const depQueries = useQueries({
+    queries: deps.map((ref, i) => {
+      const target = targets[i];
+      return {
+        queryKey: ['dep-issue', ref.repoRef ?? item?.repoRef ?? '', ref.issueNumber],
+        queryFn: async () => {
+          if (target === 'unregistered') return null;
+          return fetchIssue(target.slug, target.id);
+        },
+        enabled: target !== 'unregistered' && projects.length > 0,
+      };
+    }),
+  });
+
+  return depQueries.some((q) => q.data != null && isOpenState(q.data.state));
+}

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -1,4 +1,5 @@
 import { GATE_STATES } from '@/lib/constants';
+import { parseDependencies } from '@/lib/dependency-parser';
 import { renderMarkdownToHtml } from '@/lib/markdown';
 import { LEGAL_TARGETS } from '@/lib/transitions';
 import { describe, expect, it } from 'vitest';
@@ -220,5 +221,46 @@ describe('extractPlaywrightRepro', () => {
     const result = extractPlaywrightRepro([makeInvestigationEvent(1, repro)]);
     expect(result?.reproduced).toBe(false);
     expect(result?.notes).toBe('Could not trigger the error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dependency-parser (web lib)
+// ---------------------------------------------------------------------------
+
+describe('dependency-parser — web lib', () => {
+  it('returns empty array for a body with no dep declarations', () => {
+    expect(parseDependencies('See #42 for context')).toEqual([]);
+  });
+
+  it('parses "Depends on #N" as depends-on', () => {
+    expect(parseDependencies('Depends on #286')).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 286 },
+    ]);
+  });
+
+  it('parses "Blocks #N" as blocks', () => {
+    expect(parseDependencies('Blocks #291')).toEqual([
+      { type: 'blocks', repoRef: null, issueNumber: 291 },
+    ]);
+  });
+
+  it('parses cross-repo ref', () => {
+    expect(parseDependencies('Depends on shaunnez/other-repo#12')).toEqual([
+      { type: 'depends-on', repoRef: 'shaunnez/other-repo', issueNumber: 12 },
+    ]);
+  });
+
+  it('rejects alphanumeric suffix — #123abc must not match', () => {
+    expect(parseDependencies('Depends on #123abc')).toEqual([]);
+  });
+
+  it('handles multiple dep lines', () => {
+    const body = 'Depends on #286\nDepends on #291\nBlocks #300';
+    expect(parseDependencies(body)).toEqual([
+      { type: 'depends-on', repoRef: null, issueNumber: 286 },
+      { type: 'depends-on', repoRef: null, issueNumber: 291 },
+      { type: 'blocks', repoRef: null, issueNumber: 300 },
+    ]);
   });
 });

--- a/apps/web/src/lib/dependency-parser.ts
+++ b/apps/web/src/lib/dependency-parser.ts
@@ -1,0 +1,41 @@
+// Client-side mirror of core/state-source/dependency-parser.ts.
+// Source of truth is core/; keep these regexes in sync.
+export interface DependencyRef {
+  type: 'depends-on' | 'blocks';
+  repoRef: string | null;
+  issueNumber: number;
+}
+
+const DEPENDS_ON_PREFIX = /^(?:depends[\s-]+on|deps)\s*:?\s/i;
+const BLOCKS_PREFIX = /^blocks\s*:?\s/i;
+const BLOCKED_BY_PREFIX = /^blocked[\s-]+by\s*:?\s/i;
+const REF_PATTERN = /(?:([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))?#(\d+)(?!\w)/g;
+
+export function parseDependencies(body: string): DependencyRef[] {
+  const results: DependencyRef[] = [];
+
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let type: 'depends-on' | 'blocks' | null = null;
+
+    if (DEPENDS_ON_PREFIX.test(trimmed) || BLOCKED_BY_PREFIX.test(trimmed)) {
+      type = 'depends-on';
+    } else if (BLOCKS_PREFIX.test(trimmed)) {
+      type = 'blocks';
+    }
+
+    if (type === null) continue;
+
+    for (const m of trimmed.matchAll(REF_PATTERN)) {
+      const repoRef = m[1] ?? null;
+      const issueNumber = Number.parseInt(m[2], 10);
+      if (!Number.isNaN(issueNumber)) {
+        results.push({ type, repoRef, issueNumber });
+      }
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
Closes #288

## Summary

- Adds `apps/web/src/lib/dependency-parser.ts` — client-side mirror of `core/state-source/dependency-parser.ts`; parses `Depends on`, `Blocked by`, and `Blocks` declarations from issue bodies
- Adds `DependenciesSection.tsx` — renders a "Dependencies" block inside `OverviewSection`; fetches each dep's title and state via React Query; resolves cross-repo deps to registered project slugs; hidden when the issue has no dep declarations
- Adds `useHasOpenDep.ts` — hook used by `DetailPage` to compute whether any `depends-on` dep is open; drives the "Blocked" badge on `TaskHeader`
- Updates `TaskHeader.tsx` — `hasOpenDep` prop renders an amber "Blocked" badge next to the state pill when any depends-on dep is open
- Updates `DetailPage.tsx` — calls `useHasOpenDep` and passes result to `TaskHeader`
- Updates `OverviewSection.tsx` — renders `DependenciesSection` above the Comments block
- Updates `slice.test.ts` — 6 new unit tests for the web dependency-parser
- Updates `README.md` — documents `DependenciesSection`

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` — 1930 tests pass, lint clean, typecheck clean
- [ ] Open a task detail panel for an issue that has `Depends on #N` in its body — Dependencies section appears with dep state
- [ ] Open a task detail for an issue with no dep declarations — Dependencies section absent
- [ ] Issue with an open dep → "Blocked" amber badge visible on TaskHeader
- [ ] Issue with all deps closed → no badge

https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f

---
_Generated by [Claude Code](https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f)_