### PR TITLE
M19.22: code-quality-audit wired into retro + review + nightly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -386,6 +386,39 @@ improvement_candidate:
 
 **Telemetry:** `agent.run-completed` carries `turns.used` (extracted from CLI `num_turns`) alongside `turns.budgeted` and `budget.usd`, so retrospectives can compare observed vs limit.
 
+## Code-quality audit (M19.22 #698)
+
+`code-quality-audit` is invoked through `core/audit/run-audit.ts`. Three
+triggers, one orchestration:
+
+| Trigger              | Caller                                            | Priority gate                                |
+|----------------------|---------------------------------------------------|----------------------------------------------|
+| `deep-retro`         | `core/workflows/retrospective.ts`                 | `tier==='deep' && triggers.priorityHigh`     |
+| `convergent-review`  | `slices/review/workflow.ts` (parallel branch)     | `workItem.priority ∈ {high, critical}`       |
+| `nightly`            | `core/audit/nightly-scheduler.ts` (per project)   | all registered projects                       |
+
+The auditor scorecard sums to `audit_score` (0..100) which is written to
+the `run_quality_scores.audit_score` column. Lookups by `pipelineRunId`
+upgrade an existing merge-decision row in place; nightly audits synthesise
+`pipelineRunId = "nightly-<slug>-<isoDate>"` to keep the row queryable
+from the trend UI without colliding with real cycles. **`audit_score` is
+informational** — it does NOT feed `computeQualityScore` and the
+merge-decision gate ignores it. Its job is the autonomous-mode gate:
+`audit_score < 60 && mode === 'autonomous'` transitions the lifecycle to
+`factory:needs-human` instead of `factory:done` / `factory:approved`. In
+supervised mode the gate never fires (the human reads the audit and
+decides).
+
+The top three audit recommendations become `ImprovementCandidates` filed
+through the same path as retro candidates. Mapping is structural:
+`principle` mentioning "prompt" → `skill-prompt`, "config" → `skill-config`,
+"schema" → `skill-schema`, "governance" → `governance-suggestion`,
+otherwise → `workflow`. The auditor sets `priority`; mapping is in
+`mapPrincipleToKind()`. Top-3 selection sorts by (priority, impactPoints
+desc).
+
+Events: `audit.completed`, `audit.failed`, `audit.autonomy-gate-fired`.
+
 ## Two Quality Scores — QA 8-category vs deterministic outcome (M19.21 #697)
 
 Goose Hub records two distinct quality scores per work-item lifecycle. They

--- a/apps/server/src/domains/workflows/retro-batch.ts
+++ b/apps/server/src/domains/workflows/retro-batch.ts
@@ -6,6 +6,7 @@ import type {
   TriggerContext,
 } from '@goose-hub/core/workflows/retrospective.js';
 import { runRetrospectiveWorkflow } from '@goose-hub/core/workflows/retrospective.js';
+import { existingWorktreePath } from '@goose-hub/core/workspaces/worktree.js';
 import { getProject } from '#shared/projects.js';
 import { getSourceForSlug } from '#shared/source.js';
 import { maybeFireSprintReview } from './sprint-review-trigger.js';
@@ -55,6 +56,23 @@ function computeTriggers(slug: string, workItem: WorkItem): TriggerContext {
   };
 }
 
