### PR TITLE
M19.28: context-assembly internal split

### DIFF
--- a/core/agent-runtime/context-assembly.test.ts
+++ b/core/agent-runtime/context-assembly.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Integration tests for assembleSpawnContext (the public gateway).
+ * Unit tests for the extracted sub-modules live in:
+ *   - holdout-validator.test.ts  (findHoldoutContextLeaks, findDisallowedKeys)
+ *   - context-renderer.test.ts   (renderContext)
+ */
 import { describe, expect, it } from 'vitest';
 import { assembleSpawnContext } from './context-assembly.js';
 
@@ -118,5 +124,85 @@ describe('assembleSpawnContext', () => {
     expect(contextXml).not.toContain('projectId');
     expect(contextXml).not.toContain('workItemId');
     expect(contextXml).not.toContain('advisorFeedback');
+  });
+
+  // ── Snapshot tests: lock the pre-split behaviour ─────────────────────────────
+  // These exist to detect any drift introduced by the internal split into
+  // holdout-validator.ts and context-renderer.ts. The expected values were
+  // captured against the original context-assembly.ts implementation.
+
+  it('snapshot: implement-style mixed allowlist', () => {
+    const context = {
+      projectId: 'proj-1',
+      workItemId: 'wi-1',
+      workItem: { title: 'Add emoji', body: 'Add task', number: 258, priority: 'low' },
+      worktreePath: '/tmp/ws',
+      stack: { testCommand: 'pnpm test', lintCommand: 'pnpm lint' },
+      advisorFeedback: undefined,
+      revisionPass: 0,
+    };
+    const allowlist = [
+      'workItem.title',
+      'workItem.body',
+      'workItem.number',
+      'workItem.priority',
+      'worktreePath',
+      'stack.testCommand',
+      'stack.lintCommand',
+      'advisorFeedback',
+      'revisionPass',
+    ];
+    const { contextXml } = assembleSpawnContext(makeSpec(context, allowlist));
+    expect(contextXml).toMatchInlineSnapshot(`
+      "<task>
+        <workItem>{&quot;title&quot;:&quot;Add emoji&quot;,&quot;body&quot;:&quot;Add task&quot;,&quot;number&quot;:258,&quot;priority&quot;:&quot;low&quot;}</workItem>
+        <worktreePath>/tmp/ws</worktreePath>
+        <stack>{&quot;testCommand&quot;:&quot;pnpm test&quot;,&quot;lintCommand&quot;:&quot;pnpm lint&quot;}</stack>
+        <revisionPass>0</revisionPass>
+      </task>"
+    `);
+  });
+
+  it('snapshot: dotted-path projection', () => {
+    const { contextXml } = assembleSpawnContext(
+      makeSpec({ workItem: { title: 'Fix bug', body: 'Details', number: 42, priority: 'low' } }, [
+        'workItem.title',
+        'workItem.body',
+      ]),
+    );
+    expect(contextXml).toMatchInlineSnapshot(`
+      "<task>
+        <workItem>{&quot;title&quot;:&quot;Fix bug&quot;,&quot;body&quot;:&quot;Details&quot;}</workItem>
+      </task>"
+    `);
+  });
+
+  it('snapshot: fresh holdout spec (qa) with safe context', () => {
+    const spec = {
+      runId: 'r-qa',
+      role: 'qa' as const,
+      skill: 'qa',
+      context: {
+        projectId: 'proj-1',
+        workItemId: 'wi-1',
+        prUrl: 'https://github.com/foo/bar/pull/1',
+        issueBody: 'Fix the bug',
+      },
+      contextAllowlist: ['prUrl', 'issueBody'],
+      freshContext: true as const,
+      toolBundles: [] as string[],
+      toolExtras: [] as never[],
+      budgets: { maxTurns: 10, maxBudgetUsd: 1, timeoutMs: 30_000 },
+      personaId: 'p1',
+      outputJsonSchema: {},
+      appendSystemPrompt: '',
+    };
+    const { contextXml } = assembleSpawnContext(spec);
+    expect(contextXml).toMatchInlineSnapshot(`
+      "<task>
+        <prUrl>https://github.com/foo/bar/pull/1</prUrl>
+        <issueBody>Fix the bug</issueBody>
+      </task>"
+    `);
   });
 });

