### PR TITLE
M11.14: Auto-trigger skill-coach from convergent playbook patterns

### DIFF
--- a/apps/server/src/domains/playbooks/repository.ts
+++ b/apps/server/src/domains/playbooks/repository.ts
@@ -1,6 +1,6 @@
 import { db } from '@goose-hub/core/db/db.js';
-import { playbooks } from '@goose-hub/core/db/schema.js';
-import { and, desc, eq } from 'drizzle-orm';
+import { improvementCandidates, playbooks } from '@goose-hub/core/db/schema.js';
+import { and, count, desc, eq } from 'drizzle-orm';
 
 export interface PlaybookRow {
   id: number;
@@ -31,4 +31,13 @@ export async function getPlaybookByIdForProject(
     .where(and(eq(playbooks.projectId, projectId), eq(playbooks.id, id)))
     .all();
   return rows[0] ?? null;
+}
+
+export async function countCoachProposalsForPlaybook(playbookId: number): Promise<number> {
+  const rows = await db
+    .select({ n: count() })
+    .from(improvementCandidates)
+    .where(eq(improvementCandidates.sourcePlaybookId, playbookId))
+    .all();
+  return rows[0]?.n ?? 0;
 }

--- a/apps/server/src/domains/playbooks/service.ts
+++ b/apps/server/src/domains/playbooks/service.ts
@@ -5,6 +5,7 @@ import {
 import type { Result } from '#shared/middleware.js';
 import {
   type PlaybookRow,
+  countCoachProposalsForPlaybook,
   getPlaybookByIdForProject,
   listPlaybooksForProject,
 } from './repository.js';
@@ -17,6 +18,7 @@ export interface PlaybookSummaryDto {
   lifecycleCount: number;
   topPatternCount: number;
   topCandidateCount: number;
+  coachProposalCount: number;
   createdAt: string;
 }
 
@@ -37,7 +39,7 @@ function parseManifest(raw: string): ManifestShape {
   }
 }
 
-function toSummary(row: PlaybookRow): PlaybookSummaryDto {
+function toBaseSummary(row: PlaybookRow): Omit<PlaybookSummaryDto, 'coachProposalCount'> {
   const manifest = parseManifest(row.manifest);
   return {
     id: row.id,
@@ -57,7 +59,13 @@ export async function listPlaybooks(
   projectId: string,
 ): Promise<Result<{ playbooks: PlaybookSummaryDto[] }>> {
   const rows = await listPlaybooksForProject(projectId);
-  return { ok: true, data: { playbooks: rows.map(toSummary) } };
+  const summaries = await Promise.all(
+    rows.map(async (row) => {
+      const coachProposalCount = await countCoachProposalsForPlaybook(row.id);
+      return { ...toBaseSummary(row), coachProposalCount };
+    }),
+  );
+  return { ok: true, data: { playbooks: summaries } };
 }
 
 export async function getPlaybook(
@@ -67,11 +75,13 @@ export async function getPlaybook(
   const row = await getPlaybookByIdForProject(projectId, id);
   if (!row) return { ok: false, error: 'playbook not found', status: 404 };
   const manifest = parseManifest(row.manifest);
+  const coachProposalCount = await countCoachProposalsForPlaybook(row.id);
   return {
     ok: true,
     data: {
       playbook: {
-        ...toSummary(row),
+        ...toBaseSummary(row),
+        coachProposalCount,
         manifest,
       },
     },

--- a/apps/web/src/components/roster/components/PlaybooksTab.tsx
+++ b/apps/web/src/components/roster/components/PlaybooksTab.tsx
@@ -116,6 +116,14 @@ function PlaybookCard({ playbook, isSelected, onClick }: PlaybookCardProps) {
         <span>{playbook.topPatternCount} patterns</span>
         <span>·</span>
         <span>{playbook.topCandidateCount} candidates</span>
+        {playbook.coachProposalCount > 0 && (
+          <>
+            <span>·</span>
+            <span className="text-accent font-medium">
+              Coach proposals: {playbook.coachProposalCount}
+            </span>
+          </>
+        )}
       </div>
     </button>
   );

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -195,6 +195,7 @@ export interface PlaybookSummaryDto {
   lifecycleCount: number;
   topPatternCount: number;
   topCandidateCount: number;
+  coachProposalCount: number;
   createdAt: string;
 }
 

--- a/core/db/migrations/0004_coach_source_playbook.sql
+++ b/core/db/migrations/0004_coach_source_playbook.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `improvement_candidates` ADD COLUMN `source_playbook_id` integer;

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1746518400000,
       "tag": "0003_skill_coach_proposed_diff",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1746604800000,
+      "tag": "0004_coach_source_playbook",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -91,6 +91,7 @@ export const improvementCandidates = sqliteTable(
     githubIssueUrl: text('github_issue_url'),
     errorNote: text('error_note'),
     proposedDiff: text('proposed_diff'),
+    sourcePlaybookId: integer('source_playbook_id'),
     createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => ({

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -60,7 +60,11 @@ export type EventKind =
   // M9 fix-feedback loop — re-dispatch after QA failure
   | 'agent.fix-feedback-complete'
   // M11.13 skill-coach — coach run produced a candidate
-  | 'coach.completed';
+  | 'coach.completed'
+  // M11.14 auto-trigger — coach dispatch events from cross-run retro
+  | 'coach.dispatch-triggered'
+  | 'coach.skipped-forbidden-target'
+  | 'coach.dispatch-failed';
 
 export interface AgentEvent {
   id: number;

--- a/core/types.ts
+++ b/core/types.ts
@@ -46,6 +46,15 @@ export interface ToolAllowlist {
   extras?: string[];
 }
 
+export interface CoachPolicy {
+  /** Whether the auto-trigger is active. Default false in supervised mode. */
+  enabled: boolean;
+  /** Minimum pattern consistencyScore to treat as convergent. Default 0.8. */
+  consistencyThreshold: number;
+  /** Minimum lifecycle count in the retro window before coaching fires. Default 3. */
+  minLifecycles: number;
+}
+
 export interface AgentConfig {
   runtime: 'claude-cli';
   rolesModels: Record<Role, RoleModel>;
@@ -61,6 +70,7 @@ export interface AgentConfig {
     defaultTier: 'light' | 'deep';
     deepTriggers: string[];
   };
+  coachPolicy?: CoachPolicy;
 }
 
 export interface BudgetConfig {

--- a/core/workflows/README.md
+++ b/core/workflows/README.md
@@ -41,3 +41,26 @@ await runRetrospectiveWorkflow({
   triggers: { qaFailed: true },
 });
 ```
+
+## cross-run-retro.ts
+
+Runs on demand (via `POST /api/projects/:slug/playbooks`). Fetches a window of archived lifecycles and mined patterns, dispatches the `retrospective-cross-run` skill, and persists the validated output as a `playbooks` row.
+
+### M11.14 auto-trigger
+
+After the playbook is persisted, `dispatchCoachCandidates` scans the manifest's `improvementCandidates` and fires `skill-coaching.ts` for each eligible entry. Eligibility requires all of:
+
+- `agentConfig.coachPolicy.enabled === true`
+- `lifecycleCount >= coachPolicy.minLifecycles` (default 3)
+- At least one `topPattern` with `consistencyScore >= coachPolicy.consistencyThreshold` (default 0.8)
+- `candidate.kind ∈ {skill-prompt, skill-schema, skill-config}`
+- `targetPath` parseable to a valid skill name (`skills/<name>/...`)
+- Skill name not in the forbidden-target list
+
+Forbidden targets emit `coach.skipped-forbidden-target`; dispatches emit `coach.dispatch-triggered`; errors emit `coach.dispatch-failed`. Output is always a candidate — never auto-applied.
+
+## skill-coaching.ts
+
+Reads a target skill's source files (`prompt.md`, `schema.ts`) and cross-run evidence, dispatches the `skill-coach` agent, and persists the output as an `improvement_candidates` row with `proposedDiff` and optional `sourcePlaybookId`.
+
+Forbidden targets (`qa`, `review`, `retrospective-*`, `skill-coach`) are rejected before dispatch.

--- a/core/workflows/cross-run-retro.test.ts
+++ b/core/workflows/cross-run-retro.test.ts
@@ -308,6 +308,84 @@ describe('runCrossRunRetroWorkflow', () => {
     if (!result.ok) expect(result.error).toContain('timeout');
   });
 
+  it('does not dispatch coach when coachPolicy.enabled is false', async () => {
+    const mockCoachRunner = vi.fn();
+    mockFetchLifecyclesInWindow.mockReturnValue([
+      {
+        id: 1,
+        projectId: 'p',
+        workItemId: 'w1',
+        closedAt: '2026-04-10T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0,
+        runIds: '[]',
+      },
+      {
+        id: 2,
+        projectId: 'p',
+        workItemId: 'w2',
+        closedAt: '2026-04-11T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0,
+        runIds: '[]',
+      },
+      {
+        id: 3,
+        projectId: 'p',
+        workItemId: 'w3',
+        closedAt: '2026-04-12T00:00:00Z',
+        decisionSummaries: '[]',
+        learningEntries: '[]',
+        qualityScores: '[]',
+        costsUsd: 0,
+        runIds: '[]',
+      },
+    ]);
+    mockComputeGateThresholds.mockReturnValue([]);
+    mockComputeCostBaselines.mockReturnValue([]);
+    mockDb.all = vi.fn().mockReturnValue([{ id: 77 }]);
+    mockGetProjectBySlug.mockResolvedValueOnce({
+      budgets: {},
+      agentConfig: {
+        coachPolicy: { enabled: false, consistencyThreshold: 0.8, minLifecycles: 1 },
+      },
+    });
+    mockRun.mockResolvedValueOnce(
+      makeManifestOutput({
+        topPatterns: [
+          {
+            patternId: 'PLAN::developer',
+            pattern: 'x',
+            occurrenceCount: 3,
+            consistencyScore: 0.95,
+            exampleWorkItemIds: [],
+          },
+        ],
+        improvementCandidates: [
+          {
+            kind: 'skill-prompt',
+            targetPath: 'skills/implement/prompt.md',
+            suggestionText: 's',
+            evidence: 'pattern:x',
+            confidence: 'high',
+          },
+        ],
+      }),
+    );
+
+    await runCrossRunRetroWorkflow({
+      projectId: 'p',
+      dateRange: { startAt: '2026-04-01T00:00:00Z', endAt: '2026-05-01T00:00:00Z' },
+      deps: { coachWorkflowRunner: mockCoachRunner },
+    });
+
+    expect(mockCoachRunner).not.toHaveBeenCalled();
+  });
+
   it('passes precomputed gate thresholds + cost baselines into the skill context', async () => {
     mockFetchLifecyclesInWindow.mockReturnValue([]);
     mockComputeGateThresholds.mockReturnValue([

--- a/core/workflows/cross-run-retro.test.ts
+++ b/core/workflows/cross-run-retro.test.ts
@@ -56,6 +56,7 @@ vi.mock('../projects/loader.js', () => ({
 
 import {
   CrossRunRetroInputError,
+  dispatchCoachCandidates,
   resolveWindow,
   runCrossRunRetroWorkflow,
 } from './cross-run-retro.js';
@@ -331,5 +332,159 @@ describe('runCrossRunRetroWorkflow', () => {
     };
     expect(spec.context.precomputedGateThresholds).toHaveLength(1);
     expect(spec.context.precomputedCostBaselines).toHaveLength(1);
+  });
+});
+
+// ─── dispatchCoachCandidates — M11.14 auto-trigger ───────────────────────────
+
+function makeManifestWithCandidates(
+  patterns: { patternId: string; consistencyScore: number }[],
+  candidates: { kind: string; targetPath: string }[],
+) {
+  return {
+    outcome: 'success' as const,
+    workItemNumber: 0,
+    windowStartAt: '2026-04-01T00:00:00Z',
+    windowEndAt: '2026-05-01T00:00:00Z',
+    lifecycleCount: 5,
+    summary: { wentWell: '', didNotGoWell: '', architecturalTakeaway: '' },
+    aggregatedLearnings: [],
+    topPatterns: patterns.map((p) => ({
+      patternId: p.patternId,
+      pattern: 'some pattern',
+      occurrenceCount: 3,
+      consistencyScore: p.consistencyScore,
+      exampleWorkItemIds: [],
+    })),
+    gateThresholds: [],
+    costBaselines: [],
+    improvementCandidates: candidates.map((c) => ({
+      kind: c.kind as 'skill-prompt' | 'skill-schema' | 'skill-config',
+      targetPath: c.targetPath,
+      suggestionText: 'improve this',
+      evidence: `pattern:${c.kind} ref`,
+      confidence: 'high' as const,
+    })),
+    decisionSummaries: [] as never[],
+  };
+}
+
+describe('dispatchCoachCandidates', () => {
+  it('fires coach runner above threshold with enough lifecycles', async () => {
+    const mockCoachRunner = vi.fn().mockResolvedValue({ ok: true });
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.9 }],
+      [{ kind: 'skill-prompt', targetPath: 'skills/implement/prompt.md' }],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 1,
+      manifest,
+      lifecycleCount: 4,
+      lifecycleIds: [1, 2, 3, 4],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).toHaveBeenCalledOnce();
+    const call = mockCoachRunner.mock.calls[0][0] as {
+      targetSkillName: string;
+      sourcePlaybookId: number;
+    };
+    expect(call.targetSkillName).toBe('implement');
+    expect(call.sourcePlaybookId).toBe(1);
+    const events = mockAppendEvent.mock.calls.map((c) => c[0]);
+    expect(events.some((e) => e.kind === 'coach.dispatch-triggered')).toBe(true);
+  });
+
+  it('does not fire when consistencyScore is below threshold', async () => {
+    const mockCoachRunner = vi.fn();
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.5 }],
+      [{ kind: 'skill-prompt', targetPath: 'skills/implement/prompt.md' }],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 2,
+      manifest,
+      lifecycleCount: 5,
+      lifecycleIds: [1, 2, 3, 4, 5],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when lifecycleCount is below minLifecycles', async () => {
+    const mockCoachRunner = vi.fn();
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.95 }],
+      [{ kind: 'skill-prompt', targetPath: 'skills/implement/prompt.md' }],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 3,
+      manifest,
+      lifecycleCount: 2,
+      lifecycleIds: [1, 2],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).not.toHaveBeenCalled();
+  });
+
+  it('skips forbidden targets and emits coach.skipped-forbidden-target', async () => {
+    const mockCoachRunner = vi.fn();
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'VERDICT::qa', consistencyScore: 0.9 }],
+      [{ kind: 'skill-prompt', targetPath: 'skills/qa/prompt.md' }],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 4,
+      manifest,
+      lifecycleCount: 5,
+      lifecycleIds: [1, 2, 3, 4, 5],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).not.toHaveBeenCalled();
+    const events = mockAppendEvent.mock.calls.map((c) => c[0]);
+    expect(events.some((e) => e.kind === 'coach.skipped-forbidden-target')).toBe(true);
+  });
+
+  it('dispatches once per each matching candidate when multiple pass filters', async () => {
+    const mockCoachRunner = vi.fn().mockResolvedValue({ ok: true });
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.9 }],
+      [
+        { kind: 'skill-prompt', targetPath: 'skills/implement/prompt.md' },
+        { kind: 'skill-schema', targetPath: 'skills/triage/schema.ts' },
+      ],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 5,
+      manifest,
+      lifecycleCount: 4,
+      lifecycleIds: [1, 2, 3, 4],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).toHaveBeenCalledTimes(2);
+    const targets = mockCoachRunner.mock.calls.map(
+      (c) => (c[0] as { targetSkillName: string }).targetSkillName,
+    );
+    expect(targets).toContain('implement');
+    expect(targets).toContain('triage');
   });
 });

--- a/core/workflows/cross-run-retro.test.ts
+++ b/core/workflows/cross-run-retro.test.ts
@@ -417,8 +417,10 @@ describe('runCrossRunRetroWorkflow', () => {
 
 function makeManifestWithCandidates(
   patterns: { patternId: string; consistencyScore: number }[],
-  candidates: { kind: string; targetPath: string }[],
+  candidates: { kind: string; targetPath: string; evidence?: string }[],
 ) {
+  // Default evidence cites the first pattern's ID so the P2 per-candidate gate passes
+  const defaultEvidence = patterns[0] ? `see ${patterns[0].patternId} for details` : 'no evidence';
   return {
     outcome: 'success' as const,
     workItemNumber: 0,
@@ -440,7 +442,7 @@ function makeManifestWithCandidates(
       kind: c.kind as 'skill-prompt' | 'skill-schema' | 'skill-config',
       targetPath: c.targetPath,
       suggestionText: 'improve this',
-      evidence: `pattern:${c.kind} ref`,
+      evidence: c.evidence ?? defaultEvidence,
       confidence: 'high' as const,
     })),
     decisionSummaries: [] as never[],
@@ -564,5 +566,54 @@ describe('dispatchCoachCandidates', () => {
     );
     expect(targets).toContain('implement');
     expect(targets).toContain('triage');
+  });
+
+  it('emits coach.dispatch-failed when runner returns ok: false (P1)', async () => {
+    const mockCoachRunner = vi.fn().mockResolvedValue({ ok: false, error: 'schema mismatch' });
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.9 }],
+      [{ kind: 'skill-prompt', targetPath: 'skills/implement/prompt.md' }],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 6,
+      manifest,
+      lifecycleCount: 4,
+      lifecycleIds: [1, 2, 3, 4],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    const events = mockAppendEvent.mock.calls.map((c) => c[0]);
+    expect(events.some((e) => e.kind === 'coach.dispatch-failed')).toBe(true);
+    const failedEvent = events.find((e) => e.kind === 'coach.dispatch-failed');
+    expect((failedEvent?.payload as { error: string }).error).toBe('schema mismatch');
+  });
+
+  it('does not fire when candidate evidence does not reference an eligible pattern (P2)', async () => {
+    const mockCoachRunner = vi.fn();
+    const manifest = makeManifestWithCandidates(
+      [{ patternId: 'PLAN::developer', consistencyScore: 0.9 }],
+      [
+        {
+          kind: 'skill-prompt',
+          targetPath: 'skills/implement/prompt.md',
+          evidence: 'some unrelated evidence with no pattern citation',
+        },
+      ],
+    );
+
+    await dispatchCoachCandidates({
+      projectId: 'p',
+      playbookId: 7,
+      manifest,
+      lifecycleCount: 4,
+      lifecycleIds: [1, 2, 3, 4],
+      coachPolicy: { enabled: true, consistencyThreshold: 0.8, minLifecycles: 3 },
+      coachWorkflowRunner: mockCoachRunner,
+    });
+
+    expect(mockCoachRunner).not.toHaveBeenCalled();
   });
 });

--- a/core/workflows/cross-run-retro.ts
+++ b/core/workflows/cross-run-retro.ts
@@ -18,6 +18,13 @@ import {
   fetchLifecyclesInWindow,
 } from '../learning/playbook-stats.js';
 import { getProjectBySlug } from '../projects/loader.js';
+import type { CoachPolicy } from '../types.js';
+import {
+  FORBIDDEN_COACH_TARGETS,
+  type SkillCoachingInput,
+  type SkillCoachingOutcome,
+  runSkillCoachingWorkflow,
+} from './skill-coaching.js';
 
 export interface DateRange {
   startAt: string;
@@ -30,7 +37,11 @@ export interface CrossRunRetroInput {
   windowSize?: number;
   /** Inclusive ISO8601 bounds. Mutually exclusive with `windowSize`. */
   dateRange?: DateRange;
-  deps?: { runtime?: AgentRuntime; now?: () => Date };
+  deps?: {
+    runtime?: AgentRuntime;
+    now?: () => Date;
+    coachWorkflowRunner?: (input: SkillCoachingInput) => Promise<SkillCoachingOutcome>;
+  };
 }
 
 export interface CrossRunRetroResult {
@@ -138,6 +149,93 @@ function safeParseJsonUnknownArray(raw: string): unknown[] {
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
+  }
+}
+
+const SKILL_CANDIDATE_KINDS = new Set(['skill-prompt', 'skill-schema', 'skill-config']);
+
+function extractSkillName(targetPath: string): string | null {
+  const match = targetPath.match(/^skills\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+export interface CoachDispatchInput {
+  projectId: string;
+  playbookId: number;
+  manifest: CrossRunRetroOutput;
+  lifecycleCount: number;
+  lifecycleIds: number[];
+  coachPolicy: CoachPolicy;
+  coachWorkflowRunner: (input: SkillCoachingInput) => Promise<SkillCoachingOutcome>;
+}
+
+/**
+ * M11.14: After a playbook is persisted, scan its improvementCandidates for
+ * skill-related entries backed by convergent patterns and auto-dispatch the
+ * skill-coach for each eligible one.
+ *
+ * Guards:
+ *   - coachPolicy.enabled must be true (caller's responsibility)
+ *   - lifecycleCount >= coachPolicy.minLifecycles (not enough data otherwise)
+ *   - at least one topPattern with consistencyScore >= coachPolicy.consistencyThreshold
+ *   - candidate.kind ∈ {skill-prompt, skill-schema, skill-config}
+ *   - targetPath must yield a valid skill name ("skills/<name>/...")
+ *   - skill name must not be in FORBIDDEN_COACH_TARGETS
+ */
+export async function dispatchCoachCandidates(input: CoachDispatchInput): Promise<void> {
+  const {
+    projectId,
+    playbookId,
+    manifest,
+    lifecycleCount,
+    lifecycleIds,
+    coachPolicy,
+    coachWorkflowRunner,
+  } = input;
+
+  if (lifecycleCount < coachPolicy.minLifecycles) return;
+
+  const eligiblePatternIds = manifest.topPatterns
+    .filter((p) => p.consistencyScore >= coachPolicy.consistencyThreshold)
+    .map((p) => p.patternId);
+
+  if (eligiblePatternIds.length === 0) return;
+
+  for (const candidate of manifest.improvementCandidates) {
+    if (!SKILL_CANDIDATE_KINDS.has(candidate.kind)) continue;
+
+    const skillName = extractSkillName(candidate.targetPath);
+    if (!skillName) continue;
+
+    if (FORBIDDEN_COACH_TARGETS.has(skillName)) {
+      eventStore.appendEvent({
+        kind: 'coach.skipped-forbidden-target',
+        projectId,
+        payload: { targetSkillName: skillName, playbookId, reason: 'forbidden-target' },
+      });
+      continue;
+    }
+
+    eventStore.appendEvent({
+      kind: 'coach.dispatch-triggered',
+      projectId,
+      payload: { targetSkillName: skillName, playbookId, patternCount: eligiblePatternIds.length },
+    });
+
+    try {
+      await coachWorkflowRunner({
+        projectId,
+        targetSkillName: skillName,
+        evidence: { patternIds: eligiblePatternIds, lifecycleIds },
+        sourcePlaybookId: playbookId,
+      });
+    } catch (err) {
+      eventStore.appendEvent({
+        kind: 'coach.dispatch-failed',
+        projectId,
+        payload: { targetSkillName: skillName, playbookId, error: String(err) },
+      });
+    }
   }
 }
 
@@ -280,6 +378,21 @@ export async function runCrossRunRetroWorkflow(
       runId,
       payload: { tier: 'cross-run', playbookId, manifest },
     });
+
+    const coachPolicy = projectConfig?.agentConfig?.coachPolicy;
+    if (coachPolicy?.enabled) {
+      const lifecycleIds = lifecycles.map((l) => l.id);
+      const coachRunner = input.deps?.coachWorkflowRunner ?? runSkillCoachingWorkflow;
+      await dispatchCoachCandidates({
+        projectId,
+        playbookId,
+        manifest,
+        lifecycleCount: lifecycles.length,
+        lifecycleIds,
+        coachPolicy,
+        coachWorkflowRunner: coachRunner,
+      });
+    }
 
     return {
       ok: true,

--- a/core/workflows/cross-run-retro.ts
+++ b/core/workflows/cross-run-retro.ts
@@ -179,6 +179,7 @@ export interface CoachDispatchInput {
  *   - lifecycleCount >= coachPolicy.minLifecycles (not enough data otherwise)
  *   - at least one topPattern with consistencyScore >= coachPolicy.consistencyThreshold
  *   - candidate.kind ∈ {skill-prompt, skill-schema, skill-config}
+ *   - candidate.evidence must reference at least one eligible pattern ID (P2: per-candidate gate)
  *   - targetPath must yield a valid skill name ("skills/<name>/...")
  *   - skill name must not be in FORBIDDEN_COACH_TARGETS
  */
@@ -204,6 +205,13 @@ export async function dispatchCoachCandidates(input: CoachDispatchInput): Promis
   for (const candidate of manifest.improvementCandidates) {
     if (!SKILL_CANDIDATE_KINDS.has(candidate.kind)) continue;
 
+    // P2: verify the candidate's evidence cites at least one convergent pattern
+    const evidenceLower = (candidate.evidence ?? '').toLowerCase();
+    const backedByEligible = eligiblePatternIds.some((id) =>
+      evidenceLower.includes(id.toLowerCase()),
+    );
+    if (!backedByEligible) continue;
+
     const skillName = extractSkillName(candidate.targetPath);
     if (!skillName) continue;
 
@@ -223,12 +231,20 @@ export async function dispatchCoachCandidates(input: CoachDispatchInput): Promis
     });
 
     try {
-      await coachWorkflowRunner({
+      const outcome = await coachWorkflowRunner({
         projectId,
         targetSkillName: skillName,
         evidence: { patternIds: eligiblePatternIds, lifecycleIds },
         sourcePlaybookId: playbookId,
       });
+      // P1: runSkillCoachingWorkflow returns { ok: false } on runtime/schema failures
+      if (!outcome.ok) {
+        eventStore.appendEvent({
+          kind: 'coach.dispatch-failed',
+          projectId,
+          payload: { targetSkillName: skillName, playbookId, error: outcome.error },
+        });
+      }
     } catch (err) {
       eventStore.appendEvent({
         kind: 'coach.dispatch-failed',

--- a/core/workflows/skill-coaching.ts
+++ b/core/workflows/skill-coaching.ts
@@ -47,6 +47,8 @@ export interface SkillCoachingInput {
     patternIds: string[];
     lifecycleIds?: number[];
   };
+  /** Set when this coaching run was auto-triggered from a cross-run retro playbook. */
+  sourcePlaybookId?: number;
   deps?: { runtime?: AgentRuntime; repoRoot?: string };
 }
 
@@ -240,6 +242,7 @@ export async function runSkillCoachingWorkflow(
         suggestionText: output.rationale,
         suggestionType: 'skill-prompt',
         proposedDiff: output.proposedPatch || null,
+        sourcePlaybookId: input.sourcePlaybookId ?? null,
       })
       .returning({ id: improvementCandidates.id })
       .all();

--- a/target-projects/goose-hub-self/project.config.ts
+++ b/target-projects/goose-hub-self/project.config.ts
@@ -77,6 +77,11 @@ const config: ProjectConfig = {
         'first-run-of-skill',
       ],
     },
+    coachPolicy: {
+      enabled: false,
+      consistencyThreshold: 0.8,
+      minLifecycles: 3,
+    },
   },
   budgets: {
     dailyTokens: 5_000_000,

--- a/target-projects/nannymudnz/project.config.ts
+++ b/target-projects/nannymudnz/project.config.ts
@@ -77,6 +77,11 @@ const config: ProjectConfig = {
         'first-run-of-skill',
       ],
     },
+    coachPolicy: {
+      enabled: false,
+      consistencyThreshold: 0.8,
+      minLifecycles: 3,
+    },
   },
   budgets: {
     dailyTokens: 2_000_000,


### PR DESCRIPTION
Closes #528

## What changed

- `core/types.ts` — `CoachPolicy` interface (`enabled`, `consistencyThreshold`, `minLifecycles`) added to `AgentConfig`
- `core/db/schema.ts` + migration `0004` — `source_playbook_id` column on `improvement_candidates`
- `core/event-stream/store.ts` — three new event kinds: `coach.dispatch-triggered`, `coach.skipped-forbidden-target`, `coach.dispatch-failed`
- `core/workflows/cross-run-retro.ts` — exported `dispatchCoachCandidates` helper; after the playbook row is persisted, scans `improvementCandidates` for `kind ∈ {skill-prompt, skill-schema, skill-config}` with convergent patterns (`consistencyScore ≥ threshold`) and sufficient lifecycle coverage (`≥ minLifecycles`); honours forbidden-target list; dispatches `runSkillCoachingWorkflow` per eligible candidate
- `core/workflows/skill-coaching.ts` — `sourcePlaybookId?: number` added to input; persisted on the `improvement_candidates` row
- `apps/server/src/domains/playbooks/` — `countCoachProposalsForPlaybook` query; `coachProposalCount` added to `PlaybookSummaryDto`
- `apps/web/src/lib/types.ts` + `PlaybooksTab.tsx` — `coachProposalCount` surfaced on playbook cards
- Both project configs — `coachPolicy: { enabled: false, consistencyThreshold: 0.8, minLifecycles: 3 }`

## Tests

5 new unit tests in `core/workflows/cross-run-retro.test.ts` covering:
- Fires above threshold with enough lifecycles
- Does not fire below consistency threshold
- Does not fire below `minLifecycles`
- Skips forbidden targets + emits `coach.skipped-forbidden-target`
- Dispatches once per matching candidate when multiple pass filters

All 2022 tests pass. Lint + typecheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zvomY9zQi2SbpycoMJ3hh)_