### PR TITLE
M11.20: deterministic E2E pipeline harness — InMemoryLabelsSource + MOCK_SOURCE airtightness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,37 @@ jobs:
       - name: E2E tests
         run: pnpm test:e2e
         continue-on-error: true
+
+  pipeline-e2e:
+    name: Pipeline E2E (mock)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @goose-hub/web exec playwright install chromium --with-deps
+
+      - name: Build server
+        run: pnpm --filter @goose-hub/server build
+
+      - name: Run pipeline E2E (MOCK_AGENTS + MOCK_SOURCE)
+        run: pnpm --filter @goose-hub/web test:e2e:pipeline
+        env:
+          MOCK_AGENTS: 'true'
+          MOCK_SOURCE: 'true'
+          MOCK_OPEN_PR: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter @goose-hub/web exec playwright install chromium --with-deps
 
-      - name: Build server
-        run: pnpm --filter @goose-hub/server build
-
       - name: Run pipeline E2E (MOCK_AGENTS + MOCK_SOURCE)
         run: pnpm --filter @goose-hub/web test:e2e:pipeline
         env:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,41 @@
+name: E2E Nightly (real GitHub)
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 2am UTC daily
+  workflow_dispatch: {}
+
+jobs:
+  e2e-real:
+    name: Real-GitHub E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @goose-hub/web exec playwright install chromium --with-deps
+
+      - name: Build server
+        run: pnpm --filter @goose-hub/server build
+
+      - name: Run real-GitHub E2E specs
+        run: pnpm --filter @goose-hub/web test:e2e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MOCK_AGENTS: 'true'
+          MOCK_OPEN_PR: 'true'

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter @goose-hub/web exec playwright install chromium --with-deps
 
-      - name: Build server
-        run: pnpm --filter @goose-hub/server build
-
       - name: Run real-GitHub E2E specs
         run: pnpm --filter @goose-hub/web test:e2e
         env:

