### PR TITLE
M19.23: record-decision hook and reconciliation

### DIFF
--- a/apps/server/src/domains/decisions/router.test.ts
+++ b/apps/server/src/domains/decisions/router.test.ts
@@ -1,0 +1,128 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@goose-hub/core/tool-layer/tools/record-decision.js', () => ({
+  recordDecision: vi.fn().mockReturnValue({ recorded: true, id: 'test-id' }),
+}));
+
+import { recordDecision } from '@goose-hub/core/tool-layer/tools/record-decision.js';
+import { decisionsRouter } from './router.js';
+
+describe('POST /api/decisions', () => {
+  beforeEach(() => {
+    vi.mocked(recordDecision).mockClear();
+    vi.mocked(recordDecision).mockReturnValue({ recorded: true, id: 'test-id' });
+  });
+
+  it('accepts valid body and calls recordDecision', async () => {
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runId: 'run-abc',
+        projectId: 'proj-1',
+        kind: 'IMPLEMENTATION_PLAN',
+        what: 'Add validation in handler',
+        why: 'Request body is untrusted input',
+        iteration: 0,
+        phase: 'implement',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; recorded: boolean };
+    expect(body.ok).toBe(true);
+    expect(recordDecision).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(recordDecision).mock.calls[0][0];
+    expect(call.runId).toBe('run-abc');
+    expect(call.kind).toBe('IMPLEMENTATION_PLAN');
+    expect(call.what).toBe('Add validation in handler');
+    expect(call.why).toBe('Request body is untrusted input');
+    expect(call.iteration).toBe(0);
+    expect(call.phase).toBe('implement');
+  });
+
+  it('accepts body without optional iteration/phase', async () => {
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runId: 'run-abc',
+        projectId: 'proj-1',
+        kind: 'REPO_SELECTION',
+        what: 'Selected payments-api',
+        why: 'Keyword match on payments',
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(recordDecision).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when runId is missing', async () => {
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: 'proj-1',
+        kind: 'IMPLEMENTATION_PLAN',
+        what: 'something',
+        why: 'because',
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(recordDecision).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when what is missing', async () => {
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runId: 'run-abc',
+        projectId: 'proj-1',
+        kind: 'IMPLEMENTATION_PLAN',
+        why: 'because',
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(recordDecision).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when why is missing', async () => {
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runId: 'run-abc',
+        projectId: 'proj-1',
+        kind: 'IMPLEMENTATION_PLAN',
+        what: 'something',
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(recordDecision).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with recorded=false on duplicate', async () => {
+    vi.mocked(recordDecision).mockReturnValue({ recorded: false, id: 'existing-id', reason: 'duplicate' });
+    const app = new Hono().route('/api/decisions', decisionsRouter);
+    const res = await app.request('/api/decisions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runId: 'run-abc',
+        projectId: 'proj-1',
+        kind: 'REPO_SELECTION',
+        what: 'already recorded',
+        why: 'duplicate',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; recorded: boolean };
+    expect(body.recorded).toBe(false);
+  });
+});

--- a/apps/server/src/domains/decisions/router.ts
+++ b/apps/server/src/domains/decisions/router.ts
@@ -1,0 +1,40 @@
+import { recordDecision } from '@goose-hub/core/tool-layer/tools/record-decision.js';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { parseBody } from '#shared/middleware.js';
+
+const router = new Hono();
+
+const DecisionBodySchema = z.object({
+  runId: z.string().min(1),
+  projectId: z.string().min(1),
+  kind: z.string().min(1),
+  what: z.string().min(1),
+  why: z.string().min(1),
+  iteration: z.number().int().min(0).optional(),
+  phase: z.string().optional(),
+});
+
+/**
+ * POST /api/decisions — records a structured decision captured by the
+ * decision-capture PostToolUse hook. Validates input, coerces unknown kinds
+ * to UNKNOWN (via recordDecision), returns 200 or 400 on validation error.
+ */
+router.post('/', async (c) => {
+  const body = await parseBody<Record<string, unknown>>(c);
+  if (!body.ok) return body.error;
+
+  const parsed = DecisionBodySchema.safeParse(body.data);
+  if (!parsed.success) {
+    return c.json({ error: 'validation failed', issues: parsed.error.issues }, 400);
+  }
+
+  const { runId, kind, what, why, iteration, phase } = parsed.data;
+
+  // recordDecision coerces unrecognised kinds to UNKNOWN (ADR 0018).
+  const result = recordDecision({ runId, kind, what, why, iteration, phase });
+
+  return c.json({ ok: true, id: result.id, recorded: result.recorded }, 200);
+});
+
+export { router as decisionsRouter };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,6 +2,7 @@ import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { bootstrapRouter } from './domains/bootstrap/router.js';
+import { decisionsRouter } from './domains/decisions/router.js';
 import { costsRouter } from './domains/costs/router.js';
 import { eventsRouter } from './domains/events/router.js';
 import { inboxRouter } from './domains/inbox/router.js';
@@ -41,5 +42,6 @@ app.route('/inbox', inboxRouter); // GET/POST /inbox/**
 app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events
 app.route('/webhooks', webhooksRouter); // POST /webhooks/github
+app.route('/api/decisions', decisionsRouter); // POST /api/decisions (M19.23)
 
 export { app };

--- a/core/agent-runtime/advisor.ts
+++ b/core/agent-runtime/advisor.ts
@@ -4,6 +4,7 @@ import {
 } from '@goose-hub/skills/advise-on-plan/schema.js';
 import { eventStore } from '../event-stream/store.js';
 import type { AgentRuntime } from './interface.js';
+import { reconcileDecisionSummaries } from './reconcile-decisions.js';
 import type { AgentResult } from './interface.js';
 import { OutputValidationError, invokeSkill } from './invoke-skill.js';
 
@@ -77,15 +78,13 @@ export async function adviseOnPlan(input: AdviseOnPlanInput): Promise<AdviseOnPl
   // invokeSkill already validated result.output against AdviseOnPlanSchema via outputSchema
   const parsed = AdviseOnPlanSchema.parse(result.output);
 
-  for (const summary of parsed.decisionSummaries) {
-    eventStore.appendEvent({
-      projectId: input.projectId,
-      workItemId: input.workItemId,
-      kind: 'agent.decision-summary',
-      payload: { skill: 'advise-on-plan', ...summary },
-      runId: input.runId,
-    });
-  }
+  reconcileDecisionSummaries(
+    input.runId,
+    input.projectId,
+    input.workItemId,
+    'advise-on-plan',
+    parsed.decisionSummaries,
+  );
 
   return parsed;
 }

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -9,8 +9,10 @@ import { db } from '../db/db.js';
 import { agentRuns } from '../db/schema.js';
 import { eventStore } from '../event-stream/store.js';
 import { computeAllowlist } from '../tool-layer/allowlist.js';
+import { deployDecisionCaptureHook } from '../tool-layer/decision-capture-hook.js';
 import { deployHooks } from '../tool-layer/pre-tool-use-hook.js';
 import { writeWorkspaceSandbox } from '../tool-layer/sandbox.js';
