### PR TITLE
M19.25: dev-review revision loop

### DIFF
--- a/apps/web/src/components/settings/components/DevReviewPanel.tsx
+++ b/apps/web/src/components/settings/components/DevReviewPanel.tsx
@@ -1,0 +1,198 @@
+import { fetchDevReviewSettings, patchDevReviewSettings } from '@/lib/api';
+import type { DevReviewSettingsDto } from '@/lib/types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+interface Props {
+  slug: string;
+}
+
+const TRIGGER_ON_OPTIONS = [
+  { value: 'all', label: 'All priorities' },
+  { value: 'priority:medium+', label: 'Medium and above' },
+  { value: 'priority:high+', label: 'High and above' },
+  { value: 'priority:critical', label: 'Critical only' },
+] as const;
+
+const DEFAULTS = {
+  enabled: false,
+  triggerOn: 'priority:high+' as string,
+  maxRevisionTurns: 1,
+  perCycleMaxUsd: 2.0,
+  timeoutMs: 180_000,
+};
+
+export function DevReviewPanel({ slug }: Props) {
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery<DevReviewSettingsDto>({
+    queryKey: ['dev-review-settings', slug],
+    queryFn: ({ signal }) => fetchDevReviewSettings(slug, signal),
+    staleTime: 10_000,
+  });
+
+  const patch = useMutation({
+    mutationFn: (
+      values: Partial<{
+        enabled: boolean | null;
+        triggerOn: string | null;
+        maxRevisionTurns: number | null;
+        perCycleMaxUsd: number | null;
+        timeoutMs: number | null;
+      }>,
+    ) => patchDevReviewSettings(slug, values),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ['dev-review-settings', slug] }),
+  });
+
+  if (isLoading) return <div className="text-[12px] text-fg-3 py-4">Loading…</div>;
+  if (error || !data)
+    return <div className="text-[12px] text-danger py-4">Failed to load dev-review settings.</div>;
+
+  const effective = {
+    enabled: data.dbOverride?.enabled ?? data.config?.enabled ?? DEFAULTS.enabled,
+    triggerOn: data.dbOverride?.triggerOn ?? data.config?.triggerOn ?? DEFAULTS.triggerOn,
+    maxRevisionTurns:
+      data.dbOverride?.maxRevisionTurns ??
+      data.config?.maxRevisionTurns ??
+      DEFAULTS.maxRevisionTurns,
+    perCycleMaxUsd:
+      data.dbOverride?.perCycleMaxUsd ?? data.config?.perCycleMaxUsd ?? DEFAULTS.perCycleMaxUsd,
+    timeoutMs: data.dbOverride?.timeoutMs ?? data.config?.timeoutMs ?? DEFAULTS.timeoutMs,
+  };
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2 mb-3">
+          Dev-Review Advisor
+        </h3>
+        <p className="text-[11px] text-fg-3 mb-4">
+          Runs a Codex dev-review pass after all work packages are committed, before the PR is
+          opened. Blockers trigger a developer response turn; turns loop up to maxRevisionTurns.
+          Approved verdict exits early.
+        </p>
+
+        {/* enabled toggle */}
+        <label className="flex items-center gap-2 text-[12px] mb-5">
+          <input
+            type="checkbox"
+            data-testid="dev-review-enabled-toggle"
+            checked={effective.enabled}
+            onChange={(e) => patch.mutate({ enabled: e.target.checked })}
+            disabled={patch.isPending}
+            className="h-4 w-4 rounded border-line"
+          />
+          <span>Enable dev-review advisor</span>
+          {effective.enabled ? (
+            <span className="text-[11px] text-accent">enabled</span>
+          ) : (
+            <span className="text-[11px] text-fg-3">disabled</span>
+          )}
+        </label>
+
+        <div className="space-y-4">
+          {/* triggerOn */}
+          <div className="flex items-center gap-3">
+            <label htmlFor="dev-review-trigger-on" className="text-[12px] text-fg-2 w-36 shrink-0">
+              Trigger on
+            </label>
+            <select
+              id="dev-review-trigger-on"
+              data-testid="dev-review-trigger-on"
+              value={effective.triggerOn}
+              onChange={(e) => patch.mutate({ triggerOn: e.target.value })}
+              disabled={patch.isPending}
+              className="text-[12px] bg-bg border border-line rounded px-2 py-0.5"
+            >
+              {TRIGGER_ON_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* maxRevisionTurns */}
+          <div className="flex items-center gap-3">
+            <label htmlFor="dev-review-max-turns" className="text-[12px] text-fg-2 w-36 shrink-0">
+              Max revision turns
+            </label>
+            <input
+              id="dev-review-max-turns"
+              type="number"
+              data-testid="dev-review-max-turns"
+              min={1}
+              max={5}
+              value={effective.maxRevisionTurns}
+              onChange={(e) => {
+                const v = Number.parseInt(e.target.value, 10);
+                if (v >= 1 && v <= 5) patch.mutate({ maxRevisionTurns: v });
+              }}
+              disabled={patch.isPending}
+              className="text-[12px] bg-bg border border-line rounded px-2 py-0.5 w-20"
+            />
+            <span className="text-[11px] text-fg-3">1–5 (each = 1 Codex call)</span>
+          </div>
+
+          {/* perCycleMaxUsd */}
+          <div className="flex items-center gap-3">
+            <label htmlFor="dev-review-budget" className="text-[12px] text-fg-2 w-36 shrink-0">
+              Budget per cycle ($)
+            </label>
+            <input
+              id="dev-review-budget"
+              type="number"
+              data-testid="dev-review-budget"
+              min={0}
+              max={50}
+              step={0.5}
+              value={effective.perCycleMaxUsd}
+              onChange={(e) => {
+                const v = Number.parseFloat(e.target.value);
+                if (v >= 0 && v <= 50) patch.mutate({ perCycleMaxUsd: v });
+              }}
+              disabled={patch.isPending}
+              className="text-[12px] bg-bg border border-line rounded px-2 py-0.5 w-20"
+            />
+            <span className="text-[11px] text-fg-3">USD, 0 = skip</span>
+          </div>
+
+          {/* timeoutMs */}
+          <div className="flex items-center gap-3">
+            <label htmlFor="dev-review-timeout" className="text-[12px] text-fg-2 w-36 shrink-0">
+              Timeout (ms)
+            </label>
+            <input
+              id="dev-review-timeout"
+              type="number"
+              data-testid="dev-review-timeout"
+              min={30_000}
+              max={1_800_000}
+              step={30_000}
+              value={effective.timeoutMs}
+              onChange={(e) => {
+                const v = Number.parseInt(e.target.value, 10);
+                if (v >= 30_000 && v <= 1_800_000) patch.mutate({ timeoutMs: v });
+              }}
+              disabled={patch.isPending}
+              className="text-[12px] bg-bg border border-line rounded px-2 py-0.5 w-28"
+            />
+            <span className="text-[11px] text-fg-3">30 000 – 1 800 000</span>
+          </div>
+        </div>
+
+        {data.dbOverride?.updatedAt && (
+          <p className="text-[10px] text-fg-3 mt-4">
+            Last updated {data.dbOverride.updatedAt}
+            {data.dbOverride.updatedBy ? ` by ${data.dbOverride.updatedBy}` : ''}
+          </p>
+        )}
+
+        {data.config == null && data.dbOverride == null && (
+          <p className="text-[11px] text-fg-3 mt-3">
+            No config block in project.config.ts — all values are DB overrides or defaults.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -4,13 +4,14 @@ import type { ProjectConfigDto } from '@/lib/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
+import { DevReviewPanel } from './DevReviewPanel';
 import { PipelinePanel } from './PipelinePanel';
 import { ProjectBudgetPanel } from './ProjectBudgetPanel';
 import { ProjectConfigPanel } from './ProjectConfigPanel';
 import { ProjectModelPanel } from './ProjectModelPanel';
 import { ReviewPanel } from './ReviewPanel';
 
-type Tab = 'config' | 'budgets' | 'models' | 'pipeline' | 'review';
+type Tab = 'config' | 'budgets' | 'models' | 'pipeline' | 'review' | 'dev-review';
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
@@ -91,21 +92,23 @@ export function SettingsPage() {
 
         {/* Tab bar */}
         <div className="flex gap-1 mb-6 border-b border-line">
-          {(['config', 'budgets', 'models', 'pipeline', 'review'] as Tab[]).map((t) => (
-            <button
-              key={t}
-              type="button"
-              onClick={() => setTab(t)}
-              className={[
-                'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
-                tab === t
-                  ? 'border-accent text-fg font-medium'
-                  : 'border-transparent text-fg-2 hover:text-fg',
-              ].join(' ')}
-            >
-              {t}
-            </button>
-          ))}
+          {(['config', 'budgets', 'models', 'pipeline', 'review', 'dev-review'] as Tab[]).map(
+            (t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTab(t)}
+                className={[
+                  'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
+                  tab === t
+                    ? 'border-accent text-fg font-medium'
+                    : 'border-transparent text-fg-2 hover:text-fg',
+                ].join(' ')}
+              >
+                {t}
+              </button>
+            ),
+          )}
         </div>
 
         {tab === 'config' && selectedConfig != null && (
@@ -121,6 +124,9 @@ export function SettingsPage() {
           <PipelinePanel slug={selectedConfig.slug} />
         )}
         {tab === 'review' && selectedConfig != null && <ReviewPanel slug={selectedConfig.slug} />}
+        {tab === 'dev-review' && selectedConfig != null && (
+          <DevReviewPanel slug={selectedConfig.slug} />
+        )}
 
         {!isLoading && !error && configs.length === 0 && (
           <div className="text-[13px] text-fg-3 py-16 text-center">

--- a/apps/web/src/components/settings/slice.test.ts
+++ b/apps/web/src/components/settings/slice.test.ts
@@ -19,4 +19,9 @@ describe('settings slice', () => {
     const mod = await import('./components/PipelinePanel');
     expect(typeof mod.PipelinePanel).toBe('function');
   });
+
+  it('exports DevReviewPanel', async () => {
+    const mod = await import('./components/DevReviewPanel');
+    expect(typeof mod.DevReviewPanel).toBe('function');
+  });
 });

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -869,3 +869,482 @@ describe('dev-review e2e: perCycleMaxUsd=0 → budget-skipped, workflow continue
     expect(prOpened).toBeDefined();
   });
 });
