### PR TITLE
fix(tsc): resolve remaining web typecheck errors

### DIFF
--- a/apps/web/e2e/issue-522.spec.ts
+++ b/apps/web/e2e/issue-522.spec.ts
@@ -57,7 +57,7 @@ test('Kanban board milestone text truncates properly without overflow', async ({
       textOverflow: style.textOverflow,
       whiteSpace: style.whiteSpace,
       display: style.display,
-      width: el.offsetWidth,
+      width: (el as HTMLElement).offsetWidth,
     };
   });
 

--- a/apps/web/e2e/m11-blocked-card.spec.ts
+++ b/apps/web/e2e/m11-blocked-card.spec.ts
@@ -1,4 +1,4 @@
-import { type Route, expect, test } from '@playwright/test';
+import { type Page, type Route, expect, test } from '@playwright/test';
 
 /**
  * M11.05: UI — blocked status on Kanban card (#297).
@@ -32,7 +32,7 @@ const BLOCKED_ITEM = {
 
 const UNBLOCKED_ITEM = { ...BLOCKED_ITEM, schedule: 'current', dependsOn: [] };
 
-function stubCommon(page: Parameters<typeof test>[1]['page']) {
+function stubCommon(page: Page) {
   return Promise.all([
     page.route('**/projects', (r: Route) =>
       r.fulfill({ json: { projects: [{ slug, name: 'Goose Hub (self)' }] } }),

--- a/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
+++ b/apps/web/src/components/detail/components/MoveToCurrentDialog.tsx
@@ -71,7 +71,7 @@ export function MoveToCurrentDialog({
 
   const { data: projects = [] } = useQuery<ProjectSummary[]>({
     queryKey: ['projects'],
-    queryFn: fetchProjects,
+    queryFn: ({ signal }) => fetchProjects(signal),
     enabled: deps.length > 0,
   });
 

--- a/apps/web/src/components/inbox/lib/promote.test.ts
+++ b/apps/web/src/components/inbox/lib/promote.test.ts
@@ -8,6 +8,9 @@ function milestone(partial: Partial<MilestoneDto>): MilestoneDto {
     title: partial.title ?? 'Milestone',
     number: partial.number ?? 0,
     isActive: partial.isActive ?? false,
+    state: partial.state ?? 'open',
+    openIssues: partial.openIssues ?? 0,
+    closedIssues: partial.closedIssues ?? 0,
     ...partial,
   };
 }

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -14,10 +14,11 @@ interface Props {
 }
 
 const GLOBAL_FIELDS: Array<{
-  key: keyof NonNullable<ProjectSettingsDto['dbGlobalOverrides']>;
+  key: Exclude<keyof NonNullable<ProjectSettingsDto['dbGlobalOverrides']>, 'updatedAt' | 'updatedBy'>;
   label: string;
   configKey: string;
   isFloat?: boolean;
+  notYetEnforced?: boolean;
 }> = [
   {
     key: 'perWorkflowMaxUsd',

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -14,7 +14,10 @@ interface Props {
 }
 
 const GLOBAL_FIELDS: Array<{
-  key: Exclude<keyof NonNullable<ProjectSettingsDto['dbGlobalOverrides']>, 'updatedAt' | 'updatedBy'>;
+  key: Exclude<
+    keyof NonNullable<ProjectSettingsDto['dbGlobalOverrides']>,
+    'updatedAt' | 'updatedBy'
+  >;
   label: string;
   configKey: string;
   isFloat?: boolean;


### PR DESCRIPTION
## Summary

- **e2e/issue-522.spec.ts** — cast `el` to `HTMLElement` before accessing `offsetWidth`; `SVGElement` doesn't have that property
- **e2e/m11-blocked-card.spec.ts** — type `stubCommon`'s `page` param as `Page` directly; `Parameters<typeof test>[1]` resolves to `TestDetails` in Playwright v3, not the test-body args
- **MoveToCurrentDialog.tsx** — change `queryFn: fetchProjects` to `({ signal }) => fetchProjects(signal)` so the signature matches tanstack-query's `QueryFunction` contract
- **promote.test.ts** — add `state`, `openIssues`, `closedIssues` defaults to the `milestone()` helper; `MilestoneDto` requires all three as non-optional
- **ProjectBudgetPanel.tsx** — exclude `updatedAt`/`updatedBy` from the `key` type so `dbVal` is `number | null` not `string | number | null`; add `notYetEnforced?: boolean` to the field-row shape

`tsc --noEmit` in `apps/web` now exits clean.

## Test plan

- [ ] `tsc --noEmit` passes in `apps/web` with no errors
- [ ] Playwright e2e specs for issue-522 and m11-blocked-card run without type errors
- [ ] ProjectBudgetPanel renders and edits budget fields correctly

https://claude.ai/code/session_01JL9RpRLa1s1EjyR2kmAH78

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL9RpRLa1s1EjyR2kmAH78)_