### PR TITLE
M19.27: wire symbol index pre-lookup into scout-code-path

### DIFF
--- a/core/agent-runtime/swarm.ts
+++ b/core/agent-runtime/swarm.ts
@@ -118,6 +118,7 @@ const SCOUT_CONTEXT_ALLOWLIST: readonly string[] = [
   'scoutFocus',
   'worktreePath',
   'scoutReports',
+  'symbolIndexHints',
 ];
 
 const DEFAULT_MAX_SCOUTS = 6;

--- a/core/symbol-index/index.ts
+++ b/core/symbol-index/index.ts
@@ -3,3 +3,5 @@ export { defaultDbPath, openIndexDb } from './db.js';
 export { buildIndex, extractFromSource } from './builder.js';
 export type { BuildOptions, BuildResult } from './builder.js';
 export { findCallers, findSymbol, listExportsOf, listImports } from './query.js';
+export { extractIdentifiers, lookupWorkItemSymbols } from './lookup.js';
+export type { SymbolHint } from './lookup.js';

--- a/core/symbol-index/index.ts
+++ b/core/symbol-index/index.ts
@@ -4,4 +4,4 @@ export { buildIndex, extractFromSource } from './builder.js';
 export type { BuildOptions, BuildResult } from './builder.js';
 export { findCallers, findSymbol, listExportsOf, listImports } from './query.js';
 export { extractIdentifiers, lookupWorkItemSymbols } from './lookup.js';
-export type { SymbolHint } from './lookup.js';
+export type { LookupOptions, SymbolHint } from './lookup.js';

--- a/core/symbol-index/lookup.test.ts
+++ b/core/symbol-index/lookup.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildIndex } from './builder.js';
+import { openIndexDb } from './db.js';
+import { extractIdentifiers, lookupWorkItemSymbols } from './lookup.js';
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf8');
+}
+
+describe('extractIdentifiers', () => {
+  it('extracts camelCase identifiers', () => {
+    const ids = extractIdentifiers('Fix dispatchWave timeout handling');
+    expect(ids).toContain('dispatchWave');
+  });
+
+  it('extracts PascalCase identifiers', () => {
+    const ids = extractIdentifiers('ClaudeCliRuntime crashes on auth');
+    expect(ids).toContain('ClaudeCliRuntime');
+  });
+
+  it('extracts snake_case identifiers', () => {
+    const ids = extractIdentifiers('Update select_persona to round-robin');
+    expect(ids).toContain('select_persona');
+  });
+
+  it('prioritises backtick-quoted identifiers', () => {
+    const ids = extractIdentifiers('Fix bug in `invokeSkill` function');
+    expect(ids[0]).toBe('invokeSkill');
+  });
+
+  it('skips common prose words', () => {
+    const ids = extractIdentifiers('Fix the bug when it has been null');
+    expect(ids).not.toContain('the');
+    expect(ids).not.toContain('has');
+    expect(ids).not.toContain('been');
+    expect(ids).not.toContain('null');
+  });
+
+  it('skips lowercase-only tokens', () => {
+    const ids = extractIdentifiers('resolve issue with timeout error');
+    expect(ids).not.toContain('resolve');
+    expect(ids).not.toContain('issue');
+    expect(ids).not.toContain('timeout');
+    expect(ids).not.toContain('error');
+  });
+
+  it('caps output at 12 identifiers', () => {
+    const text =
+      'Fix AuthService UserService TaskService ProjectService ScoutService AgentService EventStore PersonaStore WorkspaceManager BudgetResolver ModelSelector';
+    const ids = extractIdentifiers(text);
+    expect(ids.length).toBeLessThanOrEqual(12);
+  });
+
+  it('deduplicates identifiers', () => {
+    const ids = extractIdentifiers('dispatchWave calls dispatchWave recursively');
+    expect(ids.filter((id) => id === 'dispatchWave')).toHaveLength(1);
+  });
+});
+
+describe('lookupWorkItemSymbols', () => {
+  let tmp: string;
+  let db: Database.Database;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'symbol-lookup-'));
+    dbPath = path.join(tmp, 'symbol-index.db');
+    db = openIndexDb(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns [] when the DB file does not exist', () => {
+    const result = lookupWorkItemSymbols('Fix dispatchWave', 'details', '/nonexistent/path.db');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when no matching symbols found', () => {
+    writeFile(tmp, 'core/foo.ts', 'export function unrelatedThing() {}');
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix AuthService bug', 'body', dbPath);
+    expect(result).toEqual([]);
+  });
+
+  it('finds exported symbols matching work item identifiers', () => {
+    writeFile(tmp, 'core/auth.ts', 'export function AuthService() {}');
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix AuthService crash', 'auth breaks', dbPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('AuthService');
+    expect(result[0].definedIn).toBe('core/auth.ts');
+    expect(result[0].kind).toBe('function');
+  });
+
+  it('populates callers list', () => {
+    writeFile(tmp, 'core/auth.ts', 'export function AuthService() {}');
+    writeFile(tmp, 'core/app.ts', `import { AuthService } from './auth.js'; AuthService();`);
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix AuthService crash', '', dbPath);
+    expect(result[0].callers).toContain('core/app.ts');
+  });
+
+  it('skips non-exported symbols', () => {
+    writeFile(tmp, 'core/auth.ts', 'function internalHelper() {}');
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix internalHelper', '', dbPath);
+    expect(result).toHaveLength(0);
+  });
+
+  it('caps callers at 5 per hint', () => {
+    writeFile(tmp, 'core/shared.ts', 'export function SharedUtil() {}');
+    for (let i = 0; i < 8; i++) {
+      writeFile(
+        tmp,
+        `core/caller${i}.ts`,
+        `import { SharedUtil } from './shared.js'; SharedUtil();`,
+      );
+    }
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix SharedUtil', '', dbPath);
+    expect(result[0].callers.length).toBeLessThanOrEqual(5);
+  });
+
+  it('caps total hints at 20', () => {
+    for (let i = 0; i < 25; i++) {
+      writeFile(tmp, `core/sym${i}.ts`, `export function Symbol${i}() {}`);
+    }
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    // Use backtick-quoted identifiers to ensure high extraction confidence
+    const title = Array.from({ length: 12 }, (_, i) => `\`Symbol${i}\``).join(' ');
+    const result = lookupWorkItemSymbols(title, '', dbPath);
+    expect(result.length).toBeLessThanOrEqual(20);
+  });
+
+  it('returns [] on DB error without throwing', () => {
+    // Write a non-SQLite file at the DB path
+    fs.writeFileSync(dbPath, 'not a sqlite file');
+    const result = lookupWorkItemSymbols('Fix AuthService', '', dbPath);
+    expect(result).toEqual([]);
+  });
+});

