### PR TITLE
M19.04: convergent adversarial review — 2 parallel reviewers per round

### DIFF
--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -97,7 +97,12 @@ export type EventKind =
   | 'parallel-implement.wp-failed'
   | 'parallel-implement.wp-timeout'
   | 'parallel-implement.wp-commit-failed'
-  | 'parallel-implement.exhausted';
+  | 'parallel-implement.exhausted'
+  // M19.04 convergent adversarial review — round lifecycle events (#561)
+  | 'review.wave-completed'
+  | 'review.wave-failed'
+  | 'review.converged'
+  | 'review.escalated';
 
 export interface AgentEvent {
   id: number;

--- a/core/review/topic-classifier.ts
+++ b/core/review/topic-classifier.ts
@@ -1,0 +1,16 @@
+const AUTH_PATTERN = /auth|session|crypto|secret|password|jwt|oauth/i;
+
+export interface TopicClassification {
+  isAuthTopic: boolean;
+  /** Minimum rounds that must complete before convergence is checked. */
+  minRounds: number;
+}
+
+/**
+ * Classifies PR changed file paths to determine review round requirements.
+ * Auth/session/crypto topics require at least 3 rounds (issue #561).
+ */
+export function classifyTopic(changedFilePaths: string[]): TopicClassification {
+  const isAuthTopic = changedFilePaths.some((p) => AUTH_PATTERN.test(p));
+  return { isAuthTopic, minRounds: isAuthTopic ? 3 : 1 };
+}

--- a/core/types.ts
+++ b/core/types.ts
@@ -134,4 +134,6 @@ export interface ProjectConfig {
   colorStripe: string;
   activeMilestone?: string;
   tickIntervalSeconds?: number;
+  /** Maximum rounds for convergent adversarial review (M19.04). Default 3. */
+  maxReviewRounds?: number;
 }

--- a/slices/review/README.md
+++ b/slices/review/README.md
@@ -27,18 +27,32 @@ The Reviewer is a holdout (FACTORY_RULES 1, 20, 23):
 
 | File | Purpose |
 |------|---------|
-| `workflow.ts` | Main workflow function `runReviewWorkflow` |
-| `slice.test.ts` | Vitest tests covering all verdicts and error path |
+| `workflow.ts` | `runReviewWorkflow` (single-reviewer) + `runConvergentReviewWorkflow` + `dispatchReviewWave` (M19.04) |
+| `slice.test.ts` | Vitest tests covering all verdicts, error path, and convergent review (M19.04) |
 | `README.md` | This file |
+
+## Convergent review (M19.04)
+
+`runConvergentReviewWorkflow` replaces single-reviewer with adversarial 2-reviewer rounds:
+
+- Round 1 spawns 2 reviewers concurrently via `dispatchReviewWave`.
+- Rounds continue until 2 consecutive rounds have 0 new CRITICAL findings (convergence).
+- Auth/session/crypto topics (`core/review/topic-classifier.ts`) force `minRounds = 3`.
+- At cap (`maxReviewRounds`, default 3 or `project.maxReviewRounds`) with unresolved CRITICAL → `factory:needs-human`.
+- Per-reviewer parse failure → immediate `factory:needs-human` (no fallback, rule 23).
+- Reviewer B in each round runs unconstrained (`extraEventPayload.unconstrained = true`).
 
 ## Usage
 
-Called by `apps/server/src/domains/workflows/review-batch.ts` via the `/run-review` endpoint.
-
 ```typescript
 import { runReviewWorkflow } from 'slices/review/workflow.js';
+import { runConvergentReviewWorkflow } from 'slices/review/workflow.js';
 
+// Single-reviewer (legacy):
 await runReviewWorkflow(workItem, stateSource, projectId, targetRepo);
+
+// Convergent adversarial review (M19.04):
+await runConvergentReviewWorkflow(workItem, stateSource, projectId, targetRepo);
 ```
 
 ## Related

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -798,6 +798,70 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
     expect(mockRun).toHaveBeenCalledTimes(6);
   });
 