--- a/apps/server/src/domains/events/service.test.ts
+++ b/apps/server/src/domains/events/service.test.ts
@@ -8,7 +8,12 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 }));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import { parseSseFilter, recordDecisionSummary, recordToolCall, recordToolResult } from './service.js';
+import {
+  parseSseFilter,
+  recordDecisionSummary,
+  recordToolCall,
+  recordToolResult,
+} from './service.js';
 
 describe('parseSseFilter (#208)', () => {
   it('passes through projectId and workItemId from input', () => {

--- a/apps/server/src/domains/issues/diff.ts
+++ b/apps/server/src/domains/issues/diff.ts
@@ -111,6 +111,9 @@ async function tryGitHubPrDiff(
   repo: string,
   fetchImpl: typeof fetch,
 ): Promise<{ diff: string; prRunId: string | null } | null> {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return { diff: '--- a/mock.ts\n+++ b/mock.ts\n@@ -1 +1 @@\n-old\n+new\n', prRunId: null };
+  }
   const token = process.env.GITHUB_TOKEN ?? '';
   if (token.length === 0) return null;
   const prEvent = [...ascending]

--- a/apps/server/src/domains/issues/router.test.ts
+++ b/apps/server/src/domains/issues/router.test.ts
@@ -612,7 +612,7 @@ describe('POST /projects/:slug/issues/:id/approve', () => {
     const body = (await res.json()) as { ok: boolean; sha: string; prNumber: number };
     expect(body.sha).toBe('abc123');
     expect(body.prNumber).toBe(77);
-    expect(mockApproveIssue).toHaveBeenCalledWith('my-project', '42');
+    expect(mockApproveIssue).toHaveBeenCalledWith('my-project', '42', expect.any(Object));
   });
 
   it('returns 400 when no PR event found', async () => {

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -131,10 +131,16 @@ router.post('/:slug/issues/:id/repo-override', async (c) => {
 router.post('/:slug/issues/:id/approve', async (c) => {
   const slug = c.req.param('slug');
   const id = c.req.param('id');
-  const result = await approveIssue(slug, id);
-  if (!result.ok && result.error === 'merge-conflict') {
+  const mockMergePR =
+    process.env.MOCK_SOURCE === 'true'
+      ? () => Promise.resolve({ sha: 'mock-sha-merged', merged: true })
+      : undefined;
+  const result = await approveIssue(slug, id, { mergePRImpl: mockMergePR });
+  if (!result.ok && result.error === 'merge-conflict' && process.env.MOCK_SOURCE !== 'true') {
     // Fire-and-forget: workflow runs out-of-band. UI polls and reflects the
     // state transition once the worker resolves or escalates.
+    // In MOCK_SOURCE mode the E2E test drives dispatch explicitly so we skip
+    // the auto-trigger here to avoid a race with the test's own /dispatch call.
     dispatchResolveConflict(slug, Number(id)).catch((err: unknown) => {
       logger.error('dispatchResolveConflict failed', { slug, id, error: String(err) });
     });

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -1,4 +1,5 @@
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
+import { checkAndClearMergeConflict } from '@goose-hub/core/agent-runtime/mock-test-registry.js';
 import {
   MergeConflictError,
   mergePR as defaultMergePR,
@@ -55,11 +56,22 @@ export async function approveIssue(
   }
 
   const token = process.env.GITHUB_TOKEN ?? '';
-  if (token.length === 0) {
+  if (token.length === 0 && process.env.MOCK_SOURCE !== 'true') {
     return { ok: false, error: 'GITHUB_TOKEN env var not set', status: 500 };
   }
 
   const mergePR = options.mergePRImpl ?? defaultMergePR;
+
+  if (process.env.MOCK_SOURCE === 'true' && checkAndClearMergeConflict(workItemId)) {
+    eventStore.appendEvent({
+      projectId: slug,
+      workItemId,
+      kind: 'merge.conflict',
+      payload: { prNumber },
+    });
+    await source.transitionState(id, 'factory:approved', 'factory:merge-conflict');
+    return { ok: false, error: 'merge-conflict', status: 409 };
+  }
 
   let merged: { sha: string; merged: boolean };
   try {

--- a/apps/server/src/domains/roster/service.ts
+++ b/apps/server/src/domains/roster/service.ts
@@ -50,6 +50,9 @@ async function createGithubImprovementIssue(
   token: string,
   candidate: ImprovementCandidateRow,
 ): Promise<string> {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return `https://github.com/${repo}/issues/mock-improvement`;
+  }
   const title = `[improvement] ${candidate.suggestionText.slice(0, 120)}`;
   const sourceLink = candidate.sourceTaskId
     ? `Source task: ${candidate.sourceTaskId}`

--- a/apps/server/src/domains/workflows/qa-batch.test.ts
+++ b/apps/server/src/domains/workflows/qa-batch.test.ts
@@ -50,6 +50,7 @@ function makeMockSource(items: WorkItem[]): StateSource {
     setLabelInGroup: vi.fn(),
     attach: vi.fn(),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/apps/server/src/domains/workflows/retro-batch.test.ts
+++ b/apps/server/src/domains/workflows/retro-batch.test.ts
@@ -90,6 +90,7 @@ function makeMockSource(items: WorkItem[] = []): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/apps/server/src/domains/workflows/review-batch.test.ts
+++ b/apps/server/src/domains/workflows/review-batch.test.ts
@@ -49,6 +49,7 @@ function makeMockSource(items: WorkItem[]): StateSource {
     setLabelInGroup: vi.fn(),
     attach: vi.fn(),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -1,5 +1,9 @@
+import { registerTestOutcomes } from '@goose-hub/core/agent-runtime/mock-test-registry.js';
 import { minePatterns } from '@goose-hub/core/learning/mine.js';
 import { logger } from '@goose-hub/core/logger.js';
+import type { StateName } from '@goose-hub/core/state-machine/states.js';
+import { InMemoryLabelsSource } from '@goose-hub/core/state-source/in-memory-labels.js';
+import type { Priority, WorkItemType } from '@goose-hub/core/state-source/interface.js';
 import {
   SkillCoachForbiddenTargetError,
   SkillCoachMissingSourceError,
@@ -8,6 +12,7 @@ import {
 import { Hono } from 'hono';
 import { dispatchForIssue, dispatchQa, dispatchRetro, dispatchReview } from '#shared/dispatch.js';
 import { parseBody } from '#shared/middleware.js';
+import { getSourceForSlug } from '#shared/source.js';
 import { runQaBatch } from './qa-batch.js';
 import { runRetroBatch } from './retro-batch.js';
 import { runReviewBatch } from './review-batch.js';
@@ -153,5 +158,54 @@ router.post('/:slug/coach', async (c) => {
     return c.json({ error: String(err) }, 500);
   }
 });
+
+// Seed endpoint: only active when MOCK_SOURCE=true. Creates fixture issues in
+// the InMemoryLabelsSource for deterministic E2E pipeline specs.
+if (process.env.MOCK_SOURCE === 'true') {
+  router.post('/test/:slug/seed-issue', async (c) => {
+    const slug = c.req.param('slug');
+    const body = await parseBody<{
+      title?: string;
+      body?: string;
+      type?: WorkItemType;
+      priority?: Priority;
+      state?: string;
+      milestoneTitle?: string;
+      dependsOn?: string[];
+      prDiff?: string;
+      outcomes?: Partial<Record<string, string | string[]>>;
+      throwMergeConflict?: boolean;
+    }>(c);
+    if (!body.ok) return body.error;
+
+    if (!body.data.title) return c.json({ error: 'title is required' }, 400);
+
+    const source = await getSourceForSlug(slug);
+    if (source == null) return c.json({ error: 'project not found' }, 404);
+    if (!(source instanceof InMemoryLabelsSource)) {
+      return c.json({ error: 'MOCK_SOURCE=true required for seed endpoint' }, 400);
+    }
+
+    const item = await source.seedIssue({
+      title: body.data.title,
+      body: body.data.body,
+      type: body.data.type,
+      priority: body.data.priority,
+      state: body.data.state as StateName | undefined,
+      milestoneTitle: body.data.milestoneTitle,
+      dependsOn: body.data.dependsOn,
+      prDiff: body.data.prDiff,
+    });
+
+    if (body.data.outcomes != null || body.data.throwMergeConflict != null) {
+      registerTestOutcomes(item.id, {
+        outcomes: body.data.outcomes,
+        throwMergeConflict: body.data.throwMergeConflict,
+      });
+    }
+
+    return c.json({ issueNumber: Number(item.externalId), workItemId: item.id }, 201);
+  });
+}
 
 export { router as workflowsRouter };

--- a/apps/server/src/domains/workflows/state-flows.test.ts
+++ b/apps/server/src/domains/workflows/state-flows.test.ts
@@ -104,6 +104,7 @@ function makeMockSource(): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/apps/server/src/domains/workflows/triage-batch.test.ts
+++ b/apps/server/src/domains/workflows/triage-batch.test.ts
@@ -107,6 +107,7 @@ function makeMockSource(items: WorkItem[] = []): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -84,6 +84,12 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
   } finally {
     parallelLock.release(slug, issueNumber);
   }
+
+  // Chain to investigation-complete routing outside the lock. In production the
+  // GitHub label-change webhook fires dispatchForLabel('factory:investigation-complete')
+  // instead; in MOCK_SOURCE mode there are no webhooks so we chain explicitly.
+  // Idempotency is enforced by the state check inside dispatchInvestigationComplete.
+  await dispatchInvestigationComplete(slug, issueNumber);
 }
 
 /** Run the M7 fix-issue workflow for a single issue (#183). Drops duplicate triggers for the same issue. */
@@ -163,6 +169,7 @@ export async function dispatchResolveConflict(slug: string, issueNumber: number)
         source: unknown,
         slug: string,
         repoRoot: string,
+        deps?: Record<string, unknown>,
       ) => Promise<unknown>;
     };
     const source = await getSourceForSlug(slug);
@@ -171,7 +178,14 @@ export async function dispatchResolveConflict(slug: string, issueNumber: number)
       return;
     }
     const item = await source.getItem(issueNumber.toString());
-    await runResolveConflictWorkflow(item, source, slug, REPO_ROOT);
+    const mockConflictDeps: Record<string, unknown> | undefined =
+      process.env.MOCK_SOURCE === 'true'
+        ? {
+            mergePRImpl: () => Promise.resolve({ sha: 'mock-sha-merged', merged: true }),
+            gitExecImpl: () => '',
+          }
+        : undefined;
+    await runResolveConflictWorkflow(item, source, slug, REPO_ROOT, mockConflictDeps);
     // Fire-and-forget retro after conflict resolution + merge, same pattern as
     // approveIssue. The label-change webhook also triggers dispatchRetro on
     // factory:retrospecting; running it here avoids waiting for webhook delivery.

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -215,6 +215,7 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
             expected: string;
             tolerance: string;
           }>;
+          runTests?: (() => Promise<null>) | undefined;
         },
       ) => Promise<unknown>;
     };

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -225,7 +225,11 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
     }
     const item = await source.getItem(issueNumber.toString());
     const verifyCommands = parseAcceptanceCriteria(item.body ?? '');
-    await runQaWorkflow(item, source, slug, item.repoRef ?? slug, { verifyCommands });
+    const qaRunTests = process.env.MOCK_SOURCE === 'true' ? () => Promise.resolve(null) : undefined;
+    await runQaWorkflow(item, source, slug, item.repoRef ?? slug, {
+      verifyCommands,
+      runTests: qaRunTests,
+    });
   } finally {
     parallelLock.release(slug, issueNumber);
   }

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -72,6 +72,7 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
         source: unknown,
         slug: string,
         repoRoot: string,
+        deps?: Record<string, unknown>,
       ) => Promise<unknown>;
     };
     const source = await getSourceForSlug(slug);
@@ -80,7 +81,14 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
       return;
     }
     const item = await source.getItem(issueNumber.toString());
-    await runInvestigateWorkflow(item, source, slug, REPO_ROOT);
+    const mockInvestigateDeps: Record<string, unknown> | undefined =
+      process.env.MOCK_AGENTS === 'true'
+        ? {
+            createWorktreeImpl: () => '/mock/worktree',
+            prewarmWorktreeImpl: () => undefined,
+          }
+        : undefined;
+    await runInvestigateWorkflow(item, source, slug, REPO_ROOT, mockInvestigateDeps);
   } finally {
     parallelLock.release(slug, issueNumber);
   }

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -129,6 +129,7 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
                 base: 'main',
               }),
             createWorktreeImpl: () => '/mock/worktree',
+            prewarmWorktreeImpl: () => undefined,
             cleanupWorktreeImpl: () => undefined,
             resolveWorktreeHeadShaImpl: () => 'mock-sha-abc123',
           }

