### PR TITLE
fix(holdout-validator): flag dotted-allowlist key when context value is scalar/null

### DIFF
--- a/core/agent-runtime/holdout-validator.test.ts
+++ b/core/agent-runtime/holdout-validator.test.ts
@@ -112,4 +112,16 @@ describe('findDisallowedKeys', () => {
     const result = findDisallowedKeys({ workItem: { title: 'T', body: 'B' } }, ['workItem.title']);
     expect(result).not.toContain('workItem');
   });
+
+  it('flags dotted-allowlist key when value is scalar (projection impossible)', () => {
+    // workItem is a scalar — renderContext cannot project workItem.title, so
+    // this key must still be flagged as disallowed (governance regression guard).
+    const result = findDisallowedKeys({ workItem: 'plain string' }, ['workItem.title']);
+    expect(result).toContain('workItem');
+  });
+
+  it('flags dotted-allowlist key when value is null', () => {
+    const result = findDisallowedKeys({ workItem: null }, ['workItem.title']);
+    expect(result).toContain('workItem');
+  });
 });

--- a/core/agent-runtime/holdout-validator.ts
+++ b/core/agent-runtime/holdout-validator.ts
@@ -84,9 +84,12 @@ export function findDisallowedKeys(
   }
   const disallowed: string[] = [];
   for (const k of Object.keys(context)) {
-    if (!exactKeys.has(k) && !dottedTopKeys.has(k) && !SYSTEM_KEYS.has(k)) {
-      disallowed.push(k);
-    }
+    if (exactKeys.has(k) || SYSTEM_KEYS.has(k)) continue;
+    // A dotted allowlist entry (e.g. workItem.title) only covers the top-level
+    // key when the value is an object — if it's scalar/null, renderContext cannot
+    // project the sub-path and the key must be flagged as disallowed.
+    if (dottedTopKeys.has(k) && typeof context[k] === 'object' && context[k] !== null) continue;
+    disallowed.push(k);
   }
   return disallowed;
 }


### PR DESCRIPTION
## Summary
- Fix `findDisallowedKeys` in `holdout-validator.ts` to correctly flag a top-level context key as disallowed when the only allowlist coverage is a dotted entry (e.g. `workItem.title`) but the runtime value is scalar or null
- Before this fix, `workItem: "text"` with `workItem.title` allowlisted would pass silently — `renderContext` drops the key (can't project), but no `tool.violation` was emitted
- This restores the pre-split `renderManifest` behaviour: dotted coverage only applies when `typeof value === 'object' && value !== null`

## Test plan
- [x] Added `it('flags dotted-allowlist key when value is scalar')` — previously would have returned `[]`, now correctly returns `['workItem']`
- [x] Added `it('flags dotted-allowlist key when value is null')` — same regression case
- [x] Existing test `'does not flag key covered by dotted allowlist entry'` (object value) continues to pass

Fixes Codex P2 issues raised on PR #704 (three duplicate comments on `holdout-validator.ts:87`).

Closes #704

https://claude.ai/code/session_017EA96fesY6ZjotwdZNPaa7

---
_Generated by [Claude Code](https://claude.ai/code/session_017EA96fesY6ZjotwdZNPaa7)_