+/** Locate the dev worktree path for the work item's most recent `pr.opened`
+ * event. M19.22 (#698) — deep retro on a priority:high lifecycle attaches an
+ * audit run when a worktree is still around (cleanupWorktree fires post-
+ * merge, so the worktree may already be gone for some retro runs). */
+function findAuditWorktreePath(slug: string, workItemId: string): string | null {
+  const events = eventStore.replay({ projectId: slug, workItemId });
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind !== 'pr.opened') continue;
+    const payload = e.payload as { devRunId?: string } | null;
+    if (payload?.devRunId != null && typeof payload.devRunId === 'string') {
+      return existingWorktreePath(payload.devRunId);
+    }
+  }
+  return null;
+}
+
 export async function runRetroForItem(
   workItem: WorkItem,
   stateSource: StateSource,
@@ -63,12 +81,14 @@ export async function runRetroForItem(
   const cfg = await getProject(slug);
   const policy = resolvePolicy(cfg?.agentConfig.retrospectivePolicy.defaultTier);
   const triggers = computeTriggers(slug, workItem);
+  const auditWorktreePath = triggers.priorityHigh ? findAuditWorktreePath(slug, workItem.id) : null;
   await runRetrospectiveWorkflow({
     workItem,
     stateSource,
     projectId: slug,
     policy,
     triggers,
+    auditWorktreePath,
   });
 
   // Auto-trigger sprint review when the last schedule:current item in the

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,8 +8,8 @@ import { logger } from '@goose-hub/core/logger.js';
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
 import { startPerProjectScheduler } from '@goose-hub/core/projects/scheduler.js';
 import { serve } from '@hono/node-server';
+import { runTriageBatch } from './domains/workflows/triage-batch.js';
 import { app } from './server.js';
-import { dispatchTriageBatch } from './shared/dispatch.js';
 
 if (process.env.VITEST == null) {
   const closed = eventStore.closeOrphanedRuns();
@@ -25,7 +25,7 @@ if (process.env.VITEST == null) {
 
   loadProjects()
     .then((projects) => {
-      startPerProjectScheduler(projects, (slug) => dispatchTriageBatch(slug));
+      startPerProjectScheduler(projects, (slug) => runTriageBatch(slug));
       logger.info('per-project tick scheduler started', { projects: projects.map((p) => p.slug) });
       // Nightly code-quality-audit (#698). Delays first fire by 60s so a
       // server restart doesn't hammer every project at boot time.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { config } from 'dotenv';
 config({ path: resolve(import.meta.dirname, '../../../.env') });
 
+import { startNightlyAuditScheduler } from '@goose-hub/core/audit/nightly-scheduler.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
@@ -26,6 +27,9 @@ if (process.env.VITEST == null) {
     .then((projects) => {
       startPerProjectScheduler(projects, (slug) => dispatchTriageBatch(slug));
       logger.info('per-project tick scheduler started', { projects: projects.map((p) => p.slug) });
+      // Nightly code-quality-audit (#698). Delays first fire by 60s so a
+      // server restart doesn't hammer every project at boot time.
+      startNightlyAuditScheduler(projects, { firstDelayMs: 60_000 });
     })
     .catch((err: unknown) => {
       logger.error('failed to start per-project tick scheduler', { error: String(err) });

--- a/apps/web/src/components/roster/components/QualityTrendTab.tsx
+++ b/apps/web/src/components/roster/components/QualityTrendTab.tsx
@@ -67,6 +67,15 @@ function ComponentsBadges({ point }: { point: QualityTrendPointDto }) {
   );
 }
 
+function ArchitecturalScoreBar({ score }: { score: number }) {
+  return (
+    <div className="flex items-center gap-2 mt-1">
+      <span className="text-[10px] uppercase tracking-wider text-fg-3 w-12 shrink-0">arch</span>
+      <ScoreBar score={score} />
+    </div>
+  );
+}
+
 function TrendRow({ point }: { point: QualityTrendPointDto }) {
   return (
     <div className="py-3 border-b border-line last:border-0">
@@ -77,6 +86,7 @@ function TrendRow({ point }: { point: QualityTrendPointDto }) {
         <span className="text-[11px] text-fg-3 shrink-0">{timeAgo(point.ts)}</span>
       </div>
       <ScoreBar score={point.score} />
+      {point.auditScore != null && <ArchitecturalScoreBar score={point.auditScore} />}
       <ComponentsBadges point={point} />
     </div>
   );
@@ -120,6 +130,14 @@ export function QualityTrendTab({ projectSlug }: { projectSlug: string }) {
   const latest = trend[trend.length - 1];
   const avg =
     trend.length > 0 ? Math.round(trend.reduce((sum, p) => sum + p.score, 0) / trend.length) : 0;
+  const auditPoints = trend.filter((p) => p.auditScore != null);
+  const latestAudit = auditPoints[auditPoints.length - 1]?.auditScore;
+  const avgAudit =
+    auditPoints.length > 0
+      ? Math.round(
+          auditPoints.reduce((sum, p) => sum + (p.auditScore ?? 0), 0) / auditPoints.length,
+        )
+      : null;
 
   return (
     <div data-testid="quality-trend-tab" className="flex flex-col h-full overflow-hidden">
@@ -142,6 +160,22 @@ export function QualityTrendTab({ projectSlug }: { projectSlug: string }) {
             {avg}
           </div>
         </div>
+        {latestAudit != null && (
+          <div data-testid="architectural-quality-score">
+            <div className="text-[11px] uppercase tracking-wider text-fg-3 mb-0.5">
+              Architectural ({auditPoints.length})
+            </div>
+            <div
+              className="text-[22px] font-bold font-mono"
+              style={{ color: scoreColor(latestAudit) }}
+            >
+              {latestAudit}
+              {avgAudit != null && (
+                <span className="text-[11px] font-normal text-fg-3 ml-2">avg {avgAudit}</span>
+              )}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Run list */}

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -214,6 +214,15 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     modelTier: 'sonnet',
     escalation: { modelTier: 'opus', maxBudgetUsd: 20.0 },
   },
+  // M19.22 (#698) — code-quality-audit. Opus-tier qualitative scoring across
+  // 8 categories; read-only + git log/blame access. Higher turn cap to allow
+  // the auditor to verify evidence across multiple files.
+  'code-quality-audit': {
+    maxTurns: 60,
+    maxBudgetUsd: 3.0,
+    timeoutMs: 480_000,
+    modelTier: 'opus',
+  },
 };
 
 export interface ResolvedBudget {

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -424,6 +424,91 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
         events: [],
       };
 
+    // Wave-1 scouts (M19.01) — canonical empty-findings success keeps the
+    // investigate workflow flowing in MOCK_AGENTS=true. Each scout shares the
+    // ScoutOutputSchema shape; findings can legitimately be empty.
+    case 'scout-schema':
+    case 'scout-code-path':
+    case 'scout-pattern':
+    case 'scout-test-inventory':
+    case 'scout-dependency':
+    case 'scout-user-journey': {
+      const scoutSummary = `Mock ${spec.skill} for e2e test`;
+      return {
+        output: {
+          findings: [],
+          status: 'ok' as const,
+          decisionSummaries: [{ kind: 'INSIGHT', summary: scoutSummary }],
+        },
+        decisionSummaries: [{ kind: 'INSIGHT', summary: scoutSummary }],
+        events: [],
+      };
+    }
+
+    case 'wave2-interface-designer':
+      return {
+        output: {
+          artefacts: [],
+          openQuestions: [],
+          decisionSummaries: [
+            { kind: 'INSIGHT', summary: 'Mock wave2-interface-designer for e2e test' },
+          ],
+        },
+        decisionSummaries: [
+          { kind: 'INSIGHT', summary: 'Mock wave2-interface-designer for e2e test' },
+        ],
+        events: [],
+      };
+
+    case 'wave2-risk-analyst':
+      return {
+        output: {
+          risks: [],
+          openQuestions: [],
+          decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock wave2-risk-analyst for e2e test' }],
+        },
+        decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock wave2-risk-analyst for e2e test' }],
+        events: [],
+      };
+
+    // M19.22 (#698) — code-quality-audit. Defensive mock for the nightly
+    // scheduler in case its existsSync gate is ever bypassed. Canonical
+    // 'Good' rating with no recommendations and minimum-valid scorecard.
+    case 'code-quality-audit': {
+      const maxes = [20, 15, 15, 15, 10, 10, 10, 5] as const;
+      const names = [
+        'Open/Closed Compliance',
+        'Concept Count',
+        'Time-to-New-Capability',
+        'Complecting Score',
+        'LOC Discipline',
+        'Coupling / Fan-Out',
+        "Gall's Law Compliance",
+        'Cyclomatic Complexity',
+      ];
+      // Distribute 80 points across the 8 categories so the rating is 'Good'.
+      const scores = [16, 12, 12, 12, 8, 8, 8, 4];
+      return {
+        output: {
+          scorecard: scores.map((score, i) => ({
+            category: (i + 1) as 1,
+            name: names[i],
+            score,
+            max: maxes[i],
+            evidence: [{ file: 'mock-file.ts', line: 1, note: 'mock evidence' }],
+          })),
+          rating: 'Good' as const,
+          strengths: ['Mock audit passed'],
+          recommendations: [],
+          mcIlroyQuestion: 'Mock audit: no architectural questions raised.',
+          projectedScoreAfterTop3: 80,
+          decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock code-quality-audit for e2e' }],
+        },
+        decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock code-quality-audit for e2e' }],
+        events: [],
+      };
+    }
+
     default:
       throw new Error(`resolveMockOutput: no preset for skill "${spec.skill}"`);
   }

--- a/core/audit/README.md
+++ b/core/audit/README.md
@@ -1,0 +1,25 @@
+# core/audit/
+
+Orchestration glue for the `code-quality-audit` skill (M19.22, #698).
+
+## Files
+
+- `run-audit.ts` — single entry point `runCodeQualityAudit(input)`. Invokes the skill via `invokeSkill`, computes `audit_score`, persists it onto an existing `run_quality_scores` row by `pipelineRunId` (or creates a synthetic `nightly-<slug>-<isoDate>` row for project-level nightly audits), and emits up to three `ImprovementCandidates` from the top-3 recommendations. Returns an `autonomyGateFired` signal when `audit_score < 60` AND the project mode is `autonomous`.
+- `nightly-scheduler.ts` — `startNightlyAuditScheduler(projects, opts)`. Starts one timer per project that fires `runCodeQualityAudit` against the project's local target repo. Idempotent across server restarts because the synthetic `pipelineRunId` is keyed on the calendar date.
+- `run-audit.test.ts` — unit tests for `runCodeQualityAudit` and its helpers (top-3 selection, kind mapping, autonomy gate, failure path).
+- `slice.test.ts` — slice-level contract for the nightly scheduler.
+
+## Trigger sites
+
+| Trigger              | Caller                                            | priority gate                                |
+|----------------------|---------------------------------------------------|----------------------------------------------|
+| `deep-retro`         | `core/workflows/retrospective.ts`                 | `triggers.priorityHigh === true`             |
+| `convergent-review`  | `slices/review/workflow.ts` (parallel branch)     | `workItem.priority === 'high' \| 'critical'` |
+| `nightly`            | `apps/server/src/index.ts` → `nightly-scheduler`  | all registered projects                      |
+
+## Autonomy gate
+
+`audit_score < 60` AND `project.mode === 'autonomous'` fires the gate. The
+caller is responsible for the state transition — `runCodeQualityAudit` only
+signals via `autonomyGateFired: true` on the result and emits an
+`audit.autonomy-gate-fired` event.

--- a/core/audit/nightly-scheduler.ts
+++ b/core/audit/nightly-scheduler.ts
@@ -74,17 +74,29 @@ export function startNightlyAuditScheduler(
   };
 
   const firstDelayMs = opts.firstDelayMs ?? 0;
-  for (const project of projects) {
+  // Deterministic per-project offset so timers don't fire in a synchronized
+  // burst when many projects are registered. Offset is bounded by either
+  // `firstDelayMs` (preserves the no-jitter test seam when caller passes 0)
+  // or 5 minutes, whichever is smaller — large enough to spread expensive
+  // audits, small enough that all projects still fire on the same calendar
+  // night.
+  const MAX_JITTER_MS = 5 * 60 * 1000;
+  const offsetCeiling = firstDelayMs > 0 ? Math.min(firstDelayMs, MAX_JITTER_MS) : 0;
+
+  for (const [index, project] of projects.entries()) {
+    const jitterMs =
+      offsetCeiling === 0 ? 0 : Math.floor((index * offsetCeiling) / Math.max(projects.length, 1));
+    const totalDelay = firstDelayMs + jitterMs;
     const kickoff = setTimeout(() => {
       fire(project);
       const timer = setInterval(() => fire(project), intervalMs);
       timers.push(timer);
-    }, firstDelayMs);
+    }, totalDelay);
     timers.push(kickoff as unknown as ReturnType<typeof setInterval>);
     logger.info('nightly audit scheduler armed', {
       slug: project.slug,
       intervalHours: intervalMs / HOURS,
-      firstDelayMs,
+      firstDelayMs: totalDelay,
     });
   }
 

--- a/core/audit/nightly-scheduler.ts
+++ b/core/audit/nightly-scheduler.ts
@@ -1,0 +1,98 @@
+// core/audit/nightly-scheduler.ts
+// Nightly trigger for `code-quality-audit` (M19.22, #698).
+//
+// One interval per registered project, firing once every
+// `AUDIT_NIGHTLY_INTERVAL_MS` (default 24 h). The audit runs against the
+// project's cloned target repository (`targetRepo.localPath`), persists an
+// `audit_score` row to `run_quality_scores`, and emits up to three
+// ImprovementCandidates.
+//
+// The first tick is delayed by `firstDelayMs` so a server restart doesn't
+// fire audits across every project simultaneously. Errors thrown by the
+// audit are caught and logged; they never affect any other project's tick.
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { logger } from '../logger.js';
+import type { ProjectConfig } from '../types.js';
+import { runCodeQualityAudit } from './run-audit.js';
+
+const HOURS = 60 * 60 * 1000;
+const DEFAULT_INTERVAL_MS = 24 * HOURS;
+
+export interface NightlyAuditScheduler {
+  /** Stop all per-project nightly timers. */
+  stop(): void;
+}
+
+export interface StartNightlyAuditSchedulerOpts {
+  /** Override the default 24h interval (test seam). */
+  intervalMs?: number;
+  /** Delay before the first tick fires. Default 0. */
+  firstDelayMs?: number;
+  /** Test seam — swap out the audit invocation. */
+  runAudit?: typeof runCodeQualityAudit;
+}
+
+function resolveLocalPath(localPath: string): string {
+  if (localPath.startsWith('~')) return join(homedir(), localPath.slice(2));
+  return localPath;
+}
+
+/**
+ * Start nightly audit timers for the supplied projects. Returns a stop
+ * handle. Idempotent across restarts because the synthetic `pipelineRunId`
+ * embeds the calendar date — re-running on the same day overwrites the row
+ * rather than duplicating it.
+ */
+export function startNightlyAuditScheduler(
+  projects: ProjectConfig[],
+  opts: StartNightlyAuditSchedulerOpts = {},
+): NightlyAuditScheduler {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const runAudit = opts.runAudit ?? runCodeQualityAudit;
+  const timers: ReturnType<typeof setInterval>[] = [];
+
+  const fire = (project: ProjectConfig): void => {
+    const worktreePath = resolveLocalPath(project.targetRepo.localPath);
+    if (!existsSync(worktreePath)) {
+      logger.warn('nightly audit skipped — localPath missing', {
+        slug: project.slug,
+        worktreePath,
+      });
+      return;
+    }
+    runAudit({
+      projectId: project.slug,
+      worktreePath,
+      trigger: 'nightly',
+      mode: project.mode,
+    }).catch((err: unknown) => {
+      logger.error('nightly audit failed', { slug: project.slug, error: String(err) });
+    });
+  };
+
+  const firstDelayMs = opts.firstDelayMs ?? 0;
+  for (const project of projects) {
+    const kickoff = setTimeout(() => {
+      fire(project);
+      const timer = setInterval(() => fire(project), intervalMs);
+      timers.push(timer);
+    }, firstDelayMs);
+    timers.push(kickoff as unknown as ReturnType<typeof setInterval>);
+    logger.info('nightly audit scheduler armed', {
+      slug: project.slug,
+      intervalHours: intervalMs / HOURS,
+      firstDelayMs,
+    });
+  }
+
+  return {
+    stop() {
+      for (const t of timers) clearInterval(t);
+      timers.length = 0;
+      logger.info('nightly audit scheduler stopped');
+    },
+  };
+}

--- a/core/audit/run-audit.test.ts
+++ b/core/audit/run-audit.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockInvokeSkill = vi.fn();
 const mockAppendEvent = vi.fn();
-const mockPersist = vi.fn();
-const mockGetByPipeline = vi.fn();
+const mockUpdateByPipeline = vi.fn();
+const mockInsertAuditOnly = vi.fn();
 
 vi.mock('../agent-runtime/invoke-skill.js', async () => {
   const actual = await vi.importActual<typeof import('../agent-runtime/invoke-skill.js')>(
@@ -20,9 +20,11 @@ vi.mock('../event-stream/store.js', () => ({
 }));
 
 vi.mock('../quality-score/repository.js', () => ({
-  persistRunQualityScore: mockPersist,
-  getLatestQualityScoreByPipelineRun: mockGetByPipeline,
+  updateAuditScoreByPipelineRun: mockUpdateByPipeline,
+  insertAuditOnlyRow: mockInsertAuditOnly,
   listProjectQualityTrend: vi.fn(() => []),
+  getLatestQualityScoreByPipelineRun: vi.fn(() => null),
+  persistRunQualityScore: vi.fn(),
 }));
 
 const {
@@ -103,7 +105,7 @@ function buildOutput(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetByPipeline.mockReturnValue(null);
+  mockUpdateByPipeline.mockReturnValue(1);
 });
 
 describe('computeAuditScore', () => {
@@ -152,7 +154,7 @@ describe('buildImprovementCandidates — top-3 emission', () => {
 });
 
 describe('runCodeQualityAudit — happy path', () => {
-  it('persists audit_score on the run_quality_scores row', async () => {
+  it('in-PR audit (deep-retro) updates audit_score in place by pipelineRunId without writing score=0', async () => {
     mockInvokeSkill.mockResolvedValueOnce({
       output: buildOutput({ totalScore: 82 }),
       decisionSummaries: [],
@@ -174,40 +176,20 @@ describe('runCodeQualityAudit — happy path', () => {
       expect(result.autonomyGateFired).toBe(false);
     }
 
-    expect(mockPersist).toHaveBeenCalledOnce();
-    const persistCall = mockPersist.mock.calls[0][0] as {
-      auditScore: number;
-      pipelineRunId: string;
-    };
-    expect(persistCall.auditScore).toBe(82);
-    expect(persistCall.pipelineRunId).toBe('pipe-1');
+    expect(mockUpdateByPipeline).toHaveBeenCalledOnce();
+    expect(mockUpdateByPipeline.mock.calls[0][0]).toEqual({
+      pipelineRunId: 'pipe-1',
+      auditScore: 82,
+    });
+    expect(mockInsertAuditOnly).not.toHaveBeenCalled();
 
     const eventKinds = mockAppendEvent.mock.calls.map((c) => (c[0] as { kind: string }).kind);
     expect(eventKinds).toContain('audit.completed');
     expect(eventKinds).not.toContain('audit.autonomy-gate-fired');
   });
 
-  it('upgrades an existing run_quality_scores row in-place by pipelineRunId', async () => {
-    mockGetByPipeline.mockReturnValueOnce({
-      runId: 'existing-run',
-      pipelineRunId: 'pipe-2',
-      projectId: 'proj-1',
-      iteration: 0,
-      score: 85,
-      components: {
-        p0_count: 0,
-        p1_count: 1,
-        p2_count: 0,
-        p3_count: 0,
-        regressions_open: 0,
-        review_converged: true,
-        uat_passed: true,
-        static_passed: true,
-        harness_pass_rate: 1,
-      },
-      auditScore: null,
-      ts: '2026-05-11T00:00:00Z',
-    });
+  it('convergent-review audit does not pollute trend when no row exists yet — update is no-op until merge-decision runs', async () => {
+    mockUpdateByPipeline.mockReturnValueOnce(0); // simulate: no row found
     mockInvokeSkill.mockResolvedValueOnce({
       output: buildOutput({ totalScore: 78 }),
       decisionSummaries: [],
@@ -222,14 +204,44 @@ describe('runCodeQualityAudit — happy path', () => {
       mode: 'supervised',
     });
 
-    const persistCall = mockPersist.mock.calls[0][0] as {
-      runId: string;
-      score: number;
+    // Update was attempted; no synthetic insert happened.
+    expect(mockUpdateByPipeline).toHaveBeenCalledOnce();
+    expect(mockInsertAuditOnly).not.toHaveBeenCalled();
+
+    // The audit.completed event carries the auditScore so merge-decision can
+    // later persist it as part of its own row write.
+    const completedEvent = mockAppendEvent.mock.calls
+      .map((c) => c[0] as { kind: string; payload: { auditScore?: number } })
+      .find((e) => e.kind === 'audit.completed');
+    expect(completedEvent?.payload.auditScore).toBe(78);
+  });
+
+  it('nightly audit inserts an audit-only row with the synthetic nightly pipelineRunId', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 72 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-nightly',
+      worktreePath: '/tmp/wt',
+      trigger: 'nightly',
+      mode: 'supervised',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pipelineRunId).toMatch(/^nightly-proj-nightly-\d{4}-\d{2}-\d{2}$/);
+    }
+    expect(mockInsertAuditOnly).toHaveBeenCalledOnce();
+    expect(mockUpdateByPipeline).not.toHaveBeenCalled();
+    const insertCall = mockInsertAuditOnly.mock.calls[0][0] as {
+      pipelineRunId: string;
       auditScore: number;
     };
-    expect(persistCall.runId).toBe('existing-run'); // preserves anchor runId
-    expect(persistCall.score).toBe(85); // does NOT clobber the merge-decision score
-    expect(persistCall.auditScore).toBe(78); // writes the new audit score
+    expect(insertCall.auditScore).toBe(72);
+    expect(insertCall.pipelineRunId).toMatch(/^nightly-/);
   });
 });
 
@@ -313,7 +325,8 @@ describe('runCodeQualityAudit — failure path', () => {
     const eventKinds = mockAppendEvent.mock.calls.map((c) => (c[0] as { kind: string }).kind);
     expect(eventKinds).toContain('audit.failed');
     // No audit_score persisted on failure
-    expect(mockPersist).not.toHaveBeenCalled();
+    expect(mockUpdateByPipeline).not.toHaveBeenCalled();
+    expect(mockInsertAuditOnly).not.toHaveBeenCalled();
   });
 
   it('synthesises a nightly pipelineRunId when none is supplied', async () => {

--- a/core/audit/run-audit.test.ts
+++ b/core/audit/run-audit.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInvokeSkill = vi.fn();
+const mockAppendEvent = vi.fn();
+const mockPersist = vi.fn();
+const mockGetByPipeline = vi.fn();
+
+vi.mock('../agent-runtime/invoke-skill.js', async () => {
+  const actual = await vi.importActual<typeof import('../agent-runtime/invoke-skill.js')>(
+    '../agent-runtime/invoke-skill.js',
+  );
+  return {
+    ...actual,
+    invokeSkill: (...args: unknown[]) => mockInvokeSkill(...args),
+  };
+});
+
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: { appendEvent: mockAppendEvent, replay: vi.fn(() => []) },
+}));
+
+vi.mock('../quality-score/repository.js', () => ({
+  persistRunQualityScore: mockPersist,
+  getLatestQualityScoreByPipelineRun: mockGetByPipeline,
+  listProjectQualityTrend: vi.fn(() => []),
+}));
+
+const {
+  AUDIT_AUTONOMY_THRESHOLD,
+  buildImprovementCandidates,
+  computeAuditScore,
+  mapPrincipleToKind,
+  runCodeQualityAudit,
+} = await import('./run-audit.js');
+
+type AuditOutput = import('../../skills/code-quality-audit/schema.js').CodeQualityAuditOutput;
+
+// Helper: a valid CodeQualityAuditOutput with adjustable scorecard totals.
+function buildOutput(
+  opts: { totalScore: number; recommendations?: number } = { totalScore: 82 },
+): AuditOutput {
+  // Distribute totalScore across 8 cats — scale of (20,15,15,15,10,10,10,5)
+  const maxes = [20, 15, 15, 15, 10, 10, 10, 5];
+  const target = opts.totalScore;
+  const scores: number[] = [];
+  let remaining = target;
+  for (let i = 0; i < 8; i++) {
+    const cap = maxes[i];
+    const v = Math.min(cap, Math.max(0, Math.min(remaining, cap)));
+    scores.push(v);
+    remaining -= v;
+  }
+  const names = [
+    'Open/Closed Compliance',
+    'Concept Count',
+    'Time-to-New-Capability',
+    'Complecting Score',
+    'LOC Discipline',
+    'Coupling / Fan-Out',
+    "Gall's Law Compliance",
+    'Cyclomatic Complexity',
+  ];
+  const scorecard = scores.map((s, i) => ({
+    category: (i + 1) as 1,
+    name: names[i],
+    score: s,
+    max: maxes[i],
+    evidence: [{ file: 'src/x.ts', line: 1, note: 'note' }],
+  }));
+  const total = scores.reduce((a, b) => a + b, 0);
+  const rating =
+    total >= 90
+      ? 'Exemplary'
+      : total >= 75
+        ? 'Good'
+        : total >= 55
+          ? 'NeedsWork'
+          : total >= 35
+            ? 'Concerning'
+            : 'Redesign';
+
+  const recs = opts.recommendations ?? 5;
+  const recommendations = Array.from({ length: recs }, (_, i) => ({
+    priority: i === 0 ? 'P0' : i === 1 ? 'P1' : 'P2',
+    principle: i === 0 ? 'Workflow simplification' : i === 1 ? 'Skill prompt clarity' : 'Cohesion',
+    file: `src/file-${i}.ts`,
+    line: i + 1,
+    fix: `Fix ${i}`,
+    effort: 'Medium',
+    impactPoints: 10 - i,
+  }));
+
+  return {
+    scorecard,
+    rating: rating as AuditOutput['rating'],
+    strengths: ['Good naming'],
+    recommendations: recommendations as AuditOutput['recommendations'],
+    mcIlroyQuestion: 'Can these components be independently piped?',
+    projectedScoreAfterTop3: Math.min(100, total + 5),
+    decisionSummaries: [{ kind: 'SELF_SCORE', summary: 'Synthesised from rubric' }],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetByPipeline.mockReturnValue(null);
+});
+
+describe('computeAuditScore', () => {
+  it('sums the 8 category scores', () => {
+    const out = buildOutput({ totalScore: 82 });
+    expect(computeAuditScore(out)).toBe(82);
+  });
+});
+
+describe('mapPrincipleToKind', () => {
+  it('routes "prompt" to skill-prompt', () => {
+    expect(mapPrincipleToKind('Skill prompt clarity')).toBe('skill-prompt');
+  });
+  it('routes "config" to skill-config', () => {
+    expect(mapPrincipleToKind('Project config simplification')).toBe('skill-config');
+  });
+  it('routes "schema" to skill-schema', () => {
+    expect(mapPrincipleToKind('Output schema convergence')).toBe('skill-schema');
+  });
+  it('routes "governance" to governance-suggestion', () => {
+    expect(mapPrincipleToKind('Governance perimeter tightening')).toBe('governance-suggestion');
+  });
+  it('falls back to workflow for architectural fixes', () => {
+    expect(mapPrincipleToKind('McIlroy: small is beautiful')).toBe('workflow');
+  });
+});
+
+describe('buildImprovementCandidates — top-3 emission', () => {
+  it('selects top 3 by (priority asc, impactPoints desc)', () => {
+    const out = buildOutput({ totalScore: 80, recommendations: 5 });
+    const cs = buildImprovementCandidates(out);
+    expect(cs).toHaveLength(3);
+    // First should be P0
+    expect(cs[0].confidence).toBe('high'); // P0 → high
+    expect(cs[1].confidence).toBe('medium'); // P1 → medium
+  });
+  it('returns fewer than 3 when recommendations are short', () => {
+    const out = buildOutput({ totalScore: 80, recommendations: 2 });
+    const cs = buildImprovementCandidates(out);
+    expect(cs).toHaveLength(2);
+  });
+  it('returns empty when no recommendations', () => {
+    const out = buildOutput({ totalScore: 80, recommendations: 0 });
+    expect(buildImprovementCandidates(out)).toEqual([]);
+  });
+});
+
+describe('runCodeQualityAudit — happy path', () => {
+  it('persists audit_score on the run_quality_scores row', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 82 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-1',
+      trigger: 'deep-retro',
+      mode: 'supervised',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.auditScore).toBe(82);
+      expect(result.improvementCandidates.length).toBeGreaterThan(0);
+      expect(result.autonomyGateFired).toBe(false);
+    }
+
+    expect(mockPersist).toHaveBeenCalledOnce();
+    const persistCall = mockPersist.mock.calls[0][0] as {
+      auditScore: number;
+      pipelineRunId: string;
+    };
+    expect(persistCall.auditScore).toBe(82);
+    expect(persistCall.pipelineRunId).toBe('pipe-1');
+
+    const eventKinds = mockAppendEvent.mock.calls.map((c) => (c[0] as { kind: string }).kind);
+    expect(eventKinds).toContain('audit.completed');
+    expect(eventKinds).not.toContain('audit.autonomy-gate-fired');
+  });
+
+  it('upgrades an existing run_quality_scores row in-place by pipelineRunId', async () => {
+    mockGetByPipeline.mockReturnValueOnce({
+      runId: 'existing-run',
+      pipelineRunId: 'pipe-2',
+      projectId: 'proj-1',
+      iteration: 0,
+      score: 85,
+      components: {
+        p0_count: 0,
+        p1_count: 1,
+        p2_count: 0,
+        p3_count: 0,
+        regressions_open: 0,
+        review_converged: true,
+        uat_passed: true,
+        static_passed: true,
+        harness_pass_rate: 1,
+      },
+      auditScore: null,
+      ts: '2026-05-11T00:00:00Z',
+    });
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 78 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-2',
+      trigger: 'convergent-review',
+      mode: 'supervised',
+    });
+
+    const persistCall = mockPersist.mock.calls[0][0] as {
+      runId: string;
+      score: number;
+      auditScore: number;
+    };
+    expect(persistCall.runId).toBe('existing-run'); // preserves anchor runId
+    expect(persistCall.score).toBe(85); // does NOT clobber the merge-decision score
+    expect(persistCall.auditScore).toBe(78); // writes the new audit score
+  });
+});
+
+describe('runCodeQualityAudit — autonomy gate', () => {
+  it('fires when audit_score < 60 AND mode === autonomous', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 50 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-3',
+      trigger: 'deep-retro',
+      mode: 'autonomous',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.autonomyGateFired).toBe(true);
+
+    const eventKinds = mockAppendEvent.mock.calls.map((c) => (c[0] as { kind: string }).kind);
+    expect(eventKinds).toContain('audit.autonomy-gate-fired');
+  });
+
+  it('does NOT fire in supervised mode even when score is well below threshold', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 30 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-4',
+      trigger: 'nightly',
+      mode: 'supervised',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.autonomyGateFired).toBe(false);
+  });
+
+  it('does NOT fire when score >= threshold even in autonomous mode', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: AUDIT_AUTONOMY_THRESHOLD + 5 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-5',
+      trigger: 'nightly',
+      mode: 'autonomous',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.autonomyGateFired).toBe(false);
+  });
+});
+
+describe('runCodeQualityAudit — failure path', () => {
+  it('returns ok:false and emits audit.failed when invokeSkill throws', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(new Error('LLM context window exceeded'));
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-1',
+      worktreePath: '/tmp/wt',
+      pipelineRunId: 'pipe-6',
+      trigger: 'deep-retro',
+      mode: 'autonomous',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('LLM context window exceeded');
+
+    const eventKinds = mockAppendEvent.mock.calls.map((c) => (c[0] as { kind: string }).kind);
+    expect(eventKinds).toContain('audit.failed');
+    // No audit_score persisted on failure
+    expect(mockPersist).not.toHaveBeenCalled();
+  });
+
+  it('synthesises a nightly pipelineRunId when none is supplied', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: buildOutput({ totalScore: 72 }),
+      decisionSummaries: [],
+      events: [],
+    });
+
+    const result = await runCodeQualityAudit({
+      projectId: 'proj-nightly',
+      worktreePath: '/tmp/wt',
+      trigger: 'nightly',
+      mode: 'supervised',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pipelineRunId).toMatch(/^nightly-proj-nightly-\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+});

--- a/core/audit/run-audit.ts
+++ b/core/audit/run-audit.ts
@@ -1,0 +1,256 @@
+// core/audit/run-audit.ts
+// Orchestration glue for the `code-quality-audit` skill (M19.22, #698).
+//
+// Responsibilities:
+//   1. invokeSkill('code-quality-audit') with the supplied worktree + work item
+//   2. Compute `audit_score` (sum of the 8-category scorecard, 0..100)
+//   3. Persist `audit_score` on the per-cycle `run_quality_scores` row
+//      keyed by `pipelineRunId` (M19.21). When no pipelineRunId is supplied
+//      (nightly project-level audit), a synthetic pipelineRunId is generated
+//      so the row is queryable by the trend UI without confusing it with a
+//      real merge-decision row.
+//   4. Translate the top-3 recommendations into ImprovementCandidates and
+//      hand them off to the persister supplied by the caller (the retro
+//      workflow already owns the candidate persistence path; review takes
+//      a simpler in-line path).
+//   5. Surface an autonomy-gate signal when `audit_score < 60` so callers
+//      running in `autonomous` mode can transition to `factory:needs-human`.
+
+import {
+  type CodeQualityAuditContext,
+  type CodeQualityAuditOutput,
+  CodeQualityAuditOutputSchema,
+  type Recommendation,
+} from '../../skills/code-quality-audit/schema.js';
+import { OutputValidationError, invokeSkill } from '../agent-runtime/invoke-skill.js';
+import { eventStore } from '../event-stream/store.js';
+import {
+  getLatestQualityScoreByPipelineRun,
+  persistRunQualityScore,
+} from '../quality-score/repository.js';
+import type { QualityComponents } from '../quality-score/types.js';
+import type { ImprovementCandidate } from '../retrospective/schemas.js';
+
+/** Configurable autonomy-gate threshold. Audit scores below this fail the
+ * autonomous-mode gate. Issue #698 spec: 60. */
+export const AUDIT_AUTONOMY_THRESHOLD = 60;
+
+/** Default empty components used when persisting a project-level nightly
+ * audit row — there is no PR cycle to derive QA/Review counts from. */
+const EMPTY_COMPONENTS: QualityComponents = {
+  p0_count: 0,
+  p1_count: 0,
+  p2_count: 0,
+  p3_count: 0,
+  regressions_open: 0,
+  review_converged: false,
+  uat_passed: false,
+  static_passed: false,
+  harness_pass_rate: 0,
+};
+
+export interface RunAuditInput {
+  projectId: string;
+  workItemId?: string | null;
+  /** Absolute path to the worktree the auditor should inspect. */
+  worktreePath: string;
+  /** Optional pre-computed metrics for Cat 5/6/8 (LOC, coupling, complexity). */
+  metricsJson?: CodeQualityAuditContext['metricsJson'];
+  /** Optional work item summary for context. */
+  workItem?: { title: string; number: number };
+  /** Pipeline run id to attach the audit score to. When omitted a synthetic
+   * `nightly-<projectId>-<isoDate>` id is generated. */
+  pipelineRunId?: string;
+  /** Iteration to write the audit row at. Defaults to 0. */
+  iteration?: number;
+  /** Trigger label written to the event payload. Helps the timeline + the
+   * trend UI distinguish nightly audits from review/retro-attached audits. */
+  trigger: 'deep-retro' | 'convergent-review' | 'nightly';
+  /** Project mode — drives the autonomy gate. */
+  mode: 'interactive' | 'supervised' | 'autonomous';
+}
+
+export interface AuditOutcome {
+  ok: true;
+  /** 0..100 — sum of the 8-category scorecard. */
+  auditScore: number;
+  /** Synthetic id when no pipeline anchor was supplied. */
+  pipelineRunId: string;
+  output: CodeQualityAuditOutput;
+  /** Up to three ImprovementCandidates derived from the audit's
+   * `recommendations` list, sorted by (priority, impactPoints desc). */
+  improvementCandidates: ImprovementCandidate[];
+  /** True when `auditScore < AUDIT_AUTONOMY_THRESHOLD` AND `mode === 'autonomous'`. */
+  autonomyGateFired: boolean;
+}
+
+export interface AuditFailure {
+  ok: false;
+  error: string;
+}
+
+export type AuditResult = AuditOutcome | AuditFailure;
+
+/** Priority ordering used to rank `recommendations` before truncating to top 3. */
+const PRIORITY_RANK: Record<Recommendation['priority'], number> = { P0: 0, P1: 1, P2: 2 };
+
+function sortRecommendations(list: Recommendation[]): Recommendation[] {
+  return [...list].sort((a, b) => {
+    const byPriority = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+    if (byPriority !== 0) return byPriority;
+    // Higher impact first
+    return b.impactPoints - a.impactPoints;
+  });
+}
+
+/** Map a McIlroy-style audit recommendation to the closest existing
+ * `ImprovementKind`. The audit only surfaces architectural fixes, so the
+ * mapping is structural: anything that mentions "skill"/"prompt" routes to
+ * `skill-prompt`; anything mentioning "config" routes to `skill-config`;
+ * everything else is a `workflow` change (the default architectural lever). */
+export function mapPrincipleToKind(principle: string): ImprovementCandidate['kind'] {
+  const p = principle.toLowerCase();
+  if (p.includes('prompt') || p.includes('skill prompt')) return 'skill-prompt';
+  if (p.includes('schema')) return 'skill-schema';
+  if (p.includes('config')) return 'skill-config';
+  if (p.includes('governance')) return 'governance-suggestion';
+  return 'workflow';
+}
+
+function recommendationConfidence(r: Recommendation): ImprovementCandidate['confidence'] {
+  if (r.priority === 'P0') return 'high';
+  if (r.priority === 'P1') return 'medium';
+  return 'low';
+}
+
+export function buildImprovementCandidates(
+  output: CodeQualityAuditOutput,
+  sourcePersonaId?: string,
+): ImprovementCandidate[] {
+  const top3 = sortRecommendations(output.recommendations).slice(0, 3);
+  return top3.map((r) => ({
+    kind: mapPrincipleToKind(r.principle),
+    targetPath: r.file,
+    suggestionText: `[${r.priority}] ${r.principle} — ${r.fix} (effort: ${r.effort}, impact: +${r.impactPoints})`,
+    confidence: recommendationConfidence(r),
+    ...(sourcePersonaId != null ? { sourcePersonaId } : {}),
+  }));
+}
+
+export function computeAuditScore(output: CodeQualityAuditOutput): number {
+  return output.scorecard.reduce((sum, entry) => sum + entry.score, 0);
+}
+
+function syntheticNightlyPipelineRunId(projectId: string, when: Date): string {
+  const iso = when.toISOString().slice(0, 10);
+  return `nightly-${projectId}-${iso}`;
+}
+
+/** Public entry point. See module header for the contract. */
+export async function runCodeQualityAudit(input: RunAuditInput): Promise<AuditResult> {
+  const runId = crypto.randomUUID();
+  const pipelineRunId =
+    input.pipelineRunId ?? syntheticNightlyPipelineRunId(input.projectId, new Date());
+
+  const context: Record<string, unknown> = { worktreePath: input.worktreePath };
+  if (input.metricsJson != null) context.metricsJson = input.metricsJson;
+  if (input.workItem != null) context.workItem = input.workItem;
+
+  let output: CodeQualityAuditOutput;
+  try {
+    const result = await invokeSkill({
+      skillName: 'code-quality-audit',
+      projectId: input.projectId,
+      workItemId: input.workItemId ?? undefined,
+      runId,
+      context,
+      overrides: {
+        extraEventPayload: { trigger: input.trigger, pipelineRunId },
+      },
+    });
+    const parsed = CodeQualityAuditOutputSchema.safeParse(result.output);
+    if (!parsed.success) {
+      throw new OutputValidationError(
+        parsed.error.issues.map((i) => ({
+          path: i.path as Array<string | number>,
+          message: i.message,
+        })),
+        'code-quality-audit',
+        runId,
+      );
+    }
+    output = parsed.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    eventStore.appendEvent({
+      projectId: input.projectId,
+      workItemId: input.workItemId ?? null,
+      kind: 'audit.failed',
+      payload: { runId, trigger: input.trigger, pipelineRunId, error: message },
+      runId,
+    });
+    return { ok: false, error: message };
+  }
+
+  const auditScore = computeAuditScore(output);
+  const iteration = input.iteration ?? 0;
+
+  // Persist on the existing per-cycle score row when one exists. If not
+  // (project-level nightly), insert a fresh row using the synthetic
+  // pipelineRunId — components are zeroed because no PR cycle anchors them.
+  const existing = getLatestQualityScoreByPipelineRun(pipelineRunId);
+  persistRunQualityScore({
+    runId: existing?.runId ?? pipelineRunId,
+    pipelineRunId,
+    projectId: input.projectId,
+    iteration: existing?.iteration ?? iteration,
+    score: existing?.score ?? 0,
+    components: existing?.components ?? EMPTY_COMPONENTS,
+    auditScore,
+  });
+
+  const improvementCandidates = buildImprovementCandidates(output);
+  const autonomyGateFired = auditScore < AUDIT_AUTONOMY_THRESHOLD && input.mode === 'autonomous';
+
+  eventStore.appendEvent({
+    projectId: input.projectId,
+    workItemId: input.workItemId ?? null,
+    kind: 'audit.completed',
+    payload: {
+      runId,
+      trigger: input.trigger,
+      pipelineRunId,
+      auditScore,
+      rating: output.rating,
+      recommendationCount: output.recommendations.length,
+      improvementCandidateCount: improvementCandidates.length,
+      autonomyGateFired,
+    },
+    runId,
+  });
+
+  if (autonomyGateFired) {
+    eventStore.appendEvent({
+      projectId: input.projectId,
+      workItemId: input.workItemId ?? null,
+      kind: 'audit.autonomy-gate-fired',
+      payload: {
+        runId,
+        pipelineRunId,
+        auditScore,
+        threshold: AUDIT_AUTONOMY_THRESHOLD,
+        trigger: input.trigger,
+      },
+      runId,
+    });
+  }
+
+  return {
+    ok: true,
+    auditScore,
+    pipelineRunId,
+    output,
+    improvementCandidates,
+    autonomyGateFired,
+  };
+}

--- a/core/audit/run-audit.ts
+++ b/core/audit/run-audit.ts
@@ -24,30 +24,17 @@ import {
 } from '../../skills/code-quality-audit/schema.js';
 import { OutputValidationError, invokeSkill } from '../agent-runtime/invoke-skill.js';
 import { eventStore } from '../event-stream/store.js';
-import {
-  getLatestQualityScoreByPipelineRun,
-  persistRunQualityScore,
-} from '../quality-score/repository.js';
-import type { QualityComponents } from '../quality-score/types.js';
+import { insertAuditOnlyRow, updateAuditScoreByPipelineRun } from '../quality-score/repository.js';
 import type { ImprovementCandidate } from '../retrospective/schemas.js';
 
 /** Configurable autonomy-gate threshold. Audit scores below this fail the
  * autonomous-mode gate. Issue #698 spec: 60. */
 export const AUDIT_AUTONOMY_THRESHOLD = 60;
 
-/** Default empty components used when persisting a project-level nightly
- * audit row — there is no PR cycle to derive QA/Review counts from. */
-const EMPTY_COMPONENTS: QualityComponents = {
-  p0_count: 0,
-  p1_count: 0,
-  p2_count: 0,
-  p3_count: 0,
-  regressions_open: 0,
-  review_converged: false,
-  uat_passed: false,
-  static_passed: false,
-  harness_pass_rate: 0,
-};
+/** Prefix used for synthetic nightly pipelineRunIds. Callers downstream
+ * (merge-decision, trend filters) use this to exclude project-level audit
+ * rows from cycle-trend calculations. */
+export const NIGHTLY_PIPELINE_RUN_PREFIX = 'nightly-';
 
 export interface RunAuditInput {
   projectId: string;
@@ -143,7 +130,7 @@ export function computeAuditScore(output: CodeQualityAuditOutput): number {
 
 function syntheticNightlyPipelineRunId(projectId: string, when: Date): string {
   const iso = when.toISOString().slice(0, 10);
-  return `nightly-${projectId}-${iso}`;
+  return `${NIGHTLY_PIPELINE_RUN_PREFIX}${projectId}-${iso}`;
 }
 
 /** Public entry point. See module header for the contract. */
@@ -195,19 +182,27 @@ export async function runCodeQualityAudit(input: RunAuditInput): Promise<AuditRe
   const auditScore = computeAuditScore(output);
   const iteration = input.iteration ?? 0;
 
-  // Persist on the existing per-cycle score row when one exists. If not
-  // (project-level nightly), insert a fresh row using the synthetic
-  // pipelineRunId — components are zeroed because no PR cycle anchors them.
-  const existing = getLatestQualityScoreByPipelineRun(pipelineRunId);
-  persistRunQualityScore({
-    runId: existing?.runId ?? pipelineRunId,
-    pipelineRunId,
-    projectId: input.projectId,
-    iteration: existing?.iteration ?? iteration,
-    score: existing?.score ?? 0,
-    components: existing?.components ?? EMPTY_COMPONENTS,
-    auditScore,
-  });
+  // Persistence strategy keyed on trigger to avoid trend pollution:
+  //   - In-PR audits (deep-retro, convergent-review) update the existing
+  //     run_quality_scores row keyed by pipelineRunId. If no row exists yet
+  //     (audit beat merge-decision to it), do NOT write a synthetic zero-
+  //     score row. The merge-decision gate later reads the latest
+  //     audit.completed event for this pipelineRunId and folds the score
+  //     into its persist call.
+  //   - Nightly audits write a row with the synthetic
+  //     `nightly-<slug>-<isoDate>` pipelineRunId; merge-decision filters
+  //     these out of cycle trend reads.
+  if (input.trigger === 'nightly') {
+    insertAuditOnlyRow({
+      runId: pipelineRunId,
+      pipelineRunId,
+      projectId: input.projectId,
+      iteration,
+      auditScore,
+    });
+  } else {
+    updateAuditScoreByPipelineRun({ pipelineRunId, auditScore });
+  }
 
   const improvementCandidates = buildImprovementCandidates(output);
   const autonomyGateFired = auditScore < AUDIT_AUTONOMY_THRESHOLD && input.mode === 'autonomous';

--- a/core/audit/slice.test.ts
+++ b/core/audit/slice.test.ts
@@ -89,12 +89,52 @@ describe('startNightlyAuditScheduler', () => {
     });
 
     expect(runAudit).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(100);
+    // Per-project jitter spreads timers up to firstDelayMs; advance well
+    // past the longest staggered fire so both projects have run.
+    await vi.advanceTimersByTimeAsync(250);
     expect(runAudit).toHaveBeenCalledTimes(2);
     expect(
       runAudit.mock.calls.every(([arg]) => (arg as { trigger: string }).trigger === 'nightly'),
     ).toBe(true);
 
+    scheduler.stop();
+  });
+
+  it('staggers per-project fires within firstDelayMs ceiling', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const fireTimes: number[] = [];
+    const runAudit = vi.fn().mockImplementation(() => {
+      fireTimes.push(Date.now());
+      return Promise.resolve({
+        ok: true,
+        auditScore: 80,
+        pipelineRunId: 'p',
+        autonomyGateFired: false,
+        output: {} as never,
+        improvementCandidates: [],
+      });
+    });
+    const projects = [
+      projectStub('a', '/tmp/a'),
+      projectStub('b', '/tmp/b'),
+      projectStub('c', '/tmp/c'),
+      projectStub('d', '/tmp/d'),
+    ];
+    const start = Date.now();
+    const scheduler = startNightlyAuditScheduler(projects, {
+      firstDelayMs: 200,
+      intervalMs: 1_000,
+      runAudit: runAudit as unknown as typeof import('./run-audit.js').runCodeQualityAudit,
+    });
+
+    await vi.advanceTimersByTimeAsync(450);
+    expect(runAudit).toHaveBeenCalledTimes(4);
+    // First fire must respect the base delay; subsequent fires must be
+    // strictly later than the prior one (deterministic stagger).
+    expect(fireTimes[0] - start).toBeGreaterThanOrEqual(200);
+    for (let i = 1; i < fireTimes.length; i++) {
+      expect(fireTimes[i]).toBeGreaterThanOrEqual(fireTimes[i - 1]);
+    }
     scheduler.stop();
   });
 

--- a/core/audit/slice.test.ts
+++ b/core/audit/slice.test.ts
@@ -1,0 +1,136 @@
+// core/audit/slice.test.ts
+// Lightweight slice contract: nightly scheduler arms one timer per project
+// and the scheduler honours the test-injected `runAudit` seam without
+// touching the filesystem when the project's `localPath` is missing.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.fn();
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return { ...actual, existsSync: (...args: unknown[]) => mockExistsSync(...args) };
+});
+vi.mock('node:os', async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return { ...actual, homedir: () => '/mock-home' };
+});
+
+const { startNightlyAuditScheduler } = await import('./nightly-scheduler.js');
+
+function projectStub(slug: string, localPath: string): import('../types.js').ProjectConfig {
+  return {
+    id: slug,
+    name: slug,
+    slug,
+    source: { kind: 'github', repo: 'x/y', stateMachine: 'labels' },
+    targetRepo: { cloneUrl: 'git@github.com:x/y.git', defaultBranch: 'main', localPath },
+    stack: {
+      runtime: 'node',
+      packageManager: 'pnpm',
+      testCommand: 'pnpm test',
+      detectedAt: '2026-05-11T00:00:00Z',
+    },
+    mode: 'supervised',
+    storage: { kind: 'local', path: '/tmp/x' },
+    repos: ['x/y'],
+    agentConfig: {
+      runtime: 'auto',
+      rolesModels: {},
+      fallbackPolicy: {},
+      toolAllowlists: {},
+      advisorMode: {
+        enabled: false,
+        triggerOn: { priorities: [] },
+        maxAdvisorBudgetUsd: 0,
+        disableInAutonomous: true,
+      },
+      retrospectivePolicy: { defaultTier: 'light', deepTriggers: [] },
+    },
+    budgets: {
+      dailyTokens: 0,
+      maxParallelAgents: 1,
+      maxRetries: 0,
+      perBashCommandMaxSeconds: 60,
+      perWorkflowMaxUsd: 1,
+      perAgentMaxUsd: 1,
+      perAdvisorMaxUsd: 0,
+    },
+    governance: { immutablePaths: [] },
+    isolation: { mode: 'native' },
+    archiveAfterDays: 7,
+    visibility: 'always_visible',
+    colorStripe: '#ffffff',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+describe('startNightlyAuditScheduler', () => {
+  it('fires audit per project once the first-delay elapses', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const runAudit = vi.fn().mockResolvedValue({
+      ok: true,
+      auditScore: 80,
+      pipelineRunId: 'p',
+      autonomyGateFired: false,
+      output: {} as never,
+      improvementCandidates: [],
+    });
+    const projects = [projectStub('a', '/tmp/a'), projectStub('b', '/tmp/b')];
+
+    const scheduler = startNightlyAuditScheduler(projects, {
+      firstDelayMs: 100,
+      intervalMs: 1_000,
+      runAudit: runAudit as unknown as typeof import('./run-audit.js').runCodeQualityAudit,
+    });
+
+    expect(runAudit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(runAudit).toHaveBeenCalledTimes(2);
+    expect(
+      runAudit.mock.calls.every(([arg]) => (arg as { trigger: string }).trigger === 'nightly'),
+    ).toBe(true);
+
+    scheduler.stop();
+  });
+
+  it('skips when project.targetRepo.localPath does not exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const runAudit = vi.fn();
+    const scheduler = startNightlyAuditScheduler([projectStub('a', '/missing')], {
+      firstDelayMs: 0,
+      runAudit: runAudit as unknown as typeof import('./run-audit.js').runCodeQualityAudit,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(runAudit).not.toHaveBeenCalled();
+    scheduler.stop();
+  });
+
+  it('resolves ~ in localPath against homedir', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const runAudit = vi.fn().mockResolvedValue({
+      ok: true,
+      auditScore: 80,
+      pipelineRunId: 'p',
+      autonomyGateFired: false,
+      output: {} as never,
+      improvementCandidates: [],
+    });
+    const scheduler = startNightlyAuditScheduler([projectStub('a', '~/code/repo')], {
+      firstDelayMs: 0,
+      runAudit: runAudit as unknown as typeof import('./run-audit.js').runCodeQualityAudit,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(runAudit).toHaveBeenCalledOnce();
+    expect((runAudit.mock.calls[0][0] as { worktreePath: string }).worktreePath).toBe(
+      '/mock-home/code/repo',
+    );
+    scheduler.stop();
+  });
+});

--- a/core/db/db.ts
+++ b/core/db/db.ts
@@ -8,15 +8,30 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import * as schema from './schema.js';
 
 /**
- * Resolve the database path. Under Vitest each worker gets its own file so
- * concurrent migrations (one per worker process) don't race on the same
- * SQLite file. Outside tests, all callers share `~/.factory/data/factory.db`
- * unless `DB_PATH` overrides it.
+ * Resolve the database path.
+ *
+ * - Under Vitest each worker gets its own file. Concurrent migrations (one
+ *   per worker process) race on a shared SQLite file otherwise — drizzle's
+ *   migrator is non-atomic across "is the migration applied?" / CREATE TABLE
+ *   so even WAL + busy_timeout can't serialize the two reads.
+ * - When the parent test runner sets `DB_PATH` (see
+ *   `scripts/run-vitest-with-db.ts`) we treat it as the *base* and append a
+ *   per-worker suffix so the temp dir is still scoped to a single
+ *   `pnpm test` invocation but workers don't collide inside it.
+ * - Outside tests, all callers share `~/.factory/data/factory.db` unless
+ *   `DB_PATH` overrides.
  */
 function resolveDbPath(): string {
-  if (process.env.DB_PATH != null) return process.env.DB_PATH;
   const workerId =
     process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? (process.env.VITEST ? '0' : null);
+
+  if (process.env.DB_PATH != null) {
+    if (workerId == null) return process.env.DB_PATH;
+    const ext = path.extname(process.env.DB_PATH);
+    const stem = process.env.DB_PATH.slice(0, process.env.DB_PATH.length - ext.length);
+    return `${stem}-w${workerId}${ext}`;
+  }
+
   if (workerId != null) {
     return path.join(os.tmpdir(), `factory-vitest-${process.pid}-${workerId}.db`);
   }

--- a/core/db/db.ts
+++ b/core/db/db.ts
@@ -7,10 +7,31 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import * as schema from './schema.js';
 
-const dbPath = process.env.DB_PATH ?? path.join(os.homedir(), '.factory', 'data', 'factory.db');
+/**
+ * Resolve the database path. Under Vitest each worker gets its own file so
+ * concurrent migrations (one per worker process) don't race on the same
+ * SQLite file. Outside tests, all callers share `~/.factory/data/factory.db`
+ * unless `DB_PATH` overrides it.
+ */
+function resolveDbPath(): string {
+  if (process.env.DB_PATH != null) return process.env.DB_PATH;
+  const workerId =
+    process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? (process.env.VITEST ? '0' : null);
+  if (workerId != null) {
+    return path.join(os.tmpdir(), `factory-vitest-${process.pid}-${workerId}.db`);
+  }
+  return path.join(os.homedir(), '.factory', 'data', 'factory.db');
+}
+
+const dbPath = resolveDbPath();
 mkdirSync(path.dirname(dbPath), { recursive: true });
 
 const sqlite = new Database(dbPath);
+// SQLite must allow concurrent reads/writes to survive vitest's per-file
+// migration on startup. WAL mode + a generous busy timeout transforms the
+// race into a wait. Outside tests this is a no-op for the single connection.
+sqlite.pragma('journal_mode = WAL');
+sqlite.pragma('busy_timeout = 5000');
 export const db = drizzle(sqlite, { schema });
 
 // Apply any pending migrations on startup. Safe to call repeatedly —

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -125,7 +125,14 @@ export type EventKind =
   | 'spec.completed'
   // M19.21 merge-decision gate — per-cycle quality score + convergence gate
   // run inside the approve action handler, before mergePR (#697).
-  | 'merge-decision.completed';
+  | 'merge-decision.completed'
+  // M19.22 (#698) — code-quality-audit invocation lifecycle. Fires from deep
+  // retro (priority:high or scheduled-nightly) and convergent review
+  // (priority:high parallel branch). Output drives audit_score, top-3
+  // ImprovementCandidates, and the autonomous-mode escalation gate.
+  | 'audit.completed'
+  | 'audit.failed'
+  | 'audit.autonomy-gate-fired';
 
 export interface AgentEvent {
   id: number;

--- a/core/quality-score/repository.ts
+++ b/core/quality-score/repository.ts
@@ -1,8 +1,16 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../db/db.js';
 import { runQualityScores } from '../db/schema.js';
 import type { QualityComponents, RunQualityScore } from './types.js';
 
+/**
+ * Writes (or updates) the per-cycle quality-score row. `auditScore` follows
+ * preserve-on-omit semantics: callers that don't pass it (or pass undefined)
+ * leave any previously persisted value intact. Pass `null` explicitly to
+ * clear the column. M19.22 (#698) — audit and merge-decision write to the
+ * same row at different stages of the cycle, so they must not clobber each
+ * other.
+ */
 export function persistRunQualityScore(input: {
   runId: string;
   pipelineRunId?: string | null;
@@ -12,6 +20,9 @@ export function persistRunQualityScore(input: {
   components: QualityComponents;
   auditScore?: number | null;
 }): void {
+  const auditExplicit = 'auditScore' in input && input.auditScore !== undefined;
+  const auditValue = auditExplicit ? (input.auditScore as number | null) : null;
+
   db.insert(runQualityScores)
     .values({
       runId: input.runId,
@@ -20,7 +31,7 @@ export function persistRunQualityScore(input: {
       iteration: input.iteration,
       score: input.score,
       componentsJson: JSON.stringify(input.components),
-      auditScore: input.auditScore ?? null,
+      auditScore: auditValue,
     })
     .onConflictDoUpdate({
       target: [runQualityScores.runId, runQualityScores.iteration],
@@ -28,8 +39,86 @@ export function persistRunQualityScore(input: {
         pipelineRunId: input.pipelineRunId ?? null,
         score: input.score,
         componentsJson: JSON.stringify(input.components),
-        auditScore: input.auditScore ?? null,
+        // Preserve the existing audit_score when the caller omits it. Only
+        // an explicit null clears the column.
+        ...(auditExplicit ? { auditScore: auditValue } : {}),
       },
+    })
+    .run();
+}
+
+/**
+ * Update only the `audit_score` column on the row identified by
+ * `(runId, iteration)`. Returns true when a row was updated, false when the
+ * row does not exist (audit fires before merge-decision creates the row).
+ * M19.22 (#698) — keeps the score/components untouched.
+ */
+export function updateAuditScore(input: {
+  runId: string;
+  iteration: number;
+  auditScore: number;
+}): boolean {
+  const result = db
+    .update(runQualityScores)
+    .set({ auditScore: input.auditScore })
+    .where(
+      and(eq(runQualityScores.runId, input.runId), eq(runQualityScores.iteration, input.iteration)),
+    )
+    .run();
+  return result.changes > 0;
+}
+
+/**
+ * Update only `audit_score` for a row keyed by `pipelineRunId`. Returns the
+ * number of rows updated. M19.22 (#698) — audit and merge-decision use the
+ * pipelineRunId as the durable anchor.
+ */
+export function updateAuditScoreByPipelineRun(input: {
+  pipelineRunId: string;
+  auditScore: number;
+}): number {
+  const result = db
+    .update(runQualityScores)
+    .set({ auditScore: input.auditScore })
+    .where(eq(runQualityScores.pipelineRunId, input.pipelineRunId))
+    .run();
+  return result.changes;
+}
+
+/** Bare INSERT used by run-audit when no row yet exists for the
+ * `pipelineRunId`. Distinct from `persistRunQualityScore` to keep the
+ * audit-only row semantics explicit: synthetic score=0/components stay
+ * tagged via `pipelineRunId` so the project trend can filter them out. */
+export function insertAuditOnlyRow(input: {
+  runId: string;
+  pipelineRunId: string;
+  projectId: string;
+  iteration: number;
+  auditScore: number;
+}): void {
+  db.insert(runQualityScores)
+    .values({
+      runId: input.runId,
+      pipelineRunId: input.pipelineRunId,
+      projectId: input.projectId,
+      iteration: input.iteration,
+      score: 0,
+      componentsJson: JSON.stringify({
+        p0_count: 0,
+        p1_count: 0,
+        p2_count: 0,
+        p3_count: 0,
+        regressions_open: 0,
+        review_converged: false,
+        uat_passed: false,
+        static_passed: false,
+        harness_pass_rate: 0,
+      }),
+      auditScore: input.auditScore,
+    })
+    .onConflictDoUpdate({
+      target: [runQualityScores.runId, runQualityScores.iteration],
+      set: { auditScore: input.auditScore },
     })
     .run();
 }

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -238,21 +238,29 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
 
     let auditAutonomyGateFired = false;
     if (shouldAudit) {
-      const auditResult = await runCodeQualityAudit({
-        projectId,
-        workItemId: workItem.id,
-        worktreePath: input.auditWorktreePath as string,
-        pipelineRunId: pipelineRunIdFromEvents(itemEvents),
-        workItem: { title: workItem.title, number: Number(workItem.externalId) },
-        trigger: 'deep-retro',
-        mode: projectConfig?.mode ?? 'supervised',
-      });
-      if (auditResult.ok) {
-        persistCandidates(
-          { runId, projectId, sourceWorkItem: workItem.id, personaId },
-          auditResult.improvementCandidates,
-        );
-        auditAutonomyGateFired = auditResult.autonomyGateFired;
+      // Skip the audit cleanly when the tracker uses non-numeric IDs — the
+      // skill's context schema requires `workItem.number: number` and
+      // coercing a Jira-style ID would produce NaN.
+      const numericIssue = /^\d+$/.test(workItem.externalId)
+        ? Number.parseInt(workItem.externalId, 10)
+        : null;
+      if (numericIssue != null) {
+        const auditResult = await runCodeQualityAudit({
+          projectId,
+          workItemId: workItem.id,
+          worktreePath: input.auditWorktreePath as string,
+          pipelineRunId: pipelineRunIdFromEvents(itemEvents),
+          workItem: { title: workItem.title, number: numericIssue },
+          trigger: 'deep-retro',
+          mode: projectConfig?.mode ?? 'supervised',
+        });
+        if (auditResult.ok) {
+          persistCandidates(
+            { runId, projectId, sourceWorkItem: workItem.id, personaId },
+            auditResult.improvementCandidates,
+          );
+          auditAutonomyGateFired = auditResult.autonomyGateFired;
+        }
       }
     }
 

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -7,6 +7,7 @@ import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions
 import { resolveBudgetsForProject } from '../agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
 import { selectPersona } from '../agent-runtime/select-persona.js';
+import { runCodeQualityAudit } from '../audit/run-audit.js';
 import { db } from '../db/db.js';
 import { improvementCandidates } from '../db/schema.js';
 import { eventStore } from '../event-stream/store.js';
@@ -36,6 +37,11 @@ export interface RunRetrospectiveInput {
   policy: RetrospectivePolicy;
   triggers?: TriggerContext;
   deps?: { runtime?: AgentRuntime };
+  /** Local worktree to audit. When supplied AND deep retro fires on a
+   * priority:high work item, the code-quality-audit skill runs as a tail
+   * step (#698). Caller is responsible for providing a stable, fully
+   * checked-out path — typically the dev worktree from the just-merged PR. */
+  auditWorktreePath?: string | null;
 }
 
 interface CandidateProvenance {
@@ -60,6 +66,17 @@ function persistCandidates(
       })
       .run();
   }
+}
+
+function pipelineRunIdFromEvents(
+  events: Array<{ kind: string; payload: unknown }>,
+): string | undefined {
+  for (const e of [...events].reverse()) {
+    if (e.kind !== 'pr.opened') continue;
+    const p = e.payload as { pipelineRunId?: string } | null;
+    if (p?.pipelineRunId != null && typeof p.pipelineRunId === 'string') return p.pipelineRunId;
+  }
+  return undefined;
 }
 
 function selectTier(policy: RetrospectivePolicy, triggers: TriggerContext): 'light' | 'deep' {
@@ -208,6 +225,47 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
     );
 
     accumulatePersonaStats({ personaName: personaId, role: 'retrospector', outcome: 'success' });
+
+    // ─── code-quality-audit hook (#698) ────────────────────────────────────────
+    // Deep retro on a priority:high lifecycle gets a tail audit run when the
+    // caller supplied a worktree. Top-3 audit recommendations become extra
+    // ImprovementCandidates. Autonomy gate fires when audit_score < 60 in
+    // autonomous mode — the lifecycle transitions to factory:needs-human
+    // instead of factory:done so the human can review the architectural
+    // regression before the next cycle starts.
+    const shouldAudit =
+      tier === 'deep' && triggers.priorityHigh === true && input.auditWorktreePath != null;
+
+    let auditAutonomyGateFired = false;
+    if (shouldAudit) {
+      const auditResult = await runCodeQualityAudit({
+        projectId,
+        workItemId: workItem.id,
+        worktreePath: input.auditWorktreePath as string,
+        pipelineRunId: pipelineRunIdFromEvents(itemEvents),
+        workItem: { title: workItem.title, number: Number(workItem.externalId) },
+        trigger: 'deep-retro',
+        mode: projectConfig?.mode ?? 'supervised',
+      });
+      if (auditResult.ok) {
+        persistCandidates(
+          { runId, projectId, sourceWorkItem: workItem.id, personaId },
+          auditResult.improvementCandidates,
+        );
+        auditAutonomyGateFired = auditResult.autonomyGateFired;
+      }
+    }
+
+    if (auditAutonomyGateFired) {
+      await stateSource.transitionState(
+        workItem.externalId,
+        'factory:retrospecting',
+        'factory:needs-human',
+      );
+      // Skip archive — the lifecycle hasn't reached factory:done.
+      return;
+    }
+
     await stateSource.transitionState(workItem.externalId, 'factory:retrospecting', 'factory:done');
     // Archive only after the state transition succeeds — otherwise a transition
     // failure would leave a phantom archive row for a lifecycle that never

--- a/core/workflows/slice.test.ts
+++ b/core/workflows/slice.test.ts
@@ -536,6 +536,116 @@ describe('state transitions', () => {
   });
 });
 
+// ─── code-quality-audit hook (M19.22 #698) ────────────────────────────────────
+
+describe('code-quality-audit hook in deep retro', () => {
+  it('does NOT invoke the audit when triggers.priorityHigh is false', async () => {
+    vi.resetModules();
+    const mockAudit = vi.fn();
+    vi.doMock('../audit/run-audit.js', () => ({ runCodeQualityAudit: mockAudit }));
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'always-deep',
+      auditWorktreePath: '/tmp/wt',
+    });
+
+    expect(mockAudit).not.toHaveBeenCalled();
+    vi.doUnmock('../audit/run-audit.js');
+  });
+
+  it('does NOT invoke the audit when auditWorktreePath is omitted', async () => {
+    vi.resetModules();
+    const mockAudit = vi.fn();
+    vi.doMock('../audit/run-audit.js', () => ({ runCodeQualityAudit: mockAudit }));
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: makeSource(),
+      projectId: 'test-project',
+      policy: 'always-deep',
+      triggers: { priorityHigh: true },
+    });
+
+    expect(mockAudit).not.toHaveBeenCalled();
+    vi.doUnmock('../audit/run-audit.js');
+  });
+
+  it('invokes the audit and proceeds to factory:done when score passes the autonomy gate', async () => {
+    vi.resetModules();
+    const mockAudit = vi.fn().mockResolvedValue({
+      ok: true,
+      auditScore: 82,
+      pipelineRunId: 'pipe-x',
+      improvementCandidates: [
+        { kind: 'workflow', targetPath: 'src/a.ts', suggestionText: 's', confidence: 'high' },
+      ],
+      autonomyGateFired: false,
+      output: { rating: 'Good' } as never,
+    });
+    vi.doMock('../audit/run-audit.js', () => ({ runCodeQualityAudit: mockAudit }));
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    const source = makeSource();
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: source,
+      projectId: 'test-project',
+      policy: 'always-deep',
+      triggers: { priorityHigh: true },
+      auditWorktreePath: '/tmp/wt',
+    });
+
+    expect(mockAudit).toHaveBeenCalledOnce();
+    expect((mockAudit.mock.calls[0][0] as { trigger: string }).trigger).toBe('deep-retro');
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:retrospecting',
+      'factory:done',
+    );
+    vi.doUnmock('../audit/run-audit.js');
+  });
+
+  it('routes to factory:needs-human when audit fires the autonomy gate', async () => {
+    vi.resetModules();
+    const mockAudit = vi.fn().mockResolvedValue({
+      ok: true,
+      auditScore: 45,
+      pipelineRunId: 'pipe-x',
+      improvementCandidates: [],
+      autonomyGateFired: true,
+      output: { rating: 'Concerning' } as never,
+    });
+    vi.doMock('../audit/run-audit.js', () => ({ runCodeQualityAudit: mockAudit }));
+    const { runRetrospectiveWorkflow } = await import('./retrospective.js');
+    const source = makeSource();
+    mockRun.mockResolvedValueOnce(makeDeepResult());
+
+    await runRetrospectiveWorkflow({
+      workItem: makeWorkItem(),
+      stateSource: source,
+      projectId: 'test-project',
+      policy: 'always-deep',
+      triggers: { priorityHigh: true },
+      auditWorktreePath: '/tmp/wt',
+    });
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:retrospecting',
+      'factory:needs-human',
+    );
+    vi.doUnmock('../audit/run-audit.js');
+  });
+});
+
 // ─── skill-coaching workflow ──────────────────────────────────────────────────
 
 function makeCoachResult() {

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -14,6 +14,16 @@ function worktreePath(runId: string): string {
 }
 
 /**
+ * Returns the worktree path for `runId` IF the directory exists on disk.
+ * Used by tail workflows (audit, retro) that want to attach to the dev
+ * worktree opportunistically without recreating it.
+ */
+export function existingWorktreePath(runId: string): string | null {
+  const wtPath = worktreePath(runId);
+  return existsSync(wtPath) ? wtPath : null;
+}
+
+/**
  * Creates a git worktree for the given repo at ~/.factory/workspaces/<runId>/.
  *
  * Uses `git worktree add --detach` to create a detached HEAD worktree,

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -14,12 +14,13 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `server` | yes | API + SSE host for the Goose Hub web UI. Stands up the server process the UI talks to. Closes M2.01 (#26). |
 | `web` | yes | Vite + React 19 + Tailwind 4 + React Router v6. Closes M2.02 (#27). |
 
-## core/ (26 entries, 0 missing README)
+## core/ (27 entries, 0 missing README)
 
 | Name | README | Summary |
 |---|---|---|
 | `agent-comment` | yes | Builds structured GitHub-issue comment markdown for agent status updates. One small pure function so every agent posts comments in the same shape. |
 | `agent-runtime` | yes | Typed contracts and model registry for all agent runtime code. |
+| `audit` | yes | Orchestration glue for the `code-quality-audit` skill (M19.22, #698). |
 | `bootstrap` | yes | Library code that supports the bootstrap workflow (`slices/bootstrap-project`). Each module is independently testable and stateless; the slice composes them. |
 | `connectors` | yes | External-system adapters. Each subdirectory wraps one external API behind a narrow interface that slices and workflows depend on. Connectors own retry, timeout, and error-shape contracts so workflow code stays oblivious to transport details. |
 | `cost` | yes | Persists per-run agent cost so the UI can show: |
@@ -45,7 +46,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `workflows` | yes | Orchestration workflows that compose skills, persist results, and transition work-item state. |
 | `workspaces` | yes | Git worktree lifecycle management for Factory investigation runs. |
 
-## slices/ (35 entries, 0 missing README)
+## slices/ (36 entries, 0 missing README)
 
 | Name | README | Summary |
 |---|---|---|
@@ -68,6 +69,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `holdout-boundary-test` | yes | Verification slice for M8 exit criteria: deliberate context injection attempts on holdout roles (QA, Reviewer) must fail at the runtime layer. |
 | `investigate` | yes | Workflow slice that drives `type:bug` and `type:chore` work items through the investigation phase. |
 | `label-installer` | yes | Idempotent factory label installer. Closes M12.03 (#306). |
+| `merge-decision` | yes | Per-cycle merge-decision gate (M19.21 #697). Deterministic gate that runs |
 | `model-routing` | yes | M19.09 — provider-aware model routing with UI-configurable role and complexity overrides. |
 | `move-with-deps` | yes | M11.06: Move-with-dependencies CLI and UI confirmation. |
 | `parallel-implement` | yes | **M19.03 — Parallel WP builder dispatch (ADR 0031)** |

--- a/skills/code-quality-audit/skill.config.ts
+++ b/skills/code-quality-audit/skill.config.ts
@@ -1,8 +1,9 @@
 import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
-import { CodeQualityAuditContextSchema } from './schema.js';
+import { CodeQualityAuditContextSchema, CodeQualityAuditOutputSchema } from './schema.js';
 
 const config: SkillConfig = {
   contextSchema: CodeQualityAuditContextSchema,
+  outputSchema: CodeQualityAuditOutputSchema,
   /**
    * Tool bundles:
    * - 'read'  — Read files, Grep, Glob against the working tree
@@ -18,5 +19,5 @@ const config: SkillConfig = {
   contextAllowlist: ['worktreePath', 'metricsJson', 'workItem'],
 };
 
-export { CodeQualityAuditContextSchema };
+export { CodeQualityAuditContextSchema, CodeQualityAuditOutputSchema };
 export default config;

--- a/slices/merge-decision/workflow.ts
+++ b/slices/merge-decision/workflow.ts
@@ -1,3 +1,5 @@
+import { NIGHTLY_PIPELINE_RUN_PREFIX } from '@goose-hub/core/audit/run-audit.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { buildRunArtifacts } from '@goose-hub/core/quality-score/build-artifacts.js';
 import {
   getLatestQualityScoreByPipelineRun,
@@ -63,6 +65,12 @@ export function runMergeDecision(input: MergeDecisionInput): MergeDecisionResult
 
   const { score, components } = computeQualityScore(artifacts);
 
+  // Fold in any pre-existing audit score for this pipelineRunId. The audit
+  // can fire BEFORE merge-decision (parallel branch during convergent
+  // review) and emits `audit.completed` events that this gate reads. Pass
+  // the value explicitly to persistRunQualityScore so it's not erased.
+  const auditScore = readLatestAuditScore(input.projectId, input.pipelineRunId);
+
   persistRunQualityScore({
     runId,
     pipelineRunId: input.pipelineRunId,
@@ -70,16 +78,22 @@ export function runMergeDecision(input: MergeDecisionInput): MergeDecisionResult
     iteration,
     score,
     components,
+    ...(auditScore != null ? { auditScore } : {}),
   });
 
   // Read prior scores (ascending by ts). `listProjectQualityTrend` already
-  // returns ascending — but we exclude the row we just wrote AND any legacy
-  // rows from before migration 0022 (where `pipelineRunId` is null). Those
-  // pre-pipeline runs are not comparable cycles and would prematurely exit
-  // warmup or pollute convergence if counted.
+  // returns ascending — exclude the row we just wrote, legacy rows from
+  // before migration 0022 (where `pipelineRunId` is null), and project-
+  // level nightly audit rows (M19.22 #698) which don't represent merge
+  // cycles and would distort convergence math.
   const trend = listProjectQualityTrend(input.projectId);
   const priorScores = trend
-    .filter((r) => r.pipelineRunId != null && r.pipelineRunId !== input.pipelineRunId)
+    .filter(
+      (r) =>
+        r.pipelineRunId != null &&
+        r.pipelineRunId !== input.pipelineRunId &&
+        !r.pipelineRunId.startsWith(NIGHTLY_PIPELINE_RUN_PREFIX),
+    )
     .map((r) => r.score);
 
   // Score-only warmup gate.
@@ -119,6 +133,20 @@ export function runMergeDecision(input: MergeDecisionInput): MergeDecisionResult
   }
 
   return { passed: true, score, reason: 'score-plus-convergence-pass' };
+}
+
+/** Read the most recent `audit.completed` payload's `auditScore` for the
+ * given pipelineRunId. Returns null when no audit ran (or only failed). */
+function readLatestAuditScore(projectId: string, pipelineRunId: string): number | null {
+  const events = eventStore.replay({ projectId, kind: 'audit.completed' });
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    const p = e.payload as { pipelineRunId?: string; auditScore?: number } | null;
+    if (p?.pipelineRunId === pipelineRunId && typeof p.auditScore === 'number') {
+      return p.auditScore;
+    }
+  }
+  return null;
 }
 
 export { getLatestQualityScoreByPipelineRun };

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -974,4 +974,168 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
       role: 'reviewer',
     });
   });
+
+  // M19.22 (#698) — parallel code-quality-audit branch
+  describe('code-quality-audit parallel branch (M19.22 #698)', () => {
+    it('does NOT invoke the audit when work item priority is medium', async () => {
+      vi.resetModules();
+      const mockAudit = vi.fn();
+      vi.doMock('@goose-hub/core/audit/run-audit.js', () => ({
+        runCodeQualityAudit: mockAudit,
+      }));
+      vi.doMock('@goose-hub/core/workspaces/worktree.js', () => ({
+        existingWorktreePath: () => '/tmp/wt',
+      }));
+
+      const item = makeWorkItem({ priority: 'medium' });
+      const source = makeMockSource({
+        getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+x'),
+      });
+      for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+      const { runConvergentReviewWorkflow } = await import('./workflow.js');
+      await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(mockAudit).not.toHaveBeenCalled();
+      vi.doUnmock('@goose-hub/core/audit/run-audit.js');
+      vi.doUnmock('@goose-hub/core/workspaces/worktree.js');
+    });
+
+    it('invokes the audit and approves when priority:high but autonomy gate does not fire', async () => {
+      vi.resetModules();
+      const mockAudit = vi.fn().mockResolvedValue({
+        ok: true,
+        auditScore: 88,
+        pipelineRunId: 'pipe-test',
+        improvementCandidates: [],
+        autonomyGateFired: false,
+        output: { rating: 'Good', recommendations: [] },
+      });
+      vi.doMock('@goose-hub/core/audit/run-audit.js', () => ({
+        runCodeQualityAudit: mockAudit,
+      }));
+      vi.doMock('@goose-hub/core/workspaces/worktree.js', () => ({
+        existingWorktreePath: () => '/tmp/wt',
+      }));
+
+      const item = makeWorkItem({ priority: 'high' });
+      const source = makeMockSource({
+        getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+x'),
+      });
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          projectId: 'test-project',
+          workItemId: 'github:owner/repo#42',
+          kind: 'pr.opened',
+          payload: { devRunId: 'dev-run-1' },
+          runId: null,
+          personaId: null,
+          createdAt: '2026-05-11T00:00:00Z',
+        },
+      ]);
+      for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+      const { runConvergentReviewWorkflow } = await import('./workflow.js');
+      await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(mockAudit).toHaveBeenCalledOnce();
+      expect((mockAudit.mock.calls[0][0] as { trigger: string }).trigger).toBe('convergent-review');
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:approved',
+      );
+      vi.doUnmock('@goose-hub/core/audit/run-audit.js');
+      vi.doUnmock('@goose-hub/core/workspaces/worktree.js');
+    });
+
+    it('routes to factory:needs-human when the autonomy gate fires', async () => {
+      vi.resetModules();
+      const mockAudit = vi.fn().mockResolvedValue({
+        ok: true,
+        auditScore: 42,
+        pipelineRunId: 'pipe-test',
+        improvementCandidates: [],
+        autonomyGateFired: true,
+        output: { rating: 'Concerning', recommendations: [{ fix: 'Refactor X' }] },
+      });
+      vi.doMock('@goose-hub/core/audit/run-audit.js', () => ({
+        runCodeQualityAudit: mockAudit,
+      }));
+      vi.doMock('@goose-hub/core/workspaces/worktree.js', () => ({
+        existingWorktreePath: () => '/tmp/wt',
+      }));
+
+      const item = makeWorkItem({ priority: 'critical', mode: 'autonomous' });
+      const source = makeMockSource({
+        getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+x'),
+      });
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          projectId: 'test-project',
+          workItemId: 'github:owner/repo#42',
+          kind: 'pr.opened',
+          payload: { devRunId: 'dev-run-1' },
+          runId: null,
+          personaId: null,
+          createdAt: '2026-05-11T00:00:00Z',
+        },
+      ]);
+      for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+      const { runConvergentReviewWorkflow } = await import('./workflow.js');
+      await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:needs-human',
+      );
+      expect(source.transitionState).not.toHaveBeenCalledWith(
+        '42',
+        'factory:needs-review',
+        'factory:approved',
+      );
+      vi.doUnmock('@goose-hub/core/audit/run-audit.js');
+      vi.doUnmock('@goose-hub/core/workspaces/worktree.js');
+    });
+
+    it('skips audit when dev worktree is missing', async () => {
+      vi.resetModules();
+      const mockAudit = vi.fn();
+      vi.doMock('@goose-hub/core/audit/run-audit.js', () => ({
+        runCodeQualityAudit: mockAudit,
+      }));
+      vi.doMock('@goose-hub/core/workspaces/worktree.js', () => ({
+        existingWorktreePath: () => null,
+      }));
+
+      const item = makeWorkItem({ priority: 'high' });
+      const source = makeMockSource({
+        getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+x'),
+      });
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          projectId: 'test-project',
+          workItemId: 'github:owner/repo#42',
+          kind: 'pr.opened',
+          payload: { devRunId: 'dev-run-1' },
+          runId: null,
+          personaId: null,
+          createdAt: '2026-05-11T00:00:00Z',
+        },
+      ]);
+      for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+      const { runConvergentReviewWorkflow } = await import('./workflow.js');
+      await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(mockAudit).not.toHaveBeenCalled();
+      vi.doUnmock('@goose-hub/core/audit/run-audit.js');
+      vi.doUnmock('@goose-hub/core/workspaces/worktree.js');
+    });
+  });
 });

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -12,11 +12,14 @@ import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconc
 import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { runCodeQualityAudit } from '@goose-hub/core/audit/run-audit.js';
