### PR TITLE
M11.07: Unregistered cross-repo dep — escalate to factory:needs-human

### DIFF
--- a/core/projects/dependency-scheduler.test.ts
+++ b/core/projects/dependency-scheduler.test.ts
@@ -44,8 +44,14 @@ function makeResolver(targets: Map<string, 'open' | 'closed' | null>): Dependenc
 
 function makeSource(
   setLabelMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+  forceStateMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+  commentMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
 ): StateSource {
-  return { setLabelInGroup: setLabelMock } as unknown as StateSource;
+  return {
+    setLabelInGroup: setLabelMock,
+    forceState: forceStateMock,
+    comment: commentMock,
+  } as unknown as StateSource;
 }
 
 // ---------------------------------------------------------------------------
@@ -205,19 +211,42 @@ describe('filterEligibleByDependencies', () => {
     expect(setLabel).not.toHaveBeenCalled();
   });
 
-  it('unregistered — skips dispatch; no label changes', async () => {
+  it('unregistered — applies factory:needs-human and posts comment on first encounter', async () => {
     const setLabel = vi.fn();
+    const forceState = vi.fn().mockResolvedValue(undefined);
+    const comment = vi.fn().mockResolvedValue(undefined);
     const fetchTarget: FetchTargetFn = async () => null;
     const item = makeItem('30', 'Depends on external/repo#5');
     const result = await filterEligibleByDependencies([item], {
       currentRepo,
       fetchTarget,
-      source: makeSource(setLabel),
+      source: makeSource(setLabel, forceState, comment),
     });
     expect(result.unregistered).toHaveLength(1);
     expect(result.eligible).toHaveLength(0);
     expect(result.blocked).toHaveLength(0);
     expect(setLabel).not.toHaveBeenCalled();
+    expect(forceState).toHaveBeenCalledWith('30', 'factory:needs-human');
+    expect(comment).toHaveBeenCalledWith('30', expect.stringContaining('external/repo#5'));
+    expect(comment).toHaveBeenCalledWith('30', expect.stringContaining('not registered'));
+  });
+
+  it('unregistered — already factory:needs-human → no re-escalation', async () => {
+    const setLabel = vi.fn();
+    const forceState = vi.fn().mockResolvedValue(undefined);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const fetchTarget: FetchTargetFn = async () => null;
+    const item = makeItem('31', 'Depends on external/repo#5');
+    // Simulate a previously-escalated item
+    item.state = 'factory:needs-human';
+    const result = await filterEligibleByDependencies([item], {
+      currentRepo,
+      fetchTarget,
+      source: makeSource(setLabel, forceState, comment),
+    });
+    expect(result.unregistered).toHaveLength(1);
+    expect(forceState).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   it('mixed batch — correctly partitions eligible / blocked / unregistered', async () => {

--- a/core/projects/dependency-scheduler.ts
+++ b/core/projects/dependency-scheduler.ts
@@ -117,11 +117,25 @@ export async function filterEligibleByDependencies(
         }
         blocked.push(item);
       } else {
-        // unregistered — M11.07 applies factory:needs-human; we only skip dispatch
-        logger.info('dep-scheduler: unregistered dep, skipping dispatch', {
-          externalId: item.externalId,
-          unregisteredDeps: evaluation.unregisteredDeps.map((d) => `${d.repoRef}#${d.issueNumber}`),
-        });
+        // unregistered — escalate to factory:needs-human on first encounter
+        if (item.state !== 'factory:needs-human') {
+          const depList = evaluation.unregisteredDeps
+            .map((d) => `\`${d.repoRef}#${d.issueNumber}\``)
+            .join(', ');
+          const commentBody = `Dependency on ${depList} cannot be resolved — repo is not registered. Register the repo or remove the dependency to unblock.`;
+          await ctx.source.forceState(item.externalId, 'factory:needs-human');
+          await ctx.source.comment(item.externalId, commentBody);
+          logger.info('dep-scheduler: unregistered dep escalated to factory:needs-human', {
+            externalId: item.externalId,
+            unregisteredDeps: evaluation.unregisteredDeps.map(
+              (d) => `${d.repoRef}#${d.issueNumber}`,
+            ),
+          });
+        } else {
+          logger.info('dep-scheduler: unregistered dep already escalated, skipping', {
+            externalId: item.externalId,
+          });
+        }
         unregistered.push(item);
       }
     }),

--- a/slices/dependency-scheduler/slice.test.ts
+++ b/slices/dependency-scheduler/slice.test.ts
@@ -33,8 +33,14 @@ function makeItem(
 
 function makeSource(
   setLabelMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+  forceStateMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+  commentMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
 ): StateSource {
-  return { setLabelInGroup: setLabelMock } as unknown as StateSource;
+  return {
+    setLabelInGroup: setLabelMock,
+    forceState: forceStateMock,
+    comment: commentMock,
+  } as unknown as StateSource;
 }
 
 // ---------------------------------------------------------------------------
@@ -93,20 +99,43 @@ describe('dependency-scheduler slice — end-to-end', () => {
     expect(setLabel).toHaveBeenCalledWith('3', 'schedule', 'current');
   });
 
-  it('unregistered cross-repo dep → unregistered partition; no label applied', async () => {
+  it('unregistered cross-repo dep → escalate to factory:needs-human + comment posted', async () => {
     const setLabel = vi.fn();
+    const forceState = vi.fn().mockResolvedValue(undefined);
+    const comment = vi.fn().mockResolvedValue(undefined);
     const fetchTarget: FetchTargetFn = async () => null;
     const item = makeItem('4', 'Depends on external/repo#5');
 
     const result = await filterEligibleByDependencies([item], {
       currentRepo,
       fetchTarget,
-      source: makeSource(setLabel),
+      source: makeSource(setLabel, forceState, comment),
     });
 
     expect(result.unregistered[0].externalId).toBe('4');
     expect(result.eligible).toHaveLength(0);
     expect(setLabel).not.toHaveBeenCalled();
+    expect(forceState).toHaveBeenCalledWith('4', 'factory:needs-human');
+    expect(comment).toHaveBeenCalledWith('4', expect.stringContaining('external/repo#5'));
+  });
+
+  it('already-escalated unregistered dep → no re-escalation on repeat tick', async () => {
+    const setLabel = vi.fn();
+    const forceState = vi.fn().mockResolvedValue(undefined);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const fetchTarget: FetchTargetFn = async () => null;
+    const item = makeItem('5', 'Depends on external/repo#5');
+    item.state = 'factory:needs-human';
+
+    const result = await filterEligibleByDependencies([item], {
+      currentRepo,
+      fetchTarget,
+      source: makeSource(setLabel, forceState, comment),
+    });
+
+    expect(result.unregistered[0].externalId).toBe('5');
+    expect(forceState).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   it('mixed sprint batch — eligible / blocked / unregistered partitioned correctly', async () => {


### PR DESCRIPTION
Closes #293

## Summary

- `filterEligibleByDependencies` in `core/projects/dependency-scheduler.ts` now escalates items with unregistered deps: calls `source.forceState(itemId, 'factory:needs-human')` then `source.comment(itemId, ...)` listing the unresolvable refs
- Idempotency guard: if the item's state is already `'factory:needs-human'`, the escalation is skipped — no duplicate labels or comments on repeat ticks
- Comment text: `"Dependency on \`owner/repo#N\` cannot be resolved — repo is not registered. Register the repo or remove the dependency to unblock."`

## Tests

- `core/projects/dependency-scheduler.test.ts`: updated `makeSource` to mock `forceState` + `comment`; replaced the old "no label applied" unregistered test with two new tests covering first-encounter escalation and idempotency
- `slices/dependency-scheduler/slice.test.ts`: same `makeSource` update; replaced unregistered test + added idempotency test
- 1991 tests pass, lint clean, typecheck clean

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test`
- [ ] Issue with unregistered dep → `factory:needs-human` applied + comment posted
- [ ] Same issue on next tick → no second comment, no second label change

https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f

---
_Generated by [Claude Code](https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f)_