### PR TITLE
M7.XX: Goose hub logo 25

### DIFF
--- a/apps/web/e2e/issue-748.spec.ts
+++ b/apps/web/e2e/issue-748.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+test('Logo displays "GooseHUB" with no space and capitals', async ({ page }) => {
+  // Mock API endpoints to prevent network delays
+  await page.route('**/api/projects*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'test-proj',
+            name: 'Test Project',
+            slug: 'test-proj',
+            color: '#888888',
+            source: { kind: 'github', repo: 'owner/repo' },
+            defaultBranch: 'main',
+          },
+        ],
+      }),
+    }),
+  );
+
+  // Navigate to home page
+  await page.goto('/');
+
+  // Wait for the sidebar to be visible
+  const sidebar = await page.waitForSelector('[data-testid="sidebar"]');
+  expect(sidebar).toBeTruthy();
+
+  // Check that the logo text is "GooseHUB" (not "Goose Hub")
+  // Expand sidebar by clicking the toggle button if it's collapsed
+  const expandButton = await page.locator('button[title="Expand sidebar"]');
+  const isVisible = await expandButton.isVisible().catch(() => false);
+
+  if (isVisible) {
+    // Sidebar is collapsed, expand it
+    await expandButton.click();
+    // Wait for the sidebar to expand
+    await page.waitForTimeout(300);
+  }
+
+  // Check for the GooseHUB text in the sidebar header
+  const logoText = await page.locator('aside span.text-\\[14px\\].font-semibold').first();
+  await expect(logoText).toContainText('GooseHUB');
+
+  // Verify old text "Goose Hub" does not exist
+  const oldText = page.locator('text=Goose Hub');
+  await expect(oldText).toHaveCount(0);
+
+  // Take screenshot as visual evidence
+  await page.screenshot({ path: 'evidence/issue-748/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import { cleanup, render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher-mock" />,
+}));
+
+beforeAll(() => {
+  const mockLocalStorage = {
+    getItem: vi.fn((key) => {
+      if (key === 'sidebar-collapsed') return 'false';
+      return null;
+    }),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+    length: 0,
+    key: vi.fn(),
+  };
+  vi.stubGlobal('localStorage', mockLocalStorage);
+});
+
+afterEach(cleanup);
+
+describe('Sidebar', () => {
+  it('renders GooseHUB in logo text', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <Sidebar />
+      </BrowserRouter>,
+    );
+    // Find the span with GooseHUB text in the header
+    const spans = container.querySelectorAll('span');
+    const hasGooseHUB = Array.from(spans).some(
+      (span) => span.textContent === 'GooseHUB' && span.className.includes('text-[14px]'),
+    );
+    expect(hasGooseHUB).toBe(true);
+  });
+
+  it('does not render old "Goose Hub" text with space', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <Sidebar />
+      </BrowserRouter>,
+    );
+    const spans = container.querySelectorAll('span');
+    const hasOldText = Array.from(spans).some(
+      (span) => span.textContent === 'Goose Hub' && span.className.includes('text-[14px]'),
+    );
+    expect(hasOldText).toBe(false);
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Goose hub logo 25

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed logo text from 'Goose Hub' to 'GooseHUB' on line 117
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Added unit tests for Sidebar logo text verification with localStorage mock
- `apps/web/e2e/issue-748.spec.ts` — Added Playwright e2e spec for visual evidence of logo text change

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)

Closes #748
