### PR TITLE
fix: complete ImprovementCandidateDto mocks and remove dead imports

### DIFF
--- a/apps/server/src/domains/roster/router.test.ts
+++ b/apps/server/src/domains/roster/router.test.ts
@@ -93,11 +93,15 @@ describe('GET /roster/candidates', () => {
     const candidates = [
       {
         id: 1,
+        projectId: 'goose-hub-self',
         personaName: 'alice',
         sourceTaskId: 'task-1',
         suggestionText: 'Add retries',
         suggestionType: 'skill-config',
         status: 'pending',
+        githubIssueUrl: null,
+        errorNote: null,
+        proposedDiff: null,
         createdAt: '2026-05-01T00:00:00Z',
       },
     ];
@@ -126,11 +130,15 @@ describe('POST /roster/candidates/:id/approve', () => {
   it('returns 200 with updated candidate on success', async () => {
     const candidate = {
       id: 1,
+      projectId: 'goose-hub-self',
       personaName: 'alice',
       status: 'approved',
       suggestionText: 'Add retries',
       suggestionType: 'skill-config',
       sourceTaskId: null,
+      githubIssueUrl: null,
+      errorNote: null,
+      proposedDiff: null,
       createdAt: '2026-05-01T00:00:00Z',
     };
     mockApproveCandidate.mockResolvedValue({ ok: true, data: { candidate } });
@@ -167,11 +175,15 @@ describe('POST /roster/candidates/:id/reject', () => {
   it('returns 200 with updated candidate on success', async () => {
     const candidate = {
       id: 1,
+      projectId: 'goose-hub-self',
       personaName: 'alice',
       status: 'rejected',
       suggestionText: 'Add retries',
       suggestionType: 'skill-config',
       sourceTaskId: null,
+      githubIssueUrl: null,
+      errorNote: null,
+      proposedDiff: null,
       createdAt: '2026-05-01T00:00:00Z',
     };
     mockRejectCandidate.mockResolvedValue({ ok: true, data: { candidate } });

--- a/apps/server/src/domains/roster/service.test.ts
+++ b/apps/server/src/domains/roster/service.test.ts
@@ -33,6 +33,7 @@ const mockCandidateRow = {
   status: 'pending',
   githubIssueUrl: null,
   errorNote: null,
+  proposedDiff: null,
   createdAt: '2026-05-01T00:00:00Z',
 };
 

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -1,6 +1,5 @@
 import { fetchIssue, fetchIssues, startFakeRun } from '@/lib/api';
 import { LANES, laneForState, sortLaneItems } from '@/lib/lanes.config';
-import type { WorkItemDto } from '@/lib/types';
 import { useActiveMilestone } from '@/state/active-milestone';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react';
@@ -22,7 +21,6 @@ import { PendingNextRunBanner } from './PendingNextRunBanner';
 import { QASection } from './QASection';
 import { RetrospectiveSection } from './RetrospectiveSection';
 import { ReviewSection } from './ReviewSection';
-import { RightRail } from './RightRail';
 import { TaskHeader } from './TaskHeader';
 import { TimelineSection } from './TimelineSection';
 import { TriageResultsSection } from './TriageResultsSection';
@@ -273,8 +271,6 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
               />
             )}
           </main>
-          {/* projectSlug={slug} id={id} workItemId={workItemId} */}
-          {/* <RightRail /> */}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/roster/slice.test.ts
+++ b/apps/web/src/components/roster/slice.test.ts
@@ -79,6 +79,7 @@ describe('roster — fetchPersonaCandidates', () => {
         status: 'pending',
         githubIssueUrl: null,
         errorNote: null,
+        proposedDiff: null,
         createdAt: '2026-05-01T00:00:00Z',
       },
     ];
@@ -119,6 +120,7 @@ describe('roster — approveCandidateById', () => {
       status: 'approved',
       githubIssueUrl: null,
       errorNote: null,
+      proposedDiff: null,
       createdAt: '2026-05-01T00:00:00Z',
     });
     const result = await approveCandidateById(1);


### PR DESCRIPTION
## Summary

- Add missing `proposedDiff` (and `projectId`/`githubIssueUrl`/`errorNote`) to all roster test mock objects in `slice.test.ts` and `router.test.ts`; the web `slice.test.ts` had typed `vi.mocked()` calls that required the full `ImprovementCandidateDto` shape, causing build-time TypeScript errors
- Add `proposedDiff` to `service.test.ts` `mockCandidateRow` for consistency
- Remove unused `WorkItemDto` type import and `RightRail` import (plus its commented-out JSX) from `DetailPage.tsx`

## Test plan

- [ ] `tsc --noEmit` passes in both `apps/web` and `apps/server` without errors related to the mock objects
- [ ] Roster-related vitest tests pass (`slice.test.ts`, `router.test.ts`, `service.test.ts`)
- [ ] `DetailPage` renders correctly with no import errors

https://claude.ai/code/session_01JL9RpRLa1s1EjyR2kmAH78

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL9RpRLa1s1EjyR2kmAH78)_