### PR TITLE
M7.XX: Goose hub logo wrong

### DIFF
--- a/apps/web/e2e/issue-681.spec.ts
+++ b/apps/web/e2e/issue-681.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test('Sidebar displays GooseHUB logo with correct branding', async ({ page }) => {
+  // Mock the API endpoints to return minimal test data
+  await page.route('**/api/projects/*/issues', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+
+  await page.route('**/api/projects/*/issues/*/timeline*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    }),
+  );
+
+  // Navigate to the home page
+  await page.goto('/');
+
+  // Wait for sidebar to be visible
+  const sidebar = await page.waitForSelector('[data-testid="sidebar"]');
+  expect(sidebar).toBeTruthy();
+
+  // Assert the logo text is "GooseHUB" (no space, all capitals)
+  const logoText = await page.textContent('span.text-\\[14px\\].font-semibold');
+  expect(logoText).toContain('GooseHUB');
+
+  // Verify it does NOT contain the old branding "Goose Hub"
+  expect(logoText).not.toContain('Goose hub');
+  expect(logoText).not.toContain('Goose Hub');
+
+  // Take a screenshot as visual evidence
+  await page.screenshot({ path: 'evidence/issue-681/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,8 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub logo wrong

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed logo text from 'Goose Hub' to 'GooseHUB'
- `apps/web/src/components/chrome/slice.test.ts` — Updated test assertion to verify 'GooseHUB' text
- `apps/web/e2e/issue-681.spec.ts` — Playwright spec for visual evidence of GooseHUB branding

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (1 cases)

Closes #681
