### PR TITLE
M19.09: provider-aware model routing + UI-configurable role/complexity overrides

### DIFF
--- a/apps/server/src/domains/project-settings/model-router.ts
+++ b/apps/server/src/domains/project-settings/model-router.ts
@@ -1,0 +1,138 @@
+import { ROLE_DEFAULTS } from '@goose-hub/core/agent-runtime/roles.js';
+import {
+  deleteRoleModelSetting,
+  readProjectModelSettings,
+  writeComplexityOverrides,
+  writeRoleModelSetting,
+} from '@goose-hub/core/db/repositories/project-model-settings.js';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { parseBody } from '#shared/middleware.js';
+import { getProject } from '#shared/projects.js';
+
+const router = new Hono();
+
+const VALID_TIERS = ['haiku', 'sonnet', 'opus'] as const;
+const TierSchema = z.enum(VALID_TIERS).nullable().optional();
+
+const RoleModelPatchSchema = z.object({
+  primaryModel: TierSchema,
+  fallbackModel: TierSchema,
+  advisorModel: TierSchema,
+});
+
+const ComplexityOverridesSchema = z.record(z.string(), z.enum(VALID_TIERS));
+
+/** GET /projects/:slug/settings/models — merged view of config + DB overrides */
+router.get('/:slug/settings/models', async (c) => {
+  const slug = c.req.param('slug');
+  const project = await getProject(slug);
+  if (project == null) return c.json({ error: 'project not found' }, 404);
+
+  const dbRows = readProjectModelSettings(project.id);
+  const configRolesModels = project.agentConfig?.rolesModels ?? {};
+
+  const roles = Object.keys(ROLE_DEFAULTS) as Array<keyof typeof ROLE_DEFAULTS>;
+  const result: Record<
+    string,
+    {
+      configRoleModel: { primary: string; fallback: string | null; advisor: string | null } | null;
+      dbRoleModel: {
+        primaryModel: string | null;
+        fallbackModel: string | null;
+        advisorModel: string | null;
+        updatedAt: string | null;
+      } | null;
+      dbComplexityOverrides: Record<string, string>;
+    }
+  > = {};
+
+  for (const role of roles) {
+    const dbRow = dbRows.get(role) ?? null;
+    const configEntry = configRolesModels[role] ?? null;
+    let complexityOverrides: Record<string, string> = {};
+    if (dbRow?.complexityOverridesJson) {
+      try {
+        complexityOverrides = JSON.parse(dbRow.complexityOverridesJson) as Record<string, string>;
+      } catch {
+        complexityOverrides = {};
+      }
+    }
+
+    result[role] = {
+      configRoleModel: configEntry
+        ? {
+            primary: configEntry.primary,
+            fallback: configEntry.fallback,
+            advisor: configEntry.advisor,
+          }
+        : null,
+      dbRoleModel: dbRow
+        ? {
+            primaryModel: dbRow.primaryModel ?? null,
+            fallbackModel: dbRow.fallbackModel ?? null,
+            advisorModel: dbRow.advisorModel ?? null,
+            updatedAt: dbRow.updatedAt,
+          }
+        : null,
+      dbComplexityOverrides: complexityOverrides,
+    };
+  }
+
+  return c.json({
+    projectId: project.id,
+    allowHoldoutOverride: project.agentConfig?.allowHoldoutOverride ?? false,
+    roles: result,
+  });
+});
+
+/** PATCH /projects/:slug/settings/models/:role — upsert per-role model assignment */
+router.patch('/:slug/settings/models/:role', async (c) => {
+  const slug = c.req.param('slug');
+  const role = c.req.param('role');
+  const project = await getProject(slug);
+  if (project == null) return c.json({ error: 'project not found' }, 404);
+
+  const body = await parseBody<unknown>(c);
+  if (!body.ok) return body.error;
+
+  const parsed = RoleModelPatchSchema.safeParse(body.data);
+  if (!parsed.success) {
+    return c.json({ error: 'invalid body', details: parsed.error.issues }, 422);
+  }
+
+  writeRoleModelSetting(project.id, role, parsed.data, 'ui');
+  return c.json({ ok: true });
+});
+
+/** PATCH /projects/:slug/settings/models/:role/complexity — upsert complexity overrides */
+router.patch('/:slug/settings/models/:role/complexity', async (c) => {
+  const slug = c.req.param('slug');
+  const role = c.req.param('role');
+  const project = await getProject(slug);
+  if (project == null) return c.json({ error: 'project not found' }, 404);
+
+  const body = await parseBody<unknown>(c);
+  if (!body.ok) return body.error;
+
+  const parsed = ComplexityOverridesSchema.safeParse(body.data);
+  if (!parsed.success) {
+    return c.json({ error: 'invalid body', details: parsed.error.issues }, 422);
+  }
+
+  writeComplexityOverrides(project.id, role, parsed.data, 'ui');
+  return c.json({ ok: true });
+});
+
+/** DELETE /projects/:slug/settings/models/:role — remove all overrides for a role */
+router.delete('/:slug/settings/models/:role', async (c) => {
+  const slug = c.req.param('slug');
+  const role = c.req.param('role');
+  const project = await getProject(slug);
+  if (project == null) return c.json({ error: 'project not found' }, 404);
+
+  deleteRoleModelSetting(project.id, role);
+  return c.json({ ok: true });
+});
+
+export { router as projectModelRouter };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -8,6 +8,7 @@ import { inboxRouter } from './domains/inbox/router.js';
 import { issuesRouter } from './domains/issues/router.js';
 import { milestonesRouter } from './domains/milestones/router.js';
 import { playbooksRouter } from './domains/playbooks/router.js';
+import { projectModelRouter } from './domains/project-settings/model-router.js';
 import { projectSettingsRouter } from './domains/project-settings/router.js';
 import { projectsRouter } from './domains/projects/router.js';
 import { rosterRouter } from './domains/roster/router.js';
@@ -35,6 +36,7 @@ app.route('/projects', costsRouter); // GET /projects/:slug/costs/summary, /proj
 app.route('/projects', playbooksRouter); // GET/POST /projects/:slug/playbooks (M11.12)
 app.route('/projects', bootstrapRouter); // POST /projects/bootstrap/{preview,run} (M12.07)
 app.route('/projects', projectSettingsRouter); // GET/PATCH/DELETE /projects/:slug/settings/**
+app.route('/projects', projectModelRouter); // GET/PATCH/DELETE /projects/:slug/settings/models/**
 app.route('/inbox', inboxRouter); // GET/POST /inbox/**
 app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events

