### PR TITLE
M11.10: queue cap-dropped workflow dispatches to prevent stranded work items

### DIFF
--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -430,7 +430,7 @@ describe('pending queue: cap-full queuing and drain', () => {
     expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
   });
 
-  it('same issue already pending is not queued a second time', async () => {
+  it('same issue + same workflow already pending is not queued a second time', async () => {
     let resolveSource!: () => void;
     mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
     mockGetSourceForSlug
@@ -460,6 +460,46 @@ describe('pending queue: cap-full queuing and drain', () => {
       expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
     });
     expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
+  });
+
+  it('different workflows for the same issue can each be queued independently', async () => {
+    let resolveSource!: () => void;
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
+    mockGetSourceForSlug
+      .mockReturnValueOnce(
+        new Promise<null>((r) => {
+          resolveSource = () => r(null);
+        }),
+      )
+      .mockResolvedValue(null);
+
+    const { dispatchFixIssue, dispatchQa } = await import('./dispatch.js');
+    const p1 = dispatchFixIssue('slug', 5);
+
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
+    });
+
+    // Two different workflows for the same issue — both should be enqueued.
+    await dispatchFixIssue('slug', 6);
+    await dispatchQa('slug', 6);
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'dispatchFixIssue: cap full, queuing work item',
+      expect.objectContaining({ issueNumber: 6 }),
+    );
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'dispatchQa: cap full, queuing work item',
+      expect.objectContaining({ issueNumber: 6 }),
+    );
+
+    resolveSource();
+    await p1;
+
+    // Both pending dispatches drain sequentially; getSourceForSlug called 3 times total.
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(3);
+    });
   });
 });
 

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -185,7 +185,7 @@ describe('dispatchInvestigate', () => {
 
     await p2;
     expect(mockLoggerWarn).toHaveBeenCalledWith(
-      'dispatchInvestigate: parallel-lock rejected (in-flight or at cap)',
+      'dispatchInvestigate: duplicate in-flight, dropping',
       expect.objectContaining({ slug: 'slug', issueNumber: 5 }),
     );
 
@@ -233,7 +233,7 @@ describe('dispatchFixIssue', () => {
 
     await p2;
     expect(mockLoggerWarn).toHaveBeenCalledWith(
-      'dispatchFixIssue: parallel-lock rejected (in-flight or at cap)',
+      'dispatchFixIssue: duplicate in-flight, dropping',
       expect.objectContaining({ slug: 'slug', issueNumber: 7 }),
     );
 
@@ -322,6 +322,144 @@ describe('dispatchFixIssue', () => {
       'dispatchFixIssue: item blocked by deps, skipping',
       expect.anything(),
     );
+  });
+});
+
+// ─── pending-queue behaviour ──────────────────────────────────────────────
+
+describe('pending queue: cap-full queuing and drain', () => {
+  it('cap-full rejection queues work item (not logged as warn)', async () => {
+    let resolveSource!: () => void;
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
+    // First call blocks, keeping slot 1 occupied; second call returns null immediately.
+    mockGetSourceForSlug
+      .mockReturnValueOnce(
+        new Promise<null>((r) => {
+          resolveSource = () => r(null);
+        }),
+      )
+      .mockResolvedValue(null);
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    const p1 = dispatchFixIssue('slug', 5);
+
+    // Wait for p1 to acquire the lock (its getMaxParallelAgents must have resolved).
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
+    });
+
+    // Fire a second dispatch for a DIFFERENT issue — cap is full.
+    await dispatchFixIssue('slug', 6);
+
+    // Should NOT emit the "duplicate in-flight" warn (issue 6 is not in-flight).
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      'dispatchFixIssue: duplicate in-flight, dropping',
+      expect.objectContaining({ issueNumber: 6 }),
+    );
+    // Should be logged as a cap-full queue.
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'dispatchFixIssue: cap full, queuing work item',
+      expect.objectContaining({ slug: 'slug', issueNumber: 6 }),
+    );
+
+    resolveSource();
+    await p1;
+    // Flush the drained dispatch (void, fire-and-forget) so it does not leak into the next test.
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('when a slot frees the pending item is dispatched', async () => {
+    let resolveSource!: () => void;
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
+    mockGetSourceForSlug
+      .mockReturnValueOnce(
+        new Promise<null>((r) => {
+          resolveSource = () => r(null);
+        }),
+      )
+      .mockResolvedValue(null); // second call (drain of issue 6) returns null → early return
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    const p1 = dispatchFixIssue('slug', 5);
+
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
+    });
+
+    await dispatchFixIssue('slug', 6); // cap-full → queued
+
+    resolveSource();
+    await p1;
+
+    // drainPending fires dispatchFixIssue('slug', 6) which calls getSourceForSlug a second time.
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('per-issue duplicate (same issue already in-flight) is not queued', async () => {
+    let resolveSource!: () => void;
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
+    mockGetSourceForSlug.mockReturnValueOnce(
+      new Promise<null>((r) => {
+        resolveSource = () => r(null);
+      }),
+    );
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    const p1 = dispatchFixIssue('slug', 5);
+    // Duplicate for the SAME issue while in-flight.
+    await dispatchFixIssue('slug', 5);
+
+    // Must be logged as a duplicate drop, not as cap-full queue.
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'dispatchFixIssue: duplicate in-flight, dropping',
+      expect.objectContaining({ slug: 'slug', issueNumber: 5 }),
+    );
+    expect(mockLoggerInfo).not.toHaveBeenCalledWith(
+      'dispatchFixIssue: cap full, queuing work item',
+      expect.anything(),
+    );
+
+    resolveSource();
+    await p1;
+
+    // Only one source lookup — the duplicate was dropped, not queued.
+    expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
+  });
+
+  it('same issue already pending is not queued a second time', async () => {
+    let resolveSource!: () => void;
+    mockGetProject.mockResolvedValue({ budgets: { maxParallelAgents: 1 } });
+    mockGetSourceForSlug
+      .mockReturnValueOnce(
+        new Promise<null>((r) => {
+          resolveSource = () => r(null);
+        }),
+      )
+      .mockResolvedValue(null);
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    const p1 = dispatchFixIssue('slug', 5);
+
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(1);
+    });
+
+    // Both of these hit cap-full; only the first should be queued.
+    await dispatchFixIssue('slug', 6);
+    await dispatchFixIssue('slug', 6);
+
+    resolveSource();
+    await p1;
+
+    // Issue 6 should be dispatched exactly once (drained once from the queue).
+    await vi.waitFor(() => {
+      expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
+    });
+    expect(mockGetSourceForSlug).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -15,6 +15,36 @@ import { getSourceForSlug } from './source.js';
 const _triageBatchInFlight = new Set<string>();
 const _triageBatchPending = new Set<string>();
 