--- a/core/agent-runtime/context-assembly.ts
+++ b/core/agent-runtime/context-assembly.ts
@@ -1,69 +1,49 @@
 import { eventStore } from '../event-stream/store.js';
+import { renderContext } from './context-renderer.js';
+import {
+  HOLDOUT_FORBIDDEN_KEYS,
+  findDisallowedKeys,
+  findHoldoutContextLeaks,
+} from './holdout-validator.js';
 import type { AgentSpec } from './interface.js';
+
+// Re-export for callers that import these from context-assembly
+export type { HoldoutContextLeak } from './holdout-validator.js';
+export { HOLDOUT_FORBIDDEN_KEYS, findHoldoutContextLeaks } from './holdout-validator.js';
 
 export interface SpawnContext {
   contextXml: string;
 }
 
-// Holdout roles that enforce strict context isolation
+// Holdout roles that enforce strict context isolation (kept here for violation event emission)
 const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
-// Keys managed by the runtime itself — not user-injected, so not violations
-const SYSTEM_KEYS = new Set(['projectId', 'workItemId']);
 
 /**
- * Context keys produced by the dev-review pipeline (M19.11) that must NEVER
- * reach a holdout role's context — even if a future caller adds them to the
- * allowlist by mistake. Defense in depth: the allowlist mechanism is the
- * primary gate, this set is the backstop.
- *
- * `assertHoldoutContextSafe()` rejects holdout specs that mention these keys
- * either in `context` or in `contextAllowlist`. ADR 0036 §holdout-discipline.
+ * Derives the effective allowlist for a spec, stripping forbidden dev-review
+ * keys when leaks have been detected.
  */
