### PR TITLE
fix: skip playwright-repro for server-side bugs

### DIFF
--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -62,7 +62,15 @@ Based on your investigation, form a hypothesis:
 
 Emit: `[decision] INSIGHT: Root cause hypothesis — <one sentence>`
 
-### Step 5 — Record open questions
+### Step 5 — Determine if browser reproduction applies
+
+Decide whether this bug can be meaningfully reproduced via a Playwright browser session against the running dev server:
+- Set `requiresBrowserRepro: true` if the bug manifests visibly in the browser UI (wrong rendering, broken interaction, visible error state, etc.)
+- Set `requiresBrowserRepro: false` if the bug is purely server-side: an API returning a wrong status code, a thrown exception in a handler, a missing file guard, DB errors, etc. For these, a browser session captures nothing useful.
+
+Emit: `[decision] INSIGHT: requiresBrowserRepro=<true|false> — <one-sentence reason>`
+
+### Step 6 — Record open questions
 
 Note any unresolved questions that would require additional investigation:
 - Missing reproduction environment details
@@ -86,6 +94,7 @@ Return a JSON object with this exact structure:
     "<question 1>",
     "<question 2>"
   ],
+  "requiresBrowserRepro": false,
   "decisionSummaries": [
     { "kind": "READ", "summary": "<one sentence>", "evidence": "<quote or signal>" },
     { "kind": "READ", "summary": "<one sentence>", "evidence": "<file names or search terms>" },

--- a/skills/investigate/schema.ts
+++ b/skills/investigate/schema.ts
@@ -13,6 +13,11 @@ export const InvestigateSchema = z.object({
   keyFiles: z.array(KeyFileSchema).describe('Files most relevant to the bug'),
   confidence: z.enum(['low', 'medium', 'high']),
   openQuestions: z.array(z.string()).describe('Unresolved questions requiring more investigation'),
+  requiresBrowserRepro: z
+    .boolean()
+    .describe(
+      'True if the bug manifests in the browser UI and can be reproduced via Playwright. False for pure server-side/API bugs where a browser repro is meaningless.',
+    ),
   decisionSummaries: z.array(DecisionSummarySchema).min(1),
 });
 

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -75,18 +75,20 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   };
 }
 
-function makeInvestigateOutput() {
+function makeInvestigateOutput(overrides: Record<string, unknown> = {}) {
   return {
     findings: 'Root cause is a null-check missing in auth middleware.',
     keyFiles: [{ path: 'apps/server/src/middleware/auth.ts', reason: 'Contains null-dereference' }],
     confidence: 'high',
     openQuestions: ['Does this also affect WebSocket upgrade path?'],
+    requiresBrowserRepro: true,
     decisionSummaries: [
       {
         kind: 'READ',
         summary: 'Read issue #42: auth middleware crashes on missing session token',
       },
     ],
+    ...overrides,
   };
 }
 
@@ -370,6 +372,22 @@ describe('runInvestigateWorkflow', () => {
 
         expect(mockRun).toHaveBeenCalledTimes(1);
       }
+    });
+
+    it('does NOT run playwright-repro for type:bug when requiresBrowserRepro is false', async () => {
+      const item = makeWorkItem({ type: 'bug' });
+      const source = makeMockSource();
+
+      mockRun.mockResolvedValueOnce({
+        output: makeInvestigateOutput({ requiresBrowserRepro: false }),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -84,9 +84,9 @@ export async function runInvestigateWorkflow(
     }
     const findings = investigateParsed.data;
 
-    // Step c: If type:bug, run playwright-repro skill
+    // Step c: If type:bug and the bug manifests in the browser, run playwright-repro skill
     let reproOutput: unknown | undefined;
-    if (workItem.type === 'bug') {
+    if (workItem.type === 'bug' && findings.requiresBrowserRepro) {
       const { personaId: playwrightPersonaId } = selectPersona(projectId, 'investigator');
       const playwrightRunId = crypto.randomUUID();
 


### PR DESCRIPTION
## Summary

- Adds `requiresBrowserRepro: boolean` to `InvestigateSchema` — investigate skill sets it based on whether the bug manifests in the browser UI
- Gates playwright-repro in `runInvestigateWorkflow` on `findings.requiresBrowserRepro` rather than blindly on `workItem.type === 'bug'`
- For server-side bugs (API 500s, missing file guards, handler exceptions), investigate now completes without spinning up a browser session that captures nothing

## Test plan

- [ ] `slices/investigate/slice.test.ts` — new test: type:bug with `requiresBrowserRepro: false` calls runtime.run exactly once (no playwright-repro)
- [ ] Existing bug-type tests pass unchanged (fixture defaults `requiresBrowserRepro: true`)
- [ ] 24/24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)