### PR TITLE
M7.XX: M662.01: replace logo content with 'hello world 2'

### DIFF
--- a/apps/web/e2e/issue-664.spec.ts
+++ b/apps/web/e2e/issue-664.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test('Sidebar logo renders "hello world 2" text (AC-1, AC-3)', async ({ page }) => {
+  // The sidebar is present on all routes. Navigate to root.
+  await page.goto('/');
+
+  // Wait for the sidebar to appear.
+  await page.waitForSelector('[data-testid="sidebar"]');
+
+  // Expand the sidebar so the brand label is visible.
+  // Default state is collapsed — click the toggle button to expand.
+  const toggleBtn = page.locator('[data-testid="sidebar"] button[title="Expand sidebar"]');
+  const isCollapsed = await toggleBtn.isVisible();
+  if (isCollapsed) {
+    await toggleBtn.click();
+  }
+
+  // The brand span should now read "hello world 2".
+  const brandSpan = page.locator('[data-testid="sidebar"] span.text-\\[14px\\]');
+  await expect(brandSpan).toBeVisible();
+  await expect(brandSpan).toHaveText('hello world 2');
+
+  await page.screenshot({ path: 'evidence/issue-664/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              hello world 2
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -14,11 +14,39 @@ const DEFERRED_SURFACES = [
   { label: 'Bootstrap', milestone: 'M12' },
 ];
 
+const LOGO_TEXT = 'hello world 2';
+
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header renders logo text "hello world 2" (AC-1)', () => {
+    expect(sidebarSource).toContain(LOGO_TEXT);
+  });
+
+  it('sidebar logo accessible name is "hello world 2" (AC-3)', () => {
+    // The visible text in the brand span IS the accessible name for screen readers.
+    // Verify the text node is present inside the brand span.
+    const spanMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
+    expect(spanMatch?.[0]).toContain(LOGO_TEXT);
+  });
+
+  it('sidebar logo does not render legacy text "Goose Hub"', () => {
+    // Brand text span must not contain the old label.
+    const spanMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
+    expect(spanMatch?.[0]).not.toContain('Goose Hub');
+  });
+
+  it('sidebar logo has no link wrapper — prior href was absent (AC-2)', () => {
+    // The brand header area must not wrap the logo text in an <a> or NavLink.
+    // Prior implementation had no click-navigation; behaviour is unchanged.
+    const headerBlock =
+      sidebarSource.match(/\{\/\* Header \*\/\}[\s\S]*?\{\/\* Project \*\/\}/)?.[0] ?? '';
+    expect(headerBlock).not.toMatch(/<a\s/);
+    // NavLink is used in nav items only; the brand header must not contain one.
+    const navLinkInHeader =
+      headerBlock.includes('<NavLink') &&
+      headerBlock.indexOf('<NavLink') < headerBlock.indexOf('/* Project */');
+    expect(navLinkInHeader).toBe(false);
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

M662.01: replace logo content with 'hello world 2'

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Replace logo text 'Goose Hub' with 'hello world 2'
- `apps/web/src/components/chrome/slice.test.ts` — Update tests to assert new logo text; add AC-1/AC-2/AC-3 coverage
- `apps/web/e2e/issue-664.spec.ts` — Playwright evidence spec verifying logo text in running app

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (4 cases)

Closes #664