-export const HOLDOUT_FORBIDDEN_KEYS: ReadonlySet<string> = new Set([
-  'devReviewFindings',
-  'devReviewVerdict',
-  'devReviewSummaries',
-]);
-
-export interface HoldoutContextLeak {
-  key: string;
-  source: 'context' | 'allowlist';
+function effectiveAllowlist(spec: AgentSpec, leaks: ReturnType<typeof findHoldoutContextLeaks>) {
+  if (leaks.length === 0) return spec.contextAllowlist;
+  return spec.contextAllowlist.filter((k) => {
+    const dot = k.indexOf('.');
+    const top = dot === -1 ? k : k.slice(0, dot);
+    return !HOLDOUT_FORBIDDEN_KEYS.has(top);
+  });
 }
 
 /**
- * For holdout roles only: returns the list of forbidden-key leaks present in
- * either `spec.context` or `spec.contextAllowlist`. Empty array for safe
- * specs and for non-holdout roles.
- *
- * Pure function — does not mutate the spec or emit events. Callers
- * (e.g. `assembleSpawnContext`) are responsible for the side effects.
+ * Derives the effective context for a spec, stripping forbidden dev-review
+ * keys when leaks have been detected.
  */
-/**
- * Returns the top-level key of an allowlist entry. `renderManifest` supports
- * dotted paths (e.g. `devReviewFindings.summary`) which project a nested
- * value through to the rendered XML — so leak detection must normalise to
- * the top-level key before comparing against the forbidden set.
- */
-function topLevelKey(allowlistEntry: string): string {
-  const dot = allowlistEntry.indexOf('.');
-  return dot === -1 ? allowlistEntry : allowlistEntry.slice(0, dot);
-}
-
-export function findHoldoutContextLeaks(spec: AgentSpec): HoldoutContextLeak[] {
-  if (!HOLDOUT_ROLES.has(spec.role)) return [];
-  const leaks: HoldoutContextLeak[] = [];
-  for (const k of Object.keys(spec.context)) {
-    if (HOLDOUT_FORBIDDEN_KEYS.has(k)) leaks.push({ key: k, source: 'context' });
-  }
-  for (const k of spec.contextAllowlist) {
-    // Compare the top-level key against the forbidden set. `key` on the leak
-    // record preserves the original entry (e.g. `devReviewFindings.summary`)
-    // so the violation event accurately reports what the caller attempted.
-    if (HOLDOUT_FORBIDDEN_KEYS.has(topLevelKey(k))) {
-      leaks.push({ key: k, source: 'allowlist' });
-    }
-  }
-  return leaks;
+function effectiveContext(
+  spec: AgentSpec,
+  leaks: ReturnType<typeof findHoldoutContextLeaks>,
+): Record<string, unknown> {
+  if (leaks.length === 0) return spec.context;
+  if (!Object.keys(spec.context).some((k) => HOLDOUT_FORBIDDEN_KEYS.has(k))) return spec.context;
+  return Object.fromEntries(
+    Object.entries(spec.context).filter(([k]) => !HOLDOUT_FORBIDDEN_KEYS.has(k)),
+  );
 }
 
 /**
@@ -90,8 +70,6 @@ export function assembleSpawnContext(spec: AgentSpec): SpawnContext {
   // both the allowlist and the context, emit a leak event per occurrence.
   // Runs BEFORE render so forbidden keys can't slip into the XML even if the
   // allowlist accidentally includes them.
-  let effectiveContext = spec.context;
-  let effectiveAllowlist = spec.contextAllowlist;
   const leaks = findHoldoutContextLeaks(spec);
   if (leaks.length > 0) {
     for (const leak of leaks) {
@@ -110,22 +88,14 @@ export function assembleSpawnContext(spec: AgentSpec): SpawnContext {
         runId: spec.runId,
       });
     }
-    // Normalise to top-level when filtering — dotted entries like
-    // `devReviewFindings.summary` would otherwise project the nested value.
-    effectiveAllowlist = spec.contextAllowlist.filter(
-      (k) => !HOLDOUT_FORBIDDEN_KEYS.has(topLevelKey(k)),
-    );
-    if (Object.keys(spec.context).some((k) => HOLDOUT_FORBIDDEN_KEYS.has(k))) {
-      effectiveContext = Object.fromEntries(
-        Object.entries(spec.context).filter(([k]) => !HOLDOUT_FORBIDDEN_KEYS.has(k)),
-      );
-    }
   }
 
-  const { contextXml, disallowedKeys } = renderManifest(effectiveContext, effectiveAllowlist);
+  const filteredContext = effectiveContext(spec, leaks);
+  const filteredAllowlist = effectiveAllowlist(spec, leaks);
 
   // Emit tool.violation for disallowed keys on holdout roles
-  if (HOLDOUT_ROLES.has(spec.role) && disallowedKeys.length > 0) {
+  if (HOLDOUT_ROLES.has(spec.role)) {
+    const disallowedKeys = findDisallowedKeys(filteredContext, filteredAllowlist);
     for (const key of disallowedKeys) {
       eventStore.appendEvent({
         projectId: typeof spec.context.projectId === 'string' ? spec.context.projectId : 'unknown',
@@ -138,76 +108,9 @@ export function assembleSpawnContext(spec: AgentSpec): SpawnContext {
     }
   }
 
+  const contextXml = renderContext(filteredContext, filteredAllowlist);
+
   if (spec.freshContext) return { contextXml };
   // Non-fresh ambient injection (event stream, persona history) deferred to M9+
   return { contextXml };
-}
-
-function renderManifest(
-  context: Record<string, unknown>,
-  allowlist: string[],
-): { contextXml: string; disallowedKeys: string[] } {
-  const disallowedKeys: string[] = [];
-  const filtered: Record<string, unknown> = {};
-
-  if (allowlist.length === 0) {
-    // empty allowlist = nothing passes; no user keys to flag as violations
-    return { contextXml: '<task></task>', disallowedKeys };
-  }
-
-  // Partition allowlist into exact top-level keys vs dotted sub-key paths.
-  const exactKeys = new Set<string>();
-  const dottedSubKeys = new Map<string, Set<string>>();
-  for (const entry of allowlist) {
-    const dot = entry.indexOf('.');
-    if (dot === -1) {
-      exactKeys.add(entry);
-    } else {
-      const top = entry.slice(0, dot);
-      const sub = entry.slice(dot + 1);
-      let subs = dottedSubKeys.get(top);
-      if (subs == null) {
-        subs = new Set();
-        dottedSubKeys.set(top, subs);
-      }
-      subs.add(sub);
-    }
-  }
-
-  for (const [k, v] of Object.entries(context)) {
-    if (exactKeys.has(k)) {
-      filtered[k] = v;
-    } else if (dottedSubKeys.has(k) && typeof v === 'object' && v !== null) {
-      const subs = dottedSubKeys.get(k) as Set<string>;
-      const projected: Record<string, unknown> = {};
-      for (const sub of subs) {
-        if (Object.prototype.hasOwnProperty.call(v, sub)) {
-          projected[sub] = (v as Record<string, unknown>)[sub];
-        }
-      }
-      filtered[k] = projected;
-    } else if (!SYSTEM_KEYS.has(k)) {
-      disallowedKeys.push(k);
-    }
-  }
-
-  const inner = Object.entries(filtered)
-    .filter(([, v]) => v !== undefined)
-    .map(([k, v]) => {
-      const safe = escapeXml(typeof v === 'string' ? v : JSON.stringify(v));
-      return `  <${k}>${safe}</${k}>`;
-    })
-    .join('\n');
-
-  const contextXml = inner.length > 0 ? `<task>\n${inner}\n</task>` : '<task></task>';
-  return { contextXml, disallowedKeys };
-}
-
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
 }

--- a/core/agent-runtime/context-renderer.test.ts
+++ b/core/agent-runtime/context-renderer.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { renderContext } from './context-renderer.js';
+
+describe('renderContext', () => {
+  it('returns empty task element when allowlist is empty', () => {
+    expect(renderContext({ a: 'hello' }, [])).toBe('<task></task>');
+  });
+
+  it('returns empty task element when all values are undefined', () => {
+    expect(renderContext({ a: undefined }, ['a'])).toBe('<task></task>');
+  });
+
+  it('renders a string value as escaped XML', () => {
+    const xml = renderContext({ title: 'hello <world>' }, ['title']);
+    expect(xml).toContain('hello &lt;world&gt;');
+  });
+
+  it('escapes ampersands', () => {
+    const xml = renderContext({ title: 'foo & bar' }, ['title']);
+    expect(xml).toContain('foo &amp; bar');
+  });
+
+  it('escapes double quotes', () => {
+    const xml = renderContext({ title: '"quoted"' }, ['title']);
+    expect(xml).toContain('&quot;quoted&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    const xml = renderContext({ title: "it's" }, ['title']);
+    expect(xml).toContain('it&apos;s');
+  });
+
+  it('renders non-string values as JSON', () => {
+    const xml = renderContext({ count: 42 }, ['count']);
+    expect(xml).toContain('<count>42</count>');
+  });
+
+  it('omits keys not in allowlist silently', () => {
+    const xml = renderContext({ a: 'visible', b: 'hidden' }, ['a']);
+    expect(xml).toContain('<a>');
+    expect(xml).not.toContain('<b>');
+  });
+
+  it('projects dotted-path sub-keys from nested objects', () => {
+    const xml = renderContext(
+      { workItem: { title: 'Fix bug', body: 'Details', number: 42, priority: 'low' } },
+      ['workItem.title', 'workItem.body'],
+    );
+    expect(xml).toContain('<workItem>');
+    expect(xml).toContain('&quot;title&quot;');
+    expect(xml).toContain('&quot;body&quot;');
+    expect(xml).not.toContain('&quot;number&quot;');
+    expect(xml).not.toContain('&quot;priority&quot;');
+  });
+
+  it('includes full nested object when top-level key is in allowlist', () => {
+    const xml = renderContext({ workItem: { title: 'Fix bug', body: 'Details' } }, ['workItem']);
+    expect(xml).toContain('<workItem>');
+    expect(xml).toContain('&quot;title&quot;');
+    expect(xml).toContain('&quot;body&quot;');
+  });
+
+  it('handles mixed dotted and scalar allowlist', () => {
+    const context = {
+      projectId: 'proj-1',
+      workItemId: 'wi-1',
+      workItem: { title: 'Add emoji', body: 'Add task', number: 258, priority: 'low' },
+      worktreePath: '/tmp/ws',
+      stack: { testCommand: 'pnpm test', lintCommand: 'pnpm lint' },
+      advisorFeedback: undefined,
+      revisionPass: 0,
+    };
+    const allowlist = [
+      'workItem.title',
+      'workItem.body',
+      'workItem.number',
+      'workItem.priority',
+      'worktreePath',
+      'stack.testCommand',
+      'stack.lintCommand',
+      'advisorFeedback',
+      'revisionPass',
+    ];
+    const xml = renderContext(context, allowlist);
+    expect(xml).toContain('<workItem>');
+    expect(xml).toContain('Add emoji');
+    expect(xml).toContain('<worktreePath>');
+    expect(xml).toContain('<stack>');
+    expect(xml).toContain('pnpm test');
+    expect(xml).not.toContain('projectId');
+    expect(xml).not.toContain('workItemId');
+    expect(xml).not.toContain('advisorFeedback');
+  });
+
+  it('returns empty task element when dotted key points to non-object', () => {
+    // dotted path on a scalar value — projected object would be empty
+    const xml = renderContext({ workItem: 'not-an-object' }, ['workItem.title']);
+    // workItem is not an object, so dottedSubKey branch is skipped, key is omitted
+    expect(xml).toBe('<task></task>');
+  });
+
+  it('wraps multiple keys in task block', () => {
+    const xml = renderContext({ a: '1', b: '2' }, ['a', 'b']);
+    expect(xml).toMatch(/^<task>\n.*<\/task>$/s);
+    expect(xml).toContain('<a>1</a>');
+    expect(xml).toContain('<b>2</b>');
+  });
+});

--- a/core/agent-runtime/context-renderer.ts
+++ b/core/agent-runtime/context-renderer.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure XML rendering layer for agent context.
+ *
+ * No governance knowledge — takes pre-filtered context and a pre-scrubbed
+ * allowlist from the caller. Returns contextXml only.
+ */
+
+/**
+ * Render `context` keys permitted by `allowlist` into an XML `<task>` block.
+ *
+ * Supports dotted-path sub-key projection (e.g. `workItem.title`) in addition
+ * to exact top-level key inclusion.
+ *
+ * Returns `<task></task>` when the allowlist is empty or all values are
+ * undefined.
+ */
+export function renderContext(context: Record<string, unknown>, allowlist: string[]): string {
+  if (allowlist.length === 0) {
+    return '<task></task>';
+  }
+
+  // Partition allowlist into exact top-level keys vs dotted sub-key paths.
+  const exactKeys = new Set<string>();
+  const dottedSubKeys = new Map<string, Set<string>>();
+  for (const entry of allowlist) {
+    const dot = entry.indexOf('.');
+    if (dot === -1) {
+      exactKeys.add(entry);
+    } else {
+      const top = entry.slice(0, dot);
+      const sub = entry.slice(dot + 1);
+      let subs = dottedSubKeys.get(top);
+      if (subs == null) {
+        subs = new Set();
+        dottedSubKeys.set(top, subs);
+      }
+      subs.add(sub);
+    }
+  }
+
+  const filtered: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(context)) {
+    if (exactKeys.has(k)) {
+      filtered[k] = v;
+    } else if (dottedSubKeys.has(k) && typeof v === 'object' && v !== null) {
+      const subs = dottedSubKeys.get(k) as Set<string>;
+      const projected: Record<string, unknown> = {};
+      for (const sub of subs) {
+        if (Object.prototype.hasOwnProperty.call(v, sub)) {
+          projected[sub] = (v as Record<string, unknown>)[sub];
+        }
+      }
+      filtered[k] = projected;
+    }
+    // Keys not in allowlist are silently omitted — governance (disallowed key
+    // detection + violation events) is the caller's responsibility.
+  }
+
+  const inner = Object.entries(filtered)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => {
+      const safe = escapeXml(typeof v === 'string' ? v : JSON.stringify(v));
+      return `  <${k}>${safe}</${k}>`;
+    })
+    .join('\n');
+
+  return inner.length > 0 ? `<task>\n${inner}\n</task>` : '<task></task>';
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/core/agent-runtime/holdout-validator.test.ts
+++ b/core/agent-runtime/holdout-validator.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HOLDOUT_FORBIDDEN_KEYS,
+  findDisallowedKeys,
+  findHoldoutContextLeaks,
+} from './holdout-validator.js';
+
+function makeSpec(role: string, context: Record<string, unknown>, allowlist: string[]) {
+  return {
+    runId: 'r1',
+    role: role as 'qa',
+    skill: 'implement',
+    context,
+    contextAllowlist: allowlist,
+    freshContext: true as const,
+    toolBundles: [] as string[],
+    toolExtras: [] as never[],
+    budgets: { maxTurns: 10, maxBudgetUsd: 1, timeoutMs: 30_000 },
+    personaId: 'p1',
+    outputJsonSchema: {},
+    appendSystemPrompt: '',
+  };
+}
+
+describe('findHoldoutContextLeaks', () => {
+  it('returns empty array for non-holdout roles', () => {
+    const spec = makeSpec('developer', { devReviewFindings: 'sensitive' }, ['devReviewFindings']);
+    expect(findHoldoutContextLeaks(spec)).toEqual([]);
+  });
+
+  it('returns empty array when no forbidden keys are present', () => {
+    const spec = makeSpec('qa', { title: 'safe', body: 'safe' }, ['title', 'body']);
+    expect(findHoldoutContextLeaks(spec)).toEqual([]);
+  });
+
+  it('detects devReviewFindings in context for holdout role', () => {
+    const spec = makeSpec('qa', { devReviewFindings: 'leak' }, ['title']);
+    expect(findHoldoutContextLeaks(spec)).toEqual([
+      { key: 'devReviewFindings', source: 'context' },
+    ]);
+  });
+
+  it('detects devReviewVerdict in context for reviewer role', () => {
+    const spec = makeSpec('reviewer', { devReviewVerdict: 'pass' }, []);
+    expect(findHoldoutContextLeaks(spec)).toEqual([{ key: 'devReviewVerdict', source: 'context' }]);
+  });
+
+  it('detects devReviewSummaries in context', () => {
+    const spec = makeSpec('qa', { devReviewSummaries: [] }, []);
+    expect(findHoldoutContextLeaks(spec)).toEqual([
+      { key: 'devReviewSummaries', source: 'context' },
+    ]);
+  });
+
+  it('detects forbidden key in allowlist (exact)', () => {
+    const spec = makeSpec('qa', {}, ['devReviewFindings']);
+    expect(findHoldoutContextLeaks(spec)).toEqual([
+      { key: 'devReviewFindings', source: 'allowlist' },
+    ]);
+  });
+
+  it('detects forbidden key via dotted allowlist entry', () => {
+    const spec = makeSpec('qa', {}, ['devReviewFindings.summary']);
+    expect(findHoldoutContextLeaks(spec)).toEqual([
+      { key: 'devReviewFindings.summary', source: 'allowlist' },
+    ]);
+  });
+
+  it('detects multiple leaks across context and allowlist', () => {
+    const spec = makeSpec('reviewer', { devReviewFindings: 'a', devReviewVerdict: 'b' }, [
+      'devReviewSummaries',
+    ]);
+    const leaks = findHoldoutContextLeaks(spec);
+    expect(leaks).toHaveLength(3);
+    expect(leaks.filter((l) => l.source === 'context')).toHaveLength(2);
+    expect(leaks.filter((l) => l.source === 'allowlist')).toHaveLength(1);
+  });
+
+  it('HOLDOUT_FORBIDDEN_KEYS contains the three dev-review keys', () => {
+    expect(HOLDOUT_FORBIDDEN_KEYS.has('devReviewFindings')).toBe(true);
+    expect(HOLDOUT_FORBIDDEN_KEYS.has('devReviewVerdict')).toBe(true);
+    expect(HOLDOUT_FORBIDDEN_KEYS.has('devReviewSummaries')).toBe(true);
+  });
+});
+
+describe('findDisallowedKeys', () => {
+  it('returns empty array when allowlist is empty', () => {
+    expect(findDisallowedKeys({ a: 1 }, [])).toEqual([]);
+  });
+
+  it('returns empty array when all keys are allowed', () => {
+    expect(findDisallowedKeys({ a: 1, b: 2 }, ['a', 'b'])).toEqual([]);
+  });
+
+  it('returns keys not in allowlist (excluding system keys)', () => {
+    const result = findDisallowedKeys({ a: 1, b: 2, c: 3 }, ['a']);
+    expect(result).toContain('b');
+    expect(result).toContain('c');
+    expect(result).not.toContain('a');
+  });
+
+  it('excludes system keys (projectId, workItemId) from disallowed', () => {
+    const result = findDisallowedKeys({ projectId: 'p1', workItemId: 'wi-1', extra: 'x' }, [
+      'title',
+    ]);
+    expect(result).not.toContain('projectId');
+    expect(result).not.toContain('workItemId');
+    expect(result).toContain('extra');
+  });
+
+  it('does not flag key covered by dotted allowlist entry', () => {
+    const result = findDisallowedKeys({ workItem: { title: 'T', body: 'B' } }, ['workItem.title']);
+    expect(result).not.toContain('workItem');
+  });
+});

