### PR TITLE
M19.01 + M19.02: swarm primitives + spec-author Engineering Spec

### DIFF
--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -131,6 +131,64 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     timeoutMs: 240_000,
     modelTier: 'sonnet',
   },
+  // M19.01 — Wave-1 scouts. Read-only fact-gathering; cheap and short.
+  // 90 s timeout matches ADR 0030 default; haiku-tier is enough for
+  // grep-and-quote work. Per-scout maxTurns capped low to enforce
+  // narrow-concern discipline (Steve "≤3 turns per intent default" —
+  // LLM Tool Base Integrations slide 5 line 119; we allow up to 10
+  // for safety while keeping the spirit).
+  'scout-schema': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  'scout-code-path': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  'scout-pattern': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  'scout-test-inventory': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  'scout-dependency': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  'scout-user-journey': {
+    maxTurns: 10,
+    maxBudgetUsd: 0.15,
+    timeoutMs: 90_000,
+    modelTier: 'haiku',
+  },
+  // M19.01 — Wave-2 deep agents. Synthesise paste-ready artefacts from
+  // scout reports; sonnet-tier for the reasoning step. Higher turn cap
+  // because the designer may need to verify scout citations in the
+  // worktree.
+  'wave2-interface-designer': {
+    maxTurns: 30,
+    maxBudgetUsd: 1.0,
+    timeoutMs: 240_000,
+    modelTier: 'sonnet',
+  },
+  'wave2-risk-analyst': {
+    maxTurns: 25,
+    maxBudgetUsd: 0.75,
+    timeoutMs: 180_000,
+    modelTier: 'sonnet',
+  },
 };
 
 export interface ResolvedBudget {

--- a/core/agent-runtime/cross-validate.test.ts
+++ b/core/agent-runtime/cross-validate.test.ts
@@ -86,6 +86,19 @@ describe('crossValidate', () => {
     expect(result.contradictions[0]?.facts).toHaveLength(3);
   });
 
+  it('does NOT flag a single scout listing multiple distinct facts at the same file:line', () => {
+    // A catalog from one scout is not a contradiction — contradictions are
+    // by definition cross-scout disagreement.
+    const result = crossValidate([
+      rep('scout-pattern', [
+        { file: 'src/x.ts', line: 7, fact: 'callsite A', confidence: 'high' },
+        { file: 'src/x.ts', line: 7, fact: 'callsite B (overload)', confidence: 'high' },
+      ]),
+    ]);
+    expect(result.contradictions).toHaveLength(0);
+    expect(result.hasContradictions).toBe(false);
+  });
+
   it('skips reports whose status is not ok (only ok scouts contribute to cross-validation)', () => {
     const ok: ScoutReport = {
       scoutName: 'ok-1',

--- a/core/agent-runtime/cross-validate.test.ts
+++ b/core/agent-runtime/cross-validate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { crossValidate } from './cross-validate.js';
+import type { ScoutReport } from './swarm.js';
+
+function rep(name: string, findings: ScoutReport['findings']): ScoutReport {
+  return {
+    scoutName: name,
+    status: 'ok',
+    findings,
+    decisionSummaries: [],
+    runId: `parent:scout:${name}:0`,
+  };
+}
+
+describe('crossValidate', () => {
+  it('detects contradictions when two scouts report differing facts at same file:line', () => {
+    const result = crossValidate([
+      rep('scout-schema', [
+        {
+          file: 'core/db/schema.ts',
+          line: 42,
+          fact: 'column "email" is unique',
+          confidence: 'high',
+        },
+      ]),
+      rep('scout-code-path', [
+        {
+          file: 'core/db/schema.ts',
+          line: 42,
+          fact: 'column "email" is NOT unique',
+          confidence: 'high',
+        },
+      ]),
+    ]);
+
+    expect(result.contradictions).toHaveLength(1);
+    expect(result.contradictions[0]?.file).toBe('core/db/schema.ts');
+    expect(result.contradictions[0]?.line).toBe(42);
+    expect(result.contradictions[0]?.scouts.sort()).toEqual(['scout-code-path', 'scout-schema']);
+    expect(result.hasContradictions).toBe(true);
+  });
+
+  it('does NOT flag agreement (same file:line, identical fact) as a contradiction', () => {
+    const result = crossValidate([
+      rep('scout-schema', [
+        { file: 'src/x.ts', line: 10, fact: 'exports default', confidence: 'high' },
+      ]),
+      rep('scout-code-path', [
+        { file: 'src/x.ts', line: 10, fact: 'exports default', confidence: 'medium' },
+      ]),
+    ]);
+
+    expect(result.contradictions).toHaveLength(0);
+    expect(result.hasContradictions).toBe(false);
+  });
+
+  it('does NOT flag different file:line as a contradiction', () => {
+    const result = crossValidate([
+      rep('a', [{ file: 'src/x.ts', line: 1, fact: 'foo', confidence: 'high' }]),
+      rep('b', [{ file: 'src/x.ts', line: 2, fact: 'bar', confidence: 'high' }]),
+    ]);
+
+    expect(result.contradictions).toHaveLength(0);
+  });
+
+  it('treats missing line numbers conservatively (file-only matches require fact equality to count as agreement)', () => {
+    const result = crossValidate([
+      rep('a', [{ file: 'src/x.ts', fact: 'imports zod', confidence: 'medium' }]),
+      rep('b', [{ file: 'src/x.ts', fact: 'imports yup', confidence: 'medium' }]),
+    ]);
+
+    // file-level disagreement on the same file is a contradiction
+    expect(result.contradictions).toHaveLength(1);
+    expect(result.contradictions[0]?.line).toBeUndefined();
+  });
+
+  it('groups all conflicting scouts at one location into a single contradiction', () => {
+    const result = crossValidate([
+      rep('a', [{ file: 'src/x.ts', line: 7, fact: 'returns null', confidence: 'high' }]),
+      rep('b', [{ file: 'src/x.ts', line: 7, fact: 'returns undefined', confidence: 'high' }]),
+      rep('c', [{ file: 'src/x.ts', line: 7, fact: 'throws', confidence: 'medium' }]),
+    ]);
+
+    expect(result.contradictions).toHaveLength(1);
+    expect(result.contradictions[0]?.scouts.sort()).toEqual(['a', 'b', 'c']);
+    expect(result.contradictions[0]?.facts).toHaveLength(3);
+  });
+
+  it('skips reports whose status is not ok (only ok scouts contribute to cross-validation)', () => {
+    const ok: ScoutReport = {
+      scoutName: 'ok-1',
+      status: 'ok',
+      findings: [{ file: 'a.ts', line: 1, fact: 'x', confidence: 'high' }],
+      decisionSummaries: [],
+      runId: 'r1',
+    };
+    const failed: ScoutReport = {
+      scoutName: 'fail-1',
+      status: 'error',
+      findings: [{ file: 'a.ts', line: 1, fact: 'NOT x', confidence: 'high' }],
+      decisionSummaries: [],
+      errorReason: 'boom',
+      runId: 'r2',
+    };
+    const result = crossValidate([ok, failed]);
+    // failed scout's findings are ignored; nothing to contradict.
+    expect(result.contradictions).toHaveLength(0);
+  });
+});

--- a/core/agent-runtime/cross-validate.ts
+++ b/core/agent-runtime/cross-validate.ts
@@ -1,0 +1,83 @@
+import type { ScoutFinding, ScoutReport } from './swarm.js';
+
+/**
+ * Cross-validation step between Wave 1 and Wave 2 (M19.01, ADR 0030).
+ *
+ * Detects contradictions across scout reports: when two or more scouts
+ * report differing facts at the *same* `file[:line]` location.
+ *
+ * Same `file:line` + identical `fact` text = agreement (no contradiction).
+ * Same `file:line` + differing `fact` text = contradiction.
+ *
+ * Per Steve's planning protocol (Harness 101 slide 4 line 103), this gate
+ * runs BEFORE Wave 2 dispatches, so Wave 2 deep agents see only
+ * cross-validated facts.
+ */
+
+export interface ContradictionFact {
+  scoutName: string;
+  fact: string;
+  confidence: ScoutFinding['confidence'];
+}
+
+export interface Contradiction {
+  /** File the contradiction applies to. */
+  file: string;
+  /** Line number, when present in the underlying findings. */
+  line?: number;
+  /** Distinct facts reported at this location. */
+  facts: ContradictionFact[];
+  /** Distinct scout names that contributed to this contradiction. */
+  scouts: string[];
+}
+
+export interface CrossValidationResult {
+  contradictions: Contradiction[];
+  hasContradictions: boolean;
+}
+
+/**
+ * Cross-validate Wave-1 scout reports. Only `status: 'ok'` reports
+ * contribute findings — failed/timeout reports are ignored to avoid
+ * surfacing spurious contradictions on incomplete data.
+ */
+export function crossValidate(reports: ScoutReport[]): CrossValidationResult {
+  // Group findings by `file::line` (line absent → "?").
+  const groups = new Map<string, ContradictionFact[]>();
+  for (const report of reports) {
+    if (report.status !== 'ok') continue;
+    for (const finding of report.findings) {
+      const key = `${finding.file}::${finding.line ?? '?'}`;
+      let arr = groups.get(key);
+      if (arr == null) {
+        arr = [];
+        groups.set(key, arr);
+      }
+      arr.push({
+        scoutName: report.scoutName,
+        fact: finding.fact,
+        confidence: finding.confidence,
+      });
+    }
+  }
+
+  const contradictions: Contradiction[] = [];
+  for (const [key, facts] of groups) {
+    // Agreement: every fact at the same key reports the same `fact` text.
+    const distinctFacts = new Set(facts.map((f) => f.fact));
+    if (distinctFacts.size <= 1) continue;
+    const sep = key.lastIndexOf('::');
+    const file = key.slice(0, sep);
+    const lineRaw = key.slice(sep + 2);
+    const line = lineRaw === '?' ? undefined : Number(lineRaw);
+
+    contradictions.push({
+      file,
+      line,
+      facts,
+      scouts: Array.from(new Set(facts.map((f) => f.scoutName))),
+    });
+  }
+
+  return { contradictions, hasContradictions: contradictions.length > 0 };
+}

--- a/core/agent-runtime/cross-validate.ts
+++ b/core/agent-runtime/cross-validate.ts
@@ -66,6 +66,13 @@ export function crossValidate(reports: ScoutReport[]): CrossValidationResult {
     // Agreement: every fact at the same key reports the same `fact` text.
     const distinctFacts = new Set(facts.map((f) => f.fact));
     if (distinctFacts.size <= 1) continue;
+    // Cross-scout discipline: a single scout reporting multiple distinct
+    // facts at the same file:line is a *catalog*, not a contradiction. Wave
+    // 1 contradictions are about scouts disagreeing — not about one scout
+    // listing several adjacent observations. Require at least two distinct
+    // scout names to flag.
+    const distinctScouts = new Set(facts.map((f) => f.scoutName));
+    if (distinctScouts.size < 2) continue;
     const sep = key.lastIndexOf('::');
     const file = key.slice(0, sep);
     const lineRaw = key.slice(sep + 2);
@@ -75,7 +82,7 @@ export function crossValidate(reports: ScoutReport[]): CrossValidationResult {
       file,
       line,
       facts,
-      scouts: Array.from(new Set(facts.map((f) => f.scoutName))),
+      scouts: Array.from(distinctScouts),
     });
   }
 

--- a/core/agent-runtime/scout-output.ts
+++ b/core/agent-runtime/scout-output.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { DecisionSummarySchema } from '../retrospective/schemas.js';
+
+/**
+ * Canonical Wave-1 scout output shape (M19.01, ADR 0030).
+ *
+ * Every `skills/scout-*` skill imports `ScoutOutputSchema` from here and
+ * re-exports it from its own `schema.ts`. Wave 1 is fact-only — `findings`
+ * is a list of file:line citations, not synthesis. Synthesis happens in
+ * Wave 2 (interface-designer / risk-analyst).
+ */
+export const ScoutFindingSchema = z.object({
+  file: z.string().min(1),
+  line: z.number().int().nonnegative().optional(),
+  fact: z.string().min(1),
+  confidence: z.enum(['high', 'medium', 'low']),
+});
+
+export const ScoutStatusSchema = z.enum(['ok', 'timeout', 'error']);
+
+export const ScoutOutputSchema = z.object({
+  findings: z.array(ScoutFindingSchema),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+  status: ScoutStatusSchema,
+});
+
+export type ScoutFinding = z.infer<typeof ScoutFindingSchema>;
+export type ScoutStatus = z.infer<typeof ScoutStatusSchema>;
+export type ScoutOutput = z.infer<typeof ScoutOutputSchema>;

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -306,6 +306,85 @@ describe('swarm.dispatchWave', () => {
     expect(v.role).toBe('scout');
   });
 
+  it('marks status: "error" when a scout returns output that fails ScoutOutputSchema validation', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const garbageRuntime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-code-path': () => Promise.resolve(okResult('scout-code-path')),
+      'scout-pattern': () => Promise.resolve(okResult('scout-pattern')),
+      // Scout that returns arbitrary text (no findings, no schema fields).
+      'scout-broken': () =>
+        Promise.resolve({
+          output: 'I am a free-text response, ignoring the schema',
+          decisionSummaries: [],
+          events: [],
+        }),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-bad',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-pattern'),
+        makeScoutSpec('scout-broken'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime: garbageRuntime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    const broken = result.reports.find((r) => r.scoutName === 'scout-broken');
+    expect(broken?.status).toBe('error');
+    expect(broken?.errorReason).toContain('schema validation');
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+    // 3 succeeded + 1 invalid: still advances (≤1 failure tolerated).
+    expect(result.shouldAdvance).toBe(true);
+  });
+
+  it('forwards loadSkillAssets results to the AgentSpec on each scout spawn', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime: AgentRuntime = {
+      async run(spec: AgentSpec): Promise<AgentResult> {
+        seenSpecs.push(spec);
+        return okResult(spec.skill);
+      },
+    };
+
+    await dispatchWave({
+      parentRunId: 'parent-assets',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-pattern'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      loadSkillAssets: (scoutName) => ({
+        appendSystemPrompt: `prompt for ${scoutName}`,
+        outputJsonSchema: { type: 'object', $id: scoutName },
+      }),
+    });
+
+    expect(seenSpecs).toHaveLength(3);
+    for (const spec of seenSpecs) {
+      expect(spec.appendSystemPrompt).toBe(`prompt for ${spec.skill}`);
+      expect(spec.outputJsonSchema).toEqual({ type: 'object', $id: spec.skill });
+    }
+  });
+
   it('routes each child spawn through assembleSpawnContext (freshContext: true per scout)', async () => {
     const { fn: appendEvent } = makeFakeAppendEvent();
     const seenSpecs: AgentSpec[] = [];

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
+import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
+import { type ScoutSpec, dispatchWave } from './swarm.js';
+
+function makeFakeAppendEvent(): {
+  fn: (input: AppendEventInput) => AgentEvent;
+  events: AppendEventInput[];
+} {
+  const events: AppendEventInput[] = [];
+  let id = 0;
+  const fn = (input: AppendEventInput): AgentEvent => {
+    events.push(input);
+    return {
+      id: ++id,
+      projectId: input.projectId,
+      workItemId: input.workItemId ?? null,
+      kind: input.kind,
+      payload: input.payload,
+      runId: input.runId ?? null,
+      personaId: input.personaId ?? null,
+      createdAt: new Date(0).toISOString(),
+    };
+  };
+  return { fn, events };
+}
+
+function makeWorkItem() {
+  return { number: 558, title: 'Wave 1/2 swarm', body: 'Add scouts.' };
+}
+
+function makeScoutSpec(scoutName: string): ScoutSpec {
+  return {
+    scoutName,
+    scoutFocus: `Inspect ${scoutName} concern.`,
+    contextSchema: { findings: [] },
+  };
+}
+
+function okResult(scoutName: string): AgentResult {
+  return {
+    output: {
+      findings: [{ file: `src/${scoutName}.ts`, line: 1, fact: 'exists', confidence: 'high' }],
+      decisionSummaries: [{ kind: 'READ', summary: `${scoutName} scanned` }],
+      status: 'ok',
+    },
+    decisionSummaries: [{ kind: 'READ', summary: `${scoutName} scanned` }],
+    events: [],
+  };
+}
+
+function makeRuntime(impls: Record<string, () => Promise<AgentResult>>): AgentRuntime {
+  return {
+    async run(spec: AgentSpec): Promise<AgentResult> {
+      const impl = impls[spec.skill];
+      if (impl == null) throw new Error(`No fake runtime for skill ${spec.skill}`);
+      return impl();
+    },
+  };
+}
+
+describe('swarm.dispatchWave', () => {
+  it('dispatches all scouts in parallel and returns ok status when all succeed', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-code-path': () => Promise.resolve(okResult('scout-code-path')),
+      'scout-test-inventory': () => Promise.resolve(okResult('scout-test-inventory')),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-1',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-test-inventory'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      heartbeatIntervalMs: 60_000, // long enough never to fire in test
+      scoutTimeoutMs: 5_000,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.shouldAdvance).toBe(true);
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.reports).toHaveLength(3);
+    expect(result.reports.every((r) => r.status === 'ok')).toBe(true);
+    // emits a wave-completed event
+    expect(events.some((e) => e.kind === 'swarm.wave-completed')).toBe(true);
+    // each scout emits a per-scout completed event
+    expect(events.filter((e) => e.kind === 'swarm.scout-completed')).toHaveLength(3);
+  });
+
+  it('caps concurrency at maxScoutAgents (default 6) — never exceeded even with 8 specs', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    let live = 0;
+    let peak = 0;
+
+    const slowScout = (): Promise<AgentResult> =>
+      new Promise((resolve) => {
+        live++;
+        peak = Math.max(peak, live);
+        setTimeout(() => {
+          live--;
+          resolve(okResult('s'));
+        }, 30);
+      });
+
+    const specs: ScoutSpec[] = [];
+    const impls: Record<string, () => Promise<AgentResult>> = {};
+    for (let i = 0; i < 8; i++) {
+      const name = `scout-${i}`;
+      specs.push(makeScoutSpec(name));
+      impls[name] = slowScout;
+    }
+
+    await dispatchWave({
+      parentRunId: 'parent-2',
+      scoutSpecs: specs,
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime: makeRuntime(impls),
+      appendEvent,
+      heartbeatIntervalMs: 60_000,
+      scoutTimeoutMs: 5_000,
+      maxScoutAgents: 4,
+    });
+
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('records timeout status when a scout exceeds scoutTimeoutMs and advances if ≥3 ok', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-code-path': () => Promise.resolve(okResult('scout-code-path')),
+      'scout-pattern': () => Promise.resolve(okResult('scout-pattern')),
+      // sleeps past timeout
+      'scout-slow': () =>
+        new Promise<AgentResult>((resolve) => {
+          setTimeout(() => resolve(okResult('scout-slow')), 200);
+        }),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-3',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-pattern'),
+        makeScoutSpec('scout-slow'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 30,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    const slow = result.reports.find((r) => r.scoutName === 'scout-slow');
+    expect(slow?.status).toBe('timeout');
+    // 3 succeeded, 1 timeout: shouldAdvance per "≤1 failure tolerated"
+    expect(result.shouldAdvance).toBe(true);
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.status).toBe('ok');
+    expect(events.some((e) => e.kind === 'swarm.scout-timeout')).toBe(true);
+    expect(events.some((e) => e.kind === 'agent.cancelled')).toBe(true);
+  });
+
+  it('halts and signals escalation when ≥2 scouts fail', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-code-path': () => Promise.resolve(okResult('scout-code-path')),
+      'scout-fail-1': () => Promise.reject(new Error('runtime error 1')),
+      'scout-fail-2': () => Promise.reject(new Error('runtime error 2')),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-4',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-fail-1'),
+        makeScoutSpec('scout-fail-2'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 5_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    expect(result.status).toBe('halted');
+    expect(result.shouldEscalate).toBe(true);
+    expect(result.shouldAdvance).toBe(false);
+    expect(result.failedScouts.sort()).toEqual(['scout-fail-1', 'scout-fail-2']);
+    expect(events.some((e) => e.kind === 'swarm.wave-halted')).toBe(true);
+  });
+
+  it('records incomplete status if fewer than 3 scouts succeed', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-fail-1': () => Promise.reject(new Error('boom')),
+      'scout-fail-2': () => Promise.reject(new Error('boom')),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-5',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-fail-1'),
+        makeScoutSpec('scout-fail-2'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 5_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    // 2 failures → halted (still escalation).
+    expect(result.shouldEscalate).toBe(true);
+    expect(events.some((e) => e.kind === 'swarm.wave-halted')).toBe(true);
+  });
+
+  it('emits swarm.heartbeat at the configured interval while scouts are running', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-a': () =>
+        new Promise<AgentResult>((resolve) => setTimeout(() => resolve(okResult('scout-a')), 80)),
+      'scout-b': () =>
+        new Promise<AgentResult>((resolve) => setTimeout(() => resolve(okResult('scout-b')), 80)),
+      'scout-c': () =>
+        new Promise<AgentResult>((resolve) => setTimeout(() => resolve(okResult('scout-c')), 80)),
+    });
+
+    await dispatchWave({
+      parentRunId: 'parent-hb',
+      scoutSpecs: [makeScoutSpec('scout-a'), makeScoutSpec('scout-b'), makeScoutSpec('scout-c')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 20,
+    });
+
+    const heartbeats = events.filter((e) => e.kind === 'swarm.heartbeat');
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits tool.violation when parent decision-summary key leaks into a scout context (holdout discipline)', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+      'scout-code-path': () => Promise.resolve(okResult('scout-code-path')),
+      'scout-pattern': () => Promise.resolve(okResult('scout-pattern')),
+    });
+
+    await dispatchWave({
+      parentRunId: 'parent-leak',
+      scoutSpecs: [
+        // a sibling decision-summary key leaks in via per-scout context
+        {
+          scoutName: 'scout-schema',
+          scoutFocus: 'schema',
+          extraContext: { parentDecisionSummaries: [{ kind: 'PLAN', summary: 'shadow' }] },
+        },
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-pattern'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    const violations = events.filter((e) => e.kind === 'tool.violation');
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    const v = violations[0]?.payload as { disallowedKey: string; role: string };
+    expect(v.disallowedKey).toBe('parentDecisionSummaries');
+    expect(v.role).toBe('scout');
+  });
+
+  it('routes each child spawn through assembleSpawnContext (freshContext: true per scout)', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime: AgentRuntime = {
+      async run(spec: AgentSpec): Promise<AgentResult> {
+        seenSpecs.push(spec);
+        return okResult(spec.skill);
+      },
+    };
+
+    await dispatchWave({
+      parentRunId: 'parent-fresh',
+      scoutSpecs: [
+        makeScoutSpec('scout-schema'),
+        makeScoutSpec('scout-code-path'),
+        makeScoutSpec('scout-pattern'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    expect(seenSpecs).toHaveLength(3);
+    for (const spec of seenSpecs) {
+      expect(spec.freshContext).toBe(true);
+      expect(spec.runId.startsWith('parent-fresh:scout:')).toBe(true);
+      // Allowlist must not include any parent-summary key
+      expect(spec.contextAllowlist).not.toContain('parentDecisionSummaries');
+      expect(spec.contextAllowlist).toContain('workItem.title');
+      expect(spec.contextAllowlist).toContain('scoutFocus');
+    }
+  });
+});

--- a/core/agent-runtime/swarm.ts
+++ b/core/agent-runtime/swarm.ts
@@ -2,6 +2,7 @@ import type { AgentEvent, AppendEventInput, EventKind } from '../event-stream/st
 import { eventStore } from '../event-stream/store.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import type { AgentResult, AgentRuntime, AgentSpec, DecisionSummary } from './interface.js';
+import { ScoutOutputSchema } from './scout-output.js';
 
 /**
  * Wave-1 / Wave-2 swarm dispatch (M19.01, ADR 0030).
@@ -89,6 +90,24 @@ export interface DispatchWaveOptions {
   personaId: string;
   /** Optional override (tests). Defaults to the real event store. */
   appendEvent?: (input: AppendEventInput) => AgentEvent;
+  /**
+   * Production callers supply this to populate `appendSystemPrompt` and
+   * `outputJsonSchema` on each scout spawn. Without it the underlying
+   * `ClaudeCliRuntime` skips `--system-prompt` and `--json-schema` and
+   * scouts run with generic CLI behaviour. Tests don't need it because
+   * they inject a fake runtime that ignores those fields.
+   *
+   * Recommended production wiring:
+   *
+   *   loadSkillAssets: (scoutName) => ({
+   *     appendSystemPrompt: readPromptWithContext(scoutName, slug),
+   *     outputJsonSchema: toJsonSchema(ScoutOutputSchema),
+   *   })
+   */
+  loadSkillAssets?: (scoutName: string) => {
+    appendSystemPrompt?: string;
+    outputJsonSchema?: Record<string, unknown>;
+  };
 }
 
 /** Keys a scout context is allowed to carry. Anything else → tool.violation. */
@@ -190,6 +209,10 @@ interface RunOneScoutContext {
   workItemId?: string;
   runtime: AgentRuntime;
   personaId: string;
+  loadSkillAssets?: (scoutName: string) => {
+    appendSystemPrompt?: string;
+    outputJsonSchema?: Record<string, unknown>;
+  };
 }
 
 async function runOneScout(
@@ -232,7 +255,11 @@ async function runOneScout(
     }
   }
 
-  // Build the AgentSpec with freshContext: true.
+  // Build the AgentSpec with freshContext: true. Production callers supply
+  // `loadSkillAssets` so `appendSystemPrompt` and `outputJsonSchema` are
+  // populated; without them the runtime would skip --system-prompt and
+  // --json-schema and the scout would run with generic CLI behaviour.
+  const skillAssets = ctx.loadSkillAssets?.(spec.scoutName);
   const spawnSpec: AgentSpec = {
     runId,
     role: 'investigator',
@@ -244,6 +271,8 @@ async function runOneScout(
     toolExtras: [],
     budgets: { maxTurns: 10, maxBudgetUsd: 0.5, timeoutMs: scoutTimeoutMs },
     personaId: ctx.personaId,
+    appendSystemPrompt: skillAssets?.appendSystemPrompt,
+    outputJsonSchema: skillAssets?.outputJsonSchema,
   };
 
   // Route through the centralized gateway so the holdout enforcement path
@@ -307,9 +336,35 @@ async function runOneScout(
     };
   }
 
-  const output = result.output as { findings?: ScoutFinding[] } | null;
-  const findings = output?.findings ?? [];
-  const decisionSummaries = result.decisionSummaries ?? [];
+  // Validate scout output against the canonical schema. Without this, a
+  // scout that ran without `--json-schema` could return arbitrary text and
+  // the swarm would silently treat it as an empty-findings success — which
+  // would let invalid Wave-1 results drive Wave-2 dispatch.
+  const parsed = ScoutOutputSchema.safeParse(result.output);
+  if (!parsed.success) {
+    const reason = `scout output failed schema validation: ${parsed.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ')}`;
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-failed',
+      payload: { runId, scoutName: spec.scoutName, errorReason: reason },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'error',
+      findings: [],
+      decisionSummaries: result.decisionSummaries ?? [],
+      errorReason: reason,
+      runId,
+    };
+  }
+
+  const findings = parsed.data.findings;
+  const decisionSummaries =
+    result.decisionSummaries.length > 0 ? result.decisionSummaries : parsed.data.decisionSummaries;
 
   append({
     projectId: ctx.projectId,

--- a/core/agent-runtime/swarm.ts
+++ b/core/agent-runtime/swarm.ts
@@ -1,0 +1,425 @@
+import type { AgentEvent, AppendEventInput, EventKind } from '../event-stream/store.js';
+import { eventStore } from '../event-stream/store.js';
+import { assembleSpawnContext } from './context-assembly.js';
+import type { AgentResult, AgentRuntime, AgentSpec, DecisionSummary } from './interface.js';
+
+/**
+ * Wave-1 / Wave-2 swarm dispatch (M19.01, ADR 0030).
+ *
+ * The orchestrator drives the wave protocol from outside the parent agent —
+ * the parent (`investigate`) decides WHICH scouts to run, but the actual
+ * fan-out lives here. Holdout discipline per child spawn (rule 1, ADR 0014):
+ * every scout routes through `assembleSpawnContext()` with its own fresh
+ * context.
+ *
+ * The runtime is injected so unit tests can drive synthetic scout outcomes
+ * without spawning subprocesses. Production callers pass a real
+ * `ClaudeCliRuntime`.
+ */
+
+/** Per-scout findings. Mirrors `ScoutOutputSchema` in each scout's schema.ts. */
+export interface ScoutFinding {
+  file: string;
+  line?: number;
+  fact: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+/** One wave-1 scout dispatch request. */
+export interface ScoutSpec {
+  /** Skill name — must match a directory under skills (e.g. `scout-schema`). */
+  scoutName: string;
+  /** One sentence describing what this scout is looking for. */
+  scoutFocus: string;
+  /**
+   * Schema-shaped context snippet the scout consumes (optional). Reserved
+   * for callers that want to pre-narrow the scout's view (e.g. a pattern
+   * scout looking for a specific identifier).
+   */
+  contextSchema?: Record<string, unknown>;
+  /**
+   * Additional context keys the caller wants to inject. Used by tests to
+   * verify holdout discipline — disallowed keys here trigger
+   * `tool.violation` events.
+   */
+  extraContext?: Record<string, unknown>;
+}
+
+/** Result of a single scout spawn. */
+export interface ScoutReport {
+  scoutName: string;
+  status: 'ok' | 'timeout' | 'error';
+  findings: ScoutFinding[];
+  decisionSummaries: DecisionSummary[];
+  errorReason?: string;
+  runId: string;
+}
+
+/** Status of a full wave dispatch. */
+export type WaveStatus = 'ok' | 'incomplete' | 'halted';
+
+export interface WaveResult {
+  status: WaveStatus;
+  reports: ScoutReport[];
+  /** Names of scouts whose `status` is `'error'` or `'timeout'`. */
+  failedScouts: string[];
+  /** True if Wave 2 may dispatch (≤1 failure AND ≥3 successes). */
+  shouldAdvance: boolean;
+  /** True if 2+ failures triggered halt → escalate `factory:needs-human`. */
+  shouldEscalate: boolean;
+}
+
+export interface DispatchWaveOptions {
+  /** Parent investigator's runId — child scouts are tagged `<parent>:scout:<n>`. */
+  parentRunId: string;
+  scoutSpecs: ScoutSpec[];
+  workItem: { number: number; title: string; body: string };
+  worktreePath: string;
+  projectId: string;
+  workItemId?: string;
+  /** Per-issue scout fan-out cap (BudgetConfig.maxScoutAgents). Default 6. */
+  maxScoutAgents?: number;
+  /** Per-scout deadline. Default 90_000 ms (rule 32 + ADR 0030). */
+  scoutTimeoutMs?: number;
+  /** Heartbeat cadence. Default 30_000 ms. */
+  heartbeatIntervalMs?: number;
+  /** Runtime — production: ClaudeCliRuntime; tests: stub. */
+  runtime: AgentRuntime;
+  /** Persona attribution for scouts; reuses parent persona by convention. */
+  personaId: string;
+  /** Optional override (tests). Defaults to the real event store. */
+  appendEvent?: (input: AppendEventInput) => AgentEvent;
+}
+
+/** Keys a scout context is allowed to carry. Anything else → tool.violation. */
+const SCOUT_CONTEXT_ALLOWLIST: readonly string[] = [
+  'workItem.title',
+  'workItem.body',
+  'workItem.number',
+  'scoutFocus',
+  'worktreePath',
+];
+
+const DEFAULT_MAX_SCOUTS = 6;
+const DEFAULT_SCOUT_TIMEOUT_MS = 90_000;
+const DEFAULT_HEARTBEAT_MS = 30_000;
+const MIN_SCOUT_SUCCESS = 3;
+const MAX_TOLERATED_FAILURES = 1;
+
+/**
+ * Dispatch a Wave-1 scout swarm. Returns a `WaveResult` with per-scout reports
+ * plus advance/escalate flags. Never throws — all failures are surfaced as
+ * scout report status.
+ */
+export async function dispatchWave(opts: DispatchWaveOptions): Promise<WaveResult> {
+  const append = opts.appendEvent ?? ((input) => eventStore.appendEvent(input));
+  const maxParallel = Math.max(
+    1,
+    Math.min(opts.scoutSpecs.length, opts.maxScoutAgents ?? DEFAULT_MAX_SCOUTS),
+  );
+  const scoutTimeoutMs = opts.scoutTimeoutMs ?? DEFAULT_SCOUT_TIMEOUT_MS;
+  const heartbeatIntervalMs = opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+
+  const heartbeat = startHeartbeat({
+    intervalMs: heartbeatIntervalMs,
+    parentRunId: opts.parentRunId,
+    projectId: opts.projectId,
+    workItemId: opts.workItemId,
+    scoutCount: opts.scoutSpecs.length,
+    append,
+  });
+
+  let reports: ScoutReport[];
+  try {
+    reports = await runWithConcurrencyCap(opts.scoutSpecs, maxParallel, (spec, idx) =>
+      runOneScout(spec, idx, opts, scoutTimeoutMs, append),
+    );
+  } finally {
+    heartbeat.stop();
+  }
+
+  const failedScouts = reports.filter((r) => r.status !== 'ok').map((r) => r.scoutName);
+  const okCount = reports.length - failedScouts.length;
+
+  let status: WaveStatus;
+  let shouldAdvance: boolean;
+  let shouldEscalate: boolean;
+
+  if (failedScouts.length >= MAX_TOLERATED_FAILURES + 1) {
+    status = 'halted';
+    shouldAdvance = false;
+    shouldEscalate = true;
+  } else if (okCount < MIN_SCOUT_SUCCESS) {
+    status = 'incomplete';
+    shouldAdvance = false;
+    shouldEscalate = false;
+  } else {
+    status = 'ok';
+    shouldAdvance = true;
+    shouldEscalate = false;
+  }
+
+  const eventKind: EventKind =
+    status === 'halted'
+      ? 'swarm.wave-halted'
+      : status === 'incomplete'
+        ? 'swarm.wave-incomplete'
+        : 'swarm.wave-completed';
+
+  append({
+    projectId: opts.projectId,
+    workItemId: opts.workItemId ?? null,
+    kind: eventKind,
+    payload: {
+      parentRunId: opts.parentRunId,
+      scoutCount: reports.length,
+      okCount,
+      failedScouts,
+    },
+    runId: opts.parentRunId,
+  });
+
+  return { status, reports, failedScouts, shouldAdvance, shouldEscalate };
+}
+
+interface RunOneScoutContext {
+  parentRunId: string;
+  workItem: { number: number; title: string; body: string };
+  worktreePath: string;
+  projectId: string;
+  workItemId?: string;
+  runtime: AgentRuntime;
+  personaId: string;
+}
+
+async function runOneScout(
+  spec: ScoutSpec,
+  idx: number,
+  ctx: RunOneScoutContext,
+  scoutTimeoutMs: number,
+  append: (input: AppendEventInput) => AgentEvent,
+): Promise<ScoutReport> {
+  const runId = `${ctx.parentRunId}:scout:${spec.scoutName}:${idx}`;
+
+  // Per-scout context, holdout-disciplined: allowlist is fixed.
+  const fullContext = {
+    ...(spec.extraContext ?? {}),
+    ...(spec.contextSchema ?? {}),
+    workItem: ctx.workItem,
+    scoutFocus: spec.scoutFocus,
+    worktreePath: ctx.worktreePath,
+    projectId: ctx.projectId,
+    workItemId: ctx.workItemId,
+  };
+
+  // Disallowed-key detection — fires `tool.violation` per disallowed key.
+  // We treat scouts as a holdout-equivalent for context isolation purposes
+  // even though they aren't on `HOLDOUT_ROLES`. This matches the rule-1
+  // "holdout boundary preserved per child spawn" requirement.
+  const SYSTEM_KEYS = new Set(['projectId', 'workItemId']);
+  const allowedTopLevelKeys = new Set(
+    SCOUT_CONTEXT_ALLOWLIST.map((k) => (k.includes('.') ? k.slice(0, k.indexOf('.')) : k)),
+  );
+  for (const key of Object.keys(fullContext)) {
+    if (!allowedTopLevelKeys.has(key) && !SYSTEM_KEYS.has(key)) {
+      append({
+        projectId: ctx.projectId,
+        workItemId: ctx.workItemId ?? null,
+        kind: 'tool.violation',
+        payload: { role: 'scout', disallowedKey: key, runId },
+        runId,
+      });
+    }
+  }
+
+  // Build the AgentSpec with freshContext: true.
+  const spawnSpec: AgentSpec = {
+    runId,
+    role: 'investigator',
+    skill: spec.scoutName,
+    context: fullContext,
+    contextAllowlist: [...SCOUT_CONTEXT_ALLOWLIST],
+    freshContext: true,
+    toolBundles: ['read'],
+    toolExtras: [],
+    budgets: { maxTurns: 10, maxBudgetUsd: 0.5, timeoutMs: scoutTimeoutMs },
+    personaId: ctx.personaId,
+  };
+
+  // Route through the centralized gateway so the holdout enforcement path
+  // is the single source of truth (ADR 0014).
+  assembleSpawnContext(spawnSpec);
+
+  const start = Date.now();
+  let result: AgentResult | undefined;
+  let timedOut = false;
+  let errorReason: string | undefined;
+
+  try {
+    result = await runWithDeadline(ctx.runtime.run(spawnSpec), scoutTimeoutMs);
+  } catch (err) {
+    if (err instanceof ScoutTimeoutError) {
+      timedOut = true;
+    } else {
+      errorReason = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  if (timedOut) {
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'agent.cancelled',
+      payload: { runId, reason: 'timeout', elapsedMs: Date.now() - start },
+      runId,
+    });
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-timeout',
+      payload: { runId, scoutName: spec.scoutName, scoutTimeoutMs },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'timeout',
+      findings: [],
+      decisionSummaries: [],
+      runId,
+    };
+  }
+
+  if (errorReason != null || result == null) {
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-failed',
+      payload: { runId, scoutName: spec.scoutName, errorReason: errorReason ?? 'unknown' },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'error',
+      findings: [],
+      decisionSummaries: [],
+      errorReason: errorReason ?? 'unknown',
+      runId,
+    };
+  }
+
+  const output = result.output as { findings?: ScoutFinding[] } | null;
+  const findings = output?.findings ?? [];
+  const decisionSummaries = result.decisionSummaries ?? [];
+
+  append({
+    projectId: ctx.projectId,
+    workItemId: ctx.workItemId ?? null,
+    kind: 'swarm.scout-completed',
+    payload: {
+      runId,
+      scoutName: spec.scoutName,
+      findingsCount: findings.length,
+      decisionSummariesCount: decisionSummaries.length,
+    },
+    runId,
+  });
+
+  return {
+    scoutName: spec.scoutName,
+    status: 'ok',
+    findings,
+    decisionSummaries,
+    runId,
+  };
+}
+
+class ScoutTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`scout timed out after ${timeoutMs}ms`);
+    this.name = 'ScoutTimeoutError';
+  }
+}
+
+function runWithDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new ScoutTimeoutError(timeoutMs));
+    }, timeoutMs);
+    promise
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}
+
+/**
+ * Bounded-concurrency map: dispatches up to `cap` scouts at a time. Order of
+ * results matches order of `items`.
+ */
+async function runWithConcurrencyCap<T, R>(
+  items: T[],
+  cap: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers: Promise<void>[] = [];
+  const workerCount = Math.max(1, Math.min(cap, items.length));
+  for (let w = 0; w < workerCount; w++) {
+    workers.push(
+      (async (): Promise<void> => {
+        while (true) {
+          const idx = next++;
+          if (idx >= items.length) return;
+          const item = items[idx];
+          if (item === undefined) return;
+          results[idx] = await fn(item, idx);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+interface HeartbeatHandle {
+  stop(): void;
+}
+
+interface StartHeartbeatOptions {
+  intervalMs: number;
+  parentRunId: string;
+  projectId: string;
+  workItemId?: string;
+  scoutCount: number;
+  append: (input: AppendEventInput) => AgentEvent;
+}
+
+function startHeartbeat(opts: StartHeartbeatOptions): HeartbeatHandle {
+  const interval = setInterval(() => {
+    opts.append({
+      projectId: opts.projectId,
+      workItemId: opts.workItemId ?? null,
+      kind: 'swarm.heartbeat',
+      payload: { parentRunId: opts.parentRunId, scoutCount: opts.scoutCount },
+      runId: opts.parentRunId,
+    });
+  }, opts.intervalMs);
+  // Allow process to exit naturally if the parent forgets to stop us.
+  if (typeof interval.unref === 'function') interval.unref();
+  return {
+    stop: () => clearInterval(interval),
+  };
+}

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -80,7 +80,16 @@ export type EventKind =
   | 'prd.advisor-skipped'
   // M13.08 PRD review actions (UI-driven approve / reject)
   | 'prd.approved'
-  | 'prd.rejected';
+  | 'prd.rejected'
+  // M19.01 Wave-1/Wave-2 swarm — sub-agent dispatch from skills (ADR 0030)
+  | 'swarm.heartbeat'
+  | 'swarm.scout-completed'
+  | 'swarm.scout-timeout'
+  | 'swarm.scout-failed'
+  | 'swarm.wave-completed'
+  | 'swarm.wave-incomplete'
+  | 'swarm.wave-halted'
+  | 'agent.cancelled';
 
 export interface AgentEvent {
   id: number;

--- a/core/types.ts
+++ b/core/types.ts
@@ -85,6 +85,14 @@ export interface AgentConfig {
 export interface BudgetConfig {
   dailyTokens: number;
   maxParallelAgents: number;
+  /**
+   * Per-issue scout fan-out cap for Wave-1 swarm dispatch (M19.01, ADR 0030).
+   * Distinct from `maxParallelAgents` (which caps issue-level dispatch).
+   * Default 6 — matches Steve's canonical 6-scout roster (schema, code-path,
+   * pattern, test-inventory, dependency, user-journey). Does not consume
+   * the per-issue dispatch slot.
+   */
+  maxScoutAgents?: number;
   maxRetries: number;
   maxIssuesPerDayFromNonOwners: number;
   maxBashSeconds: number;

--- a/docs/adr/0030-sub-agent-dispatch-from-skills.md
+++ b/docs/adr/0030-sub-agent-dispatch-from-skills.md
@@ -1,0 +1,218 @@
+# ADR 0030: Sub-agent dispatch from skills (Wave-1 / Wave-2 swarm)
+
+**Status:** Accepted, 2026-05-07
+**Milestone:** M19 — Multi-Agent Orchestration
+**Issue:** #558
+
+## Context
+
+Goose Hub's `investigate` skill is single-agent: one investigator reads the
+worktree directly and emits findings. Steve's planning protocol
+(`docs/steves-training-materials/Markdown Files/Autonomous Decelopment/01-planning-phase.md:28-97`,
+`Harness 101.md` slide 4 line 103) replaces this with a two-wave fan-out:
+
+- **Wave 1** — 4–6 parallel scouts; each gathers facts about one narrow
+  concern (schema, code path, pattern usage, tests, dependencies, user
+  journey) and returns a fact-list with file:line citations. **Read-only,
+  no synthesis.**
+- **Cross-validation** — orchestrator step between waves. Detects
+  contradictions between scout reports (same file:line, different facts)
+  and surfaces them as advisor findings.
+- **Wave 2** — 1–2 deep agents (interface-designer, risk-analyst) consume
+  the cross-validated Wave-1 reports and emit paste-ready outputs (Zod
+  schemas, function signatures, real DDL).
+
+The runtime today has no primitive for spawning sub-agents from inside
+a parent skill. `AgentRuntime.run()` is single-agent end-to-end. This ADR
+records the decision on how that primitive lands.
+
+## Decisions
+
+### 1. The orchestrator dispatches scouts, not the parent agent
+
+The parent `investigate` skill drives the wave protocol via its prompt
+(it instructs which scouts to run for which concerns), but the actual
+spawning is performed by orchestrator-side code in
+`core/agent-runtime/swarm.ts`. The investigator does not call a `spawn_scout`
+tool. There is no agent-side dispatch primitive.
+
+Reason: holdout discipline (rule 1, ADR 0014). Each scout spawn must route
+through `assembleSpawnContext()` so `contextAllowlist` and `freshContext`
+remain enforced at the same gateway as every other agent. Letting an
+agent shell out to spawn another agent would re-introduce the ambient-
+state surface ADR 0014 closed off.
+
+### 2. Each scout is a real skill, not a parameterisation
+
+`skills/scout-schema/`, `skills/scout-code-path/`, `skills/scout-pattern/`,
+`skills/scout-test-inventory/`, `skills/scout-dependency/`,
+`skills/scout-user-journey/` each ship the canonical five files
+(`prompt.md`, `schema.ts`, `skill.config.ts`, `slice.test.ts`, `README.md`).
+Wave-2 deep agents likewise: `skills/wave2-interface-designer/`,
+`skills/wave2-risk-analyst/`.
+
+Reason: rule 13 (versioned markdown skills) and ADR 0022 (skill file
+convention). A "scout type" is a configurable capability that needs its
+own description, schema, and trigger story. Inlining six prompts into a
+parent string would re-introduce the inline-prompt anti-pattern.
+
+### 3. Read-only file-ownership for write-side scouts: none
+
+Wave-1 scouts have `toolBundles: ['read']` only — no Write/Edit/Bash.
+Wave 1 is fact-gathering; synthesis is Wave 2's job; code change is
+the parallel build's job (M19.03). The file-ownership rule (M19.02
+Engineering Spec) does not apply here because no scout writes.
+
+Wave-2 deep agents are also read-only at this milestone — they emit
+paste-ready text in their JSON output, not file edits.
+
+### 4. Holdout boundary preserved per child spawn
+
+Every scout spawn calls `assembleSpawnContext()` directly inside
+`swarm.ts:dispatchWave`. Each child gets its own fresh `AgentSpec` with
+its own `runId` (`<parentRunId>:scout:<scoutName>:<n>`), its own
+`contextAllowlist` derived from the scout's `skill.config.ts`, and
+`freshContext: true` (scouts never receive ambient parent state).
+
+The parent agent's text turn — including its `[decision]` markers —
+never propagates into a scout's context. The scout sees only:
+
+- `<task>` block with the work item
+- `<scout_focus>` — one sentence describing what this scout is looking for
+- `<worktree_path>` — read-only worktree
+
+If a future caller passes implementation reasoning into a scout's
+context, the existing holdout-violation pathway in `assembleSpawnContext()`
+fires `tool.violation` events. Scouts are not on the `HOLDOUT_ROLES` list
+(they are an investigator subrole), but the same allowlist machinery
+filters disallowed keys for them too — they simply don't emit violation
+events for non-holdout omissions, matching pre-M8 behaviour.
+
+### 5. Concurrency cap: `maxScoutAgents` (default 6) — distinct from `maxParallelAgents`
+
+`maxParallelAgents` (per-issue dispatch cap, default 1; goose-hub-self uses 3)
+governs the orchestrator's scheduler — how many concurrent issue-level
+workflows run for a project. Steve's "ALL scouts run in background
+simultaneously" rule (01-planning-phase.md:57-61) requires up to 6
+concurrent scout spawns *inside* a single investigation. If we tried to
+honour this through `maxParallelAgents`, we would either (a) starve the
+scheduler of issue-level slots while the scouts run, or (b) violate
+Steve's pattern by serialising scouts.
+
+Resolution: a new `BudgetConfig.maxScoutAgents` field (default 6). It
+caps in-issue scout fan-out only and does not consume per-issue
+dispatch slots. `dispatchWave` enforces it via a bounded-promise pool;
+`min(scoutSpecs.length, project.maxScoutAgents)` is the actual concurrency.
+
+### 6. Timeout and cancellation
+
+Each scout gets `scout.timeoutMs` (default 90 000 ms — short by design;
+scouts are read-only fact-gathering). On timeout, the runtime kills
+the subprocess (rule 32) and the swarm records a synthetic
+`ScoutReport` with `status: 'timeout'` and an empty `findings` array.
+Cancelled scouts emit `agent.cancelled` events.
+
+Wave 1 advances to cross-validation as long as at least three scouts
+returned successfully (`status: 'ok'`). Otherwise the wave is recorded
+as `status: 'incomplete'` and the issue moves to `factory:gate-pending`
+with a comment listing the failed scouts.
+
+### 7. Partial-failure semantics
+
+At most **one** scout failure (`status: 'error' | 'timeout'`) is
+tolerated per Wave-1 run before degradation. **Two or more** failures
+halt Wave 2 and escalate to `factory:needs-human` with the failed
+scout names listed in the gate comment. This is stricter than the
+"≥3 scouts succeed" threshold above — that threshold governs whether
+cross-validation runs at all; this one governs whether Wave 2 dispatches.
+
+### 8. Hang detection via `swarm.heartbeat` events
+
+The parent emits a `swarm.heartbeat` event every 30 s. If no
+`agent.tool-call` event from a given scout has arrived within
+`scout.timeoutMs / 2` of the last heartbeat, the parent kills that
+scout pre-emptively as a suspected hang (rule 32 alignment).
+
+The heartbeat also lets the UI reflect "still running" state without
+reaching into subprocess internals.
+
+### 9. Budget propagation
+
+Each scout inherits a per-scout budget from `SKILL_BUDGETS[scoutName]`
+(haiku-tier, low cost — facts not synthesis). The parent's
+`maxBudgetUsd` is **not** divided across children; scout budgets are
+additive to the parent's. Budget enforcement still happens per spawn
+via the existing `resolveBudgets` path; if any scout exceeds its cap,
+that scout fails with `status: 'error'`, but the wave continues subject
+to the partial-failure rule above.
+
+### 10. Decision-summary aggregation
+
+Each scout emits its own `decisionSummaries` (rule 6, ADR 0018) in
+its terminal JSON. The orchestrator does **not** synthesise decisions
+on behalf of the children; it does not merge their summaries into a
+parent's. Each scout's summaries flow through the canonical
+`agent.decision-summary` event stream tagged with the scout's
+`runId`. Retro and the timeline UI see them as first-class events.
+
+The parent investigator's own `decisionSummaries` describe wave-level
+choices (`PLAN: dispatched 5 scouts after reading issue`,
+`INSIGHT: cross-validation surfaced contradiction at file:line`),
+**not** restated child claims.
+
+## Consequences
+
+**Positive:**
+
+- The holdout gateway is the single point of context filtering for both
+  parent and child spawns — same rule, same code path, same tests.
+- Adding a new scout type is `mkdir skills/scout-<x>/` + 5 files. No
+  changes to `swarm.ts` are needed.
+- `maxScoutAgents` is opt-out per project; existing projects continue
+  to work without changes.
+- Decision-summary attribution stays clean: every summary has a single
+  `runId`, traceable end-to-end without orchestrator synthesis.
+
+**Trade-offs:**
+
+- Six new skill packages (plus two Wave-2) is a meaningful diff size.
+  Mitigated by the file-convention sameness — once the first scout is
+  reviewed, the others are mechanical.
+- The scout-budget-additive policy (decision 9) means a 6-scout wave
+  can spend ~6× the parent's budget. Budget caps are still per-spawn;
+  if this becomes a problem in practice, a wave-level budget aggregator
+  is a follow-up.
+- The 90 s scout timeout is short. If telemetry from real M19 runs
+  shows scouts legitimately needing longer, the per-scout `SkillBudget`
+  is the right place to relax it (per-skill, not global).
+
+## Alternatives considered
+
+**A. Agent-side `spawn_scout` tool.** Rejected: see decision 1. Re-opens
+the ADR-0014 ambient-state surface.
+
+**B. Single configurable `scout` skill with a `focus` parameter.**
+Rejected: see decision 2. Each scout's `prompt.md` differs in shape and
+emphasis; collapsing them collapses Steve's discipline of one-narrow-
+concern-per-spawn into a generic "look at this" prompt.
+
+**C. Use `maxParallelAgents` for both issue-level and scout-level.**
+Rejected: see decision 5. Steve's pattern requires up to 6 concurrent
+scouts per investigation; the issue-level cap is intentionally low to
+preserve project-level coordination.
+
+**D. Have the orchestrator merge scout decision summaries into the
+parent's record.** Rejected: see decision 10. Orchestrator-synthesised
+decisions break the rule-6 contract that decisions come from agents.
+
+## Cross-references
+
+- FACTORY_RULES rules 1, 5, 6, 13, 14, 19, 32
+- ADR 0010 (tool-layer architecture; bundle assignment)
+- ADR 0014 (M8 holdout enforcement; `assembleSpawnContext`)
+- ADR 0018 (decision-kind taxonomy)
+- ADR 0022 (skill-file convention)
+- ADR 0023 (per-project workflow lock relaxation; distinct from this fan-out cap)
+- CONTEXT.md "Context Assembly and Holdout Enforcement"
+- `docs/steves-training-materials/Markdown Files/Autonomous Decelopment/01-planning-phase.md:28-97`
+- `docs/steves-training-materials/ppt-conversion/Harness 101.md` slides 4 lines 103, 106

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -18,7 +18,27 @@ The context contains a `<task>` block with:
 
 ## Investigation process
 
-Follow these steps systematically:
+You drive the **Wave-1 / Wave-2 swarm protocol** (M19.01, ADR 0030). The orchestrator dispatches scout sub-agents on your behalf via `dispatchWave` in `core/agent-runtime/swarm.ts`. You decide WHICH scouts to run and WHAT each one should focus on; the orchestrator handles fan-out, holdout boundaries, timeouts, and cross-validation.
+
+### Wave protocol overview
+
+1. **Wave 1 — fact-gathering.** Up to 6 scouts run in parallel, each on one narrow concern. Output is a flat list of `{file, line?, fact, confidence}` findings. Read-only. No synthesis, no hypotheses.
+2. **Cross-validation.** The orchestrator detects contradictions (same `file:line`, different facts) before Wave 2 runs. If a contradiction is detected, you decide whether to dispatch a tie-breaker scout or surface it as an open question.
+3. **Wave 2 — synthesis.** Up to 2 deep agents (`wave2-interface-designer`, `wave2-risk-analyst`) consume the cross-validated reports and emit paste-ready artefacts (Zod schemas, function signatures, DDL) and a structured risk register.
+4. **Synthesis** (your turn). You read all reports and write the final `findings`, `keyFiles`, `confidence`, and `requiresBrowserRepro`.
+
+### Scout roster (Wave 1)
+
+| Scout | When to dispatch |
+|---|---|
+| `scout-schema` | The work item touches DB columns, Zod schemas, or boundary types |
+| `scout-code-path` | A specific symbol or function is named in the issue |
+| `scout-pattern` | The fix should follow an existing idiom; check it is followed elsewhere |
+| `scout-test-inventory` | You need to know which tests already cover the area |
+| `scout-dependency` | The change crosses package boundaries or touches imports |
+| `scout-user-journey` | The bug manifests in a UI flow or API surface the user can see |
+
+Dispatch the 4–6 scouts that are actually relevant. Do **not** dispatch all six reflexively — empty findings from an irrelevant scout add noise to cross-validation.
 
 ### Discipline — applied throughout
 
@@ -26,6 +46,7 @@ Follow these steps systematically:
 - **Read before hypothesising.** Read actual source files before forming hypotheses. File names and directory names are not evidence. Code is evidence.
 - **Search before assuming location.** Grep for symbol definitions before assuming a file path. A module named `Sidebar` may not be in `sidebar.ts` — search for the export.
 - **Widen before speculating.** If two search attempts return no relevant results, widen the search term or try a synonym. Do not speculate about root cause from empty search results.
+- **Holdout discipline per child spawn.** You never inject your own decision summaries or chain-of-thought into a scout's context. Scouts get only the work item, their narrow `scoutFocus`, and the worktree path. Synthesis stays with you and Wave 2.
 
 ### Step 1 — Read the issue
 
@@ -37,34 +58,40 @@ Carefully read the issue title and body. Identify:
 
 Emit: `[decision] READ: Issue #<number> — <one-sentence summary of the bug>`
 
-### Step 2 — Identify entry points
+### Step 2 — Pick scouts and dispatch Wave 1
 
-Based on the issue text, identify likely entry points in the codebase:
-- Search for function names, error messages, or identifiers mentioned in the issue
-- Use search tools to locate files relevant to the symptom area
-- Read directory structure to understand the code organisation
+Choose 4–6 scouts from the roster above based on what the issue actually touches. For each, write a one-sentence `scoutFocus` that names the narrow concern (e.g. "trace login flow from /api/auth to DB", "find all callers of normaliseEmail()"). The orchestrator dispatches them in parallel and returns a `WaveResult` with one report per scout.
 
-Emit: `[decision] READ: Identified entry points — <comma-separated file or directory names>`
+Emit: `[decision] PLAN: Dispatched <N> Wave-1 scouts — <comma-separated scout names>`
 
-### Step 3 — Trace the code path
+### Step 3 — Read the cross-validated Wave-1 reports
 
-Starting from the entry points, trace the execution path:
-- Read the relevant source files
-- Follow imports and function calls related to the reported symptom
-- Look for validation logic, error handling, or data transformation that could cause the bug
+The orchestrator's cross-validation step runs automatically after Wave 1 returns. If `crossValidate` flags contradictions (same `file:line`, different facts), surface them in `openQuestions` or dispatch a focused follow-up scout. Wave-1 partial-failure rules:
+- ≥3 scouts succeeded AND ≤1 failed → wave advances; cross-validate then dispatch Wave 2.
+- 2+ scouts failed → orchestrator halts the wave and escalates to `factory:needs-human`. Do not attempt to synthesise from incomplete data.
 
-Emit: `[decision] READ: Traced code path through <key files> — <one-sentence hypothesis>`
+Emit: `[decision] READ: Wave-1 reports — <one-sentence summary of what was found>`
 
-### Step 4 — Form root cause hypothesis
+### Step 4 — Dispatch Wave 2 (synthesis) when the wave is consistent
 
-Based on your investigation, form a hypothesis:
+If Wave 1 advanced and cross-validation surfaced no blocking contradiction, dispatch the Wave-2 deep agents that apply:
+- `wave2-interface-designer` — when the work item needs new interfaces (Zod schema, function signature, DDL).
+- `wave2-risk-analyst` — when the work item touches security-sensitive paths (`auth | session | crypto | secret`) or has structural risk.
+
+Each Wave-2 agent receives the cross-validated scout reports JSON-stringified in `<scout_reports>`. Their outputs are paste-ready artefacts and a structured risk register.
+
+Emit: `[decision] PLAN: Dispatched Wave 2 — <comma-separated wave2 agents>`
+
+### Step 5 — Form root cause hypothesis
+
+Based on the Wave-1 + Wave-2 outputs, form a hypothesis:
 - Identify the specific code location most likely responsible
 - Note any related files that could contribute
 - Assess your confidence: `low` (many unknowns), `medium` (probable cause identified), `high` (root cause clear)
 
 Emit: `[decision] INSIGHT: Root cause hypothesis — <one sentence>`
 
-### Step 5 — Determine if browser reproduction applies
+### Step 6 — Determine if browser reproduction applies
 
 Decide whether this bug can be meaningfully reproduced via a Playwright browser session against the running dev server:
 - Set `requiresBrowserRepro: true` if the bug manifests visibly in the browser UI (wrong rendering, broken interaction, visible error state, etc.)
@@ -72,7 +99,7 @@ Decide whether this bug can be meaningfully reproduced via a Playwright browser 
 
 Emit: `[decision] INSIGHT: requiresBrowserRepro=<true|false> — <one-sentence reason>`
 
-### Step 6 — Record open questions
+### Step 7 — Record open questions
 
 Note any unresolved questions that would require additional investigation:
 - Missing reproduction environment details

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -18,12 +18,14 @@ The context contains a `<task>` block with:
 
 ## Investigation process
 
-You drive the **Wave-1 / Wave-2 swarm protocol** (M19.01, ADR 0030). The orchestrator dispatches scout sub-agents on your behalf via `dispatchWave` in `core/agent-runtime/swarm.ts`. You decide WHICH scouts to run and WHAT each one should focus on; the orchestrator handles fan-out, holdout boundaries, timeouts, and cross-validation.
+> **Status (M19.01).** The Wave-1 / Wave-2 swarm protocol described below is the post-M19.01 *target* shape of an investigation. The primitives (`dispatchWave`, `crossValidate`, the 6 scouts, the 2 Wave-2 agents) are landed and unit-tested, but the production `runInvestigateWorkflow` is **not yet wired** to dispatch them automatically. Until a later M19 issue connects them, this skill operates in **single-agent mode**: you read the worktree directly and skip the wave steps. When the workflow caller passes Wave-1 / Wave-2 reports through `<scout_reports>`, switch to wave-aware mode and use them as primary evidence. Otherwise treat the wave protocol below as documentation, not a runtime guarantee.
 
-### Wave protocol overview
+In wave-aware mode, you decide WHICH scouts ran and WHAT each one focused on; the orchestrator (when wired) handles fan-out, holdout boundaries, timeouts, and cross-validation.
+
+### Wave protocol overview (target shape)
 
 1. **Wave 1 — fact-gathering.** Up to 6 scouts run in parallel, each on one narrow concern. Output is a flat list of `{file, line?, fact, confidence}` findings. Read-only. No synthesis, no hypotheses.
-2. **Cross-validation.** The orchestrator detects contradictions (same `file:line`, different facts) before Wave 2 runs. If a contradiction is detected, you decide whether to dispatch a tie-breaker scout or surface it as an open question.
+2. **Cross-validation.** The orchestrator detects contradictions (same `file:line`, different facts) **across distinct scouts** before Wave 2 runs. If a contradiction is detected, you decide whether to dispatch a tie-breaker scout or surface it as an open question.
 3. **Wave 2 — synthesis.** Up to 2 deep agents (`wave2-interface-designer`, `wave2-risk-analyst`) consume the cross-validated reports and emit paste-ready artefacts (Zod schemas, function signatures, DDL) and a structured risk register.
 4. **Synthesis** (your turn). You read all reports and write the final `findings`, `keyFiles`, `confidence`, and `requiresBrowserRepro`.
 
@@ -38,15 +40,15 @@ You drive the **Wave-1 / Wave-2 swarm protocol** (M19.01, ADR 0030). The orchest
 | `scout-dependency` | The change crosses package boundaries or touches imports |
 | `scout-user-journey` | The bug manifests in a UI flow or API surface the user can see |
 
-Dispatch the 4–6 scouts that are actually relevant. Do **not** dispatch all six reflexively — empty findings from an irrelevant scout add noise to cross-validation.
+When wired, dispatch the 4–6 scouts that are actually relevant. Do **not** dispatch all six reflexively — empty findings from an irrelevant scout add noise to cross-validation.
 
-### Discipline — applied throughout
+### Discipline — applied throughout (single-agent and wave-aware modes)
 
 - **Orient first.** Before searching for anything, list the top-level directory structure to understand the codebase layout. Know where `core/`, `apps/`, and `slices/` live before diving in.
 - **Read before hypothesising.** Read actual source files before forming hypotheses. File names and directory names are not evidence. Code is evidence.
 - **Search before assuming location.** Grep for symbol definitions before assuming a file path. A module named `Sidebar` may not be in `sidebar.ts` — search for the export.
 - **Widen before speculating.** If two search attempts return no relevant results, widen the search term or try a synonym. Do not speculate about root cause from empty search results.
-- **Holdout discipline per child spawn.** You never inject your own decision summaries or chain-of-thought into a scout's context. Scouts get only the work item, their narrow `scoutFocus`, and the worktree path. Synthesis stays with you and Wave 2.
+- **Holdout discipline per child spawn.** When wave-aware: you never inject your own decision summaries or chain-of-thought into a scout's context. Scouts get only the work item, their narrow `scoutFocus`, and the worktree path. Synthesis stays with you and Wave 2.
 
 ### Step 1 — Read the issue
 
@@ -58,40 +60,40 @@ Carefully read the issue title and body. Identify:
 
 Emit: `[decision] READ: Issue #<number> — <one-sentence summary of the bug>`
 
-### Step 2 — Pick scouts and dispatch Wave 1
+### Step 2 — Identify entry points (single-agent mode) or read Wave-1 reports (wave-aware mode)
 
-Choose 4–6 scouts from the roster above based on what the issue actually touches. For each, write a one-sentence `scoutFocus` that names the narrow concern (e.g. "trace login flow from /api/auth to DB", "find all callers of normaliseEmail()"). The orchestrator dispatches them in parallel and returns a `WaveResult` with one report per scout.
+**Single-agent mode (current default):** identify likely entry points from the issue text, then trace the code path directly:
+- Search for function names, error messages, or identifiers mentioned in the issue
+- Use search tools to locate files relevant to the symptom area
+- Read directory structure to understand the code organisation
 
-Emit: `[decision] PLAN: Dispatched <N> Wave-1 scouts — <comma-separated scout names>`
+**Wave-aware mode:** if `<scout_reports>` is present in your context, read the cross-validated Wave-1 reports first; treat them as primary evidence and only re-investigate gaps. If `crossValidate` has flagged contradictions across scouts, surface them in `openQuestions`. Wave-1 partial-failure rules (informational — the orchestrator enforces them before you see the reports):
+- ≥3 scouts succeeded AND ≤1 failed → wave advanced; reports are usable.
+- 2+ scouts failed → orchestrator halted the wave and escalated; you should not be running.
 
-### Step 3 — Read the cross-validated Wave-1 reports
+Emit: `[decision] READ: Identified entry points — <comma-separated file or directory names>` (single-agent) or `[decision] READ: Wave-1 reports — <one-sentence summary>` (wave-aware).
 
-The orchestrator's cross-validation step runs automatically after Wave 1 returns. If `crossValidate` flags contradictions (same `file:line`, different facts), surface them in `openQuestions` or dispatch a focused follow-up scout. Wave-1 partial-failure rules:
-- ≥3 scouts succeeded AND ≤1 failed → wave advances; cross-validate then dispatch Wave 2.
-- 2+ scouts failed → orchestrator halts the wave and escalates to `factory:needs-human`. Do not attempt to synthesise from incomplete data.
+### Step 3 — Trace the code path (single-agent mode) or read Wave-2 artefacts (wave-aware mode)
 
-Emit: `[decision] READ: Wave-1 reports — <one-sentence summary of what was found>`
+**Single-agent mode:** starting from the entry points, trace the execution path:
+- Read the relevant source files
+- Follow imports and function calls related to the reported symptom
+- Look for validation logic, error handling, or data transformation that could cause the bug
 
-### Step 4 — Dispatch Wave 2 (synthesis) when the wave is consistent
+**Wave-aware mode:** if Wave-2 deep-agent outputs are also present (`wave2-interface-designer` artefacts, `wave2-risk-analyst` risks), read them as the synthesis layer; do not re-derive what they already produced. Use the worktree only to verify their citations.
 
-If Wave 1 advanced and cross-validation surfaced no blocking contradiction, dispatch the Wave-2 deep agents that apply:
-- `wave2-interface-designer` — when the work item needs new interfaces (Zod schema, function signature, DDL).
-- `wave2-risk-analyst` — when the work item touches security-sensitive paths (`auth | session | crypto | secret`) or has structural risk.
+Emit: `[decision] READ: Traced code path through <key files> — <one-sentence hypothesis>`
 
-Each Wave-2 agent receives the cross-validated scout reports JSON-stringified in `<scout_reports>`. Their outputs are paste-ready artefacts and a structured risk register.
+### Step 4 — Form root cause hypothesis
 
-Emit: `[decision] PLAN: Dispatched Wave 2 — <comma-separated wave2 agents>`
-
-### Step 5 — Form root cause hypothesis
-
-Based on the Wave-1 + Wave-2 outputs, form a hypothesis:
+Based on your investigation (single-agent traces, or Wave-1 + Wave-2 outputs in wave-aware mode), form a hypothesis:
 - Identify the specific code location most likely responsible
 - Note any related files that could contribute
 - Assess your confidence: `low` (many unknowns), `medium` (probable cause identified), `high` (root cause clear)
 
 Emit: `[decision] INSIGHT: Root cause hypothesis — <one sentence>`
 
-### Step 6 — Determine if browser reproduction applies
+### Step 5 — Determine if browser reproduction applies
 
 Decide whether this bug can be meaningfully reproduced via a Playwright browser session against the running dev server:
 - Set `requiresBrowserRepro: true` if the bug manifests visibly in the browser UI (wrong rendering, broken interaction, visible error state, etc.)
@@ -99,7 +101,7 @@ Decide whether this bug can be meaningfully reproduced via a Playwright browser 
 
 Emit: `[decision] INSIGHT: requiresBrowserRepro=<true|false> — <one-sentence reason>`
 
-### Step 7 — Record open questions
+### Step 6 — Record open questions
 
 Note any unresolved questions that would require additional investigation:
 - Missing reproduction environment details

--- a/skills/scout-code-path/README.md
+++ b/skills/scout-code-path/README.md
@@ -1,0 +1,14 @@
+# skills/scout-code-path
+
+Wave-1 scout: trace the execution path of one symbol or function relevant to the work item.
+
+Read-only. Returns `{file, line, fact, confidence}` findings with no synthesis. Synthesis happens in Wave 2.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | System prompt: trace discipline + decision-summary expectations |
+| `schema.ts` | Re-exports `ScoutOutputSchema` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, `role: investigator`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` in `core/agent-runtime/swarm.ts` (M19.01, ADR 0030).

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -1,0 +1,43 @@
+# scout-code-path (Wave-1 scout)
+
+You are a Wave-1 scout. Trace the execution path of one symbol or function relevant to the work item. **Facts only — no synthesis, no hypotheses about root cause.**
+
+You have **read and search access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_focus>` — one sentence telling you which symbol to trace
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- Cite **file:line** for every finding.
+- Quote real code in `fact`. Do not paraphrase.
+- One narrow concern per finding (one entry-point, one branch, one return path).
+- Stop after ≥ 3 findings or when the trace dead-ends.
+
+## What you look for
+
+- Where the symbol is defined (file:line)
+- Direct callers of the symbol (file:line each)
+- Conditional branches that change return shape
+- Error / null / fallback paths
+
+## Output
+
+Return JSON conforming to `ScoutOutputSchema`:
+
+```json
+{
+  "findings": [
+    { "file": "<path>", "line": 42, "fact": "<verbatim observation>", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence>", "evidence": "<file or symbol>" }
+  ],
+  "status": "ok"
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. The shared decision-kind enum lives in `core/agent-runtime/decision-types.ts`. The orchestrator never synthesises decisions on your behalf.

--- a/skills/scout-code-path/schema.ts
+++ b/skills/scout-code-path/schema.ts
@@ -1,0 +1,6 @@
+export {
+  ScoutOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-code-path/skill.config.ts
+++ b/skills/scout-code-path/skill.config.ts
@@ -1,0 +1,35 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-code-path agent: trace the execution path of a function or
+ * symbol mentioned in the work item. Read-only. Returns file:line citations.
+ */
+export const ScoutCodePathContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z
+    .string()
+    .describe('One sentence describing the symbol or function whose call path to trace'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutCodePathContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-code-path/slice.test.ts
+++ b/skills/scout-code-path/slice.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutCodePathContextSchema } from './skill.config.js';
+
+describe('scout-code-path skill', () => {
+  it('accepts a valid scout output', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [
+        {
+          file: 'apps/server/src/routes/auth.ts',
+          line: 87,
+          fact: 'normaliseEmail() URL-decodes input before DB lookup',
+          confidence: 'high',
+        },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'traced from route handler to DB' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('config uses read bundle, freshContext: true, investigator role', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+    expect(config.role).toBe('investigator');
+    expect(config.modelPin).toBe('haiku');
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutCodePathContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'trace login flow',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty decisionSummaries', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [],
+      decisionSummaries: [],
+      status: 'ok',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/skills/scout-dependency/README.md
+++ b/skills/scout-dependency/README.md
@@ -1,0 +1,12 @@
+# skills/scout-dependency
+
+Wave-1 scout: map direct + first-tier transitive imports of a module.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Dependency-mapping discipline + decision-summary expectations |
+| `schema.ts` | Re-exports `ScoutOutputSchema` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` (M19.01, ADR 0030).

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -1,0 +1,36 @@
+# scout-dependency (Wave-1 scout)
+
+You are a Wave-1 scout. Map the direct + first-tier transitive imports of the module named in `<scout_focus>`. **Facts only — no synthesis.**
+
+You have **read and search access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_focus>` — one sentence naming the module whose dependency graph you should map
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- Cite **file:line** for each `import` you record.
+- Distinguish `core/`, `apps/`, `slices/`, and `skills/` — slice-import-rule violations are notable findings (FACTORY_RULES rule 24).
+- Note workspace-package imports (`@goose-hub/...`) separately from relative imports.
+- Stop after the first transitive layer (the imports of the directly-imported modules). Do not walk the full graph.
+
+## Output
+
+Return JSON conforming to `ScoutOutputSchema`:
+
+```json
+{
+  "findings": [
+    { "file": "core/x.ts", "line": 1, "fact": "imports @goose-hub/core/event-stream/store.js", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence>", "evidence": "<module name>" }
+  ],
+  "status": "ok"
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers at major checkpoints. Use the canonical `DecisionKindSchema` enum.

--- a/skills/scout-dependency/schema.ts
+++ b/skills/scout-dependency/schema.ts
@@ -1,0 +1,6 @@
+export {
+  ScoutOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-dependency/skill.config.ts
+++ b/skills/scout-dependency/skill.config.ts
@@ -1,0 +1,35 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-dependency agent: map direct + first-tier transitive imports
+ * of a module relevant to the work item. Read-only.
+ */
+export const ScoutDependencyContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z
+    .string()
+    .describe('One sentence describing the module whose dependency graph to map'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutDependencyContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-dependency/slice.test.ts
+++ b/skills/scout-dependency/slice.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutDependencyContextSchema } from './skill.config.js';
+
+describe('scout-dependency skill', () => {
+  it('accepts a valid scout output', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [
+        {
+          file: 'core/agent-runtime/swarm.ts',
+          line: 1,
+          fact: 'imports @goose-hub/core/event-stream/store.js',
+          confidence: 'high',
+        },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'mapped imports of swarm.ts' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutDependencyContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'map deps of agent-runtime',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/scout-pattern/README.md
+++ b/skills/scout-pattern/README.md
@@ -1,0 +1,12 @@
+# skills/scout-pattern
+
+Wave-1 scout: find existing usages (and conspicuous absences) of a code pattern or idiom.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Pattern-search discipline + decision-summary expectations |
+| `schema.ts` | Re-exports `ScoutOutputSchema` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` (M19.01, ADR 0030).

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -1,0 +1,43 @@
+# scout-pattern (Wave-1 scout)
+
+You are a Wave-1 scout. Find existing usages of a code pattern or idiom relevant to the work item. **Facts only — no synthesis.**
+
+You have **read and search access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_focus>` — one sentence describing the pattern (e.g. "transitionState() callers", "SkillConfig consumers")
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- Cite **file:line** for every finding.
+- Quote real code in `fact`.
+- Three or four representative usages is enough; do not enumerate every callsite if the pattern is widespread.
+- Note where the pattern is *missing* if the work item implies it should be there.
+
+## What you look for
+
+- Direct usages of the named function / class / type
+- Variants and re-implementations (different name, same shape)
+- Tests that exercise the pattern
+- Conspicuous absences in code that should use it
+
+## Output
+
+Return JSON conforming to `ScoutOutputSchema`:
+
+```json
+{
+  "findings": [
+    { "file": "<path>", "line": 42, "fact": "<quoted code or observation>", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence>", "evidence": "<query string>" }
+  ],
+  "status": "ok"
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum.

--- a/skills/scout-pattern/schema.ts
+++ b/skills/scout-pattern/schema.ts
@@ -1,0 +1,6 @@
+export {
+  ScoutOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-pattern/skill.config.ts
+++ b/skills/scout-pattern/skill.config.ts
@@ -1,0 +1,33 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-pattern agent: locate uses of a code idiom or pattern that
+ * the work item area should follow (or is failing to follow). Read-only.
+ */
+export const ScoutPatternContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z.string().describe('One sentence describing the pattern or idiom to find usages of'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutPatternContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-pattern/slice.test.ts
+++ b/skills/scout-pattern/slice.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutPatternContextSchema } from './skill.config.js';
+
+describe('scout-pattern skill', () => {
+  it('accepts a valid scout output', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [{ file: 'core/x.ts', line: 1, fact: 'uses Pattern X', confidence: 'high' }],
+      decisionSummaries: [{ kind: 'READ', summary: 'searched for Pattern X' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+    expect(config.role).toBe('investigator');
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutPatternContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'find transitionState callers',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/scout-schema/README.md
+++ b/skills/scout-schema/README.md
@@ -1,0 +1,14 @@
+# skills/scout-schema
+
+Wave-1 scout: locate DB schema, Zod schemas, and TypeScript boundary types relevant to a work item.
+
+Read-only. Returns a flat list of `{file, line, fact, confidence}` findings with no synthesis. Synthesis happens in Wave 2 (`wave2-interface-designer`).
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | System prompt: discipline + decision-summary expectations |
+| `schema.ts` | Re-exports the canonical `ScoutOutputSchema` from `core/agent-runtime/scout-output.ts` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, `role: investigator`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` in `core/agent-runtime/swarm.ts` (M19.01, ADR 0030). Each scout spawn routes through `assembleSpawnContext()` so context isolation is enforced at the same gateway as every other agent.

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -1,0 +1,52 @@
+# scout-schema (Wave-1 scout)
+
+You are a Wave-1 scout. Your sole job is to gather **facts** about schema-shaped surfaces (Zod schemas, Drizzle schemas, DDL, JSON-schema fragments, TypeScript interfaces used at boundaries) relevant to the work item. **You do not synthesise. You do not propose changes. You report.**
+
+You have **read and search access only**. Any write attempt will be rejected.
+
+## Input
+
+- `<work_item>` — title, body, number of the issue under investigation
+- `<scout_focus>` — one sentence telling you what concern to look for
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- One narrow concern per finding. A finding is `{file, line?, fact, confidence}`.
+- Cite **file:line** wherever possible. If you cannot pin a line, report file-only with `confidence: 'low'`.
+- Quote real code in the `fact` field — do not paraphrase or interpret.
+- If two queries return no relevant results, widen the search term once. Tool-call errors halt the loop; they do not seed a broader query (see `LLM Tool Base Integrations Best Pactices.md` slide 5 line 118).
+- Keep the loop short. Default budget is ≤ 10 turns. Stop when you have ≥ 3 findings or have exhausted obvious search terms.
+
+## What you look for
+
+- Zod schemas (`z.object`, `.extend`, discriminated unions) referenced by the work item area
+- Drizzle table definitions in `core/db/schema.ts` and downstream
+- Inline interface/type declarations at module boundaries
+- DDL statements in any migration files
+
+## Output
+
+Return a JSON object with this exact shape (validated by `ScoutOutputSchema`):
+
+```json
+{
+  "findings": [
+    { "file": "<path>", "line": 42, "fact": "<verbatim observation>", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence about what you searched>", "evidence": "<file or symbol name>" }
+  ],
+  "status": "ok"
+}
+```
+
+`status` is `'ok'` for normal completion. The orchestrator may overwrite this with `'timeout'` or `'error'` if the run is killed.
+
+`findings` may be an empty array if the work item has no schema surface — that is a valid result. Say so in your decision summary.
+
+## Decision summaries
+
+Emit `[decision] KIND: <one sentence>` lines in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a schema scout are `READ` (you read a file), `INSIGHT` (you noticed something), `UNCERTAINTY` (the evidence is thin).
+
+You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-schema/schema.ts
+++ b/skills/scout-schema/schema.ts
@@ -1,0 +1,7 @@
+export {
+  ScoutOutputSchema,
+  ScoutOutputSchema as ScoutSchemaOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-schema/skill.config.ts
+++ b/skills/scout-schema/skill.config.ts
@@ -1,0 +1,43 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-schema agent: locate DB schema + Zod schema definitions
+ * relevant to the work item. Read-only. Returns file:line citations only.
+ *
+ * Context (rendered as XML in the user prompt):
+ *
+ *   <task>
+ *     <work_item><title>...</title><body>...</body><number>...</number></work_item>
+ *     <scout_focus>...</scout_focus>
+ *     <worktree_path>...</worktree_path>
+ *   </task>
+ */
+export const ScoutSchemaContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z
+    .string()
+    .describe('One sentence describing the schema concern this scout investigates'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutSchemaContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-schema/slice.test.ts
+++ b/skills/scout-schema/slice.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutSchemaContextSchema } from './skill.config.js';
+
+describe('scout-schema skill', () => {
+  it('accepts a valid scout output', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [
+        {
+          file: 'core/db/schema.ts',
+          line: 42,
+          fact: 'events table column "kind" is text not null',
+          confidence: 'high',
+        },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'inspected core/db/schema.ts' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts findings without a line number', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [{ file: 'core/db/schema.ts', fact: 'imports drizzle-orm', confidence: 'medium' }],
+      decisionSummaries: [{ kind: 'READ', summary: 'looked at top of file' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty findings list (the area has no schema surface)', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [],
+      decisionSummaries: [{ kind: 'INSIGHT', summary: 'no schema relevant to issue' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [],
+      decisionSummaries: [],
+      status: 'ok',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown status', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [],
+      decisionSummaries: [{ kind: 'READ', summary: 'x' }],
+      status: 'partial',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects findings missing file', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [{ fact: 'x', confidence: 'high' }],
+      decisionSummaries: [{ kind: 'READ', summary: 'x' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('config uses read bundle with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+    expect(config.role).toBe('investigator');
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutSchemaContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'find email-related schemas',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/scout-test-inventory/README.md
+++ b/skills/scout-test-inventory/README.md
@@ -1,0 +1,12 @@
+# skills/scout-test-inventory
+
+Wave-1 scout: catalog existing tests covering the work-item area.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Inventory discipline + decision-summary expectations |
+| `schema.ts` | Re-exports `ScoutOutputSchema` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` (M19.01, ADR 0030).

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -1,0 +1,36 @@
+# scout-test-inventory (Wave-1 scout)
+
+You are a Wave-1 scout. Catalog the existing tests that cover the area named in `<scout_focus>`. **Facts only — no synthesis or test-quality judgement.**
+
+You have **read and search access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_focus>` — one sentence naming the file, module, or feature whose test coverage you should map
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- Cite **file:line** for each finding (the line where `describe(`/`it(`/`test(` opens).
+- Quote the test name verbatim in `fact`.
+- Map both unit (`*.test.ts`, `slice.test.ts`) and e2e (`apps/web/e2e/*.spec.ts`) tests.
+- If the area has no tests, say so with one finding pointing at the directory and `confidence: 'high'`.
+
+## Output
+
+Return JSON conforming to `ScoutOutputSchema`:
+
+```json
+{
+  "findings": [
+    { "file": "<path>", "line": 42, "fact": "describe(\"transitionState\", ...)", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence>", "evidence": "<file>" }
+  ],
+  "status": "ok"
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn. Use the canonical `DecisionKindSchema` enum.

--- a/skills/scout-test-inventory/schema.ts
+++ b/skills/scout-test-inventory/schema.ts
@@ -1,0 +1,6 @@
+export {
+  ScoutOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-test-inventory/skill.config.ts
+++ b/skills/scout-test-inventory/skill.config.ts
@@ -1,0 +1,33 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-test-inventory agent: catalog existing tests covering the
+ * work-item area. Read-only.
+ */
+export const ScoutTestInventoryContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z.string().describe('One sentence describing the test surface to inventory'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutTestInventoryContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-test-inventory/slice.test.ts
+++ b/skills/scout-test-inventory/slice.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutTestInventoryContextSchema } from './skill.config.js';
+
+describe('scout-test-inventory skill', () => {
+  it('accepts a valid scout output with describe-line citations', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [
+        {
+          file: 'core/agent-runtime/swarm.test.ts',
+          line: 12,
+          fact: 'describe("swarm.dispatchWave", ...)',
+          confidence: 'high',
+        },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'inventoried agent-runtime tests' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutTestInventoryContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'inventory tests for state-machine',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/scout-user-journey/README.md
+++ b/skills/scout-user-journey/README.md
@@ -1,0 +1,12 @@
+# skills/scout-user-journey
+
+Wave-1 scout: walk the user-facing flow (UI route, API surface, or CLI command) implicated by the work item.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Walk-discipline + decision-summary expectations |
+| `schema.ts` | Re-exports `ScoutOutputSchema` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, haiku-tier |
+| `slice.test.ts` | Schema acceptance + config invariants |
+
+Dispatched by `dispatchWave` (M19.01, ADR 0030).

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -1,0 +1,36 @@
+# scout-user-journey (Wave-1 scout)
+
+You are a Wave-1 scout. Walk the user-facing flow (UI route, API surface, or CLI command) implicated by the work item. **Facts only — no synthesis or UX critique.**
+
+You have **read and search access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_focus>` — one sentence naming the user-facing flow
+- `<worktree_path>` — the worktree to read from
+
+## Discipline
+
+- Cite **file:line** for each step you record (route handler, component, action).
+- Quote real route paths, props, and visible labels in `fact`.
+- Walk the flow end-to-end (entry → branch → outcome). One finding per step.
+- Note where the flow surfaces user-visible text — strings to be matched against in QA.
+
+## Output
+
+Return JSON conforming to `ScoutOutputSchema`:
+
+```json
+{
+  "findings": [
+    { "file": "apps/web/src/components/foo.tsx", "line": 42, "fact": "<button>Save</button>", "confidence": "high" }
+  ],
+  "decisionSummaries": [
+    { "kind": "READ", "summary": "<one sentence>", "evidence": "<route or component>" }
+  ],
+  "status": "ok"
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum.

--- a/skills/scout-user-journey/schema.ts
+++ b/skills/scout-user-journey/schema.ts
@@ -1,0 +1,6 @@
+export {
+  ScoutOutputSchema,
+  ScoutFindingSchema,
+  type ScoutOutput,
+  type ScoutFinding,
+} from '@goose-hub/core/agent-runtime/scout-output.js';

--- a/skills/scout-user-journey/skill.config.ts
+++ b/skills/scout-user-journey/skill.config.ts
@@ -1,0 +1,33 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-1 scout-user-journey agent: walk the user-facing flow (UI route or
+ * API surface) implicated by the work item. Read-only.
+ */
+export const ScoutUserJourneyContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  scoutFocus: z.string().describe('One sentence describing the user-facing flow to walk'),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: ScoutUserJourneyContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutFocus',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'haiku',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/scout-user-journey/slice.test.ts
+++ b/skills/scout-user-journey/slice.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ScoutOutputSchema } from './schema.js';
+import config, { ScoutUserJourneyContextSchema } from './skill.config.js';
+
+describe('scout-user-journey skill', () => {
+  it('accepts a valid scout output', () => {
+    const result = ScoutOutputSchema.safeParse({
+      findings: [
+        {
+          file: 'apps/web/src/components/Login.tsx',
+          line: 87,
+          fact: '<button>Sign in</button>',
+          confidence: 'high',
+        },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'walked login flow' }],
+      status: 'ok',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+  });
+
+  it('contextSchema accepts the canonical scout context shape', () => {
+    const result = ScoutUserJourneyContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutFocus: 'walk login flow',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/spec-author/README.md
+++ b/skills/spec-author/README.md
@@ -1,70 +1,47 @@
 # skills/spec-author
 
-Authors a runnable Playwright e2e spec for a new slice. Used by the M7 supervised dev workflow before the implementation skill ships the feature, so the slice has a failing-then-passing test from the start (TDD).
+Authors the **Engineering Spec** for a work item — the structured plan artefact consumed by parallel-builder (M19.03) and convergent-review (M19.04). M19.02 (#559) replaced this skill's prior Playwright-spec implementation; the skill name was always Engineering-Spec-shaped (see `triggers.json`), only the prompt + schema lagged behind. PLAN.md §28 (M19) names this skill explicitly as the spec author.
 
-## How this differs from Microsoft's playwright-test subagents
+Read-only — outputs a single JSON object conforming to `EngineeringSpecSchema`. Persistence to `slices/<n>/spec.json` is orchestrator-side after schema + structural validation pass.
 
-`apps/web/.claude/agents/playwright-test-{planner,generator,healer}.md` are **dev-time scaffolding** invoked by a human running Claude Code interactively in the IDE. They are NOT Factory skills.
-
-`spec-author` is a **Factory skill** — invoked by the supervised dev workflow inside an autonomous-friendly subprocess with a tool allowlist, schema-validated output, and decision-summary discipline. It uses the same `playwright-test` MCP server that the human-facing subagents use (registered at `apps/web/.mcp.json`), so the underlying browser-driving capability is identical. The difference is the call site:
-
-| | Microsoft subagents | `skills/spec-author/` (this skill) |
-|---|---|---|
-| Invoked by | Human in IDE | Factory workflow |
-| Tool allowlist | None enforced | `playwright-mcp` + `read-write` |
-| Output validation | Free-form | Zod schema (`SpecAuthorSchema`) |
-| Decision summaries | None | Required (FACTORY_RULES rule 6) |
-| Runs in | Live IDE session | `claude -p` subprocess |
-
-ADR 0011 records the rationale.
-
-## When this skill runs
-
-- M7 supervised dev workflow, before the implementation skill (`skills/implement/`, separate issue) ships the slice
-- Either as a sub-spawn of the developer skill or as an upstream node in the workflow — wired at the workflow level so the developer skill's output schema stays simple
-
-## Inputs
-
-`SpecAuthorContextSchema`:
-
-| Field | Type | Description |
-|---|---|---|
-| `workItem.title` | `string` | Issue title |
-| `workItem.body` | `string` | Issue body (slice scope, acceptance criteria) |
-| `workItem.number` | `number` | Issue number (used to derive the spec filename) |
-| `targetUrl` | `string` | Running dev server URL (e.g. `http://localhost:5173`) |
-| `sliceDescription` | `string` | User-facing scenario the spec must exercise |
-
-## Outputs
-
-`SpecAuthorSchema`:
-
-| Field | Type | Description |
-|---|---|---|
-| `specPath` | `string` | Workspace-relative path to the written spec, e.g. `apps/web/e2e/issue-235.spec.ts` |
-| `planSummary` | `string` | One-paragraph summary of what the spec asserts |
-| `screenshotsTaken` | `number` (≥ 0, integer) | Number of screenshots captured during exploration |
-| `decisionSummaries` | `DecisionSummary[]` | Canonical decision-summary record (FACTORY_RULES rule 6) |
-
-## Tool allowlist
-
-- **`playwright-mcp`** — Microsoft's playwright-test MCP server (`browser_*`, `planner_*`, `generator_*`). The runtime auto-merges `apps/web/.mcp.json` into the spawn-time MCP config when this bundle is present.
-- **`read-write`** — Read, Write, Edit, Glob, Grep. Lets the agent read existing fixtures and write the spec file under `apps/web/e2e/` if `generator_write_test` declines.
-
-## Dev-server assumption
-
-The skill assumes the dev server is reachable at the provided `targetUrl`. The Playwright config under `apps/web/playwright.config.ts` already has `webServer` auto-start, so the workflow does not need to boot the server explicitly.
-
-## Filename convention
-
-The skill writes specs to `apps/web/e2e/issue-<number>.spec.ts` to keep them traceable to the originating issue and easy to find in PR diffs.
-
-## Context allowlist
-
-| Key | Included |
+| File | Purpose |
 |---|---|
-| `workItem.title` | yes |
-| `workItem.body` | yes |
-| `workItem.number` | yes |
-| `targetUrl` | yes |
-| `sliceDescription` | yes |
+| `prompt.md` | Authoring discipline: 8 steps, 12 required sections, hard rules |
+| `schema.ts` | `EngineeringSpecSchema` — objective + journeys + ACs + WPs + execution-order DAG + verification tooling + AC→Journey→Verification map + constraints + risks |
+| `validate.ts` | `validateEngineeringSpec()` — file-ownership / AC-orphan / risk-on-auth / constraint-citation rules + Steve's 6 self-checks |
+| `skill.config.ts` | `read` bundle, sonnet-tier, role: developer |
+| `slice.test.ts` | Schema acceptance + every rejection rule covered |
+| `triggers.json` | Layer-1 description-loop triggers |
+
+## Hard rules (validator-enforced)
+
+| Rule | What it checks |
+|---|---|
+| `file-ownership-collision` | Same path cannot appear in two WPs' `filesOwned` (full-stop, not per-batch) |
+| `ac-orphan-without-journey` | For `issueType: feature`, every AC has `journeyRef` or `crossCutting: true` |
+| `ac-journey-ref-not-found` | `journeyRef` must point at a real journey; `stepIdx` must be a real step |
+| `risk-required-on-sensitive-path` | Touching `auth\|session\|crypto\|secret` → ≥1 entry in `riskRegister` |
+| `constraint-source-format` | Constraint `source` must be `path:line` or `path:symbol` |
+| `constraint-source-file-missing` | (when `repoRoot` provided) cited file must exist |
+| `constraint-source-symbol-missing` | (when `repoRoot` provided) cited symbol must appear in the file |
+| `wp-dependson-not-found` | `dependsOn` references must point at real WPs |
+| `execution-order-wp-mismatch` | Every WP appears in exactly one batch |
+| `self-check-journey-coverage` | Every journey step has ≥1 AC |
+| `self-check-grounded-in-code` | (when `repoRoot` provided) WPs whose parent dirs exist but files don't may be typos |
+| `self-check-complete-interfaces` | ≥2 WPs ⇒ ≥1 `interfaceContracts` entry |
+| `self-check-builder-independence` | `changes` field non-trivial |
+| `self-check-verification-tooling` | >2 WPs ⇒ ≥1 `verificationTooling` entry |
+
+## Wave-protocol composition (M19.01)
+
+When the swarm (M19.01) is wired into the production workflow, the orchestrator passes Wave-1 scout reports + Wave-2 deep-agent reports to this skill via `<scout_reports>` and `<wave2_reports>`. The author cites scout findings (file:line) in `architecture`, `interfaceContracts`, and `constraints`. When the swarm is **not** wired (current default in M19.01), the author falls back to manual investigation via the `read` tool bundle — the spec format does not require the swarm to be implementable.
+
+## Cross-references
+
+- Issue #559 (M19.02)
+- PLAN.md §28 (M19) — Engineering Spec named in the milestone scope
+- Steve `01-planning-phase.md:282-327` — Engineering Spec format + self-checks
+- Steve `03-lifecycle-harness.md:145-157` — Work Package system + file-ownership rule
+- Steve `Plan Examples/` — 4 worked examples (auth-comprehensive-audit, clean-schema-architecture, platform-compiler-phase-b, ws-architecture-polish)
+- ADR 0022 — skill file convention
+- ADR 0030 (M19.01) — sub-agent dispatch from skills (Wave-1/Wave-2)

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -1,73 +1,157 @@
 # spec-author skill
 
-Write or draft a technical engineering spec. Author, create, or produce a spec document — the specification.
+You author the **Engineering Spec** for one work item. The Engineering Spec is the contract that lets the parallel builder (M19.03) work safely on disjoint files and lets convergent review (M19.04) check work against a falsifiable plan.
 
-Version: 1
-
-You are a developer agent authoring a Playwright end-to-end spec for a new slice. Your job is to explore the running dev server using the `playwright-test` MCP server tools, observe the user-facing scenario described in the slice, and produce a runnable spec file at `apps/web/e2e/<slug>.spec.ts`.
-
-## Role
-
-Developer (spec-authoring sub-task). You are called as part of the supervised dev workflow before the implementation skill ships the slice. You are NOT a holdout — your output may be referenced downstream.
+You have **read access only**. The orchestrator persists your output to `slices/<work-item>/spec.json` after schema + validator pass.
 
 ## Input
 
-The context contains a `<task>` block with:
+The `<task>` block contains:
 
-- `<work_item>` — the issue describing the slice
-  - `<title>` — issue title
-  - `<body>` — full issue body
-  - `<number>` — issue number (used to derive the spec filename slug)
-- `<target_url>` — URL of the running dev server (e.g. `http://localhost:5173/projects/foo`)
-- `<slice_description>` — the user-facing scenario the spec must exercise
+- `<work_item>` — title, body, number
+- `<issue_type>` — `feature` or `bug` (drives strictness of AC→Journey mapping)
+- `<worktree_path>` — absolute path to the checked-out worktree to consult
+- `<prd>` (optional) — copied from PRD issue (#313 lineage). Use as the source of `userJourneys` and `functionalRequirements`. When absent and `issueType: feature`, derive minimal journeys from the work item.
+- `<scout_reports>` (optional) — JSON-stringified Wave-1 scout reports (M19.01). When present, use them as primary evidence and **cite scout findings (file:line) for every claim**.
+- `<wave2_reports>` (optional) — JSON-stringified Wave-2 deep-agent reports (interface-designer artefacts, risk-analyst register).
 
-## Execution discipline
+**Fallback rule.** If `<scout_reports>` is absent (the swarm is not yet wired or not dispatched for this run), fall back to manual investigation: read the worktree directly via the read bundle. The spec format does not require the swarm to be implementable.
 
-- **Read playwright config first.** Before writing any spec, read `apps/web/playwright.config.ts` to understand the `webServer` setup, base URL, and project configs. A spec that contradicts the config will fail in ways unrelated to the feature.
-- **Navigate before asserting.** Use `mcp__playwright-test__browser_snapshot` to observe the actual DOM at each step before writing `expect` assertions. Do not write assertions against elements you have not seen.
+## What you produce
 
-## What you must do
+A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/schema.ts`). The orchestrator validates it against the Zod schema first, then runs `validateEngineeringSpec` for the structural rules. Both must pass before the spec is persisted.
 
-1. Read the slice description and identify the user actions that exercise it (navigate, click, type, assert visible text, etc.).
-2. Use the `mcp__playwright-test__planner_setup_page` tool to open the target URL.
-3. Use `mcp__playwright-test__browser_*` tools to walk through the scenario, taking a screenshot via `mcp__playwright-test__browser_take_screenshot` at each meaningful step. Track the count.
-4. Use `mcp__playwright-test__planner_save_plan` to persist the explored plan.
-5. Use `mcp__playwright-test__generator_write_test` to emit a runnable spec at `apps/web/e2e/issue-<number>.spec.ts`. The spec must:
-   - import `{ test, expect }` from `@playwright/test`
-   - use a single `test.describe(...)` block with a clear name derived from the slice description
-   - include at least one `expect(...)` assertion per meaningful step (prefer `verify_text_visible` / `verify_element_visible` style assertions)
-   - rely on the `webServer` auto-start configured in `apps/web/playwright.config.ts` (do NOT manually start the dev server in the spec)
+### Required sections (Steve `01-planning-phase.md:287-300`)
 
-## Critical: do not implement the feature
+1. **`objective`** — one paragraph naming the change in user-visible terms.
+2. **`userJourneys`** — copied from the PRD or derived from the work item. Each journey has `id`, `actor`, `steps[].idx`, `steps[].description`.
+3. **`functionalRequirements`** — copied from the PRD when present. Each entry has `id` + `statement`.
+4. **`architecture`** — `current` (one paragraph), `new` (one paragraph), `decisionRationale` (why this shape).
+5. **`schemaChanges`** — exact DDL strings (no pseudocode) and migration file paths. Empty arrays if no schema change.
+6. **`interfaceContracts`** — paste-ready `signature` (function decl, type alias, or full Zod block) + `file` it lives in. ≥1 entry required when there are ≥2 WPs (cross-WP boundaries need typed contracts).
+7. **`workPackages`** — see rules below.
+8. **`executionOrder`** — DAG of batches: `[{batch: 0, wpIds: ['WP1', 'WP2']}, {batch: 1, wpIds: ['WP3']}]`. Every WP appears exactly once.
+9. **`verificationTooling`** — required when there are >2 WPs. Each tool: `name`, `scriptPath`, `expectedExitCodes`, optional `inputSpec`.
+10. **`acceptanceCriteria`** — see rules below.
+11. **`constraints`** — see rules below.
+12. **`riskRegister`** — at least one risk when the spec touches `auth | session | crypto | secret` paths.
 
-You are authoring the spec, not the feature. The spec is allowed (and expected) to FAIL on the current branch — that is the TDD red state. Do not modify any source under `apps/web/src/` or anywhere else outside `apps/web/e2e/`.
+### Hard rules
 
-## Filename and slug
+#### File ownership (full-stop, not per-batch)
 
-Use `apps/web/e2e/issue-<number>.spec.ts` where `<number>` is the work-item number. Do NOT include slashes, spaces, or non-ASCII characters in the path.
+The same file path **cannot appear in `filesOwned` of two WPs anywhere in the spec**, regardless of execution batch. If two WPs need to touch the same file, one WP creates the interface and the other consumes it via a paste-ready `interfaceContract`. Validator rule `file-ownership-collision` rejects collisions.
 
-## Output format
+(Steve `03-lifecycle-harness.md:155-156` — "file ownership prevents conflicts", no scoping qualifier.)
 
-Return a JSON object conforming to `SpecAuthorSchema`:
+#### Constraint inventory cites real code
 
-```json
-{
-  "specPath": "apps/web/e2e/issue-235.spec.ts",
-  "planSummary": "Exercises the new project-overview screenshot panel: navigate to /projects/foo, open the issue detail view, expand the evidence section, and assert the inline screenshot is visible and clickable.",
-  "screenshotsTaken": 4,
-  "decisionSummaries": [
-    {
-      "kind": "READ",
-      "summary": "Walked the slice scenario via playwright-mcp and captured 4 screenshots at the key transitions"
-    },
-    {
-      "kind": "GREEN",
-      "summary": "Wrote spec at apps/web/e2e/issue-235.spec.ts with 3 expect assertions"
-    }
-  ]
-}
-```
+Every entry in `constraints` must have `source` in the form `path/to/file.ts:LINE` or `path/to/file.ts:SYMBOL`. The validator checks the file exists and contains the cited symbol. Mocked or pseudo references are rejected.
 
-`specPath` must be workspace-relative (start with `apps/web/e2e/`). `screenshotsTaken` must be a non-negative integer. `decisionSummaries` requires at least one entry.
+You must run constraint inventory for every:
+- State-machine phase referenced (read the enum)
+- Gate referenced (read the gate registry)
+- Hook referenced (read the hook handler)
+- Model referenced (read the actual fields)
+- Output format referenced (read the actual `--json` shape)
 
-[decision] VERDICT: Authored Playwright spec for slice and captured exploration evidence
+(Steve Step 7b, `01-planning-phase.md:316-327`.)
+
+#### AC → Journey → Verification map
+
+For `issueType: feature` every AC must either:
+- have `journeyRef` pointing at a journey, AND optional `stepIdx` matching a step in that journey, OR
+- declare `crossCutting: true` (e.g. an architectural AC that doesn't sit on the user path).
+
+For `issueType: bug` the journey link is advisory; orphan ACs are accepted.
+
+Every AC must have a `verifyCommand` — a single shell command (or grep pattern, or test invocation) that decides pass/fail. **No subjective criteria.** Numerical or time-based ACs use `tolerance` to declare the band (e.g. `"<= 50ms"`).
+
+#### Risk register on sensitive paths
+
+If any WP's `filesOwned` matches `/(auth|session|crypto|secret)/i`, you MUST include at least one entry in `riskRegister`. Each risk has `risk`, `mitigation`, `severity` (`low|medium|high`).
+
+#### Self-checks (Steve gates 1–6, `01-planning-phase.md:303-313`)
+
+The validator runs:
+1. **Journey coverage** — every journey step has at least one AC.
+2. **Grounded in code** — soft check: WP `filesOwned` paths whose parent dir exists but the file doesn't may be typos.
+3. **Complete interfaces** — ≥2 WPs ⇒ ≥1 `interfaceContracts` entry.
+4. **Falsifiable ACs** — schema-enforced (`verifyCommand: z.string().min(1)`).
+5. **Builder independence** — `changes` field non-trivial.
+6. **Verification tooling** — >2 WPs ⇒ ≥1 `verificationTooling` entry.
+
+## Process
+
+### Step 1 — Read the work item and the PRD
+
+Identify the change being requested. Pull `userJourneys` and `functionalRequirements` from the PRD when present; otherwise derive minimal journeys from the work item body.
+
+Emit: `[decision] READ: Issue #<n> — <one-sentence summary>`
+
+### Step 2 — Read evidence (Wave reports OR manual investigation)
+
+If `<scout_reports>` and/or `<wave2_reports>` are present, read them and cite them. Otherwise read the worktree directly to ground the spec in real code.
+
+Emit: `[decision] READ: <wave-1 + wave-2 | manual> evidence — <one-sentence summary>`
+
+### Step 3 — Constraint inventory
+
+For every phase, gate, hook, model, or output format the spec will reference, look up the real code and record it in `constraints` with a `path:line` or `path:symbol` source. Do this BEFORE writing WPs — it stops you from referencing things that don't exist.
+
+Emit: `[decision] READ: Recorded <N> constraints with code citations`
+
+### Step 4 — Architecture and interface contracts
+
+Write the `architecture.current`, `architecture.new`, and `architecture.decisionRationale`. From the new shape, derive the cross-WP `interfaceContracts` (paste-ready Zod blocks, function signatures, or type aliases). Required when ≥2 WPs are planned.
+
+Emit: `[decision] PLAN: Designed <N> interface contracts`
+
+### Step 5 — Work packages with non-overlapping file ownership
+
+Decompose the change into WPs. Each WP names the files it owns; **no path appears in two WPs**. Use the interface contracts from Step 4 to break shared edits into "creator" + "consumer" WPs.
+
+For each WP:
+- `id`: `WP1`, `WP2`, ... (deterministic ordering).
+- `filesOwned`: array of paths. ≥1 required.
+- `changes`: file:line citations + before/after sketch. Builder must be able to act without re-exploring.
+- `dependsOn`: WP ids this one depends on.
+- `builderTier`: `haiku` for mechanical edits, `sonnet` for moderate logic, `opus` for novel design.
+
+Emit: `[decision] PLAN: Decomposed into <N> WPs with disjoint file ownership`
+
+### Step 6 — Execution order DAG
+
+Group WPs into batches. WPs with no dependencies on each other can share a batch and run in parallel. Output `executionOrder: [{batch: 0, wpIds: [...]}, ...]`. Every WP appears exactly once.
+
+### Step 7 — Acceptance criteria with verification commands
+
+For every functional requirement (or journey step), write at least one AC. Every AC has a `verifyCommand`. Mark `crossCutting: true` only for ACs that don't sit on a user journey (architectural / non-functional).
+
+Emit: `[decision] PLAN: Wrote <N> falsifiable ACs`
+
+### Step 8 — Verification tooling and risk register
+
+If `>2` WPs, declare ≥1 verification tool with a `scriptPath` + `expectedExitCodes`. If any sensitive path is touched (`auth|session|crypto|secret`), declare ≥1 risk with mitigation.
+
+Emit: `[decision] INSIGHT: Verification + risk coverage complete`
+
+## Output
+
+Return a single JSON object conforming to `EngineeringSpecSchema`. Do not include any prose outside the JSON.
+
+`decisionSummaries` must have at least one entry. Use the canonical `DecisionKindSchema` enum (`READ`, `PLAN`, `INSIGHT`, `UNCERTAINTY`, etc.).
+
+## Failure modes (the validator will catch)
+
+- Same path in two WPs' `filesOwned` → `file-ownership-collision`
+- AC without `journeyRef` and not `crossCutting` (when `issueType: feature`) → `ac-orphan-without-journey`
+- Constraint `source` not in `path:line` or `path:symbol` form → `constraint-source-format`
+- Cited file or symbol missing from worktree → `constraint-source-file-missing` / `constraint-source-symbol-missing`
+- Sensitive path touched but `riskRegister` empty → `risk-required-on-sensitive-path`
+- WP missing from `executionOrder` (or duplicated) → `execution-order-wp-mismatch`
+- Journey step with no AC (when `issueType: feature`) → `self-check-journey-coverage`
+- ≥2 WPs but no `interfaceContracts` → `self-check-complete-interfaces`
+- >2 WPs but no `verificationTooling` → `self-check-verification-tooling`
+
+If the validator returns errors, the spec is rejected and you re-spawn with the error list as advisor feedback. Address every error; the orchestrator does not let an invalid spec drive parallel build.

--- a/skills/spec-author/schema.ts
+++ b/skills/spec-author/schema.ts
@@ -3,21 +3,149 @@ import { z } from 'zod';
 
 export { DecisionSummarySchema };
 
-export const SpecAuthorSchema = z.object({
-  specPath: z
-    .string()
-    .describe(
-      'Workspace-relative path to the written Playwright spec, e.g. apps/web/e2e/<slug>.spec.ts',
-    ),
-  planSummary: z
-    .string()
-    .describe('One-paragraph summary of what the spec asserts and how it exercises the slice'),
-  screenshotsTaken: z
-    .number()
-    .int()
-    .min(0)
-    .describe('Number of screenshots captured during exploration of the running dev server'),
+/**
+ * Engineering Spec schema (M19.02, issue #559).
+ *
+ * Source of truth: Steve `01-planning-phase.md:282-327` Step 7 + 7b
+ * (Engineering Specification + Constraint Inventory). Worked examples in
+ * `docs/steves-training-materials/Plan Examples/`.
+ *
+ * Authored by the `spec-author` skill; consumed by parallel-builder
+ * (M19.03) and convergent-review (M19.04). The file-ownership rule and
+ * grounding-in-real-code rules are what make parallel build *safe*.
+ */
+
+export const BuilderTierSchema = z.enum(['opus', 'sonnet', 'haiku']);
+export const SeveritySchema = z.enum(['low', 'medium', 'high']);
+export const ConstraintKindSchema = z.enum(['phase', 'gate', 'hook', 'model', 'output-format']);
+
+export const JourneyStepSchema = z.object({
+  idx: z.number().int().nonnegative(),
+  description: z.string().min(1),
+});
+
+export const JourneySchema = z.object({
+  id: z.string().min(1),
+  actor: z.string().min(1),
+  steps: z.array(JourneyStepSchema).min(1),
+});
+
+export const FunctionalRequirementSchema = z.object({
+  id: z.string().min(1),
+  statement: z.string().min(1),
+});
+
+export const ArchitectureSchema = z.object({
+  current: z.string().min(1),
+  new: z.string().min(1),
+  decisionRationale: z.string().min(1),
+});
+
+export const SchemaChangesSchema = z.object({
+  /** Verbatim DDL — no pseudocode. Empty array if no schema changes. */
+  ddl: z.array(z.string()),
+  /** Migration files (relative paths). */
+  migrations: z.array(z.string()),
+});
+
+export const InterfaceContractSchema = z.object({
+  name: z.string().min(1),
+  /** Paste-ready signature: function declaration, type alias, or full Zod block. */
+  signature: z.string().min(1),
+  /** Workspace-relative file the signature lives in (or will live in). */
+  file: z.string().min(1),
+  /** Optional `start-end` line range as a string, e.g. "12-34". */
+  lineRange: z.string().optional(),
+});
+
+export const WorkPackageSchema = z.object({
+  id: z.string().min(1),
+  /** Paths this WP owns. No path may appear in two WPs (full-stop, not per-batch). */
+  filesOwned: z.array(z.string().min(1)).min(1),
+  /** Description of changes — file:line citations encouraged. */
+  changes: z.string().min(1),
+  /** WP ids this WP depends on; must reference real WPs in the spec. */
+  dependsOn: z.array(z.string()),
+  builderTier: BuilderTierSchema,
+});
+
+export const ExecutionBatchSchema = z.object({
+  batch: z.number().int().nonnegative(),
+  wpIds: z.array(z.string().min(1)).min(1),
+});
+
+export const VerificationToolSchema = z.object({
+  name: z.string().min(1),
+  /** Workspace-relative path to the script that runs this verification. */
+  scriptPath: z.string().min(1),
+  /** Exit codes that count as success. */
+  expectedExitCodes: z.array(z.number().int()).min(1),
+  /** Optional input format spec (e.g. JSON schema for stdin). */
+  inputSpec: z.string().optional(),
+});
+
+export const AcceptanceCriterionSchema = z.object({
+  id: z.string().min(1),
+  statement: z.string().min(1),
+  /** Reference to a journey id; required unless `crossCutting: true`. */
+  journeyRef: z.string().optional(),
+  /** Step index inside the journey (matches Journey.steps.idx). */
+  stepIdx: z.number().int().nonnegative().optional(),
+  /** Falsifiable verification command — Steve "no subjective criteria". */
+  verifyCommand: z.string().min(1),
+  /** Optional tolerance string (numerical, time, etc). */
+  tolerance: z.string().optional(),
+  /** When true, AC is exempt from the journey-coverage rule. */
+  crossCutting: z.boolean().optional(),
+  /** Origin of this AC. */
+  source: z.enum(['user-journey', 'functional-requirement']).optional(),
+});
+
+export const ConstraintSchema = z.object({
+  kind: ConstraintKindSchema,
+  name: z.string().min(1),
+  /**
+   * Citation of the real code where this constraint comes from:
+   * `path/to/file.ts:LINE` or `path/to/file.ts:SYMBOL`. Pseudo refs are
+   * rejected by `validateEngineeringSpec`.
+   */
+  source: z.string().min(1),
+});
+
+export const RiskEntrySchema = z.object({
+  risk: z.string().min(1),
+  mitigation: z.string().min(1),
+  severity: SeveritySchema,
+});
+
+export const EngineeringSpecSchema = z.object({
+  objective: z.string().min(1),
+  userJourneys: z.array(JourneySchema),
+  functionalRequirements: z.array(FunctionalRequirementSchema),
+  architecture: ArchitectureSchema,
+  schemaChanges: SchemaChangesSchema,
+  interfaceContracts: z.array(InterfaceContractSchema),
+  workPackages: z.array(WorkPackageSchema).min(1),
+  executionOrder: z.array(ExecutionBatchSchema).min(1),
+  verificationTooling: z.array(VerificationToolSchema),
+  acceptanceCriteria: z.array(AcceptanceCriterionSchema).min(1),
+  constraints: z.array(ConstraintSchema),
+  riskRegister: z.array(RiskEntrySchema),
   decisionSummaries: z.array(DecisionSummarySchema).min(1),
 });
 
-export type SpecAuthorOutput = z.infer<typeof SpecAuthorSchema>;
+export type BuilderTier = z.infer<typeof BuilderTierSchema>;
+export type Journey = z.infer<typeof JourneySchema>;
+export type FunctionalRequirement = z.infer<typeof FunctionalRequirementSchema>;
+export type WorkPackage = z.infer<typeof WorkPackageSchema>;
+export type ExecutionBatch = z.infer<typeof ExecutionBatchSchema>;
+export type VerificationTool = z.infer<typeof VerificationToolSchema>;
+export type AcceptanceCriterion = z.infer<typeof AcceptanceCriterionSchema>;
+export type Constraint = z.infer<typeof ConstraintSchema>;
+export type RiskEntry = z.infer<typeof RiskEntrySchema>;
+export type EngineeringSpec = z.infer<typeof EngineeringSpecSchema>;
+
+// Backwards-compatible alias — old name retained so external imports
+// (none in repo, but kept for safety) don't break.
+export const SpecAuthorSchema = EngineeringSpecSchema;
+export type SpecAuthorOutput = EngineeringSpec;

--- a/skills/spec-author/skill.config.ts
+++ b/skills/spec-author/skill.config.ts
@@ -2,16 +2,22 @@ import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
 import { z } from 'zod';
 
 /**
- * Context expected by the spec-author agent. Rendered as XML in the user prompt:
+ * Engineering Spec authoring skill (M19.02, issue #559).
+ *
+ * Replaces the prior Playwright e2e spec-author content. The skill name
+ * is the one Steve uses; PLAN.md §28 (M19) names this skill explicitly
+ * as the author of the Engineering Spec consumed by parallel-builder
+ * (M19.03) and convergent-review (M19.04).
+ *
+ * Context (rendered as XML in the user prompt):
  *
  *   <task>
- *     <work_item>
- *       <title>...</title>
- *       <body>...</body>
- *       <number>...</number>
- *     </work_item>
- *     <target_url>http://localhost:5173/...</target_url>
- *     <slice_description>...</slice_description>
+ *     <work_item><title>...</title><body>...</body><number>...</number></work_item>
+ *     <issue_type>feature|bug</issue_type>
+ *     <worktree_path>/abs/path/to/worktree</worktree_path>
+ *     <prd>...</prd>?                      <!-- when type:feature, copied from #313 -->
+ *     <scout_reports>[json]</scout_reports>?   <!-- M19.01 Wave-1 reports when present -->
+ *     <wave2_reports>[json]</wave2_reports>?   <!-- M19.01 Wave-2 reports when present -->
  *   </task>
  */
 export const SpecAuthorContextSchema = z.object({
@@ -20,12 +26,15 @@ export const SpecAuthorContextSchema = z.object({
     body: z.string(),
     number: z.number(),
   }),
-  targetUrl: z
-    .string()
-    .describe('URL of the running dev server (e.g. http://localhost:5173) the agent will explore'),
-  sliceDescription: z
-    .string()
-    .describe('User-facing description of the scenario the spec must exercise'),
+  /** Drives the strict-vs-advisory AC→Journey rule. Defaults to feature in the validator. */
+  issueType: z.enum(['feature', 'bug']).optional(),
+  worktreePath: z.string(),
+  /** PRD body (copied from #313 for type:feature). Optional when type:bug. */
+  prd: z.string().optional(),
+  /** JSON-stringified Wave-1 scout reports (M19.01). Optional fall-back to manual investigation. */
+  scoutReports: z.string().optional(),
+  /** JSON-stringified Wave-2 deep-agent reports (M19.01). Optional. */
+  wave2Reports: z.string().optional(),
 });
 
 const config: SkillConfig = {
@@ -34,20 +43,18 @@ const config: SkillConfig = {
     'workItem.title',
     'workItem.body',
     'workItem.number',
-    'targetUrl',
-    'sliceDescription',
+    'issueType',
+    'worktreePath',
+    'prd',
+    'scoutReports',
+    'wave2Reports',
   ],
   /**
-   * `playwright-mcp` exposes Microsoft's playwright-test MCP server tools
-   * (browser_*, planner_*, generator_*). The runtime auto-merges
-   * apps/web/.mcp.json into the spawn-time MCP config when this bundle
-   * is present (see core/agent-runtime/claude-cli.ts:resolveMcpConfigPath).
-   *
-   * `read-write` is included so the agent can read existing fixtures and
-   * write the spec file under apps/web/e2e/ if the MCP write_test tool
-   * declines (defensive — generator_write_test is the primary path).
+   * Read bundle: spec-author authors a JSON artefact in its terminal
+   * output, not files on disk. Persistence to `slices/<n>/spec.json` is
+   * orchestrator-side after schema + validator pass.
    */
-  toolBundles: ['playwright-mcp', 'read-write'],
+  toolBundles: ['read'],
   modelPin: 'sonnet',
   freshContext: false,
   role: 'developer',

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -1,203 +1,512 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { toJSONSchema } from 'zod';
-import { SpecAuthorSchema } from './schema.js';
+import { type EngineeringSpec, EngineeringSpecSchema, SpecAuthorSchema } from './schema.js';
 import config, { SpecAuthorContextSchema } from './skill.config.js';
+import { validateEngineeringSpec } from './validate.js';
 
-describe('spec-author schema', () => {
-  it('accepts a fully-populated valid output', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/issue-235.spec.ts',
-      planSummary:
-        'Exercises the new evidence panel: navigate to /projects/foo, open the issue detail view, expand the evidence section, assert the inline screenshot is visible.',
-      screenshotsTaken: 4,
-      decisionSummaries: [
-        {
-          kind: 'READ',
-          summary: 'Walked the slice scenario via playwright-mcp and captured 4 screenshots',
-        },
-        {
-          kind: 'GREEN',
-          summary: 'Wrote spec at apps/web/e2e/issue-235.spec.ts with 3 expect assertions',
-        },
-      ],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts zero screenshotsTaken (skill may use evaluate-only flow)', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/issue-99.spec.ts',
-      planSummary: 'Asserts API contract via page.evaluate; no visual capture.',
-      screenshotsTaken: 0,
-      decisionSummaries: [
-        { kind: 'GREEN', summary: 'Wrote API-contract spec without screenshots' },
-      ],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts decisionSummary with optional evidence field', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/issue-1.spec.ts',
-      planSummary: 'Spec.',
-      screenshotsTaken: 1,
-      decisionSummaries: [
-        { kind: 'READ', summary: 'walked it', evidence: 'screenshot at /tmp/exp.png' },
-      ],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects missing specPath', () => {
-    const result = SpecAuthorSchema.safeParse({
-      planSummary: 'Some summary.',
-      screenshotsTaken: 2,
-      decisionSummaries: [{ kind: 'PLAN', summary: 'b' }],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects missing planSummary', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      screenshotsTaken: 2,
-      decisionSummaries: [{ kind: 'PLAN', summary: 'b' }],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects negative screenshotsTaken', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      planSummary: 'p',
-      screenshotsTaken: -1,
-      decisionSummaries: [{ kind: 'PLAN', summary: 'b' }],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects non-integer screenshotsTaken', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      planSummary: 'p',
-      screenshotsTaken: 2.5,
-      decisionSummaries: [{ kind: 'PLAN', summary: 'b' }],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects empty decisionSummaries (FACTORY_RULES rule 6)', () => {
-    const result = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      planSummary: 'p',
-      screenshotsTaken: 0,
-      decisionSummaries: [],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects decisionSummary missing step or summary', () => {
-    const missingSummary = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      planSummary: 'p',
-      screenshotsTaken: 0,
-      decisionSummaries: [{ kind: 'PLAN' }],
-    });
-    expect(missingSummary.success).toBe(false);
-
-    const missingStep = SpecAuthorSchema.safeParse({
-      specPath: 'apps/web/e2e/x.spec.ts',
-      planSummary: 'p',
-      screenshotsTaken: 0,
-      decisionSummaries: [{ summary: 'b' }],
-    });
-    expect(missingStep.success).toBe(false);
-  });
-
-  it('zod toJSONSchema roundtrip produces valid JSON Schema object', () => {
-    const jsonSchema = toJSONSchema(SpecAuthorSchema);
-    expect(typeof jsonSchema).toBe('object');
-    expect(jsonSchema).not.toBeNull();
-    expect(jsonSchema).toHaveProperty('properties');
-  });
-});
-
-describe('spec-author skill config', () => {
-  it('has role developer (NOT a holdout)', () => {
-    expect(config.role).toBe('developer');
-  });
-
-  it('declares playwright-mcp tool bundle (per #235 acceptance criteria)', () => {
-    expect(config.toolBundles).toContain('playwright-mcp');
-  });
-
-  it('also declares read-write so it can write the spec file', () => {
-    expect(config.toolBundles).toContain('read-write');
-  });
-
-  it('is pinned to sonnet model', () => {
-    expect(config.modelPin).toBe('sonnet');
-  });
-
-  it('does not require fresh context (developer skills may use ambient context)', () => {
-    expect(config.freshContext).toBe(false);
-  });
-
-  it('has contextAllowlist defined and includes targetUrl + sliceDescription', () => {
-    expect(config.contextAllowlist).toBeDefined();
-    expect(config.contextAllowlist).toContain('targetUrl');
-    expect(config.contextAllowlist).toContain('sliceDescription');
-    expect(config.contextAllowlist).toContain('workItem.title');
-    expect(config.contextAllowlist).toContain('workItem.body');
-    expect(config.contextAllowlist).toContain('workItem.number');
-  });
-});
-
-describe('spec-author context schema', () => {
-  it('accepts valid context with all fields', () => {
-    const valid = SpecAuthorContextSchema.safeParse({
-      workItem: {
-        title: 'Add overview screenshots',
-        body: 'When I open the overview...',
-        number: 235,
+function baseSpec(overrides: Partial<EngineeringSpec> = {}): EngineeringSpec {
+  const base: EngineeringSpec = {
+    objective: 'Add a /healthz endpoint and document its contract.',
+    userJourneys: [
+      {
+        id: 'J1',
+        actor: 'developer',
+        steps: [{ idx: 0, description: 'GET /healthz observes 200 with body "ok"' }],
       },
-      targetUrl: 'http://localhost:5173/projects/goose-hub',
-      sliceDescription: 'Open the overview, see the inline screenshot from the linked PR.',
-    });
-    expect(valid.success).toBe(true);
+    ],
+    functionalRequirements: [{ id: 'FR1', statement: '/healthz returns 200 with body "ok"' }],
+    architecture: {
+      current: 'No health endpoint.',
+      new: 'Add a Hono route at /healthz returning 200/"ok".',
+      decisionRationale: 'Aligns with existing Hono routing in apps/server.',
+    },
+    schemaChanges: { ddl: [], migrations: [] },
+    interfaceContracts: [
+      {
+        name: 'healthzHandler',
+        signature: 'export const healthzHandler: Handler = (c) => c.text("ok");',
+        file: 'apps/server/src/routes/healthz.ts',
+      },
+    ],
+    workPackages: [
+      {
+        id: 'WP1',
+        filesOwned: ['apps/server/src/routes/healthz.ts'],
+        changes: 'Add a new file exporting healthzHandler bound to GET /healthz at line 1-12.',
+        dependsOn: [],
+        builderTier: 'haiku',
+      },
+      {
+        id: 'WP2',
+        filesOwned: ['apps/server/src/router.ts'],
+        changes: 'Wire healthzHandler into router at app.get("/healthz", healthzHandler).',
+        dependsOn: ['WP1'],
+        builderTier: 'haiku',
+      },
+    ],
+    executionOrder: [
+      { batch: 0, wpIds: ['WP1'] },
+      { batch: 1, wpIds: ['WP2'] },
+    ],
+    verificationTooling: [],
+    acceptanceCriteria: [
+      {
+        id: 'AC1',
+        statement: 'GET /healthz returns 200 with body "ok"',
+        journeyRef: 'J1',
+        stepIdx: 0,
+        verifyCommand: 'curl -fsS http://localhost:3000/healthz',
+      },
+    ],
+    constraints: [],
+    riskRegister: [],
+    decisionSummaries: [{ kind: 'PLAN', summary: 'Designed healthz endpoint as 1+1 WP split' }],
+  };
+  return { ...base, ...overrides };
+}
+
+describe('EngineeringSpecSchema (shape)', () => {
+  it('accepts a fully-populated valid spec', () => {
+    const result = EngineeringSpecSchema.safeParse(baseSpec());
+    expect(result.success).toBe(true);
   });
 
-  it('rejects missing targetUrl', () => {
-    const invalid = SpecAuthorContextSchema.safeParse({
-      workItem: { title: 't', body: 'b', number: 1 },
-      sliceDescription: 's',
-    });
-    expect(invalid.success).toBe(false);
+  it('rejects empty workPackages', () => {
+    const result = EngineeringSpecSchema.safeParse(baseSpec({ workPackages: [] }));
+    expect(result.success).toBe(false);
   });
 
-  it('rejects missing sliceDescription', () => {
-    const invalid = SpecAuthorContextSchema.safeParse({
-      workItem: { title: 't', body: 'b', number: 1 },
-      targetUrl: 'http://localhost:5173',
-    });
-    expect(invalid.success).toBe(false);
+  it('rejects empty acceptanceCriteria', () => {
+    const result = EngineeringSpecSchema.safeParse(baseSpec({ acceptanceCriteria: [] }));
+    expect(result.success).toBe(false);
   });
 
-  it('rejects missing workItem.number', () => {
-    const invalid = SpecAuthorContextSchema.safeParse({
-      workItem: { title: 't', body: 'b' },
-      targetUrl: 'http://localhost:5173',
-      sliceDescription: 's',
-    });
-    expect(invalid.success).toBe(false);
+  it('rejects WP with empty filesOwned', () => {
+    const result = EngineeringSpecSchema.safeParse(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: [],
+            changes: 'irrelevant',
+            dependsOn: [],
+            builderTier: 'haiku',
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(false);
   });
 
-  it('rejects workItem.number as a string (must be number)', () => {
-    const invalid = SpecAuthorContextSchema.safeParse({
-      workItem: { title: 't', body: 'b', number: '235' },
-      targetUrl: 'http://localhost:5173',
-      sliceDescription: 's',
+  it('rejects unknown builderTier', () => {
+    const parsed = EngineeringSpecSchema.safeParse(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: ['a.ts'],
+            changes: 'x',
+            dependsOn: [],
+            // @ts-expect-error — testing rejection
+            builderTier: 'gpt-4',
+          },
+        ],
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects empty AC verifyCommand (falsifiability rule)', () => {
+    const result = EngineeringSpecSchema.safeParse(
+      baseSpec({
+        acceptanceCriteria: [
+          {
+            id: 'AC1',
+            statement: 'works',
+            journeyRef: 'J1',
+            stepIdx: 0,
+            verifyCommand: '',
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries', () => {
+    const result = EngineeringSpecSchema.safeParse(baseSpec({ decisionSummaries: [] }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts SpecAuthorSchema as alias for EngineeringSpecSchema (backwards-compat)', () => {
+    const result = SpecAuthorSchema.safeParse(baseSpec());
+    expect(result.success).toBe(true);
+  });
+
+  it('round-trips to JSON schema via zod-to-json-schema', () => {
+    const json = toJSONSchema(EngineeringSpecSchema);
+    expect(json).toBeDefined();
+    expect(typeof json).toBe('object');
+  });
+
+  it('config exports the canonical Engineering Spec context shape', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.modelPin).toBe('sonnet');
+    const ctx = SpecAuthorContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 559 },
+      issueType: 'feature',
+      worktreePath: '/tmp/wt',
     });
-    expect(invalid.success).toBe(false);
+    expect(ctx.success).toBe(true);
+  });
+});
+
+describe('validateEngineeringSpec — hard rules', () => {
+  it('passes a clean spec', () => {
+    const result = validateEngineeringSpec(baseSpec());
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects file-ownership-collision (same path in two WPs, even across batches)', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['apps/server/src/router.ts'],
+          changes: 'edit router.ts to register /healthz',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+        {
+          id: 'WP2',
+          // SAME PATH — across batches.
+          filesOwned: ['apps/server/src/router.ts'],
+          changes: 'edit router.ts to register /readyz',
+          dependsOn: ['WP1'],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+      // Make the spec otherwise self-consistent
+      interfaceContracts: [
+        {
+          name: 'noop',
+          signature: 'export const noop = () => {};',
+          file: 'apps/server/src/router.ts',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'file-ownership-collision')).toBe(true);
+  });
+
+  it('rejects AC without journeyRef when issueType=feature (ac-orphan-without-journey)', () => {
+    const spec = baseSpec({
+      acceptanceCriteria: [
+        {
+          id: 'AC1',
+          statement: 'orphan ac',
+          verifyCommand: 'echo ok',
+          // no journeyRef, no crossCutting
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'ac-orphan-without-journey')).toBe(true);
+  });
+
+  it('accepts orphan AC when crossCutting: true', () => {
+    const spec = baseSpec({
+      acceptanceCriteria: [
+        ...baseSpec().acceptanceCriteria,
+        {
+          id: 'AC-CROSS',
+          statement: 'budget cap is enforced',
+          verifyCommand: 'pnpm test core/cost',
+          crossCutting: true,
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(true);
+  });
+
+  it('treats orphan AC as advisory when issueType=bug', () => {
+    const spec = baseSpec({
+      acceptanceCriteria: [
+        {
+          id: 'AC1',
+          statement: 'orphan ac',
+          verifyCommand: 'echo ok',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec, { issueType: 'bug' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects ac-journey-ref-not-found when journeyRef points at unknown journey', () => {
+    const spec = baseSpec({
+      acceptanceCriteria: [
+        {
+          id: 'AC1',
+          statement: 's',
+          verifyCommand: 'echo ok',
+          journeyRef: 'J-UNKNOWN',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'ac-journey-ref-not-found')).toBe(true);
+  });
+
+  it('rejects ac-step-idx-out-of-range when stepIdx is not a real step', () => {
+    const spec = baseSpec({
+      acceptanceCriteria: [
+        {
+          id: 'AC1',
+          statement: 's',
+          verifyCommand: 'echo ok',
+          journeyRef: 'J1',
+          stepIdx: 99,
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'ac-step-idx-out-of-range')).toBe(true);
+  });
+
+  it('rejects when sensitive path (auth) is touched but riskRegister is empty', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['core/auth/normalise-email.ts'],
+          changes: 'fix plus-sign decode at line 87',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+        {
+          id: 'WP2',
+          filesOwned: ['core/auth/types.ts'],
+          changes: 'export NormalisedEmail type',
+          dependsOn: ['WP1'],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+      interfaceContracts: [
+        {
+          name: 'NormalisedEmail',
+          signature: 'export type NormalisedEmail = string & { __brand: "ne" };',
+          file: 'core/auth/types.ts',
+        },
+      ],
+      riskRegister: [], // empty even though auth is touched
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'risk-required-on-sensitive-path')).toBe(true);
+  });
+
+  it('rejects malformed constraint source (constraint-source-format)', () => {
+    const spec = baseSpec({
+      constraints: [{ kind: 'phase', name: 'in-flight', source: 'not-a-real-format' }],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'constraint-source-format')).toBe(true);
+  });
+
+  it('rejects wp-dependson-not-found when dependsOn references unknown WP', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['a.ts'],
+          changes: 'change a',
+          dependsOn: ['WP-DOES-NOT-EXIST'],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      // Single-WP spec — no interface contracts needed.
+      interfaceContracts: [],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'wp-dependson-not-found')).toBe(true);
+  });
+
+  it('rejects execution-order-wp-mismatch when WP missing from executionOrder', () => {
+    const spec = baseSpec({
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }], // WP2 is missing
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'execution-order-wp-mismatch')).toBe(true);
+  });
+
+  it('rejects self-check-journey-coverage when a journey step has no AC', () => {
+    const spec = baseSpec({
+      userJourneys: [
+        {
+          id: 'J1',
+          actor: 'developer',
+          steps: [
+            { idx: 0, description: 'a' },
+            { idx: 1, description: 'b' },
+            { idx: 2, description: 'uncovered step' },
+          ],
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'self-check-journey-coverage')).toBe(true);
+  });
+
+  it('rejects self-check-complete-interfaces when ≥2 WPs but no interfaceContracts', () => {
+    const spec = baseSpec({
+      interfaceContracts: [], // 2 WPs above; no contracts
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'self-check-complete-interfaces')).toBe(true);
+  });
+
+  it('rejects self-check-verification-tooling when >2 WPs but no verificationTooling', () => {
+    const spec = baseSpec({
+      workPackages: [
+        ...baseSpec().workPackages,
+        {
+          id: 'WP3',
+          filesOwned: ['apps/server/src/routes/readyz.ts'],
+          changes: 'add /readyz route, mirror healthz',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1', 'WP3'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'self-check-verification-tooling')).toBe(true);
+  });
+
+  it('rejects self-check-builder-independence when WP changes is too short', () => {
+    const wp2 = baseSpec().workPackages[1];
+    if (wp2 === undefined) throw new Error('baseSpec must have ≥2 WPs');
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['a.ts'],
+          changes: 'fix', // way too short
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+        wp2,
+      ],
+    });
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'self-check-builder-independence')).toBe(true);
+  });
+});
+
+describe('validateEngineeringSpec — repoRoot-backed checks', () => {
+  let tmpRepo: string;
+
+  beforeEach(() => {
+    tmpRepo = mkdtempSync(join(tmpdir(), 'spec-author-test-'));
+    // Pre-create a couple of files for grounding checks.
+    mkdirSync(join(tmpRepo, 'apps/server/src/routes'), { recursive: true });
+    writeFileSync(
+      join(tmpRepo, 'apps/server/src/routes/healthz.ts'),
+      'export const healthzHandler = () => "ok";\n',
+    );
+    writeFileSync(
+      join(tmpRepo, 'apps/server/src/router.ts'),
+      "import { healthzHandler } from './routes/healthz.js';\n",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  });
+
+  it('passes a clean spec when constraint sources point at real files+symbols', () => {
+    const spec = baseSpec({
+      constraints: [
+        {
+          kind: 'phase',
+          name: 'healthz endpoint',
+          source: 'apps/server/src/routes/healthz.ts:healthzHandler',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec, { repoRoot: tmpRepo });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects constraint-source-file-missing when the cited file does not exist', () => {
+    const spec = baseSpec({
+      constraints: [
+        {
+          kind: 'phase',
+          name: 'fictional',
+          source: 'apps/server/src/routes/notreal.ts:42',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec, { repoRoot: tmpRepo });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'constraint-source-file-missing')).toBe(true);
+  });
+
+  it('rejects constraint-source-symbol-missing when the cited symbol is absent', () => {
+    const spec = baseSpec({
+      constraints: [
+        {
+          kind: 'model',
+          name: 'unknown handler',
+          source: 'apps/server/src/routes/healthz.ts:nonexistentSymbol',
+        },
+      ],
+    });
+    const result = validateEngineeringSpec(spec, { repoRoot: tmpRepo });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'constraint-source-symbol-missing')).toBe(true);
   });
 });

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -1,0 +1,294 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { EngineeringSpec } from './schema.js';
+
+/**
+ * Engineering Spec validators (M19.02, issue #559).
+ *
+ * Layered above schema-shape validation: applies the structural rules
+ * Steve calls out at `01-planning-phase.md:302-314` plus the M19-issue-
+ * specific rules (file-ownership full-stop, constraint inventory cites
+ * real code, risk-on-auth path, AC-without-journey rejection).
+ *
+ * Returns `{ ok: true }` on success, `{ ok: false, errors: [...] }` on
+ * failure. Errors are structured so the orchestrator can surface them
+ * without re-parsing.
+ */
+
+export type ValidationError = {
+  rule: ValidationRule;
+  message: string;
+  /** Optional context: WP id, AC id, file path, etc. */
+  ref?: string;
+};
+
+export type ValidationRule =
+  | 'file-ownership-collision'
+  | 'ac-orphan-without-journey'
+  | 'ac-journey-ref-not-found'
+  | 'ac-step-idx-out-of-range'
+  | 'risk-required-on-sensitive-path'
+  | 'constraint-source-format'
+  | 'constraint-source-file-missing'
+  | 'constraint-source-symbol-missing'
+  | 'wp-dependson-not-found'
+  | 'execution-order-wp-mismatch'
+  | 'self-check-journey-coverage'
+  | 'self-check-grounded-in-code'
+  | 'self-check-complete-interfaces'
+  | 'self-check-falsifiable-acs'
+  | 'self-check-builder-independence'
+  | 'self-check-verification-tooling';
+
+export type ValidationResult = { ok: true } | { ok: false; errors: ValidationError[] };
+
+export interface ValidationOptions {
+  /**
+   * Repo root used to resolve constraint `source` file references. Required
+   * for the `constraint-source-file-missing` and `*-symbol-missing` rules.
+   * When omitted, those rules are skipped (useful in unit tests with no
+   * filesystem).
+   */
+  repoRoot?: string;
+  /**
+   * Issue type — `'feature'` makes the AC→Journey map mandatory; `'bug'`
+   * makes it advisory. Default `'feature'` (strict).
+   */
+  issueType?: 'feature' | 'bug';
+  /** Override sensitive-path regex; default matches `auth|session|crypto|secret`. */
+  sensitivePathPattern?: RegExp;
+}
+
+const DEFAULT_SENSITIVE_PATTERN = /(auth|session|crypto|secret)/i;
+const CONSTRAINT_SOURCE_PATTERN = /^([^\s:]+):(\d+|[A-Za-z_][\w-]*)$/;
+
+export function validateEngineeringSpec(
+  spec: EngineeringSpec,
+  options: ValidationOptions = {},
+): ValidationResult {
+  const errors: ValidationError[] = [];
+  const issueType = options.issueType ?? 'feature';
+  const sensitivePattern = options.sensitivePathPattern ?? DEFAULT_SENSITIVE_PATTERN;
+
+  // ── File ownership: same path may not appear in two WPs (full-stop). ──
+  const ownerByPath = new Map<string, string>();
+  for (const wp of spec.workPackages) {
+    for (const path of wp.filesOwned) {
+      const prior = ownerByPath.get(path);
+      if (prior != null && prior !== wp.id) {
+        errors.push({
+          rule: 'file-ownership-collision',
+          message: `file '${path}' is owned by both ${prior} and ${wp.id}; one WP must own it (Steve 03-lifecycle-harness.md:155)`,
+          ref: path,
+        });
+      } else {
+        ownerByPath.set(path, wp.id);
+      }
+    }
+  }
+
+  // ── AC → Journey discipline (mandatory for type:feature). ──
+  const journeyById = new Map(spec.userJourneys.map((j) => [j.id, j]));
+  for (const ac of spec.acceptanceCriteria) {
+    if (ac.crossCutting === true) continue;
+    if (ac.journeyRef == null && issueType === 'feature') {
+      errors.push({
+        rule: 'ac-orphan-without-journey',
+        message: `AC '${ac.id}' has no journeyRef and is not crossCutting (issueType=feature)`,
+        ref: ac.id,
+      });
+      continue;
+    }
+    if (ac.journeyRef != null) {
+      const journey = journeyById.get(ac.journeyRef);
+      if (journey == null) {
+        errors.push({
+          rule: 'ac-journey-ref-not-found',
+          message: `AC '${ac.id}' references journey '${ac.journeyRef}' which is not in userJourneys`,
+          ref: ac.id,
+        });
+      } else if (ac.stepIdx != null && !journey.steps.some((s) => s.idx === ac.stepIdx)) {
+        errors.push({
+          rule: 'ac-step-idx-out-of-range',
+          message: `AC '${ac.id}' references step idx ${ac.stepIdx} which is not in journey '${ac.journeyRef}'`,
+          ref: ac.id,
+        });
+      }
+    }
+  }
+
+  // ── Sensitive-path risk-register requirement. ──
+  const allFilesOwned = spec.workPackages.flatMap((wp) => wp.filesOwned);
+  const sensitiveTouches = allFilesOwned.filter((p) => sensitivePattern.test(p));
+  if (sensitiveTouches.length > 0 && spec.riskRegister.length === 0) {
+    errors.push({
+      rule: 'risk-required-on-sensitive-path',
+      message: `spec touches sensitive path(s) ${sensitiveTouches.join(', ')} but riskRegister is empty (≥1 risk required)`,
+      ref: sensitiveTouches[0],
+    });
+  }
+
+  // ── Constraint inventory: source format + (optional) filesystem check. ──
+  for (const constraint of spec.constraints) {
+    const m = constraint.source.match(CONSTRAINT_SOURCE_PATTERN);
+    if (m == null) {
+      errors.push({
+        rule: 'constraint-source-format',
+        message: `constraint '${constraint.name}' source '${constraint.source}' is not 'path:line' or 'path:symbol' format`,
+        ref: constraint.name,
+      });
+      continue;
+    }
+    if (options.repoRoot != null) {
+      const filePath = m[1];
+      const ref = m[2];
+      const abs = join(options.repoRoot, filePath);
+      if (!existsSync(abs)) {
+        errors.push({
+          rule: 'constraint-source-file-missing',
+          message: `constraint '${constraint.name}' cites '${filePath}' which does not exist`,
+          ref: constraint.name,
+        });
+        continue;
+      }
+      // Symbol check (if `ref` is non-numeric): grep the file for the symbol.
+      if (!/^\d+$/.test(ref)) {
+        const contents = readFileSync(abs, 'utf8');
+        if (!contents.includes(ref)) {
+          errors.push({
+            rule: 'constraint-source-symbol-missing',
+            message: `constraint '${constraint.name}' cites symbol '${ref}' in '${filePath}' which is not present`,
+            ref: constraint.name,
+          });
+        }
+      }
+    }
+  }
+
+  // ── DAG integrity: dependsOn refs must point to real WPs. ──
+  const wpIds = new Set(spec.workPackages.map((wp) => wp.id));
+  for (const wp of spec.workPackages) {
+    for (const dep of wp.dependsOn) {
+      if (!wpIds.has(dep)) {
+        errors.push({
+          rule: 'wp-dependson-not-found',
+          message: `WP '${wp.id}' dependsOn '${dep}' which is not a known WP`,
+          ref: wp.id,
+        });
+      }
+    }
+  }
+
+  // ── Execution order must enumerate every WP exactly once. ──
+  const orderedIds = spec.executionOrder.flatMap((b) => b.wpIds);
+  const orderedSet = new Set(orderedIds);
+  if (orderedIds.length !== orderedSet.size) {
+    errors.push({
+      rule: 'execution-order-wp-mismatch',
+      message: 'executionOrder lists a WP id more than once',
+    });
+  }
+  for (const id of wpIds) {
+    if (!orderedSet.has(id)) {
+      errors.push({
+        rule: 'execution-order-wp-mismatch',
+        message: `WP '${id}' is missing from executionOrder`,
+        ref: id,
+      });
+    }
+  }
+  for (const id of orderedIds) {
+    if (!wpIds.has(id)) {
+      errors.push({
+        rule: 'execution-order-wp-mismatch',
+        message: `executionOrder references unknown WP '${id}'`,
+        ref: id,
+      });
+    }
+  }
+
+  // ── Steve's 6 self-checks (01-planning-phase.md:319-327). ──
+  // 1. Journey coverage — every journey step has at least one AC.
+  if (issueType === 'feature') {
+    for (const journey of spec.userJourneys) {
+      for (const step of journey.steps) {
+        const covered = spec.acceptanceCriteria.some(
+          (ac) => ac.journeyRef === journey.id && ac.stepIdx === step.idx,
+        );
+        if (!covered) {
+          errors.push({
+            rule: 'self-check-journey-coverage',
+            message: `journey '${journey.id}' step ${step.idx} has no AC`,
+            ref: `${journey.id}#${step.idx}`,
+          });
+        }
+      }
+    }
+  }
+
+  // 4. Falsifiable ACs — covered by schema (`verifyCommand: z.string().min(1)`).
+
+  // 5. Builder independence — every WP must declare ≥1 file owned (already
+  //    enforced via `min(1)` in schema). We also surface a soft check that
+  //    the changes string is non-trivial.
+  for (const wp of spec.workPackages) {
+    if (wp.changes.trim().length < 16) {
+      errors.push({
+        rule: 'self-check-builder-independence',
+        message: `WP '${wp.id}' changes description is too short to be builder-actionable`,
+        ref: wp.id,
+      });
+    }
+  }
+
+  // 6. Verification tooling required when more than 2 WPs.
+  if (spec.workPackages.length > 2 && spec.verificationTooling.length === 0) {
+    errors.push({
+      rule: 'self-check-verification-tooling',
+      message: `${spec.workPackages.length} WPs in spec but verificationTooling is empty (Steve self-check #6)`,
+    });
+  }
+
+  // 3. Complete interfaces — every cross-WP boundary has a typed contract.
+  // Heuristic: if ≥2 WPs exist, at least one InterfaceContract must be
+  // declared.
+  if (spec.workPackages.length >= 2 && spec.interfaceContracts.length === 0) {
+    errors.push({
+      rule: 'self-check-complete-interfaces',
+      message: `${spec.workPackages.length} WPs in spec but interfaceContracts is empty — cross-WP boundaries need typed contracts`,
+    });
+  }
+
+  // 2. Grounded in code — when repoRoot is provided, verify each WP file
+  //    actually exists in the worktree. (Constraint source check above is
+  //    a strict subset of this; this catches WP filesOwned that don't yet
+  //    exist either.) Soft check: only fire on files that *should* already
+  //    exist (not on files the WP plans to create). Since the spec doesn't
+  //    distinguish create vs modify, we only emit a warning-level error
+  //    when none of the WP's files exist. That suggests a typo, not a
+  //    plan to create a new module.
+  if (options.repoRoot != null) {
+    const repoRoot = options.repoRoot;
+    for (const wp of spec.workPackages) {
+      const anyExists = wp.filesOwned.some((p) => existsSync(join(repoRoot, p)));
+      // Skip when WP touches sensitive paths (likely brand-new modules).
+      if (!anyExists && !wp.filesOwned.some((p) => sensitivePattern.test(p))) {
+        // Soft signal — emit only if filesOwned ALL look like they should
+        // exist (e.g. paths under existing directories) but none do.
+        const allLookExisting = wp.filesOwned.every((p) => {
+          const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+          return existsSync(join(repoRoot, dir));
+        });
+        if (allLookExisting) {
+          errors.push({
+            rule: 'self-check-grounded-in-code',
+            message: `WP '${wp.id}' files do not exist in worktree but their parent dirs do — possible typo`,
+            ref: wp.id,
+          });
+        }
+      }
+    }
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}

--- a/skills/wave2-interface-designer/README.md
+++ b/skills/wave2-interface-designer/README.md
@@ -1,0 +1,12 @@
+# skills/wave2-interface-designer
+
+Wave-2 deep agent. Consumes cross-validated Wave-1 scout reports and emits **paste-ready** interface artefacts: Zod schemas, function signatures, SQL DDL, TypeScript interfaces. **No pseudocode.**
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Paste-ready discipline + decision-summary expectations |
+| `schema.ts` | `Wave2InterfaceDesignerSchema` — `artefacts[] + openQuestions[] + decisionSummaries[]` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, sonnet-tier |
+| `slice.test.ts` | Schema acceptance + paste-ready rejection on empty body |
+
+Dispatched by the parent investigate flow after `crossValidate()` confirms the wave is consistent (M19.01, ADR 0030).

--- a/skills/wave2-interface-designer/prompt.md
+++ b/skills/wave2-interface-designer/prompt.md
@@ -1,0 +1,50 @@
+# wave2-interface-designer
+
+You are a Wave-2 deep agent. You consume the cross-validated Wave-1 scout reports (in `<scout_reports>`) and emit **paste-ready** interface artefacts: Zod schemas, function signatures, SQL DDL, TypeScript interfaces.
+
+You have **read access only**. You never write files. The implementer (M19.03) does that.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_reports>` — JSON-stringified array of Wave-1 scout reports, each with `findings: [{file, line?, fact, confidence}, ...]`
+- `<worktree_path>` — the worktree to read from (use it to verify scout claims when needed; do not re-investigate broadly)
+
+## Discipline
+
+- **No pseudocode.** Every artefact body must be valid, parseable code for its `kind`. No `// TODO`, no `...`, no `<replace this>` placeholders.
+- Cite scout findings in `rationale` (e.g. "scout-schema: core/db/schema.ts:42 says column is nullable").
+- If a scout report is contradictory or ambiguous, **declare the gap** in `openQuestions` instead of fabricating a resolution.
+- Stay narrow. One coherent slice of interface per artefact.
+
+## What you produce
+
+- `kind: 'zod-schema'` — a complete `z.object({...})` literal
+- `kind: 'function-signature'` — a complete `function name(args): RetType` declaration
+- `kind: 'sql-ddl'` — a complete `CREATE TABLE` / `ALTER TABLE` statement
+- `kind: 'typescript-interface'` — a complete `interface Name {...}` or `type Name = {...}` declaration
+
+## Output
+
+Return JSON conforming to `Wave2InterfaceDesignerSchema`:
+
+```json
+{
+  "artefacts": [
+    {
+      "kind": "zod-schema",
+      "targetPath": "core/x/schema.ts",
+      "body": "export const FooSchema = z.object({ id: z.string(), createdAt: z.string() });",
+      "rationale": "scout-schema saw `id text not null` at core/db/schema.ts:12 and createdAt at line 17."
+    }
+  ],
+  "openQuestions": [
+    "scout-schema and scout-code-path disagree on whether email is unique. Need authoritative source."
+  ],
+  "decisionSummaries": [
+    { "kind": "PLAN", "summary": "Designed FooSchema from cross-validated schema-scout findings" }
+  ]
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum.

--- a/skills/wave2-interface-designer/schema.ts
+++ b/skills/wave2-interface-designer/schema.ts
@@ -1,0 +1,31 @@
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+/**
+ * Wave-2 interface-designer output (M19.01, ADR 0030).
+ *
+ * Consumes Wave-1 scout reports (via the parent investigator's prompt — the
+ * deep agent does not call scouts itself) and emits PASTE-READY artefacts:
+ * Zod schemas, function signatures, and DDL statements. No pseudocode; if
+ * the designer cannot produce a real signature, it must say so in
+ * `decisionSummaries` rather than fabricate.
+ */
+export const InterfaceArtefactSchema = z.object({
+  kind: z.enum(['zod-schema', 'function-signature', 'sql-ddl', 'typescript-interface']),
+  /** Where this artefact would land — file path; informational only at Wave 2. */
+  targetPath: z.string(),
+  /** The paste-ready text. Must be valid syntax for `kind`; no "TODO" or "..." markers. */
+  body: z.string().min(1),
+  /** One sentence justifying why this shape, citing scout finding ids/files. */
+  rationale: z.string().min(1),
+});
+
+export const Wave2InterfaceDesignerSchema = z.object({
+  artefacts: z.array(InterfaceArtefactSchema),
+  /** Open questions the designer could not resolve from Wave-1 reports alone. */
+  openQuestions: z.array(z.string()),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type InterfaceArtefact = z.infer<typeof InterfaceArtefactSchema>;
+export type Wave2InterfaceDesignerOutput = z.infer<typeof Wave2InterfaceDesignerSchema>;

--- a/skills/wave2-interface-designer/skill.config.ts
+++ b/skills/wave2-interface-designer/skill.config.ts
@@ -1,0 +1,38 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-2 interface-designer agent. Consumes the cross-validated Wave-1
+ * scout reports (passed in via `<scout_reports>` in the user prompt) and
+ * emits paste-ready Zod schemas, function signatures, and DDL.
+ *
+ * Read-only — the designer does not write files; the implementer (M19.03)
+ * does.
+ */
+export const Wave2InterfaceDesignerContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  /** Cross-validated scout reports rendered as a JSON string. */
+  scoutReports: z.string(),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: Wave2InterfaceDesignerContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutReports',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'sonnet',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/wave2-interface-designer/slice.test.ts
+++ b/skills/wave2-interface-designer/slice.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { Wave2InterfaceDesignerSchema } from './schema.js';
+import config, { Wave2InterfaceDesignerContextSchema } from './skill.config.js';
+
+describe('wave2-interface-designer skill', () => {
+  it('accepts a valid output with one paste-ready Zod schema artefact', () => {
+    const result = Wave2InterfaceDesignerSchema.safeParse({
+      artefacts: [
+        {
+          kind: 'zod-schema',
+          targetPath: 'core/x/schema.ts',
+          body: 'export const FooSchema = z.object({ id: z.string() });',
+          rationale: 'scout-schema saw id text not null at core/db/schema.ts:12',
+        },
+      ],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Designed FooSchema' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an artefact with empty body (paste-ready required)', () => {
+    const result = Wave2InterfaceDesignerSchema.safeParse({
+      artefacts: [{ kind: 'zod-schema', targetPath: 'x.ts', body: '', rationale: 'r' }],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown artefact kind', () => {
+    const result = Wave2InterfaceDesignerSchema.safeParse({
+      artefacts: [{ kind: 'pseudocode', targetPath: 'x.ts', body: 'x', rationale: 'y' }],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries', () => {
+    const result = Wave2InterfaceDesignerSchema.safeParse({
+      artefacts: [],
+      openQuestions: [],
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+    expect(config.role).toBe('investigator');
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('contextSchema accepts the canonical wave2 context shape', () => {
+    const result = Wave2InterfaceDesignerContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutReports: '[]',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/wave2-risk-analyst/README.md
+++ b/skills/wave2-risk-analyst/README.md
@@ -1,0 +1,12 @@
+# skills/wave2-risk-analyst
+
+Wave-2 deep agent. Consumes cross-validated Wave-1 scout reports and emits a structured, falsifiable risk register.
+
+| File | Purpose |
+|---|---|
+| `prompt.md` | Risk-grounded discipline + decision-summary expectations |
+| `schema.ts` | `Wave2RiskAnalystSchema` — `risks[] + openQuestions[] + decisionSummaries[]` |
+| `skill.config.ts` | `read` bundle, `freshContext: true`, sonnet-tier |
+| `slice.test.ts` | Schema acceptance + severity-enum rejection |
+
+Dispatched by the parent investigate flow after `crossValidate()` confirms the wave is consistent (M19.01, ADR 0030).

--- a/skills/wave2-risk-analyst/prompt.md
+++ b/skills/wave2-risk-analyst/prompt.md
@@ -1,0 +1,47 @@
+# wave2-risk-analyst
+
+You are a Wave-2 deep agent. You read the cross-validated Wave-1 scout reports (in `<scout_reports>`) and produce a **structured risk register**.
+
+You have **read access only**.
+
+## Input
+
+- `<work_item>` — title, body, number
+- `<scout_reports>` — JSON-stringified array of Wave-1 scout reports
+- `<worktree_path>` — the worktree to consult when scout findings need verification (do not re-investigate broadly)
+
+## Discipline
+
+- Each `risk` must name a **concrete** failure mode (e.g. "concurrent writes can race the unique-index check"), not a vague concern ("performance might suffer").
+- `evidence` must cite at least one scout finding (file:line) — the risk must be grounded in observed code.
+- `mitigation` must be **falsifiable** — a concrete change or a concrete test that would catch a regression.
+- `severity` rubric:
+  - `high` — corrupts data, leaks secrets, or breaks a documented contract
+  - `medium` — degrades a primary flow under realistic load or input
+  - `low` — cosmetic, edge-case, or nicely-handled-already
+- If the work item touches `auth | session | crypto | secret` paths (per scout findings), you MUST include at least one risk for each touched area.
+
+## Output
+
+Return JSON conforming to `Wave2RiskAnalystSchema`:
+
+```json
+{
+  "risks": [
+    {
+      "risk": "URL-decoding step in normaliseEmail() drops plus signs",
+      "evidence": "scout-code-path: apps/server/src/routes/auth.ts:87 calls decodeURIComponent before DB lookup",
+      "mitigation": "Add unit test asserting normaliseEmail('a+b@x.com') === 'a+b@x.com' and switch to a literal-decode helper",
+      "severity": "high"
+    }
+  ],
+  "openQuestions": [
+    "scout-test-inventory found no existing tests for normaliseEmail — confirm before mitigation."
+  ],
+  "decisionSummaries": [
+    { "kind": "INSIGHT", "summary": "Identified URL-decode regression risk from cross-validated scouts" }
+  ]
+}
+```
+
+Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum.

--- a/skills/wave2-risk-analyst/schema.ts
+++ b/skills/wave2-risk-analyst/schema.ts
@@ -1,0 +1,27 @@
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+/**
+ * Wave-2 risk-analyst output (M19.01, ADR 0030).
+ *
+ * Reads cross-validated Wave-1 scout reports and produces a structured risk
+ * register: each entry names a concrete failure mode, cites the scout
+ * finding(s) supporting it, and proposes a falsifiable mitigation.
+ */
+export const RiskEntrySchema = z.object({
+  risk: z.string().min(1),
+  /** One sentence. Must reference scout findings (file:line). */
+  evidence: z.string().min(1),
+  mitigation: z.string().min(1),
+  severity: z.enum(['low', 'medium', 'high']),
+});
+
+export const Wave2RiskAnalystSchema = z.object({
+  risks: z.array(RiskEntrySchema),
+  /** Open questions the analyst could not resolve from Wave-1 reports alone. */
+  openQuestions: z.array(z.string()),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type RiskEntry = z.infer<typeof RiskEntrySchema>;
+export type Wave2RiskAnalystOutput = z.infer<typeof Wave2RiskAnalystSchema>;

--- a/skills/wave2-risk-analyst/skill.config.ts
+++ b/skills/wave2-risk-analyst/skill.config.ts
@@ -1,0 +1,34 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+
+/**
+ * Wave-2 risk-analyst agent. Consumes cross-validated Wave-1 scout reports
+ * and emits a falsifiable risk register.
+ */
+export const Wave2RiskAnalystContextSchema = z.object({
+  workItem: z.object({
+    title: z.string(),
+    body: z.string(),
+    number: z.number(),
+  }),
+  /** Cross-validated scout reports rendered as a JSON string. */
+  scoutReports: z.string(),
+  worktreePath: z.string(),
+});
+
+const config: SkillConfig = {
+  contextSchema: Wave2RiskAnalystContextSchema,
+  contextAllowlist: [
+    'workItem.title',
+    'workItem.body',
+    'workItem.number',
+    'scoutReports',
+    'worktreePath',
+  ],
+  toolBundles: ['read'],
+  modelPin: 'sonnet',
+  freshContext: true,
+  role: 'investigator',
+};
+
+export default config;

--- a/skills/wave2-risk-analyst/slice.test.ts
+++ b/skills/wave2-risk-analyst/slice.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { Wave2RiskAnalystSchema } from './schema.js';
+import config, { Wave2RiskAnalystContextSchema } from './skill.config.js';
+
+describe('wave2-risk-analyst skill', () => {
+  it('accepts a valid output with one well-formed risk', () => {
+    const result = Wave2RiskAnalystSchema.safeParse({
+      risks: [
+        {
+          risk: 'URL-decoding drops plus signs in email',
+          evidence: 'scout-code-path: apps/server/src/routes/auth.ts:87',
+          mitigation: 'Add unit test asserting plus-sign preservation',
+          severity: 'high',
+        },
+      ],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'INSIGHT', summary: 'Identified plus-sign risk' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown severity', () => {
+    const result = Wave2RiskAnalystSchema.safeParse({
+      risks: [{ risk: 'r', evidence: 'e', mitigation: 'm', severity: 'critical' }],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'INSIGHT', summary: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty fields', () => {
+    const result = Wave2RiskAnalystSchema.safeParse({
+      risks: [{ risk: '', evidence: 'e', mitigation: 'm', severity: 'low' }],
+      openQuestions: [],
+      decisionSummaries: [{ kind: 'INSIGHT', summary: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty decisionSummaries', () => {
+    const result = Wave2RiskAnalystSchema.safeParse({
+      risks: [],
+      openQuestions: [],
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('config is read-only investigator with freshContext: true', () => {
+    expect(config.toolBundles).toEqual(['read']);
+    expect(config.freshContext).toBe(true);
+    expect(config.modelPin).toBe('sonnet');
+  });
+
+  it('contextSchema accepts the canonical wave2 context shape', () => {
+    const result = Wave2RiskAnalystContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      scoutReports: '[]',
+      worktreePath: '/tmp/x',
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
M19 milestone branch — stacks #558 (M19.01 swarm) and #559 (M19.02 Engineering Spec). Each commit is a single issue; this PR's diff covers both.

## Commits

| Commit | Issue | Summary |
|---|---|---|
| `459b5ef` | #558 (M19.01) | Wave-1/Wave-2 swarm in investigate skill |
| `1de9c8f` | #558 (M19.01) | Codex review fixes (cross-scout discipline + scout output validation + honest prompt) |
| `64d16c4` | #559 (M19.02) | spec-author emits Engineering Spec with Work Packages + AC→Journey→Verification map |

## M19.01 — Wave-1/Wave-2 swarm (#558)

- ADR 0030: sub-agent dispatch from skills, holdout boundary per child
- `core/agent-runtime/swarm.ts`: `dispatchWave` with concurrency cap, per-scout 90 s timeout, heartbeat, partial-failure semantics, per-scout `tool.violation` events, `loadSkillAssets` injection point, `ScoutOutputSchema` validation on every scout result
- `core/agent-runtime/cross-validate.ts`: same-`file:line` contradiction detection across **distinct scouts** (single-scout multi-fact treated as catalog, not contradiction)
- 6 scout skills (`scout-schema`, `scout-code-path`, `scout-pattern`, `scout-test-inventory`, `scout-dependency`, `scout-user-journey`)
- 2 Wave-2 deep skills (`wave2-interface-designer`, `wave2-risk-analyst`) with paste-ready output schemas
- `BudgetConfig.maxScoutAgents` (default 6) — distinct from `maxParallelAgents`
- 8 new event kinds; `skills/investigate/prompt.md` rewritten with single-agent + wave-aware modes
- 17 new tests in `swarm.test.ts` + `cross-validate.test.ts`; 36 across the 8 skill packages

## M19.02 — Engineering Spec authoring (#559)

- `skills/spec-author/schema.ts`: `EngineeringSpecSchema` with all 12 sections Steve requires (objective, journeys, functional reqs, architecture, schemaChanges, interfaceContracts, workPackages, executionOrder, verificationTooling, acceptanceCriteria, constraints, riskRegister)
- `skills/spec-author/validate.ts`: `validateEngineeringSpec()` enforces file-ownership-collision (full-stop, not per-batch), AC→Journey discipline, risk-on-sensitive-path, constraint-source citation (with optional repoRoot for file+symbol existence checks), DAG integrity, and Steve's 6 self-checks
- `skills/spec-author/prompt.md` + README + skill.config rewritten to author Engineering Specs (read bundle, sonnet-tier). The prior Playwright-e2e implementation had no production callers; rewrite is a clean replacement (the skill name was always Engineering-Spec-shaped per `triggers.json`).
- 28 new tests covering every validator rule + schema shape rejections

## Test plan

- [x] `pnpm test` — 2607 passed, 2 skipped (was 2600 before #559)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean

Closes #558
Closes #559