### PR TITLE
M7.XX: Settings Budget Page Defaults

### DIFF
--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -56,6 +56,18 @@ router.get('/:slug/settings', async (c) => {
     };
   }
 
+  const skillDefaults: Record<
+    string,
+    { maxTurns: number; maxBudgetUsd: number; timeoutMs: number }
+  > = {};
+  for (const [skill, budget] of Object.entries(SKILL_BUDGETS)) {
+    skillDefaults[skill] = {
+      maxTurns: budget.maxTurns,
+      maxBudgetUsd: budget.maxBudgetUsd,
+      timeoutMs: budget.timeoutMs,
+    };
+  }
+
   return c.json({
     projectId: project.id,
     configBudgets: project.budgets,
@@ -74,6 +86,7 @@ router.get('/:slug/settings', async (c) => {
       : null,
     dbSkillOverrides: skillSettings,
     registeredSkills: Object.keys(SKILL_BUDGETS),
+    skillDefaults,
   });
 });
 

--- a/apps/web/e2e/issue-656.spec.ts
+++ b/apps/web/e2e/issue-656.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #656: Settings Budget Page Defaults', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the settings page
+    await page.goto('/settings');
+  });
+
+  test('displays default values for global budget fields', async ({ page }) => {
+    // Wait for the settings page to load
+    await page.waitForSelector('h3:has-text("Global budget caps")');
+
+    // Mock the API response to include specific default values
+    await page.route('**/api/projects/*/settings', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          projectId: 'test-project',
+          configBudgets: {
+            perWorkflowMaxUsd: 5.0,
+            perAgentMaxUsd: 2.5,
+            perAdvisorMaxUsd: 1.0,
+            dailyTokens: 1000000,
+            maxParallelAgents: 5,
+            maxRetries: 3,
+            perBashCommandMaxSeconds: 300,
+          },
+          dbGlobalOverrides: null,
+          dbSkillOverrides: {},
+          registeredSkills: ['implement', 'qa'],
+          skillDefaults: {
+            implement: { maxTurns: 150, maxBudgetUsd: 6.0, timeoutMs: 900000 },
+            qa: { maxTurns: 100, maxBudgetUsd: 3.0, timeoutMs: 600000 },
+          },
+        }),
+      });
+    });
+
+    // Reload to get the mocked data
+    await page.reload();
+
+    // Wait for the Global budget caps section to be visible
+    await page.waitForSelector(':text("Global budget caps")');
+
+    // Verify that global budget field labels show default values
+    await expect(page.getByText('Per-workflow max USD (default: $5.00)')).toBeVisible();
+    await expect(page.getByText('Per-agent max USD (default: $2.50)')).toBeVisible();
+    await expect(page.getByText('Per-advisor max USD (default: $1.00)')).toBeVisible();
+    await expect(page.getByText('Daily tokens (default: 1,000,000)')).toBeVisible();
+    await expect(page.getByText('Max parallel agents (default: 5)')).toBeVisible();
+    await expect(page.getByText('Max retries (default: 3)')).toBeVisible();
+    await expect(page.getByText(
+      'Per-bash-command max seconds (default: 300)'
+    )).toBeVisible();
+
+    // Take a screenshot showing the global budget defaults
+    await page.screenshot({ path: 'evidence/issue-656/step-1-global-defaults.png' });
+  });
+
+  test('displays default values for per-skill budget fields', async ({ page }) => {
+    // Wait for the settings page to load
+    await page.waitForSelector('h3:has-text("Per-skill budget overrides")');
+
+    // Mock the API response with skill defaults
+    await page.route('**/api/projects/*/settings', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          projectId: 'test-project',
+          configBudgets: {},
+          dbGlobalOverrides: null,
+          dbSkillOverrides: {},
+          registeredSkills: ['implement', 'qa', 'review'],
+          skillDefaults: {
+            implement: { maxTurns: 150, maxBudgetUsd: 6.0, timeoutMs: 900000 },
+            qa: { maxTurns: 100, maxBudgetUsd: 3.0, timeoutMs: 600000 },
+            review: { maxTurns: 25, maxBudgetUsd: 0.5, timeoutMs: 180000 },
+          },
+        }),
+      });
+    });
+
+    // Reload to get the mocked data
+    await page.reload();
+
+    // Wait for the Per-skill budget overrides section to be visible
+    await page.waitForSelector(':text("Per-skill budget overrides")');
+
+    // Verify that skill rows exist and have proper inputs
+    await expect(page.getByText('implement')).toBeVisible();
+    await expect(page.getByText('qa')).toBeVisible();
+    await expect(page.getByText('review')).toBeVisible();
+
+    // Verify that the inputs show default values in their placeholders
+    // These are spinbutton (number input) elements
+    const inputs = page.locator('input[type="number"]');
+    const count = await inputs.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Find inputs with the expected placeholder values (skill defaults)
+    const implementMaxTurnsInput = page.locator('input[placeholder="150"]');
+    const qaMaxBudgetInput = page.locator('input[placeholder="3"]');
+    const reviewTimeoutInput = page.locator('input[placeholder="180000"]');
+
+    // Verify at least one of these exists (showing defaults are displayed)
+    const hasSomeDefaults =
+      (await implementMaxTurnsInput.count()) > 0 ||
+      (await qaMaxBudgetInput.count()) > 0 ||
+      (await reviewTimeoutInput.count()) > 0;
+
+    expect(hasSomeDefaults).toBe(true);
+
+    // Take a screenshot showing the per-skill budget defaults
+    await page.screenshot({ path: 'evidence/issue-656/step-2-skill-defaults.png' });
+  });
+
+  test('correctly formats currency and numeric values', async ({ page }) => {
+    // Mock the API response with various numeric formats
+    await page.route('**/api/projects/*/settings', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          projectId: 'test-project',
+          configBudgets: {
+            perWorkflowMaxUsd: 123.456,
+            perAgentMaxUsd: 0.05,
+            perAdvisorMaxUsd: 1.5,
+            dailyTokens: 1500000,
+            maxParallelAgents: 50,
+            maxRetries: 20,
+            perBashCommandMaxSeconds: 3600,
+          },
+          dbGlobalOverrides: null,
+          dbSkillOverrides: {},
+          registeredSkills: [],
+          skillDefaults: {},
+        }),
+      });
+    });
+
+    // Navigate and reload to get the mocked data
+    await page.goto('/settings');
+    await page.waitForSelector('h3:has-text("Global budget caps")');
+
+    // Verify currency values are formatted with $ and proper decimals
+    await expect(page.getByText('Per-workflow max USD (default: $123.46)')).toBeVisible();
+    await expect(page.getByText('Per-agent max USD (default: $0.05)')).toBeVisible();
+    await expect(page.getByText('Per-advisor max USD (default: $1.50)')).toBeVisible();
+
+    // Verify integer values have thousand separators
+    await expect(page.getByText('Daily tokens (default: 1,500,000)')).toBeVisible();
+    await expect(page.getByText('Max parallel agents (default: 50)')).toBeVisible();
+    await expect(page.getByText('Max retries (default: 20)')).toBeVisible();
+    await expect(page.getByText(
+      'Per-bash-command max seconds (default: 3,600)'
+    )).toBeVisible();
+
+    // Take a screenshot showing proper formatting
+    await page.screenshot({ path: 'evidence/issue-656/step-3-formatting.png' });
+  });
+});

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
@@ -1,0 +1,179 @@
+/** @vitest-environment jsdom */
+import * as api from '@/lib/api';
+import type { ProjectSettingsDto } from '@/lib/api';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProjectBudgetPanel } from './ProjectBudgetPanel';
+
+vi.mock('@/lib/api', () => ({
+  fetchProjectSettings: vi.fn(),
+  patchGlobalBudgetSettings: vi.fn(),
+  patchSkillBudgetSetting: vi.fn(),
+  deleteSkillBudgetSetting: vi.fn(),
+}));
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function mockSettings(overrides: Partial<ProjectSettingsDto> = {}): ProjectSettingsDto {
+  return {
+    projectId: 'proj-1',
+    configBudgets: {},
+    dbGlobalOverrides: null,
+    dbSkillOverrides: {},
+    registeredSkills: [],
+    skillDefaults: {},
+    ...overrides,
+  };
+}
+
+function renderPanel(slug = 'test-project') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <ProjectBudgetPanel slug={slug} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProjectBudgetPanel', () => {
+  it('displays default values for global budget fields in labels', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(
+      mockSettings({
+        configBudgets: {
+          perWorkflowMaxUsd: 5.0,
+          perAgentMaxUsd: 2.5,
+          perAdvisorMaxUsd: 1.0,
+          dailyTokens: 1000000,
+          maxParallelAgents: 5,
+          maxRetries: 3,
+          perBashCommandMaxSeconds: 300,
+        },
+      }),
+    );
+
+    renderPanel();
+    await waitFor(() => {
+      // Check that labels show the default values
+      expect(screen.getByText('Per-workflow max USD (default: $5.00)')).toBeTruthy();
+      expect(screen.getByText('Per-agent max USD (default: $2.50)')).toBeTruthy();
+      expect(screen.getByText('Per-advisor max USD (default: $1.00)')).toBeTruthy();
+      expect(screen.getByText('Daily tokens (default: 1,000,000)')).toBeTruthy();
+      expect(screen.getByText('Max parallel agents (default: 5)')).toBeTruthy();
+      expect(screen.getByText('Max retries (default: 3)')).toBeTruthy();
+      expect(screen.getByText('Per-bash-command max seconds (default: 300)')).toBeTruthy();
+    });
+  });
+
+  it('displays skill budget defaults in placeholders', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(
+      mockSettings({
+        registeredSkills: ['implement', 'qa'],
+        skillDefaults: {
+          implement: { maxTurns: 150, maxBudgetUsd: 6.0, timeoutMs: 900000 },
+          qa: { maxTurns: 100, maxBudgetUsd: 3.0, timeoutMs: 600000 },
+        },
+      }),
+    );
+
+    renderPanel();
+    await waitFor(() => {
+      // Check that skill table rows show defaults in placeholders
+      expect(screen.getByText('implement')).toBeTruthy();
+      expect(screen.getByText('qa')).toBeTruthy();
+
+      // Find inputs for skill budget defaults
+      const inputs = screen.getAllByRole('spinbutton');
+      const implementMaxTurnsInput = inputs.find((inp) =>
+        inp.getAttribute('placeholder')?.includes('150'),
+      );
+      const qaMaxBudgetInput = inputs.find((inp) => inp.getAttribute('placeholder')?.includes('3'));
+
+      expect(implementMaxTurnsInput).toBeTruthy();
+      expect(qaMaxBudgetInput).toBeTruthy();
+    });
+  });
+
+  it('shows "—" when global config values are not set', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(mockSettings());
+
+    renderPanel();
+    await waitFor(() => {
+      // When no config budgets are set, inputs should show "—"
+      const inputs = screen.getAllByRole('spinbutton');
+      const emptyInput = inputs.find((inp) => inp.getAttribute('placeholder') === '—');
+      expect(emptyInput).toBeTruthy();
+    });
+  });
+
+  it('formats currency values with $ and decimal places', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(
+      mockSettings({
+        configBudgets: {
+          perWorkflowMaxUsd: 123.456,
+          perAgentMaxUsd: 0.05,
+          perAdvisorMaxUsd: 1.5,
+          dailyTokens: 1000000,
+          maxParallelAgents: 5,
+          maxRetries: 3,
+          perBashCommandMaxSeconds: 300,
+        },
+      }),
+    );
+
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByText('Per-workflow max USD (default: $123.46)')).toBeTruthy();
+      expect(screen.getByText('Per-agent max USD (default: $0.05)')).toBeTruthy();
+      expect(screen.getByText('Per-advisor max USD (default: $1.50)')).toBeTruthy();
+    });
+  });
+
+  it('formats integer values with thousand separators', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(
+      mockSettings({
+        configBudgets: {
+          perWorkflowMaxUsd: 1.0,
+          perAgentMaxUsd: 1.0,
+          perAdvisorMaxUsd: 1.0,
+          dailyTokens: 1500000,
+          maxParallelAgents: 50,
+          maxRetries: 20,
+          perBashCommandMaxSeconds: 3600,
+        },
+      }),
+    );
+
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByText('Daily tokens (default: 1,500,000)')).toBeTruthy();
+      expect(screen.getByText('Max parallel agents (default: 50)')).toBeTruthy();
+      expect(screen.getByText('Max retries (default: 20)')).toBeTruthy();
+      expect(screen.getByText('Per-bash-command max seconds (default: 3,600)')).toBeTruthy();
+    });
+  });
+
+  it('shows skill timeout in milliseconds with formatting', async () => {
+    vi.mocked(api.fetchProjectSettings).mockResolvedValueOnce(
+      mockSettings({
+        registeredSkills: ['implement'],
+        skillDefaults: {
+          implement: { maxTurns: 150, maxBudgetUsd: 6.0, timeoutMs: 900000 },
+        },
+      }),
+    );
+
+    renderPanel();
+    await waitFor(() => {
+      // Should display timeout default (900000 ms)
+      const inputs = screen.getAllByRole('spinbutton');
+      const timeoutInput = inputs.find((inp) =>
+        inp.getAttribute('placeholder')?.includes('900000'),
+      );
+      expect(timeoutInput).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -9,6 +9,26 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+/**
+ * Format a number for display based on key type.
+ * - USD fields: formatted as $N.NN
+ * - Integer fields: formatted with thousand separators
+ */
+function formatDefaultValue(key: string, value: number): string {
+  const isUsd =
+    key === 'perWorkflowMaxUsd' ||
+    key === 'perAgentMaxUsd' ||
+    key === 'perAdvisorMaxUsd' ||
+    key === 'maxBudgetUsd';
+
+  if (isUsd) {
+    return `$${value.toFixed(2)}`;
+  }
+
+  // Integer fields: use thousand separators
+  return value.toLocaleString();
+}
+
 interface Props {
   slug: string;
 }
@@ -145,6 +165,8 @@ export function ProjectBudgetPanel({ slug }: Props) {
             const configVal = configBudgets[configKey];
             const dbVal = dbGlobal?.[key] ?? null;
             const isOverridden = dbVal != null;
+            const defaultDisplay =
+              configVal != null ? ` (default: ${formatDefaultValue(configKey, configVal)})` : '';
             return (
               <>
                 <span
@@ -152,6 +174,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                   className="text-[12px] text-fg-2 flex items-center gap-1.5"
                 >
                   {label}
+                  {defaultDisplay}
                 </span>
                 <NumericInput
                   key={`${key}-input`}
@@ -189,6 +212,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
           <tbody>
             {data.registeredSkills.map((skill) => {
               const row = data.dbSkillOverrides[skill] ?? null;
+              const defaults = data.skillDefaults[skill];
               const hasAny =
                 row != null &&
                 (row.maxTurns != null || row.maxBudgetUsd != null || row.timeoutMs != null);
@@ -198,7 +222,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                   <td className="py-1.5 px-2">
                     <NumericInput
                       value={row?.maxTurns ?? null}
-                      placeholder="default"
+                      placeholder={defaults ? String(defaults.maxTurns) : 'default'}
                       overridden={row?.maxTurns != null}
                       onCommit={(val) => patchSkill.mutate({ skill, patch: { maxTurns: val } })}
                     />
@@ -206,7 +230,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                   <td className="py-1.5 px-2">
                     <NumericInput
                       value={row?.maxBudgetUsd ?? null}
-                      placeholder="default"
+                      placeholder={defaults ? String(defaults.maxBudgetUsd) : 'default'}
                       isFloat
                       overridden={row?.maxBudgetUsd != null}
                       onCommit={(val) => patchSkill.mutate({ skill, patch: { maxBudgetUsd: val } })}
@@ -215,7 +239,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                   <td className="py-1.5 px-2">
                     <NumericInput
                       value={row?.timeoutMs ?? null}
-                      placeholder="default"
+                      placeholder={defaults ? String(defaults.timeoutMs) : 'default'}
                       overridden={row?.timeoutMs != null}
                       onCommit={(val) => patchSkill.mutate({ skill, patch: { timeoutMs: val } })}
                     />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -522,6 +522,14 @@ export interface ProjectSettingsDto {
     }
   >;
   registeredSkills: string[];
+  skillDefaults: Record<
+    string,
+    {
+      maxTurns: number;
+      maxBudgetUsd: number;
+      timeoutMs: number;
+    }
+  >;
 }
 
 export async function fetchProjectSettings(


### PR DESCRIPTION
## Summary

Settings Budget Page Defaults

## Files
- `apps/server/src/domains/project-settings/router.ts` — Include SKILL_BUDGETS values in API response
- `apps/web/src/lib/api.ts` — Add skillDefaults field to ProjectSettingsDto type
- `apps/web/src/components/settings/components/ProjectBudgetPanel.tsx` — Display defaults in labels and placeholders with proper formatting
- `apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx` — Unit tests covering all display and formatting scenarios
- `apps/web/e2e/issue-656.spec.ts` — Playwright e2e spec with visual evidence

## Tests
- `apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx` (6 cases)

Closes #656
