### PR TITLE
M19.24: Codex hook normalisation + conditional live test

### DIFF
--- a/core/agent-runtime/codex-hook-normalize.test.ts
+++ b/core/agent-runtime/codex-hook-normalize.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { type NormalizedHookEvent, normalizeCodexHookEvent } from './codex-hook-normalize.js';
+
+// ─── Fixtures: Canonical Claude-format events ─────────────────────────────────
+// Claude CLI sends hooks in CC protocol format:
+//   PreToolUse:  { tool_name, tool_input, ... }
+//   PostToolUse: { tool_name, tool_response: { output?, error? }, transcript_path, ... }
+
+const CLAUDE_PRE: Record<string, unknown> = {
+  tool_name: 'Read',
+  tool_input: { file_path: '/foo/bar.ts' },
+  hook_event_name: 'PreToolUse',
+};
+
+const CLAUDE_POST: Record<string, unknown> = {
+  tool_name: 'Bash',
+  tool_response: { output: 'ok', error: '' },
+  transcript_path: '/tmp/transcript.jsonl',
+  hook_event_name: 'PostToolUse',
+};
+
+// ─── Fixtures: Codex-format events ───────────────────────────────────────────
+// OpenAI Codex CLI uses its own hook protocol field names.
+// PreToolUse aliases: name → tool_name, parameters / arguments / input → tool_input
+// PostToolUse aliases: output → tool_response.output, error → tool_response.error
+
+const CODEX_PRE_PARAMETERS: Record<string, unknown> = {
+  name: 'bash',
+  parameters: { command: 'ls -la' },
+};
+
+const CODEX_PRE_ARGUMENTS: Record<string, unknown> = {
+  name: 'read_file',
+  arguments: { path: '/tmp/foo.ts' },
+};
+
+const CODEX_PRE_INPUT: Record<string, unknown> = {
+  name: 'write_file',
+  input: { path: '/tmp/out.ts', content: 'hello' },
+};
+
+const CODEX_POST_OUTPUT: Record<string, unknown> = {
+  name: 'bash',
+  output: 'stdout text here',
+  transcript_path: '/tmp/codex-transcript.jsonl',
+};
+
+const CODEX_POST_ERROR: Record<string, unknown> = {
+  name: 'bash',
+  output: '',
+  error: 'command not found: foo',
+  transcript_path: '/tmp/codex-transcript.jsonl',
+};
+
+// ─── Claude pass-through (already canonical) ────────────────────────────────
+
+describe('normalizeCodexHookEvent — Claude canonical pass-through', () => {
+  it('passes through Claude PreToolUse unchanged', () => {
+    const result = normalizeCodexHookEvent(CLAUDE_PRE);
+    expect(result.tool_name).toBe('Read');
+    expect(result.tool_input).toEqual({ file_path: '/foo/bar.ts' });
+    expect(result.tool_response).toBeUndefined();
+  });
+
+  it('passes through Claude PostToolUse unchanged', () => {
+    const result = normalizeCodexHookEvent(CLAUDE_POST);
+    expect(result.tool_name).toBe('Bash');
+    expect(result.tool_response).toEqual({ output: 'ok', error: '' });
+    expect(result.tool_input).toBeUndefined();
+  });
+});
+
+// ─── Codex PreToolUse normalization ─────────────────────────────────────────
+
+describe('normalizeCodexHookEvent — Codex PreToolUse (name + parameters/arguments/input)', () => {
+  it('maps name→tool_name and parameters→tool_input', () => {
+    const result = normalizeCodexHookEvent(CODEX_PRE_PARAMETERS);
+    expect(result.tool_name).toBe('bash');
+    expect(result.tool_input).toEqual({ command: 'ls -la' });
+    expect(result.tool_response).toBeUndefined();
+  });
+
+  it('maps name→tool_name and arguments→tool_input', () => {
+    const result = normalizeCodexHookEvent(CODEX_PRE_ARGUMENTS);
+    expect(result.tool_name).toBe('read_file');
+    expect(result.tool_input).toEqual({ path: '/tmp/foo.ts' });
+  });
+
+  it('maps name→tool_name and input→tool_input', () => {
+    const result = normalizeCodexHookEvent(CODEX_PRE_INPUT);
+    expect(result.tool_name).toBe('write_file');
+    expect(result.tool_input).toEqual({ path: '/tmp/out.ts', content: 'hello' });
+  });
+});
+
+// ─── Codex PostToolUse normalization ────────────────────────────────────────
+
+describe('normalizeCodexHookEvent — Codex PostToolUse (name + output/error)', () => {
+  it('maps name→tool_name and output→tool_response.output', () => {
+    const result = normalizeCodexHookEvent(CODEX_POST_OUTPUT);
+    expect(result.tool_name).toBe('bash');
+    expect(result.tool_response).toEqual({ output: 'stdout text here', error: '' });
+    expect(result.tool_input).toBeUndefined();
+  });
+
+  it('maps name→tool_name and error→tool_response.error', () => {
+    const result = normalizeCodexHookEvent(CODEX_POST_ERROR);
+    expect(result.tool_name).toBe('bash');
+    expect(result.tool_response).toEqual({ output: '', error: 'command not found: foo' });
+  });
+});
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+describe('normalizeCodexHookEvent — edge cases', () => {
+  it('returns empty tool_name for empty input', () => {
+    const result = normalizeCodexHookEvent({});
+    expect(result.tool_name).toBe('');
+    expect(result.tool_input).toBeUndefined();
+    expect(result.tool_response).toBeUndefined();
+  });
+
+  it('tool_name takes priority over name', () => {
+    const result = normalizeCodexHookEvent({ tool_name: 'Read', name: 'bash' });
+    expect(result.tool_name).toBe('Read');
+  });
+
+  it('tool_input takes priority over parameters', () => {
+    const result = normalizeCodexHookEvent({
+      tool_name: 'Read',
+      tool_input: { file_path: '/a' },
+      parameters: { file_path: '/b' },
+    });
+    expect(result.tool_input).toEqual({ file_path: '/a' });
+  });
+
+  it('tool_response takes priority over raw output/error', () => {
+    const result = normalizeCodexHookEvent({
+      tool_name: 'Bash',
+      tool_response: { output: 'canonical', error: '' },
+      output: 'codex-raw',
+    });
+    expect(result.tool_response).toEqual({ output: 'canonical', error: '' });
+  });
+
+  it('preserves transcript_path in the normalized event', () => {
+    const result = normalizeCodexHookEvent(CODEX_POST_OUTPUT);
+    expect(result.transcript_path).toBe('/tmp/codex-transcript.jsonl');
+  });
+});
+
+// ─── Parity: key sets must match between Claude and Codex ────────────────────
+
+describe('payload key-set parity: Claude vs Codex normalized', () => {
+  it('PreToolUse: normalized Codex has same keys as Claude', () => {
+    const claudeResult = normalizeCodexHookEvent(CLAUDE_PRE);
+    const codexResult = normalizeCodexHookEvent(CODEX_PRE_PARAMETERS);
+
+    // Both must have tool_name and tool_input; neither should have tool_response.
+    const claudeKeys = Object.keys(claudeResult)
+      .filter((k) => k === 'tool_name' || k === 'tool_input' || k === 'tool_response')
+      .sort();
+    const codexKeys = Object.keys(codexResult)
+      .filter((k) => k === 'tool_name' || k === 'tool_input' || k === 'tool_response')
+      .sort();
+
+    expect(codexKeys).toEqual(claudeKeys);
+  });
+
+  it('PostToolUse: normalized Codex has same keys as Claude', () => {
+    const claudeResult = normalizeCodexHookEvent(CLAUDE_POST);
+    const codexResult = normalizeCodexHookEvent(CODEX_POST_OUTPUT);
+
+    const claudeKeys = Object.keys(claudeResult)
+      .filter((k) => k === 'tool_name' || k === 'tool_input' || k === 'tool_response')
+      .sort();
+    const codexKeys = Object.keys(codexResult)
+      .filter((k) => k === 'tool_name' || k === 'tool_input' || k === 'tool_response')
+      .sort();
+
+    expect(codexKeys).toEqual(claudeKeys);
+  });
+
+  it('audit-stream payload sent to /events/tool-call matches Claude shape', () => {
+    // The audit payload extracted from a normalized event must have exactly
+    // the same required keys as what the Claude hook sends.
+    const CLAUDE_AUDIT_KEYS = ['tool_name', 'tool_input'].sort();
+
+    const codexResult = normalizeCodexHookEvent(CODEX_PRE_PARAMETERS);
+    const codexAuditPayload = {
+      tool_name: codexResult.tool_name,
+      tool_input: codexResult.tool_input ?? {},
+    };
+    expect(Object.keys(codexAuditPayload).sort()).toEqual(CLAUDE_AUDIT_KEYS);
+  });
+});