+import { getRecordDecisionTool } from '../db/repositories/project-settings.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { resolveMockOutput } from './mock-outputs.js';
@@ -123,8 +125,11 @@ export class ClaudeCliRuntime implements AgentRuntime {
     // Bootstrap workspace
     mkdirSync(workspaceDir, { recursive: true });
     writeFileSync(MCP_CONFIG_PATH, '{"mcpServers":{}}', { flag: 'w' });
-    writeWorkspaceSandbox(workspaceDir);
+    const projectId = (spec.context.projectId as string) ?? 'unknown';
+    const recordDecisionTool = getRecordDecisionTool(projectId);
+    writeWorkspaceSandbox(workspaceDir, { role: spec.role, recordDecisionTool });
     deployHooks();
+    if (recordDecisionTool) deployDecisionCaptureHook();
 
     // Emit run-started
     eventStore.appendEvent({
@@ -181,7 +186,6 @@ export class ClaudeCliRuntime implements AgentRuntime {
     // Per-run context as the user message
     argv.push(contextXml);
 
-    const projectId = (spec.context.projectId as string) ?? 'unknown';
     const workItemId = (spec.context.workItemId as string) ?? null;
     const { personaId } = spec;
 
@@ -214,9 +218,13 @@ export class ClaudeCliRuntime implements AgentRuntime {
             }),
         FACTORY_RUN_ALLOWLIST: allowedTools.join(','),
         FACTORY_RUN_ID: runId,
+        FACTORY_PROJECT_ID: projectId,
         // Where the pre-tool-use-hook posts tool-call audit events (#209).
         // Falls back to 3001 if FACTORY_SERVER_PORT isn't set in the parent.
         FACTORY_SERVER_PORT: process.env.FACTORY_SERVER_PORT ?? '3001',
+        // iteration/phase for the decision-capture hook (M19.23).
+        FACTORY_ITERATION: String(spec.iteration ?? 0),
+        FACTORY_PHASE: spec.phase ?? '',
       };
       if (process.env.ANTHROPIC_API_KEY != null) {
         minimalEnv.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -7,8 +7,10 @@ import { recordCost } from '../cost/repository.js';
 import { stageForSkill } from '../cost/skill-stage.js';
 import { eventStore } from '../event-stream/store.js';
 import { computeAllowlist } from '../tool-layer/allowlist.js';
+import { deployDecisionCaptureHook } from '../tool-layer/decision-capture-hook.js';
 import { deployHooks } from '../tool-layer/pre-tool-use-hook.js';
 import { writeWorkspaceSandbox } from '../tool-layer/sandbox.js';
+import { getRecordDecisionTool } from '../db/repositories/project-settings.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { resolveMockOutput } from './mock-outputs.js';
@@ -270,10 +272,11 @@ export class CodexCliRuntime implements AgentRuntime {
 
     mkdirSync(workspaceDir, { recursive: true });
     writeFileSync(MCP_CONFIG_PATH, '{"mcpServers":{}}', { flag: 'w' });
-    writeWorkspaceSandbox(workspaceDir);
-    deployHooks();
-
     const projectId = (spec.context.projectId as string) ?? 'unknown';
+    const recordDecisionTool = getRecordDecisionTool(projectId);
+    writeWorkspaceSandbox(workspaceDir, { role: spec.role, recordDecisionTool });
+    deployHooks();
+    if (recordDecisionTool) deployDecisionCaptureHook();
     const workItemId = (spec.context.workItemId as string) ?? null;
     const { personaId } = spec;
 
@@ -328,7 +331,10 @@ export class CodexCliRuntime implements AgentRuntime {
             }),
         FACTORY_RUN_ALLOWLIST: allowedTools.join(','),
         FACTORY_RUN_ID: runId,
+        FACTORY_PROJECT_ID: projectId,
         FACTORY_SERVER_PORT: process.env.FACTORY_SERVER_PORT ?? '3001',
+        FACTORY_ITERATION: String(spec.iteration ?? 0),
+        FACTORY_PHASE: spec.phase ?? '',
       };
       // OPENAI_API_KEY passthrough for users who prefer key-based auth over OAuth.
       if (process.env.OPENAI_API_KEY != null) {

--- a/core/agent-runtime/dev-review-advisor.ts
+++ b/core/agent-runtime/dev-review-advisor.ts
@@ -12,6 +12,7 @@ import devReviewConfig from '@goose-hub/skills/dev-review/skill.config.js';
 import { readProjectDevReviewSettings } from '../db/repositories/project-dev-review-settings.js';
 import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
 import { eventStore } from '../event-stream/store.js';
+import { reconcileDecisionSummaries } from './reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { WorkItem } from '../state-source/interface.js';
 import type { AgentConfig } from '../types.js';
@@ -178,15 +179,13 @@ export async function runDevReview(input: RunDevReviewInput): Promise<DevReviewO
     throw new Error('dev-review output validation failed');
   }
 
-  for (const summary of parsed.data.decisionSummaries) {
-    eventStore.appendEvent({
-      projectId: input.projectId,
-      workItemId: input.workItemId,
-      kind: 'agent.decision-summary',
-      payload: { skill: 'dev-review', ...summary },
-      runId: devReviewRunId,
-    });
-  }
+  reconcileDecisionSummaries(
+    devReviewRunId,
+    input.projectId,
+    input.workItemId,
+    'dev-review',
+    parsed.data.decisionSummaries,
+  );
 
   input.appendEvent({
     projectId: input.projectId,
@@ -281,25 +280,23 @@ export async function runDevReviewResponse(
     throw new Error('dev-review-response output validation failed');
   }
 
-  // Emit per-finding decision summaries.
-  for (const disp of parsed.data.findingDispositions) {
-    const kind = disp.disposition === 'addressed' ? 'DEV_REVIEW_ADDRESSED' : 'DEV_REVIEW_DISMISSED';
-    eventStore.appendEvent({
-      projectId: input.projectId,
-      workItemId: input.workItemId,
-      kind: 'agent.decision-summary',
-      payload: {
-        skill: 'dev-review-response',
-        kind,
-        summary:
-          disp.disposition === 'addressed'
-            ? `Addressed ${disp.severity} finding at ${disp.findingRef}`
-            : `Dismissed ${disp.severity} finding at ${disp.findingRef}: ${disp.reason ?? '(no reason)'}`,
-        evidence: disp.findingRef,
-      },
-      runId: responseRunId,
-    });
-  }
+  // Synthesize per-finding decision summaries from disposition output.
+  // Passed as parsedSummaries fallback; DB rows win if hook captured them.
+  const dispositionSummaries = parsed.data.findingDispositions.map((disp) => ({
+    kind: (disp.disposition === 'addressed' ? 'DEV_REVIEW_ADDRESSED' : 'DEV_REVIEW_DISMISSED') as import('./decision-types.js').DecisionKind,
+    summary:
+      disp.disposition === 'addressed'
+        ? `Addressed ${disp.severity} finding at ${disp.findingRef}`
+        : `Dismissed ${disp.severity} finding at ${disp.findingRef}: ${disp.reason ?? '(no reason)'}`,
+    evidence: disp.findingRef,
+  }));
+  reconcileDecisionSummaries(
+    responseRunId,
+    input.projectId,
+    input.workItemId,
+    'dev-review-response',
+    dispositionSummaries,
+  );
 
   input.appendEvent({
     projectId: input.projectId,

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -62,6 +62,10 @@ export type AgentSpec<R extends RoleSpec = RoleSpec> = {
    * repo node_modules, not a worktree).
    */
   mcpConfigPath?: string;
+  /** Current iteration within a multi-pass workflow (0-indexed). Written as FACTORY_ITERATION env var. */
+  iteration?: number;
+  /** Workflow phase label (e.g. 'plan', 'implement'). Written as FACTORY_PHASE env var. */
+  phase?: string;
 };
 
 export interface AgentResult {

--- a/core/agent-runtime/reconcile-decisions.test.ts
+++ b/core/agent-runtime/reconcile-decisions.test.ts
@@ -11,7 +11,7 @@ vi.mock('../tool-layer/tools/record-decision.js', () => ({
 
 import { eventStore } from '../event-stream/store.js';
 import { readRunDecisions } from '../tool-layer/tools/record-decision.js';
-import { reconcileDecisionSummaries } from './reconcile-decisions.js';
+import { _clearEmittedIdsForTest, reconcileDecisionSummaries } from './reconcile-decisions.js';
 
 const appendEvent = vi.mocked(eventStore.appendEvent);
 const mockReadRunDecisions = vi.mocked(readRunDecisions);
@@ -20,6 +20,7 @@ beforeEach(() => {
   appendEvent.mockClear();
   mockReadRunDecisions.mockReset();
   mockReadRunDecisions.mockReturnValue([]);
+  _clearEmittedIdsForTest();
 });
 
 describe('reconcileDecisionSummaries', () => {
@@ -65,7 +66,7 @@ describe('reconcileDecisionSummaries', () => {
   describe('DB-preferred when rows exist', () => {
     it('uses DB rows when present, ignoring parsedSummaries', () => {
       const dbRows = [
-        { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'from DB', evidence: 'hook-captured' },
+        { id: 'row-1', kind: 'IMPLEMENTATION_PLAN' as const, summary: 'from DB', evidence: 'hook-captured' },
       ];
       mockReadRunDecisions.mockReturnValue(dbRows);
       const parsedSummaries = [
@@ -80,7 +81,7 @@ describe('reconcileDecisionSummaries', () => {
     });
 
     it('does NOT emit schema-field summaries when DB rows exist (no double-emission)', () => {
-      const dbRows = [{ kind: 'IMPLEMENTATION_PLAN' as const, summary: 'DB row' }];
+      const dbRows = [{ id: 'row-1', kind: 'IMPLEMENTATION_PLAN' as const, summary: 'DB row' }];
       mockReadRunDecisions.mockReturnValue(dbRows);
       const parsedSummaries = [
         { kind: 'REPO_SELECTION' as const, summary: 'schema-field summary' },
@@ -93,6 +94,35 @@ describe('reconcileDecisionSummaries', () => {
       expect(appendEvent).toHaveBeenCalledTimes(1);
       const emitted = appendEvent.mock.calls[0][0];
       expect(emitted.payload.summary).toBe('DB row');
+    });
+
+    it('does not re-emit DB rows already emitted in a prior reconcile call for the same runId', () => {
+      // Simulates grill-and-prd.ts: shared runId, 3 sequential reconcile calls.
+      // First call (skill='grill-me'): rows r1, r2.
+      const grillRows = [
+        { id: 'r1', kind: 'IMPLEMENTATION_PLAN' as const, summary: 'grill decision 1' },
+        { id: 'r2', kind: 'REPO_SELECTION' as const, summary: 'grill decision 2' },
+      ];
+      mockReadRunDecisions.mockReturnValue(grillRows);
+      reconcileDecisionSummaries(runId, projectId, workItemId, 'grill-me', []);
+
+      expect(appendEvent).toHaveBeenCalledTimes(2);
+      appendEvent.mockClear();
+
+      // Second call (skill='write-prd'): rows r1, r2, r3 (r1+r2 already emitted).
+      const prdRows = [
+        { id: 'r1', kind: 'IMPLEMENTATION_PLAN' as const, summary: 'grill decision 1' },
+        { id: 'r2', kind: 'REPO_SELECTION' as const, summary: 'grill decision 2' },
+        { id: 'r3', kind: 'INSIGHT' as const, summary: 'prd decision' },
+      ];
+      mockReadRunDecisions.mockReturnValue(prdRows);
+      reconcileDecisionSummaries(runId, projectId, workItemId, 'write-prd', []);
+
+      // Only r3 is new — r1 and r2 must not be re-emitted.
+      expect(appendEvent).toHaveBeenCalledTimes(1);
+      const emitted = appendEvent.mock.calls[0][0];
+      expect(emitted.payload.summary).toBe('prd decision');
+      expect(emitted.payload.skill).toBe('write-prd');
     });
   });
 

--- a/core/agent-runtime/reconcile-decisions.test.ts
+++ b/core/agent-runtime/reconcile-decisions.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the event store and readRunDecisions before importing the module under test.
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: { appendEvent: vi.fn().mockReturnValue({ id: 1 }) },
+}));
+
+vi.mock('../tool-layer/tools/record-decision.js', () => ({
+  readRunDecisions: vi.fn().mockReturnValue([]),
+}));
+
+import { eventStore } from '../event-stream/store.js';
+import { readRunDecisions } from '../tool-layer/tools/record-decision.js';
+import { reconcileDecisionSummaries } from './reconcile-decisions.js';
+
+const appendEvent = vi.mocked(eventStore.appendEvent);
+const mockReadRunDecisions = vi.mocked(readRunDecisions);
+
+beforeEach(() => {
+  appendEvent.mockClear();
+  mockReadRunDecisions.mockReset();
+  mockReadRunDecisions.mockReturnValue([]);
+});
+
+describe('reconcileDecisionSummaries', () => {
+  const runId = 'run-test-1';
+  const projectId = 'proj-1';
+  const workItemId = 'github:owner/repo#42';
+  const skill = 'implement';
+
+  describe('schema-field fallback (DB empty)', () => {
+    it('emits schema-field summaries when no DB rows exist', () => {
+      mockReadRunDecisions.mockReturnValue([]);
+      const parsedSummaries = [
+        { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'Added auth check', evidence: 'src/api.ts:42' },
+        { kind: 'REPO_SELECTION' as const, summary: 'Using payments-api' },
+      ];
+
+      reconcileDecisionSummaries(runId, projectId, workItemId, skill, parsedSummaries);
+
+      expect(appendEvent).toHaveBeenCalledTimes(2);
+      expect(appendEvent).toHaveBeenCalledWith({
+        projectId,
+        workItemId,
+        runId,
+        kind: 'agent.decision-summary',
+        payload: { skill, ...parsedSummaries[0] },
+      });
+      expect(appendEvent).toHaveBeenCalledWith({
+        projectId,
+        workItemId,
+        runId,
+        kind: 'agent.decision-summary',
+        payload: { skill, ...parsedSummaries[1] },
+      });
+    });
+
+    it('emits nothing when DB empty and parsedSummaries empty', () => {
+      mockReadRunDecisions.mockReturnValue([]);
+      reconcileDecisionSummaries(runId, projectId, workItemId, skill, []);
+      expect(appendEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DB-preferred when rows exist', () => {
+    it('uses DB rows when present, ignoring parsedSummaries', () => {
+      const dbRows = [
+        { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'from DB', evidence: 'hook-captured' },
+      ];
+      mockReadRunDecisions.mockReturnValue(dbRows);
+      const parsedSummaries = [
+        { kind: 'REPO_SELECTION' as const, summary: 'from schema field' },
+      ];
+
+      reconcileDecisionSummaries(runId, projectId, workItemId, skill, parsedSummaries);
+
+      expect(appendEvent).toHaveBeenCalledTimes(1);
+      const emitted = appendEvent.mock.calls[0][0];
+      expect(emitted.payload).toMatchObject({ skill, summary: 'from DB' });
+    });
+
+    it('does NOT emit schema-field summaries when DB rows exist (no double-emission)', () => {
+      const dbRows = [{ kind: 'IMPLEMENTATION_PLAN' as const, summary: 'DB row' }];
+      mockReadRunDecisions.mockReturnValue(dbRows);
+      const parsedSummaries = [
+        { kind: 'REPO_SELECTION' as const, summary: 'schema-field summary' },
+        { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'another schema-field' },
+      ];
+
+      reconcileDecisionSummaries(runId, projectId, workItemId, skill, parsedSummaries);
+
+      // Only the 1 DB row emitted, not the 2 parsed summaries.
+      expect(appendEvent).toHaveBeenCalledTimes(1);
+      const emitted = appendEvent.mock.calls[0][0];
+      expect(emitted.payload.summary).toBe('DB row');
+    });
+  });
+
+  describe('event shape', () => {
+    it('includes skill in payload', () => {
+      mockReadRunDecisions.mockReturnValue([]);
+      reconcileDecisionSummaries(runId, projectId, workItemId, 'qa', [
+        { kind: 'FUNCTIONAL_CHECK' as const, summary: 'all tests pass' },
+      ]);
+      const emitted = appendEvent.mock.calls[0][0];
+      expect(emitted.payload.skill).toBe('qa');
+    });
+
+    it('sets kind=agent.decision-summary on the event', () => {
+      mockReadRunDecisions.mockReturnValue([]);
+      reconcileDecisionSummaries(runId, projectId, null, skill, [
+        { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'test' },
+      ]);
+      const emitted = appendEvent.mock.calls[0][0];
+      expect(emitted.kind).toBe('agent.decision-summary');
+    });
+
+    it('accepts null workItemId', () => {
+      mockReadRunDecisions.mockReturnValue([]);
+      expect(() =>
+        reconcileDecisionSummaries(runId, projectId, null, skill, [
+          { kind: 'IMPLEMENTATION_PLAN' as const, summary: 'test' },
+        ]),
+      ).not.toThrow();
+      expect(appendEvent.mock.calls[0][0].workItemId).toBeNull();
+    });
+  });
+});

--- a/core/agent-runtime/reconcile-decisions.ts
+++ b/core/agent-runtime/reconcile-decisions.ts
@@ -3,6 +3,19 @@ import { eventStore } from '../event-stream/store.js';
 import type { DecisionSummary } from './interface.js';
 
 /**
+ * Tracks DB decision row IDs already emitted in this process. Prevents
+ * double-emission when the same runId spans multiple reconcile calls
+ * (e.g. grill-and-prd.ts calls this three times with a shared runId).
+ * Each new call emits only rows not yet in this set.
+ */
+const emittedDecisionIds = new Set<string>();
+
+/** Clears the emitted-ID set. Call in test beforeEach to isolate tests. */
+export function _clearEmittedIdsForTest(): void {
+  emittedDecisionIds.clear();
+}
+
+/**
  * Reconciles and emits agent.decision-summary events after a skill's parsed output
  * is available. Implements the DB-preferred, schema-field fallback strategy:
  *
@@ -11,6 +24,8 @@ import type { DecisionSummary } from './interface.js';
  *   summaries from parsed output are dropped to avoid double-emission.
  * - When no DB rows exist (flag off, hook failed, or holdout role excluded from hook),
  *   fall back to the schema-field summaries from the parsed skill output.
+ * - Each DB row ID is tracked; rows already emitted by a prior call for the same runId
+ *   are skipped, so multi-skill workflows sharing a runId do not duplicate events.
  *
  * Must be called in workflows post-parse, NOT in the runtime layer. The runtime has
  * no knowledge of per-skill decisionSummaries fields.
@@ -29,15 +44,30 @@ export function reconcileDecisionSummaries(
   parsedSummaries: DecisionSummary[],
 ): void {
   const dbRows = readRunDecisions(runId);
-  const sourceForEmission = dbRows.length > 0 ? dbRows : parsedSummaries;
 
-  for (const s of sourceForEmission) {
-    eventStore.appendEvent({
-      projectId,
-      workItemId,
-      runId,
-      kind: 'agent.decision-summary',
-      payload: { skill, ...s },
-    });
+  if (dbRows.length > 0) {
+    // DB-preferred: emit only rows not yet emitted in a prior reconcile call.
+    for (const r of dbRows) {
+      if (emittedDecisionIds.has(r.id)) continue;
+      emittedDecisionIds.add(r.id);
+      eventStore.appendEvent({
+        projectId,
+        workItemId,
+        runId,
+        kind: 'agent.decision-summary',
+        payload: { skill, kind: r.kind, summary: r.summary, ...(r.evidence ? { evidence: r.evidence } : {}) },
+      });
+    }
+  } else {
+    // Fallback: no DB rows → emit schema-field summaries from parsed output.
+    for (const s of parsedSummaries) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId,
+        runId,
+        kind: 'agent.decision-summary',
+        payload: { skill, ...s },
+      });
+    }
   }
 }

--- a/core/agent-runtime/reconcile-decisions.ts
+++ b/core/agent-runtime/reconcile-decisions.ts
@@ -1,0 +1,43 @@
+import { readRunDecisions } from '../tool-layer/tools/record-decision.js';
+import { eventStore } from '../event-stream/store.js';
+import type { DecisionSummary } from './interface.js';
+
+/**
+ * Reconciles and emits agent.decision-summary events after a skill's parsed output
+ * is available. Implements the DB-preferred, schema-field fallback strategy:
+ *
+ * - When hook-captured rows exist for `runId` (experimental.recordDecisionTool was on
+ *   and the decision-capture hook fired), those rows are authoritative. Schema-field
+ *   summaries from parsed output are dropped to avoid double-emission.
+ * - When no DB rows exist (flag off, hook failed, or holdout role excluded from hook),
+ *   fall back to the schema-field summaries from the parsed skill output.
+ *
+ * Must be called in workflows post-parse, NOT in the runtime layer. The runtime has
+ * no knowledge of per-skill decisionSummaries fields.
+ *
+ * @param runId           - Agent run ID (ULID/UUID) used as the DB key.
+ * @param projectId       - Target project ID for event routing.
+ * @param workItemId      - Work item ID for event routing.
+ * @param skill           - Skill name, included in the event payload.
+ * @param parsedSummaries - Decision summaries extracted from validated skill output.
+ */
+export function reconcileDecisionSummaries(
+  runId: string,
+  projectId: string,
+  workItemId: string | null,
+  skill: string,
+  parsedSummaries: DecisionSummary[],
+): void {
+  const dbRows = readRunDecisions(runId);
+  const sourceForEmission = dbRows.length > 0 ? dbRows : parsedSummaries;
+
+  for (const s of sourceForEmission) {
+    eventStore.appendEvent({
+      projectId,
+      workItemId,
+      runId,
+      kind: 'agent.decision-summary',
+      payload: { skill, ...s },
+    });
+  }
+}

--- a/core/db/migrations/0020_record_decision_tool.sql
+++ b/core/db/migrations/0020_record_decision_tool.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `project_settings` ADD `record_decision_tool` integer;

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1747008000000,
       "tag": "0019_project_review_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1747094400000,
+      "tag": "0020_record_decision_tool",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/repositories/project-settings.ts
+++ b/core/db/repositories/project-settings.ts
@@ -15,6 +15,7 @@ export type GlobalBudgetPatch = {
   maxRetries?: number | null;
   perBashCommandMaxSeconds?: number | null;
   useM19Pipeline?: number | null;
+  recordDecisionTool?: number | null;
 };
 
 export type SkillBudgetPatch = {
@@ -50,6 +51,22 @@ export function getUseM19Pipeline(projectId: string): boolean {
 
 export function setUseM19Pipeline(projectId: string, enabled: boolean, by: string): void {
   writeProjectSettings(projectId, { useM19Pipeline: enabled ? 1 : 0 }, by);
+}
+
+export function deriveRecordDecisionTool(row: ProjectSettingsRow | null): boolean {
+  return row?.recordDecisionTool === 1;
+}
+
+export function getRecordDecisionTool(projectId: string): boolean {
+  try {
+    return deriveRecordDecisionTool(readProjectSettings(projectId));
+  } catch (err) {
+    logger.warn('getRecordDecisionTool: read failed, defaulting to false', {
+      projectId,
+      error: String(err),
+    });
+    return false;
+  }
 }
 
 export function readProjectSkillSettings(projectId: string): Map<string, ProjectSkillSettingsRow> {

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -267,6 +267,8 @@ export const projectSettings = sqliteTable('project_settings', {
   maxRetries: integer('max_retries'),
   perBashCommandMaxSeconds: integer('per_bash_command_max_seconds'),
   useM19Pipeline: integer('use_m19_pipeline'),
+  /** experimental.recordDecisionTool — gates decision-capture hook installation. Default false (0). */
+  recordDecisionTool: integer('record_decision_tool'),
   updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   updatedBy: text('updated_by'),
 });

--- a/core/tool-layer/decision-capture-hook.ts
+++ b/core/tool-layer/decision-capture-hook.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const HOOKS_DIR = join(homedir(), '.factory', 'hooks');
+
+/**
+ * PostToolUse hook that captures [decision] KIND: what — why markers from the
+ * agent transcript and POSTs them to /api/decisions for DB persistence.
+ * Generated once to ~/.factory/hooks/ and referenced conditionally from workspace
+ * settings.local.json (excluded for holdout roles). Gated on experimental.recordDecisionTool.
+ *
+ * Heuristic what/why split: splits on " — " (em-dash with spaces), " (because ",
+ * or ". Why: ". If no separator found, what = full text, why = "(not specified)".
+ * recordDecision() requires both fields.
+ */
+const HOOK_SCRIPT = `#!/usr/bin/env node
+/**
+ * Factory decision-capture PostToolUse hook.
+ * Deployed by AgentRuntime to ~/.factory/hooks/decision-capture.js
+ * Reads [decision] KIND: what — why markers and POSTs to /api/decisions.
+ */
+import { existsSync, mkdirSync, openSync, readSync, closeSync, statSync, writeFileSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const runId = process.env.FACTORY_RUN_ID ?? 'unknown';
+const projectId = process.env.FACTORY_PROJECT_ID ?? 'unknown';
+const serverPort = process.env.FACTORY_SERVER_PORT ?? '3001';
+const iteration = parseInt(process.env.FACTORY_ITERATION ?? '0', 10) || 0;
+const phase = process.env.FACTORY_PHASE ?? '';
+const CURSOR_DIR = join(homedir(), '.factory', 'hooks', 'state');
+
+function splitWhatWhy(text) {
+  // Try em-dash separator first (canonical per issue spec)
+  const emDash = text.indexOf(' \\u2014 ');
+  if (emDash !== -1) return { what: text.slice(0, emDash).trim(), why: text.slice(emDash + 3).trim() };
+  // Try " (because "
+  const because = text.indexOf(' (because ');
+  if (because !== -1) return { what: text.slice(0, because).trim(), why: text.slice(because + 10).trim() };
+  // Try ". Why: "
+  const whyColon = text.indexOf('. Why: ');
+  if (whyColon !== -1) return { what: text.slice(0, whyColon).trim(), why: text.slice(whyColon + 7).trim() };
+  return { what: text.trim(), why: '(not specified)' };
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  let call;
+  try { call = JSON.parse(input); } catch { process.exit(0); }
+
+  const transcriptPath = call?.transcript_path;
+  if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) process.exit(0);
+
+  mkdirSync(CURSOR_DIR, { recursive: true });
+  const cursorFile = join(CURSOR_DIR, \`dc-\${runId}.cursor\`);
+  let lastOffset = 0;
+  if (existsSync(cursorFile)) {
+    try { lastOffset = parseInt(readFileSync(cursorFile, 'utf8').trim(), 10) || 0; } catch {}
+  }
+
+  let newContent = '';
+  try {
+    const stat = statSync(transcriptPath);
+    const fileSize = stat.size;
+    if (fileSize <= lastOffset) process.exit(0);
+    const fd = openSync(transcriptPath, 'r');
+    const buffer = Buffer.allocUnsafe(fileSize - lastOffset);
+    readSync(fd, buffer, 0, fileSize - lastOffset, lastOffset);
+    closeSync(fd);
+    newContent = buffer.toString('utf8');
+    writeFileSync(cursorFile, String(fileSize), 'utf8');
+  } catch { process.exit(0); }
+
+  // Match typed decision markers: [decision] KIND: <text>
+  const DECISION_RE = /^\\[decision\\]\\s+([A-Z_]+):\\s*(.+)$/gm;
+
+  const markers = [];
+  let m;
+  while ((m = DECISION_RE.exec(newContent)) !== null) {
+    markers.push({ kind: m[1].trim(), text: m[2].trim() });
+  }
+
+  if (markers.length === 0) process.exit(0);
+
+  for (const { kind, text } of markers) {
+    const { what, why } = splitWhatWhy(text);
+    try {
+      await fetch(\`http://localhost:\${serverPort}/api/decisions\`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runId, projectId, kind, what, why, iteration, phase }),
+        signal: AbortSignal.timeout(500),
+      }).catch(() => {});
+    } catch { /* best-effort */ }
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));
+`;
+
+/** Writes the decision-capture PostToolUse hook to ~/.factory/hooks/. Idempotent. */
+export function deployDecisionCaptureHook(): void {
+  mkdirSync(HOOKS_DIR, { recursive: true });
+  writeFileSync(join(HOOKS_DIR, 'decision-capture.js'), HOOK_SCRIPT, {
+    encoding: 'utf8',
+    mode: 0o755,
+  });
+}
+
+export const DECISION_CAPTURE_HOOK_PATH = join(HOOKS_DIR, 'decision-capture.js');

--- a/core/tool-layer/sandbox.ts
+++ b/core/tool-layer/sandbox.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DECISION_CAPTURE_HOOK_PATH } from './decision-capture-hook.js';
 import { POST_HOOK_PATH } from './post-tool-use-hook.js';
 import { HOOK_PATH } from './pre-tool-use-hook.js';
 
@@ -25,7 +26,27 @@ export const REQUIRE_SPEC_HOOK_PATH = join(REPO_ROOT, 'hooks', 'require-spec.sh'
 export const STOP_VERIFY_AC_HOOK_PATH = join(REPO_ROOT, 'hooks', 'stop-verify-ac.sh');
 export const WP_FILE_GUARD_HOOK_PATH = join(REPO_ROOT, 'hooks', 'wp-file-guard.sh');
 
-function buildSettings(extraDenylist: string[] = [], extraPreToolUseHooks: object[] = []) {
+// Roles that must NOT receive the decision-capture hook. Broader than HOLDOUT_ROLES
+// (which is qa + reviewer) — code-quality-audit is also excluded because it functions
+// like a holdout: its output must not be influenced by live-marker feedback loops.
+export const DECISION_CAPTURE_EXCLUDED_ROLES = new Set([
+  'qa',
+  'reviewer',
+  'code-quality-audit',
+]);
+
+export interface SandboxOptions {
+  /** Role of the spawned agent. Used to determine if decision-capture hook is installed. */
+  role?: string;
+  /** When true, install the decision-capture PostToolUse hook (experimental.recordDecisionTool). */
+  recordDecisionTool?: boolean;
+}
+
+function buildSettings(
+  extraDenylist: string[] = [],
+  extraPreToolUseHooks: object[] = [],
+  extraPostToolUseHooks: object[] = [],
+) {
   return JSON.stringify(
     {
       permissions: { deny: [...DENYLIST, ...extraDenylist] },
@@ -51,6 +72,7 @@ function buildSettings(extraDenylist: string[] = [], extraPreToolUseHooks: objec
             matcher: '.*',
             hooks: [{ type: 'command', command: `"${process.execPath}" "${POST_HOOK_PATH}"` }],
           },
+          ...extraPostToolUseHooks,
         ],
         Stop: [
           {
@@ -66,10 +88,22 @@ function buildSettings(extraDenylist: string[] = [], extraPreToolUseHooks: objec
 }
 
 /** Writes workspace .claude/settings.local.json with deny rules and hook registrations. Idempotent. */
-export function writeWorkspaceSandbox(workspacePath: string): void {
+export function writeWorkspaceSandbox(workspacePath: string, opts: SandboxOptions = {}): void {
+  const extraPostToolUseHooks: object[] = [];
+  // Decision-capture hook: install only when flag is on AND role is not excluded.
+  if (opts.recordDecisionTool && !DECISION_CAPTURE_EXCLUDED_ROLES.has(opts.role ?? '')) {
+    extraPostToolUseHooks.push({
+      matcher: '.*',
+      hooks: [{ type: 'command', command: `"${process.execPath}" "${DECISION_CAPTURE_HOOK_PATH}"` }],
+    });
+  }
   const claudeDir = join(workspacePath, '.claude');
   mkdirSync(claudeDir, { recursive: true });
-  writeFileSync(join(claudeDir, 'settings.local.json'), buildSettings(), 'utf8');
+  writeFileSync(
+    join(claudeDir, 'settings.local.json'),
+    buildSettings([], [], extraPostToolUseHooks),
+    'utf8',
+  );
 }
 
 /**
@@ -83,11 +117,13 @@ export function writeWorkspaceSandbox(workspacePath: string): void {
  * @param workspacePath - Absolute path to the WP scratch worktree.
  * @param filesOwned    - Workspace-relative paths owned by this WP.
  * @param wpId          - Work Package identifier (for violation messages).
+ * @param opts          - Optional sandbox options (role, recordDecisionTool flag).
  */
 export function writeWpBuilderSandbox(
   workspacePath: string,
   _filesOwned: string[],
   _wpId: string,
+  opts: SandboxOptions = {},
 ): void {
   const extraPreToolUseHooks = [
     {
@@ -95,11 +131,18 @@ export function writeWpBuilderSandbox(
       hooks: [{ type: 'command', command: `bash "${WP_FILE_GUARD_HOOK_PATH}"` }],
     },
   ];
+  const extraPostToolUseHooks: object[] = [];
+  if (opts.recordDecisionTool && !DECISION_CAPTURE_EXCLUDED_ROLES.has(opts.role ?? '')) {
+    extraPostToolUseHooks.push({
+      matcher: '.*',
+      hooks: [{ type: 'command', command: `"${process.execPath}" "${DECISION_CAPTURE_HOOK_PATH}"` }],
+    });
+  }
   const claudeDir = join(workspacePath, '.claude');
   mkdirSync(claudeDir, { recursive: true });
   writeFileSync(
     join(claudeDir, 'settings.local.json'),
-    buildSettings(WP_BUILDER_GIT_DENYLIST, extraPreToolUseHooks),
+    buildSettings(WP_BUILDER_GIT_DENYLIST, extraPreToolUseHooks, extraPostToolUseHooks),
     'utf8',
   );
 }

--- a/core/tool-layer/slice.test.ts
+++ b/core/tool-layer/slice.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { TOOL_BUNDLES, computeAllowlist } from './allowlist.js';
-import { writeWorkspaceSandbox } from './sandbox.js';
+import { DECISION_CAPTURE_EXCLUDED_ROLES, writeWorkspaceSandbox } from './sandbox.js';
 import { redactSecrets } from './secret-redaction.js';
 
 // ─── secret-redaction ────────────────────────────────────────────────────────
@@ -209,5 +209,77 @@ describe('writeWorkspaceSandbox', () => {
     } finally {
       rmSync(dir, { recursive: true });
     }
+  });
+});
+
+// ─── decision-capture hook (M19.23) ──────────────────────────────────────────
+
+describe('decision-capture hook installation', () => {
+  function readSettings(dir: string) {
+    const raw = readFileSync(join(dir, '.claude', 'settings.local.json'), 'utf8');
+    return JSON.parse(raw) as { hooks?: { PostToolUse?: Array<{ hooks: Array<{ command: string }> }> } };
+  }
+
+  function hasDecisionCaptureHook(cfg: ReturnType<typeof readSettings>): boolean {
+    return (cfg.hooks?.PostToolUse ?? []).some((entry) =>
+      entry.hooks?.some((h) => h.command?.includes('decision-capture.js')),
+    );
+  }
+
+  it('installs decision-capture hook when flag=true and role is non-holdout', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sandbox-dc-on-'));
+    try {
+      writeWorkspaceSandbox(dir, { role: 'developer', recordDecisionTool: true });
+      expect(hasDecisionCaptureHook(readSettings(dir))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('does NOT install decision-capture hook when flag=false', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sandbox-dc-off-'));
+    try {
+      writeWorkspaceSandbox(dir, { role: 'developer', recordDecisionTool: false });
+      expect(hasDecisionCaptureHook(readSettings(dir))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('does NOT install decision-capture hook for qa role even when flag=true', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sandbox-dc-qa-'));
+    try {
+      writeWorkspaceSandbox(dir, { role: 'qa', recordDecisionTool: true });
+      expect(hasDecisionCaptureHook(readSettings(dir))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('does NOT install decision-capture hook for reviewer role even when flag=true', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sandbox-dc-reviewer-'));
+    try {
+      writeWorkspaceSandbox(dir, { role: 'reviewer', recordDecisionTool: true });
+      expect(hasDecisionCaptureHook(readSettings(dir))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('does NOT install decision-capture hook for code-quality-audit role even when flag=true', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sandbox-dc-audit-'));
+    try {
+      writeWorkspaceSandbox(dir, { role: 'code-quality-audit', recordDecisionTool: true });
+      expect(hasDecisionCaptureHook(readSettings(dir))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('DECISION_CAPTURE_EXCLUDED_ROLES contains qa, reviewer, code-quality-audit', () => {
+    expect(DECISION_CAPTURE_EXCLUDED_ROLES.has('qa')).toBe(true);
+    expect(DECISION_CAPTURE_EXCLUDED_ROLES.has('reviewer')).toBe(true);
+    expect(DECISION_CAPTURE_EXCLUDED_ROLES.has('code-quality-audit')).toBe(true);
+    expect(DECISION_CAPTURE_EXCLUDED_ROLES.has('developer')).toBe(false);
   });
 });

--- a/core/tool-layer/tools/record-decision.ts
+++ b/core/tool-layer/tools/record-decision.ts
@@ -60,13 +60,16 @@ export function recordDecision(params: RecordDecisionParams): RecordDecisionResu
 
 /**
  * Reads all decision records for a run from agent_decisions in insertion order.
+ * Returns `id` so callers can deduplicate across multiple reconcile calls for
+ * the same runId (e.g. multi-skill workflows sharing one runId).
  * Used by reconciliation at run end when the feature flag is on.
  */
 export function readRunDecisions(
   runId: string,
-): Array<{ kind: DecisionKind; summary: string; evidence?: string }> {
+): Array<{ id: string; kind: DecisionKind; summary: string; evidence?: string }> {
   const rows = db
     .select({
+      id: agentDecisions.id,
       kind: agentDecisions.kind,
       what: agentDecisions.what,
       why: agentDecisions.why,
@@ -77,6 +80,7 @@ export function readRunDecisions(
     .all();
 
   return rows.map((r) => ({
+    id: r.id,
     kind: isDecisionKind(r.kind) ? r.kind : 'UNKNOWN',
     summary: r.what,
     evidence: r.why || undefined,

--- a/core/workflows/cross-run-retro.ts
+++ b/core/workflows/cross-run-retro.ts
@@ -17,6 +17,7 @@ import {
   computeGateThresholds,
   fetchLifecyclesInWindow,
 } from '../learning/playbook-stats.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { CoachPolicy } from '../types.js';
 import {
@@ -371,14 +372,7 @@ export async function runCrossRunRetroWorkflow(
 
     const playbookId = inserted[0]?.id ?? -1;
 
-    for (const ds of manifest.decisionSummaries) {
-      eventStore.appendEvent({
-        kind: 'agent.decision-summary',
-        projectId,
-        runId,
-        payload: { skill: skillName, ...ds },
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, null, skillName, manifest.decisionSummaries);
 
     eventStore.appendEvent({
       kind: 'retrospective.completed',

--- a/core/workflows/decompose-prd.ts
+++ b/core/workflows/decompose-prd.ts
@@ -6,6 +6,7 @@ import { resolveBudgetsForProject } from '../agent-runtime/resolve-for-project.j
 import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
 import { selectPersona } from '../agent-runtime/select-persona.js';
 import { eventStore } from '../event-stream/store.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { StateSource, WorkItem } from '../state-source/interface.js';
 
@@ -305,15 +306,7 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
     );
 
     // Step 8: Emit decision summaries
-    for (const ds of decisionSummaries) {
-      eventStore.appendEvent({
-        kind: 'agent.decision-summary',
-        projectId,
-        workItemId: workItem.id,
-        runId,
-        payload: { skill: skillName, ...ds },
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, workItem.id, skillName, decisionSummaries);
 
     // Step 9: Emit decompose.completed event
     eventStore.appendEvent({

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -25,6 +25,7 @@ import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
 import { selectPersona } from '../agent-runtime/select-persona.js';
 import { totalSpendForSkill as _totalSpendForSkill } from '../cost/repository.js';
 import { eventStore } from '../event-stream/store.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { StateName } from '../state-machine/states.js';
 import type { StateSource, WorkItem } from '../state-source/interface.js';
@@ -514,15 +515,7 @@ export async function runGrillAndPrdWorkflow(
       }
 
       // Emit any decision summaries the griller produced this round.
-      for (const ds of grillOutput.decisionSummaries) {
-        eventStore.appendEvent({
-          kind: 'agent.decision-summary',
-          projectId,
-          workItemId: workItem.id,
-          runId,
-          payload: { skill: 'grill-me', ...ds },
-        });
-      }
+      reconcileDecisionSummaries(runId, projectId, workItem.id, 'grill-me', grillOutput.decisionSummaries);
 
       // Hard cap at round 7: if the griller still hasn't declared readyForPRD,
       // force the workflow forward so we don't loop indefinitely.
@@ -781,15 +774,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     return { phase: 'needs-human' };
   }
 
-  for (const ds of prdOutput.decisionSummaries) {
-    eventStore.appendEvent({
-      kind: 'agent.decision-summary',
-      projectId,
-      workItemId: workItem.id,
-      runId,
-      payload: { skill: 'write-prd', ...ds },
-    });
-  }
+  reconcileDecisionSummaries(runId, projectId, workItem.id, 'write-prd', prdOutput.decisionSummaries);
 
   // ─── Step 3: advise-on-prd (conditional) ────────────────────────────────
   let advisorConcerns: string[] | null = null;
@@ -872,15 +857,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
         };
       }
 
-      for (const ds of advisor.decisionSummaries) {
-        eventStore.appendEvent({
-          kind: 'agent.decision-summary',
-          projectId,
-          workItemId: workItem.id,
-          runId,
-          payload: { skill: 'advise-on-prd', ...ds },
-        });
-      }
+      reconcileDecisionSummaries(runId, projectId, workItem.id, 'advise-on-prd', advisor.decisionSummaries);
     } catch (err) {
       eventStore.appendEvent({
         kind: 'agent.run-failed',

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -12,6 +12,7 @@ import { eventStore } from '../event-stream/store.js';
 import { archiveLifecycle } from '../learning/archive.js';
 import { computeTrend } from '../learning/convergence.js';
 import { accumulatePersonaStats } from '../persona/accumulate.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { ImprovementCandidate } from '../retrospective/schemas.js';
 import type { StateSource, WorkItem } from '../state-source/interface.js';
@@ -198,15 +199,7 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
         parsed.data.improvementCandidates,
       );
     }
-    for (const ds of parsed.data.decisionSummaries) {
-      eventStore.appendEvent({
-        kind: 'agent.decision-summary',
-        projectId,
-        workItemId: workItem.id,
-        runId,
-        payload: { skill: skillName, ...ds },
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, workItem.id, skillName, parsed.data.decisionSummaries);
 
     accumulatePersonaStats({ personaName: personaId, role: 'retrospector', outcome: 'success' });
     await stateSource.transitionState(workItem.externalId, 'factory:retrospecting', 'factory:done');

--- a/core/workflows/skill-coaching.ts
+++ b/core/workflows/skill-coaching.ts
@@ -11,6 +11,7 @@ import { selectPersona } from '../agent-runtime/select-persona.js';
 import { db } from '../db/db.js';
 import { archivedLifecycles, decisionPatterns, improvementCandidates } from '../db/schema.js';
 import { eventStore } from '../event-stream/store.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 
 const DEFAULT_REPO_ROOT = join(import.meta.dirname, '../..');
@@ -241,14 +242,7 @@ export async function runSkillCoachingWorkflow(
 
     const candidateId = inserted?.id ?? -1;
 
-    for (const ds of output.decisionSummaries) {
-      eventStore.appendEvent({
-        kind: 'agent.decision-summary',
-        projectId,
-        runId,
-        payload: { skill: skillName, ...ds },
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, null, skillName, output.decisionSummaries);
 
     eventStore.appendEvent({
       kind: 'coach.completed',

--- a/core/workflows/sprint-review.ts
+++ b/core/workflows/sprint-review.ts
@@ -9,6 +9,7 @@ import { selectPersona } from '../agent-runtime/select-persona.js';
 import { db } from '../db/db.js';
 import { improvementCandidates } from '../db/schema.js';
 import { eventStore } from '../event-stream/store.js';
+import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { StateSource } from '../state-source/interface.js';
 
@@ -169,14 +170,7 @@ export async function runSprintReviewWorkflow(input: RunSprintReviewInput): Prom
     await stateSource.transitionState(created.externalId, 'factory:triaging', 'factory:done');
 
     // Step 8: Emit decision summaries
-    for (const ds of decisionSummaries) {
-      eventStore.appendEvent({
-        kind: 'agent.decision-summary',
-        projectId,
-        runId,
-        payload: { skill: skillName, ...ds },
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, null, skillName, decisionSummaries);
 
     eventStore.appendEvent({
       kind: 'agent.run-completed',

--- a/skills/dev-review/prompt.md
+++ b/skills/dev-review/prompt.md
@@ -141,3 +141,13 @@ Return JSON conforming to `DevReviewOutputSchema`:
 Every finding MUST include `file` and `line` — the schema rejects findings without grounded evidence. If you cannot point at a specific line, you are speculating, and speculation is not a finding.
 
 Keep `summary` and `suggestion` to a single sentence each. The dev needs scannable, actionable items, not paragraphs.
+
+## Decision-marker pattern
+
+At key review steps, emit a live marker in your text turn:
+
+```
+[decision] KIND: what — why
+```
+
+`KIND` is an uppercase value from the shared enum (`core/agent-runtime/decision-types.ts`). Use ` — ` (space, em-dash, space) to separate the decision from its rationale. Common kinds: `READ` (diff analysis), `INSIGHT` (pattern found), `VERDICT` (final verdict). Example: `[decision] VERDICT: no-blockers — all P0/P1 checks pass; 2 low-severity style findings noted`.

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -130,4 +130,6 @@ Use the canonical `DecisionKindSchema` enum from `core/agent-runtime/decision-ty
 Common for this skill: `READ`, `PLAN`, `RED`, `GREEN`, `REFACTOR`, `LINT`, `BLOCKER`,
 `UNCERTAINTY`, `TOOL_FAILURE`.
 
+Live marker format: `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Example: `[decision] PLAN: Add helper in core/foo/bar.ts — mirrors existing baz pattern`.
+
 [decision] VERDICT: WP builder returned structured output; orchestrator commits

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -221,3 +221,5 @@ Return a JSON object conforming to `ImplementSchema`. The orchestrator opens the
 - **Self-observations:** `BLOCKER`, `RETRY`, `UNCERTAINTY`, `TOOL_FAILURE`, `INSIGHT`
 
 Use uppercase enum values both in the JSON `kind` field and in the live `[decision] KIND: …` marker line. Free-text `step` strings are no longer accepted — schema validation rejects them.
+
+Live marker format: `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Example: `[decision] PLAN: Add helper in core/foo/bar.ts — mirrors existing baz pattern, avoids new abstraction`.

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -147,18 +147,17 @@ Return a JSON object with this exact structure:
 After each major investigation step, emit a line in your text turn:
 
 ```
-[decision] KIND: <one sentence summary>
+[decision] KIND: what — why
 ```
 
 `KIND` is an uppercase value from the shared decision-kind enum (see `core/agent-runtime/decision-types.ts`). The investigator most commonly emits `READ` (issue/code reads), `INSIGHT` (root-cause hypothesis, open questions), and `UNCERTAINTY` (when evidence is thin).
 
-These marker lines are parsed by the orchestrator and stored as `agent.decision-summary` events. They are NOT forwarded to QA or Reviewer agents. Keep each summary to a single sentence. Do not include credentials, file dumps, or raw chain-of-thought.
+The ` — ` (space, em-dash, space) separates the decision (`what`) from its rationale (`why`). Both parts are required. These marker lines are parsed by the orchestrator and stored as `agent.decision-summary` events. They are NOT forwarded to QA or Reviewer agents. Keep each summary to a single sentence. Do not include credentials, file dumps, or raw chain-of-thought.
 
 Examples of good decision summaries:
-- `[decision] READ: Issue #42 — login endpoint returns 500 when email contains a plus sign`
-- `[decision] READ: Identified entry points — apps/server/src/routes/auth.ts, core/auth/validate.ts`
-- `[decision] READ: Traced email normalisation — plus signs stripped before DB lookup`
-- `[decision] INSIGHT: Root cause hypothesis — URL-decode step in normaliseEmail() drops plus sign`
+- `[decision] READ: Traced entry points to apps/server/src/routes/auth.ts — login endpoint reached via POST /auth/login`
+- `[decision] INSIGHT: Root cause in normaliseEmail() — URL-decode step strips plus signs before DB lookup`
+- `[decision] UNCERTAINTY: Cannot confirm fix without running integration tests — static analysis inconclusive`
 
 Bad decision summaries:
 - More than one sentence

--- a/skills/retrospective-deep/prompt.md
+++ b/skills/retrospective-deep/prompt.md
@@ -177,4 +177,6 @@ Return JSON conforming to `DeepRetroSchema`. No free-text outside the schema fie
 }
 ```
 
-[decision] VERDICT: Deep retro complete: <one sentence on key finding>
+Live marker format: `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Common kinds for this skill: `READ`, `INSIGHT`, `VERDICT`.
+
+[decision] VERDICT: Deep retro complete: <one sentence on key finding> — <one sentence on primary recommendation>

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -142,6 +142,8 @@ Return a single JSON object conforming to `EngineeringSpecSchema`. Do not includ
 
 `decisionSummaries` must have at least one entry. Use the canonical `DecisionKindSchema` enum (`READ`, `PLAN`, `INSIGHT`, `UNCERTAINTY`, etc.).
 
+Live markers use the format `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Example: `[decision] PLAN: Defined 5 falsifiable ACs — one per journey step, all with verifyCommand`.
+
 ## Failure modes (the validator will catch)
 
 - Same path in two WPs' `filesOwned` → `file-ownership-collision`

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -7,6 +7,7 @@ import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { runWithEscalation } from '@goose-hub/core/agent-runtime/with-escalation.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -238,15 +239,7 @@ export async function runFixFeedbackWorkflow(
       },
     });
 
-    for (const summary of implementOutput.decisionSummaries) {
-      eventStore.appendEvent({
-        projectId,
-        workItemId: workItem.id,
-        kind: 'agent.decision-summary',
-        payload: { skill: 'fix-feedback', ...summary },
-        runId,
-      });
-    }
+    reconcileDecisionSummaries(runId, projectId, workItem.id, 'fix-feedback', implementOutput.decisionSummaries);
 
     eventStore.appendEvent({
       projectId,

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -16,6 +16,7 @@ import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { runWithEscalation } from '@goose-hub/core/agent-runtime/with-escalation.js';
 import { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -422,15 +423,7 @@ async function afterImplement(input: AfterImplementInput): Promise<void> {
   );
 
   // Emit implement decision summaries (#206 pattern).
-  for (const summary of implementOutput.decisionSummaries) {
-    eventStore.appendEvent({
-      projectId,
-      workItemId: workItem.id,
-      kind: 'agent.decision-summary',
-      payload: { skill: 'implement', ...summary },
-      runId,
-    });
-  }
+  reconcileDecisionSummaries(runId, projectId, workItem.id, 'implement', implementOutput.decisionSummaries);
   eventStore.appendEvent({
     projectId,
     workItemId: workItem.id,

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -8,6 +8,7 @@ import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
@@ -260,15 +261,7 @@ export async function runQaWorkflow(
       });
     }
 
-    for (const summary of qaOutput.decisionSummaries) {
-      eventStore.appendEvent({
-        projectId: projectSlug,
-        workItemId: workItem.id,
-        kind: 'agent.decision-summary',
-        payload: { skill: 'qa', ...summary },
-        runId,
-      });
-    }
+    reconcileDecisionSummaries(runId, projectSlug, workItem.id, 'qa', qaOutput.decisionSummaries);
 
     // Determine next state. Use priorEvents (snapshotted before this run) so the
     // retry count reflects completed prior failures, not the current one.

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -17,6 +17,7 @@ import {
   readProjectReviewSettings,
 } from '@goose-hub/core/db/repositories/project-review-settings.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '@goose-hub/core/retry/retry-counter.js';
@@ -88,15 +89,7 @@ export async function runReviewWorkflow(
       runId,
     });
 
-    for (const summary of reviewOutput.decisionSummaries) {
-      eventStore.appendEvent({
-        projectId: projectSlug,
-        workItemId: workItem.id,
-        kind: 'agent.decision-summary',
-        payload: { skill: 'review', ...summary },
-        runId,
-      });
-    }
+    reconcileDecisionSummaries(runId, projectSlug, workItem.id, 'review', reviewOutput.decisionSummaries);
 
     let nextState: StateName;
     if (reviewOutput.verdict === 'needs-fix') {


### PR DESCRIPTION
## Summary

- **POST /api/decisions** HTTP endpoint — Zod-validated, coerces unknown `kind` to `UNKNOWN`, returns `{ ok, id, recorded }`
- **decision-capture.js PostToolUse hook** — JS template deployed to `~/.factory/hooks/decision-capture.js`; reads `[decision] KIND: what — why` markers from transcript and POSTs to `/api/decisions`; gated on `experimental.recordDecisionTool` flag (default false)
- **DB column** — `record_decision_tool` integer on `project_settings` with migration `0020`
- **AgentSpec extensions** — `iteration?: number`, `phase?: string`; written as `FACTORY_ITERATION` / `FACTORY_PHASE` env vars in both claude-cli and codex-cli runtimes
- **`reconcileDecisionSummaries()` helper** — DB-preferred strategy: if `readRunDecisions(runId)` returns rows, those are authoritative (skip schema-field summaries to prevent double-emission); otherwise falls back to parsed summaries
- **19-site refactor** — all existing `agent.decision-summary` emit loops across `core/agent-runtime/`, `core/workflows/`, and `slices/` replaced with single helper call
- **6 skill prompts updated** — `implement`, `implement-wp`, `investigate`, `spec-author`, `dev-review`, `retrospective-deep` now document the `[decision] KIND: what — why` format with required ` — ` separator

## Known limitation

`grill-and-prd.ts` uses a shared `runId` across multi-round grill iterations. With `recordDecisionTool=true`, `readRunDecisions(runId)` accumulates rows from all prior rounds, so a later round's reconcile call would re-emit earlier rounds' summaries. Flag defaults false so this is dormant; tracked as a follow-up.

## Test coverage

- Endpoint: valid body accepted, optional fields, missing required fields → 400, duplicate → `recorded: false`
- Hook installation: flag=false skips, qa/reviewer/code-quality-audit excluded even with flag=true
- Reconciliation: DB-preferred when rows exist, schema-fallback when DB empty, no double-emission

> Note: new test files in `core/agent-runtime/reconcile-decisions.test.ts` and `apps/server/src/domains/decisions/router.test.ts` run in CI post-merge (local vitest excludes `**/.claude/**` worktrees).

Closes #699