+type PendingWorkflowEntry = {
+  issueNumber: number;
+  dispatchFn: (slug: string, issueNumber: number) => Promise<void>;
+};
+const _workflowPending = new Map<string, PendingWorkflowEntry[]>();
+
+function enqueueWorkflow(
+  slug: string,
+  issueNumber: number,
+  dispatchFn: (slug: string, issueNumber: number) => Promise<void>,
+): void {
+  let queue = _workflowPending.get(slug);
+  if (queue == null) {
+    queue = [];
+    _workflowPending.set(slug, queue);
+  }
+  if (queue.some((e) => e.issueNumber === issueNumber)) return;
+  queue.push({ issueNumber, dispatchFn });
+}
+
+function drainPending(slug: string): void {
+  const queue = _workflowPending.get(slug);
+  if (queue == null || queue.length === 0) return;
+  const entry = queue.shift();
+  if (queue.length === 0) _workflowPending.delete(slug);
+  if (entry != null) {
+    void entry.dispatchFn(slug, entry.issueNumber);
+  }
+}
+
 async function getMaxParallelAgents(slug: string): Promise<number> {
   const cfg = await getProject(slug);
   return cfg?.budgets.maxParallelAgents ?? 1;
@@ -56,13 +86,18 @@ export function dispatchTriageBatch(slug: string): Promise<void> {
 /** Run the investigate workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchInvestigate(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchInvestigate: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchInvestigate: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchInvestigate: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchInvestigate);
     return;
   }
   try {
@@ -94,6 +129,7 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
     await runInvestigateWorkflow(item, source, slug, REPO_ROOT, mockInvestigateDeps);
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 
   // Chain to investigation-complete routing outside the lock. In production the
@@ -106,13 +142,18 @@ export async function dispatchInvestigate(slug: string, issueNumber: number): Pr
 /** Run the M7 fix-issue workflow for a single issue (#183). Drops duplicate triggers for the same issue. */
 export async function dispatchFixIssue(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchFixIssue: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchFixIssue: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchFixIssue: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchFixIssue);
     return;
   }
   try {
@@ -176,19 +217,25 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
     await runFixIssueWorkflow(item, source, slug, REPO_ROOT, mockDeps);
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
 /** Run the merge conflict resolution workflow for a single issue. Drops duplicate triggers. */
 export async function dispatchResolveConflict(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchResolveConflict: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchResolveConflict: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchResolveConflict: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchResolveConflict);
     return;
   }
   try {
@@ -230,19 +277,25 @@ export async function dispatchResolveConflict(slug: string, issueNumber: number)
     });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
 /** Run the QA holdout workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchQa(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchQa: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchQa: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchQa: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchQa);
     return;
   }
   try {
@@ -280,19 +333,25 @@ export async function dispatchQa(slug: string, issueNumber: number): Promise<voi
     });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
 /** Run the fix-feedback workflow for a single issue. Drops duplicate triggers. */
 export async function dispatchNeedsFix(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchNeedsFix: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchNeedsFix: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchNeedsFix: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchNeedsFix);
     return;
   }
   try {
@@ -325,6 +384,7 @@ export async function dispatchNeedsFix(slug: string, issueNumber: number): Promi
     await runFixFeedbackWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
@@ -335,13 +395,18 @@ export async function dispatchNeedsFix(slug: string, issueNumber: number): Promi
  */
 async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchQaFailed: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchQaFailed: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchQaFailed: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchQaFailed);
     return;
   }
   try {
@@ -377,6 +442,7 @@ async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void
     });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 
   // Fire fix-feedback outside the in-flight guard so needs-fix can also