--- a/core/agent-runtime/codex-hook-normalize.ts
+++ b/core/agent-runtime/codex-hook-normalize.ts
@@ -1,0 +1,102 @@
+/**
+ * Normalises a raw Codex CLI hook event to the canonical CC (Claude Code)
+ * PreToolUse / PostToolUse shape so the audit stream is homogeneous across
+ * providers.
+ *
+ * Claude Code hook protocol (canonical):
+ *   PreToolUse  → { tool_name: string, tool_input: object, ... }
+ *   PostToolUse → { tool_name: string, tool_response: { output?: string, error?: string }, transcript_path?: string, ... }
+ *
+ * Codex CLI hook protocol (aliased keys):
+ *   PreToolUse  → { name: string, parameters | arguments | input: object, ... }
+ *   PostToolUse → { name: string, output?: string, error?: string, transcript_path?: string, ... }
+ *
+ * Priority rules (canonical wins when both are present):
+ *   tool_name  > name
+ *   tool_input > parameters > arguments > input
+ *   tool_response > { output, error } reconstruction
+ */
+export interface NormalizedHookEvent {
+  /** Canonical tool name, e.g. "Read", "Bash", "bash". */
+  tool_name: string;
+  /** Canonical input object. Present only on PreToolUse events. */
+  tool_input?: Record<string, unknown>;
+  /** Canonical response object. Present only on PostToolUse events. */
+  tool_response?: { output: string; error: string };
+  /** Transcript path forwarded from both Claude and Codex PostToolUse events. */
+  transcript_path?: string;
+}
+
+function asObject(v: unknown): Record<string, unknown> | undefined {
+  if (v != null && typeof v === 'object' && !Array.isArray(v)) {
+    return v as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * Pure mapping from a raw hook stdin payload (either Claude or Codex format)
+ * to the canonical {@link NormalizedHookEvent} shape.
+ *
+ * Safe to call with any unknown object — never throws.
+ */
+export function normalizeCodexHookEvent(raw: Record<string, unknown>): NormalizedHookEvent {
+  // ── tool_name resolution ──────────────────────────────────────────────────
+  const tool_name = asString(raw.tool_name) || asString(raw.name);
+
+  // ── transcript_path pass-through ─────────────────────────────────────────
+  const transcript_path = typeof raw.transcript_path === 'string' ? raw.transcript_path : undefined;
+
+  // ── tool_input (PreToolUse) ───────────────────────────────────────────────
+  // Canonical: tool_input. Codex aliases: parameters, arguments, input.
+  const rawInput =
+    asObject(raw.tool_input) ??
+    asObject(raw.parameters) ??
+    asObject(raw.arguments) ??
+    asObject(raw.input);
+
+  // ── tool_response (PostToolUse) ───────────────────────────────────────────
+  // Canonical: tool_response (object with output/error). Codex: top-level
+  // output / error strings.
+  const canonicalResponse = asObject(raw.tool_response);
+  const hasRawOutputOrError =
+    raw.output !== undefined || (raw.error !== undefined && raw.error !== null);
+
+  let tool_response: NormalizedHookEvent['tool_response'];
+  if (canonicalResponse !== undefined) {
+    // Already in canonical shape — pass through (Claude origin or previously normalised).
+    tool_response = {
+      output: asString(canonicalResponse.output),
+      error: asString(canonicalResponse.error),
+    };
+  } else if (hasRawOutputOrError) {
+    // Codex PostToolUse: reconstruct tool_response from top-level fields.
+    tool_response = {
+      output: asString(raw.output),
+      error: asString(raw.error),
+    };
+  }
+
+  // ── Build result ─────────────────────────────────────────────────────────
+  // Omit undefined keys so consumers can use `key in event` reliably.
+  const result: NormalizedHookEvent = { tool_name };
+  if (transcript_path !== undefined) result.transcript_path = transcript_path;
+  if (rawInput !== undefined && tool_response === undefined) {
+    // PreToolUse: input present, no response.
+    result.tool_input = rawInput;
+  } else if (rawInput !== undefined && tool_response !== undefined) {
+    // Both present (shouldn't happen in practice, but be safe).
+    result.tool_input = rawInput;
+    result.tool_response = tool_response;
+  } else if (tool_response !== undefined) {
+    result.tool_response = tool_response;
+  } else if (rawInput !== undefined) {
+    result.tool_input = rawInput;
+  }
+
+  return result;
+}

--- a/core/tool-layer/post-tool-use-hook.ts
+++ b/core/tool-layer/post-tool-use-hook.ts
@@ -73,8 +73,16 @@ async function main() {
   }
 
   // Bash error capture: emit agent.tool-result when tool returned an error.
-  const toolName = call?.tool_name ?? '';
-  const toolError = call?.tool_response?.error ?? '';
+  // Normalise Codex hook aliases → canonical CC PostToolUse shape:
+  //   tool_name : call.tool_name ?? call.name
+  //   tool_error: call.tool_response?.error ?? call.error
+  const toolName = call?.tool_name ?? call?.name ?? '';
+  const toolError =
+    (call?.tool_response != null && typeof call.tool_response === 'object'
+      ? call.tool_response?.error
+      : undefined) ??
+    (typeof call?.error === 'string' ? call.error : '') ??
+    '';
   if (toolName === 'Bash' && typeof toolError === 'string' && toolError.length > 0) {
     const truncated = toolError.length > 2048;
     const errorText = truncated ? toolError.slice(0, 2048) : toolError;

--- a/core/tool-layer/pre-tool-use-hook.test.ts
+++ b/core/tool-layer/pre-tool-use-hook.test.ts
@@ -127,4 +127,18 @@ describe('deployHooks', () => {
     expect(writtenPaths.some((p) => p.includes('pre-tool-use.js'))).toBe(true);
     expect(writtenPaths.some((p) => p.includes('post-tool-use.js'))).toBe(true);
   });
+
+  it('the written script normalises Codex hook aliases (name→tool_name, parameters→tool_input)', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    deployHooks();
+
+    const scriptContent = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    // Must probe `name` as alias for tool_name (Codex sends `name` not `tool_name`)
+    expect(scriptContent).toContain('call?.name');
+    // Must probe `parameters` / `arguments` / `input` as aliases for tool_input
+    expect(scriptContent).toContain('parameters');
+    expect(scriptContent).toContain('arguments');
+    expect(scriptContent).toContain('call?.input');
+  });
 });

