### PR TITLE
M19.08: per-run QualityScore (0-100) with components + convergence detection

### DIFF
--- a/apps/server/src/domains/roster/router.ts
+++ b/apps/server/src/domains/roster/router.ts
@@ -4,6 +4,7 @@ import {
   getPersonaCandidates,
   getPersonaNames,
   getPersonaRuns,
+  getQualityTrend,
   listPersonas,
   rejectCandidate,
 } from './service.js';
@@ -24,6 +25,13 @@ router.get('/runs', async (c) => {
   const persona = c.req.query('persona') ?? '';
   const result = await getPersonaRuns(persona);
   return result.ok ? c.json(result.data) : c.json({ runs: [] });
+});
+
+router.get('/quality-trend', async (c) => {
+  const project = c.req.query('project') ?? '';
+  const limit = Number(c.req.query('limit') ?? '50');
+  const result = await getQualityTrend(project, Number.isNaN(limit) ? 50 : limit);
+  return result.ok ? c.json(result.data) : c.json({ trend: [] });
 });
 
 router.get('/candidates', async (c) => {

--- a/apps/server/src/domains/roster/router.ts
+++ b/apps/server/src/domains/roster/router.ts
@@ -29,8 +29,9 @@ router.get('/runs', async (c) => {
 
 router.get('/quality-trend', async (c) => {
   const project = c.req.query('project') ?? '';
-  const limit = Number(c.req.query('limit') ?? '50');
-  const result = await getQualityTrend(project, Number.isNaN(limit) ? 50 : limit);
+  const raw = Number(c.req.query('limit') ?? '50');
+  const limit = Number.isFinite(raw) && raw > 0 ? Math.min(Math.floor(raw), 200) : 50;
+  const result = await getQualityTrend(project, limit);
   return result.ok ? c.json(result.data) : c.json({ trend: [] });
 });
 

--- a/apps/server/src/domains/roster/service.ts
+++ b/apps/server/src/domains/roster/service.ts
@@ -1,3 +1,5 @@
+import { listProjectQualityTrend } from '@goose-hub/core/quality-score/repository.js';
+import type { RunQualityScore } from '@goose-hub/core/quality-score/types.js';
 import type { Result } from '#shared/middleware.js';
 import { getProject } from '#shared/projects.js';
 import type { ImprovementCandidateRow, PersonaNameRow, PersonaStat } from './repository.js';
@@ -20,6 +22,15 @@ export interface PersonaRunDto {
 
 export type { ImprovementCandidateRow as ImprovementCandidateDto };
 export type { PersonaNameRow as PersonaNameDto };
+export type { RunQualityScore as QualityTrendPointDto };
+
+export async function getQualityTrend(
+  projectId: string,
+  limit = 50,
+): Promise<Result<{ trend: RunQualityScore[] }>> {
+  const trend = listProjectQualityTrend(projectId, limit);
+  return { ok: true, data: { trend } };
+}
 
 export async function getPersonaNames(): Promise<Result<{ names: PersonaNameRow[] }>> {
   const names = await listPersonaNames();

--- a/apps/web/src/components/roster/components/QualityTrendTab.tsx
+++ b/apps/web/src/components/roster/components/QualityTrendTab.tsx
@@ -1,0 +1,155 @@
+import { fetchQualityTrend } from '@/lib/api';
+import type { QualityTrendPointDto } from '@/lib/types';
+import { timeAgo } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+
+function scoreColor(score: number): string {
+  if (score >= 80) return 'var(--success, #22c55e)';
+  if (score >= 60) return 'var(--warning, #f59e0b)';
+  return 'var(--danger, #ef4444)';
+}
+
+function ScoreBar({ score }: { score: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 bg-bg-hover rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all"
+          style={{ width: `${score}%`, background: scoreColor(score) }}
+        />
+      </div>
+      <span
+        className="text-[11px] font-mono w-8 text-right shrink-0"
+        style={{ color: scoreColor(score) }}
+      >
+        {score}
+      </span>
+    </div>
+  );
+}
+
+function ComponentsBadges({ point }: { point: QualityTrendPointDto }) {
+  const c = point.components;
+  const findings = c.p0_count + c.p1_count + c.p2_count + c.p3_count;
+  return (
+    <div className="flex flex-wrap gap-1 mt-1.5">
+      {c.p0_count > 0 && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-[color:var(--danger)] text-white">
+          P0×{c.p0_count}
+        </span>
+      )}
+      {c.p1_count > 0 && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-[color:var(--danger)]/20 text-[color:var(--danger)]">
+          P1×{c.p1_count}
+        </span>
+      )}
+      {findings === 0 && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-[color:var(--success)]/20 text-[color:var(--success)]">
+          no findings
+        </span>
+      )}
+      {c.regressions_open > 0 && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-[color:var(--warning)]/20 text-[color:var(--warning)]">
+          reg×{c.regressions_open}
+        </span>
+      )}
+      {!c.static_passed && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-bg-hover text-fg-3">
+          tier1 fail
+        </span>
+      )}
+      {!c.uat_passed && (
+        <span className="px-1 py-0.5 rounded text-[10px] font-mono bg-bg-hover text-fg-3">
+          tier2 fail
+        </span>
+      )}
+    </div>
+  );
+}
+
+function TrendRow({ point }: { point: QualityTrendPointDto }) {
+  return (
+    <div className="py-3 border-b border-line last:border-0">
+      <div className="flex items-center justify-between gap-4 mb-1.5">
+        <span className="text-[11.5px] font-mono text-fg-3 truncate">
+          {point.runId.slice(0, 12)}
+        </span>
+        <span className="text-[11px] text-fg-3 shrink-0">{timeAgo(point.ts)}</span>
+      </div>
+      <ScoreBar score={point.score} />
+      <ComponentsBadges point={point} />
+    </div>
+  );
+}
+
+export function QualityTrendTab({ projectSlug }: { projectSlug: string }) {
+  const {
+    data: trend = [],
+    isLoading,
+    error,
+  } = useQuery<QualityTrendPointDto[]>({
+    queryKey: ['quality-trend', projectSlug],
+    queryFn: () => fetchQualityTrend(projectSlug),
+    enabled: projectSlug.length > 0,
+  });
+
+  if (isLoading) {
+    return <div className="px-8 py-6 text-fg-3 text-[13px]">Loading quality trend…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="px-8 py-6 text-[color:var(--danger)] text-[13px]">
+        Failed to load quality trend.
+      </div>
+    );
+  }
+
+  if (trend.length === 0) {
+    return (
+      <div
+        data-testid="quality-trend-empty"
+        className="px-8 py-16 text-center text-fg-3 text-[13px]"
+      >
+        <p className="mb-2 font-medium text-fg-2">No quality scores yet</p>
+        <p>Scores accumulate as pipeline runs complete.</p>
+      </div>
+    );
+  }
+
+  const latest = trend[trend.length - 1];
+  const avg =
+    trend.length > 0 ? Math.round(trend.reduce((sum, p) => sum + p.score, 0) / trend.length) : 0;
+
+  return (
+    <div data-testid="quality-trend-tab" className="flex flex-col h-full overflow-hidden">
+      {/* Summary header */}
+      <div className="px-8 py-4 border-b border-line flex items-center gap-8">
+        <div>
+          <div className="text-[11px] uppercase tracking-wider text-fg-3 mb-0.5">Latest</div>
+          <div
+            className="text-[22px] font-bold font-mono"
+            style={{ color: scoreColor(latest.score) }}
+          >
+            {latest.score}
+          </div>
+        </div>
+        <div>
+          <div className="text-[11px] uppercase tracking-wider text-fg-3 mb-0.5">
+            Avg ({trend.length} runs)
+          </div>
+          <div className="text-[22px] font-bold font-mono" style={{ color: scoreColor(avg) }}>
+            {avg}
+          </div>
+        </div>
+      </div>
+
+      {/* Run list */}
+      <div className="flex-1 overflow-y-auto px-8 py-2">
+        {[...trend].reverse().map((point) => (
+          <TrendRow key={`${point.runId}-${point.iteration}`} point={point} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/components/RosterPage.tsx
+++ b/apps/web/src/components/roster/components/RosterPage.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { PersonaDrillIn } from './PersonaDrillIn';
 import { PlaybooksTab } from './PlaybooksTab';
+import { QualityTrendTab } from './QualityTrendTab';
 
 // Extracts the project slug from a persona name in the format "<slug>/<role>/<index>"
 export function personaProjectSlug(personaName: string): string {
@@ -125,7 +126,9 @@ function RoleGroup({
 export function RosterPage() {
   const params = useParams<{ slug?: string }>();
   const projectSlug = params.slug ?? 'goose-hub-self';
-  const [activeTab, setActiveTab] = useState<'personas' | 'playbooks'>('personas');
+  const [activeTab, setActiveTab] = useState<'personas' | 'playbooks' | 'quality-trend'>(
+    'personas',
+  );
   const [selectedPersona, setSelectedPersona] = useState<PersonaStatDto | null>(null);
   const [projectScope, setProjectScope] = useState<'all' | string>('all');
 
@@ -165,6 +168,17 @@ export function RosterPage() {
         <RosterTabBar activeTab={activeTab} onTabChange={setActiveTab} />
         <div className="flex-1 min-h-0 overflow-hidden">
           <PlaybooksTab projectSlug={projectSlug} />
+        </div>
+      </div>
+    );
+  }
+
+  if (activeTab === 'quality-trend') {
+    return (
+      <div data-testid="roster-page" className="flex flex-col h-full overflow-hidden">
+        <RosterTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <QualityTrendTab projectSlug={projectSlug} />
         </div>
       </div>
     );
@@ -261,8 +275,8 @@ export function RosterPage() {
 }
 
 interface RosterTabBarProps {
-  activeTab: 'personas' | 'playbooks';
-  onTabChange: (tab: 'personas' | 'playbooks') => void;
+  activeTab: 'personas' | 'playbooks' | 'quality-trend';
+  onTabChange: (tab: 'personas' | 'playbooks' | 'quality-trend') => void;
 }
 
 function RosterTabBar({ activeTab, onTabChange }: RosterTabBarProps) {
@@ -281,6 +295,13 @@ function RosterTabBar({ activeTab, onTabChange }: RosterTabBarProps) {
         onClick={() => onTabChange('playbooks')}
       >
         Playbooks
+      </TabButton>
+      <TabButton
+        testId="tab-quality-trend"
+        active={activeTab === 'quality-trend'}
+        onClick={() => onTabChange('quality-trend')}
+      >
+        Quality Trend
       </TabButton>
     </div>
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   PlaybookSummaryDto,
   ProjectConfigDto,
   ProjectSummary,
+  QualityTrendPointDto,
   SprintReviewEligibility,
   TransitionResult,
   TriageResultDto,
@@ -395,6 +396,16 @@ export async function fetchPersonaCandidates(
     `/roster/candidates?persona=${encodeURIComponent(personaName)}`,
   );
   return candidates;
+}
+
+export async function fetchQualityTrend(
+  projectId: string,
+  limit = 50,
+): Promise<QualityTrendPointDto[]> {
+  const { trend } = await getJson<{ trend: QualityTrendPointDto[] }>(
+    `/roster/quality-trend?project=${encodeURIComponent(projectId)}&limit=${limit}`,
+  );
+  return trend;
 }
 
 export async function approveCandidateById(id: number): Promise<ImprovementCandidateDto> {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -127,6 +127,28 @@ export interface IssueDiffDto {
   reason?: string;
 }
 
+export interface QualityComponentsDto {
+  p0_count: number;
+  p1_count: number;
+  p2_count: number;
+  p3_count: number;
+  regressions_open: number;
+  review_converged: boolean;
+  uat_passed: boolean;
+  static_passed: boolean;
+  harness_pass_rate: number;
+}
+
+export interface QualityTrendPointDto {
+  runId: string;
+  projectId: string;
+  iteration: number;
+  score: number;
+  components: QualityComponentsDto;
+  auditScore: number | null;
+  ts: string;
+}
+
 export type CostLabel = 'estimated' | 'exact';
 
 export type CostStage =

--- a/core/db/migrations/0008_run_quality_scores.sql
+++ b/core/db/migrations/0008_run_quality_scores.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `run_quality_scores` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`run_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`iteration` integer DEFAULT 0 NOT NULL,
+	`score` real NOT NULL,
+	`components_json` text NOT NULL,
+	`audit_score` real,
+	`ts` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `run_quality_scores_run_iteration_uniq` ON `run_quality_scores` (`run_id`,`iteration`);
+--> statement-breakpoint
+CREATE INDEX `run_quality_scores_project_ts_idx` ON `run_quality_scores` (`project_id`,`ts`);

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1746921600000,
       "tag": "0007_agent_decisions",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1746979200000,
+      "tag": "0008_run_quality_scores",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -234,6 +234,27 @@ export const agentDecisions = sqliteTable(
   }),
 );
 
+// Per-run QualityScore (M19.08, issue #565). One row per (run_id, iteration) pair.
+// components_json holds the full QualityComponents object.
+// audit_score from code-quality-audit (#564) is informational — does NOT feed the score formula.
+export const runQualityScores = sqliteTable(
+  'run_quality_scores',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    runId: text('run_id').notNull(),
+    projectId: text('project_id').notNull(),
+    iteration: integer('iteration').notNull().default(0),
+    score: real('score').notNull(),
+    componentsJson: text('components_json').notNull(),
+    auditScore: real('audit_score'),
+    ts: text('ts').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    runIterationUniq: uniqueIndex('run_quality_scores_run_iteration_uniq').on(t.runId, t.iteration),
+    projectTsIdx: index('run_quality_scores_project_ts_idx').on(t.projectId, t.ts),
+  }),
+);
+
 // One row per agent run. `runId` is unique — the same run is never recorded twice.
 // `costLabel`: 'exact' when the source provided authoritative usage metadata
 // (direct API), 'estimated' when only the Claude CLI's reported totals are

--- a/core/quality-score/README.md
+++ b/core/quality-score/README.md
@@ -1,0 +1,51 @@
+# core/quality-score
+
+Per-run QualityScore (0–100) with components and convergence detection.
+
+## What it does
+
+Computes a ship-readiness score for each agent run based on pipeline outputs.
+Persists scores to the `run_quality_scores` SQLite table for trend analysis.
+Detects convergence across the last three iterations (Steve's rule).
+
+## API
+
+### `computeQualityScore(runArtifacts: RunArtifacts): { score: number; components: QualityComponents }`
+
+Computes the 0–100 score from `QualityComponents`. A P0 finding immediately
+returns `score: 0`. See `docs/adr/0033-quality-score-weights.md` for the
+weight rationale.
+
+### `isConverged(scoreHistory: number[], latestComponents): boolean`
+
+Returns true when the last 3 scores are within a 5-point delta AND the most
+recent run has zero P0/P1 findings. Implements Steve's convergence rule
+verbatim (`08-learning-convergence-loop.md:130-145`).
+
+### `persistRunQualityScore(input)` / `listRunQualityScores(runId)` / `listProjectQualityTrend(projectId)`
+
+Repository functions for the `run_quality_scores` table.
+
+## Schema
+
+`QualityComponents` (snake_case, matches Steve verbatim):
+
+| Field             | Type    | Source                       |
+|-------------------|---------|------------------------------|
+| p0_count          | int     | QA / review findings         |
+| p1_count          | int     | QA / review findings         |
+| p2_count          | int     | QA / review findings         |
+| p3_count          | int     | QA / review findings         |
+| regressions_open  | int     | Tier-3 regression gate       |
+| review_converged  | bool    | Reviewer verdict             |
+| uat_passed        | bool    | Tier-2 functional verify     |
+| static_passed     | bool    | Tier-1 structural verify     |
+| harness_pass_rate | 0–1     | Test runner pass ratio       |
+
+`audit_score` (from code-quality-audit #564) is stored separately at the row
+level and does NOT feed `computeQualityScore`.
+
+## Autonomous-mode gate
+
+In supervised mode the score is informational only. In autonomous mode (M16)
+PR auto-merge requires `score >= 80 AND isConverged(history)`.

--- a/core/quality-score/repository.ts
+++ b/core/quality-score/repository.ts
@@ -1,0 +1,74 @@
+import { desc, eq } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { runQualityScores } from '../db/schema.js';
+import type { QualityComponents, RunQualityScore } from './types.js';
+
+export function persistRunQualityScore(input: {
+  runId: string;
+  projectId: string;
+  iteration: number;
+  score: number;
+  components: QualityComponents;
+  auditScore?: number | null;
+}): void {
+  db.insert(runQualityScores)
+    .values({
+      runId: input.runId,
+      projectId: input.projectId,
+      iteration: input.iteration,
+      score: input.score,
+      componentsJson: JSON.stringify(input.components),
+      auditScore: input.auditScore ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [runQualityScores.runId, runQualityScores.iteration],
+      set: {
+        score: input.score,
+        componentsJson: JSON.stringify(input.components),
+        auditScore: input.auditScore ?? null,
+      },
+    })
+    .run();
+}
+
+function toRunQualityScore(r: {
+  runId: string;
+  projectId: string;
+  iteration: number;
+  score: number;
+  componentsJson: string;
+  auditScore: number | null;
+  ts: string;
+}): RunQualityScore {
+  return {
+    runId: r.runId,
+    projectId: r.projectId,
+    iteration: r.iteration,
+    score: r.score,
+    components: JSON.parse(r.componentsJson) as QualityComponents,
+    auditScore: r.auditScore,
+    ts: r.ts,
+  };
+}
+
+export function listRunQualityScores(runId: string): RunQualityScore[] {
+  return db
+    .select()
+    .from(runQualityScores)
+    .where(eq(runQualityScores.runId, runId))
+    .orderBy(runQualityScores.iteration)
+    .all()
+    .map(toRunQualityScore);
+}
+
+export function listProjectQualityTrend(projectId: string, limit = 50): RunQualityScore[] {
+  return db
+    .select()
+    .from(runQualityScores)
+    .where(eq(runQualityScores.projectId, projectId))
+    .orderBy(desc(runQualityScores.ts))
+    .limit(limit)
+    .all()
+    .map(toRunQualityScore)
+    .reverse();
+}

--- a/core/quality-score/score.ts
+++ b/core/quality-score/score.ts
@@ -1,0 +1,60 @@
+// core/quality-score/score.ts
+// Per-run QualityScore (0-100) with convergence detection.
+// Formula weights are documented in docs/adr/0033-quality-score-weights.md.
+// Steve source: 03-lifecycle-harness.md:159-177, 08-learning-convergence-loop.md:88-145.
+
+import type { QualityComponents, RunArtifacts } from './types.js';
+
+// Weights — see ADR 0033 for rationale.
+const WEIGHTS = {
+  base: 20,
+  harness: 30,
+  staticPassed: 20,
+  uatPassed: 20,
+  reviewConverged: 10,
+  p1Deduction: 8,
+  p2Deduction: 4,
+  p3Deduction: 1,
+  regressionDeduction: 5,
+} as const;
+
+export function computeQualityScore(runArtifacts: RunArtifacts): {
+  score: number;
+  components: QualityComponents;
+} {
+  const { components } = runArtifacts;
+
+  // P0 finding immediately zeros the score (Steve: "P0 zeroes the score").
+  if (components.p0_count > 0) {
+    return { score: 0, components };
+  }
+
+  let score = WEIGHTS.base;
+  score += components.harness_pass_rate * WEIGHTS.harness;
+  if (components.static_passed) score += WEIGHTS.staticPassed;
+  if (components.uat_passed) score += WEIGHTS.uatPassed;
+  if (components.review_converged) score += WEIGHTS.reviewConverged;
+
+  score -= components.p1_count * WEIGHTS.p1Deduction;
+  score -= components.p2_count * WEIGHTS.p2Deduction;
+  score -= components.p3_count * WEIGHTS.p3Deduction;
+  score -= components.regressions_open * WEIGHTS.regressionDeduction;
+
+  return { score: Math.round(Math.max(0, Math.min(100, score))), components };
+}
+
+// isConverged implements Steve's rule verbatim (08-learning-convergence-loop.md:130-145):
+//   scoreHistory.length >= 3
+//   AND (max(last 3) - min(last 3)) < 5.0
+//   AND p0_count + p1_count === 0
+//
+// latestComponents must be the components from the most recent run in scoreHistory.
+export function isConverged(
+  scoreHistory: number[],
+  latestComponents: Pick<QualityComponents, 'p0_count' | 'p1_count'>,
+): boolean {
+  if (scoreHistory.length < 3) return false;
+  const last3 = scoreHistory.slice(-3);
+  const delta = Math.max(...last3) - Math.min(...last3);
+  return delta < 5.0 && latestComponents.p0_count + latestComponents.p1_count === 0;
+}

--- a/core/quality-score/types.ts
+++ b/core/quality-score/types.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+// QualityComponents matches Steve's verbatim list (08-learning-convergence-loop.md:105-119).
+// snake_case for PlaybookManifest portability (#556).
+// audit_score lives OUTSIDE components — it is informational only and does not
+// feed computeQualityScore (per issue #565 spec).
+export const QualityComponentsSchema = z.object({
+  p0_count: z.number().int().min(0),
+  p1_count: z.number().int().min(0),
+  p2_count: z.number().int().min(0),
+  p3_count: z.number().int().min(0),
+  regressions_open: z.number().int().min(0),
+  review_converged: z.boolean(),
+  uat_passed: z.boolean(),
+  static_passed: z.boolean(),
+  harness_pass_rate: z.number().min(0).max(1),
+});
+
+export type QualityComponents = z.infer<typeof QualityComponentsSchema>;
+
+// Input to computeQualityScore. The components come from the aggregated pipeline
+// outputs: finding counts from QA/review, tier results from three-tier-verify,
+// and harness_pass_rate from the test runner.
+export interface RunArtifacts {
+  runId: string;
+  projectId: string;
+  workItemId?: string | null;
+  iteration?: number;
+  components: QualityComponents;
+  // audit_score from code-quality-audit (#564) — informational, not a component
+  auditScore?: number | null;
+}
+
+export interface RunQualityScore {
+  runId: string;
+  projectId: string;
+  iteration: number;
+  score: number;
+  components: QualityComponents;
+  auditScore: number | null;
+  ts: string;
+}

--- a/core/retrospective/schemas.ts
+++ b/core/retrospective/schemas.ts
@@ -63,12 +63,34 @@ export const DecisionSummarySchema = z.object({
   evidence: z.string().optional(),
 });
 
+// Inline quality-score schemas so retrospective output is self-contained.
+// The full quality-score module lives in core/quality-score/; these mirror it
+// to avoid a cross-module circular import path.
+export const RetroQualityComponentsSchema = z.object({
+  p0_count: z.number().int().min(0),
+  p1_count: z.number().int().min(0),
+  p2_count: z.number().int().min(0),
+  p3_count: z.number().int().min(0),
+  regressions_open: z.number().int().min(0),
+  review_converged: z.boolean(),
+  uat_passed: z.boolean(),
+  static_passed: z.boolean(),
+  harness_pass_rate: z.number().min(0).max(1),
+});
+
+export const RetroRunQualityScoreSchema = z.object({
+  score: z.number().min(0).max(100),
+  components: RetroQualityComponentsSchema,
+  isConverged: z.boolean(),
+});
+
 export const RetroOutputBaseSchema = z.object({
   outcome: OutcomeSchema,
   workItemNumber: z.number().int(),
   summary: SummarySchema,
   improvementCandidates: z.array(ImprovementCandidateSchema),
   decisionSummaries: z.array(DecisionSummarySchema).min(1),
+  qualityScore: RetroRunQualityScoreSchema.optional(),
 });
 
 export type Summary = z.infer<typeof SummarySchema>;
@@ -80,6 +102,8 @@ export type ImprovementKind = z.infer<typeof ImprovementKindSchema>;
 export type ImprovementCandidate = z.infer<typeof ImprovementCandidateSchema>;
 export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
 export type Confidence = z.infer<typeof ConfidenceSchema>;
+export type RetroRunQualityScore = z.infer<typeof RetroRunQualityScoreSchema>;
+export type RetroQualityComponents = z.infer<typeof RetroQualityComponentsSchema>;
 export type RetroOutputBase = z.infer<typeof RetroOutputBaseSchema>;
 
 // Patterns must reach this confidence level before surfacing as improvement candidates.

--- a/docs/adr/0033-quality-score-weights.md
+++ b/docs/adr/0033-quality-score-weights.md
@@ -1,0 +1,113 @@
+# ADR 0033: QualityScore formula and weights
+
+**Date:** 2026-05-08
+**Status:** Accepted
+**Issue:** #565 (M19.08)
+
+## Context
+
+Issue #565 requires a 0-100 per-run QualityScore whose formula "matches Steve"
+(`03-lifecycle-harness.md:159-177`) — weighted sum, P0 zeroes score, regressions
+deduct, convergent review bumps.
+
+Steve's training materials define the _components_ (verbatim) but leave the
+weight values as design space. This ADR records the chosen weights and the
+rationale for each.
+
+## Components
+
+`QualityComponents` (snake_case for PlaybookManifest portability):
+
+| Component         | Type  | Source                           |
+|-------------------|-------|----------------------------------|
+| `p0_count`        | int   | QA / review blocker findings     |
+| `p1_count`        | int   | QA / review critical findings    |
+| `p2_count`        | int   | QA / review major findings       |
+| `p3_count`        | int   | QA / review minor findings       |
+| `regressions_open`| int   | Tier-3 regression failures       |
+| `review_converged`| bool  | Reviewer emits `approved`        |
+| `uat_passed`      | bool  | Tier-2 functional verification   |
+| `static_passed`   | bool  | Tier-1 structural verification   |
+| `harness_pass_rate`| 0-1  | Test-suite pass ratio            |
+
+`audit_score` (from code-quality-audit, #564) is stored alongside the score row
+but does NOT feed `computeQualityScore`. It is informational — the audit answers
+_architectural_ questions that are separate from ship-readiness.
+
+## Formula
+
+```
+if p0_count > 0: return 0
+
+score = base
+      + harness_pass_rate × harness_weight
+      + (static_passed  ? static_weight  : 0)
+      + (uat_passed     ? uat_weight     : 0)
+      + (review_converged ? review_weight : 0)
+      - p1_count       × p1_deduction
+      - p2_count       × p2_deduction
+      - p3_count       × p3_deduction
+      - regressions_open × regression_deduction
+
+return clamp(round(score), 0, 100)
+```
+
+## Chosen weights
+
+| Parameter            | Value | Rationale                                          |
+|----------------------|-------|----------------------------------------------------|
+| `base`               | 20    | A run that completed contributes a floor signal    |
+| `harness`            | 30    | Test suite is the primary quality signal (0-30)    |
+| `staticPassed`       | 20    | Structural verification — "did the change land?"   |
+| `uatPassed`          | 20    | Functional verification — "does it work?"          |
+| `reviewConverged`    | 10    | Human/holdout approval signals confidence          |
+| `p1Deduction`        | 8     | Critical findings are expensive; each costs 8 pts  |
+| `p2Deduction`        | 4     | Major findings cost half a critical               |
+| `p3Deduction`        | 1     | Minor findings are noise-level deductions          |
+| `regressionDeduction`| 5     | Each open regression is a ship-blocker signal      |
+
+**Score ceiling:** 100 (base + harness + static + uat + review = 20+30+20+20+10 = 100).
+
+**Typical good run** (harness=0.95, all passing, review_converged, 0 P1, 1 P2):
+`20 + 28.5 + 20 + 20 + 10 - 4 = 94.5 → 95`
+
+**Typical target** (harness=0.80, all passing, review_converged, 1 P1, 1 P2):
+`20 + 24 + 20 + 20 + 10 - 8 - 4 = 82`
+
+These typical values match the convergence example in the issue spec
+(scores 82 → 84 → 85).
+
+## Convergence rule (Steve verbatim)
+
+```
+isConverged(scoreHistory, latestComponents):
+  scoreHistory.length >= 3
+  AND (max(last 3) - min(last 3)) < 5.0
+  AND latestComponents.p0_count + latestComponents.p1_count === 0
+```
+
+No `regressions_open <= 3` clause — Steve does not require this
+(regressions_open already feeds the score directly).
+
+## Autonomous-mode gate
+
+In **supervised mode** the score is informational only (displayed in the
+Roster quality-trend tab).
+
+In **autonomous mode** (M16) PR auto-merge requires:
+```
+score >= 80 AND isConverged(history)
+```
+
+This threshold is deliberate: 80 allows one or two minor findings while still
+requiring healthy test pass rates and no critical findings.
+
+## Alternatives considered
+
+**Pure deduction model (start at 100):** Rejects because a run with zero test
+data would score 100. The base+components model forces positive signal before
+scoring high.
+
+**Steve's exact weight values:** Steve's deck describes the _component structure_
+but not specific numeric weights. We anchor to the component list verbatim
+and document our weights here for future auditability.

--- a/slices/quality-score/README.md
+++ b/slices/quality-score/README.md
@@ -1,0 +1,20 @@
+# slices/quality-score
+
+Slice tests for `core/quality-score/` — the per-run QualityScore (0–100)
+module introduced in M19.08 (issue #565).
+
+## What is tested
+
+- `computeQualityScore(runArtifacts)` — formula correctness, P0 zero-out rule,
+  finding deductions, boolean component contributions, harness_pass_rate
+  contribution, clamping to [0, 100], golden examples from the issue spec
+  (scores 82 → 84 → 85)
+- `isConverged(scoreHistory, latestComponents)` — Steve's convergence rule
+  verbatim (`08-learning-convergence-loop.md:130-145`): length ≥ 3, delta < 5.0,
+  p0+p1 = 0; all three counter-examples from the issue spec verified
+
+## References
+
+- `core/quality-score/score.ts` — implementation
+- `core/quality-score/types.ts` — QualityComponents, RunArtifacts
+- `docs/adr/0033-quality-score-weights.md` — weight rationale

--- a/slices/quality-score/slice.test.ts
+++ b/slices/quality-score/slice.test.ts
@@ -1,0 +1,229 @@
+import { computeQualityScore, isConverged } from '@goose-hub/core/quality-score/score.js';
+import type { QualityComponents, RunArtifacts } from '@goose-hub/core/quality-score/types.js';
+import { describe, expect, it } from 'vitest';
+
+function makeComponents(overrides: Partial<QualityComponents> = {}): QualityComponents {
+  return {
+    p0_count: 0,
+    p1_count: 0,
+    p2_count: 0,
+    p3_count: 0,
+    regressions_open: 0,
+    review_converged: true,
+    uat_passed: true,
+    static_passed: true,
+    harness_pass_rate: 1.0,
+    ...overrides,
+  };
+}
+
+function makeArtifacts(components: QualityComponents): RunArtifacts {
+  return { runId: 'run-1', projectId: 'proj', components };
+}
+
+// ─── computeQualityScore ──────────────────────────────────────────────────────
+
+describe('computeQualityScore — P0 zeroes score', () => {
+  it('returns 0 when p0_count > 0 regardless of other components', () => {
+    const c = makeComponents({ p0_count: 1, harness_pass_rate: 1.0 });
+    const { score } = computeQualityScore(makeArtifacts(c));
+    expect(score).toBe(0);
+  });
+
+  it('returns 0 for multiple P0 findings', () => {
+    const c = makeComponents({ p0_count: 3 });
+    const { score } = computeQualityScore(makeArtifacts(c));
+    expect(score).toBe(0);
+  });
+});
+
+describe('computeQualityScore — perfect run', () => {
+  it('scores 100 when all boolean flags true and harness = 1.0, no findings', () => {
+    const c = makeComponents();
+    const { score } = computeQualityScore(makeArtifacts(c));
+    expect(score).toBe(100);
+  });
+});
+
+describe('computeQualityScore — finding deductions', () => {
+  it('deducts 8 per P1 finding', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const withP1 = computeQualityScore(makeArtifacts(makeComponents({ p1_count: 1 }))).score;
+    expect(base - withP1).toBe(8);
+  });
+
+  it('deducts 4 per P2 finding', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const withP2 = computeQualityScore(makeArtifacts(makeComponents({ p2_count: 1 }))).score;
+    expect(base - withP2).toBe(4);
+  });
+
+  it('deducts 1 per P3 finding', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const withP3 = computeQualityScore(makeArtifacts(makeComponents({ p3_count: 1 }))).score;
+    expect(base - withP3).toBe(1);
+  });
+
+  it('deducts 5 per open regression', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const withReg = computeQualityScore(
+      makeArtifacts(makeComponents({ regressions_open: 1 })),
+    ).score;
+    expect(base - withReg).toBe(5);
+  });
+});
+
+describe('computeQualityScore — boolean component penalties', () => {
+  it('deducts 20 when uat_passed is false', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const failing = computeQualityScore(makeArtifacts(makeComponents({ uat_passed: false }))).score;
+    expect(base - failing).toBe(20);
+  });
+
+  it('deducts 20 when static_passed is false', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const failing = computeQualityScore(
+      makeArtifacts(makeComponents({ static_passed: false })),
+    ).score;
+    expect(base - failing).toBe(20);
+  });
+
+  it('deducts 10 when review_converged is false', () => {
+    const base = computeQualityScore(makeArtifacts(makeComponents())).score;
+    const failing = computeQualityScore(
+      makeArtifacts(makeComponents({ review_converged: false })),
+    ).score;
+    expect(base - failing).toBe(10);
+  });
+});
+
+describe('computeQualityScore — harness_pass_rate', () => {
+  it('score decreases as harness_pass_rate decreases', () => {
+    const full = computeQualityScore(
+      makeArtifacts(makeComponents({ harness_pass_rate: 1.0 })),
+    ).score;
+    const half = computeQualityScore(
+      makeArtifacts(makeComponents({ harness_pass_rate: 0.5 })),
+    ).score;
+    const none = computeQualityScore(
+      makeArtifacts(makeComponents({ harness_pass_rate: 0.0 })),
+    ).score;
+    expect(full).toBeGreaterThan(half);
+    expect(half).toBeGreaterThan(none);
+  });
+});
+
+describe('computeQualityScore — clamping', () => {
+  it('never returns a score below 0', () => {
+    const c = makeComponents({
+      p1_count: 20,
+      p2_count: 20,
+      regressions_open: 10,
+      uat_passed: false,
+      static_passed: false,
+      review_converged: false,
+      harness_pass_rate: 0,
+    });
+    const { score } = computeQualityScore(makeArtifacts(c));
+    expect(score).toBe(0);
+  });
+
+  it('never returns a score above 100', () => {
+    const { score } = computeQualityScore(makeArtifacts(makeComponents()));
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('computeQualityScore — golden examples from issue spec', () => {
+  // run1: harness=0.80, all passing, review_converged=T, p1=1, p2=1, p3=0 → 82
+  it('run1 scores 82', () => {
+    const c = makeComponents({
+      harness_pass_rate: 0.8,
+      p1_count: 1,
+      p2_count: 1,
+    });
+    expect(computeQualityScore(makeArtifacts(c)).score).toBe(82);
+  });
+
+  // run2: harness=0.80, all passing, review_converged=T, p1=0, p2=2, p3=2 → 84
+  it('run2 scores 84', () => {
+    const c = makeComponents({
+      harness_pass_rate: 0.8,
+      p2_count: 2,
+      p3_count: 2,
+    });
+    expect(computeQualityScore(makeArtifacts(c)).score).toBe(84);
+  });
+
+  // run3: harness=0.80, all passing, review_converged=T, p1=0, p2=2, p3=1 → 85
+  it('run3 scores 85', () => {
+    const c = makeComponents({
+      harness_pass_rate: 0.8,
+      p2_count: 2,
+      p3_count: 1,
+    });
+    expect(computeQualityScore(makeArtifacts(c)).score).toBe(85);
+  });
+});
+
+// ─── isConverged ─────────────────────────────────────────────────────────────
+
+describe('isConverged — golden examples from issue spec', () => {
+  const zeroP = { p0_count: 0, p1_count: 0 };
+
+  it('[82,84,85]: delta=3 < 5, p0+p1=0 → converged', () => {
+    expect(isConverged([82, 84, 85], zeroP)).toBe(true);
+  });
+
+  it('[78,82,84]: delta=6 ≥ 5 → NOT converged', () => {
+    expect(isConverged([78, 82, 84], zeroP)).toBe(false);
+  });
+
+  it('[82,84,85] but p1_count=1 → NOT converged', () => {
+    expect(isConverged([82, 84, 85], { p0_count: 0, p1_count: 1 })).toBe(false);
+  });
+
+  it('[82,84,85] with p0_count=1 → NOT converged', () => {
+    expect(isConverged([82, 84, 85], { p0_count: 1, p1_count: 0 })).toBe(false);
+  });
+});
+
+describe('isConverged — length guard', () => {
+  const zeroP = { p0_count: 0, p1_count: 0 };
+
+  it('returns false when fewer than 3 scores', () => {
+    expect(isConverged([], zeroP)).toBe(false);
+    expect(isConverged([85], zeroP)).toBe(false);
+    expect(isConverged([84, 85], zeroP)).toBe(false);
+  });
+
+  it('passes with exactly 3 scores that meet the rule', () => {
+    expect(isConverged([83, 84, 85], zeroP)).toBe(true);
+  });
+});
+
+describe('isConverged — uses only last 3 entries from longer history', () => {
+  it('ignores older scores outside the last-3 window', () => {
+    // First two scores have large delta, last three are tight
+    const zeroP = { p0_count: 0, p1_count: 0 };
+    expect(isConverged([50, 80, 83, 84, 85], zeroP)).toBe(true);
+  });
+});
+
+describe('isConverged — exactly 5.0 delta is NOT converged', () => {
+  it('delta must be strictly less than 5.0', () => {
+    const zeroP = { p0_count: 0, p1_count: 0 };
+    expect(isConverged([80, 82, 85], zeroP)).toBe(false); // delta = 5 → NOT converged (not < 5)
+    expect(isConverged([81, 82, 85], zeroP)).toBe(true); // delta = 4 < 5 → converged
+  });
+});
+
+// ─── components passthrough ───────────────────────────────────────────────────
+
+describe('computeQualityScore — components passthrough', () => {
+  it('returns the input components unchanged', () => {
+    const c = makeComponents({ p2_count: 3 });
+    const result = computeQualityScore(makeArtifacts(c));
+    expect(result.components).toEqual(c);
+  });
+});


### PR DESCRIPTION
Closes #565

## Scope

Implements `core/quality-score/` — the per-run 0-100 QualityScore module with convergence detection per Steve's training corpus (`08-learning-convergence-loop.md`).

## Delivered

- `core/quality-score/score.ts` — `computeQualityScore(runArtifacts)` + `isConverged(scoreHistory, latestComponents)`
- `core/quality-score/types.ts` — `QualityComponents` (snake_case, Steve-verbatim), `RunArtifacts`, `RunQualityScore`
- `core/quality-score/repository.ts` — `persistRunQualityScore`, `listRunQualityScores`, `listProjectQualityTrend`
- `core/db/schema.ts` + migration `0008_run_quality_scores.sql` — new `run_quality_scores` table
- `core/retrospective/schemas.ts` — `RetroOutputBaseSchema` extended with optional `qualityScore` field
- `docs/adr/0033-quality-score-weights.md` — explicit weight rationale
- `apps/server/src/domains/roster/` — `GET /roster/quality-trend?project=<slug>` endpoint
- `apps/web/` — `QualityTrendTab` component + wired as third tab in `RosterPage`
- `slices/quality-score/slice.test.ts` — 25 tests including all three golden counter-examples from the issue spec (82→84→85 converged, 78→82→84 not converged, p1=1 not converged)

https://claude.ai/code/session_01R6V9soW5DJuqr2xHZv6Kee

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6V9soW5DJuqr2xHZv6Kee)_