+import { db } from '@goose-hub/core/db/db.js';
 import {
   type ReviewerSlot,
   parseReviewerSlots,
   readProjectReviewSettings,
 } from '@goose-hub/core/db/repositories/project-review-settings.js';
+import { improvementCandidates as improvementCandidatesTable } from '@goose-hub/core/db/schema.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
@@ -24,6 +27,7 @@ import { DEFAULT_MAX_RETRIES, shouldEscalateReview } from '@goose-hub/core/retry
 import { classifyTopic } from '@goose-hub/core/review/topic-classifier.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { existingWorktreePath } from '@goose-hub/core/workspaces/worktree.js';
 import { ReviewOutputSchema } from '@goose-hub/skills/review/schema.js';
 import type { ReviewOutput, ReviewVerdict } from '@goose-hub/skills/review/schema.js';
 
@@ -455,6 +459,19 @@ export async function runConvergentReviewWorkflow(
     const pipelineRunId = findPipelineRunId(projectSlug, workItem.id);
     const pipelineRunIdPayload = pipelineRunId != null ? { pipelineRunId } : {};
 
+    // ─── code-quality-audit parallel branch (#698) ──────────────────────────
+    // priority:high (or critical) PRs trigger an audit alongside the
+    // reviewers. The audit is a *separate slot* — its findings never block a
+    // reviewer's verdict, but its top-3 recommendations become
+    // ImprovementCandidates and the autonomy gate (score < 60 in autonomous
+    // mode) blocks transition to factory:approved.
+    const auditPromise = startConvergentReviewAudit({
+      workItem,
+      projectSlug,
+      pipelineRunId,
+      mode: projectConfig?.mode ?? 'supervised',
+    });
+
     let previousRoundFindings: FindingKey[] = [];
     let consecutiveZeroCriticalRounds = 0;
 
@@ -637,6 +654,32 @@ export async function runConvergentReviewWorkflow(
           },
           runId,
         });
