### PR TITLE
M11.15: Model router for dev — predictive model selection by issue complexity

### DIFF
--- a/core/agent-runtime/README.md
+++ b/core/agent-runtime/README.md
@@ -8,6 +8,7 @@ Typed contracts and model registry for all agent runtime code.
 |------|---------|
 | `interface.ts` | `AgentSpec`, `AgentResult`, `AgentRuntime`, `DecisionSummary`, `AgentBudgets` |
 | `models.ts` | `MODELS`, `ModelEntry`, `ModelTier`, `defaultModelForTier`, `tierOf`, `modelsAtOrAboveTier` |
+| `model-router.ts` | `selectModel`, `SelectModelInput`, `SelectModelResult` |
 | `with-timeout.ts` | `withTimeout`, `LifecycleTimeoutError`, per-step subclasses, `DEFAULT_TIMEOUTS` |
 
 ## AgentSpec
@@ -29,6 +30,37 @@ Hardcoded in `models.ts`, git-tracked. Current IDs:
 | `haiku` | `claude-haiku-4-5-20251001` |
 
 Update by PR to `models.ts`. The git log of this file is the audit trail for model changes.
+
+## Model Router
+
+`model-router.ts` provides predictive model selection based on issue-complexity signals. It is called by the dispatch path before building the `AgentSpec`, and its result overrides the budget's default `modelTier`.
+
+```ts
+import { selectModel } from '@goose-hub/core/agent-runtime/model-router.js';
+
+const routerResult = selectModel({ workItem, role: 'developer', projectId, modelRouterConfig });
+const modelOverride = routerResult != null ? defaultModelForTier(routerResult.tier) : budgetModelOverride;
+```
+
+**Resolution order** (highest wins):
+1. `agentConfig.modelRouter.overrides` — project-level table keyed by `"role"`, `"role+type:TYPE"`, or `"role+priority:PRIORITY"`
+2. Mined `decision_patterns` with `kind = MODEL_SELECTION_OUTCOME` and `consistencyScore > 0.7`
+3. Static policy table (see below)
+
+**Static policy** (applied when no override or pattern matches):
+
+| Condition | Tier |
+|-----------|------|
+| `priority: high` or `priority: critical` | `sonnet` |
+| `type: bug` | `haiku` |
+| `type: chore` | `haiku` |
+| `type: feature` with AC count ≥ 5 OR body ≥ 1500 chars | `sonnet` (reason: `large-feature`) |
+| `type: feature` otherwise | `sonnet` (reason: `feature`) |
+| default | `sonnet` |
+
+**Holdout bypass**: `selectModel` returns `null` for `qa` and `reviewer` roles. Callers must not apply the result to holdout specs — use the skill's configured tier unchanged.
+
+Emits `agent.model-selected` event after selection so retro / mining can learn from outcomes.
 
 ## Per-step typed timeouts (#219)
 

