### PR TITLE
test(e2e): promote bootstrap-wizard spec into pipeline lane

### DIFF
--- a/apps/web/e2e/pipeline/bootstrap-wizard.spec.ts
+++ b/apps/web/e2e/pipeline/bootstrap-wizard.spec.ts
@@ -1,20 +1,11 @@
 import { expect, test } from '@playwright/test';
 
-// ---------------------------------------------------------------------------
-// E2E test for the bootstrap wizard (M12.07, issue #308).
-//
-// The Playwright run boots the server with MOCK_BOOTSTRAP=true (set in
-// playwright.config.ts), so the /api/projects/bootstrap/{preview,run}
-// endpoints return deterministic fixtures instead of hitting GitHub.
-// This test walks every wizard step and asserts the final PR URL renders.
-// ---------------------------------------------------------------------------
+// E2E test for the bootstrap wizard. Lives in the pipeline lane so it runs as
+// a required CI check; the server is booted with MOCK_BOOTSTRAP=true (see
+// playwright-e2e-pipeline.config.ts) so /api/projects/bootstrap/{preview,run}
+// return deterministic fixtures instead of hitting GitHub.
 
-test.describe('bootstrap wizard', () => {
-  test.skip(
-    process.env.MOCK_BOOTSTRAP !== 'true',
-    'requires MOCK_BOOTSTRAP=true so the server short-circuits the workflow',
-  );
-
+test.describe('bootstrap wizard (MOCK_BOOTSTRAP)', () => {
   test('walks all wizard steps and shows the PR URL on completion', async ({ page }) => {
     await page.goto('/settings');
     await expect(page.getByTestId('settings-page')).toBeVisible();
@@ -47,7 +38,7 @@ test.describe('bootstrap wizard', () => {
 
     // Step 5 — webhook setup with payload URL.
     await expect(page.getByTestId('step-webhook')).toBeVisible();
-    await expect(page.getByTestId('webhook-payload-url')).toContainText('webhook/github');
+    await expect(page.getByTestId('webhook-payload-url')).toContainText('webhooks/github');
     await page.getByTestId('wizard-next').click();
 
     // Final step — Open PR button + result.

--- a/apps/web/playwright-e2e-pipeline.config.ts
+++ b/apps/web/playwright-e2e-pipeline.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
               MOCK_AGENTS: 'true',
               MOCK_OPEN_PR: 'true',
               MOCK_SOURCE: 'true',
+              MOCK_BOOTSTRAP: 'true',
             },
           },
           {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -31,9 +31,6 @@ export default defineConfig({
             timeout: 30_000,
             env: {
               GITHUB_TOKEN: process.env.GITHUB_TOKEN ?? '',
-              // M12.07: forward MOCK_BOOTSTRAP so the bootstrap-wizard e2e can
-              // exercise the wizard against deterministic fixture endpoints.
-              MOCK_BOOTSTRAP: process.env.MOCK_BOOTSTRAP ?? '',
             },
           },
           {

--- a/apps/web/src/components/bootstrap/README.md
+++ b/apps/web/src/components/bootstrap/README.md
@@ -60,9 +60,10 @@ The split keeps the destructive `/run` step deliberate: the wizard's
 
 ## Mocking the workflow
 
-The Playwright e2e (`apps/web/e2e/bootstrap-wizard.spec.ts`) drives the
-wizard through every step against a server booted with
-`MOCK_BOOTSTRAP=true`. Both endpoints short-circuit to deterministic
+The Playwright e2e (`apps/web/e2e/pipeline/bootstrap-wizard.spec.ts`)
+drives the wizard through every step in the pipeline lane. The pipeline
+config (`playwright-e2e-pipeline.config.ts`) boots the server with
+`MOCK_BOOTSTRAP=true`, so both endpoints short-circuit to deterministic
 fixtures — no GitHub calls, no real labels installed, no PR opened.
 
 ## State machine

--- a/slices/bootstrap-wizard/README.md
+++ b/slices/bootstrap-wizard/README.md
@@ -24,8 +24,9 @@ instead of the CLI.
   `BootstrapPreviewDto` + `BootstrapRunDto`.
 - **Top-level slice manifest**: `slice.test.ts` (this folder) asserts the
   public surface contract.
-- **Playwright e2e**: `apps/web/e2e/bootstrap-wizard.spec.ts` walks the
-  wizard end-to-end against a server booted with `MOCK_BOOTSTRAP=true`.
+- **Playwright e2e**: `apps/web/e2e/pipeline/bootstrap-wizard.spec.ts` runs in
+  the pipeline lane (`pnpm test:e2e:pipeline`) — the server is booted with
+  `MOCK_BOOTSTRAP=true` automatically by `playwright-e2e-pipeline.config.ts`.
 
 The slice does **not** import from any other slice, and re-uses the core
 workflow through its public interfaces (`bootstrapProject`, `parseRepoRef`,
@@ -88,6 +89,6 @@ pnpm vitest run apps/server/src/domains/bootstrap/
 # Web component + state machine
 pnpm vitest run apps/web/src/components/bootstrap/
 
-# End-to-end (requires the dev server)
-MOCK_BOOTSTRAP=true pnpm --filter @goose-hub/web test:e2e bootstrap-wizard.spec.ts
+# End-to-end (pipeline lane — boots its own server with MOCK_BOOTSTRAP=true)
+pnpm --filter @goose-hub/web test:e2e:pipeline bootstrap-wizard
 ```


### PR DESCRIPTION
## Summary

Promotes the bootstrap wizard e2e from the optional `pnpm test:e2e` job (which is `continue-on-error: true`) into the **required** `e2e:pipeline` lane, so the wizard path is protected by a blocking CI check.

- Moves `apps/web/e2e/bootstrap-wizard.spec.ts` → `apps/web/e2e/pipeline/bootstrap-wizard.spec.ts`.
- Adds `MOCK_BOOTSTRAP: 'true'` to the pipeline config's server `env` block alongside the existing mock flags. Drops the now-unused conditional `MOCK_BOOTSTRAP` forwarding in `playwright.config.ts`.
- Drops the spec's `test.skip` guard — the pipeline lane always boots in mock mode, so the guard would have skipped the test forever.
- Fixes a pre-existing assertion typo: payload URL renders as `webhooks/github` (plural), not `webhook/github`. Spec passed before only because it was in the `continue-on-error` lane; promoting surfaced it.

This is Phase 1 of the e2e:pipeline / M12 plan discussed offline (CLI bootstrap spec + deeper bootstrap mock are separate follow-ups).

## Test plan

- [x] `pnpm --filter @goose-hub/web test:e2e:pipeline` — 9/9 specs pass (including the moved bootstrap-wizard)
- [x] `pnpm biome check` clean on all modified files
- [x] CI runs the pipeline lane as a required check


---
_Generated by [Claude Code](https://claude.ai/code/session_014obzUzjwJY7g17g8xrZGze)_