+  // Test for P1 fix: needs-human verdict from individual reviewer escalates immediately
+  it('escalates immediately when any reviewer returns needs-human verdict', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    // Round 1: reviewer A returns needs-human (no blocker findings needed for this verdict)
+    const needsHumanResult: AgentResult = {
+      output: {
+        verdict: 'needs-human',
+        confidence: 0.2,
+        criteriaChecks: [],
+        findings: [],
+        decisionSummaries: [],
+        escalationReason: 'Spec is fundamentally ambiguous',
+      },
+      decisionSummaries: [],
+      events: [],
+    };
+    mockRun.mockResolvedValueOnce(needsHumanResult); // R1-A needs-human
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R1-B approved
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    // Must escalate to needs-human immediately, not continue to round 2
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+    expect(mockRun).toHaveBeenCalledTimes(2); // only round 1 ran
+
+    // Must emit review.completed so UI/downstream consumers see the outcome
+    const completedEvents = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'review.completed');
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0]?.[0].payload).toMatchObject({ verdict: 'needs-human' });
+  });
+
+  // Test for P2 fix: review.completed emitted on convergence path
+  it('emits review.completed with verdict approved when converging', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    // 3 rounds × 2 reviewers all returning approved with no findings → converge at round 3
+    for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    const completedEvents = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'review.completed');
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0]?.[0].payload).toMatchObject({ verdict: 'approved' });
+  });
+
   // Test 4: holdout discipline — sibling decision summary leak is detected via tool.violation
   it('test 4: emits tool.violation when sibling decision summaries are injected into a reviewer context', async () => {
     const { assembleSpawnContext } = await import(

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -1,4 +1,4 @@
-import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { AgentResult, AgentSpec } from '@goose-hub/core/agent-runtime/interface.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -646,6 +646,200 @@ describe('runReviewWorkflow', () => {
         '42',
         expect.stringContaining('string error from review runtime'),
       );
+    });
+  });
+});
+
+// ─── Convergent review (M19.04) ───────────────────────────────────────────────
+
+function makeCriticalResult(description: string): AgentResult {
+  return {
+    output: {
+      verdict: 'needs-fix',
+      confidence: 0.6,
+      criteriaChecks: [],
+      findings: [
+        {
+          severity: 'blocker',
+          description,
+          file: 'src/foo.ts',
+          line: 1,
+          disposition: 'registered',
+          dispositionRef: '#999',
+        },
+      ],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+function makeApprovedResultNoFindings(): AgentResult {
+  return {
+    output: {
+      verdict: 'approved',
+      confidence: 0.95,
+      criteriaChecks: [],
+      findings: [],
+      decisionSummaries: [],
+    },
+    decisionSummaries: [],
+    events: [],
+  };
+}
+
+describe('runConvergentReviewWorkflow (M19.04)', () => {
+  beforeEach(() => {
+    mockRun.mockReset();
+    mockReplay.mockReset();
+    mockReplay.mockReturnValue([]);
+    mockExecSync.mockReset();
+    mockExecSync.mockReturnValue('');
+    mockAccumulatePersonaStats.mockClear();
+    vi.clearAllMocks();
+    mockReplay.mockReturnValue([]);
+  });
+
+  // Test 1: round 1 A finds 1 CRITICAL, B finds 0; rounds 2+3 have 0 new CRITICAL → converge at round 3
+  it('test 1: transitions to factory:approved when 2 consecutive rounds have 0 new CRITICAL findings', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    // Round 1: A finds 1 CRITICAL, B finds 0
+    mockRun.mockResolvedValueOnce(makeCriticalResult('Missing input validation')); // R1-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R1-B
+    // Round 2: both return 0 findings (0 new CRITICAL vs prior round)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R2-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R2-B
+    // Round 3: both return 0 findings (0 new CRITICAL → 2 consecutive, converge)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R3-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R3-B
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:approved',
+    );
+    // Should have run 3 rounds × 2 reviewers = 6 runtime calls
+    expect(mockRun).toHaveBeenCalledTimes(6);
+  });
+
+  // Test 2: round 3 finds new CRITICAL at cap → escalates, does NOT merge
+  it('test 2: escalates to factory:needs-human when cap reached with new CRITICAL findings', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    // Each round introduces a new CRITICAL finding so consecutiveZeroCritical stays 0
+    mockRun.mockResolvedValueOnce(makeCriticalResult('Issue A')); // R1-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R1-B
+    mockRun.mockResolvedValueOnce(makeCriticalResult('Issue B')); // R2-A (new)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R2-B
+    mockRun.mockResolvedValueOnce(makeCriticalResult('Issue C')); // R3-A (new, at cap)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R3-B
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+    // Verify it does NOT transition to approved
+    expect(source.transitionState).not.toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:approved',
+    );
+  });
+
+  // Test 3: auth-tagged PR forces minRounds=3; new CRITICAL at round 3 → escalates
+  it('test 3: auth-topic PR escalates when new CRITICAL appears at round 3 despite early zero-critical rounds', async () => {
+    const item = makeWorkItem();
+    // prDiff contains src/auth.ts → classifyTopic returns minRounds=3
+    const source = makeMockSource({
+      getPrDiff: vi
+        .fn()
+        .mockResolvedValue('diff --git a/src/auth.ts b/src/auth.ts\n+added session logic'),
+    });
+
+    // Round 1: 0 CRITICAL (consecutiveZero=1)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R1-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R1-B
+    // Round 2: 0 new CRITICAL (consecutiveZero=2, but round<minRounds=3 → NOT converged)
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R2-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R2-B
+    // Round 3: new CRITICAL appears at cap → escalate
+    mockRun.mockResolvedValueOnce(makeCriticalResult('Session token not validated')); // R3-A
+    mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings()); // R3-B
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+    expect(source.transitionState).not.toHaveBeenCalledWith(
+      '42',
+      'factory:needs-review',
+      'factory:approved',
+    );
+    // All 3 rounds must have run (minRounds=3 enforced by auth topic)
+    expect(mockRun).toHaveBeenCalledTimes(6);
+  });
+
+  // Test 4: holdout discipline — sibling decision summary leak is detected via tool.violation
+  it('test 4: emits tool.violation when sibling decision summaries are injected into a reviewer context', async () => {
+    const { assembleSpawnContext } = await import(
+      '@goose-hub/core/agent-runtime/context-assembly.js'
+    );
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    vi.mocked(eventStore.appendEvent).mockClear();
+
+    // Simulate a leaky AgentSpec where siblingDecisionSummaries (a disallowed key)
+    // is present in the reviewer's context — the assembleSpawnContext holdout
+    // enforcement must detect and report it.
+    const leakySpec: AgentSpec = {
+      runId: 'holdout-test-run',
+      role: 'reviewer',
+      skill: 'review',
+      context: {
+        projectId: 'test-project',
+        workItemId: 'github:owner/repo#42',
+        workItem: { title: 'T', body: 'B', number: 42 },
+        prDiff: '',
+        qaVerdict: undefined,
+        siblingDecisionSummaries: [
+          { kind: 'IMPLEMENTATION_PLAN', summary: 'reviewer A decided X' },
+        ],
+      },
+      contextAllowlist: ['workItem', 'prDiff', 'qaVerdict'],
+      freshContext: true,
+      toolBundles: ['read', 'validate'],
+      toolExtras: [],
+      budgets: { maxTurns: 25, maxBudgetUsd: 0.5 },
+      personaId: 'test-project/reviewer/0',
+    };
+
+    assembleSpawnContext(leakySpec);
+
+    const violations = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([e]) => e.kind === 'tool.violation');
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.[0].payload).toMatchObject({
+      disallowedKey: 'siblingDecisionSummaries',
+      role: 'reviewer',
     });
   });
 });

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -198,6 +198,10 @@ export interface ReviewWaveResult {
   reviewerOutputs: Array<{ parsed: ReviewOutput; runId: string }>;
   parseFailure: boolean;
   parseFailureError?: string;
+  /** True if any reviewer returned verdict: 'needs-human' — must escalate immediately. */
+  anyNeedsHuman: boolean;
+  /** True if any reviewer returned verdict: 'needs-fix' — prevents convergence counting. */
+  anyNeedsFix: boolean;
 }
 
 export interface DispatchReviewWaveOpts {
@@ -339,6 +343,8 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
       reviewerOutputs: [],
       parseFailure: true,
       parseFailureError: [errA, errB].filter(Boolean).join('; '),
+      anyNeedsHuman: false,
+      anyNeedsFix: false,
     };
   }
 