--- a/core/agent-runtime/holdout-validator.ts
+++ b/core/agent-runtime/holdout-validator.ts
@@ -1,0 +1,92 @@
+import type { AgentSpec } from './interface.js';
+
+// Holdout roles that enforce strict context isolation
+const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
+// Keys managed by the runtime itself — not user-injected, so not violations
+export const SYSTEM_KEYS: ReadonlySet<string> = new Set(['projectId', 'workItemId']);
+
+/**
+ * Context keys produced by the dev-review pipeline (M19.11) that must NEVER
+ * reach a holdout role's context — even if a future caller adds them to the
+ * allowlist by mistake. Defense in depth: the allowlist mechanism is the
+ * primary gate, this set is the backstop.
+ *
+ * `findHoldoutContextLeaks()` rejects holdout specs that mention these keys
+ * either in `context` or in `contextAllowlist`. ADR 0036 §holdout-discipline.
+ */
+export const HOLDOUT_FORBIDDEN_KEYS: ReadonlySet<string> = new Set([
+  'devReviewFindings',
+  'devReviewVerdict',
+  'devReviewSummaries',
+]);
+
+export interface HoldoutContextLeak {
+  key: string;
+  source: 'context' | 'allowlist';
+}
+
+/**
+ * Returns the top-level key of an allowlist entry. `renderContext` supports
+ * dotted paths (e.g. `devReviewFindings.summary`) which project a nested
+ * value through to the rendered XML — so leak detection must normalise to
+ * the top-level key before comparing against the forbidden set.
+ */
+function topLevelKey(allowlistEntry: string): string {
+  const dot = allowlistEntry.indexOf('.');
+  return dot === -1 ? allowlistEntry : allowlistEntry.slice(0, dot);
+}
+
+/**
+ * For holdout roles only: returns the list of forbidden-key leaks present in
+ * either `spec.context` or `spec.contextAllowlist`. Empty array for safe
+ * specs and for non-holdout roles.
+ *
+ * Pure function — does not mutate the spec or emit events. Callers
+ * (e.g. `assembleSpawnContext`) are responsible for the side effects.
+ */
+export function findHoldoutContextLeaks(spec: AgentSpec): HoldoutContextLeak[] {
+  if (!HOLDOUT_ROLES.has(spec.role)) return [];
+  const leaks: HoldoutContextLeak[] = [];
+  for (const k of Object.keys(spec.context)) {
+    if (HOLDOUT_FORBIDDEN_KEYS.has(k)) leaks.push({ key: k, source: 'context' });
+  }
+  for (const k of spec.contextAllowlist) {
+    // Compare the top-level key against the forbidden set. `key` on the leak
+    // record preserves the original entry (e.g. `devReviewFindings.summary`)
+    // so the violation event accurately reports what the caller attempted.
+    if (HOLDOUT_FORBIDDEN_KEYS.has(topLevelKey(k))) {
+      leaks.push({ key: k, source: 'allowlist' });
+    }
+  }
+  return leaks;
+}
+
+/**
+ * Returns keys in `context` that are not in the `allowlist` and are not
+ * system-managed keys (SYSTEM_KEYS). These are disallowed user-injected keys.
+ *
+ * Pure function — emitting events is the caller's responsibility.
+ */
+export function findDisallowedKeys(
+  context: Record<string, unknown>,
+  allowlist: string[],
+): string[] {
+  if (allowlist.length === 0) return [];
+  const exactKeys = new Set<string>();
+  const dottedTopKeys = new Set<string>();
+  for (const entry of allowlist) {
+    const dot = entry.indexOf('.');
+    if (dot === -1) {
+      exactKeys.add(entry);
+    } else {
+      dottedTopKeys.add(entry.slice(0, dot));
+    }
+  }
+  const disallowed: string[] = [];
+  for (const k of Object.keys(context)) {
+    if (!exactKeys.has(k) && !dottedTopKeys.has(k) && !SYSTEM_KEYS.has(k)) {
+      disallowed.push(k);
+    }
+  }
+  return disallowed;
+}

