### PR TITLE
feat(state-source): add initialState + extraLabels to CreateIssueInput

### DIFF
--- a/core/state-source/github-labels.ts
+++ b/core/state-source/github-labels.ts
@@ -504,12 +504,13 @@ export class GitHubLabelsSource implements StateSource {
 
   async createIssue(input: CreateIssueInput): Promise<WorkItem> {
     const labels: string[] = [
-      'factory:triaging',
+      input.initialState ?? 'factory:triaging',
       `type:${input.type ?? 'feature'}`,
       `priority:${input.priority ?? 'medium'}`,
       'schedule:current',
       'mode:supervised',
       'exec:serial',
+      ...(input.extraLabels ?? []),
     ];
     const url = `https://api.github.com/repos/${this.repoRef}/issues`;
     const res = await fetch(url, {

--- a/core/state-source/in-memory-labels.ts
+++ b/core/state-source/in-memory-labels.ts
@@ -271,7 +271,7 @@ export class InMemoryLabelsSource implements StateSource {
       externalId,
       title: input.title,
       body,
-      state: 'factory:triaging',
+      state: input.initialState ?? 'factory:triaging',
       type: input.type ?? 'chore',
       priority: input.priority ?? 'medium',
       mode: 'supervised',
@@ -287,7 +287,7 @@ export class InMemoryLabelsSource implements StateSource {
       blocks: [],
       comments: [],
       createdAt: new Date(),
-      extraLabels: new Set<string>(),
+      extraLabels: new Set<string>(input.extraLabels ?? []),
     };
     this.store.set(externalId, issue);
     return this.toWorkItem(issue);

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -63,6 +63,10 @@ export interface CreateIssueInput {
   type?: WorkItemType;
   priority?: Priority;
   milestoneId?: string;
+  /** Override the default initial state (factory:triaging). */
+  initialState?: StateName;
+  /** Additional labels to include at creation time. */
+  extraLabels?: string[];
 }
 
 export interface SourceEvent {

--- a/core/workflows/decompose-prd.ts
+++ b/core/workflows/decompose-prd.ts
@@ -218,26 +218,6 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
           }
         }
 
-        const created = await stateSource.createIssue({
-          title: issue.title,
-          body: resolvedBody,
-          type: issueType,
-          priority: issuePriority,
-        });
-
-        const childNumber = Number(created.externalId);
-        siblingNumbers.set(i, childNumber);
-        childIssueNumbers.push(childNumber);
-
-        // Set milestone if parent has one
-        if (parentMilestoneNumber != null && !Number.isNaN(parentMilestoneNumber)) {
-          await stateSource.setMilestone(created.externalId, parentMilestoneNumber);
-        }
-
-        // Apply label groups via setLabelInGroup (supports priority, schedule, type)
-        await stateSource.setLabelInGroup(created.externalId, 'type', issueType);
-        await stateSource.setLabelInGroup(created.externalId, 'priority', issuePriority);
-
         // Determine schedule label (default: 'current')
         let scheduleValue = 'current';
         for (const lbl of labelSet) {
@@ -254,19 +234,28 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
             break;
           }
         }
-        await stateSource.setLabelInGroup(created.externalId, 'schedule', scheduleValue);
 
-        // Promote child from factory:triaging (the createIssue default) to
-        // factory:accepted, leaving exec:serial and mode:supervised unchanged.
-        // Apply factory:from-prd so triage skips grilling for these children
-        // if they ever re-enter triaging (e.g. after a needs-human recovery).
-        await stateSource.removeLabel(created.externalId, 'factory:triaging');
-        await stateSource.addLabels(created.externalId, ['factory:accepted', 'factory:from-prd']);
-        await stateSource.transitionState(
-          created.externalId,
-          'factory:accepted',
-          'factory:dev-ready',
-        );
+        const created = await stateSource.createIssue({
+          title: issue.title,
+          body: resolvedBody,
+          type: issueType,
+          priority: issuePriority,
+          initialState: 'factory:dev-ready',
+          extraLabels: ['factory:from-prd'],
+        });
+
+        const childNumber = Number(created.externalId);
+        siblingNumbers.set(i, childNumber);
+        childIssueNumbers.push(childNumber);
+
+        // Set milestone if parent has one
+        if (parentMilestoneNumber != null && !Number.isNaN(parentMilestoneNumber)) {
+          await stateSource.setMilestone(created.externalId, parentMilestoneNumber);
+        }
+
+        if (scheduleValue !== 'current') {
+          await stateSource.setLabelInGroup(created.externalId, 'schedule', scheduleValue);
+        }
       }
     } catch (loopErr) {
       // Partial-create: some children were created before the failure.

--- a/slices/decompose-prd/slice.test.ts
+++ b/slices/decompose-prd/slice.test.ts
@@ -415,11 +415,11 @@ describe('child issue type derived from labels', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Children land at factory:accepted (AC #316)
+// 7. Children land at factory:dev-ready with factory:from-prd (AC #316)
 // ---------------------------------------------------------------------------
 
-describe('children land at factory:accepted', () => {
-  it('removes factory:triaging and adds factory:accepted to each child', async () => {
+describe('children land at factory:dev-ready', () => {
+  it('creates children directly in factory:dev-ready with factory:from-prd label', async () => {
     const source = new InMemoryLabelsSource(PROJECT_ID, REPO_REF);
     const parent = await source.seedIssue({
       title: 'Parent PRD epic',
@@ -442,7 +442,7 @@ describe('children land at factory:accepted', () => {
     });
 
     for (const childNum of result.childIssueNumbers) {
-      // State must be factory:dev-ready (workflow promotes triaging → accepted → dev-ready)
+      // State must be factory:dev-ready (set atomically at creation via initialState)
       const child = await source.getItem(String(childNum));
       expect(child.state).toBe('factory:dev-ready');
 


### PR DESCRIPTION
## Summary

- Adds `initialState?: StateName` and `extraLabels?: string[]` to `CreateIssueInput` interface
- `GitHubLabelsSource` and `InMemoryLabelsSource` use both fields atomically at creation time
- `decompose-prd` workflow drops the 3-step `removeLabel → addLabels → transitionState` workaround — child issues are now born in `factory:dev-ready` with `factory:from-prd` in a single `createIssue` call

## Why

Child issues from decompose-prd were created in `factory:triaging` then immediately promoted via three separate GitHub API calls. This produced noisy timeline state transitions and a race where partial failures (e.g. issue 742/743) could leave issues missing `factory:from-prd`, causing them to incorrectly route through grilling on recovery.

## Test Plan

- [ ] `core/state-source` tests pass (115 tests)
- [ ] `slices/decompose-prd` tests pass (15 tests) — including the landing-state assertion
- [ ] Typecheck passes for both `@goose-hub/core` and `@goose-hub/server`