### PR TITLE
M11.08: Multi-parallel relaxation of project lock

### DIFF
--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunTriageBatch = vi.fn();
 const mockGetSourceForSlug = vi.fn();
+const mockGetProject = vi.fn();
 const mockLoggerError = vi.fn();
 const mockLoggerInfo = vi.fn();
 const mockLoggerWarn = vi.fn();
@@ -30,6 +31,10 @@ vi.mock('./source.js', () => ({
   isValidSlug: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock('./projects.js', () => ({
+  getProject: mockGetProject,
+}));
+
 vi.mock('@goose-hub/core/logger.js', () => ({
   logger: {
     error: mockLoggerError,
@@ -47,6 +52,8 @@ beforeEach(() => {
   mockRunTriageBatch.mockResolvedValue(undefined);
   mockRunRetroForItem.mockResolvedValue(undefined);
   mockGetSourceForSlug.mockResolvedValue(null);
+  // Default: single-workflow-per-project (backward-compat) for tests that don't override.
+  mockGetProject.mockResolvedValue(null);
 });
 
 // ─── dispatchTriageBatch ──────────────────────────────────────────────────
@@ -156,7 +163,7 @@ describe('dispatchInvestigate', () => {
 
     await p2;
     expect(mockLoggerWarn).toHaveBeenCalledWith(
-      'dispatchInvestigate: already in-flight, dropping duplicate',
+      'dispatchInvestigate: parallel-lock rejected (in-flight or at cap)',
       expect.objectContaining({ slug: 'slug', issueNumber: 5 }),
     );
 
@@ -165,7 +172,10 @@ describe('dispatchInvestigate', () => {
     expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
   });
 
-  it('different issue numbers run independently', async () => {
+  it('different issue numbers run independently when maxParallelAgents allows it', async () => {
+    // Set maxParallelAgents=2 so both can run concurrently (M11 parallel dispatch).
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 2 } });
+
     const { dispatchInvestigate } = await import('./dispatch.js');
     await Promise.all([dispatchInvestigate('slug', 1), dispatchInvestigate('slug', 2)]);
     expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
@@ -201,7 +211,7 @@ describe('dispatchFixIssue', () => {
 
     await p2;
     expect(mockLoggerWarn).toHaveBeenCalledWith(
-      'dispatchFixIssue: already in-flight, dropping duplicate',
+      'dispatchFixIssue: parallel-lock rejected (in-flight or at cap)',
       expect.objectContaining({ slug: 'slug', issueNumber: 7 }),
     );
 

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -1,18 +1,20 @@
 import { join } from 'node:path';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
+import { parallelLock } from '@goose-hub/core/projects/parallel-lock.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { parseAcceptanceCriteria } from '../domains/issues/parse-acceptance.js';
 import { runRetroForItem } from '../domains/workflows/retro-batch.js';
 import { runTriageBatch } from '../domains/workflows/triage-batch.js';
+import { getProject } from './projects.js';
 import { getSourceForSlug } from './source.js';
 
 const _triageBatchInFlight = new Set<string>();
 const _triageBatchPending = new Set<string>();
-const _issueInFlight = new Set<string>();
 
-function issueKey(slug: string, issueNumber: number): string {
-  return `${slug}:${issueNumber}`;
+async function getMaxParallelAgents(slug: string): Promise<number> {
+  const cfg = await getProject(slug);
+  return cfg?.budgets.maxParallelAgents ?? 1;
 }
 
 /**
@@ -50,15 +52,16 @@ export function dispatchTriageBatch(slug: string): Promise<void> {
 
 /** Run the investigate workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchInvestigate(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchInvestigate: already in-flight, dropping duplicate', {
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchInvestigate: parallel-lock rejected (in-flight or at cap)', {
       slug,
       issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
     });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runInvestigateWorkflow } = (await import(
@@ -79,18 +82,22 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
     const item = await source.getItem(issueNumber.toString());
     await runInvestigateWorkflow(item, source, slug, REPO_ROOT);
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
 /** Run the M7 fix-issue workflow for a single issue (#183). Drops duplicate triggers for the same issue. */
 export async function dispatchFixIssue(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchFixIssue: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchFixIssue: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runFixIssueWorkflow } = (await import(
@@ -129,21 +136,22 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
 
     await runFixIssueWorkflow(item, source, slug, REPO_ROOT, mockDeps);
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
 /** Run the merge conflict resolution workflow for a single issue. Drops duplicate triggers. */
 export async function dispatchResolveConflict(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchResolveConflict: already in-flight, dropping duplicate', {
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchResolveConflict: parallel-lock rejected (in-flight or at cap)', {
       slug,
       issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
     });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runResolveConflictWorkflow } = (await import(
@@ -174,18 +182,22 @@ export async function dispatchResolveConflict(slug: string, issueNumber: number)
       });
     });
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
 /** Run the QA holdout workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchQa(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchQa: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchQa: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runQaWorkflow } = (await import(
@@ -215,18 +227,22 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
     const verifyCommands = parseAcceptanceCriteria(item.body ?? '');
     await runQaWorkflow(item, source, slug, item.repoRef ?? slug, { verifyCommands });
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
 /** Run the fix-feedback workflow for a single issue. Drops duplicate triggers. */
 export async function dispatchNeedsFix(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchNeedsFix: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchNeedsFix: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runFixFeedbackWorkflow } = (await import(
@@ -248,7 +264,7 @@ export async function dispatchNeedsFix(slug: string, issueNumber: number): Promi
     const item = await source.getItem(issueNumber.toString());
     await runFixFeedbackWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
@@ -258,12 +274,16 @@ export async function dispatchNeedsFix(slug: string, issueNumber: number): Promi
  * remain. Transition qa-failed → needs-fix and dispatch fix-feedback.
  */
 async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchQaFailed: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchQaFailed: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     const source = await getSourceForSlug(slug);
     if (source == null) {
@@ -296,7 +316,7 @@ async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void
       issueNumber,
     });
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 
   // Fire fix-feedback outside the in-flight guard so needs-fix can also
@@ -306,12 +326,16 @@ async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void
 
 /** Run the Review holdout workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchReview(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchReview: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchReview: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     // Cross-package boundary: slices/ is not a workspace package (rule 28a).
     const { runReviewWorkflow } = (await import(
@@ -332,7 +356,7 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
     const item = await source.getItem(issueNumber.toString());
     await runReviewWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
@@ -344,12 +368,16 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
  * sequential duplicate triggers must no-op once the workflow has run.
  */
 export async function dispatchRetro(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchRetro: already in-flight, dropping duplicate', { slug, issueNumber });
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchRetro: parallel-lock rejected (in-flight or at cap)', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
     return;
   }
-  _issueInFlight.add(key);
   try {
     const source = await getSourceForSlug(slug);
     if (source == null) {
@@ -367,7 +395,7 @@ export async function dispatchRetro(slug: string, issueNumber: number): Promise<
     }
     await runRetroForItem(item, source, slug);
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
@@ -377,15 +405,16 @@ export async function dispatchRetro(slug: string, issueNumber: number): Promise<
  * Medium/high → dev-ready (proceed automatically).
  */
 async function dispatchInvestigationComplete(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
-    logger.warn('dispatchInvestigationComplete: already in-flight, dropping duplicate', {
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.warn('dispatchInvestigationComplete: parallel-lock rejected (in-flight or at cap)', {
       slug,
       issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
     });
     return;
   }
-  _issueInFlight.add(key);
   try {
     const source = await getSourceForSlug(slug);
     if (source == null) {
@@ -435,7 +464,7 @@ async function dispatchInvestigationComplete(slug: string, issueNumber: number):
 
     logger.info('dispatchInvestigationComplete: transitioned', { slug, issueNumber, targetState });
   } finally {
-    _issueInFlight.delete(key);
+    parallelLock.release(slug, issueNumber);
   }
 }
 
@@ -535,8 +564,7 @@ const RESUME_WORKFLOWS: Partial<Record<StateName, ResumeEntry>> = {
  * not always legal in the normal workflow graph.
  */
 export async function dispatchResumeIssue(slug: string, issueNumber: number): Promise<void> {
-  const key = issueKey(slug, issueNumber);
-  if (_issueInFlight.has(key)) {
+  if (parallelLock.isInFlight(slug, issueNumber)) {
     logger.warn('dispatchResumeIssue: already in-flight, dropping duplicate', {
       slug,
       issueNumber,

--- a/core/projects/parallel-lock.test.ts
+++ b/core/projects/parallel-lock.test.ts
@@ -36,6 +36,16 @@ describe('ProjectParallelLock', () => {
       expect(() => lock.release('proj', 99)).not.toThrow();
     });
 
+    it('releasing the last issue removes the slug entry (no memory leak)', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1, 1);
+      lock.release('proj', 1);
+      // inFlightCount uses the map internally; 0 confirms the entry was cleaned up
+      expect(lock.inFlightCount('proj')).toBe(0);
+      // A fresh acquire must still work after the cleanup
+      expect(lock.tryAcquire('proj', 2, 1)).toBe(true);
+    });
+
     it('defaults maxParallelAgents to 1 when omitted', () => {
       const lock = new ProjectParallelLock();
       lock.tryAcquire('proj', 1);

--- a/core/projects/parallel-lock.test.ts
+++ b/core/projects/parallel-lock.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { ProjectParallelLock } from './parallel-lock.js';
+
+describe('ProjectParallelLock', () => {
+  // ---------------------------------------------------------------------------
+  // tryAcquire — maxParallelAgents=1 (original single-workflow behaviour)
+  // ---------------------------------------------------------------------------
+
+  describe('maxParallelAgents=1 (original behaviour)', () => {
+    it('first acquire on an empty project succeeds', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.tryAcquire('proj', 1, 1)).toBe(true);
+    });
+
+    it('second acquire on the same issue is rejected (per-issue lock)', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1, 1);
+      expect(lock.tryAcquire('proj', 1, 1)).toBe(false);
+    });
+
+    it('second acquire on a different issue is rejected (project cap=1)', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1, 1);
+      expect(lock.tryAcquire('proj', 2, 1)).toBe(false);
+    });
+
+    it('after release the slot is free again', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1, 1);
+      lock.release('proj', 1);
+      expect(lock.tryAcquire('proj', 2, 1)).toBe(true);
+    });
+
+    it('release on a non-held issue is a no-op', () => {
+      const lock = new ProjectParallelLock();
+      expect(() => lock.release('proj', 99)).not.toThrow();
+    });
+
+    it('defaults maxParallelAgents to 1 when omitted', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1);
+      expect(lock.tryAcquire('proj', 2)).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // tryAcquire — maxParallelAgents=2 (two issues can run in parallel)
+  // ---------------------------------------------------------------------------
+
+  describe('maxParallelAgents=2', () => {
+    it('two distinct issues both acquire successfully', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.tryAcquire('proj', 10, 2)).toBe(true);
+      expect(lock.tryAcquire('proj', 20, 2)).toBe(true);
+    });
+
+    it('budget cap rejects a 3rd distinct issue', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 10, 2);
+      lock.tryAcquire('proj', 20, 2);
+      expect(lock.tryAcquire('proj', 30, 2)).toBe(false);
+    });
+
+    it('same issue rejected even when cap not reached', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 10, 2);
+      expect(lock.tryAcquire('proj', 10, 2)).toBe(false);
+    });
+
+    it('releasing one slot allows a 3rd issue to acquire', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 10, 2);
+      lock.tryAcquire('proj', 20, 2);
+      lock.release('proj', 10);
+      expect(lock.tryAcquire('proj', 30, 2)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // inFlightCount
+  // ---------------------------------------------------------------------------
+
+  describe('inFlightCount', () => {
+    it('returns 0 for an unknown slug', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.inFlightCount('unknown')).toBe(0);
+    });
+
+    it('increments on acquire, decrements on release', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 1, 3);
+      expect(lock.inFlightCount('proj')).toBe(1);
+      lock.tryAcquire('proj', 2, 3);
+      expect(lock.inFlightCount('proj')).toBe(2);
+      lock.release('proj', 1);
+      expect(lock.inFlightCount('proj')).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isInFlight
+  // ---------------------------------------------------------------------------
+
+  describe('isInFlight', () => {
+    it('returns false when the issue has no in-flight workflow', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.isInFlight('proj', 5)).toBe(false);
+    });
+
+    it('returns true after acquiring the issue', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 5, 1);
+      expect(lock.isInFlight('proj', 5)).toBe(true);
+    });
+
+    it('returns false after releasing the issue', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj', 5, 1);
+      lock.release('proj', 5);
+      expect(lock.isInFlight('proj', 5)).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Project isolation
+  // ---------------------------------------------------------------------------
+
+  describe('project isolation', () => {
+    it('locks on different slugs are independent', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj-a', 1, 1);
+      expect(lock.tryAcquire('proj-b', 1, 1)).toBe(true);
+    });
+
+    it('inFlightCount is per-slug', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj-a', 1, 2);
+      lock.tryAcquire('proj-a', 2, 2);
+      expect(lock.inFlightCount('proj-a')).toBe(2);
+      expect(lock.inFlightCount('proj-b')).toBe(0);
+    });
+  });
+});

--- a/core/projects/parallel-lock.ts
+++ b/core/projects/parallel-lock.ts
@@ -36,7 +36,10 @@ export class ProjectParallelLock {
 
   /** Release the slot held by this issue. No-op if not held. */
   release(slug: string, issueNumber: number): void {
-    this._bySlug.get(slug)?.delete(issueNumber);
+    const set = this._bySlug.get(slug);
+    if (set == null) return;
+    set.delete(issueNumber);
+    if (set.size === 0) this._bySlug.delete(slug);
   }
 
   /** How many workflow slots are currently occupied for this project. */

--- a/core/projects/parallel-lock.ts
+++ b/core/projects/parallel-lock.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-project parallel workflow lock (M11.08).
+ *
+ * Enforces two invariants per project:
+ *   1. Per-issue uniqueness: at most one concurrent workflow per issue.
+ *   2. Per-project cap: at most maxParallelAgents concurrent workflows.
+ *
+ * This relaxes FACTORY_RULES rule 4 ("one workflow per project at a time") to
+ * "up to maxParallelAgents workflows per project, on distinct issues."
+ * See ADR 0001 (M11.09) for the decision record.
+ */
+export class ProjectParallelLock {
+  private readonly _bySlug = new Map<string, Set<number>>();
+
+  /**
+   * Try to acquire a workflow slot for the given issue.
+   *
+   * Returns false (without acquiring) when:
+   *   - the same issue already has an in-flight workflow, OR
+   *   - the project has reached its maxParallelAgents cap.
+   *
+   * Defaults maxParallelAgents to 1 so callers that omit the value keep
+   * the original single-workflow-per-project behaviour.
+   */
+  tryAcquire(slug: string, issueNumber: number, maxParallelAgents = 1): boolean {
+    let issueSet = this._bySlug.get(slug);
+    if (issueSet == null) {
+      issueSet = new Set();
+      this._bySlug.set(slug, issueSet);
+    }
+    if (issueSet.has(issueNumber)) return false;
+    if (issueSet.size >= maxParallelAgents) return false;
+    issueSet.add(issueNumber);
+    return true;
+  }
+
+  /** Release the slot held by this issue. No-op if not held. */
+  release(slug: string, issueNumber: number): void {
+    this._bySlug.get(slug)?.delete(issueNumber);
+  }
+
+  /** How many workflow slots are currently occupied for this project. */
+  inFlightCount(slug: string): number {
+    return this._bySlug.get(slug)?.size ?? 0;
+  }
+
+  /** Whether a workflow is currently in-flight for this specific issue. */
+  isInFlight(slug: string, issueNumber: number): boolean {
+    return this._bySlug.get(slug)?.has(issueNumber) ?? false;
+  }
+}
+
+/** Singleton shared across the server process. */
+export const parallelLock = new ProjectParallelLock();

--- a/slices/parallel-lock/README.md
+++ b/slices/parallel-lock/README.md
@@ -1,0 +1,60 @@
+# slices/parallel-lock
+
+Multi-parallel project lock relaxation. Closes M11.08 (#294).
+
+## What it does
+
+FACTORY_RULES rule 4 previously enforced one active workflow per project at a
+time. M11.08 relaxes this to allow up to `maxParallelAgents` concurrent
+workflows on **distinct** issues within the same project. The per-issue
+uniqueness guarantee is preserved — two workflows on the same issue are never
+allowed.
+
+## Vertical surfaces touched
+
+- **Core lib**: `core/projects/parallel-lock.ts`
+  - `ProjectParallelLock` class — tracks in-flight issue slots per project slug
+  - `parallelLock` singleton — shared across the server process
+  - `tryAcquire(slug, issueNumber, maxParallelAgents)` — returns `true` iff a
+    slot is available and not already held by this issue
+  - `release(slug, issueNumber)` — frees the slot when the workflow completes
+  - `inFlightCount(slug)` — returns current occupancy (used in log context)
+  - `isInFlight(slug, issueNumber)` — read-only check (used by `dispatchResumeIssue`)
+
+- **Server shared**: `apps/server/src/shared/dispatch.ts`
+  - Replaced `_issueInFlight: Set<string>` (flat per-issue guard) with the
+    `parallelLock` singleton
+  - Every `dispatchXxx` function now calls `parallelLock.tryAcquire` (with
+    `maxParallelAgents` from project config) before starting work, and
+    `parallelLock.release` in the `finally` block
+  - `getMaxParallelAgents(slug)` helper looks up `budgets.maxParallelAgents`
+    from the project config (defaults to 1 for backward compatibility)
+
+## Lock semantics
+
+| Condition | Result |
+|-----------|--------|
+| Issue not in-flight AND project has free slots | `tryAcquire → true` |
+| Same issue already has a workflow running | `tryAcquire → false` (per-issue lock) |
+| Project has reached `maxParallelAgents` | `tryAcquire → false` (cap) |
+
+Budget cap enforcement (per-workflow USD check) happens inside each workflow via
+`resolveBudgets()` — it is not bypassed by the parallel dispatch path.
+
+## Configuration
+
+`maxParallelAgents` lives in `ProjectConfig.budgets.maxParallelAgents` (already
+present in `core/types.ts`). Set it to `1` (default) for the original
+single-workflow-per-project behaviour, or `2+` to enable parallel dispatch.
+
+The `goose-hub-self` project config already declares `maxParallelAgents: 3`.
+
+## Running the tests
+
+```bash
+pnpm test slices/parallel-lock/slice.test.ts
+pnpm test core/projects/parallel-lock.test.ts
+```
+
+No live GitHub API required — all tests use the `ProjectParallelLock` class
+directly.

--- a/slices/parallel-lock/slice.test.ts
+++ b/slices/parallel-lock/slice.test.ts
@@ -1,0 +1,119 @@
+import { ProjectParallelLock } from '@goose-hub/core/projects/parallel-lock.js';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * End-to-end slice tests for M11.08: multi-parallel project lock relaxation.
+ *
+ * These tests exercise the lock directly (the unit that dispatch.ts wraps)
+ * to verify the three key scenarios from the acceptance criteria.
+ */
+
+describe('parallel-lock slice — M11.08', () => {
+  // ---------------------------------------------------------------------------
+  // maxParallelAgents=1: original single-workflow-per-project behaviour
+  // ---------------------------------------------------------------------------
+
+  describe('maxParallelAgents=1 (original behaviour preserved)', () => {
+    it('allows exactly one workflow per project', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.tryAcquire('goose-hub-self', 101, 1)).toBe(true);
+      expect(lock.inFlightCount('goose-hub-self')).toBe(1);
+    });
+
+    it('rejects a second workflow on the same issue', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 101, 1);
+      expect(lock.tryAcquire('goose-hub-self', 101, 1)).toBe(false);
+    });
+
+    it('rejects a second workflow on a different issue (project cap)', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 101, 1);
+      expect(lock.tryAcquire('goose-hub-self', 102, 1)).toBe(false);
+    });
+
+    it('allows next workflow after first completes', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 101, 1);
+      lock.release('goose-hub-self', 101);
+      expect(lock.tryAcquire('goose-hub-self', 102, 1)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // maxParallelAgents=2: two distinct issues dispatched in the same tick
+  // ---------------------------------------------------------------------------
+
+  describe('maxParallelAgents=2 — two eligible issues dispatched in parallel', () => {
+    it('two distinct issues both acquire (non-conflicting)', () => {
+      const lock = new ProjectParallelLock();
+      expect(lock.tryAcquire('goose-hub-self', 200, 2)).toBe(true);
+      expect(lock.tryAcquire('goose-hub-self', 201, 2)).toBe(true);
+      expect(lock.inFlightCount('goose-hub-self')).toBe(2);
+    });
+
+    it('budget cap rejects a 3rd issue when maxParallelAgents=2', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 200, 2);
+      lock.tryAcquire('goose-hub-self', 201, 2);
+
+      // 3rd attempt must be rejected — cap reached
+      expect(lock.tryAcquire('goose-hub-self', 202, 2)).toBe(false);
+      expect(lock.inFlightCount('goose-hub-self')).toBe(2);
+    });
+
+    it('completing one of the two allows the 3rd to proceed', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 200, 2);
+      lock.tryAcquire('goose-hub-self', 201, 2);
+      lock.release('goose-hub-self', 200);
+
+      expect(lock.tryAcquire('goose-hub-self', 202, 2)).toBe(true);
+    });
+
+    it('per-issue lock still enforced within parallel window', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('goose-hub-self', 200, 2);
+
+      // Same issue rejected even though cap not reached
+      expect(lock.tryAcquire('goose-hub-self', 200, 2)).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Budget cap enforced per-dispatch, not just on first
+  // ---------------------------------------------------------------------------
+
+  describe('budget cap enforced before each dispatch', () => {
+    it('cap is checked fresh on every tryAcquire call, not just the first', () => {
+      const lock = new ProjectParallelLock();
+
+      // Fill the cap
+      lock.tryAcquire('proj', 1, 2);
+      lock.tryAcquire('proj', 2, 2);
+
+      // Each subsequent attempt is independently rejected
+      expect(lock.tryAcquire('proj', 3, 2)).toBe(false);
+      expect(lock.tryAcquire('proj', 4, 2)).toBe(false);
+      expect(lock.tryAcquire('proj', 5, 2)).toBe(false);
+
+      // After one finishes, the cap is re-checked and one more is allowed
+      lock.release('proj', 1);
+      expect(lock.tryAcquire('proj', 3, 2)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cross-project isolation
+  // ---------------------------------------------------------------------------
+
+  describe('project isolation', () => {
+    it('cap for project A does not affect project B', () => {
+      const lock = new ProjectParallelLock();
+      lock.tryAcquire('proj-a', 1, 1);
+
+      // proj-b's cap is independent — should succeed
+      expect(lock.tryAcquire('proj-b', 1, 1)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #294

## What changed

Relaxes FACTORY_RULES rule 4 ("one workflow per project at a time") to allow up to `maxParallelAgents` concurrent workflows on **distinct** issues within the same project. The per-issue uniqueness guarantee is preserved.

## Surfaces touched

- `core/projects/parallel-lock.ts` — new `ProjectParallelLock` class + `parallelLock` singleton
- `apps/server/src/shared/dispatch.ts` — replaced `_issueInFlight: Set<string>` with the parallel lock; added `getMaxParallelAgents(slug)` helper
- `slices/parallel-lock/slice.test.ts` + `slices/parallel-lock/README.md` per FACTORY_RULES

## Tests

27 new tests in `core/projects/parallel-lock.test.ts` and `slices/parallel-lock/slice.test.ts`. All 2044 tests pass. Lint and typecheck clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3UHX3iCF3Kgopq9TuvBoB)_