### PR TITLE
M12.02: CLAUDE.md auditor (create + diff)

### DIFF
--- a/core/bootstrap/claude-md-auditor.ts
+++ b/core/bootstrap/claude-md-auditor.ts
@@ -64,6 +64,10 @@ const REQUIRED_SECTIONS: ReadonlyArray<string> = [
   'Commands',
   'Hard rules',
   'PR conventions',
+  // Holdout-safety boundary mandated by CONTEXT.md:275 — the workspace
+  // CLAUDE.md is auto-loaded by Claude Code on every spawn, so it must be
+  // holdout-clean by design. This section makes that boundary explicit.
+  "What goes here / What doesn't",
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -117,6 +121,16 @@ ${commandsBlock}
 - Title format: \`M<milestone>.<task>: <short description>\`
 - Body must contain \`Closes #N\` on its own line.
 - No implementation reasoning in the PR body.
+
+## What goes here / What doesn't
+
+This file is auto-loaded by Claude Code on every agent spawn, so it is
+visible to QA and Reviewer holdouts. Keep it holdout-clean.
+
+- Goes here: naming conventions, test/lint/build commands, repo layout, hard rules, PR conventions.
+- Does not go here: implementation reasoning, plans, decision summaries, chat history, agent-specific guidance.
+
+Per-skill guidance lives in \`skills/<name>/prompt.md\` or in \`AgentSpec.context\` filtered by allowlist — never in this file.
 `;
 }
 
@@ -210,6 +224,19 @@ function buildAdditionDiff(
         );
         break;
 
+      case "What goes here / What doesn't":
+        lines.push(
+          'This file is auto-loaded by Claude Code on every agent spawn, so it is',
+          'visible to QA and Reviewer holdouts. Keep it holdout-clean.',
+          '',
+          '- Goes here: naming conventions, test/lint/build commands, repo layout, hard rules, PR conventions.',
+          '- Does not go here: implementation reasoning, plans, decision summaries, chat history, agent-specific guidance.',
+          '',
+          'Per-skill guidance lives in `skills/<name>/prompt.md` or in `AgentSpec.context` filtered by allowlist — never in this file.',
+          '',
+        );
+        break;
+
       default:
         lines.push('<!-- TODO: Fill in this section. -->', '');
         break;
