### PR TITLE
M12.07: bootstrap wizard UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,7 +51,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/apps/server/src/domains/bootstrap/router.test.ts
+++ b/apps/server/src/domains/bootstrap/router.test.ts
@@ -1,0 +1,144 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPreview, mockRun } = vi.hoisted(() => ({
+  mockPreview: vi.fn(),
+  mockRun: vi.fn(),
+}));
+
+vi.mock('./service.js', () => ({
+  previewBootstrapService: mockPreview,
+  runBootstrapService: mockRun,
+}));
+
+import { bootstrapRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/projects', bootstrapRouter);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /projects/bootstrap/preview', () => {
+  it('returns 200 with the preview DTO from the service', async () => {
+    mockPreview.mockResolvedValue({
+      ok: true,
+      data: {
+        slug: 'widgets',
+        defaultBranch: 'main',
+        stack: { type: 'node', summary: 'node (pnpm)', raw: {} },
+        audit: { action: 'create', content: '...', rationale: '...' },
+        labelsToInstall: [{ name: 'factory:done', color: 'd1d5db', description: 'Done' }],
+      },
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRef: 'octo/widgets' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { slug: string };
+    expect(body.slug).toBe('widgets');
+    expect(mockPreview).toHaveBeenCalledWith('octo/widgets');
+  });
+
+  it('returns the service status code on failure', async () => {
+    mockPreview.mockResolvedValue({
+      ok: false,
+      error: 'repo not found',
+      status: 404,
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRef: 'octo/missing' }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('repo not found');
+  });
+
+  it('returns 400 when the body is missing repoRef', async () => {
+    mockPreview.mockResolvedValue({
+      ok: false,
+      error: 'repoRef is required',
+      status: 400,
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(mockPreview).toHaveBeenCalledWith('');
+  });
+});
+
+describe('POST /projects/bootstrap/run', () => {
+  it('returns 200 with the workflow result', async () => {
+    mockRun.mockResolvedValue({
+      ok: true,
+      data: {
+        status: 'created',
+        registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/100',
+        slug: 'widgets',
+        stackSummary: 'node (pnpm)',
+        auditAction: 'create',
+        labelCounts: { created: 1, updated: 0, skipped: 0 },
+      },
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRef: 'octo/widgets' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { registrationPrUrl: string };
+    expect(body.registrationPrUrl).toContain('pull/100');
+    expect(mockRun).toHaveBeenCalledWith('octo/widgets', undefined);
+  });
+
+  it('forwards a slug override', async () => {
+    mockRun.mockResolvedValue({
+      ok: true,
+      data: {
+        status: 'created',
+        registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/101',
+        slug: 'custom',
+        stackSummary: 'node',
+        auditAction: 'ok',
+      },
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRef: 'octo/widgets', slug: 'custom' }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockRun).toHaveBeenCalledWith('octo/widgets', 'custom');
+  });
+
+  it('returns the service error status on failure', async () => {
+    mockRun.mockResolvedValue({
+      ok: false,
+      error: 'workflow exploded',
+      status: 500,
+    });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRef: 'octo/widgets' }),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('workflow exploded');
+  });
+});

--- a/apps/server/src/domains/bootstrap/router.ts
+++ b/apps/server/src/domains/bootstrap/router.ts
@@ -1,0 +1,38 @@
+/**
+ * Bootstrap router — exposes preview + run endpoints for the bootstrap
+ * wizard UI (M12.07, issue #308).
+ *
+ * Routes (mounted at `/projects` in `server.ts`):
+ *   - POST /projects/bootstrap/preview { repoRef }            → BootstrapPreviewDto
+ *   - POST /projects/bootstrap/run     { repoRef, slug? }     → BootstrapRunDto
+ *
+ * The token comes from the server env (`GITHUB_TOKEN`); the browser does
+ * NOT supply tokens. When `MOCK_BOOTSTRAP=true`, both endpoints return
+ * deterministic fixture payloads (used by the Playwright e2e test).
+ */
+
+import { Hono } from 'hono';
+import { parseBody } from '#shared/middleware.js';
+import { previewBootstrapService, runBootstrapService } from './service.js';
+
+const router = new Hono();
+
+router.post('/bootstrap/preview', async (c) => {
+  const body = await parseBody<{ repoRef?: string }>(c);
+  if (!body.ok) return body.error;
+  const result = await previewBootstrapService(body.data.repoRef ?? '');
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 404 | 500 | 502);
+});
+
+router.post('/bootstrap/run', async (c) => {
+  const body = await parseBody<{ repoRef?: string; slug?: string }>(c);
+  if (!body.ok) return body.error;
+  const result = await runBootstrapService(body.data.repoRef ?? '', body.data.slug);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 404 | 500 | 502);
+});
+
+export { router as bootstrapRouter };

--- a/apps/server/src/domains/bootstrap/service.test.ts
+++ b/apps/server/src/domains/bootstrap/service.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockBootstrapProject, mockDetectStack, mockAuditClaudeMd } = vi.hoisted(() => ({
+  mockBootstrapProject: vi.fn(),
+  mockDetectStack: vi.fn(),
+  mockAuditClaudeMd: vi.fn(),
+}));
+
+vi.mock('@goose-hub/core/workflows/bootstrap-project.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('@goose-hub/core/workflows/bootstrap-project.js')
+  >('@goose-hub/core/workflows/bootstrap-project.js');
+  return {
+    ...actual,
+    bootstrapProject: mockBootstrapProject,
+  };
+});
+
+vi.mock('@goose-hub/core/bootstrap/stack-detector.js', () => ({
+  detectStack: mockDetectStack,
+}));
+
+vi.mock('@goose-hub/core/bootstrap/claude-md-auditor.js', () => ({
+  auditClaudeMd: mockAuditClaudeMd,
+}));
+
+import { previewBootstrapService, runBootstrapService } from './service.js';
+
+const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
+const ORIGINAL_MOCK = process.env.MOCK_BOOTSTRAP;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.GITHUB_TOKEN = 'test-token';
+  Reflect.deleteProperty(process.env, 'MOCK_BOOTSTRAP');
+});
+
+afterEach(() => {
+  if (ORIGINAL_TOKEN === undefined) Reflect.deleteProperty(process.env, 'GITHUB_TOKEN');
+  else process.env.GITHUB_TOKEN = ORIGINAL_TOKEN;
+  if (ORIGINAL_MOCK === undefined) Reflect.deleteProperty(process.env, 'MOCK_BOOTSTRAP');
+  else process.env.MOCK_BOOTSTRAP = ORIGINAL_MOCK;
+  vi.unstubAllGlobals();
+});
+
+describe('previewBootstrapService', () => {
+  it('returns 400 when repoRef is empty', async () => {
+    const result = await previewBootstrapService('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/repoRef/);
+    }
+  });
+
+  it('returns 400 when repoRef is malformed', async () => {
+    const result = await previewBootstrapService('not-a-valid-ref');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+  });
+
+  it('returns 500 when GITHUB_TOKEN is missing', async () => {
+    Reflect.deleteProperty(process.env, 'GITHUB_TOKEN');
+    const result = await previewBootstrapService('octo/widgets');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.error).toMatch(/GITHUB_TOKEN/);
+    }
+  });
+
+  it('returns 404 when GitHub responds 404 for the repo', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Not Found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    const result = await previewBootstrapService('octo/missing');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(404);
+  });
+
+  it('returns full preview DTO on the happy path', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ default_branch: 'develop' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    mockDetectStack.mockResolvedValue({
+      type: 'node',
+      packageManager: 'pnpm',
+      scripts: { build: 'pnpm build', test: 'pnpm test' },
+    });
+    mockAuditClaudeMd.mockResolvedValue({
+      action: 'create',
+      content: '# CLAUDE.md\n\n…\n',
+      rationale: 'No CLAUDE.md found',
+    });
+
+    const result = await previewBootstrapService('octo/widgets');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.slug).toBe('widgets');
+      expect(result.data.defaultBranch).toBe('develop');
+      expect(result.data.stack.type).toBe('node');
+      expect(result.data.stack.summary).toContain('node');
+      expect(result.data.audit.action).toBe('create');
+      expect(result.data.labelsToInstall.length).toBeGreaterThan(0);
+      expect(result.data.labelsToInstall[0]).toMatchObject({
+        name: expect.any(String),
+        color: expect.any(String),
+        description: expect.any(String),
+      });
+    }
+  });
+
+  it('returns deterministic fixture data when MOCK_BOOTSTRAP=true', async () => {
+    process.env.MOCK_BOOTSTRAP = 'true';
+    Reflect.deleteProperty(process.env, 'GITHUB_TOKEN'); // mock mode must not require a token
+    const result = await previewBootstrapService('octo/widgets');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.slug).toBe('widgets');
+      expect(result.data.stack.type).toBe('node');
+      expect(result.data.audit.action).toBe('create');
+      expect(result.data.labelsToInstall.length).toBeGreaterThan(0);
+    }
+    expect(mockDetectStack).not.toHaveBeenCalled();
+    expect(mockAuditClaudeMd).not.toHaveBeenCalled();
+  });
+});
+
+describe('runBootstrapService', () => {
+  it('returns 400 when repoRef is empty', async () => {
+    const result = await runBootstrapService('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+  });
+
+  it('returns 500 when GITHUB_TOKEN is missing', async () => {
+    Reflect.deleteProperty(process.env, 'GITHUB_TOKEN');
+    const result = await runBootstrapService('octo/widgets');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(500);
+  });
+
+  it('returns the workflow result on success', async () => {
+    mockBootstrapProject.mockResolvedValue({
+      status: 'created',
+      registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/123',
+      slug: 'widgets',
+      stackSummary: 'node (pnpm)',
+      auditAction: 'create',
+      labelCounts: { created: 5, updated: 0, skipped: 23 },
+    });
+    const result = await runBootstrapService('octo/widgets');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.status).toBe('created');
+      expect(result.data.registrationPrUrl).toBe('https://github.com/shaunnez/goose-hub/pull/123');
+      expect(result.data.slug).toBe('widgets');
+      expect(mockBootstrapProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repoRef: 'octo/widgets',
+          token: 'test-token',
+        }),
+      );
+    }
+  });
+
+  it('passes through `idempotent-skip` results', async () => {
+    mockBootstrapProject.mockResolvedValue({
+      status: 'idempotent-skip',
+      registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/9',
+      slug: 'widgets',
+      stackSummary: '(skipped)',
+      auditAction: 'ok',
+    });
+    const result = await runBootstrapService('octo/widgets');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.status).toBe('idempotent-skip');
+      expect(result.data.registrationPrUrl).toBe('https://github.com/shaunnez/goose-hub/pull/9');
+    }
+  });
+
+  it('forwards a slug override to the workflow', async () => {
+    mockBootstrapProject.mockResolvedValue({
+      status: 'created',
+      registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/124',
+      slug: 'custom-slug',
+      stackSummary: 'node (pnpm)',
+      auditAction: 'ok',
+    });
+    const result = await runBootstrapService('octo/widgets', 'custom-slug');
+    expect(result.ok).toBe(true);
+    expect(mockBootstrapProject).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'custom-slug' }),
+    );
+  });
+
+  it('returns 500 with error message when the workflow throws', async () => {
+    mockBootstrapProject.mockRejectedValue(new Error('GitHub API exploded'));
+    const result = await runBootstrapService('octo/widgets');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.error).toMatch(/GitHub API exploded/);
+    }
+  });
+
+  it('returns deterministic fixture data when MOCK_BOOTSTRAP=true', async () => {
+    process.env.MOCK_BOOTSTRAP = 'true';
+    Reflect.deleteProperty(process.env, 'GITHUB_TOKEN');
+    const result = await runBootstrapService('octo/widgets');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.status).toBe('created');
+      expect(result.data.registrationPrUrl).toContain('pull/');
+      expect(result.data.slug).toBe('widgets');
+    }
+    expect(mockBootstrapProject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/domains/bootstrap/service.test.ts
+++ b/apps/server/src/domains/bootstrap/service.test.ts
@@ -207,6 +207,18 @@ describe('runBootstrapService', () => {
     );
   });
 
