### PR TITLE
docs(tool-layer): correct dev-tools bundle row to match bundles.ts

### DIFF
--- a/core/tool-layer/README.md
+++ b/core/tool-layer/README.md
@@ -33,9 +33,11 @@ Named bundles passed via `AgentSpec.toolBundles`. At spawn, `computeAllowlist(sp
 | `read-write` | `Read`, `Write`, `Edit`, `Glob`, `Grep` | Developer agents |
 | `bash-restricted` | `Bash` | Shell agents |
 | `read` | `read`, `search`, `work-item-read` | Investigator agents (sandboxed) |
-| `dev-tools` | `read`, `search`, `work-item-read`, `write`, `bash`, `test` | Developer agents (sandboxed superset of `read`) |
+| `dev-tools` | `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash` | Developer skills (`implement`, `implement-wp`, `resolve-conflict`) and dev workflows (`fix-issue`, `parallel-implement`, `fix-feedback`) |
 | `validate` | `Read`, `Write`, `Edit`, `Glob`, `Grep`, scoped `Bash(pnpm test:e2e*)`, evidence I/O, git push | Playwright skills (`evidence-post`, `playwright-repro`) |
 | `playwright-mcp` | `mcp__playwright-test__*` (browser/planner/generator) | `spec-author` skill (auto-merges `apps/web/.mcp.json`) |
+
+**Note on `dev-tools`:** the bundle currently uses Claude Code's built-in tools. The lowercase sandboxed variants in `tools/` (`runBash`, `writeFile`, `runTests`, `readFile`, `searchFiles`) are pre-built but not yet exposed via an MCP server, so agents reach the host shell through Claude Code's `Bash` rather than `runBash`. Workspace-level deny rules in `sandbox.ts` plus the PreToolUse hook are the active safety boundary. Wiring the MCP server (and thereby enforcing fields like `perBashCommandMaxSeconds`) is tracked in #635 — see ADR 0035 for the timeout-scope decision that depends on it.
 
 ## Workspace Sandbox
 


### PR DESCRIPTION
## Summary
- The `dev-tools` row in the README documented the planned-but-never-shipped lowercase MCP variants (`read`, `search`, `write`, `bash`, `test`). The actual `bundles.ts` exports Claude Code's built-ins (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash`) and has done so since the bundle was introduced.
- Update the row to reflect reality and list the actual consumers (`implement`, `implement-wp`, `resolve-conflict`, `fix-issue`, `parallel-implement`, `fix-feedback`).
- Add a one-paragraph note explaining the gap: the sandboxed `tools/*.ts` functions exist but aren't wired through an MCP server. Workspace-level deny rules in `sandbox.ts` + PreToolUse hook are the active safety boundary today. Wiring is tracked in #635 (depends on ADR 0035).

## Test plan
- [x] No code changes; doc-only.
- [x] Cross-checked the new row against `core/tool-layer/bundles.ts:16` and the consumer list against `grep -rn "'dev-tools'"`.

https://claude.ai/code/session_01NBtF5LM5j6gxt7iFNxMN5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBtF5LM5j6gxt7iFNxMN5c)_