--- a/core/agent-runtime/decision-types.ts
+++ b/core/agent-runtime/decision-types.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 export const DecisionKindSchema = z.enum([
   // Cross-cutting decisions
   'MODEL_SELECTION',
+  'MODEL_SELECTION_OUTCOME',
   'SCOPE_CHANGE',
   'FIX_STRATEGY',
   'SKIP_GATE',

--- a/core/agent-runtime/model-router.ts
+++ b/core/agent-runtime/model-router.ts
@@ -1,0 +1,112 @@
+import { and, eq, gt } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { decisionPatterns } from '../db/schema.js';
+import type { WorkItem } from '../state-source/interface.js';
+import type { ModelTier, Role } from '../types.js';
+
+const HOLDOUT_ROLES = new Set<string>(['qa', 'reviewer']);
+
+export interface SelectModelInput {
+  workItem: WorkItem;
+  role: Role;
+  projectId: string;
+  /** Project-level model router config from agentConfig.modelRouter */
+  modelRouterConfig?: { overrides?: Record<string, ModelTier> };
+}
+
+export interface SelectModelResult {
+  tier: ModelTier;
+  reason: string;
+}
+
+function countAc(body: string): number {
+  return (body.match(/^\s*- \[[ xX]\] /gm) ?? []).length;
+}
+
+function staticPolicy(workItem: WorkItem): SelectModelResult {
+  const { type, priority, body } = workItem;
+
+  if (priority === 'high' || priority === 'critical') {
+    return { tier: 'sonnet', reason: 'priority-high-or-critical' };
+  }
+  if (type === 'bug') return { tier: 'haiku', reason: 'type-bug' };
+  if (type === 'chore') return { tier: 'haiku', reason: 'type-chore' };
+  if (type === 'feature') {
+    const acCount = countAc(body);
+    if (acCount >= 5 || body.length >= 1500) {
+      return { tier: 'sonnet', reason: 'large-feature' };
+    }
+    return { tier: 'sonnet', reason: 'feature' };
+  }
+  return { tier: 'sonnet', reason: 'default' };
+}
+
+function resolveOverride(
+  overrides: Record<string, ModelTier>,
+  role: string,
+  workItem: WorkItem,
+): ModelTier | null {
+  // Most-specific key wins: role+type, then role+priority, then role alone
+  return (
+    overrides[`${role}+type:${workItem.type}`] ??
+    overrides[`${role}+priority:${workItem.priority}`] ??
+    overrides[role] ??
+    null
+  );
+}
+
+function queryPatternTier(projectId: string, role: string): ModelTier | null {
+  const rows = db
+    .select()
+    .from(decisionPatterns)
+    .where(
+      and(
+        eq(decisionPatterns.projectId, projectId),
+        eq(decisionPatterns.kind, 'MODEL_SELECTION_OUTCOME'),
+        eq(decisionPatterns.role, role),
+        gt(decisionPatterns.consistencyScore, 0.7),
+      ),
+    )
+    .all();
+
+  if (rows.length === 0) return null;
+
+  const tier = rows[0].actionSummary;
+  if (tier === 'haiku' || tier === 'sonnet' || tier === 'opus') return tier as ModelTier;
+  return null;
+}
+
+/**
+ * Predictively selects the initial model tier for an agent run based on
+ * issue-complexity signals (type, priority, AC count, body length) plus
+ * mined MODEL_SELECTION_OUTCOME patterns when available.
+ *
+ * Returns null for holdout roles (qa, reviewer) — caller must not override
+ * their skill-configured tier.
+ *
+ * Resolution order (highest precedence first):
+ *   1. Project-level override (agentConfig.modelRouter.overrides)
+ *   2. Pattern-informed (decision_patterns with consistencyScore > 0.7)
+ *   3. Static policy table
+ */
+export function selectModel(input: SelectModelInput): SelectModelResult | null {
+  const { workItem, role, projectId, modelRouterConfig } = input;
+
+  if (HOLDOUT_ROLES.has(role)) return null;
+
+  // Project-level override — highest precedence
+  if (modelRouterConfig?.overrides != null) {
+    const overrideTier = resolveOverride(modelRouterConfig.overrides, role, workItem);
+    if (overrideTier != null) {
+      return { tier: overrideTier, reason: 'project-override' };
+    }
+  }
+
+  // Pattern-informed selection — degrades gracefully to static policy when absent
+  const patternTier = queryPatternTier(projectId, role);
+  if (patternTier != null) {
+    return { tier: patternTier, reason: 'pattern-informed' };
+  }
+
+  return staticPolicy(workItem);
+}

--- a/core/agent-runtime/slice.test.ts
+++ b/core/agent-runtime/slice.test.ts
@@ -875,3 +875,264 @@ describe('adviseOnPlan (#182)', () => {
     expect(spec.context.previousAdvisorFeedback).toBe('last time I said X');
   });
 });