--- a/core/tool-layer/pre-tool-use-hook.ts
+++ b/core/tool-layer/pre-tool-use-hook.ts
@@ -10,6 +10,11 @@ const HOOK_SCRIPT = `#!/usr/bin/env node
  * Factory PreToolUse hook — allowlist enforcement + tool-call audit.
  * Deployed by AgentRuntime to ~/.factory/hooks/pre-tool-use.js
  * Receives tool call via CC hook protocol on stdin as JSON.
+ *
+ * Normalises Codex CLI field aliases so the audit payload is homogeneous
+ * across providers (Claude and Codex both emit tool_name + tool_input):
+ *   tool_name : call.tool_name ?? call.name
+ *   tool_input: call.tool_input ?? call.parameters ?? call.arguments ?? call.input ?? {}
  */
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
@@ -20,6 +25,11 @@ const runId = process.env.FACTORY_RUN_ID ?? 'unknown';
 // subprocess (#209). Falls back to 3001 for backwards compatibility.
 const serverPort = process.env.FACTORY_SERVER_PORT ?? '3001';
 
+/** Returns v when it is a plain non-null object, else undefined. */
+function asObj(v) {
+  return (v != null && typeof v === 'object' && !Array.isArray(v)) ? v : undefined;
+}
+
 async function main() {
   let input = '';
   for await (const chunk of process.stdin) input += chunk;
@@ -27,7 +37,14 @@ async function main() {
   let call;
   try { call = JSON.parse(input); } catch { process.exit(0); }
 
+  // Normalise Codex hook aliases → canonical CC shape.
   const toolName = call?.tool_name ?? call?.name ?? '';
+  const toolInput =
+    asObj(call?.tool_input) ??
+    asObj(call?.parameters) ??
+    asObj(call?.arguments) ??
+    asObj(call?.input) ??
+    {};
 
   // Allowlist check — deny on mismatch
   if (allowlist.length > 0) {
@@ -49,7 +66,7 @@ async function main() {
     const payload = {
       tool_name: toolName,
       run_id: runId,
-      tool_input: call?.tool_input ?? {},
+      tool_input: toolInput,
     };
     await fetch(\`http://localhost:\${serverPort}/events/tool-call\`, {
       method: 'POST',

--- a/slices/codex-runtime/slice.test.ts
+++ b/slices/codex-runtime/slice.test.ts
@@ -1,6 +1,9 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { homedir as realHomedir } from 'node:os';
+import { join as realJoin } from 'node:path';
 import {
   CodexBinaryNotFoundError,
   CodexCliRuntime,
@@ -451,21 +454,34 @@ describe('selectRuntime — dispatcher', () => {
 });
 
 // ─── live integration (skipped unless local env satisfies pre-conditions) ─────
+//
+// vi.mock('node:fs') replaces existsSync with a stub above. To check the real
+// filesystem we use createRequire (CJS require bypasses Vitest ES-module mocks)
+// and the un-mocked homedir/join imports from node:os/node:path which are not
+// intercepted by any vi.mock in this file.
+
+const _realFs = createRequire(import.meta.url)('node:fs') as typeof import('node:fs');
+const _realExistsSync = _realFs.existsSync;
 
 const liveOk = (() => {
   if (process.env.MOCK_AGENTS === 'true') return false;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey != null && apiKey.length > 0) return true;
   try {
-    // Real existsSync, not the mocked one — vi.mock is per-file.
-    return true; // The actual gate is delegated to the runtime call below.
+    const authPath = realJoin(realHomedir(), '.codex', 'auth.json');
+    return _realExistsSync(authPath);
   } catch {
     return false;
   }
 })();
 
 describe.skipIf(!liveOk)('CodexCliRuntime — live integration', () => {
-  it.skip('codex exec produces a turn-complete event with non-zero usage (manual)', async () => {
-    // Intentionally skipped: live integration requires a real `codex` binary
-    // and ~/.codex/auth.json, neither present on CI runners. Run manually
-    // by removing `.skip` after `codex login` on the local machine.
+  it('codex exec produces a turn-complete event with non-zero usage', async () => {
+    // This test runs only when ~/.codex/auth.json exists or OPENAI_API_KEY is set.
+    // On CI neither is present so the outer describe.skipIf guard suppresses it.
+    const runtime = new CodexCliRuntime();
+    const spec = makeSpec({ runId: 'live-test-run', modelOverride: 'gpt-4o' });
+    const result = await runtime.run(spec);
+    expect(result.output).toBeDefined();
   }, 30_000);
 });


### PR DESCRIPTION
## Summary
- Adds `core/agent-runtime/codex-hook-normalize.ts` with `normalizeCodexHookEvent()` — pure mapping from Codex CLI hook payload aliases (`name`, `parameters`, `arguments`, `input`, `output`, `error`) to the canonical Claude hook shape (`tool_name`, `tool_input`, `tool_response`)
- Injects normalization into pre/post-tool-use hook scripts so `agent.tool-call` audit stream is homogeneous across Claude and Codex providers
- Replaces permanent `it.skip` in `slices/codex-runtime/slice.test.ts` with `describe.skipIf(!liveOk)` where `liveOk` checks real `~/.codex/auth.json` or `OPENAI_API_KEY` (using `createRequire` to bypass Vitest's `node:fs` mock)

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (204 files, 2963 tests)
- [x] pnpm build
- [x] pnpm lint
- [x] Live test skips cleanly without OPENAI_API_KEY or ~/.codex/auth.json
- [x] 15 unit tests in `codex-hook-normalize.test.ts` including key-parity assertions
- [x] New hook script normalization test in `pre-tool-use-hook.test.ts`

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)