### PR TITLE
feat: milestone management — CRUD and sprint-review eligibility in settings

### DIFF
--- a/apps/server/src/domains/milestones/router.test.ts
+++ b/apps/server/src/domains/milestones/router.test.ts
@@ -421,7 +421,11 @@ describe('DELETE /projects/:slug/milestones/:number', () => {
   });
 
   it('returns 409 when milestone has issues', async () => {
-    mockDeleteMilestone.mockResolvedValue({ ok: false, error: 'milestone has issues', status: 409 });
+    mockDeleteMilestone.mockResolvedValue({
+      ok: false,
+      error: 'milestone has issues',
+      status: 409,
+    });
     const app = makeApp();
     const res = await app.request('/projects/my-proj/milestones/14', { method: 'DELETE' });
     expect(res.status).toBe(409);

--- a/apps/server/src/domains/milestones/router.test.ts
+++ b/apps/server/src/domains/milestones/router.test.ts
@@ -10,6 +10,10 @@ const {
   mockGetActiveMilestone,
   mockSetActiveMilestone,
   mockTriggerSprintReview,
+  mockCreateMilestone,
+  mockUpdateMilestone,
+  mockDeleteMilestone,
+  mockGetSprintReviewEligibility,
 } = vi.hoisted(() => ({
   mockListMilestones: vi.fn(),
   mockListMilestoneIssues: vi.fn(),
@@ -17,6 +21,10 @@ const {
   mockGetActiveMilestone: vi.fn(),
   mockSetActiveMilestone: vi.fn(),
   mockTriggerSprintReview: vi.fn(),
+  mockCreateMilestone: vi.fn(),
+  mockUpdateMilestone: vi.fn(),
+  mockDeleteMilestone: vi.fn(),
+  mockGetSprintReviewEligibility: vi.fn(),
 }));
 
 vi.mock('./service.js', () => ({
@@ -26,6 +34,10 @@ vi.mock('./service.js', () => ({
   getActiveMilestone: mockGetActiveMilestone,
   setActiveMilestone: mockSetActiveMilestone,
   triggerSprintReview: mockTriggerSprintReview,
+  createMilestone: mockCreateMilestone,
+  updateMilestone: mockUpdateMilestone,
+  deleteMilestone: mockDeleteMilestone,
+  getSprintReviewEligibility: mockGetSprintReviewEligibility,
 }));
 
 vi.mock('@goose-hub/core/logger.js', () => ({
@@ -340,5 +352,97 @@ describe('POST /projects/:slug/milestones/:title/sprint-review', () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('project not found');
+  });
+});
+
+describe('POST /projects/:slug/milestones', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 201 with created milestone', async () => {
+    const milestone = { id: '14', number: 14, title: 'M14: Sprint', state: 'open' };
+    mockCreateMilestone.mockResolvedValue({ ok: true, data: { milestone } });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'M14: Sprint' }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { milestone: unknown };
+    expect(body.milestone).toEqual(milestone);
+  });
+
+  it('returns 422 on validation failure', async () => {
+    mockCreateMilestone.mockResolvedValue({ ok: false, error: 'title must match', status: 422 });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Bad' }),
+    });
+    expect(res.status).toBe(422);
+  });
+});
+
+describe('PATCH /projects/:slug/milestones/:number', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with updated milestone', async () => {
+    const milestone = { id: '14', number: 14, title: 'M14: Renamed', state: 'open' };
+    mockUpdateMilestone.mockResolvedValue({ ok: true, data: { milestone } });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/14', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'M14: Renamed' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for non-numeric milestone number', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/abc', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'M14: x' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /projects/:slug/milestones/:number', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 on success', async () => {
+    mockDeleteMilestone.mockResolvedValue({ ok: true, data: { ok: true } });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/14', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 409 when milestone has issues', async () => {
+    mockDeleteMilestone.mockResolvedValue({ ok: false, error: 'milestone has issues', status: 409 });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/14', { method: 'DELETE' });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('GET /projects/:slug/milestones/:number/sprint-review-eligibility', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns eligibility data', async () => {
+    const eligibility = { eligible: true, reason: '', alreadyExists: false };
+    mockGetSprintReviewEligibility.mockResolvedValue({ ok: true, data: eligibility });
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/5/sprint-review-eligibility');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(eligibility);
+  });
+
+  it('returns 400 for non-numeric number', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/my-proj/milestones/abc/sprint-review-eligibility');
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/server/src/domains/milestones/router.ts
+++ b/apps/server/src/domains/milestones/router.ts
@@ -1,12 +1,16 @@
 import { Hono } from 'hono';
 import { parseBody } from '#shared/middleware.js';
 import {
+  createMilestone,
+  deleteMilestone,
   getActiveMilestone,
+  getSprintReviewEligibility,
   listClosedMilestoneIssues,
   listMilestoneIssues,
   listMilestones,
   setActiveMilestone,
   triggerSprintReview,
+  updateMilestone,
 } from './service.js';
 
 const router = new Hono();
@@ -49,6 +53,44 @@ router.post('/:slug/milestones/:title/sprint-review', async (c) => {
     return c.json({ error: result.error }, result.status as 404 | 409 | 500);
   }
   return c.json(result.data);
+});
+
+router.post('/:slug/milestones', async (c) => {
+  const body = await parseBody<{ title: string }>(c);
+  if (!body.ok) return body.error;
+  const result = await createMilestone(c.req.param('slug'), body.data.title);
+  return result.ok
+    ? c.json(result.data, 201)
+    : c.json({ error: result.error }, result.status as 404 | 422);
+});
+
+router.patch('/:slug/milestones/:number', async (c) => {
+  const number = Number(c.req.param('number'));
+  if (Number.isNaN(number)) return c.json({ error: 'invalid milestone number' }, 400);
+  const body = await parseBody<{ title?: string; state?: 'open' | 'closed' }>(c);
+  if (!body.ok) return body.error;
+  const result = await updateMilestone(c.req.param('slug'), number, body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 404 | 422);
+});
+
+router.delete('/:slug/milestones/:number', async (c) => {
+  const number = Number(c.req.param('number'));
+  if (Number.isNaN(number)) return c.json({ error: 'invalid milestone number' }, 400);
+  const result = await deleteMilestone(c.req.param('slug'), number);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 404 | 409);
+});
+
+router.get('/:slug/milestones/:number/sprint-review-eligibility', async (c) => {
+  const number = Number(c.req.param('number'));
+  if (Number.isNaN(number)) return c.json({ error: 'invalid milestone number' }, 400);
+  const result = await getSprintReviewEligibility(c.req.param('slug'), number);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 404);
 });
 
 export { router as milestonesRouter };

