### PR TITLE
fix(dep-scheduler): comment before forceState to prevent partial-escalation silent skip

### DIFF
--- a/core/projects/dependency-scheduler.test.ts
+++ b/core/projects/dependency-scheduler.test.ts
@@ -211,10 +211,15 @@ describe('filterEligibleByDependencies', () => {
     expect(setLabel).not.toHaveBeenCalled();
   });
 
-  it('unregistered — applies factory:needs-human and posts comment on first encounter', async () => {
+  it('unregistered — posts comment then applies factory:needs-human on first encounter', async () => {
+    const callOrder: string[] = [];
     const setLabel = vi.fn();
-    const forceState = vi.fn().mockResolvedValue(undefined);
-    const comment = vi.fn().mockResolvedValue(undefined);
+    const forceState = vi.fn().mockImplementation(async () => {
+      callOrder.push('forceState');
+    });
+    const comment = vi.fn().mockImplementation(async () => {
+      callOrder.push('comment');
+    });
     const fetchTarget: FetchTargetFn = async () => null;
     const item = makeItem('30', 'Depends on external/repo#5');
     const result = await filterEligibleByDependencies([item], {
@@ -226,9 +231,11 @@ describe('filterEligibleByDependencies', () => {
     expect(result.eligible).toHaveLength(0);
     expect(result.blocked).toHaveLength(0);
     expect(setLabel).not.toHaveBeenCalled();
-    expect(forceState).toHaveBeenCalledWith('30', 'factory:needs-human');
     expect(comment).toHaveBeenCalledWith('30', expect.stringContaining('external/repo#5'));
     expect(comment).toHaveBeenCalledWith('30', expect.stringContaining('not registered'));
+    expect(forceState).toHaveBeenCalledWith('30', 'factory:needs-human');
+    // comment must precede forceState so partial failures leave the guard inactive
+    expect(callOrder).toEqual(['comment', 'forceState']);
   });
 
   it('unregistered — already factory:needs-human → no re-escalation', async () => {

--- a/core/projects/dependency-scheduler.ts
+++ b/core/projects/dependency-scheduler.ts
@@ -123,8 +123,12 @@ export async function filterEligibleByDependencies(
             .map((d) => `\`${d.repoRef}#${d.issueNumber}\``)
             .join(', ');
           const commentBody = `Dependency on ${depList} cannot be resolved — repo is not registered. Register the repo or remove the dependency to unblock.`;
-          await ctx.source.forceState(item.externalId, 'factory:needs-human');
+          // Comment before forceState so the idempotency guard (item.state ===
+          // 'factory:needs-human') only activates after both writes succeed. If
+          // forceState succeeds but comment throws, the next tick retries the
+          // whole escalation instead of silently skipping the comment.
           await ctx.source.comment(item.externalId, commentBody);
+          await ctx.source.forceState(item.externalId, 'factory:needs-human');
           logger.info('dep-scheduler: unregistered dep escalated to factory:needs-human', {
             externalId: item.externalId,
             unregisteredDeps: evaluation.unregisteredDeps.map(


### PR DESCRIPTION
## Problem

In M11.07 (`#544`), `filterEligibleByDependencies` called `forceState` before `comment`. If `forceState` succeeded but `comment` threw (transient GitHub error), the next scheduler tick saw `item.state === 'factory:needs-human'` and skipped re-escalation entirely — leaving the user with no unblock instructions.

## Fix

Swap the order: post the comment first, then set the state. The idempotency guard (`item.state === 'factory:needs-human'`) now only activates after both writes complete.

Failure modes after the fix:
- `comment` fails → exception propagates, neither write completes → next tick retries both correctly
- `comment` succeeds, `forceState` fails → state is still not `needs-human` → next tick retries (comment re-posted, minor benign duplicate vs. permanent missing comment)

## Test

Updated the escalation test to assert `callOrder === ['comment', 'forceState']` using mock implementations that record invocation sequence. 1991 tests pass, lint + typecheck clean.

https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f

---
_Generated by [Claude Code](https://claude.ai/code/session_016TPyaM11vHe7AwH5yUc86f)_