### PR TITLE
M7.XX: Goose Hub Logo wrong

### DIFF
--- a/apps/web/e2e/issue-675.spec.ts
+++ b/apps/web/e2e/issue-675.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('issue 675: Goose Hub logo displays "Goose Hub 2"', async ({ page }) => {
+  // Navigate to the app
+  await page.goto('/');
+
+  // Wait for sidebar to be visible
+  await page.waitForSelector('[data-testid="sidebar"]');
+
+  // Assert the logo text displays "Goose Hub 2"
+  const logoText = await page.locator('text=Goose Hub 2').textContent();
+  expect(logoText).toContain('Goose Hub 2');
+
+  // Take evidence screenshot
+  await page.screenshot({ path: 'evidence/issue-675/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Goose Hub 2
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,8 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "Goose Hub 2"', () => {
+    expect(sidebarSource).toContain('Goose Hub 2');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose Hub Logo wrong

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed logo text from 'Goose Hub' to 'Goose Hub 2'
- `apps/web/src/components/chrome/slice.test.ts` — Updated test to expect 'Goose Hub 2' text
- `apps/web/e2e/issue-675.spec.ts` — E2e spec to verify logo displays 'Goose Hub 2'

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (1 cases)

Closes #675