--- a/docs/adr/0014-m8-holdout-enforcement-architecture.md
+++ b/docs/adr/0014-m8-holdout-enforcement-architecture.md
@@ -59,6 +59,16 @@ This module lives in `core/retry/retry-counter.ts` (not in any slice) so both `s
 - The retry counter includes the current run's event in its count (the just-appended `qa.completed` fires before the count check). This means: with `maxRetries=2`, the second consecutive failure triggers escalation. This is the intended behaviour (first fail → retry; second fail → escalate) and is documented in `slices/retry-escalate/README.md`.
 - `getQaVerdict` in `slices/review/workflow.ts` returns `undefined` for M8 scope. The Reviewer does not receive QA context as corroborating signal. A follow-up issue should be filed for M9 to read `qa.completed` from the event store.
 
+## 2026-05-10 Amendment — Internal split (M19.28)
+
+The original implementation placed `findHoldoutContextLeaks`, `HOLDOUT_FORBIDDEN_KEYS`, `renderManifest`, and `escapeXml` all inside `context-assembly.ts`. As the module grew with M19 dev-review keys, it was split into three co-located files to separate concerns while preserving the single-gateway invariant:
+
+- **`holdout-validator.ts`** — pure functions: `findHoldoutContextLeaks`, `findDisallowedKeys`, constants `HOLDOUT_FORBIDDEN_KEYS` and `SYSTEM_KEYS`. No side effects. No event emission.
+- **`context-renderer.ts`** — pure XML rendering: `renderContext(context, allowlist): string`. No governance knowledge — takes pre-filtered inputs.
+- **`context-assembly.ts`** — thin composer. The only module that imports from both sub-modules and the only place that calls `eventStore`. Re-exports `findHoldoutContextLeaks` and `HOLDOUT_FORBIDDEN_KEYS` for backward compatibility with existing callers.
+
+`assembleSpawnContext` remains the sole public gateway. Callers outside `core/agent-runtime/` must not import `holdout-validator` or `context-renderer` directly. The `effectiveAllowlist` and `effectiveContext` helpers are lifted to named private functions in the composer to avoid duplicated filtering logic.
+
 ## Alternatives Considered
 
 **Alternative A: Enforce at the CC spawn layer** — reject the spawn call itself if disallowed keys are present. Rejected: too late in the pipeline; the rendering layer is the correct gate since it is the only place all context is assembled.


### PR DESCRIPTION
## Summary
- Extract `findHoldoutContextLeaks` + `findDisallowedKeys` + `HOLDOUT_FORBIDDEN_KEYS` / `SYSTEM_KEYS` into `holdout-validator.ts` (pure functions, no side effects)
- Extract `renderContext` (XML rendering, dotted-path projection, XML escaping) into `context-renderer.ts` (no governance knowledge)
- Slim `context-assembly.ts` to a thin composer with named `effectiveAllowlist` / `effectiveContext` helpers; `assembleSpawnContext` remains the sole public export and re-exports backward-compat symbols
- Add `holdout-validator.test.ts` (14 tests) and `context-renderer.test.ts` (13 tests); update `context-assembly.test.ts` to integration-only + inline snapshot tests locking pre-split behaviour
- Amend ADR 0014 with internal-split note

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (2983 tests pass)
- [x] pnpm build
- [x] pnpm lint
- [x] Snapshot tests of assembleSpawnContext output pass against pre-split fixtures
- [x] Single-gateway invariant preserved — no caller imports holdout-validator or context-renderer directly

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)