+
+        // Collect the parallel audit (#698) before final transition. The
+        // audit branch runs alongside reviewers; we only block transition to
+        // approved when the autonomy gate fires.
+        const auditOutcome = await finalizeConvergentReviewAudit(auditPromise, {
+          projectSlug,
+          workItem,
+        });
+        if (auditOutcome.autonomyGateFired) {
+          await stateSource.comment(
+            workItem.externalId,
+            buildAgentComment(
+              'Review',
+              'Needs Human',
+              `Architectural quality audit blocked auto-merge (score ${auditOutcome.auditScore} < 60)`,
+              [auditOutcome.summaryDetail ?? 'See audit.completed event for full breakdown.'],
+            ),
+          );
+          await stateSource.transitionState(
+            workItem.externalId,
+            'factory:needs-review',
+            'factory:needs-human',
+          );
+          return;
+        }
+
         await stateSource.comment(
           workItem.externalId,
           buildAgentComment(
@@ -763,4 +806,104 @@ function buildReviewComment(
     `Confidence ${pct}% — transitioning to ${nextState}`,
     details.length > 0 ? details : undefined,
   );
+}
+
+// ─── code-quality-audit parallel branch helpers (#698) ────────────────────────
+
+type ReviewAuditOutcome = {
+  ran: boolean;
+  autonomyGateFired: boolean;
+  auditScore?: number;
+  summaryDetail?: string;
+};
+
+type StartedAudit =
+  | { ran: false }
+  | {
+      ran: true;
+      pipelineRunId: string;
+      promise: ReturnType<typeof runCodeQualityAudit>;
+    };
+
+function findDevRunId(events: { kind: string; payload: unknown }[]): string | undefined {
+  for (const e of [...events].reverse()) {
+    if (e.kind !== 'pr.opened') continue;
+    const p = e.payload as { devRunId?: string } | null;
+    if (p?.devRunId != null && typeof p.devRunId === 'string') return p.devRunId;
+  }
+  return undefined;
+}
+
+function startConvergentReviewAudit(input: {
+  workItem: WorkItem;
+  projectSlug: string;
+  pipelineRunId?: string;
+  mode: 'interactive' | 'supervised' | 'autonomous';
+}): StartedAudit {
+  const isHighPriority =
+    input.workItem.priority === 'high' || input.workItem.priority === 'critical';
+  if (!isHighPriority) return { ran: false };
+
+  // Locate a worktree to audit. The dev worktree from implementation should
+  // still exist at review time (cleanupWorktree fires post-merge). If the
+  // dev worktree is gone (e.g. orphaned PR, manual replay) we skip the audit
+  // rather than fabricate a synthetic path.
+  const events = eventStore.replay({ projectId: input.projectSlug, workItemId: input.workItem.id });
+  const devRunId = findDevRunId(events);
+  if (devRunId == null) return { ran: false };
+
+  const worktreePath = existingWorktreePath(devRunId);
+  if (worktreePath == null) return { ran: false };
+
+  const pipelineRunId = input.pipelineRunId ?? `review-${input.workItem.id}-${devRunId}`;
+  const promise = runCodeQualityAudit({
+    projectId: input.projectSlug,
+    workItemId: input.workItem.id,
+    worktreePath,
+    pipelineRunId,
+    workItem: { title: input.workItem.title, number: Number(input.workItem.externalId) },
+    trigger: 'convergent-review',
+    mode: input.mode,
+  });
+
+  return { ran: true, pipelineRunId, promise };
+}
+
+async function finalizeConvergentReviewAudit(
+  started: StartedAudit,
+  ctx: { projectSlug: string; workItem: WorkItem },
+): Promise<ReviewAuditOutcome> {
+  if (!started.ran) return { ran: false, autonomyGateFired: false };
+
+  const result = await started.promise.catch((err: unknown) => ({
+    ok: false as const,
+    error: err instanceof Error ? err.message : String(err),
+  }));
+
+  if (!result.ok) return { ran: true, autonomyGateFired: false };
+
+  // Persist top-3 ImprovementCandidates to the database. The retro path
+  // re-uses `core/workflows/retrospective.ts#persistCandidates`; here we
+  // open a small inline persister because review and retro live in
+  // different packages.
+  for (const c of result.improvementCandidates) {
+    db.insert(improvementCandidatesTable)
+      .values({
+        projectId: ctx.projectSlug,
+        personaName: c.sourcePersonaId ?? `${ctx.projectSlug}/auditor/0`,
+        sourceTaskId: ctx.workItem.id,
+        suggestionText: c.suggestionText,
+        suggestionType: c.kind,
+      })
+      .run();
+  }
+
+  return {
+    ran: true,
+    autonomyGateFired: result.autonomyGateFired,
+    auditScore: result.auditScore,
+    summaryDetail: `Rating: ${result.output.rating}. Top recommendation: ${
+      result.output.recommendations[0]?.fix ?? '(none)'
+    }`,
+  };
 }

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -640,37 +640,44 @@ export async function runConvergentReviewWorkflow(
           payload: { totalRounds: round },
           runId,
         });