+  it('returns 400 (not 500) for an invalid slug override', async () => {
+    // sanitiseSlug throws on empty/punctuation-only inputs.
+    const result = await runBootstrapService('octo/widgets', '!!!---!!!');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/slug|empty/i);
+    }
+    // The workflow must NOT have been invoked for invalid input.
+    expect(mockBootstrapProject).not.toHaveBeenCalled();
+  });
+
   it('returns 500 with error message when the workflow throws', async () => {
     mockBootstrapProject.mockRejectedValue(new Error('GitHub API exploded'));
     const result = await runBootstrapService('octo/widgets');

--- a/apps/server/src/domains/bootstrap/service.ts
+++ b/apps/server/src/domains/bootstrap/service.ts
@@ -278,6 +278,21 @@ export async function runBootstrapService(
     };
   }
 
+  // Validate the optional client-supplied slug up front so a bad value
+  // (e.g. one that sanitises to empty) reports as 400 input error rather
+  // than being swallowed by the catch-all 500 below.
+  if (slugOverride != null) {
+    try {
+      sanitiseSlug(slugOverride);
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : `invalid slug: ${slugOverride}`,
+        status: 400,
+      };
+    }
+  }
+
   const token = getGithubToken();
   if (token == null) {
     return {

--- a/apps/server/src/domains/bootstrap/service.ts
+++ b/apps/server/src/domains/bootstrap/service.ts
@@ -1,0 +1,324 @@
+/**
+ * Bootstrap domain service — wraps the `bootstrapProject` workflow for the
+ * web UI's bootstrap wizard (M12.07, issue #308).
+ *
+ * Two service functions:
+ *  - `previewBootstrapService(repoRef)` — runs stack detection + CLAUDE.md
+ *    audit + label preview (no GitHub mutations, no PR creation). Used by
+ *    wizard steps 2–4 to populate the "review" panels before the human
+ *    confirms.
+ *  - `runBootstrapService(repoRef, slug?)` — runs the full
+ *    `bootstrapProject` workflow (which creates labels and opens the
+ *    registration PR). Used by the wizard's final "Open Registration PR"
+ *    button.
+ *
+ * The token never flows from the browser; it's read from
+ * `process.env.GITHUB_TOKEN` here. If `MOCK_BOOTSTRAP=true` is set, both
+ * functions return deterministic fixture payloads so the web e2e test can
+ * walk through the wizard without hitting GitHub or running the workflow.
+ */
+
+import * as nodeOs from 'node:os';
+import * as nodePath from 'node:path';
+import { auditClaudeMd } from '@goose-hub/core/bootstrap/claude-md-auditor.js';
+import { FACTORY_LABELS } from '@goose-hub/core/bootstrap/labels.js';
+import { detectStack } from '@goose-hub/core/bootstrap/stack-detector.js';
+import { logger } from '@goose-hub/core/logger.js';
+import {
+  type BootstrapResult,
+  bootstrapProject,
+  parseRepoRef,
+  sanitiseSlug,
+  summariseStack,
+} from '@goose-hub/core/workflows/bootstrap-project.js';
+import type { Result } from '#shared/middleware.js';
+
+export interface PreviewLabelDto {
+  name: string;
+  color: string;
+  description: string;
+}
+
+export interface BootstrapPreviewDto {
+  slug: string;
+  defaultBranch: string;
+  stack: {
+    type: string;
+    summary: string;
+    raw: unknown;
+  };
+  audit: {
+    action: 'create' | 'update' | 'ok';
+    content: string;
+    rationale: string;
+  };
+  labelsToInstall: PreviewLabelDto[];
+}
+
+export interface BootstrapRunDto {
+  status: 'created' | 'idempotent-skip';
+  registrationPrUrl: string | null;
+  slug: string;
+  stackSummary: string;
+  auditAction: 'create' | 'update' | 'ok';
+  labelCounts?: { created: number; updated: number; skipped: number };
+}
+
+const MOCK_FIXTURE_PREVIEW: BootstrapPreviewDto = {
+  slug: 'mock-repo',
+  defaultBranch: 'main',
+  stack: {
+    type: 'node',
+    summary: 'node (pnpm) — scripts: build, test, lint',
+    raw: {
+      type: 'node',
+      packageManager: 'pnpm',
+      scripts: { build: 'pnpm build', test: 'pnpm test', lint: 'pnpm lint' },
+    },
+  },
+  audit: {
+    action: 'create',
+    content: '# CLAUDE.md\n\n## What this repo is\n\nMock repo (fixture).\n',
+    rationale: 'No CLAUDE.md found in the target repo; a template will be created.',
+  },
+  labelsToInstall: FACTORY_LABELS.map((l) => ({
+    name: l.name,
+    color: l.color,
+    description: l.description,
+  })),
+};
+
+const MOCK_FIXTURE_RUN: BootstrapRunDto = {
+  status: 'created',
+  registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/9999',
+  slug: 'mock-repo',
+  stackSummary: 'node (pnpm) — scripts: build, test, lint',
+  auditAction: 'create',
+  labelCounts: { created: 28, updated: 0, skipped: 0 },
+};
+
+/** Resolve the GitHub token from env. Returns `null` if absent. */
+function getGithubToken(): string | null {
+  const raw = process.env.GITHUB_TOKEN ?? '';
+  return raw.length > 0 ? raw : null;
+}
+
+function isMockMode(): boolean {
+  return process.env.MOCK_BOOTSTRAP === 'true';
+}
+
+function getCloneRoot(): string {
+  return process.env.BOOTSTRAP_CLONE_ROOT ?? nodePath.join(nodeOs.tmpdir(), 'goose-hub-bootstrap');
+}
+
+/**
+ * Preview the stack + CLAUDE.md audit + canonical label set for `repoRef`
+ * without making any GitHub mutations.
+ *
+ * Note: this calls `detectStack` and `auditClaudeMd` against a *local*
+ * checkout of the target repo at `<cloneRoot>/<repo>`. The wizard's UX
+ * assumes the human has already cloned the repo to the standard location;
+ * if the path doesn't exist the detectors fall back to `unknown`/`create`
+ * which is still safe (the human can edit the scaffold before merging the
+ * registration PR).
+ */
+export async function previewBootstrapService(
+  repoRef: string,
+): Promise<Result<BootstrapPreviewDto>> {
+  if (typeof repoRef !== 'string' || repoRef.trim().length === 0) {
+    return { ok: false, error: 'repoRef is required', status: 400 };
+  }
+
+  if (isMockMode()) {
+    return {
+      ok: true,
+      data: { ...MOCK_FIXTURE_PREVIEW, slug: deriveSlugForRepo(repoRef) },
+    };
+  }
+
+  let parsed: { owner: string; repo: string };
+  try {
+    parsed = parseRepoRef(repoRef);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : `invalid repoRef: ${repoRef}`,
+      status: 400,
+    };
+  }
+
+  let slug: string;
+  try {
+    slug = sanitiseSlug(parsed.repo);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'failed to derive slug',
+      status: 400,
+    };
+  }
+
+  const token = getGithubToken();
+  if (token == null) {
+    return {
+      ok: false,
+      error: 'server is missing GITHUB_TOKEN; cannot validate repo accessibility',
+      status: 500,
+    };
+  }
+
+  // Validate accessibility via GET /repos/:owner/:repo. We use this to
+  // populate `defaultBranch` in the response (and to surface 404 early).
+  let defaultBranch = 'main';
+  try {
+    const res = await fetch(`https://api.github.com/repos/${parsed.owner}/${parsed.repo}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'goose-hub-bootstrap-preview',
+      },
+    });
+    if (res.status === 404) {
+      return { ok: false, error: `repo not found: ${repoRef}`, status: 404 };
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: `failed to access ${repoRef}: ${res.status} ${res.statusText}`,
+        status: 502,
+      };
+    }
+    const meta = (await res.json()) as { default_branch?: string };
+    if (meta.default_branch) defaultBranch = meta.default_branch;
+  } catch (err) {
+    logger.warn('bootstrap preview: repo accessibility check failed', {
+      repoRef,
+      error: String(err),
+    });
+    return {
+      ok: false,
+      error: `failed to reach github for ${repoRef}: ${String(err)}`,
+      status: 502,
+    };
+  }
+
+  const repoPath = nodePath.join(getCloneRoot(), parsed.repo);
+
+  let stack: Awaited<ReturnType<typeof detectStack>>;
+  try {
+    stack = await detectStack(repoPath);
+  } catch (err) {
+    logger.warn('bootstrap preview: stack detection failed', { repoRef, error: String(err) });
+    return {
+      ok: false,
+      error: `stack detection failed for ${repoRef}: ${String(err)}`,
+      status: 500,
+    };
+  }
+
+  let audit: Awaited<ReturnType<typeof auditClaudeMd>>;
+  try {
+    audit = await auditClaudeMd(repoPath, {
+      type: stack.type,
+      commands: stack.type === 'node' ? stack.scripts : undefined,
+    });
+  } catch (err) {
+    logger.warn('bootstrap preview: audit failed', { repoRef, error: String(err) });
+    return {
+      ok: false,
+      error: `CLAUDE.md audit failed for ${repoRef}: ${String(err)}`,
+      status: 500,
+    };
+  }
+
+  const dto: BootstrapPreviewDto = {
+    slug,
+    defaultBranch,
+    stack: {
+      type: stack.type,
+      summary: summariseStack(stack),
+      raw: stack,
+    },
+    audit: { action: audit.action, content: audit.content, rationale: audit.rationale },
+    labelsToInstall: FACTORY_LABELS.map((l) => ({
+      name: l.name,
+      color: l.color,
+      description: l.description,
+    })),
+  };
+
+  return { ok: true, data: dto };
+}
+
+/**
+ * Run the full bootstrap workflow end-to-end and return the registration PR
+ * URL on success.
+ */
+export async function runBootstrapService(
+  repoRef: string,
+  slugOverride?: string,
+): Promise<Result<BootstrapRunDto>> {
+  if (typeof repoRef !== 'string' || repoRef.trim().length === 0) {
+    return { ok: false, error: 'repoRef is required', status: 400 };
+  }
+
+  if (isMockMode()) {
+    const slug = slugOverride ?? deriveSlugForRepo(repoRef);
+    return { ok: true, data: { ...MOCK_FIXTURE_RUN, slug } };
+  }
+
+  try {
+    parseRepoRef(repoRef);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : `invalid repoRef: ${repoRef}`,
+      status: 400,
+    };
+  }
+
+  const token = getGithubToken();
+  if (token == null) {
+    return {
+      ok: false,
+      error: 'server is missing GITHUB_TOKEN; cannot run bootstrap workflow',
+      status: 500,
+    };
+  }
+
+  let result: BootstrapResult;
+  try {
+    result = await bootstrapProject({
+      repoRef,
+      token,
+      slug: slugOverride,
+      cloneRoot: getCloneRoot(),
+    });
+  } catch (err) {
+    logger.error('bootstrap workflow failed', { repoRef, error: String(err) });
+    return { ok: false, error: String(err), status: 500 };
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: result.status,
+      registrationPrUrl: result.registrationPrUrl ?? null,
+      slug: result.slug,
+      stackSummary: result.stackSummary,
+      auditAction: result.auditAction,
+      labelCounts: result.labelCounts,
+    },
+  };
+}
+
+/** Derive a slug from a `repoRef` using the same sanitisation as the workflow. */
+function deriveSlugForRepo(repoRef: string): string {
+  try {
+    const { repo } = parseRepoRef(repoRef);
+    return sanitiseSlug(repo);
+  } catch {
+    return 'unknown';
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,7 @@
 import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { bootstrapRouter } from './domains/bootstrap/router.js';
 import { costsRouter } from './domains/costs/router.js';
 import { eventsRouter } from './domains/events/router.js';
 import { inboxRouter } from './domains/inbox/router.js';
@@ -31,6 +32,7 @@ app.route('/projects', issuesRouter); // GET/POST /projects/:slug/issues/**
 app.route('/projects', workflowsRouter); // POST /projects/:slug/tick
 app.route('/projects', costsRouter); // GET /projects/:slug/costs/summary, /projects/:slug/issues/:id/costs
 app.route('/projects', playbooksRouter); // GET/POST /projects/:slug/playbooks (M11.12)
+app.route('/projects', bootstrapRouter); // POST /projects/bootstrap/{preview,run} (M12.07)
 app.route('/inbox', inboxRouter); // GET/POST /inbox/**
 app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events

--- a/apps/web/e2e/bootstrap-wizard.spec.ts
+++ b/apps/web/e2e/bootstrap-wizard.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// E2E test for the bootstrap wizard (M12.07, issue #308).
+//
+// The Playwright run boots the server with MOCK_BOOTSTRAP=true (set in
+// playwright.config.ts), so the /api/projects/bootstrap/{preview,run}
+// endpoints return deterministic fixtures instead of hitting GitHub.
+// This test walks every wizard step and asserts the final PR URL renders.
+// ---------------------------------------------------------------------------
+
+test.describe('bootstrap wizard', () => {
+  test.skip(
+    process.env.MOCK_BOOTSTRAP !== 'true',
+    'requires MOCK_BOOTSTRAP=true so the server short-circuits the workflow',
+  );
+
+  test('walks all wizard steps and shows the PR URL on completion', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.getByTestId('settings-page')).toBeVisible();
+
+    // Open the wizard via the "Add Project" button.
+    await page.getByTestId('add-project-button').click();
+    await expect(page.getByTestId('bootstrap-wizard')).toBeVisible();
+    await expect(page.getByTestId('step-repo')).toBeVisible();
+
+    // Step 1 — type a repo ref and advance.
+    await page.getByTestId('bootstrap-repo-input').fill('octo/widgets');
+    await page.getByTestId('wizard-next').click();
+
+    // Step 2 — stack summary.
+    await expect(page.getByTestId('step-stack')).toBeVisible();
+    await expect(page.getByTestId('stack-summary')).toContainText('node');
+    await page.getByTestId('wizard-next').click();
+
+    // Step 3 — CLAUDE.md preview (textarea, read-only).
+    await expect(page.getByTestId('step-claudemd')).toBeVisible();
+    await expect(page.getByTestId('claudemd-preview')).toBeVisible();
+    await page.getByTestId('wizard-next').click();
+
+    // Step 4 — labels list (canonical Factory labels).
+    await expect(page.getByTestId('step-labels')).toBeVisible();
+    const labels = page.getByTestId('labels-list-item');
+    await expect(labels.first()).toBeVisible();
+    expect(await labels.count()).toBeGreaterThan(0);
+    await page.getByTestId('wizard-next').click();
+
+    // Step 5 — webhook setup with payload URL.
+    await expect(page.getByTestId('step-webhook')).toBeVisible();
+    await expect(page.getByTestId('webhook-payload-url')).toContainText('webhook/github');
+    await page.getByTestId('wizard-next').click();
+
+    // Final step — Open PR button + result.
+    await expect(page.getByTestId('step-submit')).toBeVisible();
+    await page.getByTestId('bootstrap-submit').click();
+    await expect(page.getByTestId('bootstrap-result')).toBeVisible();
+
+    const link = page.getByTestId('bootstrap-pr-link');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', /github\.com\/.+\/pull\//);
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
             timeout: 30_000,
             env: {
               GITHUB_TOKEN: process.env.GITHUB_TOKEN ?? '',
+              // M12.07: forward MOCK_BOOTSTRAP so the bootstrap-wizard e2e can
+              // exercise the wizard against deterministic fixture endpoints.
+              MOCK_BOOTSTRAP: process.env.MOCK_BOOTSTRAP ?? '',
             },
           },
           {

--- a/apps/web/src/components/bootstrap/README.md
+++ b/apps/web/src/components/bootstrap/README.md
@@ -1,0 +1,76 @@
+# bootstrap
+
+Bootstrap wizard UI for adding a new project to Factory's roster. Closes #308 (M12.07).
+
+## Structure
+
+```
+bootstrap/
+  components/
+    BootstrapWizard.tsx       — multi-step modal that drives the bootstrap flow
+    BootstrapWizard.test.tsx  — DOM-level component tests (mocked api)
+  lib/
+    wizard-state.ts           — pure step-machine + repo-ref validation
+  slice.test.ts
+  README.md
+```
+
+## Entry point
+
+The "Add Project" button on the **Settings** page opens the wizard
+(`apps/web/src/components/settings/components/SettingsPage.tsx`).
+
+## Steps
+
+1. **Repository** — user types `owner/repo`. The wizard validates the format
+   client-side and calls `POST /api/projects/bootstrap/preview` to confirm
+   the server can reach the repo with its configured token. The browser
+   never collects or sends a GitHub token.
+2. **Stack** — server-detected stack summary (runtime, package manager,
+   commands). Read-only.
+3. **CLAUDE.md** — preview (`action: 'create'`) or unified diff
+   (`action: 'update'`) shown in a read-only textarea. When the existing
+   CLAUDE.md already has every required section (`action: 'ok'`), the wizard
+   shows a confirmation message instead of an empty editor.
+4. **Labels** — list of canonical Factory labels that will be installed on
+   the target repo (colour swatch + name + description per label).
+5. **Webhook** — copy-pasteable instructions for configuring a GitHub
+   webhook at `https://github.com/<owner/repo>/settings/hooks/new`. Mentions
+   `ngrok` for local development.
+6. **Open Registration PR** — single button calls
+   `POST /api/projects/bootstrap/run`, displays the resulting PR URL on
+   success.
+
+## Server contract
+
+Two endpoints under the `bootstrap` server domain
+(`apps/server/src/domains/bootstrap/`):
+
+- `POST /projects/bootstrap/preview { repoRef }` — returns
+  `BootstrapPreviewDto { slug, defaultBranch, stack, audit, labelsToInstall }`.
+  The preview endpoint is **read-only**: it runs stack detection +
+  CLAUDE.md audit + reports the canonical label set, but does NOT mutate
+  GitHub state, install labels, or open a PR.
+- `POST /projects/bootstrap/run { repoRef, slug? }` — invokes the
+  `bootstrapProject` workflow end-to-end. Returns `BootstrapRunDto` with
+  the registration PR URL.
+
+The split keeps the destructive `/run` step deliberate: the wizard's
+"Open Registration PR" button is the only call site.
+
+## Mocking the workflow
+
+The Playwright e2e (`apps/web/e2e/bootstrap-wizard.spec.ts`) drives the
+wizard through every step against a server booted with
+`MOCK_BOOTSTRAP=true`. Both endpoints short-circuit to deterministic
+fixtures — no GitHub calls, no real labels installed, no PR opened.
+
+## State machine
+
+`lib/wizard-state.ts` exports a pure 6-step state machine
+(`WIZARD_STEPS`, `nextStep`, `prevStep`, `stepIndex`, `stepLabel`) plus
+`isValidRepoRef(...)`. Tests in `slice.test.ts` cover every transition.
+
+The wizard component holds `WizardState` in `useState`; resetting the
+modal happens automatically on close (so re-opening the wizard always
+starts at step 1).

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
@@ -1,0 +1,181 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BootstrapWizard } from './BootstrapWizard';
+
+// API is mocked at the module level; each test injects fresh mock impls.
+vi.mock('@/lib/api', () => ({
+  previewBootstrap: vi.fn(),
+  runBootstrap: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const FIXTURE_PREVIEW = {
+  slug: 'widgets',
+  defaultBranch: 'main',
+  stack: { type: 'node', summary: 'node (pnpm) — scripts: build, test', raw: {} },
+  audit: {
+    action: 'create' as const,
+    content: '# CLAUDE.md\n\n## What this repo is\n\n…\n',
+    rationale: 'No CLAUDE.md found.',
+  },
+  labelsToInstall: [
+    { name: 'factory:done', color: 'd1d5db', description: 'Done' },
+    { name: 'factory:in-progress', color: '1d76db', description: 'In progress' },
+  ],
+};
+
+const FIXTURE_RESULT = {
+  status: 'created' as const,
+  registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/123',
+  slug: 'widgets',
+  stackSummary: 'node (pnpm)',
+  auditAction: 'create' as const,
+  labelCounts: { created: 5, updated: 0, skipped: 23 },
+};
+
+function renderWizard(open = true) {
+  const onClose = vi.fn();
+  render(<BootstrapWizard open={open} onClose={onClose} />);
+  return { onClose };
+}
+
+describe('BootstrapWizard', () => {
+  it('does not render when open=false', () => {
+    renderWizard(false);
+    expect(screen.queryByTestId('bootstrap-wizard')).toBeNull();
+  });
+
+  it('starts on the repo step', () => {
+    renderWizard();
+    expect(screen.getByTestId('step-repo')).toBeTruthy();
+    expect(screen.getByTestId('bootstrap-repo-input')).toBeTruthy();
+  });
+
+  it('disables the Next button when the repo ref is invalid', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    const next = screen.getByTestId('wizard-next') as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+
+    const input = screen.getByTestId('bootstrap-repo-input');
+    await user.type(input, 'not-a-valid-ref');
+    expect((screen.getByTestId('wizard-next') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('walks all five preview steps and shows the PR URL on completion', async () => {
+    const { previewBootstrap, runBootstrap } = await import('@/lib/api');
+    vi.mocked(previewBootstrap).mockResolvedValue(FIXTURE_PREVIEW);
+    vi.mocked(runBootstrap).mockResolvedValue(FIXTURE_RESULT);
+
+    const user = userEvent.setup();
+    renderWizard();
+
+    // Step 1 — enter repo + click Next.
+    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 2 — stack summary.
+    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
+    expect(screen.getByTestId('stack-summary').textContent).toContain('node');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 3 — CLAUDE.md preview.
+    await waitFor(() => expect(screen.getByTestId('step-claudemd')).toBeTruthy());
+    expect((screen.getByTestId('claudemd-preview') as HTMLTextAreaElement).value).toContain(
+      'CLAUDE.md',
+    );
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 4 — label install confirmation.
+    await waitFor(() => expect(screen.getByTestId('step-labels')).toBeTruthy());
+    expect(screen.getAllByTestId('labels-list-item').length).toBe(2);
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 5 — webhook setup.
+    await waitFor(() => expect(screen.getByTestId('step-webhook')).toBeTruthy());
+    expect(screen.getByTestId('webhook-payload-url').textContent).toContain('webhook/github');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Final step — Open PR + result render.
+    await waitFor(() => expect(screen.getByTestId('step-submit')).toBeTruthy());
+    await user.click(screen.getByTestId('bootstrap-submit'));
+    await waitFor(() => expect(screen.getByTestId('bootstrap-result')).toBeTruthy());
+    const link = screen.getByTestId('bootstrap-pr-link') as HTMLAnchorElement;
+    expect(link.href).toBe('https://github.com/shaunnez/goose-hub/pull/123');
+    expect(runBootstrap).toHaveBeenCalledWith('octo/widgets', 'widgets');
+  });
+
+  it('shows update-mode CLAUDE.md as a diff when audit.action="update"', async () => {
+    const { previewBootstrap } = await import('@/lib/api');
+    vi.mocked(previewBootstrap).mockResolvedValue({
+      ...FIXTURE_PREVIEW,
+      audit: {
+        action: 'update',
+        content: '--- existing\n+++ proposed\n+## Hard rules\n+...',
+        rationale: 'Existing CLAUDE.md missing required sections.',
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('step-claudemd')).toBeTruthy());
+    expect(screen.getByText(/diff \(update\)/i)).toBeTruthy();
+    expect((screen.getByTestId('claudemd-preview') as HTMLTextAreaElement).value).toContain(
+      '+## Hard rules',
+    );
+  });
+
+  it('hides the textarea when audit.action="ok"', async () => {
+    const { previewBootstrap } = await import('@/lib/api');
+    vi.mocked(previewBootstrap).mockResolvedValue({
+      ...FIXTURE_PREVIEW,
+      audit: { action: 'ok', content: '', rationale: 'Already complete.' },
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('claudemd-ok')).toBeTruthy());
+    expect(screen.queryByTestId('claudemd-preview')).toBeNull();
+  });
+
+  it('surfaces preview errors in a banner', async () => {
+    const { previewBootstrap } = await import('@/lib/api');
+    vi.mocked(previewBootstrap).mockRejectedValue(new Error('repo not found'));
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/missing');
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('wizard-error')).toBeTruthy());
+    expect(screen.getByTestId('wizard-error').textContent).toContain('repo not found');
+    // We stayed on the repo step.
+    expect(screen.getByTestId('step-repo')).toBeTruthy();
+  });
+
+  it('lets the user step backwards', async () => {
+    const { previewBootstrap } = await import('@/lib/api');
+    vi.mocked(previewBootstrap).mockResolvedValue(FIXTURE_PREVIEW);
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
+    await user.click(screen.getByTestId('wizard-prev'));
+    await waitFor(() => expect(screen.getByTestId('step-repo')).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
@@ -99,7 +99,9 @@ describe('BootstrapWizard', () => {
 
     // Step 5 — webhook setup.
     await waitFor(() => expect(screen.getByTestId('step-webhook')).toBeTruthy());
-    expect(screen.getByTestId('webhook-payload-url').textContent).toContain('webhook/github');
+    // Must match the actual server route in apps/server/src/server.ts (`/webhooks/github`),
+    // not the singular `/webhook/github` that previously shipped here.
+    expect(screen.getByTestId('webhook-payload-url').textContent).toContain('/webhooks/github');
     await user.click(screen.getByTestId('wizard-next'));
 
     // Final step — Open PR + result render.

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
@@ -1,0 +1,644 @@
+/**
+ * BootstrapWizard — multi-step modal that walks the human through registering
+ * a new project under Factory's roster (M12.07, issue #308).
+ *
+ * The wizard hits two server endpoints:
+ *   - POST /projects/bootstrap/preview { repoRef }  → BootstrapPreviewDto
+ *   - POST /projects/bootstrap/run     { repoRef, slug? } → BootstrapRunDto
+ *
+ * Tokens are server-held (env GITHUB_TOKEN); the browser never collects
+ * tokens. The "Open Registration PR" button on the final step calls /run.
+ */
+
+import { previewBootstrap, runBootstrap } from '@/lib/api';
+import type { BootstrapPreviewDto, BootstrapRunDto } from '@/lib/types';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  WIZARD_STEPS,
+  type WizardStep,
+  isValidRepoRef,
+  nextStep,
+  prevStep,
+  stepIndex,
+  stepLabel,
+} from '../lib/wizard-state';
+
+interface BootstrapWizardProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface WizardState {
+  step: WizardStep;
+  repoRef: string;
+  preview: BootstrapPreviewDto | null;
+  result: BootstrapRunDto | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const INITIAL_STATE: WizardState = {
+  step: 'repo',
+  repoRef: '',
+  preview: null,
+  result: null,
+  loading: false,
+  error: null,
+};
+
+export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
+  const [state, setState] = useState<WizardState>(INITIAL_STATE);
+
+  const reset = useCallback(() => setState(INITIAL_STATE), []);
+
+  useEffect(() => {
+    // Reset whenever the modal closes so the next open starts fresh.
+    if (!open) reset();
+  }, [open, reset]);
+
+  if (!open) return null;
+
+  function setError(error: string | null) {
+    setState((s) => ({ ...s, error, loading: false }));
+  }
+
+  async function handleValidateRepo() {
+    if (!isValidRepoRef(state.repoRef)) {
+      setError('Repository ref must look like "owner/repo"');
+      return;
+    }
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const preview = await previewBootstrap(state.repoRef.trim());
+      setState((s) => ({ ...s, preview, loading: false, step: nextStep(s.step) }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to validate repo');
+    }
+  }
+
+  async function handleOpenPr() {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const result = await runBootstrap(state.repoRef.trim(), state.preview?.slug);
+      setState((s) => ({ ...s, result, loading: false }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open registration PR');
+    }
+  }
+
+  function handleNext() {
+    setState((s) => ({ ...s, step: nextStep(s.step), error: null }));
+  }
+  function handlePrev() {
+    setState((s) => ({ ...s, step: prevStep(s.step), error: null }));
+  }
+
+  function handleClose() {
+    onClose();
+  }
+
+  return (
+    <div
+      data-testid="bootstrap-wizard"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.45)',
+      }}
+      onClick={handleClose}
+      onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+    >
+      <div
+        // biome-ignore lint/a11y/useSemanticElements: native <dialog> requires open/showModal lifecycle that conflicts with the existing CSS-overlay pattern used elsewhere in the app; aria-label + role="dialog" is the documented React-modal fallback.
+        role="dialog"
+        aria-label="Add Project bootstrap wizard"
+        style={{
+          background: 'var(--bg-elev)',
+          border: '1px solid var(--line)',
+          borderRadius: 8,
+          padding: '24px',
+          width: '100%',
+          maxWidth: 720,
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          color: 'var(--fg)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+      >
+        <h2
+          style={{
+            margin: '0 0 12px',
+            fontSize: 15,
+            fontWeight: 600,
+          }}
+        >
+          Add project
+        </h2>
+
+        <StepIndicator current={state.step} />
+
+        <div style={{ marginTop: 16 }}>
+          {state.step === 'repo' && (
+            <StepRepo
+              repoRef={state.repoRef}
+              onChange={(repoRef) => setState((s) => ({ ...s, repoRef, error: null }))}
+              loading={state.loading}
+              onSubmit={handleValidateRepo}
+            />
+          )}
+          {state.step === 'stack' && state.preview && <StepStack preview={state.preview} />}
+          {state.step === 'claudeMd' && state.preview && <StepClaudeMd preview={state.preview} />}
+          {state.step === 'labels' && state.preview && <StepLabels preview={state.preview} />}
+          {state.step === 'webhook' && state.preview && (
+            <StepWebhook preview={state.preview} repoRef={state.repoRef} />
+          )}
+          {state.step === 'submit' && (
+            <StepSubmit
+              repoRef={state.repoRef}
+              preview={state.preview}
+              result={state.result}
+              loading={state.loading}
+              onOpenPr={handleOpenPr}
+            />
+          )}
+        </div>
+
+        {state.error && (
+          <p
+            data-testid="wizard-error"
+            style={{ marginTop: 12, color: 'var(--danger, #e05)', fontSize: 12 }}
+          >
+            {state.error}
+          </p>
+        )}
+
+        <WizardFooter
+          step={state.step}
+          loading={state.loading}
+          hasResult={state.result != null}
+          canAdvance={canAdvance(state)}
+          onPrev={handlePrev}
+          onNext={state.step === 'repo' ? handleValidateRepo : handleNext}
+          onClose={handleClose}
+        />
+      </div>
+    </div>
+  );
+}
+
+function canAdvance(state: WizardState): boolean {
+  if (state.loading) return false;
+  if (state.step === 'repo') {
+    return isValidRepoRef(state.repoRef);
+  }
+  if (state.step === 'submit') {
+    return state.result != null;
+  }
+  return state.preview != null;
+}
+
+function StepIndicator({ current }: { current: WizardStep }) {
+  const currentIdx = stepIndex(current);
+  return (
+    <ol
+      data-testid="wizard-steps"
+      style={{
+        display: 'flex',
+        gap: 4,
+        listStyle: 'none',
+        padding: 0,
+        margin: 0,
+        fontSize: 11,
+        color: 'var(--fg-2)',
+        flexWrap: 'wrap',
+      }}
+    >
+      {WIZARD_STEPS.map((step, idx) => {
+        const isActive = step === current;
+        const isComplete = idx < currentIdx;
+        return (
+          <li
+            key={step}
+            data-testid={`wizard-step-${step}`}
+            data-active={isActive ? 'true' : 'false'}
+            style={{
+              padding: '3px 8px',
+              borderRadius: 4,
+              border: '1px solid var(--line)',
+              background: isActive
+                ? 'var(--accent, #6366f1)'
+                : isComplete
+                  ? 'var(--accent-soft, rgba(99,102,241,0.18))'
+                  : 'transparent',
+              color: isActive ? '#fff' : 'var(--fg-2)',
+            }}
+          >
+            {idx + 1}. {stepLabel(step)}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function StepRepo({
+  repoRef,
+  onChange,
+  loading,
+  onSubmit,
+}: {
+  repoRef: string;
+  onChange: (v: string) => void;
+  loading: boolean;
+  onSubmit: () => void;
+}) {
+  return (
+    <form
+      data-testid="step-repo"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!loading) onSubmit();
+      }}
+    >
+      <label
+        htmlFor="bootstrap-repo-ref"
+        style={{ display: 'block', fontSize: 12, color: 'var(--fg-2)', marginBottom: 4 }}
+      >
+        GitHub repository (owner/repo)
+      </label>
+      <input
+        id="bootstrap-repo-ref"
+        data-testid="bootstrap-repo-input"
+        type="text"
+        value={repoRef}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="octo/widgets"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        style={{
+          display: 'block',
+          width: '100%',
+          boxSizing: 'border-box',
+          padding: '6px 10px',
+          borderRadius: 6,
+          border: '1px solid var(--line)',
+          background: 'var(--bg)',
+          color: 'var(--fg)',
+          fontSize: 13,
+          fontFamily: 'monospace',
+          outline: 'none',
+        }}
+      />
+      <p style={{ marginTop: 6, fontSize: 11, color: 'var(--fg-3)' }}>
+        The server checks accessibility with its configured GITHUB_TOKEN. The browser never sees a
+        token.
+      </p>
+    </form>
+  );
+}
+
+function StepStack({ preview }: { preview: BootstrapPreviewDto }) {
+  return (
+    <div data-testid="step-stack">
+      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Detected stack</h3>
+      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
+        <strong>Type:</strong> {preview.stack.type}
+      </p>
+      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
+        <strong>Default branch:</strong>{' '}
+        <code style={{ fontFamily: 'monospace' }}>{preview.defaultBranch}</code>
+      </p>
+      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
+        <strong>Slug:</strong> <code style={{ fontFamily: 'monospace' }}>{preview.slug}</code>
+      </p>
+      <pre
+        data-testid="stack-summary"
+        style={{
+          marginTop: 12,
+          background: 'var(--bg)',
+          border: '1px solid var(--line)',
+          borderRadius: 6,
+          padding: 12,
+          fontSize: 11,
+          fontFamily: 'monospace',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all',
+        }}
+      >
+        {preview.stack.summary}
+      </pre>
+    </div>
+  );
+}
+
+function StepClaudeMd({ preview }: { preview: BootstrapPreviewDto }) {
+  const isCreate = preview.audit.action === 'create';
+  const isUpdate = preview.audit.action === 'update';
+  const isOk = preview.audit.action === 'ok';
+  return (
+    <div data-testid="step-claudemd">
+      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>
+        CLAUDE.md {isCreate ? 'preview (create)' : isUpdate ? 'diff (update)' : 'audit'}
+      </h3>
+      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
+        {preview.audit.rationale}
+      </p>
+      {!isOk && (
+        <textarea
+          data-testid="claudemd-preview"
+          readOnly
+          value={preview.audit.content}
+          rows={12}
+          style={{
+            display: 'block',
+            width: '100%',
+            boxSizing: 'border-box',
+            background: 'var(--bg)',
+            border: '1px solid var(--line)',
+            borderRadius: 6,
+            color: 'var(--fg)',
+            fontFamily: 'monospace',
+            fontSize: 11,
+            padding: 8,
+            resize: 'vertical',
+          }}
+        />
+      )}
+      {isOk && (
+        <p data-testid="claudemd-ok" style={{ margin: 0, fontSize: 12, color: 'var(--fg-2)' }}>
+          The target repo's CLAUDE.md already contains every required section. No changes proposed.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StepLabels({ preview }: { preview: BootstrapPreviewDto }) {
+  return (
+    <div data-testid="step-labels">
+      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>
+        Labels to install ({preview.labelsToInstall.length})
+      </h3>
+      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
+        These are the canonical Factory labels that will be created or updated on{' '}
+        <code style={{ fontFamily: 'monospace' }}>{preview.slug}</code>'s GitHub repo.
+      </p>
+      <ul
+        data-testid="labels-list"
+        style={{
+          listStyle: 'none',
+          padding: 0,
+          margin: 0,
+          maxHeight: 240,
+          overflowY: 'auto',
+          border: '1px solid var(--line)',
+          borderRadius: 6,
+        }}
+      >
+        {preview.labelsToInstall.map((label) => (
+          <li
+            key={label.name}
+            data-testid="labels-list-item"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '5px 10px',
+              borderBottom: '1px solid var(--line)',
+              fontSize: 12,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                width: 12,
+                height: 12,
+                borderRadius: 3,
+                background: `#${label.color}`,
+                flexShrink: 0,
+              }}
+            />
+            <code style={{ fontFamily: 'monospace', flexShrink: 0 }}>{label.name}</code>
+            <span style={{ color: 'var(--fg-3)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {label.description}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function StepWebhook({ preview, repoRef }: { preview: BootstrapPreviewDto; repoRef: string }) {
+  const payloadUrl = '<your-goose-hub-host>/webhook/github';
+  return (
+    <div data-testid="step-webhook">
+      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Webhook setup</h3>
+      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
+        After this PR merges, configure a GitHub webhook on{' '}
+        <code style={{ fontFamily: 'monospace' }}>{repoRef || preview.slug}</code> so factory ticks
+        react to label changes.
+      </p>
+      <ol style={{ margin: '0 0 8px 18px', padding: 0, fontSize: 12, lineHeight: 1.7 }}>
+        <li>
+          Go to{' '}
+          <code style={{ fontFamily: 'monospace' }}>
+            https://github.com/{repoRef || preview.slug}/settings/hooks/new
+          </code>
+          .
+        </li>
+        <li>
+          Payload URL:{' '}
+          <code data-testid="webhook-payload-url" style={{ fontFamily: 'monospace' }}>
+            {payloadUrl}
+          </code>
+        </li>
+        <li>
+          Content type: <code style={{ fontFamily: 'monospace' }}>application/json</code>
+        </li>
+        <li>
+          Secret: the value of{' '}
+          <code style={{ fontFamily: 'monospace' }}>GITHUB_WEBHOOK_SECRET</code> from your goose-hub
+          server env.
+        </li>
+        <li>Events: select Issues, Pull requests, and Issue comments.</li>
+        <li>Active: yes.</li>
+      </ol>
+      <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-3)' }}>
+        Local development: tunnel <code style={{ fontFamily: 'monospace' }}>localhost:3001</code>{' '}
+        with <code style={{ fontFamily: 'monospace' }}>ngrok http 3001</code> and use the ngrok URL
+        above instead.
+      </p>
+    </div>
+  );
+}
+
+function StepSubmit({
+  repoRef,
+  preview,
+  result,
+  loading,
+  onOpenPr,
+}: {
+  repoRef: string;
+  preview: BootstrapPreviewDto | null;
+  result: BootstrapRunDto | null;
+  loading: boolean;
+  onOpenPr: () => void;
+}) {
+  return (
+    <div data-testid="step-submit">
+      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Open registration PR</h3>
+      {result == null && (
+        <>
+          <p style={{ margin: '0 0 12px', fontSize: 12, color: 'var(--fg-2)' }}>
+            Clicking the button below will install the canonical labels on{' '}
+            <code style={{ fontFamily: 'monospace' }}>{repoRef}</code> and open a registration PR on{' '}
+            <code style={{ fontFamily: 'monospace' }}>shaunnez/goose-hub</code> with slug{' '}
+            <code style={{ fontFamily: 'monospace' }}>{preview?.slug}</code>.
+          </p>
+          <button
+            type="button"
+            data-testid="bootstrap-submit"
+            disabled={loading}
+            onClick={onOpenPr}
+            style={{
+              padding: '6px 16px',
+              borderRadius: 6,
+              border: 'none',
+              background: 'var(--accent, #6366f1)',
+              color: '#fff',
+              fontSize: 13,
+              cursor: loading ? 'not-allowed' : 'pointer',
+              opacity: loading ? 0.7 : 1,
+            }}
+          >
+            {loading ? 'Opening PR…' : 'Open Registration PR'}
+          </button>
+        </>
+      )}
+      {result != null && (
+        <div data-testid="bootstrap-result">
+          <p style={{ margin: '0 0 8px', fontSize: 12 }}>
+            <strong>Status:</strong> {result.status}
+          </p>
+          {result.registrationPrUrl && (
+            <p style={{ margin: '0 0 8px', fontSize: 12 }}>
+              <strong>PR:</strong>{' '}
+              <a
+                data-testid="bootstrap-pr-link"
+                href={result.registrationPrUrl}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--accent, #6366f1)' }}
+              >
+                {result.registrationPrUrl}
+              </a>
+            </p>
+          )}
+          {result.labelCounts && (
+            <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
+              Labels — created {result.labelCounts.created}, updated {result.labelCounts.updated},
+              skipped {result.labelCounts.skipped}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WizardFooter({
+  step,
+  loading,
+  hasResult,
+  canAdvance,
+  onPrev,
+  onNext,
+  onClose,
+}: {
+  step: WizardStep;
+  loading: boolean;
+  hasResult: boolean;
+  canAdvance: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+}) {
+  const isFirst = step === 'repo';
+  const isFinal = step === 'submit';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginTop: 24,
+        paddingTop: 12,
+        borderTop: '1px solid var(--line)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        style={{
+          padding: '5px 14px',
+          borderRadius: 6,
+          border: '1px solid var(--line)',
+          background: 'var(--bg)',
+          color: 'var(--fg-2)',
+          fontSize: 13,
+          cursor: 'pointer',
+        }}
+      >
+        {hasResult ? 'Close' : 'Cancel'}
+      </button>
+      <div style={{ display: 'flex', gap: 8 }}>
+        {!isFirst && (
+          <button
+            type="button"
+            data-testid="wizard-prev"
+            onClick={onPrev}
+            disabled={loading}
+            style={{
+              padding: '5px 14px',
+              borderRadius: 6,
+              border: '1px solid var(--line)',
+              background: 'var(--bg)',
+              color: 'var(--fg-2)',
+              fontSize: 13,
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Back
+          </button>
+        )}
+        {!isFinal && (
+          <button
+            type="button"
+            data-testid="wizard-next"
+            onClick={onNext}
+            disabled={!canAdvance || loading}
+            style={{
+              padding: '5px 14px',
+              borderRadius: 6,
+              border: 'none',
+              background: 'var(--accent, #6366f1)',
+              color: '#fff',
+              fontSize: 13,
+              cursor: !canAdvance || loading ? 'not-allowed' : 'pointer',
+              opacity: !canAdvance || loading ? 0.7 : 1,
+            }}
+          >
+            {loading ? 'Loading…' : 'Next'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
@@ -12,7 +12,7 @@
 
 import { previewBootstrap, runBootstrap } from '@/lib/api';
 import type { BootstrapPreviewDto, BootstrapRunDto } from '@/lib/types';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   WIZARD_STEPS,
   type WizardStep,
@@ -48,10 +48,16 @@ const INITIAL_STATE: WizardState = {
 
 export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
+  // Tracks whether the modal is still mounted/open by the time an in-flight
+  // preview/run request resolves. Without this guard, a late response can
+  // re-populate state after the user has closed the wizard, leaving stale
+  // step/preview data visible on the next open.
+  const openRef = useRef(open);
 
   const reset = useCallback(() => setState(INITIAL_STATE), []);
 
   useEffect(() => {
+    openRef.current = open;
     // Reset whenever the modal closes so the next open starts fresh.
     if (!open) reset();
   }, [open, reset]);
@@ -70,8 +76,10 @@ export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
       const preview = await previewBootstrap(state.repoRef.trim());
+      if (!openRef.current) return;
       setState((s) => ({ ...s, preview, loading: false, step: nextStep(s.step) }));
     } catch (err) {
+      if (!openRef.current) return;
       setError(err instanceof Error ? err.message : 'Failed to validate repo');
     }
   }
@@ -80,8 +88,10 @@ export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
       const result = await runBootstrap(state.repoRef.trim(), state.preview?.slug);
+      if (!openRef.current) return;
       setState((s) => ({ ...s, result, loading: false }));
     } catch (err) {
+      if (!openRef.current) return;
       setError(err instanceof Error ? err.message : 'Failed to open registration PR');
     }
   }
@@ -436,7 +446,7 @@ function StepLabels({ preview }: { preview: BootstrapPreviewDto }) {
 }
 
 function StepWebhook({ preview, repoRef }: { preview: BootstrapPreviewDto; repoRef: string }) {
-  const payloadUrl = '<your-goose-hub-host>/webhook/github';
+  const payloadUrl = '<your-goose-hub-host>/webhooks/github';
   return (
     <div data-testid="step-webhook">
       <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Webhook setup</h3>

--- a/apps/web/src/components/bootstrap/lib/wizard-state.ts
+++ b/apps/web/src/components/bootstrap/lib/wizard-state.ts
@@ -1,0 +1,61 @@
+/**
+ * Wizard step state machine for the bootstrap wizard (M12.07).
+ *
+ * Steps:
+ *   1. repo        — enter `owner/repo`, server validates accessibility
+ *   2. stack       — show detected stack summary, user reviews
+ *   3. claudeMd    — show CLAUDE.md preview/diff (read-only), user confirms
+ *   4. labels      — show labels-to-install list, user confirms
+ *   5. webhook     — show webhook setup instructions, user confirms
+ *   6. submit      — show "Open Registration PR" button + final result
+ *
+ * The state machine is intentionally pure: the wizard component holds the
+ * `WizardState` in `useState` and calls `next()` / `prev()` on each step.
+ */
+
+export type WizardStep = 'repo' | 'stack' | 'claudeMd' | 'labels' | 'webhook' | 'submit';
+
+export const WIZARD_STEPS: ReadonlyArray<WizardStep> = [
+  'repo',
+  'stack',
+  'claudeMd',
+  'labels',
+  'webhook',
+  'submit',
+] as const;
+
+const STEP_LABELS: Record<WizardStep, string> = {
+  repo: 'Repository',
+  stack: 'Stack',
+  claudeMd: 'CLAUDE.md',
+  labels: 'Labels',
+  webhook: 'Webhook',
+  submit: 'Open PR',
+};
+
+export function stepLabel(step: WizardStep): string {
+  return STEP_LABELS[step];
+}
+
+export function nextStep(current: WizardStep): WizardStep {
+  const idx = WIZARD_STEPS.indexOf(current);
+  if (idx < 0 || idx === WIZARD_STEPS.length - 1) return current;
+  return WIZARD_STEPS[idx + 1];
+}
+
+export function prevStep(current: WizardStep): WizardStep {
+  const idx = WIZARD_STEPS.indexOf(current);
+  if (idx <= 0) return current;
+  return WIZARD_STEPS[idx - 1];
+}
+
+export function stepIndex(step: WizardStep): number {
+  return WIZARD_STEPS.indexOf(step);
+}
+
+const REPO_REF_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/** Validate the user-typed repo ref before we hit the server. */
+export function isValidRepoRef(ref: string): boolean {
+  return REPO_REF_PATTERN.test(ref.trim());
+}

--- a/apps/web/src/components/bootstrap/slice.test.ts
+++ b/apps/web/src/components/bootstrap/slice.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WIZARD_STEPS,
+  isValidRepoRef,
+  nextStep,
+  prevStep,
+  stepIndex,
+  stepLabel,
+} from './lib/wizard-state';
+
+// ---------------------------------------------------------------------------
+// Slice contract tests for the bootstrap wizard (M12.07, issue #308).
+//
+// The wizard's behaviour is split between:
+//  - lib/wizard-state.ts — pure step machine + repoRef validation (here).
+//  - components/BootstrapWizard.tsx — DOM rendering (covered in
+//    components/BootstrapWizard.test.tsx using @testing-library/react).
+// ---------------------------------------------------------------------------
+
+describe('wizard-state — WIZARD_STEPS', () => {
+  it('lists all 6 steps in order', () => {
+    expect(WIZARD_STEPS).toEqual(['repo', 'stack', 'claudeMd', 'labels', 'webhook', 'submit']);
+  });
+
+  it('has a label for every step', () => {
+    for (const step of WIZARD_STEPS) {
+      expect(stepLabel(step)).toBeTruthy();
+    }
+  });
+
+  it('returns a stable index per step', () => {
+    expect(stepIndex('repo')).toBe(0);
+    expect(stepIndex('submit')).toBe(WIZARD_STEPS.length - 1);
+  });
+});
+
+describe('wizard-state — nextStep / prevStep', () => {
+  it('advances repo → stack → claudeMd → labels → webhook → submit', () => {
+    expect(nextStep('repo')).toBe('stack');
+    expect(nextStep('stack')).toBe('claudeMd');
+    expect(nextStep('claudeMd')).toBe('labels');
+    expect(nextStep('labels')).toBe('webhook');
+    expect(nextStep('webhook')).toBe('submit');
+  });
+
+  it('clamps at the final step', () => {
+    expect(nextStep('submit')).toBe('submit');
+  });
+
+  it('walks back submit → webhook → … → repo', () => {
+    expect(prevStep('submit')).toBe('webhook');
+    expect(prevStep('webhook')).toBe('labels');
+    expect(prevStep('labels')).toBe('claudeMd');
+    expect(prevStep('claudeMd')).toBe('stack');
+    expect(prevStep('stack')).toBe('repo');
+  });
+
+  it('clamps at the first step', () => {
+    expect(prevStep('repo')).toBe('repo');
+  });
+});
+
+describe('wizard-state — isValidRepoRef', () => {
+  it('accepts canonical owner/repo refs', () => {
+    expect(isValidRepoRef('octo/widgets')).toBe(true);
+    expect(isValidRepoRef('shaunnez/goose-hub')).toBe(true);
+    expect(isValidRepoRef('user-1/repo.name')).toBe(true);
+    expect(isValidRepoRef('user_1/repo_name')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidRepoRef('  octo/widgets  ')).toBe(true);
+  });
+
+  it('rejects refs missing the slash', () => {
+    expect(isValidRepoRef('widgets')).toBe(false);
+  });
+
+  it('rejects refs with multiple slashes', () => {
+    expect(isValidRepoRef('octo/widgets/extra')).toBe(false);
+  });
+
+  it('rejects empty owner or repo halves', () => {
+    expect(isValidRepoRef('/widgets')).toBe(false);
+    expect(isValidRepoRef('octo/')).toBe(false);
+    expect(isValidRepoRef('/')).toBe(false);
+  });
+
+  it('rejects refs with disallowed characters', () => {
+    expect(isValidRepoRef('octo/widgets!')).toBe(false);
+    expect(isValidRepoRef('octo widgets/x')).toBe(false);
+  });
+});
+
+describe('wizard slice — public surface', () => {
+  it('exports BootstrapWizard component', async () => {
+    const mod = await import('./components/BootstrapWizard');
+    expect(typeof mod.BootstrapWizard).toBe('function');
+  });
+});

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -1,13 +1,15 @@
+import { BootstrapWizard } from '@/components/bootstrap/components/BootstrapWizard';
 import { fetchProjectConfigs } from '@/lib/api';
 import type { ProjectConfigDto } from '@/lib/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { RefreshCw } from 'lucide-react';
+import { Plus, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { ProjectConfigPanel } from './ProjectConfigPanel';
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<string | null>(null);
+  const [wizardOpen, setWizardOpen] = useState(false);
 
   const {
     data: configs = [],
@@ -30,14 +32,25 @@ export function SettingsPage() {
       <div className="w-56 shrink-0 border-r border-line overflow-y-auto py-4 px-2">
         <div className="flex items-center justify-between px-2 mb-3">
           <h2 className="text-[11px] uppercase tracking-wider text-fg-2">Projects</h2>
-          <button
-            type="button"
-            title="Reload configs"
-            onClick={reload}
-            className="text-fg-2 hover:text-fg transition-colors p-1 rounded"
-          >
-            <RefreshCw size={12} />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              data-testid="add-project-button"
+              title="Add project"
+              onClick={() => setWizardOpen(true)}
+              className="text-fg-2 hover:text-fg transition-colors p-1 rounded"
+            >
+              <Plus size={12} />
+            </button>
+            <button
+              type="button"
+              title="Reload configs"
+              onClick={reload}
+              className="text-fg-2 hover:text-fg transition-colors p-1 rounded"
+            >
+              <RefreshCw size={12} />
+            </button>
+          </div>
         </div>
 
         {isLoading && <div className="text-[12px] text-fg-3 px-2">Loading…</div>}
@@ -81,6 +94,8 @@ export function SettingsPage() {
           </div>
         )}
       </div>
+
+      <BootstrapWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,7 @@
 import type {
   AgentEventDto,
+  BootstrapPreviewDto,
+  BootstrapRunDto,
   CostSummaryDto,
   ImprovementCandidateDto,
   InboxItemDto,
@@ -17,7 +19,7 @@ import type {
   TriageResultDto,
   WorkItemCostsDto,
   WorkItemDto,
-} from './types';
+} from './types.js';
 
 export type {
   ProjectConfigDto,
@@ -38,7 +40,9 @@ export type {
   WorkItemCostsDto,
   PlaybookSummaryDto,
   PlaybookDetailDto,
-} from './types';
+  BootstrapPreviewDto,
+  BootstrapRunDto,
+} from './types.js';
 
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(`/api${path}`, { headers: { Accept: 'application/json' }, signal });
@@ -356,4 +360,30 @@ export async function createPlaybook(
     `/projects/${slug}/playbooks`,
     body,
   );
+}
+
+export async function previewBootstrap(repoRef: string): Promise<BootstrapPreviewDto> {
+  const res = await fetch('/api/projects/bootstrap/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ repoRef }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST /projects/bootstrap/preview failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as BootstrapPreviewDto;
+}
+
+export async function runBootstrap(repoRef: string, slug?: string): Promise<BootstrapRunDto> {
+  const res = await fetch('/api/projects/bootstrap/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ repoRef, slug }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST /projects/bootstrap/run failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as BootstrapRunDto;
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -253,3 +253,38 @@ export interface PlaybookManifestDto {
 export interface PlaybookDetailDto extends PlaybookSummaryDto {
   manifest: PlaybookManifestDto;
 }
+
+// ---------------------------------------------------------------------------
+// Bootstrap wizard (M12.07, issue #308)
+// ---------------------------------------------------------------------------
+
+export interface BootstrapPreviewLabelDto {
+  name: string;
+  color: string;
+  description: string;
+}
+
+export interface BootstrapPreviewDto {
+  slug: string;
+  defaultBranch: string;
+  stack: {
+    type: string;
+    summary: string;
+    raw: unknown;
+  };
+  audit: {
+    action: 'create' | 'update' | 'ok';
+    content: string;
+    rationale: string;
+  };
+  labelsToInstall: BootstrapPreviewLabelDto[];
+}
+
+export interface BootstrapRunDto {
+  status: 'created' | 'idempotent-skip';
+  registrationPrUrl: string | null;
+  slug: string;
+  stackSummary: string;
+  auditAction: 'create' | 'update' | 'ok';
+  labelCounts?: { created: number; updated: number; skipped: number };
+}

--- a/slices/bootstrap-wizard/README.md
+++ b/slices/bootstrap-wizard/README.md
@@ -1,0 +1,93 @@
+# slices/bootstrap-wizard
+
+End-to-end UI for adding a new project to Factory's roster (M12.07, issue #308).
+
+The wizard wraps the existing `bootstrapProject` workflow (M12.04, slice
+`slices/bootstrap-project/`) so the human can drive it from the web UI
+instead of the CLI.
+
+## Vertical surfaces touched
+
+- **Server domain**: `apps/server/src/domains/bootstrap/`
+  - `router.ts` — `POST /projects/bootstrap/preview`, `POST /projects/bootstrap/run`
+  - `service.ts` — `previewBootstrapService`, `runBootstrapService` (DI-friendly)
+  - `service.test.ts`, `router.test.ts`
+- **Web feature**: `apps/web/src/components/bootstrap/`
+  - `components/BootstrapWizard.tsx` — 6-step modal
+  - `components/BootstrapWizard.test.tsx` — DOM tests with mocked api
+  - `lib/wizard-state.ts` — pure step machine + repoRef validation
+  - `slice.test.ts`, `README.md`
+- **Web hook-up**: `apps/web/src/components/settings/components/SettingsPage.tsx`
+  - "Add Project" `+` button next to the reload button on the Settings page
+- **Web shared lib**: `apps/web/src/lib/api.ts` adds
+  `previewBootstrap()` + `runBootstrap()` helpers; `lib/types.ts` adds
+  `BootstrapPreviewDto` + `BootstrapRunDto`.
+- **Top-level slice manifest**: `slice.test.ts` (this folder) asserts the
+  public surface contract.
+- **Playwright e2e**: `apps/web/e2e/bootstrap-wizard.spec.ts` walks the
+  wizard end-to-end against a server booted with `MOCK_BOOTSTRAP=true`.
+
+The slice does **not** import from any other slice, and re-uses the core
+workflow through its public interfaces (`bootstrapProject`, `parseRepoRef`,
+`sanitiseSlug`, `summariseStack`).
+
+## Server endpoint design
+
+Two endpoints, separated for safety:
+
+- **`POST /projects/bootstrap/preview`** — read-only.
+  - Validates `repoRef` shape (`parseRepoRef`).
+  - Calls `GET /repos/:owner/:repo` to confirm the server can reach the
+    repo with its `GITHUB_TOKEN` and to read the default branch.
+  - Runs `detectStack(<cloneRoot>/<repo>)` against any local checkout the
+    server can see (falls back to `unknown` if absent — the human can edit
+    the scaffold before merging the registration PR).
+  - Runs `auditClaudeMd(...)` to compute the create-or-diff payload.
+  - Returns the canonical `FACTORY_LABELS` set as the
+    `labelsToInstall` preview. **No** label mutations occur here.
+- **`POST /projects/bootstrap/run`** — destructive.
+  - Calls `bootstrapProject(...)` from `core/workflows/bootstrap-project.ts`
+    end-to-end (creates labels on the target repo, opens the registration
+    PR on `shaunnez/goose-hub`).
+  - Returns the resulting PR URL and label install counts.
+
+The split keeps the destructive call site explicit. The wizard uses
+`/preview` to populate steps 2-4 and only calls `/run` when the human
+clicks the "Open Registration PR" button on the final step.
+
+## Token handling
+
+The GitHub token is **always** server-held (`process.env.GITHUB_TOKEN`).
+The browser never collects, stores, or transmits a token. Both endpoints
+return 500 if the server lacks a token — this surfaces as the wizard's
+error banner so the human can fix their env.
+
+## MOCK_BOOTSTRAP for tests
+
+When the server starts with `MOCK_BOOTSTRAP=true`, both endpoints
+short-circuit to deterministic fixture payloads — no GitHub calls, no
+real labels installed, no PR opened. The Playwright e2e test boots the
+server with this flag set and walks every wizard step.
+
+## Idempotency
+
+Underlying idempotency lives in `bootstrapProject` (slice
+`bootstrap-project`). Re-running `/run` for the same `repoRef` returns
+`status: 'idempotent-skip'` and the existing PR URL — the wizard's
+result panel displays both.
+
+## Running the tests
+
+```bash
+# Slice manifest (this file)
+pnpm vitest run slices/bootstrap-wizard/slice.test.ts
+
+# Server domain
+pnpm vitest run apps/server/src/domains/bootstrap/
+
+# Web component + state machine
+pnpm vitest run apps/web/src/components/bootstrap/
+
+# End-to-end (requires the dev server)
+MOCK_BOOTSTRAP=true pnpm --filter @goose-hub/web test:e2e bootstrap-wizard.spec.ts
+```

--- a/slices/bootstrap-wizard/slice.test.ts
+++ b/slices/bootstrap-wizard/slice.test.ts
@@ -1,0 +1,68 @@
+/**
+ * slices/bootstrap-wizard — top-level slice manifest test (M12.07, #308).
+ *
+ * The bootstrap wizard ships across three vertical surfaces:
+ *
+ *   1. Server endpoints under `apps/server/src/domains/bootstrap/`
+ *   2. UI under `apps/web/src/components/bootstrap/`
+ *   3. (this) slice manifest test for FACTORY_RULES rule 24 compliance.
+ *
+ * The unit-level coverage (state machine, server services, component DOM)
+ * lives next to the code:
+ *   - apps/web/src/components/bootstrap/slice.test.ts
+ *   - apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
+ *   - apps/server/src/domains/bootstrap/{service,router}.test.ts
+ *
+ * This test asserts the public contract surface that the rest of the slice
+ * relies on so that breaking the wizard is impossible to do silently.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+describe('bootstrap-wizard slice — server contract', () => {
+  it('exports previewBootstrapService and runBootstrapService', async () => {
+    const mod = await import('../../apps/server/src/domains/bootstrap/service.js');
+    expect(typeof mod.previewBootstrapService).toBe('function');
+    expect(typeof mod.runBootstrapService).toBe('function');
+  });
+
+  it('exports a bootstrapRouter for the server to mount', async () => {
+    const mod = await import('../../apps/server/src/domains/bootstrap/router.js');
+    expect(mod.bootstrapRouter).toBeDefined();
+  });
+});
+
+describe('bootstrap-wizard slice — web contract', () => {
+  it('exports the BootstrapWizard component', async () => {
+    // Dynamic-import via a string variable so TS does not follow the path
+    // through the .tsx file (this slice test runs under a tsconfig without
+    // --jsx; the runtime resolution still works because vitest resolves the
+    // .js → .tsx alias automatically).
+    const wizardPath = '../../apps/web/src/components/bootstrap/components/BootstrapWizard.js';
+    const mod = (await import(/* @vite-ignore */ wizardPath)) as { BootstrapWizard: unknown };
+    expect(typeof mod.BootstrapWizard).toBe('function');
+  });
+
+  it('exports a 6-step wizard state machine in lib/wizard-state', async () => {
+    const mod = await import('../../apps/web/src/components/bootstrap/lib/wizard-state.js');
+    expect(mod.WIZARD_STEPS).toEqual(['repo', 'stack', 'claudeMd', 'labels', 'webhook', 'submit']);
+    expect(typeof mod.nextStep).toBe('function');
+    expect(typeof mod.prevStep).toBe('function');
+    expect(typeof mod.isValidRepoRef).toBe('function');
+  });
+
+  it('exposes the bootstrap API helpers via the shared web lib', async () => {
+    const mod = await import('../../apps/web/src/lib/api.js');
+    expect(typeof mod.previewBootstrap).toBe('function');
+    expect(typeof mod.runBootstrap).toBe('function');
+  });
+});
+
+describe('bootstrap-wizard slice — invokes the upstream workflow', () => {
+  it('runBootstrapService delegates to bootstrapProject from core', async () => {
+    const workflow = await import('@goose-hub/core/workflows/bootstrap-project.js');
+    expect(typeof workflow.bootstrapProject).toBe('function');
+    expect(typeof workflow.parseRepoRef).toBe('function');
+    expect(typeof workflow.sanitiseSlug).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #308

Multi-step "Add Project" wizard in Settings → Projects, backed by `POST /projects/bootstrap/{preview,run}` endpoints that wrap the `bootstrapProject` workflow. `MOCK_BOOTSTRAP=true` short-circuits both endpoints to deterministic fixtures for the Playwright e2e.

---
_Generated by [Claude Code](https://claude.ai/code/session_014obzUzjwJY7g17g8xrZGze)_