+
+// ─── maxRevisionTurns=2 → 2 Codex passes ────────────────────────────────────
+
+describe('dev-review e2e: maxRevisionTurns=2 → 2 Codex dev-review passes', () => {
+  it('calls runDevReview twice and emits 2 dev-review.started events', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+
+    let devReviewCallCount = 0;
+
+    const mockFindings = [
+      {
+        severity: 'P1' as const,
+        category: 'correctness' as const,
+        file: 'core/a.ts',
+        line: 10,
+        summary: 'Missing null check',
+        suggestion: 'Add null guard',
+      },
+    ];
+
+    const mockResponseOutput: import(
+      '@goose-hub/skills/dev-review-response/schema.js',
+    ).DevReviewResponseOutput = {
+      findingDispositions: [
+        {
+          findingRef: 'core/a.ts:10',
+          severity: 'P1',
+          disposition: 'addressed',
+          reason: 'Added null guard',
+        },
+      ],
+      decisionSummaries: [
+        {
+          kind: 'DEV_REVIEW_ADDRESSED',
+          summary: 'Addressed P1 at core/a.ts:10',
+          evidence: 'core/a.ts:10',
+        },
+      ],
+    };
+
+    const commitMessages: string[] = [];
+
+    await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'high' }),
+      spec,
+      'pipeline-run-multi-turn',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'all',
+          maxRevisionTurns: 2,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async (input) => {
+          devReviewCallCount++;
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.started',
+            payload: { runId: `${input.runId}:dev-review`, worktreePath: input.worktreePath },
+            runId: `${input.runId}:dev-review`,
+          });
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.completed',
+            payload: {
+              runId: `${input.runId}:dev-review`,
+              verdict: 'blockers-found',
+              findingCount: mockFindings.length,
+            },
+            runId: `${input.runId}:dev-review`,
+          });
+          return { verdict: 'blockers-found', findings: mockFindings, decisionSummaries: [] };
+        },
+        runDevReviewResponseImpl: async (input) => {
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.response-completed',
+            payload: {
+              runId: `${input.runId}:dev-review-response`,
+              addressed: 1,
+              dismissed: 0,
+            },
+            runId: `${input.runId}:dev-review-response`,
+          });
+          return mockResponseOutput;
+        },
+        commitDevReviewResponseImpl: (_wt, msg) => {
+          commitMessages.push(msg);
+          return 'sha-commit';
+        },
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl: async () => ({
+          prNumber: 10,
+          prUrl: 'https://gh/pr/10',
+          branch: 'b',
+          base: 'main',
+        }),
+        getDiffImpl: () => 'diff --git a/core/a.ts b/core/a.ts\n+null check added',
+        appendEvent,
+      },
+    );
+
+    const devReviewStartedEvents = events.filter(
+      (e) => (e.kind as string) === 'dev-review.started',
+    );
+    const devReviewCompletedEvents = events.filter(
+      (e) => (e.kind as string) === 'dev-review.completed',
+    );
+    const responseCompletedEvents = events.filter(
+      (e) => (e.kind as string) === 'dev-review.response-completed',
+    );
+
+    // Exactly 2 Codex passes for maxRevisionTurns=2 with blockers-found each time.
+    expect(devReviewCallCount).toBe(2);
+    expect(devReviewStartedEvents).toHaveLength(2);
+    expect(devReviewCompletedEvents).toHaveLength(2);
+    // 2 response turns (one per blockers-found verdict, both non-last-turn for first, last-turn for second).
+    // Turn 0: blockers-found → response; turn 1: blockers-found, last turn, NOT inconclusive → response.
+    expect(responseCompletedEvents).toHaveLength(2);
+    // Commits include turn-N suffix.
+    expect(commitMessages.some((m) => m.includes('turn-0'))).toBe(true);
+    expect(commitMessages.some((m) => m.includes('turn-1'))).toBe(true);
+    // PR still opened after loop.
+    const prOpened = events.find((e) => (e.kind as string) === 'pr.opened');
+    expect(prOpened).toBeDefined();
+  });
+});
+
+// ─── maxRevisionTurns=1 default: approved verdict exits without response ──────
+
+describe('dev-review e2e: maxRevisionTurns=1 (default) with approved verdict exits early', () => {
+  it('emits 1 dev-review.started and no response when approved', async () => {
+    const wp1 = makeWp('WP1', ['core/d.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+
+    await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'high' }),
+      spec,
+      'pipeline-run-approved',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'all',
+          maxRevisionTurns: 1,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async (input) => {
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.started',
+            payload: { runId: `${input.runId}:dev-review`, worktreePath: input.worktreePath },
+            runId: `${input.runId}:dev-review`,
+          });
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.completed',
+            payload: { runId: `${input.runId}:dev-review`, verdict: 'approved', findingCount: 0 },
+            runId: `${input.runId}:dev-review`,
+          });
+          return { verdict: 'approved', findings: [], decisionSummaries: [] };
+        },
+        runDevReviewResponseImpl: async () => {
+          throw new Error('runDevReviewResponse should NOT be called when verdict is approved');
+        },
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl: async () => ({
+          prNumber: 11,
+          prUrl: 'https://gh/pr/11',
+          branch: 'b',
+          base: 'main',
+        }),
+        getDiffImpl: () => '',
+        appendEvent,
+      },
+    );
+
+    const devReviewStartedEvents = events.filter(
+      (e) => (e.kind as string) === 'dev-review.started',
+    );
+    const responseCompletedEvents = events.filter(
+      (e) => (e.kind as string) === 'dev-review.response-completed',
+    );
+
+    // Exactly 1 Codex pass, no response.
+    expect(devReviewStartedEvents).toHaveLength(1);
+    expect(responseCompletedEvents).toHaveLength(0);
+    // PR still opened.
+    expect(events.find((e) => (e.kind as string) === 'pr.opened')).toBeDefined();
+  });
+});
+
+// ─── triggerOn priority matching: low does not trigger when set to medium+ ───
+
+describe('dev-review: triggerOn priority:medium+ does not trigger for priority:low', () => {
+  it('skips dev-review entirely for low priority work item', async () => {
+    const wp1 = makeWp('WP1', ['core/e.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+
+    await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'low' }),
+      spec,
+      'pipeline-run-low-priority',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'priority:medium+',
+          maxRevisionTurns: 2,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async () => {
+          throw new Error('runDevReview should NOT be called for low priority');
+        },
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl: async () => ({
+          prNumber: 12,
+          prUrl: 'https://gh/pr/12',
+          branch: 'b',
+          base: 'main',
+        }),
+        getDiffImpl: () => '',
+        appendEvent,
+      },
+    );
+
+    // No dev-review events for low priority item.
+    expect(events.find((e) => (e.kind as string) === 'dev-review.started')).toBeUndefined();
+    expect(events.find((e) => (e.kind as string) === 'dev-review.budget-skipped')).toBeUndefined();
+    // PR still opened.
+    expect(events.find((e) => (e.kind as string) === 'pr.opened')).toBeDefined();
+  });
+
+  it('triggers dev-review for medium priority with priority:medium+ config', async () => {
+    const wp1 = makeWp('WP1', ['core/f.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+
+    await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'medium' }),
+      spec,
+      'pipeline-run-medium-priority',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'priority:medium+',
+          maxRevisionTurns: 1,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async (input) => {
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.started',
+            payload: { runId: `${input.runId}:dev-review`, worktreePath: input.worktreePath },
+            runId: `${input.runId}:dev-review`,
+          });
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.completed',
+            payload: { runId: `${input.runId}:dev-review`, verdict: 'approved', findingCount: 0 },
+            runId: `${input.runId}:dev-review`,
+          });
+          return { verdict: 'approved', findings: [], decisionSummaries: [] };
+        },
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl: async () => ({
+          prNumber: 13,
+          prUrl: 'https://gh/pr/13',
+          branch: 'b',
+          base: 'main',
+        }),
+        getDiffImpl: () => '',
+        appendEvent,
+      },
+    );
+
+    // dev-review DID run for medium priority.
+    expect(events.find((e) => (e.kind as string) === 'dev-review.started')).toBeDefined();
+  });
+});
+
+// ─── Cost telemetry: multi-turn = multiple dev-review.completed events ────────
+
+describe('dev-review cost telemetry: multi-turn produces multiple dev-review.completed events', () => {
+  it('emits N dev-review.completed events for N Codex passes', async () => {
+    const wp1 = makeWp('WP1', ['core/g.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const MAX_TURNS = 3;
+
+    await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'critical' }),
+      spec,
+      'pipeline-run-cost-telemetry',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'all',
+          maxRevisionTurns: MAX_TURNS,
+          perCycleMaxUsd: 5.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async (input) => {
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.started',
+            payload: { runId: `${input.runId}:dev-review`, worktreePath: input.worktreePath },
+            runId: `${input.runId}:dev-review`,
+          });
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.completed',
+            payload: {
+              runId: `${input.runId}:dev-review`,
+              verdict: 'blockers-found',
+              findingCount: 1,
+            },
+            runId: `${input.runId}:dev-review`,
+          });
+          return {
+            verdict: 'blockers-found',
+            findings: [
+              {
+                severity: 'P2' as const,
+                category: 'performance' as const,
+                file: 'core/g.ts',
+                line: 5,
+                summary: 'Perf issue',
+                suggestion: 'Cache result',
+              },
+            ],
+            decisionSummaries: [],
+          };
+        },
+        runDevReviewResponseImpl: async (input) => {
+          input.appendEvent({
+            projectId: input.projectId,
+            workItemId: input.workItemId,
+            kind: 'dev-review.response-completed',
+            payload: { runId: `${input.runId}:dev-review-response`, addressed: 1, dismissed: 0 },
+            runId: `${input.runId}:dev-review-response`,
+          });
+          return {
+            findingDispositions: [
+              {
+                findingRef: 'core/g.ts:5',
+                severity: 'P2',
+                disposition: 'addressed' as const,
+                reason: 'Cached',
+              },
+            ],
+            decisionSummaries: [],
+          };
+        },
+        commitDevReviewResponseImpl: () => 'sha-x',
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl: async () => ({
+          prNumber: 14,
+          prUrl: 'https://gh/pr/14',
+          branch: 'b',
+          base: 'main',
+        }),
+        getDiffImpl: () => 'diff --git a/core/g.ts',
+        appendEvent,
+      },
+    );
+
+    const completedEvents = events.filter((e) => (e.kind as string) === 'dev-review.completed');
+    // One completed event per Codex call = MAX_TURNS calls.
+    expect(completedEvents).toHaveLength(MAX_TURNS);
+    // PR still opened after exhausting turns.
+    expect(events.find((e) => (e.kind as string) === 'pr.opened')).toBeDefined();
+  });
+});

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -891,9 +891,7 @@ describe('dev-review e2e: maxRevisionTurns=2 → 2 Codex dev-review passes', () 
       },
     ];
 