@@ -257,8 +284,12 @@ export async function auditClaudeMd(repoPath: string, stackInfo: StackInfo): Pro
   let existingContent: string | null = null;
   try {
     existingContent = await fs.readFile(claudeMdPath, 'utf-8');
-  } catch {
-    // File does not exist — that is fine, handled below
+  } catch (err) {
+    // Only ENOENT is "missing"; permission, IO, or path errors must surface
+    // so bootstrap doesn't silently misreport an unreadable file as missing.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err;
+    }
   }
 
   if (existingContent === null) {

--- a/core/bootstrap/claude-md-auditor.ts
+++ b/core/bootstrap/claude-md-auditor.ts
@@ -1,0 +1,298 @@
+/**
+ * CLAUDE.md auditor — M12.02
+ *
+ * Given a repo path and detected stack info, this module:
+ *  - Generates a CLAUDE.md template when none exists (action='create')
+ *  - Produces a unified diff of missing sections when one exists but is
+ *    incomplete (action='update')
+ *  - Returns action='ok' when the existing file already contains all required
+ *    sections
+ *
+ * NOTE: This module intentionally declares a local StackInfo type. The
+ * canonical type will live in core/bootstrap/stack-detector.ts (M12.01),
+ * which is being built in parallel. The bootstrap-project workflow (#307)
+ * will reconcile the types.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal stack description needed by the auditor. */
+export type StackInfo = {
+  /** Primary language / framework identifier (e.g. 'node', 'python'). */
+  type: string;
+  /** Detected commands for common lifecycle operations. */
+  commands?: {
+    build?: string;
+    test?: string;
+    lint?: string;
+    typecheck?: string;
+    e2e?: string;
+  };
+};
+
+/**
+ * Result returned by `auditClaudeMd`.
+ *
+ *  - `action='create'` → `content` is the full CLAUDE.md template to write
+ *  - `action='update'` → `content` is a unified diff of additions to append
+ *  - `action='ok'`    → `content` is empty string; nothing to do
+ */
+export type AuditResult = {
+  action: 'create' | 'update' | 'ok';
+  /** New file content (create) or unified diff (update) or '' (ok). */
+  content: string;
+  /** Human-readable explanation of what was found and why. */
+  rationale: string;
+};
+
+// ---------------------------------------------------------------------------
+// Required section headings
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical set of `## ` headings that every project CLAUDE.md should have.
+ * Order matters for template generation.
+ */
+const REQUIRED_SECTIONS: ReadonlyArray<string> = [
+  'What this repo is',
+  'Stack',
+  'Commands',
+  'Hard rules',
+  'PR conventions',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Template generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates the full CLAUDE.md template text populated with discovered stack
+ * commands.
+ */
+function generateTemplate(stackInfo: StackInfo): string {
+  const cmds = stackInfo.commands ?? {};
+
+  const commandLines: string[] = [];
+  if (cmds.build) commandLines.push(`- build: \`${cmds.build}\``);
+  if (cmds.test) commandLines.push(`- test: \`${cmds.test}\``);
+  if (cmds.lint) commandLines.push(`- lint: \`${cmds.lint}\``);
+  if (cmds.typecheck) commandLines.push(`- typecheck: \`${cmds.typecheck}\``);
+  if (cmds.e2e) commandLines.push(`- e2e: \`${cmds.e2e}\``);
+
+  const commandsBlock =
+    commandLines.length > 0
+      ? commandLines.join('\n')
+      : '<!-- No commands detected. Fill in manually. -->';
+
+  return `# CLAUDE.md
+
+## What this repo is
+
+<!-- TODO: Describe what this repository does and its primary purpose. -->
+
+## Stack
+
+- Language/framework: ${stackInfo.type}
+<!-- TODO: List additional technologies used in this project. -->
+
+## Commands
+
+${commandsBlock}
+
+## Hard rules
+
+- Follow vertical slice architecture — no cross-slice imports.
+- No inline prompts — all prompts live in \`skills/<name>/prompt.md\`.
+- Every agent run must produce JSON conforming to its skill schema.
+- State labels live on issues, not PRs.
+- Do not modify governance files (MISSION.md, FACTORY_RULES.md, CLAUDE.md).
+
+## PR conventions
+
+- Title format: \`M<milestone>.<task>: <short description>\`
+- Body must contain \`Closes #N\` on its own line.
+- No implementation reasoning in the PR body.
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Section detection
+// ---------------------------------------------------------------------------
+
+/** Extract the set of `## Heading` names present in a CLAUDE.md file. */
+function extractSectionHeadings(content: string): Set<string> {
+  const headings = new Set<string>();
+  for (const line of content.split('\n')) {
+    const match = /^##\s+(.+)$/.exec(line.trim());
+    if (match) {
+      headings.add(match[1].trim());
+    }
+  }
+  return headings;
+}
+
+// ---------------------------------------------------------------------------
+// Diff generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a minimal unified diff string that shows lines to be added for
+ * each missing section. The format uses `+++`, `---`, and `@@` markers so it
+ * is both human-readable and renderable in the UI / PR description.
+ *
+ * We only ever add lines (no deletions), so the `---` header references
+ * the existing file and `+++` references the proposed augmented file.
+ */
+function buildAdditionDiff(
+  existingContent: string,
+  missingHeadings: string[],
+  stackInfo: StackInfo,
+): string {
+  const cmds = stackInfo.commands ?? {};
+
+  // Build per-section content blocks for each missing heading
+  const sectionBlocks: Array<{ heading: string; lines: string[] }> = [];
+
+  for (const heading of missingHeadings) {
+    const lines: string[] = [`## ${heading}`, ''];
+
+    switch (heading) {
+      case 'What this repo is':
+        lines.push(
+          '<!-- TODO: Describe what this repository does and its primary purpose. -->',
+          '',
+        );
+        break;
+
+      case 'Stack':
+        lines.push(
+          `- Language/framework: ${stackInfo.type}`,
+          '<!-- TODO: List additional technologies. -->',
+          '',
+        );
+        break;
+
+      case 'Commands': {
+        const cmdLines: string[] = [];
+        if (cmds.build) cmdLines.push(`- build: \`${cmds.build}\``);
+        if (cmds.test) cmdLines.push(`- test: \`${cmds.test}\``);
+        if (cmds.lint) cmdLines.push(`- lint: \`${cmds.lint}\``);
+        if (cmds.typecheck) cmdLines.push(`- typecheck: \`${cmds.typecheck}\``);
+        if (cmds.e2e) cmdLines.push(`- e2e: \`${cmds.e2e}\``);
+        if (cmdLines.length === 0) {
+          cmdLines.push('<!-- No commands detected. Fill in manually. -->');
+        }
+        lines.push(...cmdLines, '');
+        break;
+      }
+
+      case 'Hard rules':
+        lines.push(
+          '- Follow vertical slice architecture — no cross-slice imports.',
+          '- No inline prompts — all prompts live in `skills/<name>/prompt.md`.',
+          '- Every agent run must produce JSON conforming to its skill schema.',
+          '- State labels live on issues, not PRs.',
+          '',
+        );
+        break;
+
+      case 'PR conventions':
+        lines.push(
+          '- Title format: `M<milestone>.<task>: <short description>`',
+          '- Body must contain `Closes #N` on its own line.',
+          '- No implementation reasoning in the PR body.',
+          '',
+        );
+        break;
+
+      default:
+        lines.push('<!-- TODO: Fill in this section. -->', '');
+        break;
+    }
+
+    sectionBlocks.push({ heading, lines });
+  }
+
+  // Count existing lines so we can set a realistic hunk offset
+  const existingLineCount = existingContent.split('\n').length;
+
+  // Build the unified diff output
+  const diffParts: string[] = ['--- a/CLAUDE.md', '+++ b/CLAUDE.md'];
+
+  let insertionOffset = existingLineCount + 1;
+
+  for (const block of sectionBlocks) {
+    const addedLines = block.lines;
+    diffParts.push(`@@ -${insertionOffset},0 +${insertionOffset},${addedLines.length} @@`);
+    for (const line of addedLines) {
+      diffParts.push(`+${line}`);
+    }
+    insertionOffset += addedLines.length;
+  }
+
+  return `${diffParts.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Audit the CLAUDE.md in `repoPath` against the detected `stackInfo`.
+ *
+ * Never writes to disk. Returns a result describing what action is needed and
+ * the content (template or diff) that should be applied.
+ */
+export async function auditClaudeMd(repoPath: string, stackInfo: StackInfo): Promise<AuditResult> {
+  const claudeMdPath = path.join(repoPath, 'CLAUDE.md');
+
+  // ------------------------------------------------------------------
+  // Case 1: no CLAUDE.md → generate a template
+  // ------------------------------------------------------------------
+  let existingContent: string | null = null;
+  try {
+    existingContent = await fs.readFile(claudeMdPath, 'utf-8');
+  } catch {
+    // File does not exist — that is fine, handled below
+  }
+
+  if (existingContent === null) {
+    const template = generateTemplate(stackInfo);
+    return {
+      action: 'create',
+      content: template,
+      rationale: 'No CLAUDE.md found. Generated a template populated with detected stack commands.',
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Case 2: CLAUDE.md exists — check for missing sections
+  // ------------------------------------------------------------------
+  const presentHeadings = extractSectionHeadings(existingContent);
+  const missingHeadings = REQUIRED_SECTIONS.filter((h) => !presentHeadings.has(h));
+
+  if (missingHeadings.length === 0) {
+    return {
+      action: 'ok',
+      content: '',
+      rationale: 'CLAUDE.md exists and contains all required sections. No changes needed.',
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Case 3: some sections are missing → produce a unified diff
+  // ------------------------------------------------------------------
+  const diff = buildAdditionDiff(existingContent, missingHeadings, stackInfo);
+  const missingList = missingHeadings.join(', ');
+
+  return {
+    action: 'update',
+    content: diff,
+    rationale: `CLAUDE.md exists but is missing required sections: ${missingList}. Diff shows additions only — existing content is preserved.`,
+  };
+}

--- a/slices/claude-md-auditor/README.md
+++ b/slices/claude-md-auditor/README.md
@@ -1,0 +1,66 @@
+# slices/claude-md-auditor
+
+CLAUDE.md auditor — create and diff. Closes M12.02 (#303).
+
+## What it does
+
+Given a repository path and detected stack information, the auditor determines
+whether a `CLAUDE.md` file needs to be created, updated, or left as-is:
+
+- **No `CLAUDE.md`** → generates a fully-populated template (`action='create'`)
+- **Partial `CLAUDE.md`** (missing required sections) → produces a unified diff
+  showing additions only; never overwrites the existing file (`action='update'`)
+- **Complete `CLAUDE.md`** (all required sections present) → returns `action='ok'`
+  with empty content
+
+## Vertical surfaces touched
+
+- **Core lib**: `core/bootstrap/claude-md-auditor.ts`
+  - `auditClaudeMd(repoPath, stackInfo)` — main entry point
+  - `AuditResult` — typed result `{ action, content, rationale }`
+  - `StackInfo` — local type (to be reconciled with M12.01 stack-detector in #307)
+
+## Required sections
+
+The auditor checks for these `## ` headings:
+
+| Heading | Description |
+|---------|-------------|
+| `What this repo is` | Project description placeholder |
+| `Stack` | Technology list with detected stack type |
+| `Commands` | Lifecycle commands (build/test/lint/typecheck/e2e) |
+| `Hard rules` | Factory governance reminders |
+| `PR conventions` | PR title + body format requirements |
+
+## AuditResult shape
+
+```typescript
+type AuditResult = {
+  action: 'create' | 'update' | 'ok';
+  content: string;   // template (create) | unified diff (update) | '' (ok)
+  rationale: string; // human-readable explanation
+};
+```
+
+## Diff format
+
+The diff uses standard unified diff markers (`---`, `+++`, `@@`) and is
+addition-only (no deletions). It is human-readable and can be rendered
+directly in the UI or in a bootstrap PR description.
+
+## Test fixtures
+
+| Fixture | Purpose |
+|---------|---------|
+| `fixtures/no-claude-md/` | Empty directory — no CLAUDE.md present |
+| `fixtures/partial-claude-md/CLAUDE.md` | Has `What this repo is` and `Stack` only |
+| `fixtures/complete-claude-md/CLAUDE.md` | Has all five required sections |
+
+## Running the tests
+
+```bash
+pnpm vitest run slices/claude-md-auditor/slice.test.ts
+```
+
+No live filesystem writes — the auditor never mutates disk. All scenarios use
+the fixture directories above as read targets.

--- a/slices/claude-md-auditor/fixtures/complete-claude-md/CLAUDE.md
+++ b/slices/claude-md-auditor/fixtures/complete-claude-md/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+## What this repo is
+
+This is a complete CLAUDE.md with all required sections.
+
+## Stack
+
+- TypeScript
+- Node.js
+- React
+
+## Commands
+
+- build: `pnpm build`
+- test: `pnpm test`
+- lint: `pnpm lint`
+- typecheck: `pnpm typecheck`
+
+## Hard rules
+
+- Follow vertical slices
+- No inline prompts
+
+## PR conventions
+
+- Title format: M<milestone>.<task>: <description>
+- Body must contain Closes #N

--- a/slices/claude-md-auditor/fixtures/complete-claude-md/CLAUDE.md
+++ b/slices/claude-md-auditor/fixtures/complete-claude-md/CLAUDE.md
@@ -26,3 +26,8 @@ This is a complete CLAUDE.md with all required sections.
 
 - Title format: M<milestone>.<task>: <description>
 - Body must contain Closes #N
+
+## What goes here / What doesn't
+
+- Goes here: naming conventions, commands, hard rules, PR conventions.
+- Does not go here: implementation reasoning, plans, decision summaries.

--- a/slices/claude-md-auditor/fixtures/partial-claude-md/CLAUDE.md
+++ b/slices/claude-md-auditor/fixtures/partial-claude-md/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+## What this repo is
+
+This is a partial CLAUDE.md with some sections missing.
+
+## Stack
+
+- TypeScript
+- Node.js

--- a/slices/claude-md-auditor/slice.test.ts
+++ b/slices/claude-md-auditor/slice.test.ts
@@ -1,0 +1,148 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  type AuditResult,
+  type StackInfo,
+  auditClaudeMd,
+} from '@goose-hub/core/bootstrap/claude-md-auditor.js';
+import { describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fixturesDir = path.join(import.meta.dirname, 'fixtures');
+
+const minimalStack: StackInfo = {
+  type: 'node',
+  commands: {
+    build: 'pnpm build',
+    test: 'pnpm test',
+    lint: 'pnpm lint',
+    typecheck: 'pnpm typecheck',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: no CLAUDE.md → action='create'
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — no CLAUDE.md', () => {
+  it('returns action=create with populated template content', async () => {
+    const repoPath = path.join(fixturesDir, 'no-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result.action).toBe('create');
+    expect(result.rationale).toBeTruthy();
+    expect(result.content).toBeTruthy();
+
+    // Template must include key sections
+    expect(result.content).toContain('## What this repo is');
+    expect(result.content).toContain('## Stack');
+    expect(result.content).toContain('## Commands');
+    expect(result.content).toContain('## Hard rules');
+    expect(result.content).toContain('## PR conventions');
+
+    // Stack commands should be populated
+    expect(result.content).toContain('pnpm build');
+    expect(result.content).toContain('pnpm test');
+    expect(result.content).toContain('pnpm lint');
+    expect(result.content).toContain('pnpm typecheck');
+  });
+
+  it('does NOT write to disk', async () => {
+    const repoPath = path.join(fixturesDir, 'no-claude-md');
+    await auditClaudeMd(repoPath, minimalStack);
+
+    // Verify no CLAUDE.md was created in the fixture dir
+    await expect(fs.access(path.join(repoPath, 'CLAUDE.md'))).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: partial CLAUDE.md (missing sections) → action='update'
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — partial CLAUDE.md (missing sections)', () => {
+  it('returns action=update with a unified diff for missing sections', async () => {
+    const repoPath = path.join(fixturesDir, 'partial-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result.action).toBe('update');
+    expect(result.rationale).toBeTruthy();
+    expect(result.content).toBeTruthy();
+
+    // Diff must include missing sections (Commands, Hard rules, PR conventions)
+    expect(result.content).toContain('## Commands');
+    expect(result.content).toContain('## Hard rules');
+    expect(result.content).toContain('## PR conventions');
+
+    // Diff format indicators
+    expect(result.content).toContain('+++');
+    expect(result.content).toContain('@@');
+
+    // Existing sections should NOT appear as additions
+    expect(result.content).not.toContain('+## What this repo is');
+    expect(result.content).not.toContain('+## Stack');
+  });
+
+  it('rationale lists the missing section names', async () => {
+    const repoPath = path.join(fixturesDir, 'partial-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result.rationale).toContain('Commands');
+    expect(result.rationale).toContain('Hard rules');
+    expect(result.rationale).toContain('PR conventions');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: complete CLAUDE.md → action='ok'
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — complete CLAUDE.md', () => {
+  it('returns action=ok with empty content and rationale', async () => {
+    const repoPath = path.join(fixturesDir, 'complete-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result.action).toBe('ok');
+    expect(result.content).toBe('');
+    expect(result.rationale).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: stack with e2e command
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — stack with e2e command', () => {
+  it('includes e2e command in generated template', async () => {
+    const repoPath = path.join(fixturesDir, 'no-claude-md');
+    const stackWithE2e: StackInfo = {
+      ...minimalStack,
+      commands: { ...minimalStack.commands, e2e: 'pnpm playwright test' },
+    };
+    const result: AuditResult = await auditClaudeMd(repoPath, stackWithE2e);
+
+    expect(result.action).toBe('create');
+    expect(result.content).toContain('pnpm playwright test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5: AuditResult shape
+// ---------------------------------------------------------------------------
+
+describe('AuditResult type shape', () => {
+  it('result has action, content, and rationale fields', async () => {
+    const repoPath = path.join(fixturesDir, 'no-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result).toHaveProperty('action');
+    expect(result).toHaveProperty('content');
+    expect(result).toHaveProperty('rationale');
+    expect(['create', 'update', 'ok']).toContain(result.action);
+    expect(typeof result.content).toBe('string');
+    expect(typeof result.rationale).toBe('string');
+  });
+});

--- a/slices/claude-md-auditor/slice.test.ts
+++ b/slices/claude-md-auditor/slice.test.ts
@@ -42,6 +42,8 @@ describe('auditClaudeMd — no CLAUDE.md', () => {
     expect(result.content).toContain('## Commands');
     expect(result.content).toContain('## Hard rules');
     expect(result.content).toContain('## PR conventions');
+    // Holdout-safety boundary mandated by CONTEXT.md:275
+    expect(result.content).toContain("## What goes here / What doesn't");
 
     // Stack commands should be populated
     expect(result.content).toContain('pnpm build');
@@ -126,6 +128,39 @@ describe('auditClaudeMd — stack with e2e command', () => {
 
     expect(result.action).toBe('create');
     expect(result.content).toContain('pnpm playwright test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: holdout-safety section is mandatory (P1 from review)
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — holdout-safety section is required (CONTEXT.md:275)', () => {
+  it('flags a CLAUDE.md missing the holdout-safety section as needing update', async () => {
+    // The partial fixture has Stack + What-this-repo-is but is missing
+    // PR conventions and What-goes-here / What-doesn't, so it must update.
+    const repoPath = path.join(fixturesDir, 'partial-claude-md');
+    const result: AuditResult = await auditClaudeMd(repoPath, minimalStack);
+
+    expect(result.action).toBe('update');
+    expect(result.content).toContain("## What goes here / What doesn't");
+    expect(result.rationale).toContain("What goes here / What doesn't");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: read errors other than ENOENT surface (P2 from review)
+// ---------------------------------------------------------------------------
+
+describe('auditClaudeMd — non-ENOENT read errors surface', () => {
+  it('rethrows when the repo path itself is not a directory', async () => {
+    // Pointing repoPath at a file rather than a directory triggers ENOTDIR
+    // when joining `<file>/CLAUDE.md`, which must surface rather than be
+    // silently misreported as "no CLAUDE.md".
+    const notADir = path.join(fixturesDir, 'partial-claude-md', 'CLAUDE.md');
+    await expect(auditClaudeMd(notADir, minimalStack)).rejects.toMatchObject({
+      code: 'ENOTDIR',
+    });
   });
 });
 


### PR DESCRIPTION
Closes #303

Adds `auditClaudeMd()` to `core/bootstrap/` — generates a CLAUDE.md template when none exists, produces an addition-only unified diff for missing sections, and returns `ok` when complete. Vertical slice with fixtures and 7 passing tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_014obzUzjwJY7g17g8xrZGze)_