@@ -387,13 +453,18 @@ async function dispatchQaFailed(slug: string, issueNumber: number): Promise<void
 /** Run the Review holdout workflow for a single issue. Drops duplicate triggers for the same issue. */
 export async function dispatchReview(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchReview: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchReview: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchReview: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchReview);
     return;
   }
   try {
@@ -417,6 +488,7 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
     await runReviewWorkflow(item, source, slug, item.repoRef ?? slug);
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
@@ -429,13 +501,18 @@ export async function dispatchReview(slug: string, issueNumber: number): Promise
  */
 export async function dispatchRetro(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchRetro: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchRetro: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchRetro: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchRetro);
     return;
   }
   try {
@@ -456,6 +533,7 @@ export async function dispatchRetro(slug: string, issueNumber: number): Promise<
     await runRetroForItem(item, source, slug);
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
@@ -466,13 +544,21 @@ export async function dispatchRetro(slug: string, issueNumber: number): Promise<
  */
 async function dispatchInvestigationComplete(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchInvestigationComplete: duplicate in-flight, dropping', {
+      slug,
+      issueNumber,
+    });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchInvestigationComplete: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchInvestigationComplete: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchInvestigationComplete);
     return;
   }
   try {
@@ -525,6 +611,7 @@ async function dispatchInvestigationComplete(slug: string, issueNumber: number):
     logger.info('dispatchInvestigationComplete: transitioned', { slug, issueNumber, targetState });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
@@ -678,13 +765,18 @@ function buildPriorReplies(
  */
 export async function dispatchGrillAndPrd(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchGrillAndPrd: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchGrillAndPrd: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchGrillAndPrd: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchGrillAndPrd);
     return;
   }
   try {
@@ -713,6 +805,7 @@ export async function dispatchGrillAndPrd(slug: string, issueNumber: number): Pr
     });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 
@@ -724,13 +817,18 @@ export async function dispatchGrillAndPrd(slug: string, issueNumber: number): Pr
  */
 export async function dispatchDecomposePrd(slug: string, issueNumber: number): Promise<void> {
   const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchDecomposePrd: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
   if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
-    logger.warn('dispatchDecomposePrd: parallel-lock rejected (in-flight or at cap)', {
+    logger.info('dispatchDecomposePrd: cap full, queuing work item', {
       slug,
       issueNumber,
       inFlight: parallelLock.inFlightCount(slug),
       maxParallel,
     });
+    enqueueWorkflow(slug, issueNumber, dispatchDecomposePrd);
     return;
   }
   try {
@@ -768,6 +866,7 @@ export async function dispatchDecomposePrd(slug: string, issueNumber: number): P
     });
   } finally {
     parallelLock.release(slug, issueNumber);
+    drainPending(slug);
   }
 }
 

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -31,7 +31,8 @@ function enqueueWorkflow(
     queue = [];
     _workflowPending.set(slug, queue);
   }
-  if (queue.some((e) => e.issueNumber === issueNumber)) return;
+  // Dedup by (issueNumber, dispatchFn) so different workflows for the same issue can both queue.
+  if (queue.some((e) => e.issueNumber === issueNumber && e.dispatchFn === dispatchFn)) return;
   queue.push({ issueNumber, dispatchFn });
 }
 
@@ -41,7 +42,13 @@ function drainPending(slug: string): void {
   const entry = queue.shift();
   if (queue.length === 0) _workflowPending.delete(slug);
   if (entry != null) {
-    void entry.dispatchFn(slug, entry.issueNumber);
+    entry.dispatchFn(slug, entry.issueNumber).catch((err: unknown) => {
+      logger.error('drainPending: dispatch failed', {
+        slug,
+        issueNumber: entry.issueNumber,
+        error: String(err),
+      });
+    });
   }
 }
 


### PR DESCRIPTION
Closes #550

## Summary
- Adds a per-project FIFO pending queue (`_workflowPending`) for workflow dispatches that are rejected solely because the `maxParallelAgents` cap is full
- Distinguishes cap-full rejections from per-issue duplicate-in-flight drops: duplicates are still dropped immediately, cap-full dispatches are queued
- Every `finally` block that calls `parallelLock.release` now also calls `drainPending`, which fires the next pending dispatch into the newly freed slot

## Test plan
- [ ] `cap-full rejection queues work item`: verifies cap-full path logs `info` (not `warn`) and does not log the duplicate-drop warning
- [ ] `when a slot frees the pending item is dispatched`: verifies `getSourceForSlug` is called a second time after the slot is freed
- [ ] `per-issue duplicate is not queued`: verifies same-issue in-flight drops still log warn and do not enter the queue
- [ ] `same issue already pending is not queued a second time`: verifies dedup within the pending queue itself
- [ ] All 195 test files pass, lint and typecheck clean

https://claude.ai/code/session_015gCB6tbpMLMjuZYk5uhcXR

---
_Generated by [Claude Code](https://claude.ai/code/session_015gCB6tbpMLMjuZYk5uhcXR)_