-    const mockResponseOutput: import(
-      '@goose-hub/skills/dev-review-response/schema.js',
-    ).DevReviewResponseOutput = {
+    const mockResponseOutput: DevReviewResponseOutput = {
       findingDispositions: [
         {
           findingRef: 'core/a.ts:10',

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -570,8 +570,9 @@ export async function runParallelImplementWorkflow(
         });
       } else {
         try {
+          const maxTurns = Math.max(1, Math.min(5, devReviewCfg.maxRevisionTurns));
           let turns = 0;
-          while (turns < devReviewCfg.maxRevisionTurns) {
+          while (turns < maxTurns) {
             // Each iteration = one Codex dev-review call.
             // Use turn-scoped runId so multi-turn events are distinguishable.
             const turnRunId = turns === 0 ? runId : `${runId}:turn-${turns}`;
@@ -594,11 +595,7 @@ export async function runParallelImplementWorkflow(
 
             if (devReviewOutput.verdict === 'approved') break;
             // On the last turn, inconclusive = no more passes available; skip response.
-            if (
-              devReviewOutput.verdict === 'inconclusive' &&
-              turns === devReviewCfg.maxRevisionTurns - 1
-            )
-              break;
+            if (devReviewOutput.verdict === 'inconclusive' && turns === maxTurns - 1) break;
 
             // Re-fetch diff after any previous response commits so Codex sees current state.
             const currentDiff = getDiffFn(issueWorktreePath, 'main');

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -552,8 +552,8 @@ export async function runParallelImplementWorkflow(
       }
     }
 
-    // ── Dev-review advisor step (M19.12) ─────────────────────────────────────
-    // Runs ONCE after all WPs are committed and BEFORE the PR is opened.
+    // ── Dev-review advisor step with maxRevisionTurns loop (M19.25) ─────────
+    // Runs after all WPs are committed, before the PR is opened.
     // Budget guard: skip if perCycleMaxUsd <= 0.
     if (
       devReviewCfg.enabled &&
@@ -570,31 +570,13 @@ export async function runParallelImplementWorkflow(
         });
       } else {
         try {
-          const prDiff = getDiffFn(issueWorktreePath, 'main');
-          const devReviewOutput = await devReviewFn({
-            runId,
-            projectId,
-            workItemId: workItem.id,
-            workItem: {
-              title: workItem.title,
-              body: workItem.body,
-              number: Number(workItem.externalId),
-              priority: workItem.priority,
-            },
-            worktreePath: issueWorktreePath,
-            baseBranch: 'main',
-            stack,
-            runtime: deps.devReviewRuntime,
-            appendEvent: append,
-          });
-
-          // If blockers found, give the dev ONE additional turn. No second Codex pass.
-          if (
-            devReviewOutput.verdict === 'blockers-found' ||
-            devReviewOutput.verdict === 'inconclusive'
-          ) {
-            await devReviewResponseFn({
-              runId,
+          let turns = 0;
+          while (turns < devReviewCfg.maxRevisionTurns) {
+            // Each iteration = one Codex dev-review call.
+            // Use turn-scoped runId so multi-turn events are distinguishable.
+            const turnRunId = turns === 0 ? runId : `${runId}:turn-${turns}`;
+            const devReviewOutput = await devReviewFn({
+              runId: turnRunId,
               projectId,
               workItemId: workItem.id,
               workItem: {
@@ -603,20 +585,47 @@ export async function runParallelImplementWorkflow(
                 number: Number(workItem.externalId),
                 priority: workItem.priority,
               },
-              prDiff,
+              worktreePath: issueWorktreePath,
+              baseBranch: 'main',
+              stack,
+              runtime: deps.devReviewRuntime,
+              appendEvent: append,
+            });
+
+            if (devReviewOutput.verdict === 'approved') break;
+            // On the last turn, inconclusive = no more passes available; skip response.
+            if (
+              devReviewOutput.verdict === 'inconclusive' &&
+              turns === devReviewCfg.maxRevisionTurns - 1
+            )
+              break;
+
+            // Re-fetch diff after any previous response commits so Codex sees current state.
+            const currentDiff = getDiffFn(issueWorktreePath, 'main');
+            await devReviewResponseFn({
+              runId: turnRunId,
+              projectId,
+              workItemId: workItem.id,
+              workItem: {
+                title: workItem.title,
+                body: workItem.body,
+                number: Number(workItem.externalId),
+                priority: workItem.priority,
+              },
+              prDiff: currentDiff,
               devReviewFindings: devReviewOutput.findings,
               worktreePath: issueWorktreePath,
               stack,
               runtime: deps.devReviewResponseRuntime,
               appendEvent: append,
             });
-            // Commit any edits the response agent made before opening the PR.
-            // orchestratorCommitAll uses --allow-empty, so no-ops safely when nothing changed.
+            // Commit response edits so the next iteration's Codex diff is current.
+            // orchestratorCommitAll uses --allow-empty, so no-ops when nothing changed.
             commitDevReviewFn(
               issueWorktreePath,
-              'chore: dev-review-response addressing/dismissing findings',
+              `chore: dev-review-response turn-${turns} addressing/dismissing findings`,
             );
-            // No second Codex dev-review pass — proceed straight to PR.
+            turns++;
           }
         } catch (devReviewErr) {
           // Dev-review failures are non-fatal. Log and continue to PR.


### PR DESCRIPTION
## Summary

- Replaces the one-pass dev-review with a real `maxRevisionTurns` loop (1–5). Each iteration is one Codex dev-review call; `approved` verdict exits early; `inconclusive` on the last turn skips response and proceeds to PR.
- Adds `DevReviewPanel` settings UI: enabled toggle, `triggerOn` dropdown (enum values from model-router schema), `maxRevisionTurns` number input (1–5), `perCycleMaxUsd`, `timeoutMs`.
- Wires the panel into a new `dev-review` tab in `SettingsPage`. Runtime reads persisted DB settings via existing `resolveDevReviewConfig`.
- Adds tests for `maxRevisionTurns=2` (2 Codex passes), default=1 with approved (0 response calls), `triggerOn priority:medium+` skips low-priority items, and cost telemetry (N `dev-review.completed` events for N turns).

Closes #700

## Human action item (not in this PR)

Edit `target-projects/goose-hub-self/project.config.ts` to add the `devReview` block (governance file, manual edit):

```ts
devReview: {
  enabled: true,
  triggerOn: 'priority:medium+',
  maxRevisionTurns: 1,
  perCycleMaxUsd: 2.00,
  timeoutMs: 600_000,
}
```

## Test plan

- [x] `pnpm test` — 211 test files, 3055 tests, all passing
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] `maxRevisionTurns=2` test verifies 2 `dev-review.started` events
- [ ] `maxRevisionTurns=1` + approved verifies 0 response calls
- [ ] `triggerOn: priority:medium+` with `priority: low` skips dev-review entirely
- [ ] Cost telemetry: 3-turn test emits 3 `dev-review.completed` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)