--- a/apps/server/src/domains/milestones/router.ts
+++ b/apps/server/src/domains/milestones/router.ts
@@ -88,9 +88,7 @@ router.get('/:slug/milestones/:number/sprint-review-eligibility', async (c) => {
   const number = Number(c.req.param('number'));
   if (Number.isNaN(number)) return c.json({ error: 'invalid milestone number' }, 400);
   const result = await getSprintReviewEligibility(c.req.param('slug'), number);
-  return result.ok
-    ? c.json(result.data)
-    : c.json({ error: result.error }, result.status as 404);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
 });
 
 export { router as milestonesRouter };

--- a/apps/server/src/domains/milestones/service.test.ts
+++ b/apps/server/src/domains/milestones/service.test.ts
@@ -14,18 +14,23 @@ vi.mock('../../shared/resolve-milestone.js', () => ({
 
 vi.mock('./repository.js', () => ({
   writeActiveMilestone: vi.fn().mockResolvedValue(undefined),
+  readActiveMilestone: vi.fn().mockResolvedValue(null),
 }));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
-import { writeActiveMilestone } from './repository.js';
+import { readActiveMilestone, writeActiveMilestone } from './repository.js';
 import {
+  createMilestone,
+  deleteMilestone,
   getActiveMilestone,
+  getSprintReviewEligibility,
   listClosedMilestoneIssues,
   listMilestoneIssues,
   listMilestones,
   setActiveMilestone,
+  updateMilestone,
 } from './service.js';
 
 const mockSource = {
@@ -33,6 +38,9 @@ const mockSource = {
   listMilestones: vi.fn().mockResolvedValue([]),
   listWorkByMilestone: vi.fn().mockResolvedValue([]),
   listClosedWorkByMilestone: vi.fn().mockResolvedValue([]),
+  createMilestone: vi.fn(),
+  updateMilestone: vi.fn(),
+  deleteMilestone: vi.fn().mockResolvedValue(undefined),
 };
 
 beforeEach(() => {
@@ -194,6 +202,135 @@ describe('listClosedMilestoneIssues', () => {
     expect(result).toMatchObject({
       ok: true,
       data: { items: [{ id: 'github:owner/repo#5' }] },
+    });
+  });
+});
+
+describe('createMilestone', () => {
+  it('returns 404 for unknown project', async () => {
+    vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
+    const result = await createMilestone('unknown', 'M14: Sprint');
+    expect(result).toEqual({ ok: false, error: 'project not found', status: 404 });
+  });
+
+  it('returns 422 for non-M-prefixed title', async () => {
+    const result = await createMilestone('my-proj', 'Freeform Title');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(422);
+  });
+
+  it('returns 422 when title has no name after colon', async () => {
+    const result = await createMilestone('my-proj', 'M14: ');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(422);
+  });
+
+  it('creates milestone and returns it', async () => {
+    const created = { id: '14', number: 14, title: 'M14: Sprint', state: 'open', openIssues: 0, closedIssues: 0, isActive: true };
+    mockSource.createMilestone.mockResolvedValueOnce(created);
+    const result = await createMilestone('my-proj', 'M14: Sprint');
+    expect(result).toEqual({ ok: true, data: { milestone: created } });
+    expect(mockSource.createMilestone).toHaveBeenCalledWith('M14: Sprint');
+  });
+});
+
+describe('updateMilestone', () => {
+  it('returns 404 for unknown project', async () => {
+    vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
+    const result = await updateMilestone('unknown', 14, { title: 'M14: New Name' });
+    expect(result).toEqual({ ok: false, error: 'project not found', status: 404 });
+  });
+
+  it('returns 422 when renaming to non-M-prefixed title', async () => {
+    const result = await updateMilestone('my-proj', 14, { title: 'Bad Title' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(422);
+  });
+
+  it('allows state-only update without title validation', async () => {
+    const updated = { id: '14', number: 14, title: 'M14: Sprint', state: 'closed', openIssues: 0, closedIssues: 5, isActive: false };
+    mockSource.updateMilestone.mockResolvedValueOnce(updated);
+    const result = await updateMilestone('my-proj', 14, { state: 'closed' });
+    expect(result).toEqual({ ok: true, data: { milestone: updated } });
+  });
+
+  it('updates milestone and returns it', async () => {
+    const updated = { id: '14', number: 14, title: 'M14: New Name', state: 'open', openIssues: 0, closedIssues: 0, isActive: true };
+    mockSource.updateMilestone.mockResolvedValueOnce(updated);
+    const result = await updateMilestone('my-proj', 14, { title: 'M14: New Name' });
+    expect(result).toEqual({ ok: true, data: { milestone: updated } });
+    expect(mockSource.updateMilestone).toHaveBeenCalledWith(14, { title: 'M14: New Name' });
+  });
+});
+
+describe('deleteMilestone', () => {
+  it('returns 404 for unknown project', async () => {
+    vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
+    const result = await deleteMilestone('unknown', 14);
+    expect(result).toEqual({ ok: false, error: 'project not found', status: 404 });
+  });
+
+  it('returns 404 when milestone not found in list', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([{ number: 13, title: 'M13', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    const result = await deleteMilestone('my-proj', 14);
+    expect(result).toEqual({ ok: false, error: 'milestone not found', status: 404 });
+  });
+
+  it('returns 409 when milestone has issues', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 3, closedIssues: 0 }]);
+    const result = await deleteMilestone('my-proj', 14);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(409);
+    expect(result.error).toMatch(/has issues/i);
+  });
+
+  it('returns 409 when milestone is currently active', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    vi.mocked(readActiveMilestone).mockResolvedValueOnce(14);
+    const result = await deleteMilestone('my-proj', 14);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(409);
+    expect(result.error).toMatch(/active/i);
+  });
+
+  it('deletes milestone when empty and not active', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    vi.mocked(readActiveMilestone).mockResolvedValueOnce(null);
+    const result = await deleteMilestone('my-proj', 14);
+    expect(result).toEqual({ ok: true, data: { ok: true } });
+    expect(mockSource.deleteMilestone).toHaveBeenCalledWith(14);
+  });
+});
+
+describe('getSprintReviewEligibility', () => {
+  it('returns 404 for unknown project', async () => {
+    vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
+    const result = await getSprintReviewEligibility('unknown', 5);
+    expect(result).toEqual({ ok: false, error: 'project not found', status: 404 });
+  });
+
+  it('returns 404 when milestone not found in list', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([]);
+    const result = await getSprintReviewEligibility('my-proj', 99);
+    expect(result).toEqual({ ok: false, error: 'milestone not found', status: 404 });
+  });
+
+  it('returns eligibility for known milestone', async () => {
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 5, title: 'M5: Sprint', state: 'open', openIssues: 0, closedIssues: 0 },
+    ]);
+    mockSource.listWorkByMilestone.mockResolvedValueOnce([
+      { schedule: 'current', state: 'factory:done', title: 'Task A' },
+    ]);
+    const result = await getSprintReviewEligibility('my-proj', 5);
+    expect(result).toEqual({
+      ok: true,
+      data: { eligible: true, reason: '', alreadyExists: false },
     });
   });
 });

