### PR TITLE
M11.06: Move-with-dependencies CLI and UI confirmation

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,12 @@ import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { db } from '@goose-hub/core/db/db.js';
 import { agentRunCosts } from '@goose-hub/core/db/schema.js';
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
+import {
+  type DepMoveMode,
+  type FetchLifecycleFn,
+  type SetScheduleFn,
+  moveIssueToCurrent,
+} from '@goose-hub/core/projects/move-with-deps.js';
 import { STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
@@ -348,6 +354,115 @@ async function runAgentCommand(rawArgs: string[]): Promise<void> {
   process.exit(0);
 }
 
+async function taskMoveCommand(rawArgs: string[]): Promise<void> {
+  // goose task move <slug> <issue-id> --to=<schedule> [--with-dependencies | --ignore-dependencies]
+  const [slug = '', id = '', ...rest] = rawArgs;
+  let to = 'current';
+  let withDeps: boolean | null = null;
+
+  for (const arg of rest) {
+    if (arg.startsWith('--to=')) to = arg.slice('--to='.length);
+    else if (arg === '--with-dependencies') withDeps = true;
+    else if (arg === '--ignore-dependencies') withDeps = false;
+  }
+
+  if (!slug || !id) {
+    console.error(
+      'Usage: goose task move <project-slug> <issue-id> --to=<schedule> [--with-dependencies | --ignore-dependencies]',
+    );
+    process.exit(1);
+  }
+
+  if (to !== 'current') {
+    console.error(`Only --to=current is supported. Got: --to=${to}`);
+    process.exit(1);
+  }
+
+  const projects = await loadProjects(targetProjectsRoot);
+  const config = projects.find((p) => p.slug === slug);
+  if (!config) {
+    console.error(`Unknown project: ${slug}. Known: ${projects.map((p) => p.slug).join(', ')}`);
+    process.exit(1);
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('GITHUB_TOKEN is required. Set it in .env or the environment.');
+    process.exit(1);
+  }
+
+  const source = new GitHubLabelsSource(config.id, config.source.repo, token);
+  let item: WorkItem;
+  try {
+    item = await source.getItem(id);
+  } catch (err) {
+    console.error(`Failed to fetch issue #${id}: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  const hasDeps = item.dependsOn.length > 0;
+  if (hasDeps && withDeps === null) {
+    console.error(
+      `Issue #${id} has dependencies. Choose one:\n  --with-dependencies   Move issue and all open deps\n  --ignore-dependencies Move issue only`,
+    );
+    process.exit(1);
+  }
+
+  const mode: DepMoveMode = withDeps === false ? 'ignore-dependencies' : 'with-dependencies';
+
+  const fetchLifecycle: FetchLifecycleFn = async (repoRef, issueNumber) => {
+    const url = `https://api.github.com/repos/${repoRef}/issues/${issueNumber}`;
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      if (!res.ok) return 'open';
+      const json = (await res.json()) as { state: 'open' | 'closed' };
+      return json.state;
+    } catch {
+      return 'open';
+    }
+  };
+
+  const setSchedule: SetScheduleFn = async (repoRef, issueNumber, schedule) => {
+    const depSource = new GitHubLabelsSource(config.id, repoRef, token);
+    await depSource.setLabelInGroup(String(issueNumber), 'schedule', schedule);
+  };
+
+  let result: Awaited<ReturnType<typeof moveIssueToCurrent>>;
+  try {
+    result = await moveIssueToCurrent(
+      item.body,
+      config.source.repo,
+      Number(item.externalId),
+      mode,
+      fetchLifecycle,
+      setSchedule,
+    );
+  } catch (err) {
+    console.error(`Move failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  console.log(`Moved #${id} to schedule:current.`);
+  if (result.depsMoved.length > 0) {
+    console.log('\nAlso moved dependencies:');
+    for (const dep of result.depsMoved) {
+      console.log(`  ${dep.repoRef}#${dep.issueNumber}`);
+    }
+  }
+  if (result.depsSkipped.length > 0) {
+    console.log('\nSkipped (closed or ignored):');
+    for (const dep of result.depsSkipped) {
+      console.log(`  ${dep.repoRef}#${dep.issueNumber} [${dep.lifecycle}]`);
+    }
+  }
+}
+
 const [, , command, ...args] = process.argv;
 
 switch (command) {
@@ -360,6 +475,16 @@ switch (command) {
   case 'run-agent':
     await runAgentCommand(args);
     break;
+  case 'task':
+    if (args[0] === 'move') {
+      await taskMoveCommand(args.slice(1));
+    } else {
+      console.error(
+        'Usage: goose task move <project-slug> <issue-id> --to=current [--with-dependencies | --ignore-dependencies]',
+      );
+      process.exit(1);
+    }
+    break;
   default:
     console.error('Usage: goose <command> [args]');
     console.error('Commands:');
@@ -367,6 +492,9 @@ switch (command) {
     console.error('  sweep <project-slug> <milestone> Archive non-terminal issues in a milestone');
     console.error(
       "  run-agent --skill=<name> --input='<json>' [--project=<slug>] [--dry-run]  Run a skill agent",
+    );
+    console.error(
+      '  task move <project-slug> <issue-id> --to=current [--with-dependencies | --ignore-dependencies]',
     );
     process.exit(1);
 }

--- a/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
+++ b/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
@@ -27,6 +27,7 @@ function resolveDepTarget(
 // ─── types ───────────────────────────────────────────────────────────────────
 
 interface MovableDep {
+  depKey: string;
   issueNumber: number;
   refLabel: string;
   title: string;
@@ -58,7 +59,7 @@ export function MoveToCurrentDialog({
 }: MoveToCurrentDialogProps) {
   const [phase, setPhase] = useState<'loading' | 'dialog' | 'working'>('loading');
   const [movableDeps, setMovableDeps] = useState<MovableDep[]>([]);
-  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [checked, setChecked] = useState<Set<string>>(new Set());
   const [error, setError] = useState('');
   // Guards against StrictMode double-firing and subsequent data refreshes re-triggering.
   const triggered = useRef(false);
@@ -113,7 +114,9 @@ export function MoveToCurrentDialog({
       if (!isOpenState(depItem.state)) continue;
       if (depItem.schedule === 'current') continue;
 
+      const repoRef = ref.repoRef ?? item.repoRef;
       movable.push({
+        depKey: `${repoRef}#${ref.issueNumber}`,
         issueNumber: ref.issueNumber,
         refLabel: ref.repoRef != null ? `${ref.repoRef}#${ref.issueNumber}` : `#${ref.issueNumber}`,
         title: depItem.title,
@@ -124,7 +127,7 @@ export function MoveToCurrentDialog({
     return movable;
     // depQueries is intentionally included to recompute when query results arrive.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allLoaded, deps, targets, depQueries, projects.length]);
+  }, [allLoaded, deps, targets, depQueries, projects.length, item.repoRef]);
 
   const doMove = useCallback(
     async (depsToMove: MovableDep[]) => {
@@ -154,21 +157,21 @@ export function MoveToCurrentDialog({
       void doMove([]);
     } else {
       setMovableDeps(movableComputed);
-      setChecked(new Set(movableComputed.map((d) => d.issueNumber)));
+      setChecked(new Set(movableComputed.map((d) => d.depKey)));
       setPhase('dialog');
     }
   }, [movableComputed, doMove]);
 
   const handleConfirm = () => {
-    const selected = movableDeps.filter((d) => checked.has(d.issueNumber));
+    const selected = movableDeps.filter((d) => checked.has(d.depKey));
     void doMove(selected);
   };
 
-  const toggleDep = (issueNumber: number) => {
+  const toggleDep = (depKey: string) => {
     setChecked((prev) => {
       const next = new Set(prev);
-      if (next.has(issueNumber)) next.delete(issueNumber);
-      else next.add(issueNumber);
+      if (next.has(depKey)) next.delete(depKey);
+      else next.add(depKey);
       return next;
     });
   };
@@ -202,7 +205,7 @@ export function MoveToCurrentDialog({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 16 }}>
               {movableDeps.map((dep) => (
                 <label
-                  key={dep.issueNumber}
+                  key={dep.depKey}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
@@ -213,10 +216,10 @@ export function MoveToCurrentDialog({
                 >
                   <input
                     type="checkbox"
-                    checked={checked.has(dep.issueNumber)}
-                    onChange={() => toggleDep(dep.issueNumber)}
+                    checked={checked.has(dep.depKey)}
+                    onChange={() => toggleDep(dep.depKey)}
                     disabled={phase === 'working'}
-                    data-testid={`dep-checkbox-${dep.issueNumber}`}
+                    data-testid={`dep-checkbox-${dep.depKey}`}
                   />
                   <span style={{ fontFamily: 'monospace', color: 'var(--accent)', flexShrink: 0 }}>
                     {dep.refLabel}

--- a/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
+++ b/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
@@ -1,0 +1,311 @@
+import { fetchIssue, fetchProjects, setLabel } from '@/lib/api';
+import { parseDependencies } from '@/lib/dependency-parser';
+import type { ProjectSummary, WorkItemDto } from '@/lib/types';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+// ─── helpers (mirrors DependenciesSection / useHasOpenDep) ───────────────────
+
+function isOpenState(state: string): boolean {
+  return state !== 'factory:done' && state !== 'factory:archived';
+}
+
+function resolveDepTarget(
+  ref: { repoRef: string | null; issueNumber: number },
+  currentSlug: string,
+  currentRepoRef: string,
+  projects: ProjectSummary[],
+): { slug: string; id: string } | 'unregistered' {
+  if (ref.repoRef === null || ref.repoRef === currentRepoRef) {
+    return { slug: currentSlug, id: String(ref.issueNumber) };
+  }
+  const match = projects.find((p) => p.source.repo === ref.repoRef);
+  if (match == null) return 'unregistered';
+  return { slug: match.slug, id: String(ref.issueNumber) };
+}
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+interface MovableDep {
+  issueNumber: number;
+  refLabel: string;
+  title: string;
+  slug: string;
+  id: string;
+}
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+interface MoveToCurrentDialogProps {
+  item: WorkItemDto;
+  projectSlug: string;
+  /** Called after the issue (and any selected deps) have been moved. */
+  onComplete: () => void;
+  /** Called when the user cancels without moving. */
+  onCancel: () => void;
+}
+
+/**
+ * Shows a confirmation dialog when moving an issue to schedule:current and it
+ * has open dependencies. If all deps are already closed or schedule:current the
+ * dialog is skipped and the issue moves immediately.
+ */
+export function MoveToCurrentDialog({
+  item,
+  projectSlug,
+  onComplete,
+  onCancel,
+}: MoveToCurrentDialogProps) {
+  const [phase, setPhase] = useState<'loading' | 'dialog' | 'working'>('loading');
+  const [movableDeps, setMovableDeps] = useState<MovableDep[]>([]);
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [error, setError] = useState('');
+  // Guards against StrictMode double-firing and subsequent data refreshes re-triggering.
+  const triggered = useRef(false);
+
+  const deps = useMemo(
+    () => parseDependencies(item.body).filter((d) => d.type === 'depends-on'),
+    [item.body],
+  );
+
+  const { data: projects = [] } = useQuery<ProjectSummary[]>({
+    queryKey: ['projects'],
+    queryFn: fetchProjects,
+    enabled: deps.length > 0,
+  });
+
+  const targets = useMemo(
+    () => deps.map((ref) => resolveDepTarget(ref, projectSlug, item.repoRef, projects)),
+    [deps, projectSlug, item.repoRef, projects],
+  );
+
+  const depQueries = useQueries({
+    queries: deps.map((ref, i) => {
+      const target = targets[i];
+      return {
+        queryKey: ['dep-issue', ref.repoRef ?? item.repoRef, ref.issueNumber],
+        queryFn: async (): Promise<WorkItemDto | null> => {
+          if (target === 'unregistered') return null;
+          return fetchIssue(target.slug, target.id);
+        },
+        enabled: target !== 'unregistered',
+      };
+    }),
+  });
+
+  const allLoaded =
+    deps.length === 0 ||
+    (depQueries.length > 0 && depQueries.every((q) => !q.isLoading && !q.isPending));
+
+  // Compute movable deps as a memoized value so the effect dep array stays stable.
+  const movableComputed = useMemo((): MovableDep[] | null => {
+    if (!allLoaded) return null;
+    if (deps.length > 0 && projects.length === 0) return null;
+
+    const movable: MovableDep[] = [];
+    for (let i = 0; i < deps.length; i++) {
+      const ref = deps[i];
+      const target = targets[i];
+      const depItem = depQueries[i]?.data;
+
+      if (target === 'unregistered') continue;
+      if (!depItem) continue;
+      if (!isOpenState(depItem.state)) continue;
+      if (depItem.schedule === 'current') continue;
+
+      movable.push({
+        issueNumber: ref.issueNumber,
+        refLabel: ref.repoRef != null ? `${ref.repoRef}#${ref.issueNumber}` : `#${ref.issueNumber}`,
+        title: depItem.title,
+        slug: (target as { slug: string; id: string }).slug,
+        id: (target as { slug: string; id: string }).id,
+      });
+    }
+    return movable;
+    // depQueries is intentionally included to recompute when query results arrive.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allLoaded, deps, targets, depQueries, projects.length]);
+
+  const doMove = useCallback(
+    async (depsToMove: MovableDep[]) => {
+      setPhase('working');
+      setError('');
+      try {
+        for (const dep of depsToMove) {
+          await setLabel(dep.slug, dep.id, 'schedule', 'current');
+        }
+        await setLabel(projectSlug, item.externalId, 'schedule', 'current');
+        onComplete();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Move failed.');
+        setPhase('dialog');
+      }
+    },
+    [projectSlug, item.externalId, onComplete],
+  );
+
+  // When movableComputed transitions from null → array, decide whether to
+  // show the dialog or auto-proceed. Runs at most once (triggered ref).
+  useEffect(() => {
+    if (movableComputed === null || triggered.current) return;
+    triggered.current = true;
+
+    if (movableComputed.length === 0) {
+      void doMove([]);
+    } else {
+      setMovableDeps(movableComputed);
+      setChecked(new Set(movableComputed.map((d) => d.issueNumber)));
+      setPhase('dialog');
+    }
+  }, [movableComputed, doMove]);
+
+  const handleConfirm = () => {
+    const selected = movableDeps.filter((d) => checked.has(d.issueNumber));
+    void doMove(selected);
+  };
+
+  const toggleDep = (issueNumber: number) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(issueNumber)) next.delete(issueNumber);
+      else next.add(issueNumber);
+      return next;
+    });
+  };
+
+  return (
+    <div
+      style={overlayStyle}
+      onClick={phase === 'loading' ? onCancel : undefined}
+      onKeyDown={(e) => e.key === 'Escape' && onCancel()}
+      data-testid="move-to-current-dialog"
+    >
+      <div
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.key === 'Escape' && onCancel()}
+      >
+        {phase === 'loading' && (
+          <p style={{ color: 'var(--fg-2)', fontSize: 13, margin: 0 }}>Checking dependencies…</p>
+        )}
+
+        {(phase === 'dialog' || phase === 'working') && (
+          <>
+            <h2 style={{ margin: '0 0 10px', fontSize: 15, fontWeight: 600 }}>
+              Move to current sprint
+            </h2>
+            <p style={{ fontSize: 13, color: 'var(--fg-2)', margin: '0 0 12px' }}>
+              This issue has open dependencies. Select which to move to{' '}
+              <code style={{ fontSize: 12 }}>schedule:current</code> together:
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 16 }}>
+              {movableDeps.map((dep) => (
+                <label
+                  key={dep.issueNumber}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    cursor: phase === 'working' ? 'not-allowed' : 'pointer',
+                    fontSize: 13,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked.has(dep.issueNumber)}
+                    onChange={() => toggleDep(dep.issueNumber)}
+                    disabled={phase === 'working'}
+                    data-testid={`dep-checkbox-${dep.issueNumber}`}
+                  />
+                  <span style={{ fontFamily: 'monospace', color: 'var(--accent)', flexShrink: 0 }}>
+                    {dep.refLabel}
+                  </span>
+                  <span
+                    style={{
+                      color: 'var(--fg)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={dep.title}
+                  >
+                    {dep.title}
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            {error && (
+              <p style={{ fontSize: 12, color: 'var(--danger, #e05)', margin: '0 0 12px' }}>
+                {error}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button
+                type="button"
+                onClick={onCancel}
+                disabled={phase === 'working'}
+                style={cancelBtnStyle}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={phase === 'working'}
+                data-testid="move-confirm-btn"
+                style={confirmBtnStyle}
+              >
+                {phase === 'working' ? 'Moving…' : 'Move to current'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── styles ──────────────────────────────────────────────────────────────────
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 50,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,0,0,0.45)',
+};
+
+const panelStyle: React.CSSProperties = {
+  background: 'var(--bg-elev)',
+  border: '1px solid var(--line)',
+  borderRadius: 8,
+  padding: 24,
+  width: '100%',
+  maxWidth: 480,
+  color: 'var(--fg)',
+};
+
+const cancelBtnStyle: React.CSSProperties = {
+  padding: '5px 14px',
+  borderRadius: 6,
+  border: '1px solid var(--line)',
+  background: 'var(--bg)',
+  color: 'var(--fg-2)',
+  fontSize: 13,
+  cursor: 'pointer',
+};
+
+const confirmBtnStyle: React.CSSProperties = {
+  padding: '5px 14px',
+  borderRadius: 6,
+  border: 'none',
+  background: 'var(--accent, #6366f1)',
+  color: '#fff',
+  fontSize: 13,
+  cursor: 'pointer',
+};

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -1,5 +1,6 @@
 import { fetchMilestones, setLabel, setMilestone } from '@/lib/api';
 import { PRIORITY_BG, PRIORITY_BORDER, PRIORITY_COLOR, STATE_LABEL } from '@/lib/constants';
+import { parseDependencies } from '@/lib/dependency-parser';
 import { laneForState } from '@/lib/lanes.config';
 import type { MilestoneDto, WorkItemDto } from '@/lib/types';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
@@ -7,6 +8,7 @@ import { formatCost, formatTokens } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useIssueCostsBreakdown } from '../lib/costs';
+import { MoveToCurrentDialog } from './MoveToCurrentDialog';
 import { PillSelect } from './PillSelect';
 import { TransitionButton } from './TransitionButton';
 
@@ -21,6 +23,7 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
   const [savingPriority, setSavingPriority] = useState(false);
   const [savingSchedule, setSavingSchedule] = useState(false);
   const [savingMilestone, setSavingMilestone] = useState(false);
+  const [showMoveDialog, setShowMoveDialog] = useState(false);
 
   const { data: milestones = [] } = useQuery<MilestoneDto[]>({
     queryKey: ['milestones', projectSlug],
@@ -52,6 +55,19 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
 
   const onSchedule = async (value: string) => {
     if (!item) return;
+
+    // When moving to schedule:current, check for open deps first.
+    // If the item has any `depends-on` entries, open the dialog which either
+    // auto-proceeds (all deps already satisfied) or presents a checkbox list.
+    if (value === 'current') {
+      const hasDeps =
+        parseDependencies(item.body).filter((d) => d.type === 'depends-on').length > 0;
+      if (hasDeps) {
+        setShowMoveDialog(true);
+        return;
+      }
+    }
+
     setSavingSchedule(true);
     try {
       await setLabel(projectSlug, item.externalId, 'schedule', value);
@@ -87,137 +103,151 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
     (item?.milestoneId != null ? `#${item.milestoneId}` : 'milestone');
 
   return (
-    <div data-testid="task-header" className="px-6 py-4 border-b border-line bg-bg-elev shrink-0">
-      <div className="flex items-start gap-4">
-        <div className="flex flex-col grow min-w-0">
-          <h1 className="text-[22px] font-semibold tracking-tight leading-tight text-fg">
-            {item?.title}
-          </h1>
-          <div className="text-[12.5px] text-fg-3 mt-1">
-            {lane} · {lastPersonaLabel}
+    <>
+      <div data-testid="task-header" className="px-6 py-4 border-b border-line bg-bg-elev shrink-0">
+        <div className="flex items-start gap-4">
+          <div className="flex flex-col grow min-w-0">
+            <h1 className="text-[22px] font-semibold tracking-tight leading-tight text-fg">
+              {item?.title}
+            </h1>
+            <div className="text-[12.5px] text-fg-3 mt-1">
+              {lane} · {lastPersonaLabel}
+            </div>
           </div>
         </div>
-      </div>
-      <div className="flex items-center gap-3 mt-3 text-[11.5px] text-fg-3 flex-wrap">
-        <span>by {item?.authorIsOwner ? 'owner' : 'guest'}</span>
-        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span>opened {item?.createdAt ? new Date(item?.createdAt).toLocaleString() : ''}</span>
-        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span data-testid="task-header-cost">
-          cost{' '}
+        <div className="flex items-center gap-3 mt-3 text-[11.5px] text-fg-3 flex-wrap">
+          <span>by {item?.authorIsOwner ? 'owner' : 'guest'}</span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span>opened {item?.createdAt ? new Date(item?.createdAt).toLocaleString() : ''}</span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span data-testid="task-header-cost">
+            cost{' '}
+            <span
+              className="font-mono"
+              title={
+                costs.runCount === 0
+                  ? 'No agent runs recorded yet'
+                  : `${formatTokens(costs.totalTokens)} tokens across ${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`
+              }
+            >
+              {costs.runCount === 0 ? '$—' : formatCost(costs.total, costs.totalLabel)}
+            </span>
+          </span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span title="Duration tracking available in M9" data-testid="duration-placeholder">
+            duration <span className="font-mono">—</span>
+          </span>
+          {/* Type — static, leftmost */}
+          <span className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">
+            {item?.type}
+          </span>
+
+          <div className="flex grow" />
+          {hasOpenDep && (
+            <span
+              data-testid="blocked-badge"
+              className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] border font-medium"
+              style={{
+                color: 'var(--warning)',
+                background: 'oklch(from var(--warning) l c h / 0.12)',
+                borderColor: 'oklch(from var(--warning) l c h / 0.4)',
+              }}
+            >
+              Blocked
+            </span>
+          )}
+          {/* State — static accent pill */}
           <span
-            className="font-mono"
-            title={
-              costs.runCount === 0
-                ? 'No agent runs recorded yet'
-                : `${formatTokens(costs.totalTokens)} tokens across ${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`
-            }
+            data-testid="state-pill"
+            className="inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full text-[11.5px] bg-accent-soft border border-accent-line text-fg"
           >
-            {costs.runCount === 0 ? '$—' : formatCost(costs.total, costs.totalLabel)}
+            <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />
+            <span className="font-medium">
+              {item?.state ? (STATE_LABEL[item?.state] ?? item?.state) : ''}
+            </span>
           </span>
-        </span>
-        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span title="Duration tracking available in M9" data-testid="duration-placeholder">
-          duration <span className="font-mono">—</span>
-        </span>
-        {/* Type — static, leftmost */}
-        <span className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">
-          {item?.type}
-        </span>
 
-        <div className="flex grow" />
-        {hasOpenDep && (
-          <span
-            data-testid="blocked-badge"
-            className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] border font-medium"
-            style={{
-              color: 'var(--warning)',
-              background: 'oklch(from var(--warning) l c h / 0.12)',
-              borderColor: 'oklch(from var(--warning) l c h / 0.4)',
-            }}
-          >
-            Blocked
-          </span>
-        )}
-        {/* State — static accent pill */}
-        <span
-          data-testid="state-pill"
-          className="inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full text-[11.5px] bg-accent-soft border border-accent-line text-fg"
-        >
-          <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />
-          <span className="font-medium">
-            {item?.state ? (STATE_LABEL[item?.state] ?? item?.state) : ''}
-          </span>
-        </span>
+          {/* Priority — pill select */}
+          {item && (
+            <PillSelect
+              data-testid="priority-pill"
+              value={item.priority}
+              label="priority"
+              saving={savingPriority}
+              pillStyle={{
+                color: priorityColor,
+                background: priorityBg,
+                borderColor: priorityBorder,
+              }}
+              options={[
+                { value: 'low', label: 'low' },
+                { value: 'medium', label: 'medium' },
+                { value: 'high', label: 'high' },
+                { value: 'critical', label: 'critical' },
+              ]}
+              onSelect={(v) => void onPriority(v)}
+            />
+          )}
 
-        {/* Priority — pill select */}
-        {item && (
-          <PillSelect
-            data-testid="priority-pill"
-            value={item.priority}
-            label="priority"
-            saving={savingPriority}
-            pillStyle={{
-              color: priorityColor,
-              background: priorityBg,
-              borderColor: priorityBorder,
-            }}
-            options={[
-              { value: 'low', label: 'low' },
-              { value: 'medium', label: 'medium' },
-              { value: 'high', label: 'high' },
-              { value: 'critical', label: 'critical' },
-            ]}
-            onSelect={(v) => void onPriority(v)}
-          />
-        )}
+          {/* Schedule — pill select */}
+          {item && (
+            <PillSelect
+              data-testid="schedule-pill"
+              value={item.schedule}
+              label="schedule"
+              saving={savingSchedule}
+              pillStyle={{
+                color: 'var(--fg-2)',
+                background: 'var(--bg-elev)',
+                borderColor: 'var(--line)',
+              }}
+              options={[
+                { value: 'current', label: 'current' },
+                { value: 'backlog', label: 'backlog' },
+                { value: 'icebox', label: 'icebox' },
+              ]}
+              onSelect={(v) => void onSchedule(v)}
+            />
+          )}
 
-        {/* Schedule — pill select */}
-        {item && (
-          <PillSelect
-            data-testid="schedule-pill"
-            value={item.schedule}
-            label="schedule"
-            saving={savingSchedule}
-            pillStyle={{
-              color: 'var(--fg-2)',
-              background: 'var(--bg-elev)',
-              borderColor: 'var(--line)',
-            }}
-            options={[
-              { value: 'current', label: 'current' },
-              { value: 'backlog', label: 'backlog' },
-              { value: 'icebox', label: 'icebox' },
-            ]}
-            onSelect={(v) => void onSchedule(v)}
-          />
-        )}
+          {/* Milestone — pill select */}
+          {item && milestones.length > 0 && (
+            <PillSelect
+              data-testid="milestone-pill"
+              value={currentMilestoneLabel}
+              label="milestone"
+              saving={savingMilestone}
+              pillStyle={{
+                color: 'var(--fg-2)',
+                background: 'var(--bg-elev)',
+                borderColor: 'var(--line)',
+              }}
+              options={milestoneOptions}
+              onSelect={(v) => void onMilestone(v)}
+            />
+          )}
 
-        {/* Milestone — pill select */}
-        {item && milestones.length > 0 && (
-          <PillSelect
-            data-testid="milestone-pill"
-            value={currentMilestoneLabel}
-            label="milestone"
-            saving={savingMilestone}
-            pillStyle={{
-              color: 'var(--fg-2)',
-              background: 'var(--bg-elev)',
-              borderColor: 'var(--line)',
-            }}
-            options={milestoneOptions}
-            onSelect={(v) => void onMilestone(v)}
-          />
-        )}
-
-        {item && (
-          <TransitionButton
-            projectSlug={projectSlug}
-            id={item?.externalId}
-            currentState={item?.state}
-          />
-        )}
+          {item && (
+            <TransitionButton
+              projectSlug={projectSlug}
+              id={item?.externalId}
+              currentState={item?.state}
+            />
+          )}
+        </div>
       </div>
-    </div>
+
+      {showMoveDialog && item && (
+        <MoveToCurrentDialog
+          item={item}
+          projectSlug={projectSlug}
+          onComplete={() => {
+            setShowMoveDialog(false);
+            invalidate();
+          }}
+          onCancel={() => setShowMoveDialog(false)}
+        />
+      )}
+    </>
   );
 }

--- a/core/projects/move-with-deps.ts
+++ b/core/projects/move-with-deps.ts
@@ -1,0 +1,69 @@
+import { parseDependencies } from '../state-source/dependency-parser.js';
+
+export type DepMoveMode = 'with-dependencies' | 'ignore-dependencies';
+
+export interface DepInfo {
+  repoRef: string;
+  issueNumber: number;
+  lifecycle: 'open' | 'closed';
+}
+
+export interface MoveWithDepsResult {
+  depsMoved: DepInfo[];
+  depsSkipped: DepInfo[];
+}
+
+export type FetchLifecycleFn = (repoRef: string, issueNumber: number) => Promise<'open' | 'closed'>;
+
+export type SetScheduleFn = (
+  repoRef: string,
+  issueNumber: number,
+  schedule: string,
+) => Promise<void>;
+
+/**
+ * Move an issue to schedule:current, optionally moving its open dependencies too.
+ *
+ * Classification:
+ *  - closed deps are always skipped (already satisfied)
+ *  - open deps: moved when mode='with-dependencies', skipped when 'ignore-dependencies'
+ *
+ * The issue itself is always moved regardless of mode.
+ */
+export async function moveIssueToCurrent(
+  itemBody: string,
+  currentRepo: string,
+  currentIssueNumber: number,
+  mode: DepMoveMode,
+  fetchLifecycle: FetchLifecycleFn,
+  setSchedule: SetScheduleFn,
+): Promise<MoveWithDepsResult> {
+  const refs = parseDependencies(itemBody).filter((r) => r.type === 'depends-on');
+
+  const depInfos: DepInfo[] = await Promise.all(
+    refs.map(async (ref) => {
+      const repoRef = ref.repoRef ?? currentRepo;
+      const lifecycle = await fetchLifecycle(repoRef, ref.issueNumber);
+      return { repoRef, issueNumber: ref.issueNumber, lifecycle };
+    }),
+  );
+
+  const openDeps = depInfos.filter((d) => d.lifecycle === 'open');
+  const closedDeps = depInfos.filter((d) => d.lifecycle === 'closed');
+
+  const depsMoved: DepInfo[] = [];
+  const depsSkipped: DepInfo[] = [...closedDeps];
+
+  if (mode === 'with-dependencies') {
+    for (const dep of openDeps) {
+      await setSchedule(dep.repoRef, dep.issueNumber, 'current');
+      depsMoved.push(dep);
+    }
+  } else {
+    depsSkipped.push(...openDeps);
+  }
+
+  await setSchedule(currentRepo, currentIssueNumber, 'current');
+
+  return { depsMoved, depsSkipped };
+}

--- a/slices/move-with-deps/README.md
+++ b/slices/move-with-deps/README.md
@@ -1,0 +1,41 @@
+# slices/move-with-deps
+
+M11.06: Move-with-dependencies CLI and UI confirmation.
+
+## What this slice does
+
+Moves an issue to `schedule:current`, optionally pulling its open dependencies along.
+
+Core logic lives in `core/projects/move-with-deps.ts`. The slice is intentionally pure — all I/O is injected so it is unit-testable without hitting GitHub.
+
+## Surfaces touched
+
+| Surface | Change |
+|---------|--------|
+| `core/projects/move-with-deps.ts` | New: `moveIssueToCurrent()`, types |
+| `apps/cli/src/index.ts` | New `goose task move` command |
+| `apps/web/…/MoveToCurrentDialog.tsx` | New: dep-aware confirmation dialog |
+| `apps/web/…/TaskHeader.tsx` | Intercepts schedule→current selection |
+
+## CLI usage
+
+```sh
+goose task move <project-slug> <issue-id> --to=current --with-dependencies
+goose task move <project-slug> <issue-id> --to=current --ignore-dependencies
+```
+
+Without either flag, the CLI errors when open dependencies exist, requiring an explicit choice.
+
+## UI behaviour
+
+When the user selects `schedule:current` on an issue that has `Depends on` entries:
+
+1. A dialog opens listing open dependencies with checkboxes (all checked by default).
+2. The user can uncheck deps they do not want to move.
+3. If all deps are already closed or in `schedule:current`, the dialog is skipped and the issue moves immediately.
+
+## Tests
+
+```sh
+pnpm vitest run slices/move-with-deps/slice.test.ts
+```

--- a/slices/move-with-deps/slice.test.ts
+++ b/slices/move-with-deps/slice.test.ts
@@ -1,0 +1,134 @@
+import { moveIssueToCurrent } from '@goose-hub/core/projects/move-with-deps.js';
+import type { FetchLifecycleFn, SetScheduleFn } from '@goose-hub/core/projects/move-with-deps.js';
+import { describe, expect, it, vi } from 'vitest';
+
+const REPO = 'shaunnez/goose-hub';
+const ISSUE = 100;
+
+describe('move-with-deps slice — moveIssueToCurrent', () => {
+  it('no deps → moves issue only; fetchLifecycle never called', async () => {
+    const fetchLifecycle = vi.fn<FetchLifecycleFn>();
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'No dependencies here.',
+      REPO,
+      ISSUE,
+      'with-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    expect(fetchLifecycle).not.toHaveBeenCalled();
+    expect(setSchedule).toHaveBeenCalledOnce();
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved).toHaveLength(0);
+    expect(result.depsSkipped).toHaveLength(0);
+  });
+
+  it('all deps closed → moves issue only; closed deps in depsSkipped', async () => {
+    const fetchLifecycle = vi.fn<FetchLifecycleFn>().mockResolvedValue('closed');
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'Depends on #50\nDepends on #51',
+      REPO,
+      ISSUE,
+      'with-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    expect(setSchedule).toHaveBeenCalledOnce();
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved).toHaveLength(0);
+    expect(result.depsSkipped).toHaveLength(2);
+    expect(result.depsSkipped.map((d) => d.issueNumber).sort()).toEqual([50, 51]);
+  });
+
+  it('open deps + with-dependencies → moves issue and all open deps', async () => {
+    const fetchLifecycle = vi.fn<FetchLifecycleFn>().mockResolvedValue('open');
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'Depends on #50\nDepends on #51',
+      REPO,
+      ISSUE,
+      'with-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    // setSchedule: dep #50, dep #51, then the issue itself
+    expect(setSchedule).toHaveBeenCalledTimes(3);
+    expect(setSchedule).toHaveBeenCalledWith(REPO, 50, 'current');
+    expect(setSchedule).toHaveBeenCalledWith(REPO, 51, 'current');
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved).toHaveLength(2);
+    expect(result.depsSkipped).toHaveLength(0);
+  });
+
+  it('open deps + ignore-dependencies → moves issue only; open deps in depsSkipped', async () => {
+    const fetchLifecycle = vi.fn<FetchLifecycleFn>().mockResolvedValue('open');
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'Depends on #50',
+      REPO,
+      ISSUE,
+      'ignore-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    expect(setSchedule).toHaveBeenCalledOnce();
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved).toHaveLength(0);
+    expect(result.depsSkipped).toHaveLength(1);
+    expect(result.depsSkipped[0].issueNumber).toBe(50);
+  });
+
+  it('mixed open+closed deps + with-dependencies → only open deps moved', async () => {
+    const fetchLifecycle = vi
+      .fn<FetchLifecycleFn>()
+      .mockImplementation(async (_repo, num) => (num === 50 ? 'closed' : 'open'));
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'Depends on #50\nDepends on #51',
+      REPO,
+      ISSUE,
+      'with-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    // #50 closed (skipped), #51 open (moved), issue moved
+    expect(setSchedule).toHaveBeenCalledTimes(2);
+    expect(setSchedule).toHaveBeenCalledWith(REPO, 51, 'current');
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved).toHaveLength(1);
+    expect(result.depsMoved[0].issueNumber).toBe(51);
+    expect(result.depsSkipped).toHaveLength(1);
+    expect(result.depsSkipped[0].issueNumber).toBe(50);
+  });
+
+  it('cross-repo dep → repoRef used for fetch and setSchedule', async () => {
+    const fetchLifecycle = vi.fn<FetchLifecycleFn>().mockResolvedValue('open');
+    const setSchedule = vi.fn<SetScheduleFn>().mockResolvedValue(undefined);
+
+    const result = await moveIssueToCurrent(
+      'Depends on other-owner/other-repo#77',
+      REPO,
+      ISSUE,
+      'with-dependencies',
+      fetchLifecycle,
+      setSchedule,
+    );
+
+    expect(fetchLifecycle).toHaveBeenCalledWith('other-owner/other-repo', 77);
+    expect(setSchedule).toHaveBeenCalledWith('other-owner/other-repo', 77, 'current');
+    expect(setSchedule).toHaveBeenCalledWith(REPO, ISSUE, 'current');
+    expect(result.depsMoved[0].repoRef).toBe('other-owner/other-repo');
+  });
+});


### PR DESCRIPTION
Closes #298

## Changes

- **`core/projects/move-with-deps.ts`** — pure `moveIssueToCurrent()` with injectable `FetchLifecycleFn` / `SetScheduleFn` types for testability; classifies deps as open/closed and moves or skips accordingly
- **`slices/move-with-deps/`** — 6 unit tests (no deps, all closed, open+with-deps, open+ignore-deps, mixed, cross-repo) and `README.md`
- **`apps/cli/src/index.ts`** — `goose task move <slug> <id> --to=current` with `--with-dependencies` / `--ignore-dependencies` flags; errors with guidance when open deps exist and no flag is supplied
- **`apps/web/…/MoveToCurrentDialog.tsx`** — modal listing open dependencies as checkboxes; auto-proceeds silently when all deps are already closed or schedule:current
- **`apps/web/…/TaskHeader.tsx`** — intercepts schedule:current selection and opens the dialog when the issue body contains `depends-on` references

---
_Generated by [Claude Code](https://claude.ai/code/session_018RcaaXeSFj5aExYTvMBmKn)_