### PR TITLE
docs: add M13 gap review and prioritized improvement plan

### DIFF
--- a/docs/m13-gap-review-2026-05-07.md
+++ b/docs/m13-gap-review-2026-05-07.md
@@ -1,0 +1,47 @@
+# M13 Gap Review (as of 2026-05-07)
+
+## Scope reviewed
+- PLAN milestone definitions for M11–M13 and dependencies.
+- Existing implementation footprints in `core/`, `skills/`, `slices/`, `apps/server`, and `apps/web`.
+- Existing local notes in `todo.md`.
+
+## Quick status against "completed through M13, with M12 partially in progress"
+
+### What looks present and wired at a high level
+1. **M12 core artifacts exist**: bootstrap workflow, stack detector, label installer, governance checks, and CLI/UI slices are all present in repo structure.
+2. **M13 core artifacts exist**: all four required skills (`grill-me`, `write-prd`, `advise-on-prd`, `decompose-issues`) plus both workflows (`grill-and-prd`, `decompose-prd`) and E2E/UI slices are present.
+3. **Sprint-review skill exists** (called out in M13 issue list) and appears scaffold-complete.
+
+### Obvious gaps/risk areas still visible from code+plan alignment
+1. **M11 dependency scheduling remains the key dependency risk for M13 quality**. `PLAN.md` still marks M11.10 tests pending and M11.16–M11.19 open, while M13 depends on reliable dependency-aware scheduling for decomposition outputs.
+2. **Move-with-dependencies remains listed pending in M11 tracking section**. If decompose generates dependency-heavy child issues, operational tooling ergonomics may still lag for manual corrections.
+3. **Loading-state UX consistency appears incomplete** (from `todo.md`): timeline and detail-page loading placeholders are inconsistent, which will impact Grill/PRD confidence during long-running agent steps.
+4. **"Remove fake triage" is still called out** in `todo.md`, suggesting some orchestration path may still be using placeholder logic.
+5. **Some milestone status text in PLAN appears optimistic relative to local notes**. Internal notes still flag wiring concerns (esp. dependency filter/smoke-gate/auto-trigger areas), so milestone closure confidence should be treated as provisional until a fresh end-to-end audit run is recorded.
+
+## Recommended improvements (prioritized)
+
+### P0 (before calling M13 fully stable)
+1. **Run and record a formal M11 dependency exit audit** (same-repo block, unblock on close, cross-repo, unregistered cross-repo, multi-parallel).
+2. **Promote that audit output to a committed artifact** under `docs/audits/` with date and command log so M13 dependency assumptions are evidence-backed.
+3. **Close the loading-state UX debt** in timeline/detail as a single vertical UX slice (shared loading component + explicit `isLoading` state contract).
+
+### P1 (hardening M13 discover experience)
+1. **Add one “vague idea → shipped slices” golden-path E2E** that asserts: grill transcript persisted, PRD approval gate, child issue creation with dependencies + milestone metadata.
+2. **Add regression tests for PRD comment parsing/rendering edge-cases** (edited comments, markdown tables, malformed section headers).
+3. **Add observability events for each gate transition** in Discover flow (`grill.started`, `prd.generated`, `prd.approved`, `decompose.completed`) to make timeline diagnosis easier.
+
+### P2 (operational maturity)
+1. **Create a milestone status ledger** (`docs/milestone-status.md`) with explicit `Shipped / Partial / Open` and links to verifying tests.
+2. **Add "definition of done" checklist for each milestone** requiring both code presence and wiring proof.
+3. **Add a “plan drift” CI check** that warns when PLAN says “shipped” but linked test/audit artifact is missing.
+
+## Suggested next actions (this week)
+1. Execute dependency-aware scheduling audit and publish evidence.
+2. Tackle loading-state consistency and fake-triage cleanup in one UI/orchestration polish pass.
+3. Run one full M13 feature-shipping dry run and record artifacts (issue links, PRD comment, child issues).
+
+## Confidence summary
+- **M13 capability footprint:** High (components exist).
+- **M13 production confidence:** Medium (depends on unresolved or recently disputed M11 wiring/tests + visible UX debt).
+- **Best leverage move now:** Verify M11 dependency behavior end-to-end and close timeline/detail loading debt.


### PR DESCRIPTION
### Motivation
- Provide an explicit checkpoint aligning code with PLAN milestones M11–M13 and surface remaining wiring and UX gaps before declaring M13 stable.

### Description
- Add a new review document at `docs/m13-gap-review-2026-05-07.md` that summarizes present coverage, enumerates obvious gaps (notably M11 dependency wiring, move-with-deps, loading-state UX, and fake-triage), and proposes prioritized P0/P1/P2 improvements and next actions.

### Testing
- This is a documentation-only change so no unit or integration tests were required; repository inspection commands (`rg`, `sed`, `nl`) were run to verify context and file content and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc620cd6e883279133a4538e778ca1)