### PR TITLE
M19.16: investigation swarm wired

### DIFF
--- a/apps/server/src/domains/workflows/state-flows.test.ts
+++ b/apps/server/src/domains/workflows/state-flows.test.ts
@@ -14,6 +14,26 @@ vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
   setUseM19Pipeline: vi.fn(),
   deriveUseM19Pipeline: vi.fn().mockReturnValue(false),
 }));
+
+const mockDispatchWaveSF = vi.fn();
+vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
+  dispatchWave: (...args: unknown[]) => mockDispatchWaveSF(...args),
+}));
+
+const mockCrossValidateSF = vi.fn();
+vi.mock('@goose-hub/core/agent-runtime/cross-validate.js', () => ({
+  crossValidate: (...args: unknown[]) => mockCrossValidateSF(...args),
+}));
+
+const mockInvokeSkillSF = vi.fn();
+vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
+  invokeSkill: (...args: unknown[]) => mockInvokeSkillSF(...args),
+}));
+
+vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
+  persistScoutReport: vi.fn(),
+}));
+
 const mockRun = vi.fn();
 
 vi.mock('@goose-hub/core/agent-runtime/claude-cli.js', () => ({
@@ -248,6 +268,21 @@ const SLUG = 'goose-hub-self';
 beforeEach(() => {
   vi.clearAllMocks();
   mockRun.mockReset();
+  mockDispatchWaveSF.mockReset();
+  mockCrossValidateSF.mockReset();
+  mockInvokeSkillSF.mockReset();
+
+  // Default happy-path returns for the investigation swarm mocks
+  mockDispatchWaveSF.mockResolvedValue({
+    status: 'ok',
+    reports: [],
+    failedScouts: [],
+    shouldAdvance: true,
+    shouldEscalate: false,
+  });
+  mockCrossValidateSF.mockReturnValue({ contradictions: [], hasContradictions: false });
+  mockInvokeSkillSF.mockResolvedValue(makeAgentResult(makeInvestigateOutput()));
+
   // fix-issue workflow checks GITHUB_TOKEN before calling openPRFn
   process.env.GITHUB_TOKEN = 'mock-github-token';
 });
@@ -562,11 +597,7 @@ describe('Layer A: Investigate state paths', () => {
     const source = makeMockSource();
     mockGetSourceForSlug.mockResolvedValue(source);
     (source.getItem as ReturnType<typeof vi.fn>).mockResolvedValue(item);
-
-    // bug items run investigate then playwright-repro (non-fatal if repro fails schema)
-    mockRun
-      .mockResolvedValueOnce(makeAgentResult(makeInvestigateOutput()))
-      .mockResolvedValueOnce(makeAgentResult(makePlaywrightReproOutput()));
+    // invokeSkill default returns makeInvestigateOutput() (requiresBrowserRepro: false)
 
     await dispatchInvestigate(SLUG, 42);
 
@@ -586,7 +617,8 @@ describe('Layer A: Investigate state paths', () => {
     mockGetSourceForSlug.mockResolvedValue(source);
     (source.getItem as ReturnType<typeof vi.fn>).mockResolvedValue(item);
 
-    mockRun.mockResolvedValueOnce(makeAgentResult({ invalid: 'garbage' }));
+    // invokeSkill throws OutputValidationError when synthesis output is invalid
+    mockInvokeSkillSF.mockRejectedValueOnce(new Error('Output validation failed: ...'));
 
     await dispatchInvestigate(SLUG, 42);
 
@@ -667,9 +699,7 @@ describe('Layer B: Full dispatch chain (dispatchForLabel → workflow → state)
     const source = makeMockSource();
     (source.getItem as ReturnType<typeof vi.fn>).mockResolvedValue(item);
     mockGetSourceForSlug.mockResolvedValue(source);
-    mockRun
-      .mockResolvedValueOnce(makeAgentResult(makeInvestigateOutput()))
-      .mockResolvedValueOnce(makeAgentResult(makePlaywrightReproOutput()));
+    // invokeSkill default returns makeInvestigateOutput() (requiresBrowserRepro: false)
 
     await dispatchForLabel(SLUG, 42, 'factory:investigating');
 

--- a/core/agent-runtime/swarm.ts
+++ b/core/agent-runtime/swarm.ts
@@ -117,6 +117,7 @@ const SCOUT_CONTEXT_ALLOWLIST: readonly string[] = [
   'workItem.number',
   'scoutFocus',
   'worktreePath',
+  'scoutReports',
 ];
 
 const DEFAULT_MAX_SCOUTS = 6;

--- a/core/db/migrations/0017_tough_meteorite.sql
+++ b/core/db/migrations/0017_tough_meteorite.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `scout_reports` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` text NOT NULL,
+	`work_item_id` text NOT NULL,
+	`investigation_run_id` text NOT NULL,
+	`scout_skill` text NOT NULL,
+	`report` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scout_reports_project_work_item_run_skill_uniq` ON `scout_reports` (`project_id`,`work_item_id`,`investigation_run_id`,`scout_skill`);--> statement-breakpoint
+CREATE INDEX `scout_reports_project_work_item_run_idx` ON `scout_reports` (`project_id`,`work_item_id`,`investigation_run_id`);

--- a/core/db/migrations/meta/0017_snapshot.json
+++ b/core/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1656 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ef63bcfd-acc6-43f8-b87b-fc8851e1b777",
+  "prevId": "f77efd11-0230-44aa-a60a-930e8a1225c4",
+  "tables": {
+    "agent_decisions": {
+      "name": "agent_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what": {
+          "name": "what",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_decisions_run_kind_what_uniq": {
+          "name": "agent_decisions_run_kind_what_uniq",
+          "columns": [
+            "run_id",
+            "kind",
+            "what"
+          ],
+          "isUnique": true
+        },
+        "agent_decisions_run_idx": {
+          "name": "agent_decisions_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_runs": {
+      "name": "agent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_runs_run_id_uniq": {
+          "name": "agent_runs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_runs_persona_idx": {
+          "name": "agent_runs_persona_idx",
+          "columns": [
+            "persona_id"
+          ],
+          "isUnique": false
+        },
+        "agent_runs_project_idx": {
+          "name": "agent_runs_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "archived_lifecycles": {
+      "name": "archived_lifecycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_summaries": {
+          "name": "decision_summaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "learning_entries": {
+          "name": "learning_entries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "quality_scores": {
+          "name": "quality_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "costs_usd": {
+          "name": "costs_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "run_ids": {
+          "name": "run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "archived_lifecycles_project_work_item_idx": {
+          "name": "archived_lifecycles_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "archived_lifecycles_project_closed_idx": {
+          "name": "archived_lifecycles_project_closed_idx",
+          "columns": [
+            "project_id",
+            "closed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_patterns": {
+      "name": "decision_patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_summary": {
+          "name": "action_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_summary": {
+          "name": "reason_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consistency_score": {
+          "name": "consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "example_work_item_ids": {
+          "name": "example_work_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "decision_patterns_project_kind_role_uniq": {
+          "name": "decision_patterns_project_kind_role_uniq",
+          "columns": [
+            "project_id",
+            "kind",
+            "role"
+          ],
+          "isUnique": true
+        },
+        "decision_patterns_project_idx": {
+          "name": "decision_patterns_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_work_item_idx": {
+          "name": "events_work_item_idx",
+          "columns": [
+            "work_item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_diff": {
+          "name": "proposed_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_playbook_id": {
+          "name": "source_playbook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playbooks": {
+      "name": "playbooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_count": {
+          "name": "lifecycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "playbooks_project_created_idx": {
+          "name": "playbooks_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "playbooks_project_window_idx": {
+          "name": "playbooks_project_window_idx",
+          "columns": [
+            "project_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_dev_review_settings": {
+      "name": "project_dev_review_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_on": {
+          "name": "trigger_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_revision_turns": {
+          "name": "max_revision_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_cycle_max_usd": {
+          "name": "per_cycle_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_model_settings": {
+      "name": "project_model_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_model": {
+          "name": "primary_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advisor_model": {
+          "name": "advisor_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity_overrides_json": {
+          "name": "complexity_overrides_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_model_settings_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "project_model_settings_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "per_workflow_max_usd": {
+          "name": "per_workflow_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_agent_max_usd": {
+          "name": "per_agent_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_advisor_max_usd": {
+          "name": "per_advisor_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_tokens": {
+          "name": "daily_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_parallel_agents": {
+          "name": "max_parallel_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_bash_command_max_seconds": {
+          "name": "per_bash_command_max_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_m19_pipeline": {
+          "name": "use_m19_pipeline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_skill_settings": {
+      "name": "project_skill_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_budget_usd": {
+          "name": "max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_skill_settings_project_id_skill_name_pk": {
+          "columns": [
+            "project_id",
+            "skill_name"
+          ],
+          "name": "project_skill_settings_project_id_skill_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_quality_scores": {
+      "name": "run_quality_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "components_json": {
+          "name": "components_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_score": {
+          "name": "audit_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "run_quality_scores_run_iteration_uniq": {
+          "name": "run_quality_scores_run_iteration_uniq",
+          "columns": [
+            "run_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "run_quality_scores_project_ts_idx": {
+          "name": "run_quality_scores_project_ts_idx",
+          "columns": [
+            "project_id",
+            "ts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scout_reports": {
+      "name": "scout_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "investigation_run_id": {
+          "name": "investigation_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scout_skill": {
+          "name": "scout_skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report": {
+          "name": "report",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "scout_reports_project_work_item_run_skill_uniq": {
+          "name": "scout_reports_project_work_item_run_skill_uniq",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id",
+            "scout_skill"
+          ],
+          "isUnique": true
+        },
+        "scout_reports_project_work_item_run_idx": {
+          "name": "scout_reports_project_work_item_run_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wp_iterations": {
+      "name": "wp_iterations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wp_id": {
+          "name": "wp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "wp_iterations_run_wp_iteration_uniq": {
+          "name": "wp_iterations_run_wp_iteration_uniq",
+          "columns": [
+            "run_id",
+            "wp_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "wp_iterations_run_wp_idx": {
+          "name": "wp_iterations_run_wp_idx",
+          "columns": [
+            "run_id",
+            "wp_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778405332227,
       "tag": "0016_grey_titania",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1778413212626,
+      "tag": "0017_tough_meteorite",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -372,3 +372,26 @@ export const projectDevReviewSettings = sqliteTable('project_dev_review_settings
   updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   updatedBy: text('updated_by'),
 });
+
+export const scoutReports = sqliteTable(
+  'scout_reports',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    projectId: text('project_id').notNull(),
+    workItemId: text('work_item_id').notNull(),
+    investigationRunId: text('investigation_run_id').notNull(),
+    scoutSkill: text('scout_skill').notNull(),
+    report: text('report').notNull(), // JSON blob
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    projectWorkItemRunSkillUniq: uniqueIndex(
+      'scout_reports_project_work_item_run_skill_uniq',
+    ).on(t.projectId, t.workItemId, t.investigationRunId, t.scoutSkill),
+    projectWorkItemRunIdx: index('scout_reports_project_work_item_run_idx').on(
+      t.projectId,
+      t.workItemId,
+      t.investigationRunId,
+    ),
+  }),
+);

--- a/core/scout-reports/README.md
+++ b/core/scout-reports/README.md
@@ -1,0 +1,25 @@
+# scout-reports
+
+SQLite persistence for scout skill outputs produced during investigation workflows.
+
+## Purpose
+
+Scout agents run in parallel during investigation, each producing a JSON report for a specific skill (e.g. `repo-scout`, `code-scout`). Reports are keyed by `(projectId, workItemId, investigationRunId, scoutSkill)` so they survive worktree cleanup and can be assembled by the aggregation node without re-running scouts.
+
+The `investigationRunId` isolates reports from different investigation cycles for the same work item — stale reports from a prior failed investigation never bleed into the current one.
+
+## API
+
+```ts
+import { persistScoutReport, listScoutReportsForInvestigation } from 'core/scout-reports/repository.js';
+
+// Upsert: safe to call multiple times for the same key (intra-run retry)
+persistScoutReport(projectId, workItemId, investigationRunId, scoutSkill, reportJson);
+
+// Retrieve all scouts for a given investigation cycle
+const reports = listScoutReportsForInvestigation(projectId, workItemId, investigationRunId);
+```
+
+## Schema
+
+Table `scout_reports` — unique index on `(project_id, work_item_id, investigation_run_id, scout_skill)`.

--- a/core/scout-reports/repository.test.ts
+++ b/core/scout-reports/repository.test.ts
@@ -1,0 +1,94 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../db/db.js';
+import { scoutReports } from '../db/schema.js';
+import { listScoutReportsForInvestigation, persistScoutReport } from './repository.js';
+
+const PROJECT = 'test-scout-reports-repo';
+const WORK_ITEM = 'github:owner/repo#99';
+const RUN_A = 'inv-run-a';
+const RUN_B = 'inv-run-b';
+
+beforeAll(() => {
+  db.run(sql`CREATE TABLE IF NOT EXISTS scout_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    work_item_id TEXT NOT NULL,
+    investigation_run_id TEXT NOT NULL,
+    scout_skill TEXT NOT NULL,
+    report TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
+  db.run(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS scout_reports_project_work_item_run_skill_uniq
+        ON scout_reports (project_id, work_item_id, investigation_run_id, scout_skill)`,
+  );
+  db.run(
+    sql`CREATE INDEX IF NOT EXISTS scout_reports_project_work_item_run_idx
+        ON scout_reports (project_id, work_item_id, investigation_run_id)`,
+  );
+});
+
+beforeEach(() => {
+  db.delete(scoutReports).where(sql`project_id = ${PROJECT}`).run();
+});
+
+afterAll(() => {
+  db.delete(scoutReports).where(sql`project_id = ${PROJECT}`).run();
+});
+
+describe('persistScoutReport', () => {
+  it('saves a report retrievable by listScoutReportsForInvestigation', () => {
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'repo-scout', { findings: ['a'] });
+
+    const rows = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, RUN_A);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      investigationRunId: RUN_A,
+      scoutSkill: 'repo-scout',
+      report: { findings: ['a'] },
+    });
+  });
+
+  it('upserts — same key written twice returns latest value', () => {
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'repo-scout', { findings: ['first'] });
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'repo-scout', { findings: ['second'] });
+
+    const rows = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, RUN_A);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].report).toEqual({ findings: ['second'] });
+  });
+
+  it('stores multiple scouts in the same investigation run', () => {
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'repo-scout', { x: 1 });
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'code-scout', { x: 2 });
+
+    const rows = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, RUN_A);
+    expect(rows).toHaveLength(2);
+    const skills = rows.map((r) => r.scoutSkill).sort();
+    expect(skills).toEqual(['code-scout', 'repo-scout']);
+  });
+});
+
+describe('listScoutReportsForInvestigation', () => {
+  it('isolates by investigationRunId — run B does not see run A reports', () => {
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_A, 'repo-scout', { run: 'a' });
+    persistScoutReport(PROJECT, WORK_ITEM, RUN_B, 'repo-scout', { run: 'b' });
+
+    const rowsA = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, RUN_A);
+    const rowsB = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, RUN_B);
+
+    expect(rowsA).toHaveLength(1);
+    expect(rowsA[0].report).toEqual({ run: 'a' });
+
+    expect(rowsB).toHaveLength(1);
+    expect(rowsB[0].report).toEqual({ run: 'b' });
+  });
+
+  it('returns empty array when no reports exist for given run', () => {
+    const rows = listScoutReportsForInvestigation(PROJECT, WORK_ITEM, 'nonexistent-run');
+    expect(rows).toEqual([]);
+  });
+});

--- a/core/scout-reports/repository.ts
+++ b/core/scout-reports/repository.ts
@@ -1,0 +1,54 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { scoutReports } from '../db/schema.js';
+import type { ScoutReport } from './types.js';
+
+export function persistScoutReport(
+  projectId: string,
+  workItemId: string,
+  investigationRunId: string,
+  scoutSkill: string,
+  report: unknown,
+): void {
+  db.insert(scoutReports)
+    .values({
+      projectId,
+      workItemId,
+      investigationRunId,
+      scoutSkill,
+      report: JSON.stringify(report),
+    })
+    .onConflictDoUpdate({
+      target: [
+        scoutReports.projectId,
+        scoutReports.workItemId,
+        scoutReports.investigationRunId,
+        scoutReports.scoutSkill,
+      ],
+      set: { report: JSON.stringify(report) },
+    })
+    .run();
+}
+
+export function listScoutReportsForInvestigation(
+  projectId: string,
+  workItemId: string,
+  investigationRunId: string,
+): ScoutReport[] {
+  const rows = db
+    .select()
+    .from(scoutReports)
+    .where(
+      and(
+        eq(scoutReports.projectId, projectId),
+        eq(scoutReports.workItemId, workItemId),
+        eq(scoutReports.investigationRunId, investigationRunId),
+      ),
+    )
+    .all();
+
+  return rows.map((r) => ({
+    ...r,
+    report: JSON.parse(r.report) as unknown,
+  }));
+}

--- a/core/scout-reports/types.ts
+++ b/core/scout-reports/types.ts
@@ -1,0 +1,9 @@
+export interface ScoutReport {
+  id: number;
+  projectId: string;
+  workItemId: string;
+  investigationRunId: string;
+  scoutSkill: string;
+  report: unknown;
+  createdAt: string;
+}

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -18,9 +18,7 @@ The context contains a `<task>` block with:
 
 ## Investigation process
 
-> **Status (M19.01).** The Wave-1 / Wave-2 swarm protocol described below is the post-M19.01 *target* shape of an investigation. The primitives (`dispatchWave`, `crossValidate`, the 6 scouts, the 2 Wave-2 agents) are landed and unit-tested, but the production `runInvestigateWorkflow` is **not yet wired** to dispatch them automatically. Until a later M19 issue connects them, this skill operates in **single-agent mode**: you read the worktree directly and skip the wave steps. When the workflow caller passes Wave-1 / Wave-2 reports through `<scout_reports>`, switch to wave-aware mode and use them as primary evidence. Otherwise treat the wave protocol below as documentation, not a runtime guarantee.
-
-In wave-aware mode, you decide WHICH scouts ran and WHAT each one focused on; the orchestrator (when wired) handles fan-out, holdout boundaries, timeouts, and cross-validation.
+In wave-aware mode, you decide WHICH scouts ran and WHAT each one focused on; the orchestrator handles fan-out, holdout boundaries, timeouts, and cross-validation.
 
 ### Wave protocol overview (target shape)
 

--- a/skills/investigate/skill.config.ts
+++ b/skills/investigate/skill.config.ts
@@ -26,12 +26,14 @@ export const InvestigateContextSchema = z.object({
     number: z.number(),
   }),
   worktreePath: z.string(),
+  /** JSON-serialised wave reports + contradictions passed by the orchestrator post-M19.16. */
+  scoutReports: z.string().optional(),
 });
 
 const config: SkillConfig = {
   contextSchema: InvestigateContextSchema,
   outputSchema: InvestigateSchema,
-  contextAllowlist: ['workItem', 'worktreePath'],
+  contextAllowlist: ['workItem', 'worktreePath', 'scoutReports'],
   /**
    * Tool bundle 'read' maps to ['read', 'search', 'work-item-read'].
    * The investigator has NO write access — file writes will be rejected.

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -1,9 +1,9 @@
-import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { AgentRuntime, AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+import type { ScoutReport, WaveResult } from '@goose-hub/core/agent-runtime/swarm.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Skip the playwright-test MCP pre-flight subprocess in workflow.ts — same
-// convention claude-cli.ts uses to bypass real spawns under tests.
+// Skip playwright-test MCP pre-flight subprocess in workflow.ts
 process.env.MOCK_AGENTS = 'true';
 afterAll(() => {
   process.env.MOCK_AGENTS = undefined;
@@ -11,7 +11,28 @@ afterAll(() => {
 
 // ─── module mocks ──────────────────────────────────────────────────────────────
 
-// Single shared mock for the runtime run fn — reset in beforeEach
+const mockDispatchWave = vi.fn();
+const mockCrossValidate = vi.fn();
+const mockInvokeSkill = vi.fn();
+const mockPersistScoutReport = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
+  dispatchWave: (...args: unknown[]) => mockDispatchWave(...args),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/cross-validate.js', () => ({
+  crossValidate: (...args: unknown[]) => mockCrossValidate(...args),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
+  invokeSkill: (...args: unknown[]) => mockInvokeSkill(...args),
+}));
+
+vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
+  persistScoutReport: (...args: unknown[]) => mockPersistScoutReport(...args),
+}));
+
+// Single shared mock for ClaudeCliRuntime (playwright-repro step)
 const mockRun = vi.fn();
 
 const mockAccumulatePersonaStats = vi.fn();
@@ -81,7 +102,7 @@ function makeInvestigateOutput(overrides: Record<string, unknown> = {}) {
     keyFiles: [{ path: 'apps/server/src/middleware/auth.ts', reason: 'Contains null-dereference' }],
     confidence: 'high',
     openQuestions: ['Does this also affect WebSocket upgrade path?'],
-    requiresBrowserRepro: true,
+    requiresBrowserRepro: false,
     decisionSummaries: [
       {
         kind: 'READ',
@@ -104,6 +125,32 @@ function makePlaywrightReproOutput() {
     reproSteps: ['Navigate to /login', 'Enter credentials', 'Click submit'],
     reproduced: true,
     notes: 'Bug reproduced consistently.',
+  };
+}
+
+function makeScoutReport(scoutName: string, overrides: Partial<ScoutReport> = {}): ScoutReport {
+  return {
+    scoutName,
+    status: 'ok',
+    findings: [{ file: 'src/app.ts', fact: 'Module entry point', confidence: 'high' }],
+    decisionSummaries: [],
+    runId: `run:scout:${scoutName}:0`,
+    ...overrides,
+  };
+}
+
+function makeWaveResult(overrides: Partial<WaveResult> = {}): WaveResult {
+  return {
+    status: 'ok',
+    reports: [
+      makeScoutReport('scout-code-path'),
+      makeScoutReport('scout-dependency'),
+      makeScoutReport('scout-pattern'),
+    ],
+    failedScouts: [],
+    shouldAdvance: true,
+    shouldEscalate: false,
+    ...overrides,
   };
 }
 
@@ -140,357 +187,447 @@ function makeMockSource(overrides: Partial<StateSource> = {}): StateSource {
 // ─── test setup ───────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  // Reset call history and queued return values on all mocks.
-  // mockRun is a hoisted vi.fn() so we reset it directly.
-  // vi.clearAllMocks() only clears call history, not return value queues,
-  // so we use mockReset() on the shared run mock to prevent once-value leakage.
+  mockDispatchWave.mockReset();
+  mockCrossValidate.mockReset();
+  mockInvokeSkill.mockReset();
+  mockPersistScoutReport.mockReset();
   mockRun.mockReset();
-  // Clear call history on the module-level mocks so per-test counts are accurate.
   vi.clearAllMocks();
   mockAccumulatePersonaStats.mockClear();
-  // Re-set mockRun after clearAllMocks since clearAllMocks doesn't remove implementations
-  // but does reset the cleared call counters — the mockReset above already cleared the queue.
+
+  // Default happy path
+  mockDispatchWave.mockResolvedValue(makeWaveResult());
+  mockCrossValidate.mockReturnValue({ contradictions: [], hasContradictions: false });
+  mockInvokeSkill.mockResolvedValue({
+    output: makeInvestigateOutput(),
+    decisionSummaries: [],
+    events: [],
+  } satisfies AgentResult);
 });
 
 // ─── tests ────────────────────────────────────────────────────────────────────
 
 describe('runInvestigateWorkflow', () => {
-  describe('happy path — non-bug type', () => {
-    it('creates a worktree with the target repo and runId', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
-      const { createWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+  describe('swarm dispatch — acceptance criterion 1', () => {
+    it('calls dispatchWave exactly twice (Wave 1 then Wave 2)', async () => {
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(createWorktree).toHaveBeenCalledWith('/path/to/repo', expect.any(String));
+      expect(mockDispatchWave).toHaveBeenCalledTimes(2);
     });
 
-    it('runs the investigate skill once for a non-bug item', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
+    it('calls crossValidate exactly once with Wave 1 reports', async () => {
+      const wave1 = makeWaveResult();
+      mockDispatchWave.mockResolvedValueOnce(wave1).mockResolvedValueOnce(makeWaveResult());
 
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(mockRun).toHaveBeenCalledTimes(1);
-      const callArg = mockRun.mock.calls[0][0] as { skill: string };
-      expect(callArg.skill).toBe('investigate');
+      expect(mockCrossValidate).toHaveBeenCalledTimes(1);
+      expect(mockCrossValidate).toHaveBeenCalledWith(wave1.reports);
     });
 
-    it('persists agent.investigation-complete event with findings', async () => {
-      const item = makeWorkItem({ type: 'chore' });
+    it('Wave 2 scouts receive scoutReports in extraContext', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const wave2Opts = mockDispatchWave.mock.calls[1][0] as {
+        scoutSpecs: Array<{ extraContext?: Record<string, unknown> }>;
+      };
+      for (const spec of wave2Opts.scoutSpecs) {
+        expect(spec.extraContext).toHaveProperty('scoutReports');
+        expect(typeof spec.extraContext?.scoutReports).toBe('string');
+      }
+    });
+
+    it('creates worktree and always cleans it up', async () => {
+      const { createWorktree, cleanupWorktree } = await import(
+        '@goose-hub/core/workspaces/worktree.js'
+      );
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String));
+      expect(cleanupWorktree).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('scout report persistence — acceptance criterion 2', () => {
+    it('persists ok-status Wave 1 scouts to DB', async () => {
+      const wave1 = makeWaveResult({
+        reports: [
+          makeScoutReport('scout-code-path'),
+          makeScoutReport('scout-dependency', { status: 'timeout', findings: [], runId: 'x' }),
+        ],
+        failedScouts: ['scout-dependency'],
+      });
+      // Wave 2 uses different names to avoid assertion collision with wave1 scout names
+      const wave2 = makeWaveResult({
+        reports: [makeScoutReport('wave2-interface-designer'), makeScoutReport('wave2-risk-analyst')],
+      });
+      mockDispatchWave.mockResolvedValueOnce(wave1).mockResolvedValueOnce(wave2);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockPersistScoutReport).toHaveBeenCalledWith(
+        'goose-hub-self',
+        'github:shaunnez/goose-hub#42',
+        expect.any(String),
+        'scout-code-path',
+        expect.anything(),
+      );
+      expect(mockPersistScoutReport).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'scout-dependency',
+        expect.anything(),
+      );
+    });
+
+    it('persists ok-status Wave 2 scouts to DB', async () => {
+      const wave2 = makeWaveResult({
+        reports: [
+          makeScoutReport('wave2-interface-designer'),
+          makeScoutReport('wave2-risk-analyst', { status: 'error', findings: [], runId: 'e', errorReason: 'oops' }),
+        ],
+        failedScouts: ['wave2-risk-analyst'],
+      });
+      mockDispatchWave.mockResolvedValueOnce(makeWaveResult()).mockResolvedValueOnce(wave2);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockPersistScoutReport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'wave2-interface-designer',
+        expect.anything(),
+      );
+      expect(mockPersistScoutReport).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'wave2-risk-analyst',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('cross-validate surfaces contradiction — acceptance criterion 3', () => {
+    it('passes contradiction data to synthesis via scoutReports context', async () => {
+      const contradiction = {
+        file: 'src/auth.ts',
+        line: 42,
+        facts: [
+          { scoutName: 'scout-code-path', fact: 'Token check exists', confidence: 'high' as const },
+          { scoutName: 'scout-pattern', fact: 'Token check missing', confidence: 'high' as const },
+        ],
+        scouts: ['scout-code-path', 'scout-pattern'],
+      };
+      mockCrossValidate.mockReturnValue({
+        contradictions: [contradiction],
+        hasContradictions: true,
+      });
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const invokeOpts = mockInvokeSkill.mock.calls[0][0] as {
+        context: { scoutReports: string };
+      };
+      const scoutReports = JSON.parse(invokeOpts.context.scoutReports) as {
+        contradictions: unknown[];
+      };
+      expect(scoutReports.contradictions).toHaveLength(1);
+    });
+  });
+
+  describe('scout timeout → workflow continues — acceptance criterion 4', () => {
+    it('advances to Wave 2 when one scout times out but shouldAdvance is true', async () => {
+      const wave1 = makeWaveResult({
+        status: 'ok',
+        shouldAdvance: true,
+        shouldEscalate: false,
+        reports: [
+          makeScoutReport('scout-code-path'),
+          makeScoutReport('scout-dependency'),
+          makeScoutReport('scout-pattern'),
+          makeScoutReport('scout-schema', { status: 'timeout', findings: [], runId: 't' }),
+        ],
+        failedScouts: ['scout-schema'],
+      });
+      mockDispatchWave.mockResolvedValueOnce(wave1).mockResolvedValueOnce(makeWaveResult());
+
       const source = makeMockSource();
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
 
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
+      expect(mockDispatchWave).toHaveBeenCalledTimes(2);
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:investigating',
+        'factory:investigation-complete',
+      );
+    });
 
+    it('does not persist timed-out scout reports', async () => {
+      const wave1 = makeWaveResult({
+        reports: [
+          makeScoutReport('scout-code-path'),
+          makeScoutReport('scout-schema', { status: 'timeout', findings: [], runId: 't' }),
+        ],
+        failedScouts: ['scout-schema'],
+      });
+      mockDispatchWave.mockResolvedValueOnce(wave1).mockResolvedValueOnce(makeWaveResult());
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockPersistScoutReport).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'scout-schema',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('2 scout failures → escalate — acceptance criterion 5', () => {
+    it('transitions to factory:needs-human when wave1 shouldEscalate', async () => {
+      mockDispatchWave.mockResolvedValueOnce(
+        makeWaveResult({
+          status: 'halted',
+          shouldAdvance: false,
+          shouldEscalate: true,
+          failedScouts: ['scout-code-path', 'scout-dependency'],
+        }),
+      );
+
+      const source = makeMockSource();
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:investigating',
+        'factory:needs-human',
+      );
+    });
+
+    it('does not dispatch Wave 2 when escalating', async () => {
+      mockDispatchWave.mockResolvedValueOnce(
+        makeWaveResult({ status: 'halted', shouldAdvance: false, shouldEscalate: true }),
+      );
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockDispatchWave).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts a GitHub comment when escalating', async () => {
+      mockDispatchWave.mockResolvedValueOnce(
+        makeWaveResult({ status: 'halted', shouldAdvance: false, shouldEscalate: true }),
+      );
+
+      const source = makeMockSource();
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
+
+      expect(source.comment).toHaveBeenCalled();
+    });
+
+    it('still cleans up worktree when escalating', async () => {
+      mockDispatchWave.mockResolvedValueOnce(
+        makeWaveResult({ status: 'halted', shouldAdvance: false, shouldEscalate: true }),
+      );
+
+      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(cleanupWorktree).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('holdout-key enforcement — acceptance criterion 6', () => {
+    it('Wave 2 scoutSpecs contain only scoutReports in extraContext (no disallowed keys)', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const wave2Opts = mockDispatchWave.mock.calls[1][0] as {
+        scoutSpecs: Array<{ extraContext?: Record<string, unknown> }>;
+      };
+      for (const spec of wave2Opts.scoutSpecs) {
+        const extraKeys = Object.keys(spec.extraContext ?? {});
+        expect(extraKeys).not.toContain('investigationFindings');
+        expect(extraKeys).not.toContain('devDecisionSummaries');
+        expect(extraKeys).toEqual(['scoutReports']);
+      }
+    });
+
+    it('dispatchWave fires tool.violation for disallowed key in extraContext', async () => {
+      const fakeRuntime = {
+        run: vi.fn().mockResolvedValue({
+          output: { findings: [], decisionSummaries: [], confidence: 'medium', openQuestions: [] },
+          decisionSummaries: [],
+          events: [],
+        }),
+      };
+
+      const violations: Array<{ disallowedKey: string }> = [];
+      const fakeAppend = vi.fn().mockImplementation(
+        (input: { kind: string; payload: { disallowedKey: string } }) => {
+          if (input.kind === 'tool.violation') violations.push(input.payload);
+          return { id: 1, kind: input.kind, payload: input.payload, createdAt: '' };
+        },
+      );
+
+      const { dispatchWave: realDispatchWave } = await vi.importActual<
+        typeof import('@goose-hub/core/agent-runtime/swarm.js')
+      >('@goose-hub/core/agent-runtime/swarm.js');
+
+      await realDispatchWave({
+        parentRunId: 'holdout-test-run',
+        scoutSpecs: [
+          {
+            scoutName: 'scout-code-path',
+            scoutFocus: 'test holdout enforcement',
+            extraContext: { investigationFindings: 'should not be here' },
+          },
+        ],
+        workItem: { number: 42, title: 'Test', body: 'Test body' },
+        worktreePath: '/tmp/test-tree',
+        projectId: 'test-project',
+        workItemId: 'github:test/repo#42',
+        runtime: fakeRuntime as unknown as AgentRuntime,
+        personaId: 'test-project/investigator/0',
+        appendEvent: fakeAppend,
+      });
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].disallowedKey).toBe('investigationFindings');
+    });
+  });
+
+  describe('investigation-complete event', () => {
+    it('includes investigationRunId in payload', async () => {
       const { runInvestigateWorkflow } = await import('./workflow.js');
       const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
       const call = vi
         .mocked(eventStore.appendEvent)
         .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
       expect(call).toBeDefined();
+      const payload = call?.[0].payload as { investigationRunId: string };
+      expect(typeof payload.investigationRunId).toBe('string');
+      expect(payload.investigationRunId.length).toBeGreaterThan(0);
+    });
+
+    it('includes investigate findings in payload', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const call = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
       const payload = call?.[0].payload as { investigate: unknown };
       expect(payload.investigate).toBeDefined();
     });
 
-    it('transitions state from factory:investigating to factory:investigation-complete', async () => {
-      const item = makeWorkItem({ type: 'chore' });
+    it('transitions to factory:investigation-complete on success', async () => {
       const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
 
       expect(source.transitionState).toHaveBeenCalledWith(
         '42',
         'factory:investigating',
         'factory:investigation-complete',
       );
-      expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
-        personaName: 'test-project/investigator/0',
-        role: 'investigator',
-        outcome: 'success',
-      });
     });
 
-    it('always cleans up the worktree via finally block', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
+    it('records persona success stat', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
+      expect(mockAccumulatePersonaStats).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'success' }),
+      );
+    });
+  });
+
+  describe('type:bug — playwright-repro still runs', () => {
+    it('runs playwright-repro for type:bug when requiresBrowserRepro is true', async () => {
+      mockInvokeSkill.mockResolvedValueOnce({
+        output: makeInvestigateOutput({ requiresBrowserRepro: true }),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
       mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
+        output: makePlaywrightReproOutput(),
         decisionSummaries: [],
         events: [],
       } satisfies AgentResult);
 
-      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem({ type: 'bug' }), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(cleanupWorktree).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('bug type — playwright-repro also runs', () => {
-    it('runs both investigate and playwright-repro skills for type:bug', async () => {
-      const item = makeWorkItem({ type: 'bug' });
-      const source = makeMockSource();
-
-      mockRun
-        .mockResolvedValueOnce({
-          output: makeInvestigateOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult)
-        .mockResolvedValueOnce({
-          output: makePlaywrightReproOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      expect(mockRun).toHaveBeenCalledTimes(2);
-      const firstCall = mockRun.mock.calls[0][0] as { skill: string };
-      const secondCall = mockRun.mock.calls[1][0] as { skill: string };
-      expect(firstCall.skill).toBe('investigate');
-      expect(secondCall.skill).toBe('playwright-repro');
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({ skill: 'playwright-repro' }),
+      );
     });
 
-    it('persists playwrightRepro in investigation-complete event for type:bug', async () => {
-      const item = makeWorkItem({ type: 'bug' });
-      const source = makeMockSource();
-
-      mockRun
-        .mockResolvedValueOnce({
-          output: makeInvestigateOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult)
-        .mockResolvedValueOnce({
-          output: makePlaywrightReproOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      const call = vi
-        .mocked(eventStore.appendEvent)
-        .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
-      expect(call).toBeDefined();
-      const payload = call?.[0].payload as { playwrightRepro: unknown };
-      expect(payload.playwrightRepro).toBeDefined();
-    });
-
-    it('passes workItem.number and workItem.repo into playwright-repro context (evidence pipeline)', async () => {
-      const item = makeWorkItem({ type: 'bug' });
-      const source = makeMockSource();
-
-      mockRun
-        .mockResolvedValueOnce({
-          output: makeInvestigateOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult)
-        .mockResolvedValueOnce({
-          output: makePlaywrightReproOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      const playwrightCall = mockRun.mock.calls[1][0] as {
-        context: { workItem: { number?: number; repo?: string } };
-      };
-      expect(playwrightCall.context.workItem.number).toBe(42);
-      expect(playwrightCall.context.workItem.repo).toBe('shaunnez/goose-hub');
-    });
-
-    it('uses validate tool bundle for playwright-repro skill', async () => {
-      const item = makeWorkItem({ type: 'bug' });
-      const source = makeMockSource();
-
-      mockRun
-        .mockResolvedValueOnce({
-          output: makeInvestigateOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult)
-        .mockResolvedValueOnce({
-          output: makePlaywrightReproOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      const playwrightCall = mockRun.mock.calls[1][0] as {
-        toolBundles: string[];
-      };
-      expect(playwrightCall.toolBundles).toContain('validate');
-    });
-
-    it('does NOT run playwright-repro for non-bug items', async () => {
-      for (const type of ['feature', 'chore', 'research'] as const) {
-        mockRun.mockReset();
-        mockRun.mockResolvedValueOnce({
-          output: makeInvestigateOutput(),
-          decisionSummaries: [],
-          events: [],
-        } satisfies AgentResult);
-
-        const item = makeWorkItem({ type });
-        const source = makeMockSource();
-
-        const { runInvestigateWorkflow } = await import('./workflow.js');
-        await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-        expect(mockRun).toHaveBeenCalledTimes(1);
-      }
-    });
-
-    it('does NOT run playwright-repro for type:bug when requiresBrowserRepro is false', async () => {
-      const item = makeWorkItem({ type: 'bug' });
-      const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
+    it('skips playwright-repro when requiresBrowserRepro is false', async () => {
+      mockInvokeSkill.mockResolvedValueOnce({
         output: makeInvestigateOutput({ requiresBrowserRepro: false }),
         decisionSummaries: [],
         events: [],
       } satisfies AgentResult);
 
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem({ type: 'bug' }), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(mockRun).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('failure path', () => {
-    it('cleans up worktree on failure', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockRejectedValueOnce(new Error('Agent failed'));
-
-      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      // cleanupWorktree is called in finally — always runs
-      expect(cleanupWorktree).toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
     });
 
-    it('transitions to factory:needs-human on failure', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockRejectedValueOnce(new Error('Subprocess error'));
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      expect(source.transitionState).toHaveBeenCalledWith(
-        '42',
-        'factory:investigating',
-        'factory:needs-human',
-      );
-      expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
-        personaName: 'test-project/investigator/0',
-        role: 'investigator',
-        outcome: 'failure',
-      });
-    });
-
-    it('posts a GitHub comment on failure', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-      const errorMessage = 'Subprocess timed out';
-
-      mockRun.mockRejectedValueOnce(new Error(errorMessage));
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      expect(source.comment).toHaveBeenCalledWith(
-        '42',
-        expect.stringContaining('Investigation failed'),
-      );
-    });
-
-    it('persists agent.run-failed event on failure', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockRejectedValueOnce(new Error('Runtime crashed'));
+    it('persists playwrightRepro in investigation-complete event', async () => {
+      mockInvokeSkill.mockResolvedValueOnce({
+        output: makeInvestigateOutput({ requiresBrowserRepro: true }),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+      mockRun.mockResolvedValueOnce({
+        output: makePlaywrightReproOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
 
       const { runInvestigateWorkflow } = await import('./workflow.js');
       const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem({ type: 'bug' }), makeMockSource(), 'goose-hub-self', '/repo');
 
-      const failCall = vi
+      const call = vi
         .mocked(eventStore.appendEvent)
-        .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
-      expect(failCall).toBeDefined();
+        .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
+      const payload = call?.[0].payload as { playwrightRepro: unknown };
+      expect(payload.playwrightRepro).toBeDefined();
     });
+  });
 
-    it('does not throw — handles errors gracefully', async () => {
-      const item = makeWorkItem({ type: 'chore' });
+  describe('unexpected error path', () => {
+    it('escalates to factory:needs-human on dispatchWave error', async () => {
+      mockDispatchWave.mockRejectedValueOnce(new Error('Runtime failure'));
+
       const source = makeMockSource();
-
-      mockRun.mockRejectedValueOnce(new Error('Unexpected crash'));
-
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await expect(
-        runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo'),
-      ).resolves.not.toThrow();
-    });
-
-    it('handles validation failure as an error — transitions to factory:needs-human', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      // Returns invalid output that fails schema validation
-      mockRun.mockResolvedValueOnce({
-        output: { bad: 'data', missing_required: true },
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
 
       expect(source.transitionState).toHaveBeenCalledWith(
         '42',
@@ -498,155 +635,36 @@ describe('runInvestigateWorkflow', () => {
         'factory:needs-human',
       );
     });
-  });
 
-  describe('AgentSpec fields', () => {
-    it('uses opus model override for investigate skill', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
+    it('still cleans up worktree after error', async () => {
+      mockDispatchWave.mockRejectedValueOnce(new Error('Runtime failure'));
 
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
+      const { cleanupWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      const callArg = mockRun.mock.calls[0][0] as { modelOverride: string };
-      expect(callArg.modelOverride).toBe('claude-opus-4-7');
+      expect(cleanupWorktree).toHaveBeenCalledOnce();
     });
 
-    it('includes personaId in investigate AgentSpec', async () => {
-      const item = makeWorkItem({ type: 'chore' });
+    it('posts a comment on unexpected error', async () => {
+      mockDispatchWave.mockRejectedValueOnce(new Error('Runtime failure'));
+
       const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
 
-      const callArg = mockRun.mock.calls[0][0] as { personaId: string };
-      expect(callArg.personaId).toBe('test-project/investigator/0');
+      expect(source.comment).toHaveBeenCalled();
     });
 
-    it('passes worktreePath in investigate context', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
+    it('records persona failure stat on error', async () => {
+      mockDispatchWave.mockRejectedValueOnce(new Error('Runtime failure'));
 
       const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      const callArg = mockRun.mock.calls[0][0] as {
-        context: Record<string, unknown>;
-        contextAllowlist: string[];
-      };
-      expect(callArg.context.worktreePath).toBe('/tmp/test-worktree');
-      expect(callArg.contextAllowlist).toContain('worktreePath');
+      expect(mockAccumulatePersonaStats).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: 'failure' }),
+      );
     });
-
-    it('uses read tool bundle for investigate skill', async () => {
-      const item = makeWorkItem({ type: 'chore' });
-      const source = makeMockSource();
-
-      mockRun.mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
-      const { runInvestigateWorkflow } = await import('./workflow.js');
-      await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-      const callArg = mockRun.mock.calls[0][0] as { toolBundles: string[] };
-      expect(callArg.toolBundles).toContain('read-only');
-    });
-  });
-});
-
-describe('investigate — line 138 non-Error catch branch', () => {
-  it('wraps non-Error thrown value as Error and transitions to needs-human', async () => {
-    const item = makeWorkItem({ type: 'chore' });
-    const source = makeMockSource();
-
-    // Throw a string (not an Error object) to cover the false branch of `err instanceof Error`
-    // eslint-disable-next-line prefer-promise-reject-errors
-    mockRun.mockRejectedValueOnce('string error — not an Error instance');
-
-    const { runInvestigateWorkflow } = await import('./workflow.js');
-    await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-    expect(source.transitionState).toHaveBeenCalledWith(
-      '42',
-      'factory:investigating',
-      'factory:needs-human',
-    );
-    expect(source.comment).toHaveBeenCalledWith(
-      '42',
-      expect.stringContaining('Investigation failed'),
-    );
-  });
-});
-
-describe('investigate — playwright-repro parse failure (line 138 branch)', () => {
-  it('continues to success when playwright-repro output parse fails (non-fatal)', async () => {
-    const item = makeWorkItem({ type: 'bug' });
-    const source = makeMockSource();
-
-    mockRun
-      .mockResolvedValueOnce({
-        output: makeInvestigateOutput(),
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult)
-      .mockResolvedValueOnce({
-        // Invalid output — PlaywrightReproSchema.safeParse will return success:false
-        output: { bad: 'schema', missingFields: true },
-        decisionSummaries: [],
-        events: [],
-      } satisfies AgentResult);
-
-    const { runInvestigateWorkflow } = await import('./workflow.js');
-    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
-    await runInvestigateWorkflow(item, source, 'goose-hub-self', '/path/to/repo');
-
-    // Should still transition successfully (playwright-repro failure is non-fatal)
-    expect(source.transitionState).toHaveBeenCalledWith(
-      '42',
-      'factory:investigating',
-      'factory:investigation-complete',
-    );
-
-    // investigation-complete event should still be emitted
-    const call = vi
-      .mocked(eventStore.appendEvent)
-      .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
-    expect(call).toBeDefined();
-
-    // playwrightRepro should be undefined (parse failed but non-fatal)
-    const payload = call?.[0].payload as { playwrightRepro: unknown };
-    expect(payload.playwrightRepro).toBeUndefined();
-  });
-});
-
-describe('selectPersona', () => {
-  it('returns round-robin persona IDs for sequential calls (mocked)', async () => {
-    // The actual round-robin is DB-backed; here we verify the mock integration
-    const { selectPersona } = await import('@goose-hub/core/agent-runtime/select-persona.js');
-
-    const result = selectPersona('test-project', 'investigator');
-    expect(result).toEqual({ personaId: 'test-project/investigator/0', codename: 'Grey Honker' });
-    expect(selectPersona).toHaveBeenCalledWith('test-project', 'investigator');
   });
 });

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -1,30 +1,57 @@
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { ClaudeCliRuntime } from '@goose-hub/core/agent-runtime/claude-cli.js';
+import { crossValidate } from '@goose-hub/core/agent-runtime/cross-validate.js';
+import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { dispatchWave } from '@goose-hub/core/agent-runtime/swarm.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
+import { persistScoutReport } from '@goose-hub/core/scout-reports/repository.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import {
   cleanupWorktree,
   createWorktree,
   prewarmWorktree,
 } from '@goose-hub/core/workspaces/worktree.js';
-import { InvestigateSchema } from '@goose-hub/skills/investigate/schema.js';
+import type { z } from 'zod';
+import type { InvestigateSchema } from '@goose-hub/skills/investigate/schema.js';
 import { PlaywrightReproSchema } from '@goose-hub/skills/playwright-repro/schema.js';
+
+type InvestigateOutput = z.infer<typeof InvestigateSchema>;
+
+/**
+ * Wave-1 scouts dispatched on every investigation run.
+ * The orchestrator fans them all out; scouts that aren't relevant return empty findings.
+ */
+const WAVE_1_SCOUTS = [
+  { scoutName: 'scout-code-path', scoutFocus: 'Trace code paths and call sites for symbols named in the work item' },
+  { scoutName: 'scout-dependency', scoutFocus: 'Map dependencies crossing package boundaries touched by this change' },
+  { scoutName: 'scout-pattern', scoutFocus: 'Identify existing patterns the fix should follow' },
+  { scoutName: 'scout-schema', scoutFocus: 'Find DB schemas, Zod schemas, and API contracts relevant to this work item' },
+  { scoutName: 'scout-test-inventory', scoutFocus: 'Locate existing tests covering the affected area' },
+  { scoutName: 'scout-user-journey', scoutFocus: 'Map user-visible UI flows and API surfaces related to this issue' },
+];
 
 /**
  * Runs the investigate workflow for a work item in `factory:investigating` state.
  *
  * Workflow:
  * 1. createWorktree for the target repo
- * 2. Run the `investigate` skill (investigator persona, opus-tier)
- * 3. If type:bug, run the `playwright-repro` skill
- * 4. Persist findings as `agent.investigation-complete` event
- * 5. Transition state: factory:investigating → factory:investigation-complete
+ * 2. Wave 1 — dispatch 6 scouts in parallel
+ * 3. Persist ok scout reports to DB
+ * 4. If wave halted (≥2 failures) → escalate factory:needs-human
+ * 5. Cross-validate Wave 1 reports
+ * 6. Wave 2 — dispatch 2 deep agents with cross-validated context
+ * 7. Persist Wave 2 ok reports
+ * 8. Synthesis — run investigate skill with all scout reports
+ * 9. If type:bug + requiresBrowserRepro → run playwright-repro skill
+ * 10. Persist agent.investigation-complete event (includes investigationRunId)
+ * 11. Transition state: factory:investigating → factory:investigation-complete
  *
  * On failure: cleanup worktree, persist agent.run-failed event,
  * post GitHub comment, transition to factory:needs-human.
@@ -46,55 +73,137 @@ export async function runInvestigateWorkflow(
 
   const runId = crypto.randomUUID();
   const runtime = new ClaudeCliRuntime();
-  const investigatePrompt = readPromptWithContext('investigate', projectId);
-  const playwrightReproPrompt = readPromptWithContext('playwright-repro', projectId);
-  const investigateJsonSchema = toJsonSchema(InvestigateSchema);
-  const playwrightReproJsonSchema = toJsonSchema(PlaywrightReproSchema);
-
   const { personaId } = selectPersona(projectId, 'investigator');
   const projectConfig = await getProjectBySlug(projectId);
   const worktreePath = createWtFn(targetRepo, runId);
+
   if (workItem.type === 'bug') {
     prewarmWtFn(worktreePath, '@goose-hub/web');
   }
 
+  const workItemCtx = {
+    number: Number(workItem.externalId),
+    title: workItem.title,
+    body: workItem.body,
+  };
+
+  const scoutJsonSchema = toJsonSchema(ScoutOutputSchema);
+
+  function loadSkillAssets(scoutName: string) {
+    return {
+      appendSystemPrompt: readPromptWithContext(scoutName, projectId),
+      outputJsonSchema: scoutJsonSchema,
+    };
+  }
+
   try {
-    // Step a: Run the investigate skill
-    const investigateResult = await runtime.run({
-      runId,
-      role: 'investigator',
-      skill: 'investigate',
-      context: {
-        projectId,
-        workItemId: workItem.id,
-        workItem: {
-          title: workItem.title,
-          body: workItem.body,
-          number: Number(workItem.externalId),
-        },
-        worktreePath,
-      },
-      contextAllowlist: ['workItem', 'worktreePath'],
-      freshContext: false,
-      toolBundles: ['read-only'],
-      toolExtras: [],
-      ...resolveBudgetsForProject('investigate', projectConfig?.budgets, projectId),
+    // Wave 1 — parallel fact-gathering
+    const wave1Result = await dispatchWave({
+      parentRunId: runId,
+      scoutSpecs: WAVE_1_SCOUTS,
+      workItem: workItemCtx,
+      worktreePath,
+      projectId,
+      workItemId: workItem.id,
+      runtime,
       personaId,
-      outputJsonSchema: investigateJsonSchema,
-      appendSystemPrompt: investigatePrompt,
+      loadSkillAssets,
     });
 
-    // Step b: Validate investigate output
-    const investigateParsed = InvestigateSchema.safeParse(investigateResult.output);
-    if (!investigateParsed.success) {
-      throw new Error(
-        `Investigate output validation failed: ${JSON.stringify(investigateParsed.error.issues)}`,
-      );
+    for (const report of wave1Result.reports) {
+      if (report.status === 'ok') {
+        persistScoutReport(projectId, workItem.id, runId, report.scoutName, {
+          findings: report.findings,
+          decisionSummaries: report.decisionSummaries,
+        });
+      }
     }
-    const findings = investigateParsed.data;
 
-    // Step c: If type:bug and the bug manifests in the browser, run playwright-repro skill
+    if (wave1Result.shouldEscalate) {
+      await stateSource.comment(
+        workItem.externalId,
+        buildAgentComment(
+          'Investigate',
+          'Escalated',
+          'Too many scouts failed — escalating to needs-human',
+          [`Failed scouts: ${wave1Result.failedScouts.join(', ')}`],
+        ),
+      );
+      await stateSource.transitionState(
+        workItem.externalId,
+        'factory:investigating',
+        'factory:needs-human',
+      );
+      return;
+    }
+
+    // Cross-validate Wave 1 before dispatching Wave 2
+    const cvResult = crossValidate(wave1Result.reports);
+    const wave1Context = JSON.stringify({
+      wave1: wave1Result.reports,
+      contradictions: cvResult.contradictions,
+    });
+
+    // Wave 2 — deep synthesis agents with cross-validated context
+    const wave2Result = await dispatchWave({
+      parentRunId: runId,
+      scoutSpecs: [
+        {
+          scoutName: 'wave2-interface-designer',
+          scoutFocus: 'Design interfaces and type signatures based on cross-validated scout findings',
+          extraContext: { scoutReports: wave1Context },
+        },
+        {
+          scoutName: 'wave2-risk-analyst',
+          scoutFocus: 'Identify risks and edge cases in the implementation approach',
+          extraContext: { scoutReports: wave1Context },
+        },
+      ],
+      workItem: workItemCtx,
+      worktreePath,
+      projectId,
+      workItemId: workItem.id,
+      runtime,
+      personaId,
+      loadSkillAssets,
+    });
+
+    for (const report of wave2Result.reports) {
+      if (report.status === 'ok') {
+        persistScoutReport(projectId, workItem.id, runId, report.scoutName, {
+          findings: report.findings,
+          decisionSummaries: report.decisionSummaries,
+        });
+      }
+    }
+
+    // Build full context for the synthesis investigator
+    const allScoutReports = JSON.stringify({
+      wave1: wave1Result.reports,
+      wave2: wave2Result.reports,
+      contradictions: cvResult.contradictions,
+    });
+
+    // Synthesis — invoke investigate skill with scout evidence
+    const synthResult = await invokeSkill({
+      skillName: 'investigate',
+      projectId,
+      workItemId: workItem.id,
+      runId,
+      context: {
+        workItem: workItemCtx,
+        worktreePath,
+        scoutReports: allScoutReports,
+      },
+      overrides: { runtimeOverride: runtime },
+    });
+
+    const findings = synthResult.output as InvestigateOutput;
+
+    // Playwright repro for browser-manifesting bugs
     let reproOutput: unknown | undefined;
+    const playwrightReproPrompt = readPromptWithContext('playwright-repro', projectId);
+    const playwrightReproJsonSchema = toJsonSchema(PlaywrightReproSchema);
     if (workItem.type === 'bug' && findings.requiresBrowserRepro) {
       const { personaId: playwrightPersonaId } = selectPersona(projectId, 'investigator');
       const playwrightRunId = crypto.randomUUID();
@@ -155,23 +264,17 @@ export async function runInvestigateWorkflow(
           });
         }
       } catch (err) {
-        // playwright-repro failure is non-fatal — investigate findings are persisted regardless
         const error = err instanceof Error ? err : new Error(String(err));
         eventStore.appendEvent({
           projectId,
           workItemId: workItem.id,
           kind: 'agent.run-failed',
-          payload: {
-            runId: playwrightRunId,
-            skill: 'playwright-repro',
-            error: error.message,
-          },
+          payload: { runId: playwrightRunId, skill: 'playwright-repro', error: error.message },
           runId: playwrightRunId,
         });
       }
     }
 
-    // Step d: Persist findings as agent.investigation-complete event
     eventStore.appendEvent({
       projectId,
       workItemId: workItem.id,
@@ -179,11 +282,11 @@ export async function runInvestigateWorkflow(
       payload: {
         investigate: findings,
         playwrightRepro: reproOutput,
+        investigationRunId: runId,
       },
       runId,
     });
 
-    // Step e: Transition state
     accumulatePersonaStats({ personaName: personaId, role: 'investigator', outcome: 'success' });
     await stateSource.transitionState(
       workItem.externalId,
@@ -194,7 +297,6 @@ export async function runInvestigateWorkflow(
     accumulatePersonaStats({ personaName: personaId, role: 'investigator', outcome: 'failure' });
     const error = err instanceof Error ? err : new Error(String(err));
 
-    // Persist failure event
     eventStore.appendEvent({
       projectId,
       workItemId: workItem.id,
@@ -213,14 +315,12 @@ export async function runInvestigateWorkflow(
       ),
     );
 
-    // Transition to error state
     await stateSource.transitionState(
       workItem.externalId,
       'factory:investigating',
       'factory:needs-human',
     );
   } finally {
-    // Always cleanup the worktree — cleanupWorktree is idempotent
     cleanupWorktree(runId);
   }
 }


### PR DESCRIPTION
Closes #692

Wires the investigation workflow to dispatch Wave 1 (6 scouts) + Wave 2 (2 deep agents) + cross-validate + synthesis via `invokeSkill`.

## Changes

- `slices/investigate/workflow.ts` — replaced single-agent flow with Wave 1 → crossValidate → Wave 2 → synthesis pipeline; `agent.investigation-complete` payload now includes `investigationRunId`
- `slices/investigate/slice.test.ts` — replaced old single-agent tests with swarm-wired integration tests covering all 6 acceptance criteria
- `core/agent-runtime/swarm.ts` — added `'scoutReports'` to `SCOUT_CONTEXT_ALLOWLIST` so Wave 2 agents can receive cross-validated findings
- `skills/investigate/skill.config.ts` — added `scoutReports: z.string().optional()` to `InvestigateContextSchema` and `contextAllowlist`
- `skills/investigate/prompt.md` — removed "not yet wired" status note
- `apps/server/src/domains/workflows/state-flows.test.ts` — added `dispatchWave`/`crossValidate`/`invokeSkill`/`persistScoutReport` mocks; updated investigate tests to match new flow