### PR TITLE
refactor(core): consolidate role/state/label constants and validate at ingress

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -22,7 +22,7 @@ import {
   type SetScheduleFn,
   moveIssueToCurrent,
 } from '@goose-hub/core/projects/move-with-deps.js';
-import { STATES } from '@goose-hub/core/state-machine/states.js';
+import { STATES, TERMINAL_STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -135,8 +135,6 @@ async function statusCommand(slug: string): Promise<void> {
     // DB may not be initialised in CI or dry-run environments — silently skip
   }
 }
-
-const TERMINAL_STATES = new Set<string>(['factory:done', 'factory:archived', 'factory:rejected']);
 
 async function sweepCommand(slug: string, milestoneArg: string): Promise<void> {
   if (!slug || !milestoneArg) {

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -160,8 +160,18 @@ describe('commentOnIssue — validation', () => {
 
 describe('setIssueLabel — validation', () => {
   it('returns 400 for unknown group', async () => {
-    const result = await setIssueLabel('proj', '1', 'type', 'bug');
+    const result = await setIssueLabel('proj', '1', 'milestone', 'foo');
     expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('returns 400 for invalid type value', async () => {
+    const result = await setIssueLabel('proj', '1', 'type', 'epic');
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('returns ok for valid type:bug', async () => {
+    const result = await setIssueLabel('proj', '1', 'type', 'bug');
+    expect(result.ok).toBe(true);
   });
 
   it('returns 400 for invalid priority value', async () => {
@@ -197,6 +207,26 @@ describe('setIssueLabel — validation', () => {
       'github:owner/repo#1',
       'schedule',
       'blocked-by',
+    );
+  });
+
+  it('translates UI schedule:backlog to canonical schedule:next at the boundary', async () => {
+    const result = await setIssueLabel('proj', '1', 'schedule', 'backlog');
+    expect(result.ok).toBe(true);
+    expect(mockSource.setLabelInGroup).toHaveBeenCalledWith(
+      'github:owner/repo#1',
+      'schedule',
+      'next',
+    );
+  });
+
+  it('translates UI schedule:icebox to canonical schedule:later at the boundary', async () => {
+    const result = await setIssueLabel('proj', '1', 'schedule', 'icebox');
+    expect(result.ok).toBe(true);
+    expect(mockSource.setLabelInGroup).toHaveBeenCalledWith(
+      'github:owner/repo#1',
+      'schedule',
+      'later',
     );
   });
 });

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -1,4 +1,8 @@
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import {
+  SCHEDULE_UI_TO_VALUE,
+  type ScheduleUIValue,
+} from '@goose-hub/core/state-source/github-labels.js';
 import type { Result } from '#shared/middleware.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
@@ -159,7 +163,13 @@ export async function setIssueMilestone(
 }
 
 const VALID_PRIORITY = ['low', 'medium', 'high', 'critical'] as const;
+/**
+ * UI-facing schedule values. The labels written to GitHub use `next`/`later`
+ * (canonical Schedule), but the UI exposes `backlog`/`icebox` as friendlier
+ * synonyms — `SCHEDULE_UI_TO_VALUE` translates before calling the data layer.
+ */
 const VALID_SCHEDULE = ['current', 'backlog', 'icebox', 'blocked-by'] as const;
+const VALID_TYPE = ['feature', 'bug', 'chore', 'research'] as const;
 
 export async function setIssueLabel(
   slug: string,
@@ -167,8 +177,8 @@ export async function setIssueLabel(
   group: unknown,
   value: unknown,
 ): Promise<Result<{ ok: true }>> {
-  if (group !== 'priority' && group !== 'schedule') {
-    return { ok: false, error: 'group must be priority or schedule', status: 400 };
+  if (group !== 'priority' && group !== 'schedule' && group !== 'type') {
+    return { ok: false, error: 'group must be priority, schedule, or type', status: 400 };
   }
   if (group === 'priority' && !VALID_PRIORITY.includes(value as never)) {
     return { ok: false, error: 'invalid priority', status: 400 };
@@ -176,16 +186,25 @@ export async function setIssueLabel(
   if (group === 'schedule' && !VALID_SCHEDULE.includes(value as never)) {
     return { ok: false, error: 'invalid schedule', status: 400 };
   }
+  if (group === 'type' && !VALID_TYPE.includes(value as never)) {
+    return { ok: false, error: 'invalid type', status: 400 };
+  }
   const source = await getSourceForSlug(slug);
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
   const repoRef = await getRepoRef(slug);
   const workItemId = `github:${repoRef}#${id}`;
-  await source.setLabelInGroup(workItemId, group, value as string);
+  // Translate UI-facing schedule synonyms (`backlog`/`icebox`) to the canonical
+  // label values (`next`/`later`) before the data layer sees them. Without
+  // this, the in-memory source silently no-ops and GitHub gets an invalid
+  // `schedule:backlog` label name.
+  const persistedValue =
+    group === 'schedule' ? SCHEDULE_UI_TO_VALUE[value as ScheduleUIValue] : (value as string);
+  await source.setLabelInGroup(workItemId, group, persistedValue);
   eventStore.appendEvent({
     projectId: slug,
     workItemId,
     kind: 'manual.action',
-    payload: { action: `set-${group}`, value },
+    payload: { action: `set-${group}`, value: persistedValue },
   });
   return { ok: true, data: { ok: true } };
 }

--- a/apps/server/src/domains/workflows/sprint-review-eligibility.ts
+++ b/apps/server/src/domains/workflows/sprint-review-eligibility.ts
@@ -1,3 +1,4 @@
+import { TERMINAL_STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 
 export interface SprintReviewEligibility {
@@ -6,8 +7,6 @@ export interface SprintReviewEligibility {
   alreadyExists: boolean;
   existingIssueUrl?: string;
 }
-
-const TERMINAL_STATES = new Set(['factory:done', 'factory:archived', 'factory:rejected']);
 
 export async function checkSprintReviewEligibility(
   stateSource: StateSource,

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -403,7 +403,25 @@ describe('POST /projects/:slug/issues/:id/set-label', () => {
     const res = await app.request('/projects/goose-hub-self/issues/1/set-label', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ group: 'milestone', value: 'foo' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 for valid type:bug', async () => {
+    const res = await app.request('/projects/goose-hub-self/issues/1/set-label', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ group: 'type', value: 'bug' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for invalid type value', async () => {
+    const res = await app.request('/projects/goose-hub-self/issues/1/set-label', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ group: 'type', value: 'epic' }),
     });
     expect(res.status).toBe(400);
   });

--- a/apps/web/src/components/settings/components/ProjectModelPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectModelPanel.tsx
@@ -23,6 +23,9 @@ interface Props {
 }
 
 const TIERS: ModelTier[] = ['haiku', 'sonnet', 'opus'];
+// Mirrors HOLDOUT_ROLES in core/agent-runtime/roles.ts. Duplicated here because
+// apps/web does not import @goose-hub/core (would pull server-only modules into
+// the React bundle). Keep in sync if the canonical set changes.
 const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
 
 const COMPLEXITY_KEY_OPTIONS = [

--- a/apps/web/src/lib/usePersonaMap.ts
+++ b/apps/web/src/lib/usePersonaMap.ts
@@ -47,6 +47,9 @@ export function getPersonaInitials(
     .join('');
 }
 
+// Mirrors ROLE_ABBREV in core/agent-runtime/persona-names.ts. Duplicated
+// because apps/web does not import from @goose-hub/core (no path alias / vite
+// alias is wired). Keep in sync if a new role is added.
 const ROLE_ABBREV: Record<string, string> = {
   triager: 'TRG',
   developer: 'DEV',

--- a/core/agent-runtime/advisor.ts
+++ b/core/agent-runtime/advisor.ts
@@ -7,6 +7,7 @@ import type { AgentRuntime } from './interface.js';
 import type { AgentResult } from './interface.js';
 import { OutputValidationError, invokeSkill } from './invoke-skill.js';
 import { reconcileDecisionSummaries } from './reconcile-decisions.js';
+import { ADVISOR_GATED_PRIORITIES } from './roles.js';
 
 interface AdviseOnPlanInput {
   runId: string;
@@ -21,8 +22,6 @@ interface AdviseOnPlanInput {
   /** Optional runtime override — defaults to a new ClaudeCliRuntime. */
   runtime?: AgentRuntime;
 }
-
-const ADVISOR_GATED_PRIORITIES = new Set(['high', 'critical']);
 
 /**
  * adviseOnPlan(input) (#182).

--- a/core/agent-runtime/context-assembly.ts
+++ b/core/agent-runtime/context-assembly.ts
@@ -6,6 +6,7 @@ import {
   findHoldoutContextLeaks,
 } from './holdout-validator.js';
 import type { AgentSpec } from './interface.js';
+import { HOLDOUT_ROLES } from './roles.js';
 
 // Re-export for callers that import these from context-assembly
 export type { HoldoutContextLeak } from './holdout-validator.js';
@@ -14,9 +15,6 @@ export { HOLDOUT_FORBIDDEN_KEYS, findHoldoutContextLeaks } from './holdout-valid
 export interface SpawnContext {
   contextXml: string;
 }
-
-// Holdout roles that enforce strict context isolation (kept here for violation event emission)
-const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
 
 /**
  * Derives the effective allowlist for a spec, stripping forbidden dev-review

--- a/core/agent-runtime/fallback.ts
+++ b/core/agent-runtime/fallback.ts
@@ -2,14 +2,12 @@ export { HoldoutFallbackForbiddenError } from './interface.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { HoldoutFallbackForbiddenError } from './interface.js';
 import { modelsAtOrAboveTier, providerOf, tierOf } from './models.js';
+import { ADVISOR_GATED_PRIORITIES, HOLDOUT_ROLES } from './roles.js';
 
 export interface FallbackPolicy {
   allowDownTier: boolean;
   maxAttempts: number;
 }
-
-const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
-const CRITICAL_PRIORITIES = new Set(['critical', 'high']);
 
 /**
  * Wraps any AgentRuntime with the M4 fallback policy:
@@ -22,7 +20,7 @@ export function withFallback(runtime: AgentRuntime, policy: FallbackPolicy): Age
     async run(spec: AgentSpec): Promise<AgentResult> {
       const isHoldout = HOLDOUT_ROLES.has(spec.role);
       const priority = (spec.context.priority as string | undefined) ?? 'medium';
-      const isCriticalOrHigh = CRITICAL_PRIORITIES.has(priority);
+      const isCriticalOrHigh = ADVISOR_GATED_PRIORITIES.has(priority);
 
       // Holdout roles: no fallback — catch primary failure and surface as typed error
       if (isHoldout) {

--- a/core/agent-runtime/holdout-validator.ts
+++ b/core/agent-runtime/holdout-validator.ts
@@ -1,7 +1,5 @@
 import type { AgentSpec } from './interface.js';
-
-// Holdout roles that enforce strict context isolation
-const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
+import { HOLDOUT_ROLES } from './roles.js';
 // Keys managed by the runtime itself — not user-injected, so not violations
 export const SYSTEM_KEYS: ReadonlySet<string> = new Set(['projectId', 'workItemId']);
 

--- a/core/agent-runtime/model-router.ts
+++ b/core/agent-runtime/model-router.ts
@@ -3,8 +3,7 @@ import { db } from '../db/db.js';
 import { decisionPatterns } from '../db/schema.js';
 import type { WorkItem } from '../state-source/interface.js';
 import type { ModelTier, Role } from '../types.js';
-
-const HOLDOUT_ROLES = new Set<string>(['qa', 'reviewer']);
+import { HOLDOUT_ROLES } from './roles.js';
 
 export interface SelectModelInput {
   workItem: WorkItem;

--- a/core/agent-runtime/roles.ts
+++ b/core/agent-runtime/roles.ts
@@ -7,6 +7,21 @@ export interface RoleDefaults {
 }
 
 /**
+ * Roles that enforce holdout discipline (FACTORY_RULES rule 1): they never
+ * see implementation reasoning, never receive a fallback retry, and never
+ * have their model tier overridden by the router. Any reference to
+ * `new Set(['qa', 'reviewer'])` should import this constant instead.
+ */
+export const HOLDOUT_ROLES: ReadonlySet<Role> = new Set<Role>(['qa', 'reviewer']);
+
+/**
+ * Priorities that gate the advise-on-plan skill and disable model fallback.
+ * Same data was previously duplicated as `CRITICAL_PRIORITIES` (fallback.ts)
+ * and `ADVISOR_GATED_PRIORITIES` (advisor.ts) — single source of truth here.
+ */
+export const ADVISOR_GATED_PRIORITIES: ReadonlySet<string> = new Set(['critical', 'high']);
+
+/**
  * Per-role default model tier and agent budgets.
  * Project configs override these via agentConfig.rolesModels and budgets.skillBudgetOverrides.
  * The orchestrator merges project overrides on top of these defaults at runtime.

--- a/core/agent-runtime/with-escalation.ts
+++ b/core/agent-runtime/with-escalation.ts
@@ -6,8 +6,7 @@ import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { HoldoutFallbackForbiddenError } from './interface.js';
 import { tierOf } from './models.js';
 import { resolveEscalatedBudgetsForProject } from './resolve-for-project.js';
-
-const HOLDOUT_ROLES = new Set(['qa', 'reviewer']);
+import { HOLDOUT_ROLES } from './roles.js';
 
 // Local rank table — duplicates the order in models.ts but kept private here
 // so we don't widen models.ts' public surface for one defensive check.

--- a/core/state-machine/states.ts
+++ b/core/state-machine/states.ts
@@ -29,3 +29,13 @@ export const STATES = Object.freeze([
 
 export type StateName = (typeof STATES)[number];
 export type State = StateName;
+
+/**
+ * Terminal states a work item can settle into. Used by sprint-review filtering
+ * and CLI dashboards to exclude items no longer in active flow.
+ */
+export const TERMINAL_STATES: ReadonlySet<StateName> = new Set<StateName>([
+  'factory:done',
+  'factory:archived',
+  'factory:rejected',
+]);

--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -5,29 +5,56 @@ import { isLegalTransition } from '../state-machine/transitions.js';
 import type {
   Artifact,
   CreateIssueInput,
-  ExecMode,
   IssueComment,
   Milestone,
-  Mode,
-  Priority,
   Schedule,
   SourceEvent,
   StateSource,
   Subscription,
   WorkItem,
-  WorkItemType,
 } from './interface.js';
+import {
+  LABEL_GROUPS,
+  extractLabelValue,
+  parseExec,
+  parseMode,
+  parsePriority,
+  parseSchedule,
+  parseWorkItemType,
+} from './label-parsers.js';
 
 function parseIssueNumber(itemId: string): string {
   return itemId.match(/#(\d+)$/)?.[1] ?? itemId;
 }
 
-export const SCHEDULE_UI_TO_LABEL: Record<string, string> = {
+/**
+ * Schedule values exposed in the UI. `backlog` and `icebox` are aliases for
+ * the canonical Schedule values `next` and `later` respectively (the human-
+ * facing wording diverges from the label namespace for historical reasons).
+ */
+export type ScheduleUIValue = 'current' | 'backlog' | 'icebox' | 'blocked-by';
+
+/**
+ * UI → canonical Schedule value (the `value` part of a `schedule:<value>`
+ * label). Used at the server boundary before calling `setLabelInGroup` so
+ * the data layer never sees `backlog`/`icebox` (which would silently no-op
+ * in `in-memory-labels` and produce an invalid label name on GitHub).
+ */
+export const SCHEDULE_UI_TO_VALUE: Record<ScheduleUIValue, Schedule> = {
+  current: 'current',
+  backlog: 'next',
+  icebox: 'later',
+  // 'blocked-by' is a manual override the human sets via the UI — round-trips
+  // through unchanged (#202).
+  'blocked-by': 'blocked-by',
+};
+
+/** UI → full GitHub label (with `schedule:` prefix). Kept for callers that
+ * need to compare against raw label names directly. */
+export const SCHEDULE_UI_TO_LABEL: Record<ScheduleUIValue, string> = {
   current: 'schedule:current',
   backlog: 'schedule:next',
   icebox: 'schedule:later',
-  // 'blocked-by' is a manual override label set by the human; the API must
-  // accept it so the UI can roundtrip the value (#202).
   'blocked-by': 'schedule:blocked-by',
 };
 
@@ -87,52 +114,15 @@ function mapIssueToWorkItem(issue: GithubIssue, repoRef: string, ownerLogin: str
   // State: run full conflict resolver; handles multi-label, archived-wins, zero-label cases.
   const { state } = resolveState(labelNames);
 
-  // Type
-  const typeLabel = labelNames.find((n) => n.startsWith('type:'));
-  const typeValue = typeLabel?.slice('type:'.length);
-  const type: WorkItemType =
-    typeValue === 'feature' ||
-    typeValue === 'bug' ||
-    typeValue === 'chore' ||
-    typeValue === 'research'
-      ? typeValue
-      : 'feature';
-
-  // Priority
-  const priorityLabel = labelNames.find((n) => n.startsWith('priority:'));
-  const priorityValue = priorityLabel?.slice('priority:'.length);
-  const priority: Priority =
-    priorityValue === 'critical' ||
-    priorityValue === 'high' ||
-    priorityValue === 'medium' ||
-    priorityValue === 'low'
-      ? priorityValue
-      : 'medium';
-
-  // Mode
-  const modeLabel = labelNames.find((n) => n.startsWith('mode:'));
-  const modeValue = modeLabel?.slice('mode:'.length);
-  const mode: Mode =
-    modeValue === 'supervised' || modeValue === 'autonomous' || modeValue === 'interactive'
-      ? modeValue
-      : 'supervised';
-
-  // Schedule
-  const scheduleLabel = labelNames.find((n) => n.startsWith('schedule:'));
-  const scheduleValue = scheduleLabel?.slice('schedule:'.length);
-  const schedule: Schedule =
-    scheduleValue === 'current' ||
-    scheduleValue === 'next' ||
-    scheduleValue === 'later' ||
-    scheduleValue === 'blocked-by'
-      ? scheduleValue
-      : 'later';
-
-  // Exec
-  const execLabel = labelNames.find((n) => n.startsWith('exec:'));
-  const execValue = execLabel?.slice('exec:'.length);
-  const exec: ExecMode =
-    execValue === 'serial' || execValue === 'parallel' ? execValue : 'parallel';
+  // Per ADR 0039 the github-labels mapper is the single ingress for label
+  // values — narrow the strings to typed enums here, then trust the type
+  // downstream. Unknown values fall back to the documented DEFAULT_* in
+  // interface.ts (one place to change a default).
+  const type = parseWorkItemType(extractLabelValue(labelNames, LABEL_GROUPS.TYPE));
+  const priority = parsePriority(extractLabelValue(labelNames, LABEL_GROUPS.PRIORITY));
+  const mode = parseMode(extractLabelValue(labelNames, LABEL_GROUPS.MODE));
+  const schedule: Schedule = parseSchedule(extractLabelValue(labelNames, LABEL_GROUPS.SCHEDULE));
+  const exec = parseExec(extractLabelValue(labelNames, LABEL_GROUPS.EXEC));
 
   const body = issue.body ?? '';
 
@@ -352,7 +342,7 @@ export class GitHubLabelsSource implements StateSource {
       .map((l) => l.name)
       .filter((name) => {
         if (removeFactoryLabels === 'all') {
-          return !name.startsWith('factory:');
+          return !name.startsWith(LABEL_GROUPS.STATE);
         }
         return name !== removeFactoryLabels;
       });

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -7,6 +7,17 @@ export type Mode = 'interactive' | 'supervised' | 'autonomous';
 export type Schedule = 'current' | 'next' | 'later' | 'blocked-by';
 export type ExecMode = 'serial' | 'parallel';
 
+/**
+ * Default values applied when a work item has no label in the corresponding
+ * group. Used by the ingress parsers in `github-labels.ts` so the fallback
+ * value is named once in a single, type-checked location.
+ */
+export const DEFAULT_WORK_ITEM_TYPE: WorkItemType = 'feature';
+export const DEFAULT_PRIORITY: Priority = 'medium';
+export const DEFAULT_MODE: Mode = 'supervised';
+export const DEFAULT_SCHEDULE: Schedule = 'later';
+export const DEFAULT_EXEC: ExecMode = 'parallel';
+
 export interface WorkItem {
   id: string; // global: "github:shaunnez/goose-hub#42"
   externalId: string; // "42" or "PROJ-123"

--- a/core/state-source/label-parsers.ts
+++ b/core/state-source/label-parsers.ts
@@ -1,0 +1,123 @@
+import { STATES, type StateName } from '../state-machine/states.js';
+import type { Role } from '../types.js';
+import {
+  DEFAULT_EXEC,
+  DEFAULT_MODE,
+  DEFAULT_PRIORITY,
+  DEFAULT_SCHEDULE,
+  DEFAULT_WORK_ITEM_TYPE,
+  type ExecMode,
+  type Mode,
+  type Priority,
+  type Schedule,
+  type WorkItemType,
+} from './interface.js';
+
+/**
+ * Group prefixes for the GitHub-labels state machine. Use this constant
+ * instead of repeating bare strings like `'priority:'` across the codebase —
+ * adding a new group means changing one place.
+ */
+export const LABEL_GROUPS = {
+  STATE: 'factory:',
+  TYPE: 'type:',
+  PRIORITY: 'priority:',
+  MODE: 'mode:',
+  SCHEDULE: 'schedule:',
+  EXEC: 'exec:',
+} as const;
+
+const STATE_SET: ReadonlySet<string> = new Set(STATES);
+const PRIORITY_SET: ReadonlySet<string> = new Set<Priority>(['critical', 'high', 'medium', 'low']);
+const MODE_SET: ReadonlySet<string> = new Set<Mode>(['interactive', 'supervised', 'autonomous']);
+const SCHEDULE_SET: ReadonlySet<string> = new Set<Schedule>([
+  'current',
+  'next',
+  'later',
+  'blocked-by',
+]);
+const EXEC_SET: ReadonlySet<string> = new Set<ExecMode>(['serial', 'parallel']);
+const TYPE_SET: ReadonlySet<string> = new Set<WorkItemType>([
+  'feature',
+  'bug',
+  'chore',
+  'research',
+]);
+const ROLE_SET: ReadonlySet<string> = new Set<Role>([
+  'triager',
+  'griller',
+  'prd-writer',
+  'decomposer',
+  'investigator',
+  'developer',
+  'qa',
+  'reviewer',
+  'dev-reviewer',
+  'retrospector',
+  'researcher',
+  'auditor',
+]);
+
+/**
+ * Parse a raw `factory:*` label name to a typed StateName, returning null
+ * when the label is absent or unrecognised. Strict version — used at ingress
+ * to surface unknown states explicitly. Per ADR 0039: validate at the seam,
+ * trust the type downstream.
+ */
+export function parseState(raw: string | undefined): StateName | null {
+  if (raw == null) return null;
+  return STATE_SET.has(raw) ? (raw as StateName) : null;
+}
+
+/** Parse the bare value part of a `priority:<value>` label. */
+export function parsePriority(raw: string | undefined): Priority {
+  if (raw != null && PRIORITY_SET.has(raw)) return raw as Priority;
+  return DEFAULT_PRIORITY;
+}
+
+/** Parse the bare value part of a `mode:<value>` label. */
+export function parseMode(raw: string | undefined): Mode {
+  if (raw != null && MODE_SET.has(raw)) return raw as Mode;
+  return DEFAULT_MODE;
+}
+
+/** Parse the bare value part of a `schedule:<value>` label. */
+export function parseSchedule(raw: string | undefined): Schedule {
+  if (raw != null && SCHEDULE_SET.has(raw)) return raw as Schedule;
+  return DEFAULT_SCHEDULE;
+}
+
+/** Parse the bare value part of an `exec:<value>` label. */
+export function parseExec(raw: string | undefined): ExecMode {
+  if (raw != null && EXEC_SET.has(raw)) return raw as ExecMode;
+  return DEFAULT_EXEC;
+}
+
+/** Parse the bare value part of a `type:<value>` label. */
+export function parseWorkItemType(raw: string | undefined): WorkItemType {
+  if (raw != null && TYPE_SET.has(raw)) return raw as WorkItemType;
+  return DEFAULT_WORK_ITEM_TYPE;
+}
+
+/**
+ * Parse a free-string role identifier, returning null when it doesn't match
+ * a known Role. Callers decide how to handle null (skip, default, throw).
+ */
+export function parseRole(raw: string | undefined): Role | null {
+  if (raw == null) return null;
+  return ROLE_SET.has(raw) ? (raw as Role) : null;
+}
+
+/**
+ * Strip a known group prefix from a raw label name, returning the bare value
+ * or undefined when no labels in the array carry that prefix. Centralises the
+ * `labels.find(...).slice(prefix.length)` pattern used throughout the
+ * github-labels mapper.
+ */
+export function extractLabelValue(
+  labelNames: readonly string[],
+  prefix: string,
+): string | undefined {
+  const match = labelNames.find((n) => n.startsWith(prefix));
+  return match?.slice(prefix.length);
+}

--- a/core/tool-layer/allowlist.ts
+++ b/core/tool-layer/allowlist.ts
@@ -1,3 +1,4 @@
+import { HOLDOUT_ROLES } from '../agent-runtime/roles.js';
 import type { Role } from '../types.js';
 import { type BundleName, TOOL_BUNDLES } from './bundles.js';
 
@@ -9,8 +10,6 @@ export { TOOL_BUNDLES };
  * violating the holdout discipline (FACTORY_RULES rule 1).
  */
 const HOLDOUT_BLOCKED_BUNDLES = new Set<BundleName>(['decision-record-only']);
-
-const HOLDOUT_ROLES = new Set<Role>(['qa', 'reviewer']);
 
 interface AllowlistSpec {
   toolBundles: string[];

--- a/docs/adr/0039-label-parsers-at-ingress.md
+++ b/docs/adr/0039-label-parsers-at-ingress.md
@@ -1,0 +1,94 @@
+# ADR 0039 — Validate label values at ingress, trust the type downstream
+
+**Status:** Accepted
+**Date:** 2026-05-11
+
+## Context
+
+A code-quality scan flagged ~1,300 string-literal references to state names
+and ~1,000 references to priority/role/work-item-type values across the
+codebase. The labels are GitHub label names (`factory:done`, `priority:high`,
+`type:feature`, etc.) — strings on the wire, but with strict, well-known
+domains.
+
+Two recurring patterns made this a problem rather than just verbose code:
+
+1. **Untyped fallback ladders.** Every label-mapping site (notably
+   `mapIssueToWorkItem` in `core/state-source/github-labels.ts`) re-asserted
+   the value space inline — long `value === 'critical' || value === 'high'
+   || ... ? value : 'medium'` ladders. The fallback default (`'medium'`,
+   `'supervised'`, `'later'`, `'parallel'`, etc.) was a bare literal next to
+   the ladder, easy to drift from the intended default.
+2. **No central validator.** New consumers manually re-implemented the same
+   narrowing predicate, sometimes with a slightly different default. There
+   was no obvious single function to import.
+
+Auditing 80+ files of state-name string literals or 35+ files of
+priority/type literals one-by-one is the wrong order of magnitude for the
+problem. The literals themselves aren't the bug — the bug is that nothing
+narrowed the strings to typed enums *at the seam between GitHub and core*.
+
+## Decision
+
+Validate label values at one ingress (`core/state-source/`); trust the
+TypeScript type system downstream.
+
+**New module:** `core/state-source/label-parsers.ts`. Exports:
+
+- `LABEL_GROUPS` — constant map of group prefixes (`'priority:'`, `'type:'`,
+  `'schedule:'`, `'mode:'`, `'exec:'`, `'factory:'`). Replaces ad-hoc
+  template literals like `` `${group}:` ``.
+- `parseState(raw)` — strict, returns `StateName | null`. Used at ingress to
+  surface unknown state labels rather than silently coercing.
+- `parsePriority`, `parseMode`, `parseSchedule`, `parseExec`,
+  `parseWorkItemType` — narrow the bare value of `<group>:<value>` to the
+  typed enum, falling back to the documented `DEFAULT_*` constant on
+  unknown input. Defaults live in `core/state-source/interface.ts`
+  (`DEFAULT_PRIORITY`, `DEFAULT_MODE`, …) so changing one is a single edit.
+- `parseRole(raw)` — strict, returns `Role | null`. Used by callers that
+  ingest persona/role names from external systems (DB rows, persona files).
+- `extractLabelValue(labelNames, prefix)` — small helper that codifies the
+  `labels.find(...).slice(prefix.length)` pattern.
+
+**`mapIssueToWorkItem`** in `github-labels.ts` is rewritten to use these
+parsers. Five inline ladders collapse to five calls. Default values are no
+longer co-located with the narrowing logic — they come from
+`interface.ts`.
+
+**Defaults moved out of github-labels.ts:**
+
+| Group     | Default       | Symbol               |
+|-----------|---------------|----------------------|
+| Type      | `feature`     | `DEFAULT_WORK_ITEM_TYPE` |
+| Priority  | `medium`      | `DEFAULT_PRIORITY`   |
+| Mode      | `supervised`  | `DEFAULT_MODE`       |
+| Schedule  | `later`       | `DEFAULT_SCHEDULE`   |
+| Exec      | `parallel`    | `DEFAULT_EXEC`       |
+
+## What this is NOT
+
+- **Not a sweep of all 1,300 state-literal callsites.** Those callsites
+  already work — they hand a known-good string to other code that's already
+  typed as `StateName`. Auditing them adds no safety because the values are
+  already constrained by the type system at every consumption point. Future
+  drift will be caught by the parser at the next ingress, not by a manual
+  audit of historical code.
+- **Not a Zod migration.** The discriminated-union approach inside
+  `ReviewOutputSchema` and `RetroOutputSchema` already uses Zod where
+  validation needs to be runtime-enforceable. Label parsing is a tighter,
+  cheaper case (single-key lookup against a small `Set`); a Zod schema would
+  add weight without buying anything.
+- **Not a generalised label registry.** The label namespace is small and
+  static. If/when projects need custom label groups, that's a separate ADR.
+
+## Consequences
+
+- New consumers that touch label values are expected to import from
+  `label-parsers.ts` rather than re-asserting the value space inline.
+- Default values for missing labels are now named constants — adding a new
+  group means one place to change instead of three (interface, ingress,
+  ad-hoc fallback).
+- If GitHub's label namespace ever grows a value the parser doesn't know
+  (e.g. a new priority `urgent`), `mapIssueToWorkItem` returns the default
+  rather than crashing. Callers that need strict failure should use
+  `parseState(...) ?? throw …` or an equivalent at their own seam.

--- a/skills/review/schema.ts
+++ b/skills/review/schema.ts
@@ -83,3 +83,4 @@ export type DecisionSummary = z.infer<typeof DecisionSummarySchema>;
 export type CriterionCheck = z.infer<typeof CriterionCheckSchema>;
 export type ReviewFinding = z.infer<typeof ReviewFindingSchema>;
 export type ReviewOutput = z.infer<typeof ReviewOutputSchema>;
+export type ReviewVerdict = ReviewOutput['verdict'];

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -25,7 +25,7 @@ import { classifyTopic } from '@goose-hub/core/review/topic-classifier.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
-import type { ReviewOutput } from '@goose-hub/skills/review/schema.js';
+import type { ReviewOutput, ReviewVerdict } from '@goose-hub/skills/review/schema.js';
 
 export interface ReviewWorkflowDeps {
   runtime?: AgentRuntime;
@@ -112,9 +112,13 @@ export async function runReviewWorkflow(
         });
       }
     } else {
-      const VERDICT_TO_STATE: Record<string, StateName> = {
+      // verdict is narrowed to Exclude<ReviewVerdict, 'needs-fix'> here, but
+      // the lookup map covers the full union for defence-in-depth — if a new
+      // verdict literal is added to the schema, TypeScript flags this branch.
+      const VERDICT_TO_STATE: Record<ReviewVerdict, StateName> = {
         approved: 'factory:approved',
         'needs-human': 'factory:needs-human',
+        'needs-fix': 'factory:needs-fix',
       };
       nextState = VERDICT_TO_STATE[reviewOutput.verdict] ?? 'factory:needs-human';
     }


### PR DESCRIPTION
Actions the wave-by-wave plan in `Code Quality Improvements types.md`. Splits naturally into three groups: pure de-duplication, an active bug fix, and a small architectural change with an ADR.

## Wave 1 — pure de-duplication

- **`HOLDOUT_ROLES`** exported from `core/agent-runtime/roles.ts`. Six server-side duplicates removed (`fallback.ts`, `with-escalation.ts`, `holdout-validator.ts`, `context-assembly.ts`, `model-router.ts`, `allowlist.ts`). The web-side copy in `ProjectModelPanel.tsx` is intentionally kept — `apps/web` does not import `@goose-hub/core` (importing `roles.ts` would transitively pull `eventStore`/Drizzle into the React bundle); annotated with a sync comment instead. Same treatment for `ROLE_ABBREV` in `usePersonaMap.ts`.
- **`TERMINAL_STATES`** exported from `core/state-machine/states.ts`; CLI and `sprint-review-eligibility` now import it.
- **`ReviewVerdict`** type exported from `skills/review/schema.ts`. `VERDICT_TO_STATE` in `slices/review/workflow.ts` is now `Record<ReviewVerdict, StateName>` — TypeScript will flag this branch if a new verdict literal is ever added to the schema.

## Wave 2 — naming / contract reconciliation

- **`ADVISOR_GATED_PRIORITIES`** (canonical) replaces both `fallback.ts` `CRITICAL_PRIORITIES` and `advisor.ts` `ADVISOR_GATED_PRIORITIES` (same data, different names and orders).
- **`setLabelInGroup` 'type' mismatch.** The plan suggested removing `'type'` from the interface, but real callers exist in `triage-batch` and `decompose-prd` workflows — removing it would break triage. Instead, the server endpoint is widened to accept `'type'` with a `VALID_TYPE` allowlist, bringing the HTTP surface in line with the data layer. Tests added.

## Wave 3 — Schedule UI translation (active bug)

`SCHEDULE_UI_TO_LABEL` exists in `github-labels.ts` but isn't called at the right boundary. UI sends `backlog`/`icebox`; the in-memory source silently no-ops; GitHub gets an invalid `schedule:backlog` label name. Fix:

- New `ScheduleUIValue` type (`current | backlog | icebox | blocked-by`) and `SCHEDULE_UI_TO_VALUE` map exported from `github-labels.ts`.
- Server `setIssueLabel` translates UI synonyms to canonical Schedule values (`next`, `later`) before calling `source.setLabelInGroup`.
- Two new tests cover the translation.

## Wave 3+4 — label parsers at ingress (ADR 0039)

Rather than auditing 1,300+ state-name and 1,000+ priority/role/work-item-type literals one-by-one, narrow at the seam:

- **`core/state-source/label-parsers.ts`** — `LABEL_GROUPS` prefix map plus `parseState`, `parsePriority`, `parseMode`, `parseSchedule`, `parseExec`, `parseWorkItemType`, `parseRole`, `extractLabelValue`.
- **`mapIssueToWorkItem`** in `github-labels.ts` collapses five inline narrowing ladders into five parser calls.
- **Defaults** (`DEFAULT_PRIORITY`, `DEFAULT_MODE`, `DEFAULT_SCHEDULE`, `DEFAULT_EXEC`, `DEFAULT_WORK_ITEM_TYPE`) exported from `interface.ts` so the fallback for an absent label is named in one place.
- **ADR 0039** documents the trade-off: not a sweep of historical literals, not a Zod migration, not a generalised label registry — just one ingress, then trust the type system.

## Verification

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — **3076 passed | 3 skipped** (211 test files)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Manual smoke: change a schedule from `backlog` to `current` in the web UI on a goose-hub-self issue and confirm the GitHub label written is `schedule:next`, not `schedule:backlog`.
- [ ] Manual smoke: trigger `/projects/<slug>/issues/<id>/set-label` with `{ group: 'type', value: 'bug' }` and confirm 200 + GitHub label `type:bug`.

https://claude.ai/code/session_01XzCPYNWDK2oxvUh1QXnLYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzCPYNWDK2oxvUh1QXnLYC)_