--- a/apps/server/src/shared/source.fetch-guard.test.ts
+++ b/apps/server/src/shared/source.fetch-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Fetch-guard test (#566 Phase 4).
+ *
+ * Verifies that when MOCK_SOURCE=true, no real GitHub API calls escape to
+ * api.github.com or github.com. Monkey-patches globalThis.fetch to throw on
+ * those domains.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('MOCK_SOURCE fetch guard', () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = process.env.MOCK_SOURCE;
+
+  beforeEach(() => {
+    process.env.MOCK_SOURCE = 'true';
+    process.env.MOCK_AGENTS = 'true';
+    process.env.MOCK_OPEN_PR = 'true';
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (/api\.github\.com|github\.com/.test(url)) {
+        throw new Error(`[fetch-guard] Real GitHub fetch blocked in MOCK_SOURCE mode: ${url}`);
+      }
+      return originalFetch(input, _init);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv == null) {
+      process.env.MOCK_SOURCE = undefined;
+    } else {
+      process.env.MOCK_SOURCE = originalEnv;
+    }
+    process.env.MOCK_AGENTS = undefined;
+    process.env.MOCK_OPEN_PR = undefined;
+
+    // Reset source cache so each test gets a fresh InMemoryLabelsSource
+    vi.resetModules();
+  });
+
+  it('InMemoryLabelsSource does not call fetch', async () => {
+    const { InMemoryLabelsSource } = await import(
+      '@goose-hub/core/state-source/in-memory-labels.js'
+    );
+    const source = new InMemoryLabelsSource('test-project', 'shaunnez/goose-hub');
+
+    // These operations must not hit real GitHub
+    const item = await source.createIssue({ title: 'Test issue', body: 'body' });
+    await source.comment(item.externalId, 'a comment');
+    const comments = await source.listComments(item.externalId);
+    const open = await source.listOpenWork();
+    const fetched = await source.getItem(item.externalId);
+    await source.forceState(item.externalId, 'factory:accepted');
+    await source.transitionState(item.externalId, 'factory:accepted', 'factory:dev-ready');
+    const milestone = await source.getActiveMilestone();
+
+    expect(comments).toHaveLength(1);
+    expect(open).toHaveLength(1);
+    expect(fetched.externalId).toBe(item.externalId);
+    expect(milestone).not.toBeNull();
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('MOCK_SOURCE merge-pr early-return skips fetch', async () => {
+    const { mergePR } = await import('@goose-hub/core/connectors/github/merge-pr.js');
+    const result = await mergePR({ repo: 'shaunnez/goose-hub', prNumber: 999, token: '' });
+    expect(result).toEqual({ sha: 'mock-sha', merged: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('MOCK_SOURCE open-pr early-return skips fetch and git', async () => {
+    const { openPR } = await import('@goose-hub/core/connectors/github/open-pr.js');
+    const result = await openPR({
+      worktreePath: '/mock/worktree',
+      repo: 'shaunnez/goose-hub',
+      issueNumber: 1,
+      title: 'M7.01: mock',
+      body: 'Closes #1',
+      branchName: 'factory/mock',
+      token: '',
+    });
+    expect(result.prNumber).toBe(999);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('MOCK_SOURCE dependency-resolver skips fetch', async () => {
+    const { createProjectAwareTargetSource } = await import(
+      '@goose-hub/core/state-source/dependency-resolver.js'
+    );
+    const fetchTarget = await createProjectAwareTargetSource({
+      projects: [
+        {
+          id: 'test',
+          slug: 'test',
+          source: { kind: 'github', repo: 'shaunnez/goose-hub' },
+          budgets: { maxParallelAgents: 1, maxIssuesPerDayFromNonOwners: 5, maxRetries: 2 },
+        } as never,
+      ],
+    });
+    const target = await fetchTarget('shaunnez/goose-hub', 42);
+    expect(target).not.toBeNull();
+    expect((target as { state: string }).state).toBe('open');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/shared/source.fetch-guard.test.ts
+++ b/apps/server/src/shared/source.fetch-guard.test.ts
@@ -17,7 +17,7 @@ describe('MOCK_SOURCE fetch guard', () => {
     process.env.MOCK_AGENTS = 'true';
     process.env.MOCK_OPEN_PR = 'true';
 
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
       if (/api\.github\.com|github\.com/.test(url)) {
         throw new Error(`[fetch-guard] Real GitHub fetch blocked in MOCK_SOURCE mode: ${url}`);

--- a/apps/server/src/shared/source.ts
+++ b/apps/server/src/shared/source.ts
@@ -1,4 +1,5 @@
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
+import { InMemoryLabelsSource } from '@goose-hub/core/state-source/in-memory-labels.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import { getProject } from './projects.js';
 
@@ -22,6 +23,14 @@ export async function getSourceForSlug(slug: string): Promise<StateSource | null
 
   const cfg = await getProject(slug);
   if (cfg == null) return null;
+
+  if (process.env.MOCK_SOURCE === 'true') {
+    const repoRef = cfg.source.kind === 'github' ? cfg.source.repo : slug;
+    const source = new InMemoryLabelsSource(cfg.id, repoRef);
+    sourceCache.set(slug, source);
+    return source;
+  }
+
   if (cfg.source.kind !== 'github') {
     throw new Error(`Unsupported source kind for ${slug}: ${cfg.source.kind}`);
   }
@@ -35,4 +44,8 @@ export async function getSourceForSlug(slug: string): Promise<StateSource | null
   const source = new GitHubLabelsSource(cfg.id, cfg.source.repo, token, ownerLogin);
   sourceCache.set(slug, source);
   return source;
+}
+
+export function resetSourceCache(): void {
+  sourceCache.clear();
 }

--- a/apps/web/e2e/pipeline/bug-investigation.spec.ts
+++ b/apps/web/e2e/pipeline/bug-investigation.spec.ts
@@ -37,15 +37,15 @@ test.describe('Bug investigation (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage (bug type) → accepted → investigating
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:investigating', { timeout: 60_000 });
+    await expect(statePill).toHaveText('investigating', { timeout: 60_000 });
 
     // Investigate (high-confidence) → investigation-complete → dev-ready
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
   });
 
   test('low-confidence investigate → investigation-complete → gate-pending', async ({ page }) => {
@@ -59,11 +59,11 @@ test.describe('Bug investigation (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage (bug type) → accepted → investigating
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:investigating', { timeout: 60_000 });
+    await expect(statePill).toHaveText('investigating', { timeout: 60_000 });
 
     // Investigate (low-confidence) → investigation-complete → gate-pending
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);

--- a/apps/web/e2e/pipeline/bug-investigation.spec.ts
+++ b/apps/web/e2e/pipeline/bug-investigation.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  outcomes?: Record<string, string | string[]>;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('Bug investigation (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('high-confidence investigate → investigation-complete → dev-ready', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Bug High Confidence ${Date.now()}`,
+      type: 'bug',
+      outcomes: { investigate: 'high-confidence' },
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage (bug type) → accepted → investigating
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:investigating', { timeout: 60_000 });
+
+    // Investigate (high-confidence) → investigation-complete → dev-ready
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+  });
+
+  test('low-confidence investigate → investigation-complete → gate-pending', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Bug Low Confidence ${Date.now()}`,
+      type: 'bug',
+      outcomes: { investigate: 'low-confidence' },
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage (bug type) → accepted → investigating
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:investigating', { timeout: 60_000 });
+
+    // Investigate (low-confidence) → investigation-complete → gate-pending
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:gate-pending', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/escalation.spec.ts
+++ b/apps/web/e2e/pipeline/escalation.spec.ts
@@ -41,27 +41,27 @@ test.describe('QA escalation (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage → dev-ready
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // Each QA failure cycles: needs-qa → qa-failed → needs-fix → needs-qa
     for (let i = 0; i < QA_FAIL_COUNT; i++) {
       await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-      await expect(statePill).toHaveText('factory:qa-failed', { timeout: 60_000 });
+      await expect(statePill).toHaveText('qa-failed', { timeout: 60_000 });
       // dispatchQaFailed → needs-fix → fix-feedback → needs-qa
       await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-      await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+      await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
     }
 
     // (QA_FAIL_COUNT+1)th QA attempt: shouldEscalateQa is true → needs-human
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-human', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-human', { timeout: 60_000 });
   });
 });

--- a/apps/web/e2e/pipeline/escalation.spec.ts
+++ b/apps/web/e2e/pipeline/escalation.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+// DEFAULT_MAX_RETRIES = 2: escalate after 2 QA failures (3rd dispatch triggers needs-human)
+const QA_FAIL_COUNT = 2;
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  outcomes?: Record<string, string | string[]>;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('QA escalation (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test(`exhaust ${QA_FAIL_COUNT} QA retries → needs-human`, async ({ page }) => {
+    test.setTimeout(300_000);
+
+    // Queue QA_FAIL_COUNT failures. shouldEscalateQa triggers on the (N+1)th attempt.
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] QA Escalation ${Date.now()}`,
+      type: 'chore',
+      outcomes: { qa: Array(QA_FAIL_COUNT).fill('fail') },
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage → dev-ready
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // Each QA failure cycles: needs-qa → qa-failed → needs-fix → needs-qa
+    for (let i = 0; i < QA_FAIL_COUNT; i++) {
+      await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+      await expect(statePill).toHaveText('factory:qa-failed', { timeout: 60_000 });
+      // dispatchQaFailed → needs-fix → fix-feedback → needs-qa
+      await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+      await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    }
+
+    // (QA_FAIL_COUNT+1)th QA attempt: shouldEscalateQa is true → needs-human
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-human', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/full-lifecycle.spec.ts
+++ b/apps/web/e2e/pipeline/full-lifecycle.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  outcomes?: Record<string, string | string[]>;
+  throwMergeConflict?: boolean;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('Full lifecycle (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('chore: triaging → done', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Full Lifecycle ${Date.now()}`,
+      type: 'chore',
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage: triaging → accepted → dev-ready (chore type skips investigation)
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue: dev-ready → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA: needs-qa → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review: needs-review → approved
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+
+    // Approve gate: approved → retrospecting → done
+    await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
+    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+
+    // Timeline should show key agent events
+    await page.getByRole('link', { name: 'Timeline' }).click();
+    await expect(page.locator('[data-event-kind="agent.triage-complete"]').first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator('[data-event-kind="pr.opened"]').first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/web/e2e/pipeline/full-lifecycle.spec.ts
+++ b/apps/web/e2e/pipeline/full-lifecycle.spec.ts
@@ -37,27 +37,27 @@ test.describe('Full lifecycle (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage: triaging → accepted → dev-ready (chore type skips investigation)
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue: dev-ready → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA: needs-qa → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review: needs-review → approved
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
 
     // Approve gate: approved → retrospecting → done
     await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
-    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+    await expect(statePill).toHaveText('done', { timeout: 60_000 });
 
     // Timeline should show key agent events
     await page.getByRole('link', { name: 'Timeline' }).click();

--- a/apps/web/e2e/pipeline/gate-reject-loop.spec.ts
+++ b/apps/web/e2e/pipeline/gate-reject-loop.spec.ts
@@ -35,44 +35,44 @@ test.describe('Gate reject loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage → dev-ready
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA (pass) → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review (approve) → approved
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
 
     // Human rejects at gate: approved → needs-fix
     await postServer(`/projects/${SLUG}/issues/${issueNumber}/reject`, {
       reason: 'e2e gate reject test',
     });
-    await expect(statePill).toHaveText('factory:needs-fix', { timeout: 15_000 });
+    await expect(statePill).toHaveText('needs-fix', { timeout: 15_000 });
 
     // Fix-feedback (implement mock) → in-progress → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review → approved
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
 
     // Approve → retrospecting → done
     await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
-    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+    await expect(statePill).toHaveText('done', { timeout: 60_000 });
   });
 });

--- a/apps/web/e2e/pipeline/gate-reject-loop.spec.ts
+++ b/apps/web/e2e/pipeline/gate-reject-loop.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('Gate reject loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('approved → needs-fix (gate reject) → drive forward to done', async ({ page }) => {
+    test.setTimeout(180_000);
+
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Gate Reject Loop ${Date.now()}`,
+      type: 'chore',
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage → dev-ready
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA (pass) → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review (approve) → approved
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+
+    // Human rejects at gate: approved → needs-fix
+    await postServer(`/projects/${SLUG}/issues/${issueNumber}/reject`, {
+      reason: 'e2e gate reject test',
+    });
+    await expect(statePill).toHaveText('factory:needs-fix', { timeout: 15_000 });
+
+    // Fix-feedback (implement mock) → in-progress → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review → approved
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+
+    // Approve → retrospecting → done
+    await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
+    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/merge-conflict.spec.ts
+++ b/apps/web/e2e/pipeline/merge-conflict.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  throwMergeConflict?: boolean;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`seed-issue → ${res.status}: ${text}`);
+  }
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('Merge conflict (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('mergePR throws once → approved → merge-conflict → resolve-conflict → retrospecting → done', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    // throwMergeConflict=true causes the first approve to throw MergeConflictError
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Merge Conflict ${Date.now()}`,
+      type: 'chore',
+      throwMergeConflict: true,
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage → dev-ready
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review → approved
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+
+    // Approve (merge conflict thrown once) → merge-conflict
+    const approveRes = await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
+    expect(approveRes.status).toBe(409);
+    await expect(statePill).toHaveText('factory:merge-conflict', { timeout: 15_000 });
+
+    // Resolve-conflict workflow: merge-conflict → retrospecting → done
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/merge-conflict.spec.ts
+++ b/apps/web/e2e/pipeline/merge-conflict.spec.ts
@@ -40,31 +40,31 @@ test.describe('Merge conflict (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage → dev-ready
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review → approved
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
 
     // Approve (merge conflict thrown once) → merge-conflict
     const approveRes = await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
     expect(approveRes.status).toBe(409);
-    await expect(statePill).toHaveText('factory:merge-conflict', { timeout: 15_000 });
+    await expect(statePill).toHaveText('merge-conflict', { timeout: 15_000 });
 
     // Resolve-conflict workflow: merge-conflict → retrospecting → done
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:done', { timeout: 60_000 });
+    await expect(statePill).toHaveText('done', { timeout: 60_000 });
   });
 });

--- a/apps/web/e2e/pipeline/qa-fail-loop.spec.ts
+++ b/apps/web/e2e/pipeline/qa-fail-loop.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  outcomes?: Record<string, string | string[]>;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('QA fail loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('needs-qa → qa-failed → needs-fix → in-progress → needs-qa (pass) → needs-review', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    // QA fails once then passes
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] QA Fail Loop ${Date.now()}`,
+      type: 'chore',
+      outcomes: { qa: ['fail', 'pass'] },
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage → dev-ready
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA (fail) → qa-failed
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:qa-failed', { timeout: 60_000 });
+
+    // dispatchQaFailed → needs-fix → fix-feedback → in-progress → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA (pass this time) → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/qa-fail-loop.spec.ts
+++ b/apps/web/e2e/pipeline/qa-fail-loop.spec.ts
@@ -40,26 +40,26 @@ test.describe('QA fail loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage → dev-ready
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA (fail) → qa-failed
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:qa-failed', { timeout: 60_000 });
+    await expect(statePill).toHaveText('qa-failed', { timeout: 60_000 });
 
     // dispatchQaFailed → needs-fix → fix-feedback → in-progress → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA (pass this time) → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
   });
 });

--- a/apps/web/e2e/pipeline/review-sendback-loop.spec.ts
+++ b/apps/web/e2e/pipeline/review-sendback-loop.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+
+async function postServer(path: string, body?: unknown) {
+  const res = await fetch(`${SERVER_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST ${path} → ${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function seedIssue(opts: {
+  title: string;
+  type?: string;
+  outcomes?: Record<string, string | string[]>;
+}): Promise<{ issueNumber: number; workItemId: string }> {
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
+}
+
+test.describe('Review sendback loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
+  test('review needs-fix once → loop → pass on second pass', async ({ page }) => {
+    test.setTimeout(180_000);
+
+    // Review sends back once then approves
+    const { issueNumber } = await seedIssue({
+      title: `[E2E] Review Sendback ${Date.now()}`,
+      type: 'chore',
+      outcomes: { review: ['needs-fix', 'approved'] },
+    });
+
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
+    const statePill = page.getByTestId('state-pill');
+    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+
+    // Triage → dev-ready
+    await postServer(`/projects/${SLUG}/tick`);
+    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+
+    // Fix-issue → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA (pass) → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review (needs-fix) → needs-fix
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-fix', { timeout: 60_000 });
+
+    // Fix-feedback → needs-qa
+    await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+
+    // QA (pass) → needs-review
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+
+    // Review (approved on second pass) → approved
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+  });
+});

--- a/apps/web/e2e/pipeline/review-sendback-loop.spec.ts
+++ b/apps/web/e2e/pipeline/review-sendback-loop.spec.ts
@@ -38,34 +38,34 @@ test.describe('Review sendback loop (MOCK_AGENTS + MOCK_SOURCE)', () => {
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     const statePill = page.getByTestId('state-pill');
-    await expect(statePill).toHaveText('factory:triaging', { timeout: 15_000 });
+    await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
     // Triage → dev-ready
     await postServer(`/projects/${SLUG}/tick`);
-    await expect(statePill).toHaveText('factory:dev-ready', { timeout: 60_000 });
+    await expect(statePill).toHaveText('dev-ready', { timeout: 60_000 });
 
     // Fix-issue → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA (pass) → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review (needs-fix) → needs-fix
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-fix', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-fix', { timeout: 60_000 });
 
     // Fix-feedback → needs-qa
     await postServer(`/projects/${SLUG}/dispatch/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-qa', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA (pass) → needs-review
     await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:needs-review', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
 
     // Review (approved on second pass) → approved
     await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
-    await expect(statePill).toHaveText('factory:approved', { timeout: 60_000 });
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
   });
 });

--- a/apps/web/playwright-e2e-pipeline.config.ts
+++ b/apps/web/playwright-e2e-pipeline.config.ts
@@ -8,6 +8,7 @@ const PORT = Number(process.env.WEB_PORT ?? 5173);
 
 export default defineConfig({
   testDir: './e2e/pipeline',
+  testIgnore: ['**/state-flow.spec.ts'],
   timeout: 120_000,
   expect: { timeout: 30_000 },
   fullyParallel: false,
@@ -28,9 +29,11 @@ export default defineConfig({
             reuseExistingServer: !process.env.CI,
             timeout: 30_000,
             env: {
-              GITHUB_TOKEN: process.env.GITHUB_TOKEN ?? '',
+              GITHUB_TOKEN: '',
+              GITHUB_WEBHOOK_SECRET: 'mock-webhook-secret-for-e2e',
               MOCK_AGENTS: 'true',
               MOCK_OPEN_PR: 'true',
+              MOCK_SOURCE: 'true',
             },
           },
           {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -8,6 +8,7 @@ const PORT = Number(process.env.WEB_PORT ?? 5173);
 
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: ['**/pipeline/**'],
   timeout: 30_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -6,8 +6,9 @@ import type { MilestoneDto, WorkItemDto } from '@/lib/types';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
 import { formatCost, formatTokens } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useIssueCostsBreakdown } from '../lib/costs';
+import { EVENT_KIND_LABEL } from '../lib/timeline';
 import { MoveToCurrentDialog } from './MoveToCurrentDialog';
 import { PillSelect } from './PillSelect';
 import { TransitionButton } from './TransitionButton';
@@ -37,10 +38,23 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
   const lane = item?.state ? (laneForState(item.state) ?? item.state.replace('factory:', '')) : '—';
   const lastPersonaLabel = getPersonaLabel(personaMap, item?.lastPersonaId) ?? '—';
 
-  const invalidate = () => {
+  const invalidate = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, item?.externalId] });
     void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
-  };
+  }, [queryClient, projectSlug, item?.externalId]);
+
+  // Re-fetch state when any SSE event arrives for this work item so the state
+  // pill reflects server-side transitions without requiring a page reload.
+  useEffect(() => {
+    if (!item?.id) return;
+    const url = `/events?projectId=${encodeURIComponent(projectSlug)}&workItemId=${encodeURIComponent(item.id)}`;
+    const es = new EventSource(url);
+    const handler = () => invalidate();
+    for (const kind of Object.keys(EVENT_KIND_LABEL)) {
+      es.addEventListener(kind, handler);
+    }
+    return () => es.close();
+  }, [projectSlug, item?.id, invalidate]);
 
   const onPriority = async (value: string) => {
     if (!item) return;

--- a/core/agent-runtime/mock-outputs.test.ts
+++ b/core/agent-runtime/mock-outputs.test.ts
@@ -80,20 +80,21 @@ describe('resolveMockOutput — investigate', () => {
 });
 
 describe('resolveMockOutput — qa', () => {
-  it('returns a passing functional verdict', () => {
+  it('returns a passing verdict with tierResults', () => {
     const r = resolveMockOutput(makeSpec({ skill: 'qa' }));
-    const out = r.output as { verdict: string; tier: string };
+    const out = r.output as { verdict: string; overallScore: number; tierResults: object };
     expect(out.verdict).toBe('pass');
-    expect(out.tier).toBe('functional');
+    expect(out.overallScore).toBeGreaterThan(70);
+    expect(out.tierResults).toBeDefined();
   });
 });
 
 describe('resolveMockOutput — review', () => {
-  it('returns an "approved" verdict with no feedback', () => {
+  it('returns an "approved" verdict with confidence', () => {
     const r = resolveMockOutput(makeSpec({ skill: 'review' }));
-    const out = r.output as { verdict: string; feedback: string | null };
+    const out = r.output as { verdict: string; confidence: number };
     expect(out.verdict).toBe('approved');
-    expect(out.feedback).toBeNull();
+    expect(out.confidence).toBeGreaterThan(0);
   });
 });
 

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -1,8 +1,26 @@
 import type { AgentResult, AgentSpec } from './interface.js';
+import { getNextOutcome } from './mock-test-registry.js';
 
 export function resolveMockOutput(spec: AgentSpec): AgentResult {
+  const workItemId = spec.context.workItemId as string | undefined;
+  const testOutcome =
+    getNextOutcome(workItemId, spec.skill) ?? (spec.context.testOutcome as string | undefined);
+
   switch (spec.skill) {
     case 'triage': {
+      if (testOutcome === 'reject') {
+        return {
+          output: {
+            type: 'chore',
+            priority: 'p3',
+            labels: [],
+            reasoning: 'e2e reject fixture',
+            decisionSummaries: [{ kind: 'VERDICT', summary: 'Rejected for e2e test' }],
+          },
+          decisionSummaries: [{ kind: 'VERDICT', summary: 'Rejected for e2e test' }],
+          events: [],
+        };
+      }
       const workItem = (spec.context?.workItem ?? {}) as { type?: string };
       const incoming = workItem.type;
       const type =
@@ -50,41 +68,190 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
         events: [],
       };
 
-    case 'investigate':
+    case 'investigate': {
+      const confidence =
+        testOutcome === 'low-confidence'
+          ? 'low'
+          : testOutcome === 'medium-confidence'
+            ? 'medium'
+            : 'high';
       return {
         output: {
           findings: 'E2E mock findings',
           keyFiles: [],
-          confidence: 'high',
+          confidence,
           openQuestions: [],
           decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock investigation for e2e test' }],
         },
         decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock investigation for e2e test' }],
         events: [],
       };
+    }
 
-    case 'qa':
+    case 'qa': {
+      if (testOutcome === 'fail') {
+        const emptyTier = { passed: false, findings: [] };
+        return {
+          output: {
+            verdict: 'fail',
+            overallScore: 20,
+            threshold: 70,
+            tierResults: {
+              structural: emptyTier,
+              functional: {
+                passed: false,
+                findings: [
+                  {
+                    tier: 'functional',
+                    severity: 'error',
+                    description: 'mock qa failure',
+                    disposition: 'register',
+                    dispositionRef: 'e2e-test',
+                  },
+                ],
+              },
+              regression: emptyTier,
+            },
+            qualityScores: {
+              openClosed: 5,
+              conceptCount: 5,
+              timeToCapability: 5,
+              complecting: 5,
+              loc: 0,
+              coupling: 0,
+              gallsLaw: 0,
+              cyclomaticComplexity: 0,
+            },
+            findings: [],
+            decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA fail for e2e test' }],
+          },
+          decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA fail for e2e test' }],
+          events: [],
+        };
+      }
+      const emptyTierPass = { passed: true, findings: [] };
       return {
         output: {
           verdict: 'pass',
-          tier: 'functional',
-          criteriaResults: [],
+          overallScore: 85,
+          threshold: 70,
+          tierResults: {
+            structural: emptyTierPass,
+            functional: emptyTierPass,
+            regression: emptyTierPass,
+          },
+          qualityScores: {
+            openClosed: 18,
+            conceptCount: 12,
+            timeToCapability: 12,
+            complecting: 12,
+            loc: 8,
+            coupling: 8,
+            gallsLaw: 8,
+            cyclomaticComplexity: 5,
+          },
+          findings: [],
           decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA pass for e2e test' }],
         },
         decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA pass for e2e test' }],
         events: [],
       };
+    }
 
-    case 'review':
+    case 'review': {
+      if (testOutcome === 'needs-fix') {
+        return {
+          output: {
+            verdict: 'needs-fix',
+            confidence: 0.4,
+            criteriaChecks: [],
+            findings: [],
+            decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review needs-fix for e2e test' }],
+          },
+          decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review needs-fix for e2e test' }],
+          events: [],
+        };
+      }
       return {
         output: {
           verdict: 'approved',
-          feedback: null,
+          confidence: 0.95,
+          criteriaChecks: [],
+          findings: [],
           decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review approval for e2e test' }],
         },
         decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review approval for e2e test' }],
         events: [],
       };
+    }
+
+    case 'retrospective-light':
+    case 'retrospective-deep': {
+      const workItemCtx = (spec.context?.workItem ?? {}) as { number?: number };
+      const workItemNumber = workItemCtx.number ?? 0;
+      const base = {
+        outcome: 'success' as const,
+        workItemNumber,
+        summary: {
+          wentWell: 'E2E mock run completed successfully',
+          didNotGoWell: 'Nothing — this is a mock',
+          architecturalTakeaway: 'MOCK_AGENTS=true bypasses real model calls',
+        },
+        improvementCandidates: [],
+        decisionSummaries: [{ kind: 'INSIGHT' as const, summary: 'Mock retro for e2e test' }],
+      };
+      if (spec.skill === 'retrospective-deep') {
+        return {
+          output: {
+            ...base,
+            triggerReasons: ['e2e-mock'],
+            personaQualityScores: [],
+            learningEntries: [],
+            decisionPatterns: [],
+          },
+          decisionSummaries: base.decisionSummaries,
+          events: [],
+        };
+      }
+      return {
+        output: base,
+        decisionSummaries: base.decisionSummaries,
+        events: [],
+      };
+    }
+
+    case 'resolve-conflict': {
+      if (testOutcome === 'unresolvable') {
+        return {
+          output: {
+            resolved: [],
+            unresolvable: ['mock-conflict.ts'],
+            confidence: 'low',
+            decisionSummaries: [
+              { kind: 'VERDICT', summary: 'Mock resolve-conflict unresolvable for e2e test' },
+            ],
+          },
+          decisionSummaries: [
+            { kind: 'VERDICT', summary: 'Mock resolve-conflict unresolvable for e2e test' },
+          ],
+          events: [],
+        };
+      }
+      return {
+        output: {
+          resolved: ['mock-conflict.ts'],
+          unresolvable: [],
+          confidence: 'high',
+          decisionSummaries: [
+            { kind: 'VERDICT', summary: 'Mock resolve-conflict resolved for e2e test' },
+          ],
+        },
+        decisionSummaries: [
+          { kind: 'VERDICT', summary: 'Mock resolve-conflict resolved for e2e test' },
+        ],
+        events: [],
+      };
+    }
 
     default:
       throw new Error(`resolveMockOutput: no preset for skill "${spec.skill}"`);

--- a/core/agent-runtime/mock-test-registry.ts
+++ b/core/agent-runtime/mock-test-registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-issue test outcome registry for deterministic E2E pipeline specs.
+ * Only consulted when MOCK_AGENTS=true.
+ *
+ * Outcomes are consumed queue-style: each call to getNextOutcome pops the
+ * first entry; the last entry is kept so subsequent calls use the final value.
+ */
+
+interface IssueTestConfig {
+  outcomeQueues: Partial<Record<string, string[]>>;
+  throwMergeConflict?: boolean;
+}
+
+const registry = new Map<string, IssueTestConfig>();
+
+export function registerTestOutcomes(
+  workItemId: string,
+  config: {
+    outcomes?: Partial<Record<string, string | string[]>>;
+    throwMergeConflict?: boolean;
+  },
+): void {
+  const outcomeQueues: Partial<Record<string, string[]>> = {};
+  for (const [skill, outcome] of Object.entries(config.outcomes ?? {})) {
+    if (outcome == null) continue;
+    outcomeQueues[skill] = Array.isArray(outcome) ? [...outcome] : [outcome];
+  }
+  registry.set(workItemId, {
+    outcomeQueues,
+    throwMergeConflict: config.throwMergeConflict ?? false,
+  });
+}
+
+export function getNextOutcome(workItemId: string | undefined, skill: string): string | undefined {
+  if (workItemId == null) return undefined;
+  const config = registry.get(workItemId);
+  if (!config) return undefined;
+  const queue = config.outcomeQueues[skill];
+  if (!queue || queue.length === 0) return undefined;
+  if (queue.length === 1) return queue[0];
+  return queue.shift();
+}
+
+export function checkAndClearMergeConflict(workItemId: string): boolean {
+  const config = registry.get(workItemId);
+  if (!config?.throwMergeConflict) return false;
+  registry.set(workItemId, { ...config, throwMergeConflict: false });
+  return true;
+}
+
+export function clearTestConfig(workItemId: string): void {
+  registry.delete(workItemId);
+}

--- a/core/connectors/github/merge-pr.ts
+++ b/core/connectors/github/merge-pr.ts
@@ -38,6 +38,10 @@ export interface MergePrResult {
 }
 
 export async function mergePR(input: MergePrInput): Promise<MergePrResult> {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return { sha: 'mock-sha', merged: true };
+  }
+
   const { repo, prNumber, token, mergeMethod = 'merge', fetchImpl = fetch } = input;
   const url = `https://api.github.com/repos/${repo}/pulls/${prNumber}/merge`;
   const response = await fetchImpl(url, {

--- a/core/connectors/github/open-pr.ts
+++ b/core/connectors/github/open-pr.ts
@@ -55,6 +55,15 @@ export function validatePrBody(body: string, issueNumber: number): void {
 }
 
 export async function openPR(input: OpenPrInput): Promise<OpenPrResult> {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return {
+      prNumber: 999,
+      prUrl: `https://github.com/${input.repo}/pull/999`,
+      branch: input.branchName,
+      base: input.baseBranch ?? 'main',
+    };
+  }
+
   const {
     worktreePath,
     repo,

--- a/core/state-source/dependency-resolver.ts
+++ b/core/state-source/dependency-resolver.ts
@@ -172,6 +172,9 @@ export async function createProjectAwareTargetSource(
  * "repo not registered" (which is the only path to `state: 'unregistered'`).
  */
 function defaultFetchTargetForProject(token: string): ProjectIssueFetcher {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return async (_repoRef, _issueNumber) => ({ state: 'open', title: 'mock-dep' });
+  }
   return async (repoRef, issueNumber) => {
     const url = `https://api.github.com/repos/${repoRef}/issues/${issueNumber}`;
     let response: Response;

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -1,3 +1,4 @@
+import { eventStore } from '../event-stream/store.js';
 import { resolveState } from '../state-machine/conflict-resolver.js';
 import type { StateName } from '../state-machine/states.js';
 import { isLegalTransition } from '../state-machine/transitions.js';
@@ -452,6 +453,32 @@ export class GitHubLabelsSource implements StateSource {
     }
     const issue = (await res.json()) as GithubIssue;
     return mapIssueToWorkItem(issue, this.repoRef, this.ownerLogin);
+  }
+
+  async getPrDiff(itemId: string): Promise<string> {
+    const number = parseIssueNumber(itemId);
+    const workItemId = `github:${this.repoRef}#${number}`;
+    const events = eventStore.replay({ workItemId });
+    const prOpened = events
+      .slice()
+      .reverse()
+      .find((e) => e.kind === 'pr.opened');
+    if (prOpened == null) return '';
+    const payload = prOpened.payload as Record<string, unknown>;
+    const prNumber = typeof payload.prNumber === 'number' ? payload.prNumber : undefined;
+    if (prNumber == null) return '';
+    try {
+      const res = await fetch(`https://api.github.com/repos/${this.repoRef}/pulls/${prNumber}`, {
+        headers: {
+          ...this.baseHeaders,
+          Accept: 'application/vnd.github.v3.diff',
+        },
+      });
+      if (!res.ok) return '';
+      return await res.text();
+    } catch {
+      return '';
+    }
   }
 
   async watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {

--- a/core/state-source/in-memory-labels.ts
+++ b/core/state-source/in-memory-labels.ts
@@ -1,0 +1,294 @@
+import { resolveState } from '../state-machine/conflict-resolver.js';
+import type { StateName } from '../state-machine/states.js';
+import { isLegalTransition } from '../state-machine/transitions.js';
+import type {
+  Artifact,
+  CreateIssueInput,
+  ExecMode,
+  IssueComment,
+  Milestone,
+  Mode,
+  Priority,
+  Schedule,
+  SourceEvent,
+  StateSource,
+  Subscription,
+  WorkItem,
+  WorkItemType,
+} from './interface.js';
+
+function parseIssueNumber(itemId: string): string {
+  return itemId.match(/#(\d+)$/)?.[1] ?? itemId;
+}
+
+function parseDependsOn(body: string): string[] {
+  const refs: string[] = [];
+  for (const line of body.split('\n')) {
+    if (!/depends[\s-]+on\s*:?\s/i.test(line)) continue;
+    const matches = line.matchAll(/(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#(\d+)/g);
+    for (const m of matches) refs.push(m[1]);
+  }
+  return refs;
+}
+
+interface MockIssueStore {
+  externalId: string;
+  title: string;
+  body: string;
+  state: StateName;
+  type: WorkItemType;
+  priority: Priority;
+  mode: Mode;
+  schedule: Schedule;
+  exec: ExecMode;
+  milestoneId?: string;
+  milestoneTitle?: string;
+  dependsOn: string[];
+  blocks: string[];
+  comments: IssueComment[];
+  createdAt: Date;
+  prDiff?: string;
+}
+
+const DEFAULT_MILESTONE: Milestone = {
+  id: '1',
+  title: 'E2E Test',
+  number: 1,
+  description: 'In-memory milestone for E2E tests',
+  isActive: true,
+};
+
+export interface SeedIssueOptions {
+  title: string;
+  body?: string;
+  type?: WorkItemType;
+  priority?: Priority;
+  state?: StateName;
+  schedule?: Schedule;
+  milestoneTitle?: string;
+  milestoneId?: string;
+  dependsOn?: string[];
+  prDiff?: string;
+}
+
+export class InMemoryLabelsSource implements StateSource {
+  private readonly store = new Map<string, MockIssueStore>();
+  private counter = 0;
+  private milestones: Milestone[] = [DEFAULT_MILESTONE];
+
+  constructor(
+    readonly projectId: string,
+    readonly repoRef: string,
+  ) {}
+
+  private toWorkItem(issue: MockIssueStore): WorkItem {
+    return {
+      id: `github:${this.repoRef}#${issue.externalId}`,
+      externalId: issue.externalId,
+      repoRef: this.repoRef,
+      title: issue.title,
+      body: issue.body,
+      type: issue.type,
+      priority: issue.priority,
+      mode: issue.mode,
+      state: issue.state,
+      authorIsOwner: true,
+      milestoneId: issue.milestoneId,
+      milestoneTitle: issue.milestoneTitle,
+      schedule: issue.schedule,
+      exec: issue.exec,
+      dependsOn: issue.dependsOn,
+      blocks: issue.blocks,
+      createdAt: issue.createdAt,
+    };
+  }
+
+  private getByExternalId(externalId: string): MockIssueStore | undefined {
+    return this.store.get(externalId);
+  }
+
+  async listOpenWork(milestoneNumber?: number): Promise<WorkItem[]> {
+    const results: WorkItem[] = [];
+    for (const issue of this.store.values()) {
+      if (issue.state === 'factory:done' || issue.state === 'factory:archived') continue;
+      if (milestoneNumber != null && issue.milestoneId !== String(milestoneNumber)) continue;
+      results.push(this.toWorkItem(issue));
+    }
+    return results;
+  }
+
+  async listClosedWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]> {
+    const results: WorkItem[] = [];
+    for (const issue of this.store.values()) {
+      if (issue.state !== 'factory:done' && issue.state !== 'factory:archived') continue;
+      if (issue.milestoneId !== String(milestoneNumber)) continue;
+      results.push(this.toWorkItem(issue));
+    }
+    return results;
+  }
+
+  async listWorkByMilestone(milestoneNumber: number): Promise<WorkItem[]> {
+    const results: WorkItem[] = [];
+    for (const issue of this.store.values()) {
+      if (issue.milestoneId !== String(milestoneNumber)) continue;
+      results.push(this.toWorkItem(issue));
+    }
+    return results;
+  }
+
+  async getItem(itemId: string): Promise<WorkItem> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    return this.toWorkItem(issue);
+  }
+
+  async listMilestones(): Promise<Milestone[]> {
+    return [...this.milestones];
+  }
+
+  async getActiveMilestone(): Promise<Milestone | null> {
+    return this.milestones.find((m) => m.isActive) ?? null;
+  }
+
+  async transitionState(itemId: string, from: StateName, to: StateName): Promise<void> {
+    if (!isLegalTransition(from, to)) {
+      throw new Error(`Illegal transition: ${from} -> ${to}`);
+    }
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    const { state: resolved } = resolveState([issue.state]);
+    if (resolved !== from) {
+      throw new Error(
+        `InMemoryLabelsSource: expected state ${from} but found ${resolved} for issue #${number}`,
+      );
+    }
+    issue.state = to;
+  }
+
+  async forceState(itemId: string, to: StateName): Promise<void> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    issue.state = to;
+  }
+
+  async comment(itemId: string, body: string): Promise<void> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    issue.comments.push({
+      id: issue.comments.length + 1,
+      body,
+      authorLogin: 'factory-bot',
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  async listComments(itemId: string): Promise<IssueComment[]> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) return [];
+    return [...issue.comments];
+  }
+
+  async setMilestone(itemId: string, milestoneNumber: number | null): Promise<void> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    if (milestoneNumber == null) {
+      issue.milestoneId = undefined;
+      issue.milestoneTitle = undefined;
+    } else {
+      const ms = this.milestones.find((m) => m.number === milestoneNumber);
+      issue.milestoneId = String(milestoneNumber);
+      issue.milestoneTitle = ms?.title;
+    }
+  }
+
+  async setLabelInGroup(
+    itemId: string,
+    group: 'priority' | 'schedule' | 'type',
+    value: string,
+  ): Promise<void> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
+    if (group === 'priority') {
+      const p = value as Priority;
+      if (p === 'critical' || p === 'high' || p === 'medium' || p === 'low') issue.priority = p;
+    } else if (group === 'schedule') {
+      const s = value as Schedule;
+      if (s === 'current' || s === 'next' || s === 'later' || s === 'blocked-by')
+        issue.schedule = s;
+    } else if (group === 'type') {
+      const t = value as WorkItemType;
+      if (t === 'feature' || t === 'bug' || t === 'chore' || t === 'research') issue.type = t;
+    }
+  }
+
+  async attach(_itemId: string, _artifact: Artifact): Promise<void> {
+    throw new Error('not implemented in M1');
+  }
+
+  async createIssue(input: CreateIssueInput): Promise<WorkItem> {
+    this.counter += 1;
+    const externalId = String(this.counter);
+    const activeMilestone = this.milestones.find((m) => m.isActive);
+    const body = input.body ?? '';
+    const issue: MockIssueStore = {
+      externalId,
+      title: input.title,
+      body,
+      state: 'factory:triaging',
+      type: input.type ?? 'chore',
+      priority: input.priority ?? 'medium',
+      mode: 'supervised',
+      schedule: 'current',
+      exec: 'serial',
+      milestoneId: input.milestoneId ?? (activeMilestone != null ? activeMilestone.id : undefined),
+      milestoneTitle:
+        activeMilestone?.title ??
+        (input.milestoneId != null
+          ? this.milestones.find((m) => m.id === input.milestoneId)?.title
+          : undefined),
+      dependsOn: parseDependsOn(body),
+      blocks: [],
+      comments: [],
+      createdAt: new Date(),
+    };
+    this.store.set(externalId, issue);
+    return this.toWorkItem(issue);
+  }
+
+  async seedIssue(opts: SeedIssueOptions): Promise<WorkItem> {
+    const item = await this.createIssue({
+      title: opts.title,
+      body: opts.body ?? '',
+      type: opts.type,
+      priority: opts.priority,
+      milestoneId: opts.milestoneId,
+    });
+    const issue = this.getByExternalId(item.externalId);
+    if (issue == null) throw new Error('InMemoryLabelsSource: created issue not found');
+    if (opts.state != null && opts.state !== 'factory:triaging') {
+      issue.state = opts.state;
+    }
+    if (opts.schedule != null) issue.schedule = opts.schedule;
+    if (opts.dependsOn != null) issue.dependsOn = opts.dependsOn;
+    if (opts.prDiff != null) issue.prDiff = opts.prDiff;
+    if (opts.milestoneTitle != null) issue.milestoneTitle = opts.milestoneTitle;
+    return this.toWorkItem(issue);
+  }
+
+  async getPrDiff(itemId: string): Promise<string> {
+    const number = parseIssueNumber(itemId);
+    const issue = this.getByExternalId(number);
+    return issue?.prDiff ?? '--- a/mock.ts\n+++ b/mock.ts\n@@ -1 +1 @@\n-old\n+new\n';
+  }
+
+  async watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {
+    throw new Error('not implemented until M3');
+  }
+}

--- a/core/state-source/interface.test.ts
+++ b/core/state-source/interface.test.ts
@@ -76,6 +76,10 @@ class StubStateSource implements StateSource {
     return Promise.reject(new Error('not implemented'));
   }
 
+  getPrDiff(_itemId: string): Promise<string> {
+    return Promise.resolve('');
+  }
+
   watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {
     return Promise.resolve({ unsubscribe: () => {} });
   }

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -91,5 +91,7 @@ export interface StateSource {
   attach(itemId: string, artifact: Artifact): Promise<void>;
   createIssue(input: CreateIssueInput): Promise<WorkItem>;
 
+  getPrDiff(itemId: string): Promise<string>;
+
   watchForUpdates(callback: (event: SourceEvent) => void): Promise<Subscription>;
 }

--- a/core/workflows/slice.test.ts
+++ b/core/workflows/slice.test.ts
@@ -79,6 +79,7 @@ function makeSource(overrides: Partial<StateSource> = {}): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
     ...overrides,
   };

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -75,6 +75,7 @@ function makeStateSource(): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/slices/fix-issue/chore-shipping.test.ts
+++ b/slices/fix-issue/chore-shipping.test.ts
@@ -86,6 +86,7 @@ function makeStateSource(): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -90,6 +90,7 @@ function makeStateSource(): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };
 }

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -418,7 +418,7 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
 
   // Step 5: open PR.
   const token = process.env.GITHUB_TOKEN ?? '';
-  if (token.length === 0) {
+  if (token.length === 0 && process.env.MOCK_OPEN_PR !== 'true') {
     throw new Error('GITHUB_TOKEN env var is required to open PR');
   }
   const repoRef = stateSource.repoRef;

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -123,6 +123,7 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
     ...overrides,
   };

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -29,12 +29,21 @@ import { PlaywrightReproSchema } from '@goose-hub/skills/playwright-repro/schema
  * On failure: cleanup worktree, persist agent.run-failed event,
  * post GitHub comment, transition to factory:needs-human.
  */
+export interface InvestigateWorkflowDeps {
+  createWorktreeImpl?: typeof createWorktree;
+  prewarmWorktreeImpl?: typeof prewarmWorktree;
+}
+
 export async function runInvestigateWorkflow(
   workItem: WorkItem,
   stateSource: StateSource,
   projectId: string,
   targetRepo: string,
+  deps: InvestigateWorkflowDeps = {},
 ): Promise<void> {
+  const createWtFn = deps.createWorktreeImpl ?? createWorktree;
+  const prewarmWtFn = deps.prewarmWorktreeImpl ?? prewarmWorktree;
+
   const runId = crypto.randomUUID();
   const runtime = new ClaudeCliRuntime();
   const investigatePrompt = readPromptWithContext('investigate', projectId);
@@ -44,9 +53,9 @@ export async function runInvestigateWorkflow(
 
   const { personaId } = selectPersona(projectId, 'investigator');
   const projectConfig = await getProjectBySlug(projectId);
-  const worktreePath = createWorktree(targetRepo, runId);
+  const worktreePath = createWtFn(targetRepo, runId);
   if (workItem.type === 'bug') {
-    prewarmWorktree(worktreePath, '@goose-hub/web');
+    prewarmWtFn(worktreePath, '@goose-hub/web');
   }
 
   try {

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -209,6 +209,7 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
     ...overrides,
   };

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -134,6 +134,7 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     attach: vi.fn().mockResolvedValue(undefined),
     createIssue: vi.fn(),
+    getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
     ...overrides,
   };
@@ -167,28 +168,24 @@ describe('runReviewWorkflow', () => {
       expect(getPrDiff).toHaveBeenCalledWith('42');
     });
 
-    it('uses gh pr diff via pr.opened event when stateSource has no getPrDiff', async () => {
+    it('passes the prDiff from stateSource to the agent', async () => {
       const item = makeWorkItem();
-      const source = makeMockSource();
+      const getPrDiff = vi.fn().mockResolvedValue('diff --git a/foo.ts b/foo.ts\n+added line');
+      const source = makeMockSource({ getPrDiff } as never);
       mockRun.mockResolvedValueOnce(makeApprovedResult());
-      mockExecSync.mockReturnValueOnce('diff --git a/foo.ts b/foo.ts\n+added line');
-      mockReplay.mockReturnValue([
-        { kind: 'pr.opened', payload: { prNumber: 9100 }, workItemId: item.id },
-      ]);
 
       const { runReviewWorkflow } = await import('./workflow.js');
       await runReviewWorkflow(item, source, 'test-project', 'owner/repo');
 
-      expect(mockExecSync).toHaveBeenCalledWith('gh pr diff 9100', expect.any(Object));
+      expect(getPrDiff).toHaveBeenCalledWith('42');
       const spec = mockRun.mock.calls[0][0] as { context: Record<string, unknown> };
       expect(spec.context.prDiff).toBe('diff --git a/foo.ts b/foo.ts\n+added line');
     });
 
-    it('passes empty prDiff when no pr.opened event exists', async () => {
+    it('passes empty prDiff when stateSource returns empty string', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();
       mockRun.mockResolvedValueOnce(makeApprovedResult());
-      mockReplay.mockReturnValue([]);
 
       const { runReviewWorkflow } = await import('./workflow.js');
       await runReviewWorkflow(item, source, 'test-project', 'owner/repo');

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -1,4 +1,3 @@
-import { execSync } from 'node:child_process';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { resolveBudgets } from '@goose-hub/core/agent-runtime/budgets.js';
 import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
@@ -157,24 +156,7 @@ export async function runReviewWorkflow(
 }
 
 async function getPrDiff(workItem: WorkItem, stateSource: StateSource): Promise<string> {
-  if ('getPrDiff' in stateSource && typeof stateSource.getPrDiff === 'function') {
-    return (stateSource.getPrDiff as (id: string) => Promise<string>)(workItem.externalId);
-  }
-  // Fall back to reading prNumber from the pr.opened event and shelling out to gh.
-  const events = eventStore.replay({ workItemId: workItem.id });
-  const prOpened = events
-    .slice()
-    .reverse()
-    .find((e) => e.kind === 'pr.opened');
-  if (prOpened == null) return '';
-  const payload = prOpened.payload as Record<string, unknown>;
-  const prNumber = typeof payload.prNumber === 'number' ? payload.prNumber : undefined;
-  if (prNumber == null) return '';
-  try {
-    return execSync(`gh pr diff ${prNumber}`, { encoding: 'utf8', timeout: 30_000 });
-  } catch {
-    return '';
-  }
+  return stateSource.getPrDiff(workItem.externalId);
 }
 
 function getQaVerdict(


### PR DESCRIPTION
Closes #566

## Summary

- **Phase 0**: MOCK_SOURCE guards on all non-StateSource GitHub-touching paths (merge-pr, open-pr, diff fetcher, improvement issue creator, dependency resolver, merge-conflict branch in transitions)
- **Phase 1**: `InMemoryLabelsSource` implements full `StateSource` interface via in-process Map; `getPrDiff` promoted to required interface method eliminating shell-injection risk; seed endpoint `POST /projects/test/:slug/seed-issue` registered only when `MOCK_SOURCE=true`
- **Phase 2**: New `mock-test-registry.ts` with per-workItemId FIFO outcome queues and merge-conflict flag; `mock-outputs.ts` extended with retro/resolve-conflict skills and testOutcome variants (reject, low-confidence, qa-fail, review-needs-fix)
- **Phase 3**: 7 new Playwright pipeline specs covering full-lifecycle, qa-fail-loop, gate-reject-loop, review-sendback-loop, merge-conflict, escalation, and bug-investigation paths
- **Phase 4**: Dedicated `pipeline-e2e` CI job (no `continue-on-error`); nightly real-GitHub workflow; Vitest fetch-guard test verifying zero real network calls in MOCK_SOURCE mode

## Test plan

- [ ] All 2097 unit/integration tests pass (`pnpm test`)
- [ ] Lint clean (`pnpm lint`)
- [ ] `pipeline-e2e` CI job runs 7 E2E specs with `MOCK_AGENTS=true MOCK_SOURCE=true MOCK_OPEN_PR=true` — no GITHUB_TOKEN required
- [ ] `source.fetch-guard.test.ts` confirms no real GitHub API calls escape from MOCK_SOURCE mode
- [ ] `e2e-nightly.yml` workflow triggers daily with real GITHUB_TOKEN for smoke-testing against live GitHub

https://claude.ai/code/session_01JViQebt4akzs1pH7ik1RJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01JViQebt4akzs1pH7ik1RJu)_