### PR TITLE
chore(goose-hub-self): bump activeMilestone M11 → M12

### DIFF
--- a/target-projects/goose-hub-self/project.config.ts
+++ b/target-projects/goose-hub-self/project.config.ts
@@ -110,7 +110,7 @@ const config: ProjectConfig = {
   visibility: 'always_visible',
   machineScope: undefined,
   colorStripe: '#7c3aed',
-  activeMilestone: 'M11: Dependency-aware Scheduling',
+  activeMilestone: 'M12: Project Bootstrap Workflow',
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Single-line bump: `target-projects/goose-hub-self/project.config.ts:113` `activeMilestone: 'M11: …'` → `'M12: Project Bootstrap Workflow'`
- M11 closed via PR #580 (exit audit verdict: READY-TO-CLOSE; the three soft follow-ups landed in that same PR)
- Per `docs/PLAN.md` section 28, M12 is "Project Bootstrap Workflow"

## Governance note

`target-projects/<slug>/project.config.ts` is a governance file under FACTORY_RULES rule 12. Amendments by the human system owner are out-of-scope of the rule; this PR was requested explicitly by Shaun, so it falls under the exception. Diff is intentionally one line so the change is unambiguous.

## What's still on the human's plate (per `docs/exit-audit.md`)

- [ ] Write `docs/retros/m11.md` (200–500 words; what worked / what didn't / what to change for M12)
- [ ] Confirm M12 issues are filed and labelled `schedule:current` in the new milestone

Note: retros for M5, M6, M7, M8, and M10 are also missing. Happy to draft them from merged PRs / audit reports / git history if that's useful — just say.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] CI green
- [ ] Human merges and starts M12 work (next `/start the next issue` will pick up M12 issues with `schedule:current`)

https://claude.ai/code/session_013W9fbRfT3RGL6JpCYboMC9

---
_Generated by [Claude Code](https://claude.ai/code/session_013W9fbRfT3RGL6JpCYboMC9)_