### PR TITLE
M12.05: governance PR check with bootstrap-pr exception

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,36 @@
+name: Governance PR check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  governance-check:
+    name: Governance file protection (rule 12)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run governance check
+        run: pnpm tsx scripts/governance-check-pr.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/bootstrap/governance-check.ts
+++ b/core/bootstrap/governance-check.ts
@@ -1,0 +1,123 @@
+/**
+ * Governance file change checker.
+ *
+ * Implements rule 12 of FACTORY_RULES.md:
+ *   - Governance files cannot be modified by any Factory-dispatched PR.
+ *   - They can be created only in PRs tagged factory:bootstrap-pr.
+ *
+ * Governance perimeter:
+ *   - MISSION.md (root)
+ *   - FACTORY_RULES.md (root)
+ *   - CLAUDE.md (root only)
+ *   - target-projects/<slug>/project.config.ts
+ *   - target-projects/<slug>/personas/**
+ *   - target-projects/<slug>/MISSION.md (overlay)
+ *   - target-projects/<slug>/FACTORY_RULES.md (overlay)
+ */
+
+export type FileStatus = 'added' | 'modified' | 'removed' | 'renamed';
+
+export interface ChangedFile {
+  path: string;
+  status: FileStatus;
+}
+
+export interface Violation {
+  path: string;
+  reason: string;
+}
+
+export interface GovernanceCheckResult {
+  ok: boolean;
+  violations: Violation[];
+}
+
+/**
+ * Returns true if the given path falls within the governance perimeter.
+ */
+export function isGovernancePath(path: string): boolean {
+  // Root-level governance files (exact match)
+  if (path === 'MISSION.md') return true;
+  if (path === 'FACTORY_RULES.md') return true;
+  if (path === 'CLAUDE.md') return true;
+
+  // target-projects/<slug>/project.config.ts
+  if (/^target-projects\/[^/]+\/project\.config\.ts$/.test(path)) return true;
+
+  // target-projects/<slug>/personas/** (any depth)
+  if (/^target-projects\/[^/]+\/personas\//.test(path)) return true;
+
+  // target-projects/<slug>/MISSION.md overlay
+  if (/^target-projects\/[^/]+\/MISSION\.md$/.test(path)) return true;
+
+  // target-projects/<slug>/FACTORY_RULES.md overlay
+  if (/^target-projects\/[^/]+\/FACTORY_RULES\.md$/.test(path)) return true;
+
+  return false;
+}
+
+/**
+ * Returns true if the given path is allowed to be ADDED on a bootstrap PR.
+ *
+ * Bootstrap PRs may add (not modify) files under target-projects/<slug>/ and
+ * may add the root CLAUDE.md (initial creation only).
+ */
+export function isBootstrapAllowedAddition(path: string): boolean {
+  // Adding root CLAUDE.md on bootstrap is allowed (initial project setup)
+  if (path === 'CLAUDE.md') return true;
+
+  // Adding any governance file under target-projects/<slug>/ is allowed
+  if (/^target-projects\/[^/]+\//.test(path)) return true;
+
+  return false;
+}
+
+/**
+ * Check PR changed files against the governance perimeter.
+ *
+ * @param changes    List of files changed in the PR with their git status.
+ * @param hasBootstrapLabel  Whether the PR carries the `factory:bootstrap-pr` label.
+ * @returns GovernanceCheckResult — ok=true means the check passes.
+ */
+export function checkGovernance(
+  changes: ChangedFile[],
+  hasBootstrapLabel: boolean,
+): GovernanceCheckResult {
+  const violations: Violation[] = [];
+
+  for (const file of changes) {
+    if (!isGovernancePath(file.path)) {
+      // Not a governance file — always fine.
+      continue;
+    }
+
+    if (hasBootstrapLabel && file.status === 'added' && isBootstrapAllowedAddition(file.path)) {
+      // Bootstrap PR adding a new governance file — allowed.
+      continue;
+    }
+
+    // Everything else that touches a governance path is a violation.
+    const action =
+      file.status === 'added'
+        ? 'Creation of governance file'
+        : file.status === 'modified'
+          ? 'Modification of governance file'
+          : file.status === 'removed'
+            ? 'Deletion of governance file'
+            : 'Renaming of governance file';
+
+    const hint =
+      hasBootstrapLabel && file.status !== 'added'
+        ? ' (bootstrap PRs may only ADD new governance files, not modify/remove/rename existing ones)'
+        : !hasBootstrapLabel && file.status === 'added'
+          ? ' (only factory:bootstrap-pr PRs may add governance files)'
+          : '';
+
+    violations.push({
+      path: file.path,
+      reason: `${action} \`${file.path}\` is not allowed.${hint}`,
+    });
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/core/bootstrap/governance-check.ts
+++ b/core/bootstrap/governance-check.ts
@@ -22,6 +22,45 @@ export interface ChangedFile {
   status: FileStatus;
 }
 
+export interface PrFileChange {
+  filename: string;
+  status: string;
+  previous_filename?: string;
+}
+
+function normaliseStatus(s: string): FileStatus {
+  switch (s) {
+    case 'added':
+      return 'added';
+    case 'removed':
+      return 'removed';
+    case 'renamed':
+      return 'renamed';
+    default:
+      return 'modified';
+  }
+}
+
+/**
+ * Expand the GitHub PR-files API response into ChangedFile entries.
+ *
+ * Renames are split into a `removed` of the previous path plus a `renamed` of
+ * the new path. Without this, a rename of a governance file out of the perimeter
+ * (e.g. MISSION.md -> docs/MISSION.md) would bypass the check because only the
+ * new path is inspected.
+ */
+export function expandPrFileChanges(prFiles: PrFileChange[]): ChangedFile[] {
+  const out: ChangedFile[] = [];
+  for (const f of prFiles) {
+    const status = normaliseStatus(f.status);
+    if (status === 'renamed' && f.previous_filename && f.previous_filename !== f.filename) {
+      out.push({ path: f.previous_filename, status: 'removed' });
+    }
+    out.push({ path: f.filename, status });
+  }
+  return out;
+}
+
 export interface Violation {
   path: string;
   reason: string;

--- a/scripts/governance-check-pr.ts
+++ b/scripts/governance-check-pr.ts
@@ -18,14 +18,15 @@
  */
 
 import fs from 'node:fs';
-import type { ChangedFile, FileStatus } from '../core/bootstrap/governance-check.js';
-import { checkGovernance } from '../core/bootstrap/governance-check.js';
+import type { PrFileChange } from '../core/bootstrap/governance-check.js';
+import { checkGovernance, expandPrFileChanges } from '../core/bootstrap/governance-check.js';
 
 const BOOTSTRAP_LABEL = 'factory:bootstrap-pr';
 
 interface GitHubPRFile {
   filename: string;
   status: string;
+  previous_filename?: string;
 }
 
 interface GitHubLabel {
@@ -39,19 +40,6 @@ interface GitHubEventPR {
 
 interface GitHubEvent {
   pull_request?: GitHubEventPR;
-}
-
-function normaliseStatus(githubStatus: string): FileStatus {
-  switch (githubStatus) {
-    case 'added':
-      return 'added';
-    case 'removed':
-      return 'removed';
-    case 'renamed':
-      return 'renamed';
-    default:
-      return 'modified';
-  }
 }
 
 async function fetchPRFiles(
@@ -129,10 +117,7 @@ async function main(): Promise<void> {
   const prFiles = await fetchPRFiles(token, repo, prNumber);
   console.log(`Changed files: ${prFiles.length}`);
 
-  const changes: ChangedFile[] = prFiles.map((f) => ({
-    path: f.filename,
-    status: normaliseStatus(f.status),
-  }));
+  const changes = expandPrFileChanges(prFiles as PrFileChange[]);
 
   const result = checkGovernance(changes, hasBootstrapLabel);
 

--- a/scripts/governance-check-pr.ts
+++ b/scripts/governance-check-pr.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env tsx
+/**
+ * Governance PR check script.
+ *
+ * Called by .github/workflows/governance-check.yml on every pull_request event.
+ * Reads the GitHub event payload, fetches the PR's changed files via REST,
+ * and passes them through checkGovernance() from core/bootstrap/governance-check.ts.
+ *
+ * Exits 0 on pass, 1 on failure (with a clear error listing each violation).
+ *
+ * Usage (in CI):
+ *   pnpm tsx scripts/governance-check-pr.ts
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN       — GitHub Actions token with read access to pull requests
+ *   GITHUB_EVENT_PATH  — Path to the GitHub Actions event JSON payload
+ *   GITHUB_REPOSITORY  — e.g. "shaunnez/goose-hub"
+ */
+
+import fs from 'node:fs';
+import type { ChangedFile, FileStatus } from '../core/bootstrap/governance-check.js';
+import { checkGovernance } from '../core/bootstrap/governance-check.js';
+
+const BOOTSTRAP_LABEL = 'factory:bootstrap-pr';
+
+interface GitHubPRFile {
+  filename: string;
+  status: string;
+}
+
+interface GitHubLabel {
+  name: string;
+}
+
+interface GitHubEventPR {
+  number: number;
+  labels?: GitHubLabel[];
+}
+
+interface GitHubEvent {
+  pull_request?: GitHubEventPR;
+}
+
+function normaliseStatus(githubStatus: string): FileStatus {
+  switch (githubStatus) {
+    case 'added':
+      return 'added';
+    case 'removed':
+      return 'removed';
+    case 'renamed':
+      return 'renamed';
+    default:
+      return 'modified';
+  }
+}
+
+async function fetchPRFiles(
+  token: string,
+  repo: string,
+  prNumber: number,
+): Promise<GitHubPRFile[]> {
+  const all: GitHubPRFile[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'goose-hub-governance-check',
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`GitHub API error ${res.status}: ${body}`);
+      process.exit(1);
+    }
+
+    const batch = (await res.json()) as GitHubPRFile[];
+    all.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+
+  return all;
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repo = process.env.GITHUB_REPOSITORY;
+
+  if (!token) {
+    console.error('GITHUB_TOKEN is not set.');
+    process.exit(1);
+  }
+  if (!eventPath) {
+    console.error('GITHUB_EVENT_PATH is not set.');
+    process.exit(1);
+  }
+  if (!repo) {
+    console.error('GITHUB_REPOSITORY is not set.');
+    process.exit(1);
+  }
+
+  // Read the event payload.
+  const event: GitHubEvent = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+  const pr = event.pull_request;
+
+  if (!pr) {
+    console.log('Not a pull_request event — skipping governance check.');
+    process.exit(0);
+  }
+
+  const prNumber = pr.number;
+
+  // Determine bootstrap label from the event payload (most up-to-date for
+  // labeled/unlabeled events). For synchronize/opened, GitHub also includes
+  // current labels on the PR object.
+  const hasBootstrapLabel = (pr.labels ?? []).some((l) => l.name === BOOTSTRAP_LABEL);
+
+  console.log(`Governance check for PR #${prNumber} in ${repo}`);
+  console.log(`factory:bootstrap-pr label present: ${hasBootstrapLabel}`);
+
+  // Fetch changed files.
+  const prFiles = await fetchPRFiles(token, repo, prNumber);
+  console.log(`Changed files: ${prFiles.length}`);
+
+  const changes: ChangedFile[] = prFiles.map((f) => ({
+    path: f.filename,
+    status: normaliseStatus(f.status),
+  }));
+
+  const result = checkGovernance(changes, hasBootstrapLabel);
+
+  if (result.ok) {
+    console.log('Governance check PASSED — no governance file violations.');
+    process.exit(0);
+  }
+
+  console.error('\nGovernance check FAILED — the following violations were found:\n');
+  for (const v of result.violations) {
+    console.error(`  - ${v.reason}`);
+  }
+  console.error(
+    '\nGovernance files (MISSION.md, FACTORY_RULES.md, CLAUDE.md, project configs, persona configs)',
+  );
+  console.error('cannot be modified by Factory-dispatched PRs (FACTORY_RULES rule 12).');
+  console.error(
+    'Only PRs labelled `factory:bootstrap-pr` may ADD new governance files (not modify/remove/rename).',
+  );
+  process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/slices/governance-check/README.md
+++ b/slices/governance-check/README.md
@@ -1,0 +1,63 @@
+# slices/governance-check
+
+Governance PR protection check. Closes M12.05 (#305).
+
+## What it does
+
+Enforces FACTORY_RULES rule 12: governance files cannot be modified by any
+Factory-dispatched PR. They can only be created in PRs tagged
+`factory:bootstrap-pr`.
+
+A GitHub Actions workflow runs on every `pull_request` event
+(opened, synchronize, reopened, labeled, unlabeled). It fetches the PR's
+changed files via the GitHub REST API and runs them through `checkGovernance()`.
+The check fails with a clear per-file error message if any governance file is
+touched in a disallowed way.
+
+## Governance perimeter
+
+| Path pattern | Covered by |
+|---|---|
+| `MISSION.md` | Root governance — immutable |
+| `FACTORY_RULES.md` | Root governance — immutable |
+| `CLAUDE.md` | Root governance — immutable |
+| `target-projects/<slug>/project.config.ts` | Project config |
+| `target-projects/<slug>/personas/**` | Persona configs |
+| `target-projects/<slug>/MISSION.md` | Per-project overlay |
+| `target-projects/<slug>/FACTORY_RULES.md` | Per-project overlay |
+
+## Bootstrap exception
+
+PRs labelled `factory:bootstrap-pr` may ADD (not modify/remove/rename) files
+within the perimeter. The rationale: bootstrapping a new project requires
+creating its governance set for the first time. Modification of existing
+governance files is still blocked even on bootstrap PRs.
+
+Root `CLAUDE.md` addition is also permitted on bootstrap PRs to support
+initial repository setup.
+
+## Vertical surfaces touched
+
+- **Core lib**: `core/bootstrap/governance-check.ts`
+  - `isGovernancePath(path)` — returns true if a path is in the perimeter
+  - `isBootstrapAllowedAddition(path)` — returns true if a path may be added
+    on a bootstrap PR
+  - `checkGovernance(changes, hasBootstrapLabel)` — pure function, no I/O;
+    returns `{ ok, violations }` where each violation includes `path` and `reason`
+
+- **Script**: `scripts/governance-check-pr.ts`
+  - Reads `GITHUB_EVENT_PATH`, fetches PR files via GitHub REST, calls
+    `checkGovernance`, exits non-zero on failure
+
+- **Workflow**: `.github/workflows/governance-check.yml`
+  - Triggers on `pull_request` (opened, synchronize, reopened, labeled, unlabeled)
+  - Runs `pnpm tsx scripts/governance-check-pr.ts`
+
+## Running the tests
+
+```bash
+pnpm vitest run slices/governance-check/slice.test.ts
+```
+
+No live GitHub API required — the pure `checkGovernance` function is tested
+directly with injected file lists.

--- a/slices/governance-check/slice.test.ts
+++ b/slices/governance-check/slice.test.ts
@@ -1,5 +1,9 @@
-import { checkGovernance, isGovernancePath } from '@goose-hub/core/bootstrap/governance-check.js';
-import type { ChangedFile } from '@goose-hub/core/bootstrap/governance-check.js';
+import {
+  checkGovernance,
+  expandPrFileChanges,
+  isGovernancePath,
+} from '@goose-hub/core/bootstrap/governance-check.js';
+import type { ChangedFile, PrFileChange } from '@goose-hub/core/bootstrap/governance-check.js';
 import { describe, expect, it } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -210,6 +214,88 @@ describe('checkGovernance — bootstrap PR (factory:bootstrap-pr label)', () => 
 // ---------------------------------------------------------------------------
 // Acceptance criteria scenario: the issue specifies this exact test case
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// expandPrFileChanges — rename bypass guard
+// ---------------------------------------------------------------------------
+
+describe('expandPrFileChanges', () => {
+  it('passes added/modified/removed entries through unchanged', () => {
+    const prFiles: PrFileChange[] = [
+      { filename: 'src/a.ts', status: 'added' },
+      { filename: 'src/b.ts', status: 'modified' },
+      { filename: 'src/c.ts', status: 'removed' },
+    ];
+    expect(expandPrFileChanges(prFiles)).toEqual([
+      { path: 'src/a.ts', status: 'added' },
+      { path: 'src/b.ts', status: 'modified' },
+      { path: 'src/c.ts', status: 'removed' },
+    ]);
+  });
+
+  it('splits a renamed entry into a removed of the previous path plus the renamed new path', () => {
+    const prFiles: PrFileChange[] = [
+      { filename: 'docs/MISSION.md', status: 'renamed', previous_filename: 'MISSION.md' },
+    ];
+    expect(expandPrFileChanges(prFiles)).toEqual([
+      { path: 'MISSION.md', status: 'removed' },
+      { path: 'docs/MISSION.md', status: 'renamed' },
+    ]);
+  });
+
+  it('handles a rename without a previous_filename gracefully', () => {
+    const prFiles: PrFileChange[] = [{ filename: 'src/x.ts', status: 'renamed' }];
+    expect(expandPrFileChanges(prFiles)).toEqual([{ path: 'src/x.ts', status: 'renamed' }]);
+  });
+
+  it('does not emit a duplicate removed when previous_filename equals filename', () => {
+    const prFiles: PrFileChange[] = [
+      { filename: 'src/x.ts', status: 'renamed', previous_filename: 'src/x.ts' },
+    ];
+    expect(expandPrFileChanges(prFiles)).toEqual([{ path: 'src/x.ts', status: 'renamed' }]);
+  });
+
+  it('coerces unknown statuses to modified', () => {
+    const prFiles: PrFileChange[] = [{ filename: 'src/y.ts', status: 'copied' }];
+    expect(expandPrFileChanges(prFiles)).toEqual([{ path: 'src/y.ts', status: 'modified' }]);
+  });
+});
+
+describe('checkGovernance — rename bypass guard (P1)', () => {
+  it('FAILS when a governance file is renamed OUT of the perimeter', () => {
+    // Simulates: MISSION.md -> docs/MISSION.md
+    const changes = expandPrFileChanges([
+      { filename: 'docs/MISSION.md', status: 'renamed', previous_filename: 'MISSION.md' },
+    ]);
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    // The previous (governance) path is flagged as a removal violation.
+    expect(result.violations.some((v) => v.path === 'MISSION.md')).toBe(true);
+  });
+
+  it('FAILS when an existing project.config.ts is renamed under bootstrap label', () => {
+    const changes = expandPrFileChanges([
+      {
+        filename: 'target-projects/old/renamed-config.ts',
+        status: 'renamed',
+        previous_filename: 'target-projects/old/project.config.ts',
+      },
+    ]);
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+    expect(result.violations.some((v) => v.path === 'target-projects/old/project.config.ts')).toBe(
+      true,
+    );
+  });
+
+  it('still passes when a non-governance file is renamed', () => {
+    const changes = expandPrFileChanges([
+      { filename: 'src/new.ts', status: 'renamed', previous_filename: 'src/old.ts' },
+    ]);
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(true);
+  });
+});
 
 describe('acceptance criteria scenario', () => {
   const newProjectConfigPath = 'target-projects/test-slug/project.config.ts';

--- a/slices/governance-check/slice.test.ts
+++ b/slices/governance-check/slice.test.ts
@@ -1,0 +1,230 @@
+import { checkGovernance, isGovernancePath } from '@goose-hub/core/bootstrap/governance-check.js';
+import type { ChangedFile } from '@goose-hub/core/bootstrap/governance-check.js';
+import { describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// isGovernancePath — unit tests
+// ---------------------------------------------------------------------------
+
+describe('isGovernancePath', () => {
+  it.each([
+    'MISSION.md',
+    'FACTORY_RULES.md',
+    'CLAUDE.md',
+    'target-projects/my-slug/project.config.ts',
+    'target-projects/my-slug/personas/reviewer.md',
+    'target-projects/my-slug/personas/nested/deep.md',
+    'target-projects/my-slug/MISSION.md',
+    'target-projects/my-slug/FACTORY_RULES.md',
+  ])('recognises governance path: %s', (path) => {
+    expect(isGovernancePath(path)).toBe(true);
+  });
+
+  it.each([
+    'core/bootstrap/governance-check.ts',
+    'slices/governance-check/slice.test.ts',
+    '.github/workflows/governance-check.yml',
+    'scripts/governance-check-pr.ts',
+    'target-projects/my-slug/project.config.ts.bak', // extension mismatch
+    'target-projects/my-slug/agent-context/dev.md', // not in perimeter
+    'docs/PLAN.md',
+    'CLAUDE.md.backup', // not exact root CLAUDE.md
+    'some/nested/MISSION.md', // not root
+  ])('does NOT flag non-governance path: %s', (path) => {
+    expect(isGovernancePath(path)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGovernance — PR without bootstrap label
+// ---------------------------------------------------------------------------
+
+describe('checkGovernance — regular PR (no bootstrap label)', () => {
+  it('passes when no governance files are touched', () => {
+    const changes: ChangedFile[] = [
+      { path: 'src/index.ts', status: 'modified' },
+      { path: 'core/bootstrap/governance-check.ts', status: 'added' },
+    ];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('fails when MISSION.md is modified', () => {
+    const changes: ChangedFile[] = [{ path: 'MISSION.md', status: 'modified' }];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].path).toBe('MISSION.md');
+    expect(result.violations[0].reason).toMatch(/Modification of governance file/);
+    expect(result.violations[0].reason).toMatch(/`MISSION\.md`/);
+  });
+
+  it('fails when FACTORY_RULES.md is modified', () => {
+    const changes: ChangedFile[] = [{ path: 'FACTORY_RULES.md', status: 'modified' }];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/FACTORY_RULES\.md/);
+  });
+
+  it('fails when CLAUDE.md is modified', () => {
+    const changes: ChangedFile[] = [{ path: 'CLAUDE.md', status: 'modified' }];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails when a project.config.ts is modified', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/my-proj/project.config.ts', status: 'modified' },
+    ];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/Modification of governance file/);
+  });
+
+  it('fails when a personas file is modified', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/my-proj/personas/reviewer.md', status: 'modified' },
+    ];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails when a governance file is ADDED on a regular PR', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/new-slug/project.config.ts', status: 'added' },
+    ];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/only factory:bootstrap-pr PRs may add/);
+  });
+
+  it('fails when a governance file is REMOVED', () => {
+    const changes: ChangedFile[] = [{ path: 'MISSION.md', status: 'removed' }];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/Deletion of governance file/);
+  });
+
+  it('reports all violations in a single pass', () => {
+    const changes: ChangedFile[] = [
+      { path: 'MISSION.md', status: 'modified' },
+      { path: 'FACTORY_RULES.md', status: 'modified' },
+      { path: 'src/util.ts', status: 'added' },
+    ];
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGovernance — bootstrap PR (factory:bootstrap-pr label present)
+// ---------------------------------------------------------------------------
+
+describe('checkGovernance — bootstrap PR (factory:bootstrap-pr label)', () => {
+  it('passes when new target-projects/<slug>/project.config.ts is ADDED', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/test-slug/project.config.ts', status: 'added' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('passes when new personas file is ADDED under target-projects/<slug>/', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/test-slug/personas/reviewer.md', status: 'added' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+  });
+
+  it('passes when CLAUDE.md is ADDED (initial creation)', () => {
+    const changes: ChangedFile[] = [{ path: 'CLAUDE.md', status: 'added' }];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+  });
+
+  it('passes when both new project governance files and CLAUDE.md are added', () => {
+    const changes: ChangedFile[] = [
+      { path: 'CLAUDE.md', status: 'added' },
+      { path: 'target-projects/test-slug/project.config.ts', status: 'added' },
+      { path: 'target-projects/test-slug/personas/dev.md', status: 'added' },
+      { path: 'target-projects/test-slug/MISSION.md', status: 'added' },
+      { path: 'target-projects/test-slug/FACTORY_RULES.md', status: 'added' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('FAILS when MISSION.md (root) is MODIFIED even on bootstrap PR', () => {
+    const changes: ChangedFile[] = [{ path: 'MISSION.md', status: 'modified' }];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/bootstrap PRs may only ADD/);
+  });
+
+  it('FAILS when FACTORY_RULES.md is MODIFIED on bootstrap PR', () => {
+    const changes: ChangedFile[] = [{ path: 'FACTORY_RULES.md', status: 'modified' }];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+  });
+
+  it('FAILS when an existing project.config.ts is MODIFIED on bootstrap PR', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/existing-slug/project.config.ts', status: 'modified' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/bootstrap PRs may only ADD/);
+  });
+
+  it('FAILS when a governance file is REMOVED on bootstrap PR', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/some-slug/personas/dev.md', status: 'removed' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+  });
+
+  it('FAILS when CLAUDE.md is MODIFIED (not added) on bootstrap PR', () => {
+    const changes: ChangedFile[] = [{ path: 'CLAUDE.md', status: 'modified' }];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toMatch(/bootstrap PRs may only ADD/);
+  });
+
+  it('passes for non-governance files alongside bootstrap additions', () => {
+    const changes: ChangedFile[] = [
+      { path: 'target-projects/test-slug/project.config.ts', status: 'added' },
+      { path: 'core/orchestrator/index.ts', status: 'modified' },
+      { path: 'scripts/setup.sh', status: 'added' },
+    ];
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria scenario: the issue specifies this exact test case
+// ---------------------------------------------------------------------------
+
+describe('acceptance criteria scenario', () => {
+  const newProjectConfigPath = 'target-projects/test-slug/project.config.ts';
+  const changes: ChangedFile[] = [{ path: newProjectConfigPath, status: 'added' }];
+
+  it('bootstrap PR with new target-projects/test-slug/project.config.ts → check passes', () => {
+    const result = checkGovernance(changes, true);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('regular PR with same change → check fails', () => {
+    const result = checkGovernance(changes, false);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].path).toBe(newProjectConfigPath);
+  });
+});


### PR DESCRIPTION
Closes #305

Adds governance file protection enforcing FACTORY_RULES rule 12. The pure `checkGovernance()` function in `core/bootstrap/governance-check.ts` validates PR changed files against the full governance perimeter. A GitHub Actions workflow triggers on every pull_request event and runs the check via `scripts/governance-check-pr.ts`, exiting non-zero with a per-file violation list on failure. PRs with `factory:bootstrap-pr` may add new governance files; modification of existing governance files is blocked on all PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_014obzUzjwJY7g17g8xrZGze)_