--- a/apps/server/src/domains/milestones/service.test.ts
+++ b/apps/server/src/domains/milestones/service.test.ts
@@ -228,7 +228,15 @@ describe('createMilestone', () => {
   });
 
   it('creates milestone and returns it', async () => {
-    const created = { id: '14', number: 14, title: 'M14: Sprint', state: 'open', openIssues: 0, closedIssues: 0, isActive: true };
+    const created = {
+      id: '14',
+      number: 14,
+      title: 'M14: Sprint',
+      state: 'open',
+      openIssues: 0,
+      closedIssues: 0,
+      isActive: true,
+    };
     mockSource.createMilestone.mockResolvedValueOnce(created);
     const result = await createMilestone('my-proj', 'M14: Sprint');
     expect(result).toEqual({ ok: true, data: { milestone: created } });
@@ -251,14 +259,30 @@ describe('updateMilestone', () => {
   });
 
   it('allows state-only update without title validation', async () => {
-    const updated = { id: '14', number: 14, title: 'M14: Sprint', state: 'closed', openIssues: 0, closedIssues: 5, isActive: false };
+    const updated = {
+      id: '14',
+      number: 14,
+      title: 'M14: Sprint',
+      state: 'closed',
+      openIssues: 0,
+      closedIssues: 5,
+      isActive: false,
+    };
     mockSource.updateMilestone.mockResolvedValueOnce(updated);
     const result = await updateMilestone('my-proj', 14, { state: 'closed' });
     expect(result).toEqual({ ok: true, data: { milestone: updated } });
   });
 
   it('updates milestone and returns it', async () => {
-    const updated = { id: '14', number: 14, title: 'M14: New Name', state: 'open', openIssues: 0, closedIssues: 0, isActive: true };
+    const updated = {
+      id: '14',
+      number: 14,
+      title: 'M14: New Name',
+      state: 'open',
+      openIssues: 0,
+      closedIssues: 0,
+      isActive: true,
+    };
     mockSource.updateMilestone.mockResolvedValueOnce(updated);
     const result = await updateMilestone('my-proj', 14, { title: 'M14: New Name' });
     expect(result).toEqual({ ok: true, data: { milestone: updated } });
@@ -274,13 +298,17 @@ describe('deleteMilestone', () => {
   });
 
   it('returns 404 when milestone not found in list', async () => {
-    mockSource.listMilestones.mockResolvedValueOnce([{ number: 13, title: 'M13', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 13, title: 'M13', state: 'open', openIssues: 0, closedIssues: 0 },
+    ]);
     const result = await deleteMilestone('my-proj', 14);
     expect(result).toEqual({ ok: false, error: 'milestone not found', status: 404 });
   });
 
   it('returns 409 when milestone has issues', async () => {
-    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 3, closedIssues: 0 }]);
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 14, title: 'M14', state: 'open', openIssues: 3, closedIssues: 0 },
+    ]);
     const result = await deleteMilestone('my-proj', 14);
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -289,7 +317,9 @@ describe('deleteMilestone', () => {
   });
 
   it('returns 409 when milestone is currently active', async () => {
-    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 },
+    ]);
     vi.mocked(readActiveMilestone).mockResolvedValueOnce(14);
     const result = await deleteMilestone('my-proj', 14);
     expect(result.ok).toBe(false);
