### PR TITLE
M19.06: record-decision runtime tool — synchronous SQLite write with iteration + phase metadata

### DIFF
--- a/core/db/migrations/0007_agent_decisions.sql
+++ b/core/db/migrations/0007_agent_decisions.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `agent_decisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`run_id` text NOT NULL,
+	`iteration` integer DEFAULT 0 NOT NULL,
+	`phase` text DEFAULT '' NOT NULL,
+	`kind` text NOT NULL,
+	`what` text NOT NULL,
+	`why` text NOT NULL,
+	`ts` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `agent_decisions_run_kind_what_uniq` ON `agent_decisions` (`run_id`,`kind`,`what`);--> statement-breakpoint
+CREATE INDEX `agent_decisions_run_idx` ON `agent_decisions` (`run_id`);

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778197779792,
       "tag": "0006_redundant_emma_frost",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1746921600000,
+      "tag": "0007_agent_decisions",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -212,6 +212,28 @@ export const wpIterations = sqliteTable(
   }),
 );
 
+// One structured decision record per mid-run recordDecision() tool call (M19.06).
+// Deduplication key: (run_id, kind, what) — second call with same key is a no-op.
+// Reconciliation: at run end, orchestrator reads these rows (when flag on) instead
+// of relying solely on the skill schema's decisionSummaries JSON field.
+export const agentDecisions = sqliteTable(
+  'agent_decisions',
+  {
+    id: text('id').primaryKey(), // crypto.randomUUID()
+    runId: text('run_id').notNull(),
+    iteration: integer('iteration').notNull().default(0),
+    phase: text('phase').notNull().default(''),
+    kind: text('kind').notNull(),
+    what: text('what').notNull(),
+    why: text('why').notNull(),
+    ts: text('ts').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    runKindWhatUniq: uniqueIndex('agent_decisions_run_kind_what_uniq').on(t.runId, t.kind, t.what),
+    runIdx: index('agent_decisions_run_idx').on(t.runId),
+  }),
+);
+
 // One row per agent run. `runId` is unique — the same run is never recorded twice.
 // `costLabel`: 'exact' when the source provided authoritative usage metadata
 // (direct API), 'estimated' when only the Claude CLI's reported totals are

--- a/core/tool-layer/allowlist.ts
+++ b/core/tool-layer/allowlist.ts
@@ -1,15 +1,34 @@
+import type { Role } from '../types.js';
 import { type BundleName, TOOL_BUNDLES } from './bundles.js';
 
 export { TOOL_BUNDLES };
 
+/**
+ * Bundles that holdout roles (qa, reviewer) are forbidden from receiving.
+ * These bundles can leak decision-summary state from the implementation phase,
+ * violating the holdout discipline (FACTORY_RULES rule 1).
+ */
+const HOLDOUT_BLOCKED_BUNDLES = new Set<BundleName>(['decision-record-only']);
+
+const HOLDOUT_ROLES = new Set<Role>(['qa', 'reviewer']);
+
 interface AllowlistSpec {
   toolBundles: string[];
   toolExtras: string[];
+  /** When provided, holdout-blocked bundles are stripped for holdout roles. */
+  role?: Role;
 }
 
 export function computeAllowlist(spec: AllowlistSpec): string[] {
   const tools: string[] = [];
   for (const bundle of spec.toolBundles) {
+    if (
+      spec.role != null &&
+      HOLDOUT_ROLES.has(spec.role) &&
+      HOLDOUT_BLOCKED_BUNDLES.has(bundle as BundleName)
+    ) {
+      continue;
+    }
     const bundleTools = TOOL_BUNDLES[bundle as BundleName];
     if (bundleTools != null) {
       tools.push(...bundleTools);

--- a/core/tool-layer/bundles.ts
+++ b/core/tool-layer/bundles.ts
@@ -62,6 +62,13 @@ export const TOOL_BUNDLES = {
     'Bash(gh issue comment*)',
   ],
   /**
+   * M19.06 — record-decision tool (opt-in, feature-flagged).
+   * Exposes a single mid-run MCP tool that writes DecisionRecords to SQLite.
+   * MUST NOT be granted to holdout roles (qa, reviewer) — enforced by
+   * computeAllowlist when `role` is provided.
+   */
+  'decision-record-only': ['record-decision'],
+  /**
    * Playwright-test MCP bundle. Tool list extracted from Microsoft's
    * apps/web/.claude/agents/playwright-test-{planner,generator}.md.
    *

--- a/core/tool-layer/slice.test.ts
+++ b/core/tool-layer/slice.test.ts
@@ -136,6 +136,39 @@ describe('computeAllowlist', () => {
     const list = computeAllowlist({ toolBundles: [], toolExtras: [] });
     expect(list).toHaveLength(0);
   });
+
+  it('strips decision-record-only from qa role', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'qa',
+    });
+    expect(list).not.toContain('record-decision');
+    expect(list).toHaveLength(0);
+  });
+
+  it('strips decision-record-only from reviewer role', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'reviewer',
+    });
+    expect(list).not.toContain('record-decision');
+  });
+
+  it('allows decision-record-only for non-holdout roles', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'developer',
+    });
+    expect(list).toContain('record-decision');
+  });
+
+  it('allows decision-record-only when no role specified', () => {
+    const list = computeAllowlist({ toolBundles: ['decision-record-only'], toolExtras: [] });
+    expect(list).toContain('record-decision');
+  });
 });
 
 // ─── workspace sandbox ────────────────────────────────────────────────────────

--- a/core/tool-layer/tools/record-decision.ts
+++ b/core/tool-layer/tools/record-decision.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { type DecisionKind, isDecisionKind } from '../../agent-runtime/decision-types.js';
+import { db } from '../../db/db.js';
+import { agentDecisions } from '../../db/schema.js';
+
+export interface RecordDecisionParams {
+  runId: string;
+  kind: string;
+  what: string;
+  why: string;
+  /** Current iteration within the run. Defaults to 0. */
+  iteration?: number;
+  /** Current phase label (e.g. 'plan', 'implement'). Defaults to ''. */
+  phase?: string;
+}
+
+export type RecordDecisionResult =
+  | { recorded: true; id: string }
+  | { recorded: false; id: string; reason: 'duplicate' };
+
+/**
+ * Synchronously records a structured decision to the agent_decisions SQLite table.
+ * Unknown `kind` values are coerced to 'UNKNOWN' (ADR 0018).
+ * Deduplication: (runId, kind, what) — a second call with the same triple no-ops.
+ * Callers must check `experimental.recordDecisionTool` before calling.
+ */
+export function recordDecision(params: RecordDecisionParams): RecordDecisionResult {
+  const { runId, what, why, iteration = 0, phase = '' } = params;
+
+  const kind: DecisionKind = isDecisionKind(params.kind) ? params.kind : 'UNKNOWN';
+
+  const id = randomUUID();
+
+  const result = db
+    .insert(agentDecisions)
+    .values({ id, runId, iteration, phase, kind, what, why })
+    .onConflictDoNothing()
+    .run();
+
+  if (result.changes > 0) {
+    return { recorded: true, id };
+  }
+
+  // Row already existed — look up its id for the caller.
+  const existing = db
+    .select({ id: agentDecisions.id })
+    .from(agentDecisions)
+    .where(
+      and(
+        eq(agentDecisions.runId, runId),
+        eq(agentDecisions.kind, kind),
+        eq(agentDecisions.what, what),
+      ),
+    )
+    .get();
+
+  return { recorded: false, id: existing?.id ?? id, reason: 'duplicate' };
+}
+
+/**
+ * Reads all decision records for a run from agent_decisions in insertion order.
+ * Used by reconciliation at run end when the feature flag is on.
+ */
+export function readRunDecisions(
+  runId: string,
+): Array<{ kind: DecisionKind; summary: string; evidence?: string }> {
+  const rows = db
+    .select({
+      kind: agentDecisions.kind,
+      what: agentDecisions.what,
+      why: agentDecisions.why,
+    })
+    .from(agentDecisions)
+    .where(eq(agentDecisions.runId, runId))
+    .orderBy(agentDecisions.ts)
+    .all();
+
+  return rows.map((r) => ({
+    kind: isDecisionKind(r.kind) ? r.kind : 'UNKNOWN',
+    summary: r.what,
+    evidence: r.why || undefined,
+  }));
+}

--- a/core/tool-layer/tools/record-decision.ts
+++ b/core/tool-layer/tools/record-decision.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { type DecisionKind, isDecisionKind } from '../../agent-runtime/decision-types.js';
 import { db } from '../../db/db.js';
 import { agentDecisions } from '../../db/schema.js';
@@ -73,7 +73,7 @@ export function readRunDecisions(
     })
     .from(agentDecisions)
     .where(eq(agentDecisions.runId, runId))
-    .orderBy(agentDecisions.ts)
+    .orderBy(agentDecisions.ts, sql`rowid`)
     .all();
 
   return rows.map((r) => ({

--- a/core/types.ts
+++ b/core/types.ts
@@ -144,4 +144,9 @@ export interface ProjectConfig {
    * See docs/adr/0032-regression-policy.md
    */
   regressionPolicy?: 'revert' | 'escalate' | 'ignore';
+  /** Feature flags for experimental capabilities. Opt-in per project. */
+  experimental?: {
+    /** M19.06 — ship record-decision MCP tool for A/B evaluation. Default false. */
+    recordDecisionTool?: boolean;
+  };
 }

--- a/scripts/eval-decision-streams.ts
+++ b/scripts/eval-decision-streams.ts
@@ -1,0 +1,188 @@
+/**
+ * M19.06 eval harness: compares per-run decision counts and content quality
+ * between runs with experimental.recordDecisionTool = true (flag-on) and
+ * flag-off runs that rely on the existing two-stream model.
+ *
+ * Usage:
+ *   pnpm tsx scripts/eval-decision-streams.ts [--json] [--run-id <id>]
+ *
+ * Output (default): human-readable comparison table.
+ * Output (--json):  JSON array of EvalResult objects written to stdout.
+ *
+ * The script reads from the operational SQLite database. Set DB_PATH env var
+ * to override the default (~/.factory/data/factory.db).
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { db } from '../core/db/db.js';
+import { agentDecisions, events } from '../core/db/schema.js';
+
+interface EvalResult {
+  runId: string;
+  /** Decisions recorded via the record-decision tool (flag-on). */
+  toolDecisionCount: number;
+  /** Decisions extracted from the canonical schema field (flag-off / fallback). */
+  schemaDecisionCount: number;
+  /** Decision kinds that appear in tool stream but not schema stream. */
+  toolOnly: string[];
+  /** Decision kinds that appear in schema stream but not tool stream. */
+  schemaOnly: string[];
+  /** Ratio of tool decisions to schema decisions (1.0 = identical count). */
+  coverageRatio: number;
+}
+
+function fetchToolDecisions(runId?: string): Map<string, number> {
+  const query = runId
+    ? db
+        .select({ runId: agentDecisions.runId, count: sql<number>`count(*)` })
+        .from(agentDecisions)
+        .where(eq(agentDecisions.runId, runId))
+        .groupBy(agentDecisions.runId)
+    : db
+        .select({ runId: agentDecisions.runId, count: sql<number>`count(*)` })
+        .from(agentDecisions)
+        .groupBy(agentDecisions.runId);
+
+  const rows = query.all();
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    map.set(row.runId, row.count);
+  }
+  return map;
+}
+
+function fetchSchemaDecisions(runId?: string): Map<string, number> {
+  const filter = runId
+    ? eq(events.runId, runId)
+    : eq(events.kind, 'agent.decision-summary');
+
+  const rows = db
+    .select({ runId: events.runId, payload: events.payload })
+    .from(events)
+    .where(runId ? eq(events.runId, runId) : eq(events.kind, 'agent.decision-summary'))
+    .all();
+
+  void filter;
+
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    if (row.runId == null) continue;
+    try {
+      const payload = JSON.parse(row.payload) as { decisionSummaries?: unknown[] };
+      const count = Array.isArray(payload.decisionSummaries) ? payload.decisionSummaries.length : 0;
+      map.set(row.runId, (map.get(row.runId) ?? 0) + count);
+    } catch {
+      // malformed payload — skip
+    }
+  }
+  return map;
+}
+
+function fetchKindsByRun(runId: string): { toolKinds: Set<string>; schemaKinds: Set<string> } {
+  const toolRows = db
+    .select({ kind: agentDecisions.kind })
+    .from(agentDecisions)
+    .where(eq(agentDecisions.runId, runId))
+    .all();
+
+  const toolKinds = new Set(toolRows.map((r) => r.kind));
+
+  const eventRows = db
+    .select({ payload: events.payload })
+    .from(events)
+    .where(eq(events.runId, runId))
+    .all();
+
+  const schemaKinds = new Set<string>();
+  for (const row of eventRows) {
+    try {
+      const payload = JSON.parse(row.payload) as { decisionSummaries?: Array<{ kind: string }> };
+      if (Array.isArray(payload.decisionSummaries)) {
+        for (const ds of payload.decisionSummaries) {
+          if (typeof ds.kind === 'string') schemaKinds.add(ds.kind);
+        }
+      }
+    } catch {
+      // skip
+    }
+  }
+
+  return { toolKinds, schemaKinds };
+}
+
+function buildResults(targetRunId?: string): EvalResult[] {
+  const toolCounts = fetchToolDecisions(targetRunId);
+  const schemaCounts = fetchSchemaDecisions(targetRunId);
+
+  const allRunIds = new Set([...toolCounts.keys(), ...schemaCounts.keys()]);
+  if (targetRunId) {
+    allRunIds.add(targetRunId);
+  }
+
+  const results: EvalResult[] = [];
+
+  for (const runId of allRunIds) {
+    const toolDecisionCount = toolCounts.get(runId) ?? 0;
+    const schemaDecisionCount = schemaCounts.get(runId) ?? 0;
+
+    const { toolKinds, schemaKinds } = fetchKindsByRun(runId);
+
+    const toolOnly = [...toolKinds].filter((k) => !schemaKinds.has(k));
+    const schemaOnly = [...schemaKinds].filter((k) => !toolKinds.has(k));
+    const coverageRatio =
+      schemaDecisionCount === 0
+        ? toolDecisionCount > 0
+          ? 2.0
+          : 1.0
+        : toolDecisionCount / schemaDecisionCount;
+
+    results.push({ runId, toolDecisionCount, schemaDecisionCount, toolOnly, schemaOnly, coverageRatio });
+  }
+
+  return results.sort((a, b) => a.runId.localeCompare(b.runId));
+}
+
+function printTable(results: EvalResult[]): void {
+  if (results.length === 0) {
+    process.stdout.write('No runs found. Run with --run-id <id> or ensure DB has data.\n');
+    return;
+  }
+
+  const header = ['run_id', 'tool#', 'schema#', 'ratio', 'tool_only', 'schema_only'];
+  const rows = results.map((r) => [
+    r.runId.slice(0, 8),
+    String(r.toolDecisionCount),
+    String(r.schemaDecisionCount),
+    r.coverageRatio.toFixed(2),
+    r.toolOnly.join(',') || '—',
+    r.schemaOnly.join(',') || '—',
+  ]);
+
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => r[i]?.length ?? 0)),
+  );
+
+  const fmt = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(widths[i] ?? 0)).join('  ');
+
+  process.stdout.write(`${fmt(header)}\n`);
+  process.stdout.write(`${widths.map((w) => '-'.repeat(w)).join('  ')}\n`);
+  for (const row of rows) {
+    process.stdout.write(`${fmt(row)}\n`);
+  }
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const jsonMode = args.includes('--json');
+const runIdIdx = args.indexOf('--run-id');
+const targetRunId = runIdIdx !== -1 ? args[runIdIdx + 1] : undefined;
+
+const results = buildResults(targetRunId);
+
+if (jsonMode) {
+  process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+} else {
+  printTable(results);
+}

--- a/scripts/eval-decision-streams.ts
+++ b/scripts/eval-decision-streams.ts
@@ -52,28 +52,23 @@ function fetchToolDecisions(runId?: string): Map<string, number> {
 }
 
 function fetchSchemaDecisions(runId?: string): Map<string, number> {
-  const filter = runId
-    ? eq(events.runId, runId)
+  // Each agent.decision-summary event carries one decision with a flat payload
+  // { skill, kind, summary, evidence? } — emitted one-per-decision by workflows.
+  const whereClause = runId
+    ? and(eq(events.kind, 'agent.decision-summary'), eq(events.runId, runId))
     : eq(events.kind, 'agent.decision-summary');
 
   const rows = db
     .select({ runId: events.runId, payload: events.payload })
     .from(events)
-    .where(runId ? eq(events.runId, runId) : eq(events.kind, 'agent.decision-summary'))
+    .where(whereClause)
     .all();
-
-  void filter;
 
   const map = new Map<string, number>();
   for (const row of rows) {
     if (row.runId == null) continue;
-    try {
-      const payload = JSON.parse(row.payload) as { decisionSummaries?: unknown[] };
-      const count = Array.isArray(payload.decisionSummaries) ? payload.decisionSummaries.length : 0;
-      map.set(row.runId, (map.get(row.runId) ?? 0) + count);
-    } catch {
-      // malformed payload — skip
-    }
+    // One event = one decision; increment the count for this runId.
+    map.set(row.runId, (map.get(row.runId) ?? 0) + 1);
   }
   return map;
 }
@@ -87,23 +82,20 @@ function fetchKindsByRun(runId: string): { toolKinds: Set<string>; schemaKinds: 
 
   const toolKinds = new Set(toolRows.map((r) => r.kind));
 
+  // Each agent.decision-summary event has a flat payload { skill, kind, summary, evidence? }.
   const eventRows = db
     .select({ payload: events.payload })
     .from(events)
-    .where(eq(events.runId, runId))
+    .where(and(eq(events.kind, 'agent.decision-summary'), eq(events.runId, runId)))
     .all();
 
   const schemaKinds = new Set<string>();
   for (const row of eventRows) {
     try {
-      const payload = JSON.parse(row.payload) as { decisionSummaries?: Array<{ kind: string }> };
-      if (Array.isArray(payload.decisionSummaries)) {
-        for (const ds of payload.decisionSummaries) {
-          if (typeof ds.kind === 'string') schemaKinds.add(ds.kind);
-        }
-      }
+      const payload = JSON.parse(row.payload) as { kind?: string };
+      if (typeof payload.kind === 'string') schemaKinds.add(payload.kind);
     } catch {
-      // skip
+      // skip malformed payloads
     }
   }
 

--- a/slices/record-decision/README.md
+++ b/slices/record-decision/README.md
@@ -1,0 +1,67 @@
+# slices/record-decision
+
+M19.06: `record-decision` runtime tool — synchronous SQLite write with iteration + phase metadata.
+
+Closes #563.
+
+## What it does
+
+Adds a mid-run tool (`record-decision`) that agents can call synchronously to persist structured `DecisionRecord` entries to the `agent_decisions` SQLite table. This is an A/B evaluation against the existing two-stream decision model (live `[decision]` markers + end-of-run schema field).
+
+Shipped behind `experimental.recordDecisionTool: true` in project config (default: false).
+
+## Components
+
+| Path | Export | Purpose |
+|------|--------|---------|
+| `core/db/schema.ts` | `agentDecisions` | New `agent_decisions` table |
+| `core/db/migrations/0007_agent_decisions.sql` | — | DDL migration |
+| `core/types.ts` | `ProjectConfig.experimental.recordDecisionTool` | Feature flag |
+| `core/tool-layer/tools/record-decision.ts` | `recordDecision`, `readRunDecisions` | Business logic |
+| `core/tool-layer/bundles.ts` | `'decision-record-only'` | New bundle |
+| `core/tool-layer/allowlist.ts` | `computeAllowlist` | Role-aware holdout filtering |
+| `scripts/eval-decision-streams.ts` | — | A/B eval harness |
+
+## `agent_decisions` table
+
+```
+id TEXT PRIMARY KEY         -- randomUUID()
+run_id TEXT NOT NULL        -- links to the agent run
+iteration INTEGER           -- iteration within the run (default 0)
+phase TEXT                  -- e.g. 'plan', 'implement', '' (default '')
+kind TEXT NOT NULL          -- DecisionKind; unknown values coerced to 'UNKNOWN'
+what TEXT NOT NULL          -- summary (maps to DecisionSummary.summary)
+why TEXT NOT NULL           -- rationale (maps to DecisionSummary.evidence)
+ts TEXT                     -- ISO timestamp (set by SQLite default)
+```
+
+Deduplication: `UNIQUE (run_id, kind, what)` — a second call with the same triple is a no-op returning `{ recorded: false, id: <existing>, reason: 'duplicate' }`.
+
+## Holdout discipline
+
+`decision-record-only` bundle is stripped from `qa` and `reviewer` roles by `computeAllowlist`. This prevents holdout agents from leaking implementation-phase decisions (FACTORY_RULES rule 1).
+
+Enforcement path: `computeAllowlist(spec)` in `core/agent-runtime/claude-cli.ts` receives the full `AgentSpec` including `role`; the new role-aware branch filters the bundle before it reaches `--allowedTools`.
+
+## Reconciliation at run end
+
+When the flag is on and the run made tool calls, `readRunDecisions(runId)` returns the DB rows as `DecisionSummary[]`. The orchestrator can use these in place of (or merged with) the end-of-run schema field extractions.
+
+## A/B evaluation
+
+```sh
+# Compare all runs in the DB
+pnpm tsx scripts/eval-decision-streams.ts
+
+# Focus on one run
+pnpm tsx scripts/eval-decision-streams.ts --run-id <id>
+
+# JSON output for piping
+pnpm tsx scripts/eval-decision-streams.ts --json
+```
+
+After 5–10 M19 runs with the flag on, decide whether to promote, discard, or keep as hybrid (per issue #563 open question).
+
+## State transitions
+
+This slice contains no workflow or state transition logic. It is a pure infrastructure addition consumed by the orchestrator.

--- a/slices/record-decision/slice.test.ts
+++ b/slices/record-decision/slice.test.ts
@@ -1,0 +1,207 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { db } from '../../core/db/db.js';
+import { agentDecisions } from '../../core/db/schema.js';
+import { computeAllowlist } from '../../core/tool-layer/allowlist.js';
+import { readRunDecisions, recordDecision } from '../../core/tool-layer/tools/record-decision.js';
+
+const RUN_A = 'test-record-decision-run-a';
+const RUN_B = 'test-record-decision-run-b';
+
+// ─── setup ────────────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  db.run(sql`CREATE TABLE IF NOT EXISTS agent_decisions (
+    id TEXT PRIMARY KEY NOT NULL,
+    run_id TEXT NOT NULL,
+    iteration INTEGER NOT NULL DEFAULT 0,
+    phase TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL,
+    what TEXT NOT NULL,
+    why TEXT NOT NULL,
+    ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
+  db.run(sql`CREATE UNIQUE INDEX IF NOT EXISTS agent_decisions_run_kind_what_uniq
+    ON agent_decisions (run_id, kind, what)`);
+  db.run(sql`CREATE INDEX IF NOT EXISTS agent_decisions_run_idx
+    ON agent_decisions (run_id)`);
+
+  // Clean up any stale test rows from prior runs
+  db.delete(agentDecisions).where(sql`run_id IN (${RUN_A}, ${RUN_B})`).run();
+});
+
+afterAll(() => {
+  db.delete(agentDecisions).where(sql`run_id IN (${RUN_A}, ${RUN_B})`).run();
+});
+
+// ─── recordDecision ───────────────────────────────────────────────────────────
+
+describe('recordDecision', () => {
+  it('records a valid decision and returns recorded: true', () => {
+    const result = recordDecision({
+      runId: RUN_A,
+      kind: 'PLAN',
+      what: 'chose TDD',
+      why: 'faster feedback',
+    });
+    expect(result.recorded).toBe(true);
+    expect(typeof result.id).toBe('string');
+    expect(result.id.length).toBeGreaterThan(0);
+  });
+
+  it('coerces unknown kind to UNKNOWN', () => {
+    const result = recordDecision({
+      runId: RUN_A,
+      kind: 'NOT_A_REAL_KIND',
+      what: 'mystery',
+      why: 'test',
+    });
+    expect(result.recorded).toBe(true);
+
+    const rows = db
+      .select({ kind: agentDecisions.kind })
+      .from(agentDecisions)
+      .where(sql`run_id = ${RUN_A} AND what = 'mystery'`)
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('UNKNOWN');
+  });
+
+  it('deduplicates on (runId, kind, what) — second call returns recorded: false', () => {
+    const first = recordDecision({
+      runId: RUN_A,
+      kind: 'READ',
+      what: 'opened handler',
+      why: 'initial',
+    });
+    expect(first.recorded).toBe(true);
+
+    const second = recordDecision({
+      runId: RUN_A,
+      kind: 'READ',
+      what: 'opened handler',
+      why: 'different why',
+    });
+    expect(second.recorded).toBe(false);
+    if (!second.recorded) {
+      expect(second.reason).toBe('duplicate');
+      expect(second.id).toBe(first.id);
+    }
+  });
+
+  it('allows the same (kind, what) for a different runId', () => {
+    recordDecision({ runId: RUN_A, kind: 'GREEN', what: 'tests pass', why: 'run A' });
+    const result = recordDecision({
+      runId: RUN_B,
+      kind: 'GREEN',
+      what: 'tests pass',
+      why: 'run B',
+    });
+    expect(result.recorded).toBe(true);
+  });
+
+  it('persists iteration and phase metadata', () => {
+    recordDecision({
+      runId: RUN_B,
+      kind: 'REFACTOR',
+      what: 'extracted helper',
+      why: 'DRY',
+      iteration: 2,
+      phase: 'implement',
+    });
+    const rows = db
+      .select({ iteration: agentDecisions.iteration, phase: agentDecisions.phase })
+      .from(agentDecisions)
+      .where(sql`run_id = ${RUN_B} AND what = 'extracted helper'`)
+      .all();
+    expect(rows[0].iteration).toBe(2);
+    expect(rows[0].phase).toBe('implement');
+  });
+});
+
+// ─── readRunDecisions ─────────────────────────────────────────────────────────
+
+describe('readRunDecisions', () => {
+  it('returns all decisions for a run as DecisionSummary-shaped objects', () => {
+    const decisions = readRunDecisions(RUN_A);
+    expect(decisions.length).toBeGreaterThan(0);
+    for (const d of decisions) {
+      expect(typeof d.kind).toBe('string');
+      expect(typeof d.summary).toBe('string');
+    }
+  });
+
+  it('returns empty array for an unknown runId', () => {
+    const decisions = readRunDecisions('run-that-does-not-exist');
+    expect(decisions).toHaveLength(0);
+  });
+
+  it('maps what → summary and why → evidence', () => {
+    const runId = 'test-map-run';
+    db.delete(agentDecisions).where(sql`run_id = ${runId}`).run();
+    recordDecision({ runId, kind: 'COMMIT', what: 'committed fix', why: 'all tests green' });
+
+    const decisions = readRunDecisions(runId);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].summary).toBe('committed fix');
+    expect(decisions[0].evidence).toBe('all tests green');
+
+    db.delete(agentDecisions).where(sql`run_id = ${runId}`).run();
+  });
+});
+
+// ─── holdout role blocked bundle ──────────────────────────────────────────────
+
+describe('holdout role denied bundle assignment', () => {
+  it('qa role does not receive record-decision from decision-record-only bundle', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'qa',
+    });
+    expect(list).not.toContain('record-decision');
+  });
+
+  it('reviewer role does not receive record-decision from decision-record-only bundle', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'reviewer',
+    });
+    expect(list).not.toContain('record-decision');
+  });
+
+  it('developer role receives record-decision from decision-record-only bundle', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'developer',
+    });
+    expect(list).toContain('record-decision');
+  });
+
+  it('investigator role receives record-decision from decision-record-only bundle', () => {
+    const list = computeAllowlist({
+      toolBundles: ['decision-record-only'],
+      toolExtras: [],
+      role: 'investigator',
+    });
+    expect(list).toContain('record-decision');
+  });
+});
+
+// ─── flag-off fallback ────────────────────────────────────────────────────────
+
+describe('flag-off behaviour', () => {
+  it('decision-record-only excluded from bundles when flag not set', () => {
+    // When the flag is off, the orchestrator simply does not add 'decision-record-only'
+    // to the toolBundles list. computeAllowlist returns nothing for it in that case.
+    const listWithout = computeAllowlist({ toolBundles: ['dev-tools'], toolExtras: [] });
+    expect(listWithout).not.toContain('record-decision');
+  });
+
+  it('readRunDecisions returns empty when no tool calls were made (flag-off run)', () => {
+    const decisions = readRunDecisions('flag-off-run-no-decisions');
+    expect(decisions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #563

## Summary

- Adds `agent_decisions` SQLite table with deduplication on `(run_id, kind, what)` and migration `0007_agent_decisions.sql`
- Ships `core/tool-layer/tools/record-decision.ts`: `recordDecision()` (mid-run write) and `readRunDecisions()` (reconciliation at run end)
- Adds `decision-record-only` bundle to `bundles.ts`; holdout roles (`qa`, `reviewer`) are stripped from this bundle in `computeAllowlist` (enforced via new `role?` param)
- Adds `experimental.recordDecisionTool?: boolean` to `ProjectConfig` — default `false`, opt-in per project
- Adds `scripts/eval-decision-streams.ts` A/B harness: compares per-run decision counts/kinds between flag-on and flag-off runs
- Slice in `slices/record-decision/` with 14 tests covering: valid insert, unknown-kind coercion → `UNKNOWN`, deduplication, cross-run isolation, iteration/phase metadata, holdout role blocking, flag-off behaviour

## Test plan

- [ ] `pnpm test slices/record-decision/slice.test.ts` — 14 tests pass
- [ ] `pnpm test` — all 2719 tests pass
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean

https://claude.ai/code/session_01PzxV531P9W7mS1uUXC4abq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzxV531P9W7mS1uUXC4abq)_