### PR TITLE
M7.XX: Timeline agent selected format wrong

### DIFF
--- a/apps/web/e2e/issue-655.spec.ts
+++ b/apps/web/e2e/issue-655.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+test('Timeline agent.model-selected event renders formatted content', async ({ page }) => {
+  // Mock the events API to return an agent.model-selected event
+  await page.route('**/api/events/**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        events: [
+          {
+            id: 1,
+            projectId: 'test-proj',
+            workItemId: 'test-wi',
+            kind: 'agent.model-selected',
+            payload: {
+              runId: 'test-run-123',
+              role: 'developer',
+              selectedTier: 'haiku',
+              reason: 'type-chore',
+            },
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        hasMore: false,
+      }),
+    });
+  });
+
+  // Navigate to an issue detail page
+  await page.goto('/issues/1');
+  await page.waitForSelector('[data-event-kind="agent.model-selected"]');
+
+  // Verify the event is rendered with proper formatting
+  const eventElement = page.locator('[data-event-kind="agent.model-selected"]');
+  expect(await eventElement.isVisible()).toBe(true);
+
+  // Verify the content shows formatted labels instead of raw JSON
+  const headerText = eventElement.locator('.font-mono.uppercase.tracking-wider').first();
+  expect(await headerText.textContent()).toContain('Model selected');
+
+  // Verify payload details are displayed
+  const content = await eventElement.textContent();
+  expect(content).toContain('developer');
+  expect(content).toContain('haiku');
+  expect(content).toContain('type-chore');
+
+  // Verify no raw JSON is visible (it should be formatted)
+  expect(content).not.toContain('{');
+  expect(content).not.toContain('}');
+
+  // Take screenshot as evidence
+  await page.screenshot({ path: 'evidence/issue-655/step-1.png' });
+});

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -6,6 +6,7 @@ import {
   AgentSpawnedEvent,
   AgentTerminatedEvent,
 } from './timeline/AgentLifecycleEvents';
+import { AgentModelSelectedEvent } from './timeline/AgentModelSelectedEvent';
 import { AgentToolCallEvent } from './timeline/AgentToolCallEvent';
 import { AgentToolResultEvent } from './timeline/AgentToolResultEvent';
 import { AgentTriageCompleteEvent } from './timeline/AgentTriageCompleteEvent';
@@ -129,6 +130,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <GateRejectedEvent key={event.id} event={event} />;
     case 'agent.implement-complete':
       return <AgentImplementCompleteEvent key={event.id} event={event} />;
+    case 'agent.model-selected':
+      return <AgentModelSelectedEvent key={event.id} event={event} />;
     case 'grill.question-posted':
       return <GrillQuestionPostedEvent key={event.id} event={event} />;
     case 'grill.completed':

--- a/apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.test.tsx
@@ -1,0 +1,71 @@
+/** @vitest-environment jsdom */
+import type { AgentEventDto } from '@/lib/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AgentModelSelectedEvent } from './AgentModelSelectedEvent';
+
+afterEach(cleanup);
+
+describe('AgentModelSelectedEvent', () => {
+  it('renders with icon, label, and timestamp', () => {
+    const event: AgentEventDto = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'wi-1',
+      kind: 'agent.model-selected',
+      payload: {
+        runId: 'cef34921-290b-4c2b-a16c-9800fe1cdfa9',
+        role: 'developer',
+        selectedTier: 'haiku',
+        reason: 'type-chore',
+      },
+      createdAt: new Date('2026-05-09T10:45:14Z').toISOString(),
+    };
+
+    const { container } = render(<AgentModelSelectedEvent event={event} />);
+
+    expect(screen.getByText('Model selected')).toBeDefined();
+    expect(screen.getByText('developer')).toBeDefined();
+    expect(screen.getByText('haiku')).toBeDefined();
+    expect(screen.getByText('type-chore')).toBeDefined();
+    expect(container.querySelector('[data-event-kind="agent.model-selected"]')).toBeDefined();
+  });
+
+  it('renders with all payload fields when present', () => {
+    const event: AgentEventDto = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'wi-1',
+      kind: 'agent.model-selected',
+      payload: {
+        runId: 'run-123',
+        role: 'qa',
+        selectedTier: 'opus',
+        reason: 'critical-issue',
+      },
+      createdAt: new Date().toISOString(),
+    };
+
+    render(<AgentModelSelectedEvent event={event} />);
+
+    expect(screen.getByText('qa')).toBeDefined();
+    expect(screen.getByText('opus')).toBeDefined();
+    expect(screen.getByText('critical-issue')).toBeDefined();
+  });
+
+  it('renders gracefully with minimal payload', () => {
+    const event: AgentEventDto = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'wi-1',
+      kind: 'agent.model-selected',
+      payload: {},
+      createdAt: new Date().toISOString(),
+    };
+
+    const { container } = render(<AgentModelSelectedEvent event={event} />);
+
+    expect(screen.getByText('Model selected')).toBeDefined();
+    expect(container.querySelector('[data-event-kind="agent.model-selected"]')).toBeDefined();
+  });
+});

--- a/apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.tsx
+++ b/apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.tsx
@@ -1,0 +1,41 @@
+import type { AgentEventDto } from '@/lib/types';
+import { Cpu } from 'lucide-react';
+
+export function AgentModelSelectedEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as {
+    role?: string;
+    selectedTier?: string;
+    reason?: string;
+  } | null;
+
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-line bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="flex items-center gap-2 mb-1.5 text-[11px] text-fg-3">
+        <Cpu size={13} className="shrink-0 text-[color:var(--accent)]" />
+        <span className="font-mono uppercase tracking-wider">Model selected</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="flex gap-4 text-[11.5px] text-fg-3">
+        {p?.role != null && (
+          <span>
+            role: <span className="text-fg-2 font-medium">{p.role}</span>
+          </span>
+        )}
+        {p?.selectedTier != null && (
+          <span>
+            tier: <span className="text-fg-2 font-medium">{p.selectedTier}</span>
+          </span>
+        )}
+        {p?.reason != null && (
+          <span>
+            reason: <span className="text-fg-2 font-medium">{p.reason}</span>
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -42,6 +42,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.triage-complete': 'Triage complete',
   'agent.investigation-complete': 'Investigation complete',
   'agent.implement-complete': 'Implement complete',
+  'agent.model-selected': 'Model selected',
   'pr.opened': 'PR opened',
   'pr.merged': 'PR merged',
   'gate.approved': 'Gate approved',


### PR DESCRIPTION
## Summary

Timeline agent selected format wrong

## Files
- `apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.tsx` — New component to format agent.model-selected events with icon, role, tier, reason labels
- `apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.test.tsx` — Tests for AgentModelSelectedEvent covering full payload, partial payload, empty payload cases
- `apps/web/src/components/detail/lib/timeline.ts` — Added agent.model-selected label to EVENT_KIND_LABEL map
- `apps/web/src/components/detail/components/TimelineEvents.tsx` — Added import and case statement for agent.model-selected event type
- `apps/web/e2e/issue-655.spec.ts` — Playwright e2e test verifying agent.model-selected renders formatted content, not raw JSON

## Tests
- `apps/web/src/components/detail/components/timeline/AgentModelSelectedEvent.test.tsx` (3 cases)

Closes #655