@@ -299,7 +329,9 @@ describe('deleteMilestone', () => {
   });
 
   it('deletes milestone when empty and not active', async () => {
-    mockSource.listMilestones.mockResolvedValueOnce([{ number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 }]);
+    mockSource.listMilestones.mockResolvedValueOnce([
+      { number: 14, title: 'M14', state: 'open', openIssues: 0, closedIssues: 0 },
+    ]);
     vi.mocked(readActiveMilestone).mockResolvedValueOnce(null);
     const result = await deleteMilestone('my-proj', 14);
     expect(result).toEqual({ ok: true, data: { ok: true } });

--- a/apps/server/src/domains/milestones/service.ts
+++ b/apps/server/src/domains/milestones/service.ts
@@ -3,7 +3,8 @@ import { runSprintReviewWorkflow } from '@goose-hub/core/workflows/sprint-review
 import type { Result } from '#shared/middleware.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
-import { writeActiveMilestone } from './repository.js';
+import { checkSprintReviewEligibility } from '../workflows/sprint-review-eligibility.js';
+import { readActiveMilestone, writeActiveMilestone } from './repository.js';
 
 export async function getActiveMilestone(
   slug: string,
@@ -67,6 +68,81 @@ export async function listClosedMilestoneIssues(
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
   const items = await source.listClosedWorkByMilestone(milestone);
   return { ok: true, data: { items } };
+}
+
+const MILESTONE_TITLE_VALID_RE = /^M\d+:\s+\S/;
+
+export async function createMilestone(
+  slug: string,
+  title: string,
+): Promise<Result<{ milestone: unknown }>> {
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+  if (!MILESTONE_TITLE_VALID_RE.test(title)) {
+    return { ok: false, error: 'title must match M<N>: <name> format', status: 422 };
+  }
+  const milestone = await source.createMilestone(title);
+  return { ok: true, data: { milestone } };
+}
+
+export async function updateMilestone(
+  slug: string,
+  number: number,
+  patch: { title?: string; state?: 'open' | 'closed' },
+): Promise<Result<{ milestone: unknown }>> {
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+  if (patch.title != null && !MILESTONE_TITLE_VALID_RE.test(patch.title)) {
+    return { ok: false, error: 'title must match M<N>: <name> format', status: 422 };
+  }
+  // Note: renaming invalidates configMilestoneCache in resolve-milestone.ts (process-lifetime cache).
+  // If project.config.ts still references the old title, resolution falls back to GitHub default
+  // until server restart. This is pre-existing file-managed config behavior.
+  const milestone = await source.updateMilestone(number, patch);
+  return { ok: true, data: { milestone } };
+}
+
+export async function deleteMilestone(
+  slug: string,
+  number: number,
+): Promise<Result<{ ok: true }>> {
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+
+  const milestones = await source.listMilestones();
+  const target = milestones.find((m) => m.number === number);
+  if (target == null) return { ok: false, error: 'milestone not found', status: 404 };
+
+  if (target.openIssues + target.closedIssues > 0) {
+    return { ok: false, error: 'milestone has issues', status: 409 };
+  }
+
+  const activeMilestone = await readActiveMilestone(slug);
+  if (activeMilestone === number) {
+    return {
+      ok: false,
+      error: 'milestone is currently active; switch away before deleting',
+      status: 409,
+    };
+  }
+
+  await source.deleteMilestone(number);
+  return { ok: true, data: { ok: true } };
+}
+
+export async function getSprintReviewEligibility(
+  slug: string,
+  milestoneNumber: number,
+): Promise<Result<{ eligible: boolean; reason: string; alreadyExists: boolean }>> {
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+
+  const milestones = await source.listMilestones();
+  const milestone = milestones.find((m) => m.number === milestoneNumber);
+  if (milestone == null) return { ok: false, error: 'milestone not found', status: 404 };
+
+  const eligibility = await checkSprintReviewEligibility(source, milestoneNumber, milestone.title);
+  return { ok: true, data: eligibility };
 }
 
 export async function triggerSprintReview(

--- a/apps/server/src/domains/milestones/service.ts
+++ b/apps/server/src/domains/milestones/service.ts
@@ -102,10 +102,7 @@ export async function updateMilestone(
   return { ok: true, data: { milestone } };
 }
 
-export async function deleteMilestone(
-  slug: string,
-  number: number,
-): Promise<Result<{ ok: true }>> {
+export async function deleteMilestone(slug: string, number: number): Promise<Result<{ ok: true }>> {
   const source = await getSourceForSlug(slug);
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
 

--- a/apps/server/src/domains/workflows/sprint-review-eligibility.test.ts
+++ b/apps/server/src/domains/workflows/sprint-review-eligibility.test.ts
@@ -1,6 +1,6 @@
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import { describe, expect, it } from 'vitest';
 import { checkSprintReviewEligibility } from './sprint-review-eligibility.js';
-import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 
 function makeSource(items: { schedule: string; state: string; title: string }[]): StateSource {
   return {

--- a/apps/server/src/domains/workflows/sprint-review-eligibility.test.ts
+++ b/apps/server/src/domains/workflows/sprint-review-eligibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { checkSprintReviewEligibility } from './sprint-review-eligibility.js';
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+
+function makeSource(items: { schedule: string; state: string; title: string }[]): StateSource {
+  return {
+    listWorkByMilestone: async () => items as never,
+  } as unknown as StateSource;
+}
+
+describe('checkSprintReviewEligibility', () => {
+  it('returns eligible when all schedule:current items are terminal', async () => {
+    const source = makeSource([
+      { schedule: 'current', state: 'factory:done', title: 'Task A' },
+      { schedule: 'current', state: 'factory:archived', title: 'Task B' },
+      { schedule: 'next', state: 'factory:triage', title: 'Backlog item' },
+    ]);
+    const result = await checkSprintReviewEligibility(source, 5, 'M5: Sprint');
+    expect(result).toEqual({ eligible: true, reason: '', alreadyExists: false });
+  });
+
+  it('returns ineligible when no schedule:current items exist', async () => {
+    const source = makeSource([
+      { schedule: 'next', state: 'factory:triage', title: 'Backlog item' },
+    ]);
+    const result = await checkSprintReviewEligibility(source, 5, 'M5: Sprint');
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toMatch(/no schedule:current/i);
+  });
+
+  it('returns ineligible when some schedule:current items are not terminal', async () => {
+    const source = makeSource([
+      { schedule: 'current', state: 'factory:done', title: 'Task A' },
+      { schedule: 'current', state: 'factory:implementing', title: 'Task B' },
+    ]);
+    const result = await checkSprintReviewEligibility(source, 5, 'M5: Sprint');
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toMatch(/1 schedule:current/i);
+  });
+
+  it('sets alreadyExists when a sprint-review issue exists for the milestone', async () => {
+    const source = makeSource([
+      { schedule: 'current', state: 'factory:done', title: 'Task A' },
+      { schedule: 'current', state: 'factory:done', title: 'Sprint Review: M5: Sprint' },
+    ]);
+    const result = await checkSprintReviewEligibility(source, 5, 'M5: Sprint');
+    expect(result.alreadyExists).toBe(true);
+  });
+});

--- a/apps/server/src/domains/workflows/sprint-review-eligibility.ts
+++ b/apps/server/src/domains/workflows/sprint-review-eligibility.ts
@@ -1,0 +1,35 @@
+import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+
+export interface SprintReviewEligibility {
+  eligible: boolean;
+  reason: string;
+  alreadyExists: boolean;
+}
+
+const TERMINAL_STATES = new Set(['factory:done', 'factory:archived', 'factory:rejected']);
+
+export async function checkSprintReviewEligibility(
+  stateSource: StateSource,
+  milestoneNumber: number,
+  milestoneTitle: string,
+): Promise<SprintReviewEligibility> {
+  const allItems = await stateSource.listWorkByMilestone(milestoneNumber);
+  const currentItems = allItems.filter((item) => item.schedule === 'current');
+  const sprintReviewTitle = `Sprint Review: ${milestoneTitle}`;
+  const alreadyExists = allItems.some((item) => item.title === sprintReviewTitle);
+
+  if (currentItems.length === 0) {
+    return { eligible: false, reason: 'No schedule:current issues in milestone', alreadyExists };
+  }
+
+  const openCurrentItems = currentItems.filter((item) => !TERMINAL_STATES.has(item.state));
+  if (openCurrentItems.length > 0) {
+    return {
+      eligible: false,
+      reason: `${openCurrentItems.length} schedule:current issue(s) not yet terminal`,
+      alreadyExists,
+    };
+  }
+
+  return { eligible: true, reason: '', alreadyExists };
+}

--- a/apps/server/src/domains/workflows/sprint-review-trigger.ts
+++ b/apps/server/src/domains/workflows/sprint-review-trigger.ts
@@ -1,9 +1,7 @@
 import { logger } from '@goose-hub/core/logger.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import { runSprintReviewWorkflow } from '@goose-hub/core/workflows/sprint-review.js';
-
-/** States that count as terminal for the sprint-review trigger (PLAN §12.6). */
-const TERMINAL_STATES = new Set(['factory:done', 'factory:archived', 'factory:rejected']);
+import { checkSprintReviewEligibility } from './sprint-review-eligibility.js';
 
 /**
  * Fires sprint-review if all schedule:current items in the milestone have
@@ -21,27 +19,18 @@ export async function maybeFireSprintReview(
   stateSource: StateSource,
 ): Promise<void> {
   try {
-    const allItems = await stateSource.listWorkByMilestone(milestoneNumber);
+    const { eligible, alreadyExists } = await checkSprintReviewEligibility(
+      stateSource,
+      milestoneNumber,
+      milestoneTitle,
+    );
 
-    const currentItems = allItems.filter((item) => item.schedule === 'current');
-
-    // Need at least one terminal item to fire (milestone isn't empty).
-    const terminalItems = currentItems.filter((item) => TERMINAL_STATES.has(item.state));
-    if (terminalItems.length === 0) {
-      return;
-    }
-
-    // Every schedule:current item must be terminal.
-    const openCurrentItems = currentItems.filter((item) => !TERMINAL_STATES.has(item.state));
-    if (openCurrentItems.length > 0) {
-      return;
-    }
-
-    // Dedup: check if a sprint-review issue already exists.
-    const sprintReviewTitle = `Sprint Review: ${milestoneTitle}`;
-    const alreadyExists = allItems.some((item) => item.title === sprintReviewTitle);
     if (alreadyExists) {
       logger.info('sprint-review: already exists, skipping', { slug, milestoneTitle });
+      return;
+    }
+
+    if (!eligible) {
       return;
     }
 

--- a/apps/web/src/components/detail/components/PendingNextRunBanner.test.tsx
+++ b/apps/web/src/components/detail/components/PendingNextRunBanner.test.tsx
@@ -1,6 +1,6 @@
+import type { AgentEventDto } from '@/lib/types';
 import { describe, expect, it } from 'vitest';
 import { computeIsLive } from './PendingNextRunBanner';
-import type { AgentEventDto } from '@/lib/types';
 
 function makeEvent(kind: string, id: number): AgentEventDto {
   return {

--- a/apps/web/src/components/settings/components/MilestonesPanel.tsx
+++ b/apps/web/src/components/settings/components/MilestonesPanel.tsx
@@ -48,7 +48,9 @@ function SprintReviewButton({
     mutationFn: () => triggerSprintReview(slug, milestone.title),
     onSuccess: () => {
       setFired(true);
-      void queryClient.invalidateQueries({ queryKey: ['sprint-review-eligibility', slug, milestone.number] });
+      void queryClient.invalidateQueries({
+        queryKey: ['sprint-review-eligibility', slug, milestone.number],
+      });
       onFired();
     },
     onError: (err: Error) => setError(err.message),
@@ -114,7 +116,10 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
 
   const rename = useMutation({
     mutationFn: (title: string) => updateMilestone(slug, milestone.number, { title }),
-    onSuccess: () => { setEditing(false); invalidate(); },
+    onSuccess: () => {
+      setEditing(false);
+      invalidate();
+    },
     onError: (err: Error) => setRowError(err.message),
   });
 
@@ -133,7 +138,10 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
       invalidate();
       void queryClient.invalidateQueries({ queryKey: ['active-milestone', slug] });
     },
-    onError: (err: Error) => { setConfirmDelete(false); setRowError(err.message); },
+    onError: (err: Error) => {
+      setConfirmDelete(false);
+      setRowError(err.message);
+    },
   });
 
   const canDelete = milestone.openIssues + milestone.closedIssues === 0;
@@ -146,7 +154,10 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
         setRowError('Title must match M<N>: <name>');
       }
     }
-    if (e.key === 'Escape') { setEditing(false); setEditTitle(milestone.title); }
+    if (e.key === 'Escape') {
+      setEditing(false);
+      setEditTitle(milestone.title);
+    }
   }
 
   return (
@@ -198,7 +209,11 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
       {confirmDelete ? (
         <span className="flex items-center gap-1.5 text-[11px] shrink-0">
           <span className="text-fg-2">Delete? Cannot be undone.</span>
-          <button type="button" onClick={() => setConfirmDelete(false)} className="text-fg-2 hover:text-fg">
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(false)}
+            className="text-fg-2 hover:text-fg"
+          >
             Cancel
           </button>
           <button
@@ -214,7 +229,10 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
           <button
             type="button"
             title="Rename"
-            onClick={() => { setEditing(true); setEditTitle(milestone.title); }}
+            onClick={() => {
+              setEditing(true);
+              setEditTitle(milestone.title);
+            }}
             className="p-1 text-fg-3 hover:text-fg rounded transition-colors"
           >
             <Pencil size={11} />
@@ -243,9 +261,7 @@ function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
         </span>
       )}
 
-      {rowError != null && (
-        <span className="text-[10px] text-danger ml-1">{rowError}</span>
-      )}
+      {rowError != null && <span className="text-[10px] text-danger ml-1">{rowError}</span>}
     </div>
   );
 }
@@ -260,6 +276,11 @@ export function MilestonesPanel({ slug }: Props) {
   const [showAdd, setShowAdd] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
+  const addInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (showAdd) addInputRef.current?.focus();
+  }, [showAdd]);
 
   const { data: milestones = [], isLoading } = useQuery<MilestoneDto[]>({
     queryKey: ['milestones', slug],
@@ -315,7 +336,7 @@ export function MilestonesPanel({ slug }: Props) {
       {showAdd && (
         <div className="flex items-center gap-2 mb-2 px-2 py-1.5">
           <input
-            autoFocus
+            ref={addInputRef}
             value={newTitle}
             onChange={(e) => setNewTitle(e.target.value)}
             onKeyDown={(e) => {

--- a/apps/web/src/components/settings/components/MilestonesPanel.tsx
+++ b/apps/web/src/components/settings/components/MilestonesPanel.tsx
@@ -1,0 +1,364 @@
+import {
+  createMilestone,
+  deleteMilestone,
+  fetchActiveMilestone,
+  fetchMilestones,
+  fetchSprintReviewEligibility,
+  triggerSprintReview,
+  updateMilestone,
+} from '@/lib/api';
+import type { MilestoneDto, SprintReviewEligibility } from '@/lib/types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ChevronUp, Pencil, Play, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  slug: string;
+}
+
+const MILESTONE_RE = /^M\d+:\s+\S/;
+
+function maxMilestoneNumber(milestones: MilestoneDto[]): number {
+  return milestones.reduce((max, m) => {
+    const n = Number.parseInt(m.title.match(/^M(\d+)/)?.[1] ?? '0', 10);
+    return Math.max(max, n);
+  }, 0);
+}
+
+function SprintReviewButton({
+  slug,
+  milestone,
+  onFired,
+}: {
+  slug: string;
+  milestone: MilestoneDto;
+  onFired: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { data: elig, isLoading } = useQuery<SprintReviewEligibility>({
+    queryKey: ['sprint-review-eligibility', slug, milestone.number],
+    queryFn: () => fetchSprintReviewEligibility(slug, milestone.number),
+    staleTime: 30_000,
+  });
+
+  const [error, setError] = useState<string | null>(null);
+  const [fired, setFired] = useState(false);
+
+  const fire = useMutation({
+    mutationFn: () => triggerSprintReview(slug, milestone.title),
+    onSuccess: () => {
+      setFired(true);
+      void queryClient.invalidateQueries({ queryKey: ['sprint-review-eligibility', slug, milestone.number] });
+      onFired();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (isLoading) return <span className="text-[11px] text-fg-3">…</span>;
+  if (!elig) return null;
+
+  if (elig.alreadyExists || fired) {
+    return (
+      <span className="text-[11px] text-fg-3 flex items-center gap-1">
+        <Play size={10} />
+        Review done
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-0.5">
+      <button
+        type="button"
+        disabled={!elig.eligible || fire.isPending}
+        title={elig.eligible ? 'Trigger sprint review' : elig.reason}
+        onClick={() => fire.mutate()}
+        className={[
+          'flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded transition-colors',
+          elig.eligible && !fire.isPending
+            ? 'text-fg hover:bg-bg-hover cursor-pointer'
+            : 'text-fg-3 cursor-not-allowed',
+        ].join(' ')}
+      >
+        <Play size={10} />
+        Sprint Review
+      </button>
+      {error != null && <span className="text-[10px] text-danger">{error}</span>}
+    </div>
+  );
+}
+
+interface RowProps {
+  slug: string;
+  milestone: MilestoneDto;
+  isActive: boolean;
+  onMutated: () => void;
+}
+
+function MilestoneRow({ slug, milestone, isActive, onMutated }: RowProps) {
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(milestone.title);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['milestones', slug] });
+    onMutated();
+  };
+
+  const rename = useMutation({
+    mutationFn: (title: string) => updateMilestone(slug, milestone.number, { title }),
+    onSuccess: () => { setEditing(false); invalidate(); },
+    onError: (err: Error) => setRowError(err.message),
+  });
+
+  const toggle = useMutation({
+    mutationFn: () =>
+      updateMilestone(slug, milestone.number, {
+        state: milestone.state === 'open' ? 'closed' : 'open',
+      }),
+    onSuccess: invalidate,
+    onError: (err: Error) => setRowError(err.message),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => deleteMilestone(slug, milestone.number),
+    onSuccess: () => {
+      invalidate();
+      void queryClient.invalidateQueries({ queryKey: ['active-milestone', slug] });
+    },
+    onError: (err: Error) => { setConfirmDelete(false); setRowError(err.message); },
+  });
+
+  const canDelete = milestone.openIssues + milestone.closedIssues === 0;
+
+  function handleRenameKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      if (MILESTONE_RE.test(editTitle) && editTitle !== milestone.title) {
+        rename.mutate(editTitle);
+      } else if (!MILESTONE_RE.test(editTitle)) {
+        setRowError('Title must match M<N>: <name>');
+      }
+    }
+    if (e.key === 'Escape') { setEditing(false); setEditTitle(milestone.title); }
+  }
+
+  return (
+    <div
+      className={[
+        'flex items-center gap-2 py-1.5 px-2 rounded-md border-l-2 text-[12px]',
+        isActive ? 'border-accent bg-accent-soft' : 'border-transparent',
+      ].join(' ')}
+    >
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            onKeyDown={handleRenameKeyDown}
+            onBlur={() => {
+              if (MILESTONE_RE.test(editTitle) && editTitle !== milestone.title) {
+                rename.mutate(editTitle);
+              } else {
+                setEditing(false);
+                setEditTitle(milestone.title);
+              }
+            }}
+            className="w-full bg-bg border border-line rounded px-1.5 py-0.5 text-[12px] font-mono focus:outline-none focus:border-accent"
+          />
+        ) : (
+          <span className="font-mono truncate">{milestone.title}</span>
+        )}
+      </div>
+
+      <span
+        className={[
+          'text-[10px] px-1 py-0.5 rounded uppercase tracking-wider shrink-0',
+          milestone.state === 'open' ? 'bg-success/10 text-success' : 'bg-fg-3/10 text-fg-3',
+        ].join(' ')}
+      >
+        {milestone.state}
+      </span>
+
+      {milestone.state === 'open' && (
+        <SprintReviewButton
+          slug={slug}
+          milestone={milestone}
+          onFired={() => void queryClient.invalidateQueries({ queryKey: ['milestones', slug] })}
+        />
+      )}
+
+      {confirmDelete ? (
+        <span className="flex items-center gap-1.5 text-[11px] shrink-0">
+          <span className="text-fg-2">Delete? Cannot be undone.</span>
+          <button type="button" onClick={() => setConfirmDelete(false)} className="text-fg-2 hover:text-fg">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => remove.mutate()}
+            className="text-danger hover:text-danger/80 font-medium"
+          >
+            Delete
+          </button>
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            title="Rename"
+            onClick={() => { setEditing(true); setEditTitle(milestone.title); }}
+            className="p-1 text-fg-3 hover:text-fg rounded transition-colors"
+          >
+            <Pencil size={11} />
+          </button>
+          <button
+            type="button"
+            title={milestone.state === 'open' ? 'Close milestone' : 'Reopen milestone'}
+            onClick={() => toggle.mutate()}
+            disabled={toggle.isPending}
+            className="p-1 text-fg-3 hover:text-fg rounded transition-colors"
+          >
+            {milestone.state === 'open' ? <ChevronDown size={11} /> : <ChevronUp size={11} />}
+          </button>
+          <button
+            type="button"
+            title={canDelete ? 'Delete milestone' : 'Milestone has issues'}
+            disabled={!canDelete}
+            onClick={() => setConfirmDelete(true)}
+            className={[
+              'p-1 rounded transition-colors',
+              canDelete ? 'text-fg-3 hover:text-danger' : 'text-fg-3/30 cursor-not-allowed',
+            ].join(' ')}
+          >
+            <Trash2 size={11} />
+          </button>
+        </span>
+      )}
+
+      {rowError != null && (
+        <span className="text-[10px] text-danger ml-1">{rowError}</span>
+      )}
+    </div>
+  );
+}
+
+export function MilestonesPanel({ slug }: Props) {
+  const queryClient = useQueryClient();
+  const { data: activeMilestoneData } = useQuery({
+    queryKey: ['active-milestone', slug],
+    queryFn: ({ signal }) => fetchActiveMilestone(slug, signal),
+  });
+  const activeNumber = activeMilestoneData?.milestoneNumber ?? null;
+  const [showAdd, setShowAdd] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const { data: milestones = [], isLoading } = useQuery<MilestoneDto[]>({
+    queryKey: ['milestones', slug],
+    queryFn: ({ signal }) => fetchMilestones(slug, signal),
+  });
+
+  function nextTitle() {
+    const n = maxMilestoneNumber(milestones) + 1;
+    return `M${n}: `;
+  }
+
+  function handleOpenAdd() {
+    setNewTitle(nextTitle());
+    setAddError(null);
+    setShowAdd(true);
+  }
+
+  const add = useMutation({
+    mutationFn: (title: string) => createMilestone(slug, title),
+    onSuccess: () => {
+      setShowAdd(false);
+      setNewTitle('');
+      void queryClient.invalidateQueries({ queryKey: ['milestones', slug] });
+    },
+    onError: (err: Error) => setAddError(err.message),
+  });
+
+  function handleAddSubmit() {
+    if (!MILESTONE_RE.test(newTitle)) {
+      setAddError('Title must match M<N>: <name>');
+      return;
+    }
+    add.mutate(newTitle);
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-[11px] uppercase tracking-wider text-fg-2">Milestones</h3>
+        {!showAdd && (
+          <button
+            type="button"
+            onClick={handleOpenAdd}
+            className="text-[11px] text-fg-2 hover:text-fg px-1.5 py-0.5 rounded hover:bg-bg-hover transition-colors"
+          >
+            + Add
+          </button>
+        )}
+      </div>
+
+      {isLoading && <div className="text-[12px] text-fg-3 py-2">Loading…</div>}
+
+      {showAdd && (
+        <div className="flex items-center gap-2 mb-2 px-2 py-1.5">
+          <input
+            autoFocus
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAddSubmit();
+              if (e.key === 'Escape') setShowAdd(false);
+            }}
+            placeholder="M14: Sprint Name"
+            className="flex-1 bg-bg border border-line rounded px-1.5 py-0.5 text-[12px] font-mono focus:outline-none focus:border-accent"
+          />
+          <button
+            type="button"
+            disabled={!MILESTONE_RE.test(newTitle) || add.isPending}
+            onClick={handleAddSubmit}
+            className="text-[11px] px-2 py-0.5 rounded bg-accent text-white disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Create
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAdd(false)}
+            className="text-[11px] text-fg-2 hover:text-fg"
+          >
+            Cancel
+          </button>
+          {addError != null && <span className="text-[10px] text-danger">{addError}</span>}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-0.5">
+        {milestones.map((m) => (
+          <MilestoneRow
+            key={m.number}
+            slug={slug}
+            milestone={m}
+            isActive={m.number === activeNumber}
+            onMutated={() => void queryClient.invalidateQueries({ queryKey: ['milestones', slug] })}
+          />
+        ))}
+      </div>
+
+      {!isLoading && milestones.length === 0 && (
+        <p className="text-[12px] text-fg-3 py-2">No milestones found.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/components/ProjectConfigPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectConfigPanel.tsx
@@ -1,4 +1,5 @@
 import type { ProjectConfigDto } from '@/lib/types';
+import { MilestonesPanel } from './MilestonesPanel';
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
@@ -47,11 +48,9 @@ export function ProjectConfigPanel({ config }: Props) {
       <Row label="Daily tokens" value={config.budgets.dailyTokens.toLocaleString()} />
       <Row label="Per-advisor $" value={`$${config.budgets.perAdvisorMaxUsd}`} />
 
-      <p className="mt-4 text-[11.5px] text-fg-2">
-        To edit, modify{' '}
-        <code className="font-mono text-fg-3">target-projects/{config.slug}/project.config.ts</code>{' '}
-        and restart the server.
-      </p>
+      <div className="mt-6 border-t border-line pt-6">
+        <MilestonesPanel slug={config.slug} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -82,7 +82,8 @@ export function SettingsPage() {
       <div className="flex-1 overflow-y-auto px-8 py-6">
         <h1 className="text-[15px] font-semibold mb-1">Settings</h1>
         <p className="text-[12px] text-fg-2 mb-6">
-          Read-only. All values sourced from project config files.
+          Config fields are read-only (sourced from project config files). Milestones are editable
+          below.
         </p>
 
         {selectedConfig != null && <ProjectConfigPanel config={selectedConfig} />}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   PlaybookSummaryDto,
   ProjectConfigDto,
   ProjectSummary,
+  SprintReviewEligibility,
   TransitionResult,
   TriageResultDto,
   WorkItemCostsDto,
@@ -28,6 +29,7 @@ export type {
   IssueCommentDto,
   IssueDiffDto,
   MilestoneDto,
+  SprintReviewEligibility,
   AgentEventDto,
   TransitionResult,
   InboxItemDto,
@@ -64,6 +66,30 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     throw new Error(`POST ${path} failed: ${res.status} ${res.statusText} ${text}`);
   }
   return (await res.json()) as T;
+}
+
+async function patchJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`PATCH ${path} failed: ${res.status} ${res.statusText} ${text}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function deleteRequest(path: string): Promise<void> {
+  const res = await fetch(`/api${path}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`DELETE ${path} failed: ${res.status} ${res.statusText} ${text}`);
+  }
 }
 
 export async function fetchProjects(signal?: AbortSignal): Promise<ProjectSummary[]> {
@@ -130,6 +156,49 @@ export async function setActiveMilestone(
   milestoneNumber: number | null,
 ): Promise<void> {
   await postJson(`/projects/${slug}/active-milestone`, { milestoneNumber });
+}
+
+export async function createMilestone(slug: string, title: string): Promise<MilestoneDto> {
+  const { milestone } = await postJson<{ milestone: MilestoneDto }>(
+    `/projects/${slug}/milestones`,
+    { title },
+  );
+  return milestone;
+}
+
+export async function updateMilestone(
+  slug: string,
+  number: number,
+  patch: { title?: string; state?: 'open' | 'closed' },
+): Promise<MilestoneDto> {
+  const { milestone } = await patchJson<{ milestone: MilestoneDto }>(
+    `/projects/${slug}/milestones/${number}`,
+    patch,
+  );
+  return milestone;
+}
+
+export async function deleteMilestone(slug: string, number: number): Promise<void> {
+  await deleteRequest(`/projects/${slug}/milestones/${number}`);
+}
+
+export async function fetchSprintReviewEligibility(
+  slug: string,
+  number: number,
+): Promise<SprintReviewEligibility> {
+  return getJson<SprintReviewEligibility>(
+    `/projects/${slug}/milestones/${number}/sprint-review-eligibility`,
+  );
+}
+
+export async function triggerSprintReview(
+  slug: string,
+  milestoneTitle: string,
+): Promise<{ issueNumber: number }> {
+  return postJson<{ issueNumber: number }>(
+    `/projects/${slug}/milestones/${encodeURIComponent(milestoneTitle)}/sprint-review`,
+    {},
+  );
 }
 
 export async function fetchTriageResult(slug: string, id: string): Promise<TriageResultDto | null> {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -45,6 +45,15 @@ export interface MilestoneDto {
   description?: string;
   dueOn?: string;
   isActive: boolean;
+  state: 'open' | 'closed';
+  openIssues: number;
+  closedIssues: number;
+}
+
+export interface SprintReviewEligibility {
+  eligible: boolean;
+  reason: string;
+  alreadyExists: boolean;
 }
 
 export interface AgentEventDto {

--- a/core/workflows/sprint-review.test.ts
+++ b/core/workflows/sprint-review.test.ts
@@ -98,9 +98,9 @@ function makeMockSource(items: WorkItem[] = []): StateSource {
     createIssue: vi
       .fn()
       .mockResolvedValue(makeWorkItem({ externalId: '99', state: 'factory:done' })),
-    createMilestone: vi.fn(),
-    updateMilestone: vi.fn(),
-    deleteMilestone: vi.fn(),
+    createMilestone: vi.fn().mockResolvedValue(undefined),
+    updateMilestone: vi.fn().mockResolvedValue(undefined),
+    deleteMilestone: vi.fn().mockResolvedValue(undefined),
     getPrDiff: vi.fn().mockResolvedValue(''),
     watchForUpdates: vi.fn(),
   };


### PR DESCRIPTION
Implements the milestone management design spec (`docs/superpowers/specs/2026-05-08-milestone-management-design.md`).

## Completed criteria

- `core/state-source`: `Milestone` type enriched with `state`, `openIssues`, `closedIssues`; `createMilestone`, `updateMilestone`, `deleteMilestone` added to `StateSource` interface and `GitHubLabelsSource` impl
- `checkSprintReviewEligibility` helper extracted to `apps/server/src/domains/workflows/sprint-review-eligibility.ts`; `maybeFireSprintReview` updated to use it
- Server service: `createMilestone`, `updateMilestone`, `deleteMilestone`, `getSprintReviewEligibility` functions with title validation (422 for non-`M<N>:` titles), delete guard (409 on issues or active milestone)
- Server router: `POST /:slug/milestones`, `PATCH /:slug/milestones/:number`, `DELETE /:slug/milestones/:number`, `GET /:slug/milestones/:number/sprint-review-eligibility`
- Web: `MilestoneDto` enriched, `SprintReviewEligibility` type added, API functions (`createMilestone`, `updateMilestone`, `deleteMilestone`, `fetchSprintReviewEligibility`, `triggerSprintReview`) added
- `MilestonesPanel` component: per-row rename (inline input, Enter/Esc), open/close toggle, delete with inline confirm (disabled when has issues), sprint-review button with eligibility state, `+ Add` inline form pre-filled with `M{N+1}: `
- `ProjectConfigPanel` updated to mount `MilestonesPanel` below config rows; settings subtitle updated
- All new code passes typecheck and lint; 66 new unit tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMgbnEGUCsRqgrHVzGzkdQ)_