@@ -358,6 +364,8 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
       { parsed: parsedB.data, runId: runIdB },
     ],
     parseFailure: false,
+    anyNeedsHuman: parsedA.data.verdict === 'needs-human' || parsedB.data.verdict === 'needs-human',
+    anyNeedsFix: parsedA.data.verdict === 'needs-fix' || parsedB.data.verdict === 'needs-fix',
   };
 }
 
@@ -432,11 +440,61 @@ export async function runConvergentReviewWorkflow(
           round,
           roundFindingsCount: waveResult.roundFindings.length,
           newCriticalCount: waveResult.newCriticalFindings.length,
+          anyNeedsHuman: waveResult.anyNeedsHuman,
+          anyNeedsFix: waveResult.anyNeedsFix,
         },
         runId: crypto.randomUUID(),
       });
 
-      if (waveResult.newCriticalFindings.length === 0) {
+      // P1 fix: a reviewer returning needs-human must escalate immediately (rule 23, holdout).
+      if (waveResult.anyNeedsHuman) {
+        const humanReviewer = waveResult.reviewerOutputs.find(
+          (r) => r.parsed.verdict === 'needs-human',
+        );
+        const escalationReason =
+          humanReviewer?.parsed.verdict === 'needs-human'
+            ? humanReviewer.parsed.escalationReason
+            : 'Reviewer requested human review';
+        const runId = crypto.randomUUID();
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.escalated',
+          payload: { reason: 'reviewer-needs-human', round, escalationReason },
+          runId,
+        });
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.completed',
+          payload: {
+            verdict: 'needs-human',
+            confidence: humanReviewer?.parsed.confidence ?? 0,
+            criteriaChecks: humanReviewer?.parsed.criteriaChecks ?? [],
+            findings: humanReviewer?.parsed.findings ?? [],
+            escalationReason,
+          },
+          runId,
+        });
+        await stateSource.comment(
+          workItem.externalId,
+          buildAgentComment(
+            'Review',
+            'Needs Human',
+            `Round ${round} reviewer requested human review: ${escalationReason}`,
+            [],
+          ),
+        );
+        await stateSource.transitionState(
+          workItem.externalId,
+          'factory:needs-review',
+          'factory:needs-human',
+        );
+        return;
+      }
+
+      // P1 fix: needs-fix verdict (even without blockers) prevents convergence counting.
+      if (waveResult.newCriticalFindings.length === 0 && !waveResult.anyNeedsFix) {
         consecutiveZeroCriticalRounds++;
       } else {
         consecutiveZeroCriticalRounds = 0;
@@ -448,12 +506,31 @@ export async function runConvergentReviewWorkflow(
       const isConverged = consecutiveZeroCriticalRounds >= 2 && round >= minRounds;
 
       if (isConverged) {
+        const lastOutputs = waveResult.reviewerOutputs;
+        const avgConfidence =
+          lastOutputs.length > 0
+            ? lastOutputs.reduce((s, r) => s + r.parsed.confidence, 0) / lastOutputs.length
+            : 1;
+        const runId = crypto.randomUUID();
         eventStore.appendEvent({
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.converged',
           payload: { totalRounds: round },
-          runId: crypto.randomUUID(),
+          runId,
+        });
+        // P2 fix: emit canonical review.completed so UI and fix-feedback loop can consume it.
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.completed',
+          payload: {
+            verdict: 'approved',
+            confidence: avgConfidence,
+            criteriaChecks: [],
+            findings: lastOutputs.flatMap((r) => r.parsed.findings),
+          },
+          runId,
         });
         await stateSource.comment(
           workItem.externalId,
@@ -472,8 +549,9 @@ export async function runConvergentReviewWorkflow(
         return;
       }
 
-      // At round cap with unresolved CRITICAL — escalate. Do NOT continue past cap.
+      // At round cap with unresolved CRITICAL or unconverged — escalate. Do NOT continue past cap.
       if (round === maxReviewRounds && waveResult.newCriticalFindings.length > 0) {
+        const runId = crypto.randomUUID();
         eventStore.appendEvent({
           projectId: projectSlug,
           workItemId: workItem.id,
@@ -483,7 +561,22 @@ export async function runConvergentReviewWorkflow(
             round,
             unconvergedFindingsCount: waveResult.newCriticalFindings.length,
           },
-          runId: crypto.randomUUID(),
+          runId,
+        });
+        const allFindings = waveResult.reviewerOutputs.flatMap((r) => r.parsed.findings);
+        // P2 fix: emit review.completed so downstream consumers see the outcome.
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.completed',
+          payload: {
+            verdict: 'needs-human',
+            confidence: 0,
+            criteriaChecks: [],
+            findings: allFindings,
+            escalationReason: `Failed to converge after ${round} rounds: ${waveResult.newCriticalFindings.length} unresolved CRITICAL finding(s)`,
+          },
+          runId,
         });
         const details = waveResult.newCriticalFindings
           .slice(0, 5)

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -1,7 +1,12 @@
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { resolveBudgets } from '@goose-hub/core/agent-runtime/budgets.js';
 import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
-import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { assembleSpawnContext } from '@goose-hub/core/agent-runtime/context-assembly.js';
+import type {
+  AgentResult,
+  AgentRuntime,
+  AgentSpec,
+} from '@goose-hub/core/agent-runtime/interface.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
@@ -9,9 +14,11 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '@goose-hub/core/retry/retry-counter.js';
+import { classifyTopic } from '@goose-hub/core/review/topic-classifier.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
+import type { ReviewOutput } from '@goose-hub/skills/review/schema.js';
 
 export interface ReviewWorkflowDeps {
   runtime?: AgentRuntime;
@@ -171,6 +178,364 @@ function getQaVerdict(
   };
   if (p.verdict == null || p.overallScore == null) return undefined;
   return { verdict: p.verdict, overallScore: p.overallScore };
+}
+
+// ─── Convergent adversarial review (M19.04) ──────────────────────────────────
+
+const DEFAULT_MAX_REVIEW_ROUNDS = 3;
+
+/** Composite deduplication key for a review finding. Maps `description` as ruleId surrogate. */
+export interface FindingKey {
+  file: string;
+  line: number;
+  ruleId: string;
+  isCritical: boolean;
+}
+
+export interface ReviewWaveResult {
+  roundFindings: FindingKey[];
+  newCriticalFindings: FindingKey[];
+  reviewerOutputs: Array<{ parsed: ReviewOutput; runId: string }>;
+  parseFailure: boolean;
+  parseFailureError?: string;
+}
+
+export interface DispatchReviewWaveOpts {
+  pr: { externalId: string; prDiff: string };
+  qaResult?: { verdict: string; overallScore: number };
+  round: number;
+  /** Findings from the immediately prior round (empty for round 1). */
+  priorFindings: FindingKey[];
+  workItem: WorkItem;
+  projectSlug: string;
+  runtime: AgentRuntime;
+}
+
+function toFindingKey(f: {
+  file?: string;
+  line?: number;
+  description: string;
+  severity: string;
+}): FindingKey {
+  return {
+    file: f.file ?? '',
+    line: f.line ?? -1,
+    ruleId: f.description,
+    isCritical: f.severity === 'blocker',
+  };
+}
+
+function findingKeyStr(k: FindingKey): string {
+  return JSON.stringify([k.file, k.line, k.ruleId]);
+}
+
+function deduplicateFindings(
+  findings: Array<{ file?: string; line?: number; description: string; severity: string }>,
+): FindingKey[] {
+  const seen = new Set<string>();
+  const result: FindingKey[] = [];
+  for (const f of findings) {
+    const key = toFindingKey(f);
+    const str = findingKeyStr(key);
+    if (!seen.has(str)) {
+      seen.add(str);
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+function extractChangedFilePaths(prDiff: string): string[] {
+  const paths: string[] = [];
+  for (const line of prDiff.split('\n')) {
+    const m = line.match(/^diff --git a\/.+ b\/(.+)$/);
+    if (m?.[1] != null) paths.push(m[1]);
+  }
+  return paths;
+}
+
+/**
+ * Spawns 2 reviewers concurrently for one review round (M19.04).
+ * Reviewer B runs unconstrained (no scope guidance). Each spawn routes
+ * through assembleSpawnContext for holdout boundary enforcement (rule 1, ADR 0014).
+ * No advisor (rule 20). Per-reviewer parse failure → returns parseFailure: true.
+ */
+export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<ReviewWaveResult> {
+  const { pr, qaResult, round, priorFindings, workItem, projectSlug, runtime } = opts;
+
+  const projectConfig = await getProjectBySlug(projectSlug);
+  const reviewPrompt = readPromptWithContext('review', projectSlug);
+  const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
+
+  const runIdA = crypto.randomUUID();
+  const runIdB = crypto.randomUUID();
+  const { personaId: personaIdA } = selectPersona(projectSlug, 'reviewer');
+  const { personaId: personaIdB } = selectPersona(projectSlug, 'reviewer');
+
+  const makeSpec = (runId: string, personaId: string, unconstrained: boolean): AgentSpec => ({
+    runId,
+    role: 'reviewer',
+    skill: 'review',
+    context: {
+      projectId: projectSlug,
+      workItemId: workItem.id,
+      workItem: {
+        title: workItem.title,
+        body: workItem.body,
+        number: Number(workItem.externalId),
+      },
+      prDiff: pr.prDiff,
+      qaVerdict: qaResult,
+    },
+    contextAllowlist: ['workItem', 'prDiff', 'qaVerdict'],
+    freshContext: true,
+    toolBundles: ['read', 'validate'],
+    toolExtras: [],
+    ...resolveBudgets('review', projectConfig?.budgets),
+    personaId,
+    outputJsonSchema: reviewJsonSchema,
+    appendSystemPrompt: reviewPrompt,
+    extraEventPayload: { round, unconstrained },
+  });
+
+  const specA = makeSpec(runIdA, personaIdA, false);
+  const specB = makeSpec(runIdB, personaIdB, true);
+
+  // Route each spawn through assembleSpawnContext to enforce holdout boundary.
+  // This fires tool.violation events if sibling decision summaries were injected.
+  assembleSpawnContext(specA);
+  assembleSpawnContext(specB);
+
+  const [resultA, resultB] = await Promise.all([
+    runtime
+      .run(specA)
+      .catch((err: unknown) => (err instanceof Error ? err : new Error(String(err)))),
+    runtime
+      .run(specB)
+      .catch((err: unknown) => (err instanceof Error ? err : new Error(String(err)))),
+  ]);
+
+  const parsedA =
+    resultA instanceof Error ? null : ReviewOutputSchema.safeParse((resultA as AgentResult).output);
+  const parsedB =
+    resultB instanceof Error ? null : ReviewOutputSchema.safeParse((resultB as AgentResult).output);
+
+  if (parsedA == null || !parsedA.success || parsedB == null || !parsedB.success) {
+    const errA =
+      resultA instanceof Error
+        ? resultA.message
+        : !parsedA?.success
+          ? JSON.stringify(parsedA?.error.issues)
+          : null;
+    const errB =
+      resultB instanceof Error
+        ? resultB.message
+        : !parsedB?.success
+          ? JSON.stringify(parsedB?.error.issues)
+          : null;
+    return {
+      roundFindings: [],
+      newCriticalFindings: [],
+      reviewerOutputs: [],
+      parseFailure: true,
+      parseFailureError: [errA, errB].filter(Boolean).join('; '),
+    };
+  }
+
+  const allFindings = [...parsedA.data.findings, ...parsedB.data.findings];
+  const roundFindings = deduplicateFindings(allFindings);
+
+  const priorKeyStrs = new Set(priorFindings.map(findingKeyStr));
+  const newCriticalFindings = roundFindings.filter(
+    (k) => k.isCritical && !priorKeyStrs.has(findingKeyStr(k)),
+  );
+
+  return {
+    roundFindings,
+    newCriticalFindings,
+    reviewerOutputs: [
+      { parsed: parsedA.data, runId: runIdA },
+      { parsed: parsedB.data, runId: runIdB },
+    ],
+    parseFailure: false,
+  };
+}
+
+/**
+ * Convergent adversarial review workflow (M19.04).
+ * Runs up to maxReviewRounds rounds of 2-reviewer parallel dispatch.
+ * Converges when 2 consecutive rounds have 0 new CRITICAL findings and
+ * round >= minRounds. Escalates on parse failure or unresolved CRITICAL at cap.
+ */
+export async function runConvergentReviewWorkflow(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  projectSlug: string,
+  _targetRepo: string,
+  deps: ReviewWorkflowDeps = {},
+): Promise<void> {
+  const runtime = deps.runtime ?? new ClaudeCliRuntime();
+  const projectConfig = await getProjectBySlug(projectSlug);
+  const maxReviewRounds = projectConfig?.maxReviewRounds ?? DEFAULT_MAX_REVIEW_ROUNDS;
+
+  try {
+    const prDiff = await stateSource.getPrDiff(workItem.externalId);
+    const changedFilePaths = extractChangedFilePaths(prDiff);
+    const { minRounds } = classifyTopic(changedFilePaths);
+    const qaResult = getQaVerdict(eventStore.replay({ workItemId: workItem.id }));
+    const pr = { externalId: workItem.externalId, prDiff };
+
+    let previousRoundFindings: FindingKey[] = [];
+    let consecutiveZeroCriticalRounds = 0;
+
+    for (let round = 1; round <= maxReviewRounds; round++) {
+      const waveResult = await dispatchReviewWave({
+        pr,
+        qaResult,
+        round,
+        priorFindings: previousRoundFindings,
+        workItem,
+        projectSlug,
+        runtime,
+      });
+
+      if (waveResult.parseFailure) {
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.wave-failed',
+          payload: { round, error: waveResult.parseFailureError },
+          runId: crypto.randomUUID(),
+        });
+        await stateSource.comment(
+          workItem.externalId,
+          buildAgentComment(
+            'Review',
+            'Failed',
+            `Round ${round} reviewer parse failure — escalating to needs-human`,
+            [`Error: ${waveResult.parseFailureError}`],
+          ),
+        );
+        await stateSource.transitionState(
+          workItem.externalId,
+          'factory:needs-review',
+          'factory:needs-human',
+        );
+        return;
+      }
+
+      eventStore.appendEvent({
+        projectId: projectSlug,
+        workItemId: workItem.id,
+        kind: 'review.wave-completed',
+        payload: {
+          round,
+          roundFindingsCount: waveResult.roundFindings.length,
+          newCriticalCount: waveResult.newCriticalFindings.length,
+        },
+        runId: crypto.randomUUID(),
+      });
+
+      if (waveResult.newCriticalFindings.length === 0) {
+        consecutiveZeroCriticalRounds++;
+      } else {
+        consecutiveZeroCriticalRounds = 0;
+      }
+
+      // Update prior findings to this round's findings for next-round comparison.
+      previousRoundFindings = waveResult.roundFindings;
+
+      const isConverged = consecutiveZeroCriticalRounds >= 2 && round >= minRounds;
+
+      if (isConverged) {
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.converged',
+          payload: { totalRounds: round },
+          runId: crypto.randomUUID(),
+        });
+        await stateSource.comment(
+          workItem.externalId,
+          buildAgentComment(
+            'Review',
+            'Approved',
+            `Converged after ${round} round(s) — advancing to merge-ready`,
+            [],
+          ),
+        );
+        await stateSource.transitionState(
+          workItem.externalId,
+          'factory:needs-review',
+          'factory:approved',
+        );
+        return;
+      }
+
+      // At round cap with unresolved CRITICAL — escalate. Do NOT continue past cap.
+      if (round === maxReviewRounds && waveResult.newCriticalFindings.length > 0) {
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'review.escalated',
+          payload: {
+            reason: 'cap-with-new-critical',
+            round,
+            unconvergedFindingsCount: waveResult.newCriticalFindings.length,
+          },
+          runId: crypto.randomUUID(),
+        });
+        const details = waveResult.newCriticalFindings
+          .slice(0, 5)
+          .map((k) => `[CRITICAL] ${k.ruleId}`);
+        await stateSource.comment(
+          workItem.externalId,
+          buildAgentComment(
+            'Review',
+            'Needs Human',
+            `Failed to converge after ${round} round(s) — ${waveResult.newCriticalFindings.length} unresolved CRITICAL finding(s)`,
+            details,
+          ),
+        );
+        await stateSource.transitionState(
+          workItem.externalId,
+          'factory:needs-review',
+          'factory:needs-human',
+        );
+        return;
+      }
+    }
+
+    // Edge case: loop exhausted without convergence or escalation (e.g. maxReviewRounds=0)
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    eventStore.appendEvent({
+      projectId: projectSlug,
+      workItemId: workItem.id,
+      kind: 'agent.run-failed',
+      payload: { error: error.message, skill: 'review' },
+      runId: crypto.randomUUID(),
+    });
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Review',
+        'Failed',
+        'Convergent review run failed — escalating to needs-human',
+        [`Error: ${error.message}`],
+      ),
+    );
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-review',
+      'factory:needs-human',
+    );
+  }
 }
 
 function buildReviewComment(


### PR DESCRIPTION
Closes #561

## What ships

- `core/review/topic-classifier.ts` — regex classifier for auth/session/crypto/secret/password/jwt/oauth file paths; bumps `minRounds` to 3
- `slices/review/workflow.ts` — adds `dispatchReviewWave` (2-reviewer concurrent dispatch) and `runConvergentReviewWorkflow` (round loop with convergence detection and cap escalation)
- `core/types.ts` — adds `maxReviewRounds?: number` to `ProjectConfig` (default 3, project-overridable)

## Acceptance criteria satisfied

- [x] `dispatchReviewWave({pr, qaResult, round}): Promise` — round-1 spawns 2 reviewers concurrently via `Promise.all`; each routes through `assembleSpawnContext()` for holdout boundary enforcement
- [x] Convergence rule: union findings per round; `newCriticalFindings.length === 0` for 2 consecutive rounds → advance to merge-ready
- [x] Cap behaviour: `maxReviewRounds` reached with `newCriticalFindings.length > 0` → escalate to `factory:needs-human` with unconverged findings; does NOT continue past cap, does NOT silently pass
- [x] Auth topic: forces `minRounds = 3`; round-3 new CRITICAL escalates same as cap
- [x] `maxReviewRounds` default 3, project-overridable via `project.maxReviewRounds`
- [x] Reviewer B per round runs with `unconstrained: true` in `extraEventPayload`
- [x] Topic auto-classifier in `core/review/topic-classifier.ts`
- [x] Per-reviewer holdout discipline preserved: `freshContext: true`, `contextAllowlist` filters, no sibling decision summaries cross-pollinate (asserted by test 4)
- [x] Findings aggregation: dedup by `(file, line, description)` — new = not present in prior round
- [x] No advisor (rule 20), no fallback (rule 23); per-reviewer parse failure → `factory:needs-human`
- [x] Integration test 1: round 1 A finds CRITICAL, rounds 2+3 zero-new-CRITICAL → converge at round 3
- [x] Integration test 2: new CRITICAL at cap → escalates, does NOT merge
- [x] Integration test 3: auth-tagged PR, new CRITICAL at round 3 → escalates
- [x] Integration test 4: `assembleSpawnContext` emits `tool.violation` when sibling decision summaries injected into reviewer context

All 28 tests pass, lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyeBCod47ubszcQjMpcDvG)_