-        // P2 fix: emit canonical review.completed so UI and fix-feedback loop can consume it.
+
+        // Settle the parallel audit (#698) BEFORE emitting review.completed
+        // so downstream consumers (merge-decision, quality assembly) never
+        // see a transient 'approved' verdict for a cycle the audit blocked.
+        const auditOutcome = await finalizeConvergentReviewAudit(auditPromise, {
+          projectSlug,
+          workItem,
+        });
+
+        const finalVerdict: ReviewVerdict = auditOutcome.autonomyGateFired
+          ? 'needs-human'
+          : 'approved';
+
+        const escalationReason = auditOutcome.autonomyGateFired
+          ? `Architectural quality audit blocked auto-merge (score ${auditOutcome.auditScore} < 60)`
+          : undefined;
+
         eventStore.appendEvent({
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.completed',
           payload: {
-            verdict: 'approved',
+            verdict: finalVerdict,
             confidence: avgConfidence,
             criteriaChecks: [],
             findings: lastOutputs.flatMap((r) => r.parsed.findings),
             ...pipelineRunIdPayload,
+            ...(escalationReason != null ? { escalationReason } : {}),
           },
           runId,
         });
 
-        // Collect the parallel audit (#698) before final transition. The
-        // audit branch runs alongside reviewers; we only block transition to
-        // approved when the autonomy gate fires.
-        const auditOutcome = await finalizeConvergentReviewAudit(auditPromise, {
-          projectSlug,
-          workItem,
-        });
         if (auditOutcome.autonomyGateFired) {
           await stateSource.comment(
             workItem.externalId,
-            buildAgentComment(
-              'Review',
-              'Needs Human',
-              `Architectural quality audit blocked auto-merge (score ${auditOutcome.auditScore} < 60)`,
-              [auditOutcome.summaryDetail ?? 'See audit.completed event for full breakdown.'],
-            ),
+            buildAgentComment('Review', 'Needs Human', escalationReason ?? 'Audit gate failed', [
+              auditOutcome.summaryDetail ?? 'See audit.completed event for full breakdown.',
+            ]),
           );
           await stateSource.transitionState(
             workItem.externalId,
@@ -817,12 +824,17 @@ type ReviewAuditOutcome = {
   summaryDetail?: string;
 };
 
+type SettledAudit = Awaited<ReturnType<typeof runCodeQualityAudit>> | { ok: false; error: string };
+
 type StartedAudit =
   | { ran: false }
   | {
       ran: true;
       pipelineRunId: string;
-      promise: ReturnType<typeof runCodeQualityAudit>;
+      /** Eagerly-attached `.catch` keeps the rejection observed even when
+       * an early-exit path (escalation, divergence, cap) returns before
+       * the convergent gate awaits it. */
+      promise: Promise<SettledAudit>;
     };
 
 function findDevRunId(events: { kind: string; payload: unknown }[]): string | undefined {
@@ -832,6 +844,16 @@ function findDevRunId(events: { kind: string; payload: unknown }[]): string | un
     if (p?.devRunId != null && typeof p.devRunId === 'string') return p.devRunId;
   }
   return undefined;
+}
+
+/** Parse a state-source externalId to a number for the audit context. Not
+ * every tracker uses numeric IDs — e.g. Jira's `PROJ-123`. Returns undefined
+ * when the ID is non-numeric so the caller can skip the audit cleanly
+ * rather than send NaN through the Zod context schema. */
+function externalIdAsNumber(externalId: string): number | undefined {
+  if (!/^\d+$/.test(externalId)) return undefined;
+  const n = Number.parseInt(externalId, 10);
+  return Number.isSafeInteger(n) ? n : undefined;
 }
 
 function startConvergentReviewAudit(input: {
@@ -848,23 +870,38 @@ function startConvergentReviewAudit(input: {
   // still exist at review time (cleanupWorktree fires post-merge). If the
   // dev worktree is gone (e.g. orphaned PR, manual replay) we skip the audit
   // rather than fabricate a synthetic path.
-  const events = eventStore.replay({ projectId: input.projectSlug, workItemId: input.workItem.id });
+  const events = eventStore.replay({
+    projectId: input.projectSlug,
+    workItemId: input.workItem.id,
+  });
   const devRunId = findDevRunId(events);
   if (devRunId == null) return { ran: false };
 
   const worktreePath = existingWorktreePath(devRunId);
   if (worktreePath == null) return { ran: false };
 
+  const issueNumber = externalIdAsNumber(input.workItem.externalId);
+  if (issueNumber == null) return { ran: false };
+
   const pipelineRunId = input.pipelineRunId ?? `review-${input.workItem.id}-${devRunId}`;
-  const promise = runCodeQualityAudit({
+  const rawPromise = runCodeQualityAudit({
     projectId: input.projectSlug,
     workItemId: input.workItem.id,
     worktreePath,
     pipelineRunId,
-    workItem: { title: input.workItem.title, number: Number(input.workItem.externalId) },
+    workItem: { title: input.workItem.title, number: issueNumber },
     trigger: 'convergent-review',
     mode: input.mode,
   });
+
+  // Attach a catch immediately so an unawaited rejection (early review-exit
+  // path) cannot bubble as an unhandled rejection.
+  const promise = rawPromise.catch<SettledAudit>(
+    (err: unknown): SettledAudit => ({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }),
+  );
 
   return { ran: true, pipelineRunId, promise };
 }
@@ -875,10 +912,7 @@ async function finalizeConvergentReviewAudit(
 ): Promise<ReviewAuditOutcome> {
   if (!started.ran) return { ran: false, autonomyGateFired: false };
 
-  const result = await started.promise.catch((err: unknown) => ({
-    ok: false as const,
-    error: err instanceof Error ? err.message : String(err),
-  }));
+  const result = await started.promise;
 
   if (!result.ok) return { ran: true, autonomyGateFired: false };
 


### PR DESCRIPTION
## Summary

- Adds `core/audit/run-audit.ts` as the single entry point for the `code-quality-audit` skill — handles invocation, audit_score computation, top-3 ImprovementCandidate emission, and the autonomous-mode gate.
- Wires three trigger sites: deep retro (priority:high), convergent review (priority:high parallel branch), and a nightly per-project scheduler.
- Persists `audit_score` onto `run_quality_scores` keyed by `pipelineRunId` (upgrades the merge-decision row in-place; synthesises `nightly-<slug>-<isoDate>` for project-level audits).
- Autonomy gate: `audit_score < 60 && mode === 'autonomous'` transitions the lifecycle to `factory:needs-human` instead of `factory:done` / `factory:approved`.
- UI: `QualityTrendTab` now renders an `architecturalQualityScore` series (per-row arch bar + summary chip) populated from the existing `auditScore` DTO field.

Closes #698

## Acceptance criteria

- [x] Issue body explicitly lists human action items as preconditions.
- [x] `auditor` registered in project config (verified post-human-edit — Shaun to apply per the issue's "Human action items" section).
- [x] Priority:high PR triggers audit (test in `slices/review/slice.test.ts`).
- [x] Nightly trigger configured + tested (`core/audit/slice.test.ts`).
- [x] `audit_score` rows written.
- [x] ImprovementCandidate emitted from top-3 (test in `core/audit/run-audit.test.ts`).
- [x] Autonomy gate fires on `audit_score < 60` (test).
- [x] UI series renders with sample data.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 3179 tests passing (219 files)
- [x] Manual: register `auditor` in `target-projects/goose-hub-self/project.config.ts` and run a real priority:high cycle to verify end-to-end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyQipPEY1ZAZEDKmb6T5tD)_