--- a/apps/web/src/components/settings/components/ProjectModelPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectModelPanel.tsx
@@ -1,0 +1,331 @@
+import {
+  type ModelTier,
+  type ProjectModelSettingsDto,
+  type RoleModelDto,
+  deleteRoleModelSetting,
+  fetchProjectModelSettings,
+  patchComplexityOverrides,
+  patchRoleModelSetting,
+} from '@/lib/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface Props {
+  slug: string;
+}
+
+const TIERS: ModelTier[] = ['haiku', 'sonnet', 'opus'];
+const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
+
+const COMPLEXITY_KEY_OPTIONS = [
+  { value: 'type:bug', label: 'type: bug' },
+  { value: 'type:feature', label: 'type: feature' },
+  { value: 'type:chore', label: 'type: chore' },
+  { value: 'type:research', label: 'type: research' },
+  { value: 'priority:low', label: 'priority: low' },
+  { value: 'priority:medium', label: 'priority: medium' },
+  { value: 'priority:high', label: 'priority: high' },
+  { value: 'priority:critical', label: 'priority: critical' },
+  { value: 'default', label: 'default (all others)' },
+];
+
+function TierSelect({
+  value,
+  overridden,
+  placeholder,
+  disabled,
+  onChange,
+}: {
+  value: ModelTier | null;
+  overridden: boolean;
+  placeholder: string;
+  disabled?: boolean;
+  onChange: (val: ModelTier | null) => void;
+}) {
+  return (
+    <div className="relative flex items-center gap-1">
+      <select
+        disabled={disabled}
+        value={value ?? ''}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v === '' ? null : (v as ModelTier));
+        }}
+        className={[
+          'rounded border px-2 py-0.5 text-[12px] bg-bg text-fg appearance-none pr-6',
+          overridden ? 'border-accent' : 'border-line',
+          disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+        ].join(' ')}
+      >
+        <option value="">{placeholder}</option>
+        {TIERS.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      {overridden && <span className="text-[10px] text-accent font-medium shrink-0">override</span>}
+    </div>
+  );
+}
+
+function ComplexityEditor({
+  role,
+  slug,
+  overrides,
+  onSave,
+}: {
+  role: string;
+  slug: string;
+  overrides: Record<string, ModelTier>;
+  onSave: () => void;
+}) {
+  const [newKey, setNewKey] = useState('type:bug');
+  const [newTier, setNewTier] = useState<ModelTier>('haiku');
+
+  const qc = useQueryClient();
+  const patch = useMutation({
+    mutationFn: (next: Record<string, ModelTier>) => patchComplexityOverrides(slug, role, next),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['project-model-settings', slug] });
+      onSave();
+    },
+  });
+
+  function addRule() {
+    patch.mutate({ ...overrides, [newKey]: newTier });
+  }
+
+  function removeRule(key: string) {
+    const next = { ...overrides };
+    delete next[key];
+    patch.mutate(next);
+  }
+
+  return (
+    <div className="mt-2 ml-4 border-l-2 border-line pl-4 space-y-2">
+      <p className="text-[11px] text-fg-3">
+        Complexity rules override model tier per issue type/priority. DB rules win over config file.
+      </p>
+      {Object.entries(overrides).map(([key, tier]) => (
+        <div key={key} className="flex items-center gap-2 text-[12px]">
+          <span className="font-mono text-fg-2 w-40 shrink-0">{key}</span>
+          <span className="text-fg">→</span>
+          <span className="font-mono text-accent">{tier}</span>
+          <button
+            type="button"
+            onClick={() => removeRule(key)}
+            className="text-fg-3 hover:text-danger transition-colors p-0.5"
+            title="Remove rule"
+          >
+            <Trash2 size={11} />
+          </button>
+        </div>
+      ))}
+      <div className="flex items-center gap-2">
+        <select
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          className="rounded border border-line px-2 py-0.5 text-[12px] bg-bg text-fg"
+        >
+          {COMPLEXITY_KEY_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <span className="text-fg-2">→</span>
+        <select
+          value={newTier}
+          onChange={(e) => setNewTier(e.target.value as ModelTier)}
+          className="rounded border border-line px-2 py-0.5 text-[12px] bg-bg text-fg"
+        >
+          {TIERS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={addRule}
+          disabled={patch.isPending}
+          className="flex items-center gap-0.5 text-[11px] text-accent hover:text-fg transition-colors border border-accent/40 rounded px-1.5 py-0.5"
+        >
+          <Plus size={10} />
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RoleRow({
+  role,
+  slug,
+  data,
+  allowHoldoutOverride,
+}: {
+  role: string;
+  slug: string;
+  data: RoleModelDto;
+  allowHoldoutOverride: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const qc = useQueryClient();
+
+  const isHoldout = HOLDOUT_ROLES.has(role);
+  const locked = isHoldout && !allowHoldoutOverride;
+
+  const patchRole = useMutation({
+    mutationFn: (patch: {
+      primaryModel?: ModelTier | null;
+      fallbackModel?: ModelTier | null;
+      advisorModel?: ModelTier | null;
+    }) => patchRoleModelSetting(slug, role, patch),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['project-model-settings', slug] }),
+  });
+
+  const clearRole = useMutation({
+    mutationFn: () => deleteRoleModelSetting(slug, role),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['project-model-settings', slug] }),
+  });
+
+  const db = data.dbRoleModel;
+  const hasDbOverride =
+    db != null && (db.primaryModel != null || db.fallbackModel != null || db.advisorModel != null);
+  const hasComplexity = Object.keys(data.dbComplexityOverrides).length > 0;
+
+  const configPrimary = (data.configRoleModel?.primary as ModelTier) ?? null;
+
+  return (
+    <>
+      <tr className="border-b border-line/50 hover:bg-bg-hover">
+        <td className="py-1.5">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center gap-1 font-mono text-fg text-[12px]"
+          >
+            {expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+            {role}
+            {isHoldout && (
+              <span className="text-[9px] uppercase tracking-wider font-medium text-fg-3 border border-line rounded px-1">
+                holdout
+              </span>
+            )}
+          </button>
+        </td>
+        <td className="py-1.5 px-2">
+          <TierSelect
+            value={db?.primaryModel ?? null}
+            overridden={db?.primaryModel != null}
+            placeholder={configPrimary ?? 'skill default'}
+            disabled={locked}
+            onChange={(val) => patchRole.mutate({ primaryModel: val })}
+          />
+        </td>
+        <td className="py-1.5 px-2">
+          <TierSelect
+            value={db?.fallbackModel ?? null}
+            overridden={db?.fallbackModel != null}
+            placeholder={data.configRoleModel?.fallback ?? '—'}
+            disabled={locked}
+            onChange={(val) => patchRole.mutate({ fallbackModel: val })}
+          />
+        </td>
+        <td className="py-1.5 px-2">
+          <TierSelect
+            value={db?.advisorModel ?? null}
+            overridden={db?.advisorModel != null}
+            placeholder={data.configRoleModel?.advisor ?? '—'}
+            disabled={locked}
+            onChange={(val) => patchRole.mutate({ advisorModel: val })}
+          />
+        </td>
+        <td className="py-1.5 pl-1">
+          {(hasDbOverride || hasComplexity) && (
+            <button
+              type="button"
+              title="Clear all overrides for this role"
+              onClick={() => clearRole.mutate()}
+              className="text-fg-3 hover:text-danger transition-colors p-0.5 rounded"
+            >
+              <Trash2 size={11} />
+            </button>
+          )}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-line/30">
+          <td colSpan={5} className="py-2 px-2">
+            {locked ? (
+              <p className="text-[11px] text-fg-3 ml-4">
+                Holdout role — set <code>agentConfig.allowHoldoutOverride: true</code> in project
+                config to enable overrides.
+              </p>
+            ) : (
+              <ComplexityEditor
+                role={role}
+                slug={slug}
+                overrides={data.dbComplexityOverrides}
+                onSave={() => setExpanded(true)}
+              />
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export function ProjectModelPanel({ slug }: Props) {
+  const { data, isLoading, error } = useQuery<ProjectModelSettingsDto>({
+    queryKey: ['project-model-settings', slug],
+    queryFn: ({ signal }) => fetchProjectModelSettings(slug, signal),
+    staleTime: 10_000,
+  });
+
+  if (isLoading) return <div className="text-[12px] text-fg-3 py-4">Loading…</div>;
+  if (error || !data)
+    return <div className="text-[12px] text-danger py-4">Failed to load model settings.</div>;
+
+  const roles = Object.keys(data.roles);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2 mb-1">
+          Role model assignments
+        </h3>
+        <p className="text-[11px] text-fg-3 mb-4">
+          DB overrides win over project config <code>rolesModels</code> and skill defaults. Clear a
+          field to revert to config. Expand a row to set complexity-based rules.
+        </p>
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-fg-3 text-left border-b border-line">
+              <th className="pb-2 font-medium">Role</th>
+              <th className="pb-2 font-medium px-2">Primary</th>
+              <th className="pb-2 font-medium px-2">Fallback</th>
+              <th className="pb-2 font-medium px-2">Advisor</th>
+              <th className="pb-2 w-6" />
+            </tr>
+          </thead>
+          <tbody>
+            {roles.map((role) => (
+              <RoleRow
+                key={role}
+                role={role}
+                slug={slug}
+                data={data.roles[role]}
+                allowHoldoutOverride={data.allowHoldoutOverride}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -6,8 +6,9 @@ import { Plus, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { ProjectBudgetPanel } from './ProjectBudgetPanel';
 import { ProjectConfigPanel } from './ProjectConfigPanel';
+import { ProjectModelPanel } from './ProjectModelPanel';
 
-type Tab = 'config' | 'budgets';
+type Tab = 'config' | 'budgets' | 'models';
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
@@ -88,7 +89,7 @@ export function SettingsPage() {
 
         {/* Tab bar */}
         <div className="flex gap-1 mb-6 border-b border-line">
-          {(['config', 'budgets'] as Tab[]).map((t) => (
+          {(['config', 'budgets', 'models'] as Tab[]).map((t) => (
             <button
               key={t}
               type="button"
@@ -110,6 +111,9 @@ export function SettingsPage() {
         )}
         {tab === 'budgets' && selectedConfig != null && (
           <ProjectBudgetPanel slug={selectedConfig.slug} />
+        )}
+        {tab === 'models' && selectedConfig != null && (
+          <ProjectModelPanel slug={selectedConfig.slug} />
         )}
 
         {!isLoading && !error && configs.length === 0 && (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -534,3 +534,58 @@ export async function patchSkillBudgetSetting(
 export async function deleteSkillBudgetSetting(slug: string, skill: string): Promise<void> {
   await deleteRequest(`/projects/${slug}/settings/skills/${encodeURIComponent(skill)}`);
 }
+
+// ─── Model settings ──────────────────────────────────────────────────────────
+
+export type ModelTier = 'haiku' | 'sonnet' | 'opus';
+
+export interface RoleModelDto {
+  configRoleModel: { primary: string; fallback: string | null; advisor: string | null } | null;
+  dbRoleModel: {
+    primaryModel: ModelTier | null;
+    fallbackModel: ModelTier | null;
+    advisorModel: ModelTier | null;
+    updatedAt: string | null;
+  } | null;
+  dbComplexityOverrides: Record<string, ModelTier>;
+}
+
+export interface ProjectModelSettingsDto {
+  projectId: string;
+  allowHoldoutOverride: boolean;
+  roles: Record<string, RoleModelDto>;
+}
+
+export async function fetchProjectModelSettings(
+  slug: string,
+  signal?: AbortSignal,
+): Promise<ProjectModelSettingsDto> {
+  return getJson<ProjectModelSettingsDto>(`/projects/${slug}/settings/models`, signal);
+}
+
+export async function patchRoleModelSetting(
+  slug: string,
+  role: string,
+  patch: {
+    primaryModel?: ModelTier | null;
+    fallbackModel?: ModelTier | null;
+    advisorModel?: ModelTier | null;
+  },
+): Promise<void> {
+  await patchJson(`/projects/${slug}/settings/models/${encodeURIComponent(role)}`, patch);
+}
+
+export async function patchComplexityOverrides(
+  slug: string,
+  role: string,
+  overrides: Record<string, ModelTier>,
+): Promise<void> {
+  await patchJson(
+    `/projects/${slug}/settings/models/${encodeURIComponent(role)}/complexity`,
+    overrides,
+  );
+}
+
+export async function deleteRoleModelSetting(slug: string, role: string): Promise<void> {
+  await deleteRequest(`/projects/${slug}/settings/models/${encodeURIComponent(role)}`);
+}

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -78,6 +78,8 @@ export interface SkillConfig {
   contextSchema: ZodType;
   toolBundles: string[];
   modelPin: ModelTier;
+  /** Provider that executes this skill. Defaults to 'claude' when absent. */
+  provider?: 'claude' | 'codex';
   freshContext: boolean;
   role?: Role;
   contextAllowlist?: string[];

--- a/core/agent-runtime/model-router.ts
+++ b/core/agent-runtime/model-router.ts
@@ -12,6 +12,13 @@ export interface SelectModelInput {
   projectId: string;
   /** Project-level model router config from agentConfig.modelRouter */
   modelRouterConfig?: { overrides?: Record<string, ModelTier> };
+  /**
+   * DB-sourced complexity overrides for this role (from project_model_settings).
+   * Keys are "type:<T>", "priority:<P>", or "default". These win over
+   * modelRouterConfig.overrides when present.
+   * Use resolveComplexityOverridesForProject() to build this map.
+   */
+  dbComplexityOverrides?: Record<string, ModelTier>;
 }
 
 export interface SelectModelResult {
@@ -77,6 +84,22 @@ function queryPatternTier(projectId: string, role: string): ModelTier | null {
 }
 
 /**
+ * Resolves a complexity override tier from a bare-key map (keys are "type:<T>",
+ * "priority:<P>", or "default" — no role prefix).
+ */
+function resolveBareOverride(
+  overrides: Record<string, ModelTier>,
+  workItem: WorkItem,
+): ModelTier | null {
+  return (
+    overrides[`type:${workItem.type}`] ??
+    overrides[`priority:${workItem.priority}`] ??
+    overrides.default ??
+    null
+  );
+}
+
+/**
  * Predictively selects the initial model tier for an agent run based on
  * issue-complexity signals (type, priority, AC count, body length) plus
  * mined MODEL_SELECTION_OUTCOME patterns when available.
@@ -85,16 +108,25 @@ function queryPatternTier(projectId: string, role: string): ModelTier | null {
  * their skill-configured tier.
  *
  * Resolution order (highest precedence first):
- *   1. Project-level override (agentConfig.modelRouter.overrides)
- *   2. Pattern-informed (decision_patterns with consistencyScore > 0.7)
- *   3. Static policy table
+ *   1. DB complexity overrides for this role (dbComplexityOverrides) — UI-editable
+ *   2. Project-level override (agentConfig.modelRouter.overrides)
+ *   3. Pattern-informed (decision_patterns with consistencyScore > 0.7)
+ *   4. Static policy table
  */
 export function selectModel(input: SelectModelInput): SelectModelResult | null {
-  const { workItem, role, projectId, modelRouterConfig } = input;
+  const { workItem, role, projectId, modelRouterConfig, dbComplexityOverrides } = input;
 
   if (HOLDOUT_ROLES.has(role)) return null;
 
-  // Project-level override — highest precedence
+  // DB complexity overrides — highest precedence, UI-editable
+  if (dbComplexityOverrides != null && Object.keys(dbComplexityOverrides).length > 0) {
+    const dbTier = resolveBareOverride(dbComplexityOverrides, workItem);
+    if (dbTier != null) {
+      return { tier: dbTier, reason: 'db-complexity-override' };
+    }
+  }
+
+  // Project-level override
   if (modelRouterConfig?.overrides != null) {
     const overrideTier = resolveOverride(modelRouterConfig.overrides, role, workItem);
     if (overrideTier != null) {

--- a/core/agent-runtime/models.ts
+++ b/core/agent-runtime/models.ts
@@ -2,16 +2,20 @@ import type { ModelTier } from '../types.js';
 
 export type { ModelTier };
 
+export type ModelProvider = 'claude' | 'codex';
+
 export interface ModelEntry {
   id: string;
   tier: ModelTier;
+  /** Provider that executes this model. Defaults to 'claude' when absent. */
+  provider?: ModelProvider;
   deprecated?: boolean;
 }
 
 export const MODELS: ModelEntry[] = [
-  { id: 'claude-opus-4-7', tier: 'opus' },
-  { id: 'claude-sonnet-4-6', tier: 'sonnet' },
-  { id: 'claude-haiku-4-5-20251001', tier: 'haiku' },
+  { id: 'claude-opus-4-7', tier: 'opus', provider: 'claude' },
+  { id: 'claude-sonnet-4-6', tier: 'sonnet', provider: 'claude' },
+  { id: 'claude-haiku-4-5-20251001', tier: 'haiku', provider: 'claude' },
 ];
 
 const TIER_ORDER: ModelTier[] = ['haiku', 'sonnet', 'opus'];

--- a/core/agent-runtime/resolve-for-project.ts
+++ b/core/agent-runtime/resolve-for-project.ts
@@ -1,13 +1,20 @@
 import {
+  parseComplexityOverrides,
+  readProjectModelSettingsForRole,
+} from '../db/repositories/project-model-settings.js';
+import {
   readProjectSettings,
   readProjectSkillSettings,
 } from '../db/repositories/project-settings.js';
+import type { AgentConfig, ModelTier, Role } from '../types.js';
 import {
   type ResolvedBudget,
   type SkillBudgetOverride,
   resolveBudgets,
   resolveEscalatedBudgets,
 } from './budgets.js';
+import type { SkillConfig } from './interface.js';
+import { type RoleModelResult, selectModelForRole } from './select-model-for-role.js';
 
 /** Merged global settings: DB row wins over projectConfig value when non-null. */
 export interface EffectiveGlobalSettings {
@@ -75,4 +82,56 @@ export function resolveEscalatedBudgetsForProject(
 ): ResolvedBudget | null {
   const globalRow = readProjectSettings(projectId);
   return resolveEscalatedBudgets(skill, projectBudgets, globalRow?.perWorkflowMaxUsd);
+}
+
+/**
+ * selectModelForRole with DB override applied. Reads project_model_settings for
+ * the given projectId+role and passes the result to the pure selectModelForRole.
+ *
+ * Use this in workflow code that has a projectId; use selectModelForRole directly
+ * only when no DB access is available.
+ */
+export function selectModelForRoleForProject(
+  role: Role,
+  projectId: string,
+  agentConfig: Pick<AgentConfig, 'rolesModels' | 'allowHoldoutOverride'> | undefined,
+  skillConfig: Pick<SkillConfig, 'modelPin'> | undefined,
+): RoleModelResult {
+  const dbRow = readProjectModelSettingsForRole(projectId, role);
+  return selectModelForRole(role, agentConfig, skillConfig, dbRow ?? undefined);
+}
+
+/**
+ * Returns the complexity overrides for a role from the DB, merged with any
+ * project-config overrides. DB wins per key. Keys are "type:<T>",
+ * "priority:<P>", or "default". Values are ModelTier strings.
+ *
+ * These are fed into selectModel() as the highest-priority override layer.
+ */
+export function resolveComplexityOverridesForProject(
+  role: Role,
+  projectId: string,
+  configOverrides: Record<string, ModelTier> | undefined,
+): Record<string, ModelTier> {
+  const dbRow = readProjectModelSettingsForRole(projectId, role);
+  const dbOverrides = dbRow ? parseComplexityOverrides(dbRow) : {};
+
+  // Build the merged map: configOverrides as base, DB keys win over config keys
+  const merged: Record<string, ModelTier> = {};
+  if (configOverrides) {
+    for (const [key, tier] of Object.entries(configOverrides)) {
+      // Config keys are "role+type:T" / "role+priority:P" / "role" — strip role prefix
+      const rolePrefix = `${role}+`;
+      const bare = key.startsWith(rolePrefix)
+        ? key.slice(rolePrefix.length)
+        : key === role
+          ? 'default'
+          : null;
+      if (bare != null) merged[bare] = tier;
+    }
+  }
+  for (const [key, tier] of Object.entries(dbOverrides)) {
+    merged[key] = tier;
+  }
+  return merged;
 }

--- a/core/agent-runtime/select-model-for-role.ts
+++ b/core/agent-runtime/select-model-for-role.ts
@@ -47,25 +47,31 @@ export function selectModelForRole(
   const isHoldout = HOLDOUT_ROLES.has(role);
   const allowOverride = agentConfig?.allowHoldoutOverride === true;
 
+  const canUseDb = dbParams != null && (!isHoldout || allowOverride);
+
   // DB override — dropped for holdout roles unless allowHoldoutOverride
-  if (dbParams != null && (!isHoldout || allowOverride)) {
-    if (isValidTier(dbParams.primaryModel)) {
-      return {
-        primary: dbParams.primaryModel,
-        fallback: isValidTier(dbParams.fallbackModel) ? dbParams.fallbackModel : null,
-        advisor: isValidTier(dbParams.advisorModel) ? dbParams.advisorModel : null,
-        source: 'db',
-      };
-    }
+  if (canUseDb && isValidTier(dbParams?.primaryModel)) {
+    return {
+      primary: dbParams?.primaryModel,
+      fallback: isValidTier(dbParams?.fallbackModel) ? dbParams?.fallbackModel : null,
+      advisor: isValidTier(dbParams?.advisorModel) ? dbParams?.advisorModel : null,
+      source: 'db',
+    };
   }
+
+  // DB fallback/advisor survive even when primaryModel is null — merge with lower-layer primary
+  const rawDbFallback = canUseDb ? dbParams?.fallbackModel : undefined;
+  const rawDbAdvisor = canUseDb ? dbParams?.advisorModel : undefined;
+  const dbFallback = isValidTier(rawDbFallback) ? rawDbFallback : null;
+  const dbAdvisor = isValidTier(rawDbAdvisor) ? rawDbAdvisor : null;
 
   // Project config rolesModels — dropped for holdout roles unless allowHoldoutOverride
   const configEntry: RoleModel | undefined = agentConfig?.rolesModels[role];
   if (configEntry != null && (!isHoldout || allowOverride)) {
     return {
       primary: configEntry.primary,
-      fallback: configEntry.fallback,
-      advisor: configEntry.advisor,
+      fallback: dbFallback ?? configEntry.fallback,
+      advisor: dbAdvisor ?? configEntry.advisor,
       source: 'project-config',
     };
   }
@@ -74,8 +80,8 @@ export function selectModelForRole(
   if (skillConfig?.modelPin != null) {
     return {
       primary: skillConfig.modelPin,
-      fallback: null,
-      advisor: null,
+      fallback: dbFallback,
+      advisor: dbAdvisor,
       source: 'skill-default',
     };
   }
@@ -84,8 +90,8 @@ export function selectModelForRole(
   const roleDefault = ROLE_DEFAULTS[role];
   return {
     primary: roleDefault?.modelTier ?? 'sonnet',
-    fallback: null,
-    advisor: null,
+    fallback: dbFallback,
+    advisor: dbAdvisor,
     source: 'role-default',
   };
 }

--- a/core/agent-runtime/select-model-for-role.ts
+++ b/core/agent-runtime/select-model-for-role.ts
@@ -1,0 +1,91 @@
+import type { AgentConfig, ModelTier, Role, RoleModel } from '../types.js';
+import type { SkillConfig } from './interface.js';
+import { ROLE_DEFAULTS } from './roles.js';
+
+const HOLDOUT_ROLES = new Set<string>(['qa', 'reviewer']);
+
+export interface RoleModelResult {
+  primary: ModelTier;
+  fallback: ModelTier | null;
+  advisor: ModelTier | null;
+  /** Which layer provided the primary tier. */
+  source: 'db' | 'project-config' | 'skill-default' | 'role-default';
+}
+
+export interface DbRoleModelParams {
+  primaryModel?: string | null;
+  fallbackModel?: string | null;
+  advisorModel?: string | null;
+}
+
+function isValidTier(v: string | null | undefined): v is ModelTier {
+  return v === 'haiku' || v === 'sonnet' || v === 'opus';
+}
+
+/**
+ * Resolves the model tier assignment for a role.
+ *
+ * Resolution order (highest wins):
+ *   1. DB row (project_model_settings) — UI-editable
+ *   2. agentConfig.rolesModels[role] — project.config.ts
+ *   3. skillConfig.modelPin — skill default
+ *   4. ROLE_DEFAULTS[role].modelTier — hard-coded fallback
+ *
+ * Holdout gating: qa and reviewer overrides are silently dropped unless
+ * agentConfig.allowHoldoutOverride === true. This protects holdout
+ * integrity regardless of how the project config is tuned.
+ *
+ * Pure function — no DB access. Use selectModelForRoleForProject() when
+ * a projectId is available so the DB layer is consulted.
+ */
+export function selectModelForRole(
+  role: Role,
+  agentConfig: Pick<AgentConfig, 'rolesModels' | 'allowHoldoutOverride'> | undefined,
+  skillConfig: Pick<SkillConfig, 'modelPin'> | undefined,
+  dbParams?: DbRoleModelParams,
+): RoleModelResult {
+  const isHoldout = HOLDOUT_ROLES.has(role);
+  const allowOverride = agentConfig?.allowHoldoutOverride === true;
+
+  // DB override — dropped for holdout roles unless allowHoldoutOverride
+  if (dbParams != null && (!isHoldout || allowOverride)) {
+    if (isValidTier(dbParams.primaryModel)) {
+      return {
+        primary: dbParams.primaryModel,
+        fallback: isValidTier(dbParams.fallbackModel) ? dbParams.fallbackModel : null,
+        advisor: isValidTier(dbParams.advisorModel) ? dbParams.advisorModel : null,
+        source: 'db',
+      };
+    }
+  }
+
+  // Project config rolesModels — dropped for holdout roles unless allowHoldoutOverride
+  const configEntry: RoleModel | undefined = agentConfig?.rolesModels[role];
+  if (configEntry != null && (!isHoldout || allowOverride)) {
+    return {
+      primary: configEntry.primary,
+      fallback: configEntry.fallback,
+      advisor: configEntry.advisor,
+      source: 'project-config',
+    };
+  }
+
+  // Skill modelPin
+  if (skillConfig?.modelPin != null) {
+    return {
+      primary: skillConfig.modelPin,
+      fallback: null,
+      advisor: null,
+      source: 'skill-default',
+    };
+  }
+
+  // Hard-coded role default
+  const roleDefault = ROLE_DEFAULTS[role];
+  return {
+    primary: roleDefault?.modelTier ?? 'sonnet',
+    fallback: null,
+    advisor: null,
+    source: 'role-default',
+  };
+}

--- a/core/db/migrations/0010_project_model_settings.sql
+++ b/core/db/migrations/0010_project_model_settings.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `project_model_settings` (
+	`project_id` text NOT NULL,
+	`role` text NOT NULL,
+	`primary_model` text,
+	`fallback_model` text,
+	`advisor_model` text,
+	`complexity_overrides_json` text,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`updated_by` text,
+	PRIMARY KEY(`project_id`, `role`)
+);

--- a/core/db/migrations/meta/0010_snapshot.json
+++ b/core/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1242 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0010_project_model_settings",
+  "prevId": "0010_project_model_settings",
+  "tables": {
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "archived_lifecycles": {
+      "name": "archived_lifecycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_summaries": {
+          "name": "decision_summaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "learning_entries": {
+          "name": "learning_entries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "quality_scores": {
+          "name": "quality_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "costs_usd": {
+          "name": "costs_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "run_ids": {
+          "name": "run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "archived_lifecycles_project_work_item_idx": {
+          "name": "archived_lifecycles_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "archived_lifecycles_project_closed_idx": {
+          "name": "archived_lifecycles_project_closed_idx",
+          "columns": [
+            "project_id",
+            "closed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_patterns": {
+      "name": "decision_patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_summary": {
+          "name": "action_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_summary": {
+          "name": "reason_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consistency_score": {
+          "name": "consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "example_work_item_ids": {
+          "name": "example_work_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "decision_patterns_project_kind_role_uniq": {
+          "name": "decision_patterns_project_kind_role_uniq",
+          "columns": [
+            "project_id",
+            "kind",
+            "role"
+          ],
+          "isUnique": true
+        },
+        "decision_patterns_project_idx": {
+          "name": "decision_patterns_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_work_item_idx": {
+          "name": "events_work_item_idx",
+          "columns": [
+            "work_item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_diff": {
+          "name": "proposed_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_playbook_id": {
+          "name": "source_playbook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playbooks": {
+      "name": "playbooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_count": {
+          "name": "lifecycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "playbooks_project_created_idx": {
+          "name": "playbooks_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "playbooks_project_window_idx": {
+          "name": "playbooks_project_window_idx",
+          "columns": [
+            "project_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "per_workflow_max_usd": {
+          "name": "per_workflow_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_agent_max_usd": {
+          "name": "per_agent_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_advisor_max_usd": {
+          "name": "per_advisor_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_tokens": {
+          "name": "daily_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_parallel_agents": {
+          "name": "max_parallel_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_bash_seconds": {
+          "name": "max_bash_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_issues_per_day_from_non_owners": {
+          "name": "max_issues_per_day_from_non_owners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_skill_settings": {
+      "name": "project_skill_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_budget_usd": {
+          "name": "max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_skill_settings_project_id_skill_name_pk": {
+          "columns": [
+            "project_id",
+            "skill_name"
+          ],
+          "name": "project_skill_settings_project_id_skill_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wp_iterations": {
+      "name": "wp_iterations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wp_id": {
+          "name": "wp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "wp_iterations_run_wp_iteration_uniq": {
+          "name": "wp_iterations_run_wp_iteration_uniq",
+          "columns": [
+            "run_id",
+            "wp_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "wp_iterations_run_wp_idx": {
+          "name": "wp_iterations_run_wp_idx",
+          "columns": [
+            "run_id",
+            "wp_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_model_settings": {
+      "name": "project_model_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_model": {
+          "name": "primary_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advisor_model": {
+          "name": "advisor_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity_overrides_json": {
+          "name": "complexity_overrides_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_model_settings_project_id_role_pk": {
+          "name": "project_model_settings_project_id_role_pk",
+          "columns": [
+            "project_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778227415565,
       "tag": "0009_project_budget_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778256000000,
+      "tag": "0010_project_model_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/repositories/project-model-settings.ts
+++ b/core/db/repositories/project-model-settings.ts
@@ -1,0 +1,106 @@
+import { and, eq } from 'drizzle-orm';
+import type { ModelTier } from '../../types.js';
+import { db } from '../db.js';
+import { projectModelSettings } from '../schema.js';
+
+export type ProjectModelSettingsRow = typeof projectModelSettings.$inferSelect;
+
+export type RoleModelPatch = {
+  primaryModel?: ModelTier | null;
+  fallbackModel?: ModelTier | null;
+  advisorModel?: ModelTier | null;
+};
+
+/** Complexity overrides for a single role: keys are "type:<T>", "priority:<P>", or "default". */
+export type ComplexityOverrides = Record<string, ModelTier>;
+
+export function readProjectModelSettings(projectId: string): Map<string, ProjectModelSettingsRow> {
+  const rows = db
+    .select()
+    .from(projectModelSettings)
+    .where(eq(projectModelSettings.projectId, projectId))
+    .all();
+  const map = new Map<string, ProjectModelSettingsRow>();
+  for (const row of rows) {
+    map.set(row.role, row);
+  }
+  return map;
+}
+
+export function readProjectModelSettingsForRole(
+  projectId: string,
+  role: string,
+): ProjectModelSettingsRow | null {
+  const rows = db
+    .select()
+    .from(projectModelSettings)
+    .where(and(eq(projectModelSettings.projectId, projectId), eq(projectModelSettings.role, role)))
+    .all();
+  return rows[0] ?? null;
+}
+
+export function writeRoleModelSetting(
+  projectId: string,
+  role: string,
+  patch: RoleModelPatch,
+  by: string,
+): void {
+  const now = new Date().toISOString();
+  const where = and(
+    eq(projectModelSettings.projectId, projectId),
+    eq(projectModelSettings.role, role),
+  );
+  const existing = db.select().from(projectModelSettings).where(where).all();
+
+  if (existing.length === 0) {
+    db.insert(projectModelSettings)
+      .values({ projectId, role, ...patch, updatedAt: now, updatedBy: by })
+      .run();
+  } else {
+    db.update(projectModelSettings)
+      .set({ ...patch, updatedAt: now, updatedBy: by })
+      .where(where)
+      .run();
+  }
+}
+
+export function writeComplexityOverrides(
+  projectId: string,
+  role: string,
+  overrides: ComplexityOverrides,
+  by: string,
+): void {
+  const now = new Date().toISOString();
+  const json = JSON.stringify(overrides);
+  const where = and(
+    eq(projectModelSettings.projectId, projectId),
+    eq(projectModelSettings.role, role),
+  );
+  const existing = db.select().from(projectModelSettings).where(where).all();
+
+  if (existing.length === 0) {
+    db.insert(projectModelSettings)
+      .values({ projectId, role, complexityOverridesJson: json, updatedAt: now, updatedBy: by })
+      .run();
+  } else {
+    db.update(projectModelSettings)
+      .set({ complexityOverridesJson: json, updatedAt: now, updatedBy: by })
+      .where(where)
+      .run();
+  }
+}
+
+export function deleteRoleModelSetting(projectId: string, role: string): void {
+  db.delete(projectModelSettings)
+    .where(and(eq(projectModelSettings.projectId, projectId), eq(projectModelSettings.role, role)))
+    .run();
+}
+
+export function parseComplexityOverrides(row: ProjectModelSettingsRow): ComplexityOverrides {
+  if (!row.complexityOverridesJson) return {};
+  try {
+    return JSON.parse(row.complexityOverridesJson) as ComplexityOverrides;
+  } catch {
+    return {};
+  }
+}

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -289,6 +289,28 @@ export const projectSkillSettings = sqliteTable(
   }),
 );
 
+// Per-project per-role model overrides (M19.09). One row per (project_id, role).
+// primary_model / fallback_model / advisor_model win over project.config.ts rolesModels
+// and skill modelPin defaults. complexity_overrides_json stores a JSON object whose keys
+// are "type:<T>", "priority:<P>", or "default" and whose values are ModelTier strings;
+// these win over agentConfig.modelRouter.overrides for complexity-based tier selection.
+export const projectModelSettings = sqliteTable(
+  'project_model_settings',
+  {
+    projectId: text('project_id').notNull(),
+    role: text('role').notNull(),
+    primaryModel: text('primary_model'),
+    fallbackModel: text('fallback_model'),
+    advisorModel: text('advisor_model'),
+    complexityOverridesJson: text('complexity_overrides_json'),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedBy: text('updated_by'),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.projectId, table.role] }),
+  }),
+);
+
 // One row per agent run. `runId` is unique — the same run is never recorded twice.
 // `costLabel`: 'exact' when the source provided authoritative usage metadata
 // (direct API), 'estimated' when only the Claude CLI's reported totals are

--- a/core/types.ts
+++ b/core/types.ts
@@ -57,7 +57,12 @@ export interface CoachPolicy {
 }
 
 export interface AgentConfig {
-  runtime: 'claude-cli';
+  /**
+   * Agent runtime backend. 'auto' picks the runtime that matches the resolved
+   * model's provider (Claude → claude-cli, Codex → codex-cli). M19.10 lands
+   * the Codex CLI; this field declares the dispatcher shape.
+   */
+  runtime: 'claude-cli' | 'codex-cli' | 'auto';
   rolesModels: Partial<Record<Role, RoleModel>>;
   fallbackPolicy: Record<string, FallbackPolicy>;
   toolAllowlists: Partial<Record<Role, ToolAllowlist>>;
@@ -80,6 +85,16 @@ export interface AgentConfig {
      * Example: { "developer+type:bug": "sonnet", "developer": "haiku" }
      */
     overrides?: Record<string, ModelTier>;
+  };
+  /**
+   * When true, rolesModels may downgrade qa or reviewer model tiers.
+   * Default false — override attempts are silently dropped to protect holdout
+   * integrity. Only set this if you have a deliberate cost/quality trade-off.
+   */
+  allowHoldoutOverride?: boolean;
+  holdoutReview?: {
+    /** Run a Codex reviewer in parallel with the Claude reviewer (M19.13). Default false. */
+    codexEnabled: boolean;
   };
 }
 

--- a/docs/adr/0034-provider-aware-model-routing.md
+++ b/docs/adr/0034-provider-aware-model-routing.md
@@ -1,0 +1,103 @@
+# ADR 0034 — Provider-aware model routing and UI-configurable role/complexity overrides
+
+**Status:** Accepted  
+**Date:** 2026-05-08  
+**Issue:** #593 (M19.09)
+
+## Context
+
+Before this ADR, model selection had two disconnected layers:
+
+1. **Active** — `skills/*/skill.config.ts` declares `modelPin: ModelTier`. The runtime maps tier → concrete model ID via `defaultModelForTier()`. Every call site used the skill pin directly.
+
+2. **Orphaned** — every `project.config.ts` carries `agentConfig.rolesModels: Partial<Record<Role, RoleModel>>` parsed by the schema but never read at runtime. Intent existed (different roles should be able to use different models per project) but the wiring was missing.
+
+A third layer — `agentConfig.modelRouter.overrides` — handled complexity-based tier selection (e.g. `developer+type:bug → haiku`) but was stored only in the config file, making it cumbersome to tune without a code change.
+
+No model entry carried provider information, limiting the architecture to Claude-only despite M19.10 planning a Codex CLI runtime.
+
+## Decision
+
+### 1. Provider field on model entries
+
+`ModelEntry` in `core/agent-runtime/models.ts` gains `provider: 'claude' | 'codex'`. All existing entries default to `'claude'`. Codex models will be added in M19.10.
+
+`SkillConfig` in `core/agent-runtime/interface.ts` gains optional `provider?: 'claude' | 'codex'`. Defaults to `'claude'` when absent. No skill changes its declared provider in this issue.
+
+`agentConfig.runtime` in `AgentConfig` is extended from `'claude-cli'` to `'claude-cli' | 'codex-cli' | 'auto'`. `'auto'` (the future default) picks the runtime matching the resolved model's provider. The Codex CLI runtime itself is M19.10.
+
+### 2. `selectModelForRole()` — pure resolver wiring `rolesModels`
+
+`core/agent-runtime/select-model-for-role.ts` exports a pure function:
+
+```ts
+selectModelForRole(role, agentConfig, skillConfig, dbParams?) → RoleModelResult
+```
+
+Resolution order (highest wins):
+1. `dbParams` — DB row from `project_model_settings` (UI-editable)
+2. `agentConfig.rolesModels[role]` — project config
+3. `skillConfig.modelPin` — skill default
+4. `ROLE_DEFAULTS[role].modelTier` — hard-coded fallback
+
+The pure function has no DB imports. `selectModelForRoleForProject()` in `resolve-for-project.ts` reads the DB and delegates.
+
+### 3. Holdout override gating
+
+`qa` and `reviewer` model overrides are silently dropped unless `agentConfig.allowHoldoutOverride: true` is set on the project config. Default is false.
+
+The gating applies at all override layers (DB and project config). Without the flag, holdout roles always use their skill-declared tier. This prevents accidental model downgrade from undermining QA/review quality.
+
+The UI renders holdout roles as read-only unless `allowHoldoutOverride` is true in the project config.
+
+### 4. Complexity-based overrides in DB
+
+`project_model_settings` stores `complexity_overrides_json` per `(project_id, role)`. Keys are `"type:<T>"`, `"priority:<P>"`, or `"default"` (no role prefix — the row is already scoped to a role).
+
+`resolveComplexityOverridesForProject()` merges config-file `modelRouter.overrides` (stripping role prefix) with DB overrides, with DB winning per key. The result is passed to `selectModel()` as `dbComplexityOverrides`, which is evaluated before config-file overrides.
+
+Full resolution order for `selectModel()`:
+1. `dbComplexityOverrides` (DB, UI-editable) — highest
+2. `agentConfig.modelRouter.overrides` (project config)
+3. Pattern-informed (decision_patterns with consistencyScore > 0.7)
+4. Static policy table
+
+### 5. Settings UI — "Models" tab
+
+`ProjectModelPanel.tsx` adds a third tab to the Settings page alongside Config and Budgets. It provides:
+
+- A per-role table: Primary / Fallback / Advisor tier selectors (dropdowns, inline save on change)
+- Expandable rows: per-role complexity rules editor (add/remove key→tier rules)
+- Holdout roles shown with a "holdout" badge; selectors disabled unless `allowHoldoutOverride`
+- Clear button per row removes all DB overrides for that role
+
+### 6. DB schema
+
+New table `project_model_settings(project_id, role, primary_model, fallback_model, advisor_model, complexity_overrides_json, updated_at, updated_by)` with composite primary key `(project_id, role)`. Migration 0010.
+
+## Override precedence summary
+
+| Layer | Source | Editable |
+|---|---|---|
+| 1. Skill `modelPin` | `skills/*/skill.config.ts` | No |
+| 2. Project config `rolesModels` | `project.config.ts` | No (governed) |
+| 3. DB `project_model_settings` | SQLite | **Yes — Settings UI** |
+
+For complexity selection:
+
+| Layer | Source | Editable |
+|---|---|---|
+| 1. Static policy | Hard-coded in model-router.ts | No |
+| 2. Pattern history | `decision_patterns` DB table | Auto-learned |
+| 3. Config `modelRouter.overrides` | `project.config.ts` | No (governed) |
+| 4. DB `complexity_overrides_json` | SQLite | **Yes — Settings UI** |
+
+## Why `rolesModels` was kept (not renamed)
+
+The field name `rolesModels` is established in the config schema and in project configs. Renaming would require updating all project configs (a governed file touch). The field is now wired rather than replaced.
+
+## Consequences
+
+- Any workflow calling `resolveBudgetsForProject()` for budget resolution can now also call `selectModelForRoleForProject()` for model tier resolution; the wrapper pattern is symmetric.
+- M19.10 (Codex CLI) can land without touching this code: it registers `provider: 'codex'` model entries and the `'auto'` dispatcher picks up the correct runtime from `provider`.
+- M19.13 (Codex holdout review) interacts with `holdoutReview.codexEnabled` on `AgentConfig`, which is declared here but implemented in M19.13.

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -6,7 +6,10 @@ import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { selectModel } from '@goose-hub/core/agent-runtime/model-router.js';
 import { defaultModelForTier, tierOf } from '@goose-hub/core/agent-runtime/models.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
-import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
+import {
+  resolveBudgetsForProject,
+  resolveComplexityOverridesForProject,
+} from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { runWithEscalation } from '@goose-hub/core/agent-runtime/with-escalation.js';
@@ -310,11 +313,17 @@ async function runImplement(input: RunImplementInput): Promise<ImplementOutputSh
     input.projectId,
   );
 
+  const dbComplexityOverrides = resolveComplexityOverridesForProject(
+    'developer',
+    input.projectId,
+    projectConfig?.agentConfig?.modelRouter?.overrides,
+  );
   const routerResult = selectModel({
     workItem: input.workItem,
     role: 'developer',
     projectId: input.projectId,
     modelRouterConfig: projectConfig?.agentConfig?.modelRouter,
+    dbComplexityOverrides,
   });
   const modelOverride =
     routerResult != null ? defaultModelForTier(routerResult.tier) : budgetModelOverride;

--- a/slices/model-routing/README.md
+++ b/slices/model-routing/README.md
@@ -1,0 +1,47 @@
+# slices/model-routing
+
+M19.09 — provider-aware model routing with UI-configurable role and complexity overrides.
+
+## What this slice covers
+
+- `selectModelForRole()` — wires the previously-orphaned `rolesModels` in project config.
+- `selectModel()` extension — DB complexity overrides as highest-priority layer.
+- `ProjectModelPanel` — Settings → Models tab for live UI editing.
+
+## Resolution order
+
+### Static role assignment (`selectModelForRole`)
+
+1. DB `project_model_settings.primary_model` (UI-editable)
+2. `agentConfig.rolesModels[role]` (project config)
+3. `skill.config.ts` `modelPin`
+4. `ROLE_DEFAULTS[role].modelTier`
+
+### Complexity-based tier selection (`selectModel`)
+
+1. DB `project_model_settings.complexity_overrides_json` (UI-editable)
+2. `agentConfig.modelRouter.overrides` (project config)
+3. Decision pattern history (`decision_patterns` with `consistencyScore > 0.7`)
+4. Static policy (priority → type → AC count)
+
+## Holdout gating
+
+`qa` and `reviewer` overrides are silently dropped unless
+`agentConfig.allowHoldoutOverride: true` is set on the project config. The
+Settings UI renders holdout rows as read-only when the flag is absent.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `core/agent-runtime/select-model-for-role.ts` | Pure resolver |
+| `core/agent-runtime/resolve-for-project.ts` | DB-reading wrappers |
+| `core/agent-runtime/model-router.ts` | Extended with `dbComplexityOverrides` |
+| `core/db/repositories/project-model-settings.ts` | CRUD |
+| `core/db/migrations/0010_project_model_settings.sql` | Schema |
+| `apps/server/src/domains/project-settings/model-router.ts` | API routes |
+| `apps/web/src/components/settings/components/ProjectModelPanel.tsx` | UI |
+
+## ADR
+
+`docs/adr/0034-provider-aware-model-routing.md`

--- a/slices/model-routing/slice.test.ts
+++ b/slices/model-routing/slice.test.ts
@@ -4,16 +4,21 @@ import { selectModel } from '../../core/agent-runtime/model-router.js';
 import type { WorkItem } from '../../core/state-source/interface.js';
 
 const baseWorkItem: WorkItem = {
-  id: '1',
+  id: 'github:owner/repo#1',
+  externalId: '1',
+  repoRef: 'owner/repo',
   title: 'Test issue',
   body: '- [ ] AC1',
   type: 'feature',
   priority: 'medium',
-  state: 'open',
-  labels: [],
-  number: 1,
-  createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-01-01T00:00:00Z',
+  mode: 'supervised',
+  state: 'factory:accepted',
+  authorIsOwner: true,
+  schedule: 'current',
+  exec: 'serial',
+  dependsOn: [],
+  blocks: [],
+  createdAt: new Date('2026-01-01T00:00:00Z'),
 };
 
 // ─── selectModelForRole ────────────────────────────────────────────────────────

--- a/slices/model-routing/slice.test.ts
+++ b/slices/model-routing/slice.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { selectModelForRole } from '../../core/agent-runtime/select-model-for-role.js';
+import { selectModel } from '../../core/agent-runtime/model-router.js';
+import type { WorkItem } from '../../core/state-source/interface.js';
+
+const baseWorkItem: WorkItem = {
+  id: '1',
+  title: 'Test issue',
+  body: '- [ ] AC1',
+  type: 'feature',
+  priority: 'medium',
+  state: 'open',
+  labels: [],
+  number: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+// ─── selectModelForRole ────────────────────────────────────────────────────────
+
+describe('selectModelForRole', () => {
+  it('returns skill default when no config or DB override', () => {
+    const result = selectModelForRole('developer', undefined, { modelPin: 'haiku' });
+    expect(result.primary).toBe('haiku');
+    expect(result.source).toBe('skill-default');
+  });
+
+  it('project config rolesModels wins over skill default', () => {
+    const result = selectModelForRole(
+      'developer',
+      {
+        rolesModels: { developer: { primary: 'sonnet', fallback: 'haiku', advisor: null } },
+        allowHoldoutOverride: false,
+      },
+      { modelPin: 'haiku' },
+    );
+    expect(result.primary).toBe('sonnet');
+    expect(result.fallback).toBe('haiku');
+    expect(result.source).toBe('project-config');
+  });
+
+  it('DB override wins over project config', () => {
+    const result = selectModelForRole(
+      'developer',
+      {
+        rolesModels: { developer: { primary: 'sonnet', fallback: null, advisor: null } },
+        allowHoldoutOverride: false,
+      },
+      { modelPin: 'haiku' },
+      { primaryModel: 'opus', fallbackModel: null, advisorModel: null },
+    );
+    expect(result.primary).toBe('opus');
+    expect(result.source).toBe('db');
+  });
+
+  it('holdout override silently dropped without allowHoldoutOverride', () => {
+    const result = selectModelForRole(
+      'qa',
+      {
+        rolesModels: { qa: { primary: 'haiku', fallback: null, advisor: null } },
+        allowHoldoutOverride: false,
+      },
+      { modelPin: 'sonnet' },
+      { primaryModel: 'haiku', fallbackModel: null, advisorModel: null },
+    );
+    // Both DB and config override dropped; falls through to skill default
+    expect(result.primary).toBe('sonnet');
+    expect(result.source).toBe('skill-default');
+  });
+
+  it('holdout override applied with allowHoldoutOverride: true', () => {
+    const result = selectModelForRole(
+      'qa',
+      {
+        rolesModels: { qa: { primary: 'haiku', fallback: null, advisor: null } },
+        allowHoldoutOverride: true,
+      },
+      { modelPin: 'sonnet' },
+      { primaryModel: 'haiku', fallbackModel: null, advisorModel: null },
+    );
+    expect(result.primary).toBe('haiku');
+    expect(result.source).toBe('db');
+  });
+
+  it('reviewer holdout override also gated', () => {
+    const result = selectModelForRole(
+      'reviewer',
+      { rolesModels: {}, allowHoldoutOverride: false },
+      { modelPin: 'sonnet' },
+      { primaryModel: 'haiku', fallbackModel: null, advisorModel: null },
+    );
+    expect(result.primary).toBe('sonnet');
+    expect(result.source).toBe('skill-default');
+  });
+
+  it('falls back to role default when no skill config', () => {
+    const result = selectModelForRole('triager', undefined, undefined);
+    expect(result.primary).toBe('haiku');
+    expect(result.source).toBe('role-default');
+  });
+
+  it('DB override with invalid tier is ignored (no valid primaryModel)', () => {
+    const result = selectModelForRole(
+      'developer',
+      undefined,
+      { modelPin: 'haiku' },
+      { primaryModel: null, fallbackModel: null, advisorModel: null },
+    );
+    // null primaryModel → not valid → falls through to skill default
+    expect(result.primary).toBe('haiku');
+    expect(result.source).toBe('skill-default');
+  });
+});
+
+// ─── selectModel (complexity-based) ────────────────────────────────────────────
+
+describe('selectModel', () => {
+  it('returns null for holdout roles', () => {
+    expect(selectModel({ workItem: baseWorkItem, role: 'qa', projectId: 'p1' })).toBeNull();
+    expect(selectModel({ workItem: baseWorkItem, role: 'reviewer', projectId: 'p1' })).toBeNull();
+  });
+
+  it('DB complexity override wins over config override', () => {
+    const result = selectModel({
+      workItem: { ...baseWorkItem, type: 'bug' },
+      role: 'developer',
+      projectId: 'p1',
+      modelRouterConfig: { overrides: { 'developer+type:bug': 'sonnet' } },
+      dbComplexityOverrides: { 'type:bug': 'haiku' },
+    });
+    expect(result?.tier).toBe('haiku');
+    expect(result?.reason).toBe('db-complexity-override');
+  });
+
+  it('config override used when no DB override matches', () => {
+    const result = selectModel({
+      workItem: { ...baseWorkItem, type: 'bug' },
+      role: 'developer',
+      projectId: 'p1',
+      modelRouterConfig: { overrides: { 'developer+type:bug': 'sonnet' } },
+      dbComplexityOverrides: { 'type:chore': 'haiku' },
+    });
+    expect(result?.tier).toBe('sonnet');
+    expect(result?.reason).toBe('project-override');
+  });
+
+  it('DB default key applies when no type/priority key matches', () => {
+    const result = selectModel({
+      workItem: { ...baseWorkItem, type: 'feature', priority: 'low' },
+      role: 'developer',
+      projectId: 'p1',
+      dbComplexityOverrides: { default: 'opus' },
+    });
+    expect(result?.tier).toBe('opus');
+    expect(result?.reason).toBe('db-complexity-override');
+  });
+
+  it('DB priority override wins over static policy', () => {
+    const result = selectModel({
+      workItem: { ...baseWorkItem, priority: 'high' },
+      role: 'developer',
+      projectId: 'p1',
+      dbComplexityOverrides: { 'priority:high': 'haiku' },
+    });
+    expect(result?.tier).toBe('haiku');
+    expect(result?.reason).toBe('db-complexity-override');
+  });
+
+  it('falls through to static policy when no overrides match', () => {
+    const result = selectModel({
+      workItem: { ...baseWorkItem, type: 'bug', priority: 'low' },
+      role: 'developer',
+      projectId: 'p1',
+      dbComplexityOverrides: {},
+    });
+    expect(result?.tier).toBe('haiku');
+    expect(result?.reason).toBe('type-bug');
+  });
+});

--- a/slices/model-routing/slice.test.ts
+++ b/slices/model-routing/slice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { selectModelForRole } from '../../core/agent-runtime/select-model-for-role.js';
 import { selectModel } from '../../core/agent-runtime/model-router.js';
+import { selectModelForRole } from '../../core/agent-runtime/select-model-for-role.js';
 import type { WorkItem } from '../../core/state-source/interface.js';
 
 const baseWorkItem: WorkItem = {
@@ -114,6 +114,22 @@ describe('selectModelForRole', () => {
     // null primaryModel → not valid → falls through to skill default
     expect(result.primary).toBe('haiku');
     expect(result.source).toBe('skill-default');
+  });
+
+  it('DB fallback/advisor survive when primaryModel is null', () => {
+    const result = selectModelForRole(
+      'developer',
+      {
+        rolesModels: { developer: { primary: 'sonnet', fallback: null, advisor: null } },
+        allowHoldoutOverride: false,
+      },
+      { modelPin: 'haiku' },
+      { primaryModel: null, fallbackModel: 'haiku', advisorModel: null },
+    );
+    // Primary comes from project config (DB primary is null), but fallback from DB wins
+    expect(result.primary).toBe('sonnet');
+    expect(result.fallback).toBe('haiku');
+    expect(result.source).toBe('project-config');
   });
 });
 

--- a/slices/resolve-conflict/slice.test.ts
+++ b/slices/resolve-conflict/slice.test.ts
@@ -6,6 +6,10 @@ vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
   readProjectSettings: vi.fn().mockReturnValue(null),
   readProjectSkillSettings: vi.fn().mockReturnValue(new Map()),
 }));
+vi.mock('@goose-hub/core/db/repositories/project-model-settings.js', () => ({
+  readProjectModelSettingsForRole: vi.fn().mockReturnValue(null),
+  parseComplexityOverrides: vi.fn().mockReturnValue({}),
+}));
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     appendEvent: vi.fn().mockReturnValue({ id: 1 }),


### PR DESCRIPTION
## Summary

- Wires the previously-orphaned `agentConfig.rolesModels` field so per-role primary/fallback/advisor model tiers are actually applied at runtime
- Adds DB override layer (`project_model_settings`, migration 0010) so both role assignments and complexity-based tier rules are editable via Settings UI without touching config files
- Adds **Settings → Models tab** (`ProjectModelPanel`) with per-role tier selectors and an expandable complexity rules editor per row
- Extends `selectModel()` so DB complexity overrides sit above `modelRouter.overrides` in the resolution stack
- Adds `provider: 'claude' | 'codex'` to `ModelEntry` and optional `provider?` to `SkillConfig`; extends `AgentConfig.runtime` to `'claude-cli' | 'codex-cli' | 'auto'` (M19.10 hook)
- Adds `agentConfig.allowHoldoutOverride` flag; without it, `qa`/`reviewer` tier downgrades are silently dropped

## Key files

| File | What changed |
|---|---|
| `core/agent-runtime/models.ts` | `provider?` field on `ModelEntry` |
| `core/agent-runtime/interface.ts` | `provider?` on `SkillConfig` |
| `core/types.ts` | `runtime` union extended; `allowHoldoutOverride`; `holdoutReview` stub |
| `core/agent-runtime/select-model-for-role.ts` | New pure resolver |
| `core/agent-runtime/resolve-for-project.ts` | `selectModelForRoleForProject()`, `resolveComplexityOverridesForProject()` |
| `core/agent-runtime/model-router.ts` | `dbComplexityOverrides` as highest-priority layer |
| `core/db/schema.ts` + migration 0010 | `project_model_settings` table |
| `core/db/repositories/project-model-settings.ts` | Sync CRUD |
| `apps/server/src/domains/project-settings/model-router.ts` | API routes |
| `apps/web/src/components/settings/components/ProjectModelPanel.tsx` | UI panel |
| `apps/web/src/components/settings/components/SettingsPage.tsx` | Models tab added |
| `docs/adr/0034-provider-aware-model-routing.md` | ADR |
| `slices/model-routing/` | Slice tests + README |

Closes #593

https://claude.ai/code/session_01WTxtxziVBMkGPQDsp1Ut39

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTxtxziVBMkGPQDsp1Ut39)_