+
+// ─── model-router — predictive model selection (#529) ───────────────────────
+
+const { mockRouterDb } = vi.hoisted(() => {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {} as never;
+  for (const m of ['select', 'from', 'where'] as const) {
+    (chain as Record<string, unknown>)[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain.all = vi.fn().mockReturnValue([]);
+  return { mockRouterDb: chain };
+});
+
+vi.mock('../db/db.js', () => ({ db: mockRouterDb }));
+vi.mock('../db/schema.js', () => ({
+  decisionPatterns: { projectId: 'p', kind: 'k', role: 'r', consistencyScore: 'cs' },
+}));
+
+function makeWorkItem(
+  overrides: Partial<{
+    type: 'feature' | 'bug' | 'chore' | 'research';
+    priority: 'critical' | 'high' | 'medium' | 'low';
+    body: string;
+  }> = {},
+) {
+  return {
+    id: 'github:owner/repo#42',
+    externalId: '42',
+    repoRef: 'owner/repo',
+    title: 'Test issue',
+    body: overrides.body ?? 'Short body',
+    type: overrides.type ?? 'feature',
+    priority: overrides.priority ?? 'medium',
+    mode: 'supervised' as const,
+    state: 'factory:dev-ready' as const,
+    authorIsOwner: true,
+    schedule: 'current' as const,
+    exec: 'serial' as const,
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+  };
+}
+
+describe('selectModel (#529)', () => {
+  beforeEach(() => {
+    mockRouterDb.all.mockReturnValue([]);
+    vi.clearAllMocks();
+    mockRouterDb.all.mockReturnValue([]);
+    for (const m of ['select', 'from', 'where']) {
+      mockRouterDb[m].mockReturnValue(mockRouterDb);
+    }
+  });
+
+  describe('holdout role bypass', () => {
+    it('returns null for qa role', async () => {
+      const { selectModel } = await import('./model-router.js');
+      expect(selectModel({ workItem: makeWorkItem(), role: 'qa', projectId: 'proj' })).toBeNull();
+    });
+
+    it('returns null for reviewer role', async () => {
+      const { selectModel } = await import('./model-router.js');
+      expect(
+        selectModel({ workItem: makeWorkItem(), role: 'reviewer', projectId: 'proj' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('static policy — type:bug', () => {
+    it('returns haiku for type:bug at medium priority', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'bug', priority: 'medium' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('type-bug');
+    });
+  });
+
+  describe('static policy — type:chore', () => {
+    it('returns haiku for type:chore', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'chore' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('type-chore');
+    });
+  });
+
+  describe('static policy — priority overrides type', () => {
+    it('returns sonnet for priority:high regardless of type', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'bug', priority: 'high' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('priority-high-or-critical');
+    });
+
+    it('returns sonnet for priority:critical', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'chore', priority: 'critical' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('priority-high-or-critical');
+    });
+  });
+
+  describe('static policy — type:feature', () => {
+    it('returns sonnet with reason "feature" for small feature (< 5 AC, body < 1500)', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const body = '- [ ] AC one\n- [ ] AC two\nSome description';
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'feature', body }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('feature');
+    });
+
+    it('returns sonnet with reason "large-feature" when AC count ≥ 5', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const body = ['- [ ] AC 1', '- [ ] AC 2', '- [ ] AC 3', '- [ ] AC 4', '- [ ] AC 5'].join(
+        '\n',
+      );
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'feature', body }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('large-feature');
+    });
+
+    it('returns sonnet with reason "large-feature" when body length ≥ 1500', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const body = `- [ ] One AC\n${'x'.repeat(1500)}`;
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'feature', body }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('large-feature');
+    });
+  });
+
+  describe('project-level override', () => {
+    it('applies role-level override', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'feature' }),
+        role: 'developer',
+        projectId: 'proj',
+        modelRouterConfig: { overrides: { developer: 'opus' } },
+      });
+      expect(result?.tier).toBe('opus');
+      expect(result?.reason).toBe('project-override');
+    });
+
+    it('role+type override wins over role-only override', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'bug' }),
+        role: 'developer',
+        projectId: 'proj',
+        modelRouterConfig: {
+          overrides: { developer: 'haiku', 'developer+type:bug': 'sonnet' },
+        },
+      });
+      expect(result?.tier).toBe('sonnet');
+      expect(result?.reason).toBe('project-override');
+    });
+
+    it('role+priority override wins over role-only override', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem({ priority: 'low' }),
+        role: 'developer',
+        projectId: 'proj',
+        modelRouterConfig: {
+          overrides: { developer: 'sonnet', 'developer+priority:low': 'haiku' },
+        },
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('project-override');
+    });
+
+    it('does not apply override to holdout roles', async () => {
+      const { selectModel } = await import('./model-router.js');
+      const result = selectModel({
+        workItem: makeWorkItem(),
+        role: 'qa',
+        projectId: 'proj',
+        modelRouterConfig: { overrides: { qa: 'opus' } },
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('pattern-informed selection', () => {
+    it('uses pattern tier when consistencyScore > 0.7 and pattern is present', async () => {
+      const { selectModel } = await import('./model-router.js');
+      mockRouterDb.all.mockReturnValue([{ actionSummary: 'opus', consistencyScore: 0.9 }]);
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'feature' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('opus');
+      expect(result?.reason).toBe('pattern-informed');
+    });
+
+    it('falls back to static policy when no patterns exist', async () => {
+      const { selectModel } = await import('./model-router.js');
+      mockRouterDb.all.mockReturnValue([]);
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'bug' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('type-bug');
+    });
+
+    it('falls back to static policy when pattern tier is unrecognised', async () => {
+      const { selectModel } = await import('./model-router.js');
+      mockRouterDb.all.mockReturnValue([{ actionSummary: 'unknown-tier', consistencyScore: 0.95 }]);
+      const result = selectModel({
+        workItem: makeWorkItem({ type: 'bug' }),
+        role: 'developer',
+        projectId: 'proj',
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('type-bug');
+    });
+
+    it('project-level override takes precedence over patterns', async () => {
+      const { selectModel } = await import('./model-router.js');
+      mockRouterDb.all.mockReturnValue([{ actionSummary: 'opus', consistencyScore: 0.95 }]);
+      const result = selectModel({
+        workItem: makeWorkItem(),
+        role: 'developer',
+        projectId: 'proj',
+        modelRouterConfig: { overrides: { developer: 'haiku' } },
+      });
+      expect(result?.tier).toBe('haiku');
+      expect(result?.reason).toBe('project-override');
+    });
+  });
+});

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -64,7 +64,9 @@ export type EventKind =
   // M11.14 auto-trigger — coach dispatch events from cross-run retro
   | 'coach.dispatch-triggered'
   | 'coach.skipped-forbidden-target'
-  | 'coach.dispatch-failed';
+  | 'coach.dispatch-failed'
+  // M11.15 model router — predictive model selection
+  | 'agent.model-selected';
 
 export interface AgentEvent {
   id: number;

--- a/core/types.ts
+++ b/core/types.ts
@@ -71,6 +71,15 @@ export interface AgentConfig {
     deepTriggers: string[];
   };
   coachPolicy?: CoachPolicy;
+  modelRouter?: {
+    /**
+     * Project-level override table for model tier selection.
+     * Keys are "role" (applies to all items for that role) or
+     * "role+type:TYPE" / "role+priority:PRIORITY" for finer-grained control.
+     * Example: { "developer+type:bug": "sonnet", "developer": "haiku" }
+     */
+    overrides?: Record<string, ModelTier>;
+  };
 }
 
 export interface BudgetConfig {

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -4,6 +4,8 @@ import { adviseOnPlan } from '@goose-hub/core/agent-runtime/advisor.js';
 import { resolveBudgets } from '@goose-hub/core/agent-runtime/budgets.js';
 import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { selectModel } from '@goose-hub/core/agent-runtime/model-router.js';
+import { defaultModelForTier, tierOf } from '@goose-hub/core/agent-runtime/models.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
@@ -293,6 +295,33 @@ interface ImplementOutputShape {
 
 async function runImplement(input: RunImplementInput): Promise<ImplementOutputShape> {
   const projectConfig = await getProjectBySlug(input.projectId);
+  const { budgets, modelOverride: budgetModelOverride } = resolveBudgets(
+    'implement',
+    projectConfig?.budgets,
+  );
+
+  const routerResult = selectModel({
+    workItem: input.workItem,
+    role: 'developer',
+    projectId: input.projectId,
+    modelRouterConfig: projectConfig?.agentConfig?.modelRouter,
+  });
+  const modelOverride =
+    routerResult != null ? defaultModelForTier(routerResult.tier) : budgetModelOverride;
+
+  eventStore.appendEvent({
+    projectId: input.projectId,
+    workItemId: input.workItem.id,
+    kind: 'agent.model-selected',
+    payload: {
+      runId: input.runId,
+      role: 'developer',
+      selectedTier: routerResult?.tier ?? tierOf(budgetModelOverride),
+      reason: routerResult?.reason ?? 'budget-default',
+    },
+    runId: input.runId,
+  });
+
   const { output } = await runWithEscalation({
     runtime: input.runtime,
     schema: ImplementSchema,
@@ -332,7 +361,8 @@ async function runImplement(input: RunImplementInput): Promise<ImplementOutputSh
       freshContext: false,
       toolBundles: ['dev-tools'],
       toolExtras: [],
-      ...resolveBudgets('implement', projectConfig?.budgets),
+      budgets,
+      modelOverride,
       personaId: input.personaId,
       outputJsonSchema: input.outputJsonSchema,
       appendSystemPrompt: input.appendSystemPrompt,


### PR DESCRIPTION
Closes #529

## What ships

- `core/agent-runtime/model-router.ts` — `selectModel({ workItem, role, projectId, modelRouterConfig })` returns `{ tier, reason } | null`
- `MODEL_SELECTION_OUTCOME` added to `DecisionKindSchema` for pattern mining
- `agent.model-selected` event kind added to the event store
- `agentConfig.modelRouter.overrides` config field on `AgentConfig`
- Fix-issue dispatch path (`runImplement`) calls the router before building the `AgentSpec`, overriding the budget's default `modelTier` with the router's selection and emitting `agent.model-selected`

## Resolution order

1. Project-level override (`agentConfig.modelRouter.overrides`) — keyed by `"role"`, `"role+type:TYPE"`, or `"role+priority:PRIORITY"`
2. Pattern-informed (`decision_patterns` with `kind=MODEL_SELECTION_OUTCOME`, `consistencyScore > 0.7`)
3. Static policy (priority:high/critical → sonnet; type:bug → haiku; type:chore → haiku; type:feature → sonnet with large-feature variant; default → sonnet)

Holdout roles (`qa`, `reviewer`) return `null` — their skill-configured tier is preserved unchanged.

## Tests

16 new tests in `core/agent-runtime/slice.test.ts` covering: each static policy branch, priority-overrides-type, holdout bypass, project override specificity, pattern-informed with and without patterns, unrecognised pattern tier fallback, override takes precedence over patterns.

---
_Generated by [Claude Code](https://claude.ai/code/session_015CLT5JiKf4iJctRMMgWcn9)_