### PR TITLE
M12.03: idempotent label installer

### DIFF
--- a/core/bootstrap/label-installer.ts
+++ b/core/bootstrap/label-installer.ts
@@ -1,0 +1,144 @@
+/**
+ * Idempotent label installer for any GitHub repository.
+ *
+ * Uses the canonical `FACTORY_LABELS` set from `./labels.ts` as the
+ * single source of truth. Accepts an injected `fetch` implementation
+ * for testability.
+ *
+ * Algorithm:
+ *   1. GET `/repos/{owner}/{repo}/labels?per_page=100` (paginate all pages).
+ *   2. For each canonical label:
+ *      - absent   → POST  (create)
+ *      - present but color or description differs → PATCH (update)
+ *      - present and identical → skip
+ *   3. Return `InstallResult` with counts and any per-label errors.
+ */
+
+import { FACTORY_LABELS } from './labels.js';
+import type { Label } from './labels.js';
+
+export interface InstallError {
+  name: string;
+  message: string;
+}
+
+export interface InstallResult {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: InstallError[];
+}
+
+interface GitHubLabel {
+  name: string;
+  color: string;
+  description: string;
+}
+
+export async function installLabels(
+  repoRef: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<InstallResult> {
+  const baseUrl = `https://api.github.com/repos/${repoRef}/labels`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'goose-hub-bootstrap',
+  };
+
+  // Step 1: paginate all existing labels
+  const existing = await fetchAllExistingLabels(baseUrl, headers, fetchImpl);
+
+  // Step 2: reconcile each canonical label
+  const result: InstallResult = { created: 0, updated: 0, skipped: 0, errors: [] };
+
+  for (const label of FACTORY_LABELS) {
+    const current = existing.get(label.name);
+
+    if (current == null) {
+      const err = await createLabel(baseUrl, label, headers, fetchImpl);
+      if (err != null) {
+        result.errors.push({ name: label.name, message: err });
+      } else {
+        result.created += 1;
+      }
+    } else if (current.color !== label.color || (current.description ?? '') !== label.description) {
+      const err = await updateLabel(baseUrl, label, headers, fetchImpl);
+      if (err != null) {
+        result.errors.push({ name: label.name, message: err });
+      } else {
+        result.updated += 1;
+      }
+    } else {
+      result.skipped += 1;
+    }
+  }
+
+  return result;
+}
+
+async function fetchAllExistingLabels(
+  baseUrl: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+): Promise<Map<string, GitHubLabel>> {
+  const all: GitHubLabel[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `${baseUrl}?per_page=100&page=${page}`;
+    const res = await fetchImpl(url, { headers });
+    if (!res.ok) {
+      throw new Error(`Failed to list labels: ${res.status} ${res.statusText}`);
+    }
+    const batch = (await res.json()) as GitHubLabel[];
+    all.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+
+  return new Map(all.map((l) => [l.name, l]));
+}
+
+async function createLabel(
+  baseUrl: string,
+  label: Label,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  const res = await fetchImpl(baseUrl, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(label),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return `${res.status} ${text}`;
+  }
+  return null;
+}
+
+async function updateLabel(
+  baseUrl: string,
+  label: Label,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  const url = `${baseUrl}/${encodeURIComponent(label.name)}`;
+  const res = await fetchImpl(url, {
+    method: 'PATCH',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      new_name: label.name,
+      color: label.color,
+      description: label.description,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return `${res.status} ${text}`;
+  }
+  return null;
+}

--- a/core/bootstrap/labels.ts
+++ b/core/bootstrap/labels.ts
@@ -1,0 +1,107 @@
+/**
+ * Canonical factory label definitions — single source of truth.
+ *
+ * Both `scripts/install-labels.ts` and `core/bootstrap/label-installer.ts`
+ * consume this module.  Colors are 6-char hex without '#'.
+ */
+
+export interface Label {
+  name: string;
+  color: string;
+  description: string;
+}
+
+export const FACTORY_LABELS: Label[] = [
+  // factory:* state machine
+  { name: 'factory:triaging', color: 'fbca04', description: 'Awaiting triage decision' },
+  { name: 'factory:accepted', color: '0e8a16', description: 'Accepted by triage' },
+  { name: 'factory:rejected', color: 'e6e6e6', description: 'Rejected by triage' },
+  { name: 'factory:grilling', color: '8b5cf6', description: 'Grill-me chat in progress' },
+  { name: 'factory:prd-drafting', color: '8b5cf6', description: 'PRD being written' },
+  { name: 'factory:prd-review', color: '8b5cf6', description: 'Awaiting human PRD approval' },
+  { name: 'factory:decomposing', color: '8b5cf6', description: 'PRD being decomposed into slices' },
+  { name: 'factory:issues-created', color: '8b5cf6', description: 'Child slices created' },
+  { name: 'factory:research-pending', color: 'ec4899', description: 'Research analysis pending' },
+  { name: 'factory:research-complete', color: 'ec4899', description: 'Research analysis complete' },
+  { name: 'factory:investigating', color: '06b6d4', description: 'Investigation in progress' },
+  {
+    name: 'factory:investigation-complete',
+    color: '06b6d4',
+    description: 'Investigation complete',
+  },
+  { name: 'factory:dev-ready', color: '1d76db', description: 'Ready for development' },
+  { name: 'factory:in-progress', color: '1d76db', description: 'PR opened, work in progress' },
+  { name: 'factory:needs-qa', color: 'f97316', description: 'Awaiting QA holdout' },
+  { name: 'factory:qa-failed', color: '1d76db', description: 'QA failed; back to dev' },
+  {
+    name: 'factory:needs-review',
+    color: '22c55e',
+    description: 'QA passed; awaiting Review holdout',
+  },
+  { name: 'factory:needs-fix', color: '1d76db', description: 'Review found issues; back to dev' },
+  { name: 'factory:approved', color: '22c55e', description: 'Approved; awaiting human merge gate' },
+  { name: 'factory:retrospecting', color: '14b8a6', description: 'Retrospective in progress' },
+  { name: 'factory:needs-human', color: 'b91c1c', description: 'Escalated to human; agents stop' },
+  { name: 'factory:done', color: 'd1d5db', description: 'Done' },
+  { name: 'factory:archived', color: 'd1d5db', description: 'Archived (post-done sweep)' },
+
+  // factory:* control / safety
+  { name: 'factory:rate-limited', color: 'b91c1c', description: 'Held by flood protection' },
+  { name: 'factory:budget-exceeded', color: 'b91c1c', description: 'Held by budget cap' },
+  {
+    name: 'factory:tool-violation',
+    color: 'b91c1c',
+    description: 'Agent attempted forbidden tool',
+  },
+  {
+    name: 'factory:gate-pending',
+    color: 'fbca04',
+    description: 'Awaiting human approval at a gate',
+  },
+  {
+    name: 'factory:improvement-candidate',
+    color: '14b8a6',
+    description: 'Retrospective flagged for review',
+  },
+  { name: 'factory:advisor-flagged', color: 'fbca04', description: 'Advisor recommended revision' },
+  {
+    name: 'factory:bootstrap-pr',
+    color: '8b5cf6',
+    description: 'Bootstrap PR; governance creation allowed',
+  },
+  { name: 'factory:docs', color: '0075ca', description: 'Plan/doc issue' },
+
+  // type:*
+  { name: 'type:feature', color: '0e8a16', description: 'New capability' },
+  { name: 'type:bug', color: 'b91c1c', description: 'Defect to fix' },
+  { name: 'type:chore', color: 'd1d5db', description: 'Maintenance / infra' },
+  { name: 'type:research', color: 'ec4899', description: 'Research lane' },
+
+  // priority:*
+  { name: 'priority:critical', color: '7f1d1d', description: 'Critical priority' },
+  { name: 'priority:high', color: 'b91c1c', description: 'High priority' },
+  { name: 'priority:medium', color: 'f97316', description: 'Medium priority' },
+  { name: 'priority:low', color: 'd1d5db', description: 'Low priority' },
+
+  // mode:*
+  {
+    name: 'mode:supervised',
+    color: '6b7280',
+    description: 'Override: supervised mode for this issue',
+  },
+  {
+    name: 'mode:autonomous',
+    color: '6b7280',
+    description: 'Override: autonomous mode for this issue',
+  },
+
+  // schedule:*
+  { name: 'schedule:current', color: '0075ca', description: 'In active milestone, ready to work' },
+  { name: 'schedule:next', color: '93c5fd', description: 'Queued for next milestone' },
+  { name: 'schedule:later', color: 'dbeafe', description: 'Parked, no milestone yet' },
+  { name: 'schedule:blocked-by', color: 'fbca04', description: 'Waiting on dependency (see body)' },
+
+  // exec:*
+  { name: 'exec:serial', color: 'a5b4fc', description: 'Must run serially with siblings' },
+  { name: 'exec:parallel', color: 'c7d2fe', description: 'May run alongside siblings' },
+];

--- a/scripts/install-labels.ts
+++ b/scripts/install-labels.ts
@@ -7,13 +7,12 @@
  *
  * Idempotent: existing labels are updated to match the canonical color/description.
  *             Labels not in this script are left alone (we never delete).
+ *
+ * Label definitions live in core/bootstrap/labels.ts — single source of truth.
  */
 
-interface Label {
-  name: string;
-  color: string;
-  description: string;
-}
+import { FACTORY_LABELS } from '../core/bootstrap/labels.js';
+import type { Label } from '../core/bootstrap/labels.js';
 
 interface GitHubLabel extends Label {
   id: number;
@@ -32,71 +31,6 @@ if (!REPO || !REPO.includes('/')) {
   console.error('Usage: GITHUB_TOKEN=xxx pnpm install-labels <owner>/<repo>');
   process.exit(1);
 }
-
-// Canonical label set. Colors are 6-char hex without #.
-// Grouped by category for readability — order does not matter.
-const LABELS: Label[] = [
-  // factory:* state machine
-  { name: 'factory:triaging',               color: 'fbca04', description: 'Awaiting triage decision' },
-  { name: 'factory:accepted',               color: '0e8a16', description: 'Accepted by triage' },
-  { name: 'factory:rejected',               color: 'e6e6e6', description: 'Rejected by triage' },
-  { name: 'factory:grilling',               color: '8b5cf6', description: 'Grill-me chat in progress' },
-  { name: 'factory:prd-drafting',           color: '8b5cf6', description: 'PRD being written' },
-  { name: 'factory:prd-review',             color: '8b5cf6', description: 'Awaiting human PRD approval' },
-  { name: 'factory:decomposing',            color: '8b5cf6', description: 'PRD being decomposed into slices' },
-  { name: 'factory:issues-created',         color: '8b5cf6', description: 'Child slices created' },
-  { name: 'factory:research-pending',       color: 'ec4899', description: 'Research analysis pending' },
-  { name: 'factory:research-complete',      color: 'ec4899', description: 'Research analysis complete' },
-  { name: 'factory:investigating',          color: '06b6d4', description: 'Investigation in progress' },
-  { name: 'factory:investigation-complete', color: '06b6d4', description: 'Investigation complete' },
-  { name: 'factory:dev-ready',              color: '1d76db', description: 'Ready for development' },
-  { name: 'factory:in-progress',            color: '1d76db', description: 'PR opened, work in progress' },
-  { name: 'factory:needs-qa',               color: 'f97316', description: 'Awaiting QA holdout' },
-  { name: 'factory:qa-failed',              color: '1d76db', description: 'QA failed; back to dev' },
-  { name: 'factory:needs-review',           color: '22c55e', description: 'QA passed; awaiting Review holdout' },
-  { name: 'factory:needs-fix',              color: '1d76db', description: 'Review found issues; back to dev' },
-  { name: 'factory:approved',               color: '22c55e', description: 'Approved; awaiting human merge gate' },
-  { name: 'factory:retrospecting',          color: '14b8a6', description: 'Retrospective in progress' },
-  { name: 'factory:needs-human',            color: 'b91c1c', description: 'Escalated to human; agents stop' },
-  { name: 'factory:done',                   color: 'd1d5db', description: 'Done' },
-  { name: 'factory:archived',               color: 'd1d5db', description: 'Archived (post-done sweep)' },
-
-  // factory:* control / safety
-  { name: 'factory:rate-limited',           color: 'b91c1c', description: 'Held by flood protection' },
-  { name: 'factory:budget-exceeded',        color: 'b91c1c', description: 'Held by budget cap' },
-  { name: 'factory:tool-violation',         color: 'b91c1c', description: 'Agent attempted forbidden tool' },
-  { name: 'factory:gate-pending',           color: 'fbca04', description: 'Awaiting human approval at a gate' },
-  { name: 'factory:improvement-candidate',  color: '14b8a6', description: 'Retrospective flagged for review' },
-  { name: 'factory:advisor-flagged',        color: 'fbca04', description: 'Advisor recommended revision' },
-  { name: 'factory:bootstrap-pr',           color: '8b5cf6', description: 'Bootstrap PR; governance creation allowed' },
-  { name: 'factory:docs',                   color: '0075ca', description: 'Plan/doc issue' },
-
-  // type:*
-  { name: 'type:feature',                   color: '0e8a16', description: 'New capability' },
-  { name: 'type:bug',                        color: 'b91c1c', description: 'Defect to fix' },
-  { name: 'type:chore',                      color: 'd1d5db', description: 'Maintenance / infra' },
-  { name: 'type:research',                   color: 'ec4899', description: 'Research lane' },
-
-  // priority:*
-  { name: 'priority:critical',              color: '7f1d1d', description: 'Critical priority' },
-  { name: 'priority:high',                  color: 'b91c1c', description: 'High priority' },
-  { name: 'priority:medium',                color: 'f97316', description: 'Medium priority' },
-  { name: 'priority:low',                   color: 'd1d5db', description: 'Low priority' },
-
-  // mode:*
-  { name: 'mode:supervised',                color: '6b7280', description: 'Override: supervised mode for this issue' },
-  { name: 'mode:autonomous',                color: '6b7280', description: 'Override: autonomous mode for this issue' },
-
-  // schedule:*
-  { name: 'schedule:current',               color: '0075ca', description: 'In active milestone, ready to work' },
-  { name: 'schedule:next',                  color: '93c5fd', description: 'Queued for next milestone' },
-  { name: 'schedule:later',                 color: 'dbeafe', description: 'Parked, no milestone yet' },
-  { name: 'schedule:blocked-by',            color: 'fbca04', description: 'Waiting on dependency (see body)' },
-
-  // exec:*
-  { name: 'exec:serial',                    color: 'a5b4fc', description: 'Must run serially with siblings' },
-  { name: 'exec:parallel',                  color: 'c7d2fe', description: 'May run alongside siblings' },
-];
 
 const API = `https://api.github.com/repos/${REPO}/labels`;
 
@@ -155,7 +89,7 @@ async function updateLabel(oldName: string, label: Label): Promise<boolean> {
 }
 
 async function main(): Promise<void> {
-  console.log(`Installing ${LABELS.length} labels on ${REPO}...`);
+  console.log(`Installing ${FACTORY_LABELS.length} labels on ${REPO}...`);
   const existing = await getExistingLabels();
 
   let created = 0;
@@ -163,7 +97,7 @@ async function main(): Promise<void> {
   let unchanged = 0;
   let failed = 0;
 
-  for (const label of LABELS) {
+  for (const label of FACTORY_LABELS) {
     const current = existing.get(label.name);
     if (!current) {
       const ok = await createLabel(label);

--- a/slices/label-installer/README.md
+++ b/slices/label-installer/README.md
@@ -1,0 +1,52 @@
+# slices/label-installer
+
+Idempotent factory label installer. Closes M12.03 (#306).
+
+## What it does
+
+Provides a programmatic API to install the canonical `factory:*` label set onto
+any GitHub repository the caller has write access to.
+
+## Vertical surfaces touched
+
+- **Shared definitions**: `core/bootstrap/labels.ts`
+  - `Label` — TypeScript interface `{ name, color, description }`
+  - `FACTORY_LABELS: Label[]` — canonical label set (single source of truth)
+
+- **Core lib**: `core/bootstrap/label-installer.ts`
+  - `installLabels(repoRef, token, fetch?)` — reconciles the repo label set
+  - `InstallResult` — `{ created, updated, skipped, errors }`
+  - `InstallError` — `{ name, message }`
+
+- **Refactored script**: `scripts/install-labels.ts`
+  - CLI wrapper; imports `FACTORY_LABELS` from `core/bootstrap/labels.ts`
+  - No longer duplicates the label list
+
+## Algorithm
+
+1. GET `/repos/{owner}/{repo}/labels?per_page=100` — paginate all existing labels.
+2. For each canonical label:
+   - absent → POST (create)
+   - present but color/description differ → PATCH (update)
+   - present and identical → skip
+3. Return `InstallResult` with `created`, `updated`, `skipped`, and any `errors`.
+
+Labels not in the canonical set are left untouched (never deleted).
+
+## Usage
+
+```ts
+import { installLabels } from '@goose-hub/core/bootstrap/label-installer.js';
+
+const result = await installLabels('owner/repo', process.env.GITHUB_TOKEN!);
+console.log(result);
+// { created: 50, updated: 0, skipped: 0, errors: [] }
+```
+
+## Running the tests
+
+```bash
+pnpm test slices/label-installer/slice.test.ts
+```
+
+No live GitHub API required — all tests use injected fetch mocks.

--- a/slices/label-installer/slice.test.ts
+++ b/slices/label-installer/slice.test.ts
@@ -1,0 +1,206 @@
+import { installLabels } from '@goose-hub/core/bootstrap/label-installer.js';
+import type { InstallResult } from '@goose-hub/core/bootstrap/label-installer.js';
+import { FACTORY_LABELS } from '@goose-hub/core/bootstrap/labels.js';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal GitHub label shape returned by GET /repos/{owner}/{repo}/labels */
+interface GHLabel {
+  name: string;
+  color: string;
+  description: string;
+}
+
+function makeGHLabel(name: string, color: string, description: string): GHLabel {
+  return { name, color, description };
+}
+
+/**
+ * Build a mock `fetch` that handles:
+ *   GET  /repos/…/labels?…   → returns `existing` (paginated: one page)
+ *   POST /repos/…/labels     → 201 Created
+ *   PATCH /repos/…/labels/{name} → 200 OK
+ */
+function makeMockFetch(existing: GHLabel[], opts?: { failCreate?: string; failPatch?: string }) {
+  return vi.fn(async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    const urlStr = String(url);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (method === 'GET' && urlStr.includes('/labels')) {
+      return new Response(JSON.stringify(existing), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (method === 'POST' && urlStr.endsWith('/labels')) {
+      const body = JSON.parse(init?.body as string) as GHLabel;
+      if (opts?.failCreate === body.name) {
+        return new Response(JSON.stringify({ message: 'Validation failed' }), { status: 422 });
+      }
+      return new Response(JSON.stringify({ ...body, id: 1 }), { status: 201 });
+    }
+
+    if (method === 'PATCH' && urlStr.includes('/labels/')) {
+      const body = JSON.parse(init?.body as string) as { new_name?: string };
+      const name = body.new_name ?? '';
+      if (opts?.failPatch === name) {
+        return new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 });
+      }
+      return new Response(JSON.stringify({ name, id: 2 }), { status: 200 });
+    }
+
+    return new Response('Not Found', { status: 404 });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// label-installer slice — end-to-end
+// ---------------------------------------------------------------------------
+
+describe('label-installer slice — end-to-end', () => {
+  const repoRef = 'owner/repo';
+  const token = 'ghp_test';
+
+  it('empty repo: all labels created, none skipped', async () => {
+    const mockFetch = makeMockFetch([]);
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.created).toBe(FACTORY_LABELS.length);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('partially labeled repo: some created, matching ones skipped', async () => {
+    // Pre-install 3 labels with correct color/description → should be skipped
+    const preInstalled: GHLabel[] = [
+      makeGHLabel(FACTORY_LABELS[0].name, FACTORY_LABELS[0].color, FACTORY_LABELS[0].description),
+      makeGHLabel(FACTORY_LABELS[1].name, FACTORY_LABELS[1].color, FACTORY_LABELS[1].description),
+      makeGHLabel(FACTORY_LABELS[2].name, FACTORY_LABELS[2].color, FACTORY_LABELS[2].description),
+    ];
+
+    const mockFetch = makeMockFetch(preInstalled);
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.skipped).toBe(3);
+    expect(result.created).toBe(FACTORY_LABELS.length - 3);
+    expect(result.updated).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fully labeled repo: all skipped, none created or updated', async () => {
+    const allPresent: GHLabel[] = FACTORY_LABELS.map((l) =>
+      makeGHLabel(l.name, l.color, l.description),
+    );
+
+    const mockFetch = makeMockFetch(allPresent);
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(FACTORY_LABELS.length);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('label present with wrong color → updated, not created', async () => {
+    const existing: GHLabel[] = [
+      makeGHLabel(FACTORY_LABELS[0].name, 'ffffff', FACTORY_LABELS[0].description),
+    ];
+
+    const mockFetch = makeMockFetch(existing);
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(FACTORY_LABELS.length - 1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('label present with wrong description → updated', async () => {
+    const existing: GHLabel[] = [
+      makeGHLabel(FACTORY_LABELS[0].name, FACTORY_LABELS[0].color, 'old description'),
+    ];
+
+    const mockFetch = makeMockFetch(existing);
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(FACTORY_LABELS.length - 1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('create failure → recorded in errors, counts not incremented', async () => {
+    const failName = FACTORY_LABELS[0].name;
+    const mockFetch = makeMockFetch([], { failCreate: failName });
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].name).toBe(failName);
+    expect(result.created).toBe(FACTORY_LABELS.length - 1);
+  });
+
+  it('patch failure → recorded in errors, counts not incremented', async () => {
+    const target = FACTORY_LABELS[0];
+    const existing: GHLabel[] = [makeGHLabel(target.name, 'ffffff', target.description)];
+    const mockFetch = makeMockFetch(existing, { failPatch: target.name });
+    const result: InstallResult = await installLabels(repoRef, token, mockFetch as typeof fetch);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].name).toBe(target.name);
+    expect(result.updated).toBe(0);
+  });
+
+  it('paginates: fetches page 2 when first page is full (100 items)', async () => {
+    // Create 100 fake labels for page 1 (all unknown to canonical), plus one
+    // real canonical label that will appear on page 2.
+    const page1: GHLabel[] = Array.from({ length: 100 }, (_, i) =>
+      makeGHLabel(`custom:label-${i}`, 'aabbcc', 'custom'),
+    );
+    const page2: GHLabel[] = [
+      makeGHLabel(FACTORY_LABELS[0].name, FACTORY_LABELS[0].color, FACTORY_LABELS[0].description),
+    ];
+
+    let callCount = 0;
+    const paginatingFetch = vi.fn(
+      async (url: string | URL, init?: RequestInit): Promise<Response> => {
+        const urlStr = String(url);
+        const method = (init?.method ?? 'GET').toUpperCase();
+
+        if (method === 'GET' && urlStr.includes('/labels')) {
+          callCount += 1;
+          // First call returns 100 items (triggers pagination), second returns 1
+          const data = callCount === 1 ? page1 : page2;
+          return new Response(JSON.stringify(data), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        if (method === 'POST') {
+          return new Response(JSON.stringify({}), { status: 201 });
+        }
+
+        return new Response('Not Found', { status: 404 });
+      },
+    );
+
+    const result: InstallResult = await installLabels(
+      repoRef,
+      token,
+      paginatingFetch as typeof fetch,
+    );
+
+    // Page 2 contained FACTORY_LABELS[0] with correct values → should be skipped
+    expect(result.skipped).toBe(1);
+    expect(result.created).toBe(FACTORY_LABELS.length - 1);
+    // Must have made 2 GET calls (page 1 = 100 items, page 2 = 1 item) + N-1 POSTs
+    expect(paginatingFetch).toHaveBeenCalledTimes(
+      2 + (FACTORY_LABELS.length - 1), // 2 GETs + N-1 POSTs
+    );
+  });
+});


### PR DESCRIPTION
Closes #306

Extracts the canonical factory label set to `core/bootstrap/labels.ts` (single source of truth) and provides a programmatic `installLabels()` API in `core/bootstrap/label-installer.ts`. The existing CLI script is refactored to consume the shared module — no duplication.

---
_Generated by [Claude Code](https://claude.ai/code/session_014obzUzjwJY7g17g8xrZGze)_