### PR TITLE
M19.18: parallel-implement wiring and payload alignment

### DIFF
--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -21,6 +21,9 @@ vi.mock('node:child_process', async (importOriginal) => {
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: { appendEvent: vi.fn(), replay: vi.fn().mockReturnValue([]) },
 }));
+vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
+  cleanupWorktree: vi.fn(),
+}));
 vi.mock('@goose-hub/core/state-machine/states.js', () => ({
   STATES: ['factory:triaging', 'factory:accepted', 'factory:in-progress', 'factory:done'],
 }));
@@ -56,6 +59,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { isLegalTransition } from '@goose-hub/core/state-machine/transitions.js';
+import { cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
 import { bustCache } from '#shared/cache.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
@@ -485,6 +489,33 @@ describe('approveIssue / rejectIssue (#186)', () => {
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'pr.merged');
     expect(merged).toBeDefined();
+  });
+
+  it('approveIssue cleans up the dev worktree using devRunId from pr.opened after merge', async () => {
+    const prOpenedEvent = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+      kind: 'pr.opened',
+      runId: 'dev-run-123',
+      payload: {
+        prNumber: 99,
+        prUrl: 'u',
+        branch: 'b',
+        worktreePath: '/wt/dev-run-123',
+        devRunId: 'dev-run-123',
+        pipelineRunId: 'pipeline-run-123',
+      },
+      createdAt: '2026-05-02T22:00:00Z',
+    };
+    vi.mocked(eventStore.replay).mockReturnValue([prOpenedEvent] as never);
+    const mergePRImpl = vi.fn().mockResolvedValueOnce({ sha: 'abc1234', merged: true });
+
+    const { approveIssue } = await import('./service.js');
+    const result = await approveIssue('proj', '1', { mergePRImpl });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(cleanupWorktree).toHaveBeenCalledWith('dev-run-123');
   });
 
   it('approveIssue returns 409 and transitions to merge-conflict when GitHub 405', async () => {

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -19,6 +19,25 @@ const mockRunRetroForItem = vi.fn();
 const mockFilterEligibleByDependencies = vi.fn();
 const mockCreateProjectAwareTargetSource = vi.fn();
 const mockRunGrillAndPrdWorkflow = vi.fn();
+const mockGetUseM19Pipeline = vi.fn();
+const mockGetEngineeringSpec = vi.fn();
+const mockRunParallelImplementWorkflow = vi.fn();
+
+vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
+  readProjectSettings: vi.fn().mockReturnValue(null),
+  readProjectSkillSettings: vi.fn().mockReturnValue(new Map()),
+  getUseM19Pipeline: mockGetUseM19Pipeline,
+  setUseM19Pipeline: vi.fn(),
+  deriveUseM19Pipeline: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@goose-hub/core/engineering-specs/repository.js', () => ({
+  getEngineeringSpec: mockGetEngineeringSpec,
+}));
+
+vi.mock('../../../../slices/parallel-implement/workflow.js', () => ({
+  runParallelImplementWorkflow: mockRunParallelImplementWorkflow,
+}));
 
 vi.mock('@goose-hub/core/projects/dependency-scheduler.js', () => ({
   filterEligibleByDependencies: mockFilterEligibleByDependencies,
@@ -67,9 +86,12 @@ beforeEach(() => {
   mockRunTriageBatch.mockResolvedValue(undefined);
   mockRunRetroForItem.mockResolvedValue(undefined);
   mockRunGrillAndPrdWorkflow.mockResolvedValue(undefined);
+  mockRunParallelImplementWorkflow.mockResolvedValue({ status: 'success' });
   mockGetSourceForSlug.mockResolvedValue(null);
   // Default: single-workflow-per-project (backward-compat) for tests that don't override.
   mockGetProject.mockResolvedValue(null);
+  mockGetUseM19Pipeline.mockReturnValue(false);
+  mockGetEngineeringSpec.mockReturnValue(null);
   mockCreateProjectAwareTargetSource.mockResolvedValue(vi.fn());
   mockFilterEligibleByDependencies.mockResolvedValue({
     eligible: [],
@@ -577,6 +599,203 @@ describe('dispatchForLabel', () => {
     await dispatchForLabel('my-project', 1, 'factory:needs-qa');
 
     expect(mockRunTriageBatch).not.toHaveBeenCalled();
+  });
+
+  it('routes factory:spec-ready through parallel-implement when M19 pipeline is enabled', async () => {
+    const item = {
+      id: 'github:shaunnez/goose-hub#694',
+      externalId: '694',
+      repoRef: 'shaunnez/goose-hub',
+      title: 'parallel implement',
+      body: 'body',
+      state: 'factory:spec-ready',
+      priority: 'high',
+      type: 'feature',
+      schedule: 'current',
+    };
+    const source = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi.fn().mockResolvedValue(item),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+      comment: vi.fn().mockResolvedValue(undefined),
+    };
+    const spec = {
+      objective: 'Implement dispatch wiring',
+      userJourneys: [],
+      functionalRequirements: [],
+      architecture: { current: 'stub', new: 'wired', decisionRationale: 'test' },
+      schemaChanges: { ddl: [], migrations: [] },
+      interfaceContracts: [],
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['apps/server/src/shared/dispatch.ts'],
+          changes: 'Wire it',
+          dependsOn: [],
+          builderTier: 'sonnet',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      verificationTooling: [],
+      acceptanceCriteria: [
+        { id: 'AC1', statement: 'Dispatches', verifyCommand: 'pnpm test', crossCutting: true },
+      ],
+      constraints: [],
+      riskRegister: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetUseM19Pipeline.mockReturnValue(true);
+    mockGetEngineeringSpec.mockReturnValue({
+      id: 1,
+      projectId: 'goose-hub-self',
+      workItemId: item.id,
+      pipelineRunId: 'pipeline-run-dispatch',
+      spec,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: '2026-05-10T00:00:00Z',
+    });
+
+    const { dispatchForLabel } = await import('./dispatch.js');
+    await dispatchForLabel('goose-hub-self', 694, 'factory:spec-ready');
+
+    expect(source.transitionState).toHaveBeenNthCalledWith(
+      1,
+      '694',
+      'factory:spec-ready',
+      'factory:in-progress',
+    );
+    expect(mockRunParallelImplementWorkflow).toHaveBeenCalledWith(
+      item,
+      spec,
+      'pipeline-run-dispatch',
+      source,
+      'goose-hub-self',
+      expect.any(String),
+    );
+    expect(source.transitionState).toHaveBeenNthCalledWith(
+      2,
+      '694',
+      'factory:in-progress',
+      'factory:needs-qa',
+    );
+    expect(source.transitionState.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRunParallelImplementWorkflow.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('escalates factory:spec-ready to needs-human when the engineering spec is missing', async () => {
+    const item = {
+      id: 'github:shaunnez/goose-hub#694',
+      externalId: '694',
+      repoRef: 'shaunnez/goose-hub',
+      title: 'parallel implement',
+      body: 'body',
+      state: 'factory:spec-ready',
+      priority: 'high',
+      type: 'feature',
+      schedule: 'current',
+    };
+    const source = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi.fn().mockResolvedValue(item),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+      comment: vi.fn().mockResolvedValue(undefined),
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetUseM19Pipeline.mockReturnValue(true);
+    mockGetEngineeringSpec.mockReturnValue(null);
+
+    const { dispatchForLabel } = await import('./dispatch.js');
+    await dispatchForLabel('goose-hub-self', 694, 'factory:spec-ready');
+
+    expect(mockRunParallelImplementWorkflow).not.toHaveBeenCalled();
+    expect(source.comment).toHaveBeenCalledWith('694', expect.stringContaining('engineering spec'));
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '694',
+      'factory:spec-ready',
+      'factory:needs-human',
+    );
+  });
+
+  it('transitions in-progress to needs-human when parallel-implement returns failed', async () => {
+    const item = {
+      id: 'github:shaunnez/goose-hub#694',
+      externalId: '694',
+      repoRef: 'shaunnez/goose-hub',
+      title: 'parallel implement',
+      body: 'body',
+      state: 'factory:spec-ready',
+      priority: 'high',
+      type: 'feature',
+      schedule: 'current',
+    };
+    const source = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi.fn().mockResolvedValue(item),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+      comment: vi.fn().mockResolvedValue(undefined),
+    };
+    const spec = {
+      objective: 'Implement dispatch wiring',
+      userJourneys: [],
+      functionalRequirements: [],
+      architecture: { current: 'stub', new: 'wired', decisionRationale: 'test' },
+      schemaChanges: { ddl: [], migrations: [] },
+      interfaceContracts: [],
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['apps/server/src/shared/dispatch.ts'],
+          changes: 'Wire it',
+          dependsOn: [],
+          builderTier: 'sonnet',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      verificationTooling: [],
+      acceptanceCriteria: [
+        { id: 'AC1', statement: 'Dispatches', verifyCommand: 'pnpm test', crossCutting: true },
+      ],
+      constraints: [],
+      riskRegister: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetUseM19Pipeline.mockReturnValue(true);
+    mockGetEngineeringSpec.mockReturnValue({
+      id: 1,
+      projectId: 'goose-hub-self',
+      workItemId: item.id,
+      pipelineRunId: 'pipeline-run-dispatch',
+      spec,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: '2026-05-10T00:00:00Z',
+    });
+    mockRunParallelImplementWorkflow.mockResolvedValueOnce({
+      status: 'failed',
+      devRunId: 'dev-run-123',
+      errorReason: 'builder failed',
+    });
+
+    const { dispatchForLabel } = await import('./dispatch.js');
+    await dispatchForLabel('goose-hub-self', 694, 'factory:spec-ready');
+
+    expect(source.transitionState).toHaveBeenNthCalledWith(
+      1,
+      '694',
+      'factory:spec-ready',
+      'factory:in-progress',
+    );
+    expect(source.transitionState).toHaveBeenNthCalledWith(
+      2,
+      '694',
+      'factory:in-progress',
+      'factory:needs-human',
+    );
   });
 });
 

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -645,7 +645,10 @@ describe('dispatchForLabel', () => {
       decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
     };
     mockGetSourceForSlug.mockResolvedValue(source);
-    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetProject.mockResolvedValue({
+      id: 'project-config-id',
+      budgets: { maxParallelAgents: 1 },
+    });
     mockGetUseM19Pipeline.mockReturnValue(true);
     mockGetEngineeringSpec.mockReturnValue({
       id: 1,
@@ -660,6 +663,8 @@ describe('dispatchForLabel', () => {
     const { dispatchForLabel } = await import('./dispatch.js');
     await dispatchForLabel('goose-hub-self', 694, 'factory:spec-ready');
 
+    expect(mockGetUseM19Pipeline).toHaveBeenCalledWith('project-config-id');
+    expect(mockGetEngineeringSpec).toHaveBeenCalledWith('goose-hub-self', item.id);
     expect(source.transitionState).toHaveBeenNthCalledWith(
       1,
       '694',
@@ -704,7 +709,10 @@ describe('dispatchForLabel', () => {
       comment: vi.fn().mockResolvedValue(undefined),
     };
     mockGetSourceForSlug.mockResolvedValue(source);
-    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetProject.mockResolvedValue({
+      id: 'project-config-id',
+      budgets: { maxParallelAgents: 1 },
+    });
     mockGetUseM19Pipeline.mockReturnValue(true);
     mockGetEngineeringSpec.mockReturnValue(null);
 
@@ -764,7 +772,10 @@ describe('dispatchForLabel', () => {
       decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
     };
     mockGetSourceForSlug.mockResolvedValue(source);
-    mockGetProject.mockResolvedValue({ id: 'goose-hub-self', budgets: { maxParallelAgents: 1 } });
+    mockGetProject.mockResolvedValue({
+      id: 'project-config-id',
+      budgets: { maxParallelAgents: 1 },
+    });
     mockGetUseM19Pipeline.mockReturnValue(true);
     mockGetEngineeringSpec.mockReturnValue({
       id: 1,

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -363,7 +363,7 @@ export async function dispatchParallelImplement(slug: string, issueNumber: numbe
       return;
     }
 
-    const specRecord = getEngineeringSpec(projectId, item.id);
+    const specRecord = getEngineeringSpec(slug, item.id);
     if (specRecord == null) {
       await source.comment(
         item.externalId,
@@ -390,7 +390,7 @@ export async function dispatchParallelImplement(slug: string, issueNumber: numbe
         parsedSpec.data,
         specRecord.pipelineRunId,
         source,
-        projectId,
+        slug,
         REPO_ROOT,
       );
       if (result.status === 'success') {

--- a/apps/server/src/shared/dispatch.ts
+++ b/apps/server/src/shared/dispatch.ts
@@ -1,12 +1,14 @@
 import { join } from 'node:path';
 import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { getUseM19Pipeline } from '@goose-hub/core/db/repositories/project-settings.js';
+import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { filterEligibleByDependencies } from '@goose-hub/core/projects/dependency-scheduler.js';
 import { parallelLock } from '@goose-hub/core/projects/parallel-lock.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { createProjectAwareTargetSource } from '@goose-hub/core/state-source/dependency-resolver.js';
+import { EngineeringSpecSchema } from '@goose-hub/skills/spec-author/schema.js';
 import { parseAcceptanceCriteria } from '../domains/issues/parse-acceptance.js';
 import { runRetroForItem } from '../domains/workflows/retro-batch.js';
 import { maybeFireSprintReview } from '../domains/workflows/sprint-review-trigger.js';
@@ -296,6 +298,114 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
         : undefined;
 
     await runFixIssueWorkflow(item, source, slug, REPO_ROOT, mockDeps);
+  } finally {
+    parallelLock.release(slug, issueNumber);
+    drainPending(slug);
+  }
+}
+
+/** Run M19 parallel-implement for a spec-ready issue. Drops duplicate triggers. */
+export async function dispatchParallelImplement(slug: string, issueNumber: number): Promise<void> {
+  const projectForFlag = await getProject(slug);
+  const projectId = projectForFlag?.id ?? slug;
+  const useM19 = projectForFlag != null ? getUseM19Pipeline(projectId) : false;
+  logger.info('dispatchParallelImplement: pipeline flag', {
+    slug,
+    issueNumber,
+    useM19Pipeline: useM19,
+  });
+  if (!useM19) {
+    logger.info('dispatchParallelImplement: pipeline disabled, skipping', { slug, issueNumber });
+    return;
+  }
+
+  const maxParallel = await getMaxParallelAgents(slug);
+  if (parallelLock.isInFlight(slug, issueNumber)) {
+    logger.warn('dispatchParallelImplement: duplicate in-flight, dropping', { slug, issueNumber });
+    return;
+  }
+  if (!parallelLock.tryAcquire(slug, issueNumber, maxParallel)) {
+    logger.info('dispatchParallelImplement: cap full, queuing work item', {
+      slug,
+      issueNumber,
+      inFlight: parallelLock.inFlightCount(slug),
+      maxParallel,
+    });
+    enqueueWorkflow(slug, issueNumber, dispatchParallelImplement);
+    return;
+  }
+  try {
+    // Cross-package boundary: slices/ is not a workspace package (rule 28a).
+    const { runParallelImplementWorkflow } = (await import(
+      new URL('../../../../slices/parallel-implement/workflow.js', import.meta.url).href
+    )) as {
+      runParallelImplementWorkflow: (
+        item: unknown,
+        spec: unknown,
+        pipelineRunId: string,
+        source: unknown,
+        slug: string,
+        targetRepo: string,
+      ) => Promise<{ status: 'success' | 'failed'; errorReason?: string }>;
+    };
+    const source = await getSourceForSlug(slug);
+    if (source == null) {
+      logger.error('dispatchParallelImplement: no source for slug', { slug });
+      return;
+    }
+    const item = await source.getItem(issueNumber.toString());
+    if (item.state !== 'factory:spec-ready') {
+      logger.info('dispatchParallelImplement: state already moved, skipping', {
+        slug,
+        issueNumber,
+        state: item.state,
+      });
+      return;
+    }
+
+    const specRecord = getEngineeringSpec(projectId, item.id);
+    if (specRecord == null) {
+      await source.comment(
+        item.externalId,
+        'parallel-implement: no engineering spec found for this work item. Escalating to needs-human.',
+      );
+      await source.transitionState(item.externalId, 'factory:spec-ready', 'factory:needs-human');
+      return;
+    }
+
+    const parsedSpec = EngineeringSpecSchema.safeParse(specRecord.spec);
+    if (!parsedSpec.success) {
+      await source.comment(
+        item.externalId,
+        'parallel-implement: persisted engineering spec failed schema validation. Escalating to needs-human.',
+      );
+      await source.transitionState(item.externalId, 'factory:spec-ready', 'factory:needs-human');
+      return;
+    }
+
+    await source.transitionState(item.externalId, 'factory:spec-ready', 'factory:in-progress');
+    try {
+      const result = await runParallelImplementWorkflow(
+        item,
+        parsedSpec.data,
+        specRecord.pipelineRunId,
+        source,
+        projectId,
+        REPO_ROOT,
+      );
+      if (result.status === 'success') {
+        await source.transitionState(item.externalId, 'factory:in-progress', 'factory:needs-qa');
+      } else {
+        await source.transitionState(item.externalId, 'factory:in-progress', 'factory:needs-human');
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      await source.comment(
+        item.externalId,
+        `parallel-implement: workflow failed after dispatch. Escalating to needs-human.\n\nError: ${error.message}`,
+      );
+      await source.transitionState(item.externalId, 'factory:in-progress', 'factory:needs-human');
+    }
   } finally {
     parallelLock.release(slug, issueNumber);
     drainPending(slug);
@@ -768,14 +878,7 @@ export async function dispatchForLabel(
     return;
   }
   if (labelName === 'factory:spec-ready') {
-    // M19.18 will wire parallel-implement here; stub for now.
-    logger.info(
-      'dispatchForLabel: factory:spec-ready — parallel-implement not yet wired (M19.18)',
-      {
-        slug,
-        issueNumber,
-      },
-    );
+    await dispatchParallelImplement(slug, issueNumber);
     return;
   }
   if (labelName === 'factory:needs-qa') {
@@ -1051,8 +1154,7 @@ const RESUME_WORKFLOWS: Partial<Record<StateName, ResumeEntry>> = {
     dispatch: (slug: string, _issueNumber: number) => dispatchTriageBatch(slug),
   },
   'factory:dev-ready': { targetState: 'factory:dev-ready', dispatch: dispatchFixIssue },
-  // M19.18 will wire parallel-implement here; omitted from RESUME_WORKFLOWS until then
-  // to avoid re-running spec-author on an already-specced issue.
+  'factory:spec-ready': { targetState: 'factory:spec-ready', dispatch: dispatchParallelImplement },
   'factory:in-progress': { targetState: 'factory:dev-ready', dispatch: dispatchFixIssue },
   'factory:needs-qa': { targetState: 'factory:needs-qa', dispatch: dispatchQa },
   'factory:needs-review': { targetState: 'factory:needs-review', dispatch: dispatchReview },
@@ -1149,9 +1251,8 @@ export async function dispatchResumeIssue(slug: string, issueNumber: number): Pr
     return;
   }
 
-  // M19: parallel-implement (M19.18) is not yet wired. Resuming factory:in-progress
-  // via dispatchFixIssue → dispatchSpecAuthor would re-run spec-author on an already-specced
-  // item and overwrite the stored spec/pipelineRunId. Skip until M19.18 lands.
+  // M19: avoid resuming factory:in-progress through dev-ready, which would re-run
+  // spec-author and overwrite the stored spec/pipelineRunId.
   if (fromState === 'factory:in-progress') {
     const projectForFlag = await getProject(slug);
     const useM19Resume = projectForFlag != null ? getUseM19Pipeline(projectForFlag.id) : false;

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -21,6 +21,13 @@ import type { ImplementWpOutput } from '@goose-hub/skills/implement-wp/schema.js
 import type { EngineeringSpec, WorkPackage } from '@goose-hub/skills/spec-author/schema.js';
 import { runParallelImplementWorkflow } from './workflow.js';
 
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue({
+    personaId: 'goose-hub-self/developer/0',
+    codename: 'Test Developer',
+  }),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -141,6 +148,7 @@ describe('parallel-implement rollback: WP3 fails after WP1+WP2 committed', () =>
     await runParallelImplementWorkflow(
       makeWorkItem(),
       spec,
+      'pipeline-run-123',
       makeStateSource(),
       'goose-hub-self',
       '/tmp/repo',
@@ -228,6 +236,7 @@ describe('parallel-implement concurrency: 3 fake builders on disjoint files', ()
     await runParallelImplementWorkflow(
       makeWorkItem(),
       spec,
+      'pipeline-run-123',
       makeStateSource(),
       'goose-hub-self',
       '/tmp/repo',
@@ -277,9 +286,63 @@ describe('parallel-implement concurrency: 3 fake builders on disjoint files', ()
     // PR opened event emitted
     const prEvent = events.find((e) => (e.kind as string) === 'pr.opened');
     expect(prEvent).toBeDefined();
+    expect(prEvent?.payload).toMatchObject({
+      worktreePath: '/tmp/issue-wt',
+      pipelineRunId: 'pipeline-run-123',
+    });
+    expect(prEvent?.payload).toHaveProperty('devRunId');
+
+    const pipelineEvents = events.filter((e) =>
+      (e.kind as string).startsWith('parallel-implement.'),
+    );
+    expect(pipelineEvents.length).toBeGreaterThan(0);
+    expect(
+      pipelineEvents.every(
+        (e) => (e.payload as { pipelineRunId?: string }).pipelineRunId === 'pipeline-run-123',
+      ),
+    ).toBe(true);
 
     // No failures
     expect(iterations.some((i) => i.status === 'failed')).toBe(false);
+  });
+});
+
+describe('parallel-implement workflow contract: dispatcher owns state transitions', () => {
+  it('does not transition work item state internally on success', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const source = makeStateSource();
+    const { fn: appendEvent } = makeAppendEvent();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem({ state: 'factory:spec-ready' }),
+      spec,
+      'pipeline-run-456',
+      source,
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'abc123',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: () => 'ok',
+        openPRImpl: async () => ({
+          prNumber: 1,
+          prUrl: 'https://gh/pr/1',
+          branch: 'b',
+          base: 'main',
+        }),
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(source.transitionState).not.toHaveBeenCalled();
   });
 });
 
@@ -512,6 +575,7 @@ describe('dev-review e2e: P1 finding addressed in one extra turn, no second pass
     await runParallelImplementWorkflow(
       makeWorkItem({ priority: 'high' }),
       spec,
+      'pipeline-run-dev-review-1',
       makeStateSource(),
       'goose-hub-self',
       '/tmp/repo',
@@ -652,6 +716,7 @@ describe('dev-review e2e: dismissed finding captures DEV_REVIEW_DISMISSED', () =
     await runParallelImplementWorkflow(
       makeWorkItem({ priority: 'high' }),
       spec,
+      'pipeline-run-dev-review-2',
       makeStateSource(),
       'goose-hub-self',
       '/tmp/repo',
@@ -749,6 +814,7 @@ describe('dev-review e2e: perCycleMaxUsd=0 → budget-skipped, workflow continue
     await runParallelImplementWorkflow(
       makeWorkItem({ priority: 'high' }),
       spec,
+      'pipeline-run-dev-review-3',
       makeStateSource(),
       'goose-hub-self',
       '/tmp/repo',

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -48,6 +48,10 @@ export interface WpDispatchResult {
   runId: string;
 }
 
+export type ParallelImplementWorkflowResult =
+  | { status: 'success'; devRunId: string; worktreePath: string; prNumber: number; prUrl: string }
+  | { status: 'failed'; devRunId: string; errorReason: string };
+
 export interface ParallelImplementDeps {
   runtime?: AgentRuntime;
   /** Separate runtime for the dev-review Codex pass (defaults to auto-selected Codex runtime). */
@@ -74,6 +78,8 @@ export interface ParallelImplementDeps {
   runDevReviewResponseImpl?: typeof runDevReviewResponse;
   /** Override the orchestrator commit-all for dev-review-response edits (for testing). */
   commitDevReviewResponseImpl?: (worktreePath: string, msg: string) => string;
+  /** Override persona selection for tests that should not touch SQLite routing state. */
+  selectPersonaImpl?: typeof selectPersona;
 }
 
 // ─── DB helpers ───────────────────────────────────────────────────────────────
@@ -337,13 +343,21 @@ async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpBuildPha
 export async function runParallelImplementWorkflow(
   workItem: WorkItem,
   spec: EngineeringSpec,
+  pipelineRunId: string,
   stateSource: StateSource,
   projectId: string,
   targetRepo: string,
   deps: ParallelImplementDeps = {},
-): Promise<void> {
+): Promise<ParallelImplementWorkflowResult> {
   const runId = crypto.randomUUID();
-  const append = deps.appendEvent ?? ((input) => eventStore.appendEvent(input));
+  const baseAppend = deps.appendEvent ?? ((input) => eventStore.appendEvent(input));
+  const append = (input: AppendEventInput): AgentEvent => {
+    const payload =
+      input.payload != null && typeof input.payload === 'object' && !Array.isArray(input.payload)
+        ? { ...(input.payload as Record<string, unknown>), pipelineRunId }
+        : { value: input.payload, pipelineRunId };
+    return baseAppend({ ...input, payload });
+  };
   const runtime =
     deps.runtime ??
     (() => {
@@ -375,7 +389,7 @@ export async function runParallelImplementWorkflow(
     deps.commitDevReviewResponseImpl ??
     ((wt: string, msg: string) => orchestratorCommitAll(wt, msg));
 
-  const { personaId } = selectPersona(projectId, 'developer');
+  const { personaId } = (deps.selectPersonaImpl ?? selectPersona)(projectId, 'developer');
   const implementWpPrompt = readPromptWithContext('implement-wp', projectId);
   const implementWpJsonSchema = toJsonSchema(ImplementWpSchema);
 
@@ -392,12 +406,6 @@ export async function runParallelImplementWorkflow(
   let issueWorktreePath: string | undefined;
 
   try {
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:dev-ready',
-      'factory:in-progress',
-    );
-
     // Create the integration worktree (all WP commits land here).
     issueWorktreePath = createIssueFn(targetRepo, runId);
 
@@ -536,12 +544,11 @@ export async function runParallelImplementWorkflow(
             [`Failed WPs: ${stillFailed.join(', ')}`],
           ),
         );
-        await stateSource.transitionState(
-          workItem.externalId,
-          'factory:in-progress',
-          'factory:needs-human',
-        );
-        return;
+        return {
+          status: 'failed',
+          devRunId: runId,
+          errorReason: `Parallel implement exhausted ${maxRetries + 1} iterations`,
+        };
       }
     }
 
@@ -650,7 +657,13 @@ export async function runParallelImplementWorkflow(
       projectId,
       workItemId: workItem.id,
       kind: 'pr.opened',
-      payload: { prNumber: prResult.prNumber, prUrl: prResult.prUrl, branch: prResult.branch },
+      payload: {
+        prNumber: prResult.prNumber,
+        prUrl: prResult.prUrl,
+        branch: prResult.branch,
+        worktreePath: issueWorktreePath ?? '',
+        devRunId: runId,
+      },
       runId,
     });
 
@@ -664,11 +677,13 @@ export async function runParallelImplementWorkflow(
       ),
     );
 
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:in-progress',
-      'factory:needs-qa',
-    );
+    return {
+      status: 'success',
+      devRunId: runId,
+      worktreePath: issueWorktreePath ?? '',
+      prNumber: prResult.prNumber,
+      prUrl: prResult.prUrl,
+    };
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     append({
@@ -684,11 +699,7 @@ export async function runParallelImplementWorkflow(
         `Error: ${error.message}`,
       ]),
     );
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:in-progress',
-      'factory:needs-human',
-    );
+    return { status: 'failed', devRunId: runId, errorReason: error.message };
   } finally {
     cleanupWpsFn(runId, allWpIds);
     if (issueWorktreePath != null) {

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -548,6 +548,35 @@ describe('runQaWorkflow', () => {
       expect(runTests).toHaveBeenCalledWith('/wt/abc', expect.stringContaining('pnpm test'));
     });
 
+    it('uses worktreePath from the parallel-implement pr.opened payload', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: {
+            prNumber: 99,
+            prUrl: 'https://github.com/owner/repo/pull/99',
+            branch: 'factory/dev-run-123',
+            worktreePath: '/wt/parallel-abc',
+            devRunId: 'dev-run-123',
+            pipelineRunId: 'pipeline-run-123',
+          },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+      const runTests = vi.fn().mockResolvedValue(sampleTestRun);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', { runTests });
+
+      expect(runTests).toHaveBeenCalledWith('/wt/parallel-abc', expect.any(String));
+      const spec = mockRun.mock.calls[0][0] as { workspaceDir?: string };
+      expect(spec.workspaceDir).toBe('/wt/parallel-abc');
+    });
+
     it('passes testRun into the agent context and allowlists it', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();


### PR DESCRIPTION
## Summary
- Wire factory:spec-ready to the M19 parallel-implement workflow when the pipeline flag is enabled.
- Move parallel-implement state transitions into the dispatcher and carry pipelineRunId through emitted payloads.
- Align pr.opened payloads with worktreePath, devRunId, and pipelineRunId, with QA and merge-cleanup regressions covered.

## Tests
- pnpm vitest run core/state-machine/transitions.test.ts apps/server/src/shared/dispatch.test.ts slices/parallel-implement/slice.test.ts slices/qa/slice.test.ts apps/server/src/domains/issues/service.test.ts apps/server/src/domains/workflows/state-flows.test.ts
- pnpm typecheck
- pnpm exec biome check apps/server/src/shared/dispatch.ts apps/server/src/shared/dispatch.test.ts slices/parallel-implement/workflow.ts slices/parallel-implement/slice.test.ts slices/qa/slice.test.ts apps/server/src/domains/issues/service.test.ts

Closes #694