--- a/core/symbol-index/lookup.test.ts
+++ b/core/symbol-index/lookup.test.ts
@@ -80,7 +80,9 @@ describe('lookupWorkItemSymbols', () => {
   });
 
   it('returns [] when the DB file does not exist', () => {
-    const result = lookupWorkItemSymbols('Fix dispatchWave', 'details', '/nonexistent/path.db');
+    const result = lookupWorkItemSymbols('Fix dispatchWave', 'details', {
+      dbPath: '/nonexistent/path.db',
+    });
     expect(result).toEqual([]);
   });
 
@@ -89,7 +91,7 @@ describe('lookupWorkItemSymbols', () => {
     buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
     db.close();
 
-    const result = lookupWorkItemSymbols('Fix AuthService bug', 'body', dbPath);
+    const result = lookupWorkItemSymbols('Fix AuthService bug', 'body', { dbPath });
     expect(result).toEqual([]);
   });
 
@@ -98,7 +100,7 @@ describe('lookupWorkItemSymbols', () => {
     buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
     db.close();
 
-    const result = lookupWorkItemSymbols('Fix AuthService crash', 'auth breaks', dbPath);
+    const result = lookupWorkItemSymbols('Fix AuthService crash', 'auth breaks', { dbPath });
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('AuthService');
     expect(result[0].definedIn).toBe('core/auth.ts');
@@ -111,7 +113,7 @@ describe('lookupWorkItemSymbols', () => {
     buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
     db.close();
 
-    const result = lookupWorkItemSymbols('Fix AuthService crash', '', dbPath);
+    const result = lookupWorkItemSymbols('Fix AuthService crash', '', { dbPath });
     expect(result[0].callers).toContain('core/app.ts');
   });
 
@@ -120,7 +122,7 @@ describe('lookupWorkItemSymbols', () => {
     buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
     db.close();
 
-    const result = lookupWorkItemSymbols('Fix internalHelper', '', dbPath);
+    const result = lookupWorkItemSymbols('Fix internalHelper', '', { dbPath });
     expect(result).toHaveLength(0);
   });
 
@@ -136,7 +138,7 @@ describe('lookupWorkItemSymbols', () => {
     buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
     db.close();
 
-    const result = lookupWorkItemSymbols('Fix SharedUtil', '', dbPath);
+    const result = lookupWorkItemSymbols('Fix SharedUtil', '', { dbPath });
     expect(result[0].callers.length).toBeLessThanOrEqual(5);
   });
 
@@ -149,14 +151,79 @@ describe('lookupWorkItemSymbols', () => {
 
     // Use backtick-quoted identifiers to ensure high extraction confidence
     const title = Array.from({ length: 12 }, (_, i) => `\`Symbol${i}\``).join(' ');
-    const result = lookupWorkItemSymbols(title, '', dbPath);
+    const result = lookupWorkItemSymbols(title, '', { dbPath });
     expect(result.length).toBeLessThanOrEqual(20);
   });
 
   it('returns [] on DB error without throwing', () => {
     // Write a non-SQLite file at the DB path
     fs.writeFileSync(dbPath, 'not a sqlite file');
-    const result = lookupWorkItemSymbols('Fix AuthService', '', dbPath);
+    const result = lookupWorkItemSymbols('Fix AuthService', '', { dbPath });
     expect(result).toEqual([]);
+  });
+
+  it('worktreePath guard: excludes hints whose definedIn does not exist in worktree', () => {
+    writeFile(tmp, 'core/auth.ts', 'export function AuthService() {}');
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    // Use a worktreePath that does NOT contain core/auth.ts
+    const emptyWorktree = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-wt-'));
+    try {
+      const result = lookupWorkItemSymbols('Fix AuthService', '', {
+        dbPath,
+        worktreePath: emptyWorktree,
+      });
+      expect(result).toHaveLength(0);
+    } finally {
+      fs.rmSync(emptyWorktree, { recursive: true, force: true });
+    }
+  });
+
+  it('worktreePath guard: includes hints when definedIn exists in worktree', () => {
+    writeFile(tmp, 'core/auth.ts', 'export function AuthService() {}');
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    // tmp is also the worktree root — core/auth.ts exists there
+    const result = lookupWorkItemSymbols('Fix AuthService', '', {
+      dbPath,
+      worktreePath: tmp,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('AuthService');
+  });
+
+  it('returns empty callers when same name exported from multiple files', () => {
+    writeFile(tmp, 'core/a.ts', 'export function Config() {}');
+    writeFile(tmp, 'core/b.ts', 'export function Config() {}');
+    writeFile(tmp, 'core/app.ts', `import { Config } from './a.js';`);
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix Config', '', { dbPath });
+    // Two symbols named Config — callers are ambiguous
+    for (const hint of result) {
+      expect(hint.callers).toHaveLength(0);
+    }
+  });
+
+  it('includes callers when name is unambiguous', () => {
+    writeFile(tmp, 'core/auth.ts', 'export function UniqueService() {}');
+    writeFile(tmp, 'core/app.ts', `import { UniqueService } from './auth.js';`);
+    buildIndex({ repoRoot: tmp, db, includeDirs: ['core'] });
+    db.close();
+
+    const result = lookupWorkItemSymbols('Fix UniqueService', '', { dbPath });
+    expect(result[0].callers).toContain('core/app.ts');
+  });
+
+  it('extracts identifier tokens from backtick spans containing punctuation', () => {
+    const ids = extractIdentifiers('fix `dispatchWave()` and `AuthService.login`');
+    expect(ids).toContain('dispatchWave');
+    expect(ids).toContain('AuthService');
+    // The punctuation-bearing spans should not appear as-is
+    expect(ids).not.toContain('dispatchWave()');
+    expect(ids).not.toContain('AuthService.login');
   });
 });

--- a/core/symbol-index/lookup.ts
+++ b/core/symbol-index/lookup.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import path from 'node:path';
 import type Database from 'better-sqlite3';
 import { defaultDbPath, openIndexDb } from './db.js';
 import { findCallers, findSymbol } from './query.js';
@@ -9,6 +10,12 @@ export interface SymbolHint {
   line: number;
   kind: string;
   callers: string[];
+}
+
+export interface LookupOptions {
+  dbPath?: string;
+  /** When provided, hints are filtered to only files that exist in this directory tree. */
+  worktreePath?: string;
 }
 
 const SKIP_WORDS = new Set([
@@ -78,13 +85,16 @@ const MAX_HINTS = 20;
 const MAX_CALLERS_PER_HINT = 5;
 
 export function extractIdentifiers(text: string): string[] {
-  // Backtick-quoted identifiers are high-confidence code references — collect first
+  // Backtick spans are high-confidence code references — extract identifier tokens from them first
   const backtickIds: string[] = [];
-  for (const [, inner] of text.matchAll(/`([^`\s]{2,})`/g)) {
-    if (inner) backtickIds.push(inner);
+  for (const [, inner] of text.matchAll(/`([^`]+)`/g)) {
+    if (!inner) continue;
+    // Parse valid identifier tokens out of the span (handles `fn()`, `Type.method`, etc.)
+    const tokens = inner.match(/\b[a-zA-Z_][a-zA-Z0-9_]{2,}\b/g) ?? [];
+    backtickIds.push(...tokens);
   }
 
-  // Then camelCase / PascalCase / snake_case tokens from the remaining text
+  // Then camelCase / PascalCase / snake_case tokens from the full text
   const allTokens = text.match(/\b[a-zA-Z_][a-zA-Z0-9_]{2,}\b/g) ?? [];
 
   const seen = new Set<string>();
@@ -94,7 +104,7 @@ export function extractIdentifiers(text: string): string[] {
     if (seen.has(token)) continue;
     seen.add(token);
     if (SKIP_WORDS.has(token.toLowerCase())) continue;
-    // Require at least one uppercase letter or an underscore — filters prose
+    // Require at least one uppercase letter or underscore — filters prose
     const looksLikeCode = /[A-Z]/.test(token) || token.includes('_') || /[a-z][A-Z]/.test(token);
     if (!looksLikeCode) continue;
     result.push(token);
@@ -106,9 +116,17 @@ export function extractIdentifiers(text: string): string[] {
 /**
  * Query the local symbol index for identifiers mentioned in a work item.
  * Returns [] gracefully when the index file is absent, empty, or errored.
+ *
+ * Pass `worktreePath` to restrict hints to files that actually exist in the
+ * active worktree — prevents Goose Hub-internal paths from leaking into
+ * investigations against unrelated target repos.
  */
-export function lookupWorkItemSymbols(title: string, body: string, dbPath?: string): SymbolHint[] {
-  const resolved = dbPath ?? defaultDbPath();
+export function lookupWorkItemSymbols(
+  title: string,
+  body: string,
+  options?: LookupOptions,
+): SymbolHint[] {
+  const resolved = options?.dbPath ?? defaultDbPath();
   if (!existsSync(resolved)) return [];
 
   let db: Database.Database | null = null;
@@ -119,8 +137,23 @@ export function lookupWorkItemSymbols(title: string, body: string, dbPath?: stri
     const seen = new Set<string>();
 
     for (const name of identifiers) {
-      for (const sym of findSymbol(db, name)) {
-        if (!sym.exported) continue;
+      const exported = findSymbol(db, name).filter((s) => s.exported);
+      // Only include callers when the name is unambiguous — multiple exports with
+      // the same name would merge unrelated caller sets.
+      const callers =
+        exported.length === 1 ? findCallers(db, name).slice(0, MAX_CALLERS_PER_HINT) : [];
+
+      for (const sym of exported) {
+        // Skip hints whose source file doesn't exist in the active worktree.
+        // This prevents Goose Hub-internal paths from appearing in investigations
+        // against unrelated target repos.
+        if (
+          options?.worktreePath !== undefined &&
+          !existsSync(path.join(options.worktreePath, sym.filePath))
+        ) {
+          continue;
+        }
+
         const key = `${sym.filePath}:${sym.name}`;
         if (seen.has(key)) continue;
         seen.add(key);
@@ -129,7 +162,7 @@ export function lookupWorkItemSymbols(title: string, body: string, dbPath?: stri
           definedIn: sym.filePath,
           line: sym.line,
           kind: sym.kind,
-          callers: findCallers(db, sym.name).slice(0, MAX_CALLERS_PER_HINT),
+          callers,
         });
         if (hints.length >= MAX_HINTS) break;
       }

--- a/core/symbol-index/lookup.ts
+++ b/core/symbol-index/lookup.ts
@@ -1,0 +1,144 @@
+import { existsSync } from 'node:fs';
+import type Database from 'better-sqlite3';
+import { defaultDbPath, openIndexDb } from './db.js';
+import { findCallers, findSymbol } from './query.js';
+
+export interface SymbolHint {
+  name: string;
+  definedIn: string;
+  line: number;
+  kind: string;
+  callers: string[];
+}
+
+const SKIP_WORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'this',
+  'that',
+  'with',
+  'from',
+  'but',
+  'not',
+  'has',
+  'have',
+  'been',
+  'when',
+  'where',
+  'what',
+  'which',
+  'who',
+  'how',
+  'are',
+  'was',
+  'were',
+  'will',
+  'would',
+  'could',
+  'should',
+  'may',
+  'can',
+  'fix',
+  'bug',
+  'add',
+  'get',
+  'set',
+  'use',
+  'run',
+  'see',
+  'new',
+  'old',
+  'all',
+  'any',
+  'let',
+  'var',
+  'null',
+  'true',
+  'false',
+  'void',
+  'async',
+  'await',
+  'return',
+  'import',
+  'export',
+  'default',
+  'class',
+  'function',
+  'interface',
+  'type',
+  'enum',
+  'const',
+  'then',
+  'else',
+]);
+
+const MAX_IDENTIFIERS = 12;
+const MAX_HINTS = 20;
+const MAX_CALLERS_PER_HINT = 5;
+
+export function extractIdentifiers(text: string): string[] {
+  // Backtick-quoted identifiers are high-confidence code references — collect first
+  const backtickIds: string[] = [];
+  for (const [, inner] of text.matchAll(/`([^`\s]{2,})`/g)) {
+    if (inner) backtickIds.push(inner);
+  }
+
+  // Then camelCase / PascalCase / snake_case tokens from the remaining text
+  const allTokens = text.match(/\b[a-zA-Z_][a-zA-Z0-9_]{2,}\b/g) ?? [];
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const token of [...backtickIds, ...allTokens]) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    if (SKIP_WORDS.has(token.toLowerCase())) continue;
+    // Require at least one uppercase letter or an underscore — filters prose
+    const looksLikeCode = /[A-Z]/.test(token) || token.includes('_') || /[a-z][A-Z]/.test(token);
+    if (!looksLikeCode) continue;
+    result.push(token);
+    if (result.length >= MAX_IDENTIFIERS) break;
+  }
+  return result;
+}
+
+/**
+ * Query the local symbol index for identifiers mentioned in a work item.
+ * Returns [] gracefully when the index file is absent, empty, or errored.
+ */
+export function lookupWorkItemSymbols(title: string, body: string, dbPath?: string): SymbolHint[] {
+  const resolved = dbPath ?? defaultDbPath();
+  if (!existsSync(resolved)) return [];
+
+  let db: Database.Database | null = null;
+  try {
+    db = openIndexDb(resolved);
+    const identifiers = extractIdentifiers(`${title} ${body}`);
+    const hints: SymbolHint[] = [];
+    const seen = new Set<string>();
+
+    for (const name of identifiers) {
+      for (const sym of findSymbol(db, name)) {
+        if (!sym.exported) continue;
+        const key = `${sym.filePath}:${sym.name}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        hints.push({
+          name: sym.name,
+          definedIn: sym.filePath,
+          line: sym.line,
+          kind: sym.kind,
+          callers: findCallers(db, sym.name).slice(0, MAX_CALLERS_PER_HINT),
+        });
+        if (hints.length >= MAX_HINTS) break;
+      }
+      if (hints.length >= MAX_HINTS) break;
+    }
+    return hints;
+  } catch {
+    return [];
+  } finally {
+    db?.close();
+  }
+}

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -9,6 +9,7 @@ You have **read and search access only**.
 - `<work_item>` — title, body, number
 - `<scout_focus>` — one sentence telling you which symbol to trace
 - `<worktree_path>` — the worktree to read from
+- `<symbol_index_hints>` *(optional)* — pre-resolved symbol locations from the local symbol index. Each entry has `name`, `definedIn` (file path), `line`, `kind`, and `callers` (files that import this symbol). **When present, start your trace here instead of grepping.** Jump directly to `definedIn:line`. Still read the file — the index gives location, not content.
 
 ## Discipline
 

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - `<work_item>` — title, body, number
 - `<scout_focus>` — one sentence telling you which symbol to trace
 - `<worktree_path>` — the worktree to read from
-- `<symbol_index_hints>` *(optional)* — pre-resolved symbol locations from the local symbol index. Each entry has `name`, `definedIn` (file path), `line`, `kind`, and `callers` (files that import this symbol). **When present, start your trace here instead of grepping.** Jump directly to `definedIn:line`. Still read the file — the index gives location, not content.
+- `<symbolIndexHints>` *(optional)* — pre-resolved symbol locations from the local symbol index. Each entry has `name`, `definedIn` (file path), `line`, `kind`, and `callers` (files that import this symbol). **When present, start your trace here instead of grepping.** Jump directly to `definedIn:line`. Still read the file — the index gives location, not content.
 
 ## Discipline
 

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -15,9 +15,14 @@ const mockDispatchWave = vi.fn();
 const mockCrossValidate = vi.fn();
 const mockInvokeSkill = vi.fn();
 const mockPersistScoutReport = vi.fn();
+const mockLookupWorkItemSymbols = vi.fn();
 
 vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
   dispatchWave: (...args: unknown[]) => mockDispatchWave(...args),
+}));
+
+vi.mock('@goose-hub/core/symbol-index/lookup.js', () => ({
+  lookupWorkItemSymbols: (...args: unknown[]) => mockLookupWorkItemSymbols(...args),
 }));
 
 vi.mock('@goose-hub/core/agent-runtime/cross-validate.js', () => ({
@@ -194,6 +199,7 @@ beforeEach(() => {
   mockRun.mockReset();
   vi.clearAllMocks();
   mockAccumulatePersonaStats.mockClear();
+  mockLookupWorkItemSymbols.mockReturnValue([]);
 
   // Default happy path
   mockDispatchWave.mockResolvedValue(makeWaveResult());
@@ -686,6 +692,66 @@ describe('runInvestigateWorkflow', () => {
       expect(mockAccumulatePersonaStats).toHaveBeenCalledWith(
         expect.objectContaining({ outcome: 'failure' }),
       );
+    });
+  });
+
+  describe('symbol index pre-lookup — acceptance criterion (issue #724)', () => {
+    it('injects symbolIndexHints into scout-code-path extraContext when hints found', async () => {
+      const hints = [
+        { name: 'AuthService', definedIn: 'core/auth.ts', line: 10, kind: 'function', callers: [] },
+      ];
+      mockLookupWorkItemSymbols.mockReturnValue(hints);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const wave1Opts = mockDispatchWave.mock.calls[0][0] as {
+        scoutSpecs: Array<{ scoutName: string; extraContext?: Record<string, unknown> }>;
+      };
+      const codePath = wave1Opts.scoutSpecs.find((s) => s.scoutName === 'scout-code-path');
+      expect(codePath?.extraContext).toEqual({ symbolIndexHints: hints });
+    });
+
+    it('does not inject extraContext when symbol index returns empty', async () => {
+      mockLookupWorkItemSymbols.mockReturnValue([]);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const wave1Opts = mockDispatchWave.mock.calls[0][0] as {
+        scoutSpecs: Array<{ scoutName: string; extraContext?: Record<string, unknown> }>;
+      };
+      const codePath = wave1Opts.scoutSpecs.find((s) => s.scoutName === 'scout-code-path');
+      expect(codePath?.extraContext).toBeUndefined();
+    });
+
+    it('other Wave 1 scouts are unaffected by symbol index hints', async () => {
+      const hints = [
+        { name: 'AuthService', definedIn: 'core/auth.ts', line: 10, kind: 'function', callers: [] },
+      ];
+      mockLookupWorkItemSymbols.mockReturnValue(hints);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const wave1Opts = mockDispatchWave.mock.calls[0][0] as {
+        scoutSpecs: Array<{ scoutName: string; extraContext?: Record<string, unknown> }>;
+      };
+      for (const spec of wave1Opts.scoutSpecs) {
+        if (spec.scoutName !== 'scout-code-path') {
+          expect(spec.extraContext).toBeUndefined();
+        }
+      }
+    });
+
+    it('lookupWorkItemSymbols called with work item title and body', async () => {
+      const workItem = makeWorkItem({ title: 'Fix AuthService', body: 'Crashes on login' });
+      mockLookupWorkItemSymbols.mockReturnValue([]);
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(workItem, makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockLookupWorkItemSymbols).toHaveBeenCalledWith('Fix AuthService', 'Crashes on login');
     });
   });
 });

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -744,14 +744,18 @@ describe('runInvestigateWorkflow', () => {
       }
     });
 
-    it('lookupWorkItemSymbols called with work item title and body', async () => {
+    it('lookupWorkItemSymbols called with work item title, body, and worktreePath', async () => {
       const workItem = makeWorkItem({ title: 'Fix AuthService', body: 'Crashes on login' });
       mockLookupWorkItemSymbols.mockReturnValue([]);
 
       const { runInvestigateWorkflow } = await import('./workflow.js');
       await runInvestigateWorkflow(workItem, makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(mockLookupWorkItemSymbols).toHaveBeenCalledWith('Fix AuthService', 'Crashes on login');
+      expect(mockLookupWorkItemSymbols).toHaveBeenCalledWith(
+        'Fix AuthService',
+        'Crashes on login',
+        expect.objectContaining({ worktreePath: '/tmp/test-worktree' }),
+      );
     });
   });
 });

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -13,6 +13,7 @@ import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { persistScoutReport } from '@goose-hub/core/scout-reports/repository.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { lookupWorkItemSymbols } from '@goose-hub/core/symbol-index/lookup.js';
 import {
   cleanupWorktree,
   createWorktree,
@@ -112,10 +113,18 @@ export async function runInvestigateWorkflow(
   }
 
   try {
+    // Pre-fetch symbol index hints for scout-code-path (best-effort; empty if index absent)
+    const symbolIndexHints = lookupWorkItemSymbols(workItem.title, workItem.body);
+    const wave1Scouts = WAVE_1_SCOUTS.map((spec) =>
+      spec.scoutName === 'scout-code-path' && symbolIndexHints.length > 0
+        ? { ...spec, extraContext: { symbolIndexHints } }
+        : spec,
+    );
+
     // Wave 1 — parallel fact-gathering
     const wave1Result = await dispatchWave({
       parentRunId: runId,
-      scoutSpecs: WAVE_1_SCOUTS,
+      scoutSpecs: wave1Scouts,
       workItem: workItemCtx,
       worktreePath,
       projectId,

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -113,8 +113,10 @@ export async function runInvestigateWorkflow(
   }
 
   try {
-    // Pre-fetch symbol index hints for scout-code-path (best-effort; empty if index absent)
-    const symbolIndexHints = lookupWorkItemSymbols(workItem.title, workItem.body);
+    // Pre-fetch symbol index hints for scout-code-path (best-effort; empty if index absent).
+    // Pass worktreePath so hints are filtered to files that actually exist in the target repo,
+    // preventing Goose Hub-internal paths from leaking into non-goose-hub investigations.
+    const symbolIndexHints = lookupWorkItemSymbols(workItem.title, workItem.body, { worktreePath });
     const wave1Scouts = WAVE_1_SCOUTS.map((spec) =>
       spec.scoutName === 'scout-code-path' && symbolIndexHints.length > 0
         ? { ...spec, extraContext: { symbolIndexHints } }


### PR DESCRIPTION
## Summary

- Adds `core/symbol-index/lookup.ts` — extracts code identifiers from a work item title/body, queries `~/.factory/symbol-index.db`, returns `SymbolHint[]` (name, definedIn, line, kind, callers). Falls back to `[]` when index is absent, empty, or errors.
- Before Wave-1 dispatch in `slices/investigate/workflow.ts`, calls `lookupWorkItemSymbols` and injects results into `scout-code-path` `extraContext` as `symbolIndexHints` when non-empty.
- Adds `symbolIndexHints` to `SCOUT_CONTEXT_ALLOWLIST` in `core/agent-runtime/swarm.ts` so it passes holdout validation and reaches the agent context.
- Updates `skills/scout-code-path/prompt.md` to use hints as the trace starting point when present.

## Test plan

- [x] `core/symbol-index/lookup.test.ts` — 16 new tests covering identifier extraction (camelCase/PascalCase/snake_case/backtick priority/dedup/cap), DB-missing fallback, caller capping, hint cap, error resilience
- [x] `slices/investigate/slice.test.ts` — 4 new tests: hints injected into scout-code-path, no injection when empty, other scouts unaffected, lookup called with correct args
- [x] All 220 test files, 3192 tests passing
- [x] Typecheck and lint clean

Closes #724