### PR TITLE
refactor(grill-and-prd): extract sub-modules and migrate to invokeSkill

### DIFF
--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -10,20 +10,10 @@
  */
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { AdvisePRDOutputSchema } from '../../skills/advise-on-prd/schema.js';
-import { GrillMeOutputSchema } from '../../skills/grill-me/schema.js';
 import type { PRDOutput } from '../../skills/write-prd/schema.js';
-import { PRDOutputSchema } from '../../skills/write-prd/schema.js';
 import { ClaudeCliRuntime } from '../agent-runtime/claude-cli.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
-import {
-  resolveBudgetsForProject,
-  resolveGlobalSettingsForProject,
-} from '../agent-runtime/resolve-for-project.js';
-import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
-import { selectPersona } from '../agent-runtime/select-persona.js';
 import { totalSpendForSkill as _totalSpendForSkill } from '../cost/repository.js';
 import { emitStateTransitionEvent } from '../event-stream/state-transition.js';
 import { eventStore } from '../event-stream/store.js';
@@ -32,6 +22,10 @@ import type { StateName } from '../state-machine/states.js';
 import type { StateSource, WorkItem } from '../state-source/interface.js';
 import type { ProjectConfig, StackConfig } from '../types.js';
 import { cleanupWorktree, createWorktree } from '../workspaces/worktree.js';
+import { runAdvisorReview } from './grill-and-prd/advisor-review.js';
+import { runGrillRound } from './grill-and-prd/grill-round.js';
+import { runPrdDraft } from './grill-and-prd/prd-draft.js';
+import { withManagedWorktree } from './grill-and-prd/worktree-lifecycle.js';
 
 export interface ProjectContextBundle {
   stackSummary: string;
@@ -201,38 +195,6 @@ export interface GrillAndPrdResult {
   prdOutput?: unknown;
 }
 
-const FALLBACK_GRILL_BUDGET = {
-  budgets: { maxTurns: 15, maxBudgetUsd: 0.2, timeoutMs: 300_000 },
-  modelOverride: 'sonnet',
-};
-const FALLBACK_PRD_BUDGET = {
-  budgets: { maxTurns: 40, maxBudgetUsd: 2.0, timeoutMs: 420_000 },
-  modelOverride: 'opus',
-};
-const FALLBACK_ADVISOR_BUDGET = {
-  budgets: { maxTurns: 15, maxBudgetUsd: 1.0, timeoutMs: 180_000 },
-  modelOverride: 'opus',
-};
-
-function safeResolveBudgets(
-  skill: string,
-  projectBudgets: ProjectConfig['budgets'] | undefined,
-  fallback: {
-    budgets: { maxTurns: number; maxBudgetUsd: number; timeoutMs: number };
-    modelOverride: string;
-  },
-  projectId?: string,
-): {
-  budgets: { maxTurns: number; maxBudgetUsd: number; timeoutMs: number };
-  modelOverride: string;
-} {
-  try {
-    return resolveBudgetsForProject(skill, projectBudgets, projectId ?? '');
-  } catch {
-    return fallback;
-  }
-}
-
 /**
  * Move the work item into `factory:gate-pending` and emit a `state.transitioned`
  * event. The legal-transition table does not allow `factory:grilling ->
@@ -390,12 +352,160 @@ export async function runGrillAndPrdWorkflow(
     await stateSource.forceState(workItem.externalId, 'factory:needs-human');
     return { phase: 'needs-human' };
   }
-  const expandedRepoPath = localRepoPath.startsWith('~/')
-    ? join(process.env.HOME ?? '/root', localRepoPath.slice(2))
-    : localRepoPath;
-  let worktreePath: string;
+
+  // Deferred result variables — all grill-phase exits set these so the finally
+  // block always fires before we return or fall through to write-prd.
+  let grillPhaseReturn: GrillAndPrdResult | null = null;
+  let refinedIntentForPrd: string | null = null;
+
+  // Augment priorReplies with crystallizations from the event store. Hoisted
+  // outside try/finally so the post-finally write-prd call can re-augment.
+  const augmentedPriorReplies = augmentPriorRepliesWithCrystallizations(
+    priorReplies,
+    projectId,
+    workItem.id,
+  );
+
   try {
-    worktreePath = createWorktreeFn(expandedRepoPath, workflowRunId);
+    await withManagedWorktree(
+      localRepoPath,
+      workflowRunId,
+      async (worktreePath) => {
+        const roundNumber =
+          augmentedPriorReplies.filter(
+            (r) => r.role === 'agent' && !r.content.startsWith('<!-- factory:prd -->'),
+          ).length + 1;
+
+        const grillRunId = childRunId('grill-me');
+
+        const outcome = await runGrillRound({
+          workItem: {
+            id: workItem.id,
+            title: workItem.title,
+            body: workItem.body,
+            externalId: workItem.externalId,
+          },
+          projectId,
+          workItemId: workItem.id,
+          runId: grillRunId,
+          workflowRunId,
+          worktreePath,
+          priorReplies: augmentedPriorReplies,
+          projectContext: fullProjectContext,
+          projectConfig,
+          deps: { runtime: deps.runtime },
+        });
+
+        if (outcome.status === 'invalid' || outcome.status === 'failed') {
+          const errMsg =
+            outcome.status === 'invalid'
+              ? 'grill-me returned invalid output; waiting for human to resume grilling.'
+              : 'grill-me failed; waiting for human to resume grilling.';
+          eventStore.appendEvent({
+            kind: 'agent.run-failed',
+            projectId,
+            workItemId: workItem.id,
+            runId: grillRunId,
+            payload: { skill: 'grill-me', workflowRunId, error: outcome.error },
+          });
+          await stateSource.comment(workItem.externalId, `<!-- factory:system -->\n${errMsg}`);
+          await ensureGatePending(
+            stateSource,
+            workItem.externalId,
+            workItem.state,
+            projectId,
+            workItem.id,
+          );
+          grillPhaseReturn = { phase: 'grilling' };
+          return;
+        }
+
+        const grillOutput = outcome.output;
+
+        if (
+          typeof grillOutput.crystallizedDecision === 'string' &&
+          grillOutput.crystallizedDecision.trim() !== '' &&
+          roundNumber > 1
+        ) {
+          eventStore.appendEvent({
+            kind: 'grill.decision-crystallized',
+            projectId,
+            workItemId: workItem.id,
+            runId: workflowRunId,
+            payload: {
+              workflowRunId,
+              roundNumber: roundNumber - 1,
+              decision: grillOutput.crystallizedDecision.trim(),
+            },
+          });
+        }
+
+        reconcileDecisionSummaries(
+          grillRunId,
+          projectId,
+          workItem.id,
+          'grill-me',
+          grillOutput.decisionSummaries,
+        );
+
+        if (outcome.status === 'question') {
+          const recommendedBlock =
+            outcome.recommendedAnswer != null
+              ? `\n<!-- factory:recommended-answer -->\nRecommended: ${outcome.recommendedAnswer}`
+              : '';
+          await stateSource.comment(
+            workItem.externalId,
+            `<!-- factory:grill-question -->\n**Round ${roundNumber}** — ${outcome.question}${recommendedBlock}`,
+          );
+          await ensureGatePending(
+            stateSource,
+            workItem.externalId,
+            workItem.state,
+            projectId,
+            workItem.id,
+          );
+          eventStore.appendEvent({
+            kind: 'grill.question-posted',
+            projectId,
+            workItemId: workItem.id,
+            runId: workflowRunId,
+            payload: { workflowRunId, roundNumber, question: outcome.question },
+          });
+          grillPhaseReturn = { phase: 'grilling', questionPosted: outcome.question };
+          return;
+        }
+
+        // outcome.status === 'ready'
+        const forced = roundNumber > 7;
+        eventStore.appendEvent({
+          kind: 'grill.completed',
+          projectId,
+          workItemId: workItem.id,
+          runId: workflowRunId,
+          payload: {
+            workflowRunId,
+            refinedIntent: outcome.refinedIntent,
+            rounds: roundNumber,
+            ...(forced && { forced: true }),
+          },
+        });
+        refinedIntentForPrd = outcome.refinedIntent;
+      },
+      (err) => {
+        eventStore.appendEvent({
+          kind: 'agent.run-failed',
+          projectId,
+          workItemId: workItem.id,
+          runId: workflowRunId,
+          payload: {
+            skill: 'grill-and-prd',
+            workflowRunId,
+            error: `worktree cleanup failed: ${String(err)}`,
+          },
+        });
+      },
+      { createWorktreeImpl: createWorktreeFn, cleanupWorktreeImpl: cleanupWorktreeFn },
+    );
   } catch (err) {
     eventStore.appendEvent({
       kind: 'agent.run-failed',
@@ -420,274 +530,6 @@ export async function runGrillAndPrdWorkflow(
       workItem.id,
     );
     return { phase: 'grilling' };
-  }
-
-  // Deferred result variables — all grill-phase exits set these so the finally
-  // block always fires before we return or fall through to write-prd.
-  let grillPhaseReturn: GrillAndPrdResult | null = null;
-  let refinedIntentForPrd: string | null = null;
-
-  // Augment priorReplies with crystallizations from the event store. Hoisted
-  // outside try/finally so the post-finally write-prd call can re-augment.
-  const augmentedPriorReplies = augmentPriorRepliesWithCrystallizations(
-    priorReplies,
-    projectId,
-    workItem.id,
-  );
-
-  try {
-    // Round-number is 1-indexed and counts how many times grill-me has produced
-    // a question in the conversation so far, plus one (the round we're about to run).
-    const roundNumber =
-      augmentedPriorReplies.filter(
-        (r) => r.role === 'agent' && !r.content.startsWith('<!-- factory:prd -->'),
-      ).length + 1;
-
-    // ─── Step 1: grill-me ──────────────────────────────────────────────────
-    const grillerPersona = selectPersona(projectId, 'griller');
-    const grillBudget = safeResolveBudgets(
-      'grill-me',
-      projectConfig?.budgets,
-      FALLBACK_GRILL_BUDGET,
-      projectId,
-    );
-    const grillPrompt = readPromptWithContext('grill-me', projectId);
-    const grillJsonSchema = toJsonSchema(GrillMeOutputSchema);
-    const grillRunId = childRunId('grill-me');
-
-    let grillOutput: import('../../skills/grill-me/schema.js').GrillMeOutput | null = null;
-
-    try {
-      const grillResult = await runtime.run({
-        runId: grillRunId,
-        role: 'griller',
-        skill: 'grill-me',
-        workspaceDir: worktreePath,
-        context: {
-          projectId,
-          workItemId: workItem.id,
-          workItem: {
-            title: workItem.title,
-            body: workItem.body,
-            number: Number(workItem.externalId),
-          },
-          priorReplies: augmentedPriorReplies,
-          roundNumber,
-          projectContext: fullProjectContext,
-          worktreePath,
-        },
-        contextAllowlist: [
-          'workItem',
-          'priorReplies',
-          'roundNumber',
-          'projectContext',
-          'worktreePath',
-        ],
-        freshContext: false,
-        toolBundles: ['read'],
-        toolExtras: [],
-        ...grillBudget,
-        personaId: grillerPersona.personaId,
-        appendSystemPrompt: grillPrompt,
-        outputJsonSchema: grillJsonSchema,
-        extraEventPayload: { roundNumber, workflowRunId },
-      });
-
-      const parsed = GrillMeOutputSchema.safeParse(grillResult.output);
-      if (!parsed.success) {
-        eventStore.appendEvent({
-          kind: 'agent.run-failed',
-          projectId,
-          workItemId: workItem.id,
-          runId: grillRunId,
-          payload: { skill: 'grill-me', workflowRunId, error: parsed.error.message },
-        });
-        await stateSource.comment(
-          workItem.externalId,
-          '<!-- factory:system -->\ngrill-me returned invalid output; waiting for human to resume grilling.',
-        );
-        await ensureGatePending(
-          stateSource,
-          workItem.externalId,
-          workItem.state,
-          projectId,
-          workItem.id,
-        );
-        grillPhaseReturn = { phase: 'grilling' };
-      } else {
-        grillOutput = parsed.data;
-      }
-    } catch (err) {
-      eventStore.appendEvent({
-        kind: 'agent.run-failed',
-        projectId,
-        workItemId: workItem.id,
-        runId: grillRunId,
-        payload: { skill: 'grill-me', workflowRunId, error: String(err) },
-      });
-      await stateSource.comment(
-        workItem.externalId,
-        '<!-- factory:system -->\ngrill-me failed; waiting for human to resume grilling.',
-      );
-      await ensureGatePending(
-        stateSource,
-        workItem.externalId,
-        workItem.state,
-        projectId,
-        workItem.id,
-      );
-      grillPhaseReturn = { phase: 'grilling' };
-    }
-
-    if (grillOutput != null) {
-      // Persist the crystallized decision from the previous Q+A round (if present).
-      // roundNumber is the current round; the crystallizedDecision describes round N-1.
-      if (
-        typeof grillOutput.crystallizedDecision === 'string' &&
-        grillOutput.crystallizedDecision.trim() !== '' &&
-        roundNumber > 1
-      ) {
-        eventStore.appendEvent({
-          kind: 'grill.decision-crystallized',
-          projectId,
-          workItemId: workItem.id,
-          runId: workflowRunId,
-          payload: {
-            workflowRunId,
-            roundNumber: roundNumber - 1,
-            decision: grillOutput.crystallizedDecision.trim(),
-          },
-        });
-      }
-
-      // Emit any decision summaries the griller produced this round.
-      reconcileDecisionSummaries(
-        grillRunId,
-        projectId,
-        workItem.id,
-        'grill-me',
-        grillOutput.decisionSummaries,
-      );
-
-      // Hard cap at round 7: if the griller still hasn't declared readyForPRD,
-      // force the workflow forward so we don't loop indefinitely.
-      let grillCompletedEmitted = false;
-      if (!grillOutput.readyForPRD && roundNumber > 7) {
-        const forcedRefinedIntent =
-          grillOutput.refinedIntent.trim() !== '' ? grillOutput.refinedIntent : workItem.body;
-        eventStore.appendEvent({
-          kind: 'grill.completed',
-          projectId,
-          workItemId: workItem.id,
-          runId: workflowRunId,
-          payload: {
-            workflowRunId,
-            refinedIntent: forcedRefinedIntent,
-            rounds: roundNumber,
-            forced: true,
-          },
-        });
-        grillCompletedEmitted = true;
-        grillOutput = { ...grillOutput, refinedIntent: forcedRefinedIntent, readyForPRD: true };
-      }
-
-      if (!grillOutput.readyForPRD) {
-        // Defensively pick the first question even though the skill is supposed
-        // to ask exactly one. Empty `questions` with readyForPRD:false is a skill
-        // contract violation — escalate to the human.
-        const questionEntry = grillOutput.questions[0];
-        if (questionEntry == null || questionEntry.text.trim() === '') {
-          eventStore.appendEvent({
-            kind: 'agent.run-failed',
-            projectId,
-            workItemId: workItem.id,
-            runId: grillRunId,
-            payload: {
-              skill: 'grill-me',
-              workflowRunId,
-              error: 'grill-me returned readyForPRD:false with no questions',
-            },
-          });
-          await stateSource.comment(
-            workItem.externalId,
-            '<!-- factory:system -->\ngrill-me returned no questions; waiting for human to resume grilling.',
-          );
-          await ensureGatePending(
-            stateSource,
-            workItem.externalId,
-            workItem.state,
-            projectId,
-            workItem.id,
-          );
-          grillPhaseReturn = { phase: 'grilling' };
-        } else {
-          // Prefix with the `<!-- factory:grill-question -->` HTML marker so the
-          // Grill chat tab in the UI can distinguish agent questions from user
-          // replies. The marker is invisible in rendered Markdown.
-          // Append the recommended answer using `<!-- factory:recommended-answer -->`
-          // so the UI can parse and render it as a clickable pill.
-          const recommendedBlock =
-            questionEntry.recommendedAnswer != null
-              ? `\n<!-- factory:recommended-answer -->\nRecommended: ${questionEntry.recommendedAnswer}`
-              : '';
-          await stateSource.comment(
-            workItem.externalId,
-            `<!-- factory:grill-question -->\n**Round ${roundNumber}** — ${questionEntry.text}${recommendedBlock}`,
-          );
-          await ensureGatePending(
-            stateSource,
-            workItem.externalId,
-            workItem.state,
-            projectId,
-            workItem.id,
-          );
-
-          eventStore.appendEvent({
-            kind: 'grill.question-posted',
-            projectId,
-            workItemId: workItem.id,
-            runId: workflowRunId,
-            payload: { workflowRunId, roundNumber, question: questionEntry.text },
-          });
-
-          grillPhaseReturn = { phase: 'grilling', questionPosted: questionEntry.text };
-        }
-      } else {
-        // readyForPRD === true — the griller is done. Emit completion (unless
-        // already emitted by the round-7 forced cap above) and proceed to write-prd.
-        if (!grillCompletedEmitted) {
-          eventStore.appendEvent({
-            kind: 'grill.completed',
-            projectId,
-            workItemId: workItem.id,
-            runId: workflowRunId,
-            payload: {
-              workflowRunId,
-              refinedIntent: grillOutput.refinedIntent,
-              rounds: roundNumber,
-            },
-          });
-        }
-
-        refinedIntentForPrd = grillOutput.refinedIntent;
-      }
-    }
-  } finally {
-    try {
-      cleanupWorktreeFn(workflowRunId);
-    } catch (err) {
-      eventStore.appendEvent({
-        kind: 'agent.run-failed',
-        projectId,
-        workItemId: workItem.id,
-        runId: workflowRunId,
-        payload: {
-          skill: 'grill-and-prd',
-          workflowRunId,
-          error: `worktree cleanup failed: ${String(err)}`,
-        },
-      });
-    }
   }
 
   if (grillPhaseReturn != null) {
@@ -743,10 +585,6 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     priorReplies,
   } = input;
 
-  // ─── Step 2: write-prd ──────────────────────────────────────────────────
-  // Transition into prd-drafting. Only `factory:grilling` legally targets
-  // `factory:prd-drafting`; if we entered here from `factory:gate-pending`
-  // (e.g. user replied while we were waiting), force the state.
   try {
     if (workItem.state === 'factory:grilling') {
       await stateSource.transitionState(
@@ -761,86 +599,35 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     await stateSource.forceState(workItem.externalId, 'factory:prd-drafting');
   }
 
-  const prdPersona = selectPersona(projectId, 'prd-writer');
-  const prdBudget = safeResolveBudgets(
-    'write-prd',
-    projectConfig?.budgets,
-    FALLBACK_PRD_BUDGET,
-    projectId,
-  );
-  const prdPrompt = readPromptWithContext('write-prd', projectId);
-  const prdJsonSchema = toJsonSchema(PRDOutputSchema);
   const prdRunId = `${workflowRunId}:write-prd`;
 
-  let prdOutput: PRDOutput;
+  const prdDraftOutcome = await runPrdDraft({
+    workItem,
+    projectId,
+    workItemId: workItem.id,
+    runId: prdRunId,
+    workflowRunId,
+    refinedIntent,
+    fullProjectContext,
+    projectConfig,
+    priorReplies,
+    priorPrd,
+    humanConcerns,
+    deps: { runtime },
+  });
 
-  try {
-    const prdResult = await runtime.run({
-      runId: prdRunId,
-      role: 'prd-writer',
-      skill: 'write-prd',
-      context: {
-        projectId,
-        workItemId: workItem.id,
-        workItem: {
-          title: workItem.title,
-          body: workItem.body,
-          number: Number(workItem.externalId),
-        },
-        refinedIntent,
-        priority: workItem.priority,
-        projectContext: fullProjectContext,
-        ...(priorReplies != null ? { priorReplies } : {}),
-        ...(priorPrd != null ? { priorPrd } : {}),
-        ...(humanConcerns != null ? { humanConcerns } : {}),
-      },
-      contextAllowlist: [
-        'workItem.title',
-        'workItem.body',
-        'workItem.number',
-        'refinedIntent',
-        'priority',
-        'projectContext',
-        'priorReplies',
-        'priorPrd',
-        'humanConcerns',
-      ],
-      freshContext: true,
-      toolBundles: ['read', 'core'],
-      toolExtras: [],
-      ...prdBudget,
-      personaId: prdPersona.personaId,
-      appendSystemPrompt: prdPrompt,
-      outputJsonSchema: prdJsonSchema,
-      extraEventPayload: { workflowRunId },
-    });
-
-    const parsed = PRDOutputSchema.safeParse(prdResult.output);
-    if (!parsed.success) {
-      eventStore.appendEvent({
-        kind: 'agent.run-failed',
-        projectId,
-        workItemId: workItem.id,
-        runId: prdRunId,
-        payload: { skill: 'write-prd', workflowRunId, error: parsed.error.message },
-      });
-      // Leave state as factory:prd-drafting so dispatchResumeIssue can re-enter
-      // via the existing prd-drafting resume handler (forces → grilling).
-      return { phase: 'needs-human' };
-    }
-    prdOutput = parsed.data;
-  } catch (err) {
+  if (prdDraftOutcome.status === 'invalid' || prdDraftOutcome.status === 'failed') {
     eventStore.appendEvent({
       kind: 'agent.run-failed',
       projectId,
       workItemId: workItem.id,
       runId: prdRunId,
-      payload: { skill: 'write-prd', workflowRunId, error: String(err) },
+      payload: { skill: 'write-prd', workflowRunId, error: prdDraftOutcome.error },
     });
-    // Leave state as factory:prd-drafting so dispatchResumeIssue can re-enter
-    // via the existing prd-drafting resume handler (forces → grilling).
     return { phase: 'needs-human' };
   }
+
+  let prdOutput = prdDraftOutcome.prdOutput;
 
   reconcileDecisionSummaries(
     prdRunId,
@@ -850,110 +637,52 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     prdOutput.decisionSummaries,
   );
 
-  // ─── Step 3: advise-on-prd (conditional) ────────────────────────────────
-  let advisorConcerns: string[] | null = null;
-  const advisorEligibleByPriority =
-    workItem.priority === 'high' || workItem.priority === 'critical';
-  const advisorBudget = safeResolveBudgets(
-    'advise-on-prd',
-    projectConfig?.budgets,
-    FALLBACK_ADVISOR_BUDGET,
+  const advisorRunId = `${workflowRunId}:advise-on-prd`;
+
+  const advisorOutcome = await runAdvisorReview({
+    workItem,
     projectId,
-  );
-  const globalSettings = resolveGlobalSettingsForProject(projectId, projectConfig?.budgets);
-  const perAdvisorMaxUsd = globalSettings.perAdvisorMaxUsd ?? Number.POSITIVE_INFINITY;
-  const advisorSpentUsd = totalSpendForSkill(projectId, 'advise-on-prd');
-  const advisorBudgetAvailable =
-    advisorSpentUsd + advisorBudget.budgets.maxBudgetUsd <= perAdvisorMaxUsd;
+    workItemId: workItem.id,
+    runId: advisorRunId,
+    workflowRunId,
+    prdOutput,
+    projectConfig,
+    totalSpendForSkill,
+    deps: { runtime },
+  });
 
-  if (!advisorEligibleByPriority) {
+  let advisorConcerns: string[] | null = null;
+
+  if (advisorOutcome.status === 'skipped') {
     eventStore.appendEvent({
       kind: 'prd.advisor-skipped',
       projectId,
       workItemId: workItem.id,
       runId: workflowRunId,
-      payload: { workflowRunId, reason: 'priority' },
+      payload: { workflowRunId, reason: advisorOutcome.reason },
     });
-  } else if (!advisorBudgetAvailable) {
+  } else if (advisorOutcome.status === 'invalid' || advisorOutcome.status === 'failed') {
     eventStore.appendEvent({
-      kind: 'prd.advisor-skipped',
+      kind: 'agent.run-failed',
       projectId,
       workItemId: workItem.id,
-      runId: workflowRunId,
-      payload: { workflowRunId, reason: 'budget' },
+      runId: advisorRunId,
+      payload: { skill: 'advise-on-prd', workflowRunId, error: advisorOutcome.error },
     });
+    await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+    return { phase: 'needs-human' };
   } else {
-    // The advisor uses the same `prd-writer` role (advisor mode).
-    const advisorPersona = selectPersona(projectId, 'prd-writer');
-    const advisorPrompt = readPromptWithContext('advise-on-prd', projectId);
-    const advisorJsonSchema = toJsonSchema(AdvisePRDOutputSchema);
-    const advisorRunId = `${workflowRunId}:advise-on-prd`;
-
-    try {
-      const advisorResult = await runtime.run({
-        runId: advisorRunId,
-        role: 'prd-writer',
-        skill: 'advise-on-prd',
-        context: { projectId, workItemId: workItem.id, prdOutput, priority: workItem.priority },
-        contextAllowlist: ['prdOutput', 'priority'],
-        freshContext: true,
-        toolBundles: ['read', 'core'],
-        toolExtras: [],
-        ...advisorBudget,
-        personaId: advisorPersona.personaId,
-        appendSystemPrompt: advisorPrompt,
-        outputJsonSchema: advisorJsonSchema,
-        extraEventPayload: { workflowRunId },
-      });
-
-      const parsed = AdvisePRDOutputSchema.safeParse(advisorResult.output);
-      if (!parsed.success) {
-        eventStore.appendEvent({
-          kind: 'agent.run-failed',
-          projectId,
-          workItemId: workItem.id,
-          runId: advisorRunId,
-          payload: { skill: 'advise-on-prd', workflowRunId, error: parsed.error.message },
-        });
-        // Fail loud — do not silently continue with un-revised PRD when the
-        // advisor produced malformed output. Human triage required.
-        await stateSource.forceState(workItem.externalId, 'factory:needs-human');
-        return { phase: 'needs-human' };
-      }
-
-      const advisor = parsed.data;
-      advisorConcerns = advisor.concerns.length > 0 ? advisor.concerns : null;
-
-      // Shallow merge revised sections over the PRD. Schema invariant
-      // already guarantees `revisedSections` is empty on `approve`.
-      if (Object.keys(advisor.revisedSections).length > 0) {
-        prdOutput = {
-          ...prdOutput,
-          ...(advisor.revisedSections as unknown as Partial<typeof prdOutput>),
-        };
-      }
-
-      reconcileDecisionSummaries(
-        advisorRunId,
-        projectId,
-        workItem.id,
-        'advise-on-prd',
-        advisor.decisionSummaries,
-      );
-    } catch (err) {
-      eventStore.appendEvent({
-        kind: 'agent.run-failed',
-        projectId,
-        workItemId: workItem.id,
-        runId: advisorRunId,
-        payload: { skill: 'advise-on-prd', workflowRunId, error: String(err) },
-      });
-      await stateSource.forceState(workItem.externalId, 'factory:needs-human');
-      return { phase: 'needs-human' };
-    }
+    prdOutput = advisorOutcome.prdOutput;
+    advisorConcerns = advisorOutcome.concerns;
+    reconcileDecisionSummaries(
+      advisorRunId,
+      projectId,
+      workItem.id,
+      'advise-on-prd',
+      advisorOutcome.decisionSummaries,
+    );
   }
 
-  // ─── Step 4: post final PRD and transition to prd-review ────────────────
   const concernsBlock =
     advisorConcerns != null && advisorConcerns.length > 0
       ? `\n\n## Advisor concerns\n${advisorConcerns.map((c) => `- ${c}`).join('\n')}`

--- a/core/workflows/grill-and-prd/advisor-review.ts
+++ b/core/workflows/grill-and-prd/advisor-review.ts
@@ -1,0 +1,118 @@
+import type { AdvisePRDOutput } from '../../../skills/advise-on-prd/schema.js';
+import { AdvisePRDOutputSchema } from '../../../skills/advise-on-prd/schema.js';
+import type { PRDOutput } from '../../../skills/write-prd/schema.js';
+import type { AgentRuntime } from '../../agent-runtime/interface.js';
+import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import {
+  resolveBudgetsForProject,
+  resolveGlobalSettingsForProject,
+} from '../../agent-runtime/resolve-for-project.js';
+import type { ProjectConfig } from '../../types.js';
+
+const FALLBACK_ADVISOR_BUDGET = {
+  budgets: { maxTurns: 15, maxBudgetUsd: 1.0, timeoutMs: 180_000 },
+  modelOverride: 'opus',
+};
+
+export type AdvisorOutcome =
+  | { status: 'skipped'; reason: 'priority' | 'budget' }
+  | {
+      status: 'ok';
+      prdOutput: PRDOutput;
+      concerns: string[] | null;
+      decisionSummaries: AdvisePRDOutput['decisionSummaries'];
+    }
+  | { status: 'invalid'; error: string }
+  | { status: 'failed'; error: string };
+
+export interface RunAdvisorReviewInput {
+  workItem: { id: string; priority: string };
+  projectId: string;
+  workItemId: string;
+  runId: string;
+  workflowRunId: string;
+  prdOutput: PRDOutput;
+  projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
+  totalSpendForSkill: (projectId: string, skill: string) => number;
+  deps?: { runtime?: AgentRuntime };
+}
+
+export async function runAdvisorReview(input: RunAdvisorReviewInput): Promise<AdvisorOutcome> {
+  const {
+    workItem,
+    projectId,
+    workItemId,
+    runId,
+    workflowRunId,
+    prdOutput,
+    projectConfig,
+    totalSpendForSkill,
+    deps,
+  } = input;
+
+  if (workItem.priority !== 'high' && workItem.priority !== 'critical') {
+    return { status: 'skipped', reason: 'priority' };
+  }
+
+  let advisorBudget: {
+    budgets: { maxTurns: number; maxBudgetUsd: number; timeoutMs: number };
+    modelOverride: string;
+  };
+  try {
+    advisorBudget = resolveBudgetsForProject('advise-on-prd', projectConfig?.budgets, projectId);
+  } catch {
+    advisorBudget = FALLBACK_ADVISOR_BUDGET;
+  }
+
+  const globalSettings = resolveGlobalSettingsForProject(projectId, projectConfig?.budgets);
+  const perAdvisorMaxUsd = globalSettings.perAdvisorMaxUsd ?? Number.POSITIVE_INFINITY;
+  const advisorSpentUsd = totalSpendForSkill(projectId, 'advise-on-prd');
+
+  if (advisorSpentUsd + advisorBudget.budgets.maxBudgetUsd > perAdvisorMaxUsd) {
+    return { status: 'skipped', reason: 'budget' };
+  }
+
+  let result: Awaited<ReturnType<typeof invokeSkill>>;
+
+  try {
+    result = await invokeSkill({
+      skillName: 'advise-on-prd',
+      projectId,
+      workItemId,
+      runId,
+      context: {
+        projectId,
+        workItemId,
+        prdOutput,
+        priority: workItem.priority,
+      },
+      overrides: { runtimeOverride: deps?.runtime, extraEventPayload: { workflowRunId } },
+    });
+  } catch (err) {
+    if (err instanceof OutputValidationError) {
+      return { status: 'invalid', error: err.message };
+    }
+    return { status: 'failed', error: String(err) };
+  }
+
+  const parsed = AdvisePRDOutputSchema.safeParse(result.output);
+  if (!parsed.success) {
+    return { status: 'invalid', error: parsed.error.message };
+  }
+
+  const advisor = parsed.data;
+  let mergedOutput = prdOutput;
+  if (Object.keys(advisor.revisedSections).length > 0) {
+    mergedOutput = {
+      ...prdOutput,
+      ...(advisor.revisedSections as unknown as Partial<typeof prdOutput>),
+    };
+  }
+
+  return {
+    status: 'ok',
+    prdOutput: mergedOutput,
+    concerns: advisor.concerns.length > 0 ? advisor.concerns : null,
+    decisionSummaries: advisor.decisionSummaries,
+  };
+}

--- a/core/workflows/grill-and-prd/grill-and-prd.test.ts
+++ b/core/workflows/grill-and-prd/grill-and-prd.test.ts
@@ -1,0 +1,576 @@
+import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
+/**
+ * Focused unit tests for the grill-and-prd sub-modules:
+ *   - withManagedWorktree  (worktree-lifecycle.ts)
+ *   - runGrillRound        (grill-round.ts)
+ *   - runPrdDraft          (prd-draft.ts)
+ *   - runAdvisorReview     (advisor-review.ts)
+ *
+ * invokeSkill is mocked at the module level so tests never hit disk or the
+ * real skill loader. withManagedWorktree uses injected fake impls.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PRDOutput } from '../../../skills/write-prd/schema.js';
+import type { Priority } from '../../state-source/interface.js';
+import type { ProjectConfig, StackConfig, TargetRepoConfig } from '../../types.js';
+
+// ---------------------------------------------------------------------------
+// Module-level mock — must be hoisted before any imports that use invokeSkill
+// ---------------------------------------------------------------------------
+
+const { mockInvokeSkill } = vi.hoisted(() => {
+  return { mockInvokeSkill: vi.fn() };
+});
+
+vi.mock('../../agent-runtime/invoke-skill.js', () => {
+  class OutputValidationError extends Error {
+    issues: Array<{ path: Array<string | number>; message: string }>;
+    runTelemetry: { runId: string; skill: string };
+    constructor(
+      issues: Array<{ path: Array<string | number>; message: string }>,
+      skillName: string,
+      runId: string,
+    ) {
+      super(`invokeSkill: output validation failed for '${skillName}'`);
+      this.name = 'OutputValidationError';
+      this.issues = issues;
+      this.runTelemetry = { runId, skill: skillName };
+    }
+  }
+  class ContextValidationError extends Error {
+    issues: Array<{ path: Array<string | number>; message: string }>;
+    constructor(
+      issues: Array<{ path: Array<string | number>; message: string }>,
+      skillName: string,
+    ) {
+      super(`invokeSkill: context validation failed for '${skillName}'`);
+      this.name = 'ContextValidationError';
+      this.issues = issues;
+    }
+  }
+  return { invokeSkill: mockInvokeSkill, OutputValidationError, ContextValidationError };
+});
+
+import { OutputValidationError } from '../../agent-runtime/invoke-skill.js';
+import { runAdvisorReview } from './advisor-review.js';
+import { runGrillRound } from './grill-round.js';
+import { runPrdDraft } from './prd-draft.js';
+// Import after mocks are established
+import { withManagedWorktree } from './worktree-lifecycle.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAgentResult(output: unknown): AgentResult {
+  return { output, decisionSummaries: [], events: [] };
+}
+
+function minimalGrillOutput(
+  overrides: Partial<{
+    questions: Array<{ text: string; recommendedAnswer?: string }>;
+    refinedIntent: string;
+    readyForPRD: boolean;
+    crystallizedDecision: string;
+    decisionSummaries: Array<{ kind: string; summary: string }>;
+  }> = {},
+) {
+  return {
+    questions: [] as Array<{ text: string; recommendedAnswer?: string }>,
+    refinedIntent: 'Do the thing.',
+    readyForPRD: true as boolean,
+    decisionSummaries: [{ kind: 'PLAN' as const, summary: 'Ready.' }],
+    ...overrides,
+  };
+}
+
+function minimalPrdOutput(): PRDOutput {
+  return {
+    title: 'Test PRD',
+    problem: 'A problem exists.',
+    proposedSolution: 'Fix it.',
+    outOfScope: [],
+    successCriteria: ['Criterion 1'],
+    acceptanceCriteria: [{ id: 'AC-1', statement: 'It works.', crossCutting: true }],
+    journeys: [
+      {
+        id: 'J-1',
+        persona: 'User',
+        trigger: 'Opens app',
+        steps: [
+          {
+            userAction: 'Click',
+            systemResponse: 'Response',
+            dataShown: 'Data',
+            stateChange: 'Changed',
+          },
+        ],
+        successState: 'Done',
+        errorStates: [],
+        edgeCases: [],
+      },
+    ],
+    functionalSpec: {
+      // biome-ignore lint/suspicious/noThenProperty: mirrors schema field from #313
+      behaviors: [{ when: 'X', given: 'Y', then: 'Z' }],
+      stateModel: [
+        {
+          state: 'idle',
+          entryCondition: 'Start',
+          behaviorsAvailable: ['act'],
+          exitTransitions: ['done'],
+        },
+      ],
+      invalidTransitions: [],
+      dataConstraints: [],
+    },
+    verticalSlices: [{ title: 'S1', goal: 'Do', estimatedSize: 'S', journeyRefs: ['J-1'] }],
+    estimatedComplexity: 'low',
+    implementationDecisions: [{ decision: 'Use existing utilities', rationale: 'Fast' }],
+    testingDecisions: { approach: 'Unit tests', modulesToTest: ['src/'] },
+    decisionSummaries: [{ kind: 'PLAN', summary: 'Simple.' }],
+  };
+}
+
+function minimalAdvisorOutput(
+  overrides: Partial<{
+    verdict: 'approve' | 'revise';
+    concerns: string[];
+    revisedSections: Record<string, unknown>;
+    decisionSummaries: Array<{ kind: string; summary: string }>;
+  }> = {},
+) {
+  return {
+    verdict: 'approve' as 'approve' | 'revise',
+    concerns: [] as string[],
+    revisedSections: {} as Record<string, unknown>,
+    decisionSummaries: [{ kind: 'VERDICT' as const, summary: 'Looks good.' }],
+    ...overrides,
+  };
+}
+
+function testWorkItem(priority: Priority = 'high') {
+  return { id: 'wi-1', title: 'Test item', body: 'Body.', externalId: '42', priority };
+}
+
+function uniqueId() {
+  return `test-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function projectConfigWithBudget(
+  perAdvisorMaxUsd: number,
+): Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> {
+  return {
+    budgets: {
+      perAdvisorMaxUsd,
+      perWorkflowMaxUsd: 50,
+    } as ProjectConfig['budgets'],
+    stack: {
+      runtime: 'node',
+      packageManager: 'pnpm',
+      testCommand: 'pnpm test',
+      detectedAt: '2026-01-01T00:00:00Z',
+    } as StackConfig,
+    targetRepo: {
+      cloneUrl: 'https://github.com/test/repo',
+      defaultBranch: 'main',
+      localPath: '/tmp/test-repo',
+    } as TargetRepoConfig,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. withManagedWorktree
+// ---------------------------------------------------------------------------
+
+describe('withManagedWorktree', () => {
+  it('calls body with worktree path and cleans up on success', async () => {
+    const created: string[] = [];
+    const cleaned: string[] = [];
+    const createImpl = vi.fn((_repo: string, runId: string) => {
+      const p = `/wt/${runId}`;
+      created.push(p);
+      return p;
+    });
+    const cleanupImpl = vi.fn((runId: string) => {
+      cleaned.push(runId);
+    });
+
+    const bodyCalls: string[] = [];
+    const result = await withManagedWorktree(
+      '/repo',
+      'run-1',
+      async (p) => {
+        bodyCalls.push(p);
+        return 'ok';
+      },
+      () => {},
+      { createWorktreeImpl: createImpl, cleanupWorktreeImpl: cleanupImpl },
+    );
+
+    expect(result).toBe('ok');
+    expect(bodyCalls).toEqual(['/wt/run-1']);
+    expect(createImpl).toHaveBeenCalledWith('/repo', 'run-1');
+    expect(cleanupImpl).toHaveBeenCalledWith('run-1');
+    expect(cleaned).toEqual(['run-1']);
+  });
+
+  it('calls cleanup in finally even when body throws', async () => {
+    const cleaned: string[] = [];
+    const createImpl = vi.fn((_repo: string, runId: string) => `/wt/${runId}`);
+    const cleanupImpl = vi.fn((runId: string) => {
+      cleaned.push(runId);
+    });
+
+    await expect(
+      withManagedWorktree(
+        '/repo',
+        'run-throw',
+        async () => {
+          throw new Error('body boom');
+        },
+        () => {},
+        { createWorktreeImpl: createImpl, cleanupWorktreeImpl: cleanupImpl },
+      ),
+    ).rejects.toThrow('body boom');
+
+    expect(cleaned).toEqual(['run-throw']);
+  });
+
+  it('calls onCleanupError when cleanup fails, does not rethrow cleanup error', async () => {
+    const cleanupErrors: unknown[] = [];
+    const createImpl = vi.fn((_repo: string, runId: string) => `/wt/${runId}`);
+    const cleanupImpl = vi.fn(() => {
+      throw new Error('cleanup boom');
+    });
+
+    const result = await withManagedWorktree(
+      '/repo',
+      'run-cleanup-fail',
+      async () => 'done',
+      (err) => {
+        cleanupErrors.push(err);
+      },
+      { createWorktreeImpl: createImpl, cleanupWorktreeImpl: cleanupImpl },
+    );
+
+    expect(result).toBe('done');
+    expect(cleanupErrors).toHaveLength(1);
+    expect((cleanupErrors[0] as Error).message).toBe('cleanup boom');
+  });
+
+  it('rethrows create failure without calling cleanup or body', async () => {
+    const createImpl = vi.fn(() => {
+      throw new Error('create boom');
+    });
+    const cleanupImpl = vi.fn();
+    const bodyFn = vi.fn(async () => 'never');
+
+    await expect(
+      withManagedWorktree('/repo', 'run-create-fail', bodyFn, () => {}, {
+        createWorktreeImpl: createImpl,
+        cleanupWorktreeImpl: cleanupImpl,
+      }),
+    ).rejects.toThrow('create boom');
+
+    expect(bodyFn).not.toHaveBeenCalled();
+    expect(cleanupImpl).not.toHaveBeenCalled();
+  });
+
+  it('expands tilde in repoPath', async () => {
+    const receivedRepos: string[] = [];
+    const createImpl = vi.fn((repo: string, runId: string) => {
+      receivedRepos.push(repo);
+      return `/wt/${runId}`;
+    });
+    const cleanupImpl = vi.fn();
+
+    const home = process.env.HOME ?? '/root';
+    await withManagedWorktree(
+      '~/myrepo',
+      'run-tilde',
+      async () => 'ok',
+      () => {},
+      {
+        createWorktreeImpl: createImpl,
+        cleanupWorktreeImpl: cleanupImpl,
+      },
+    );
+
+    expect(receivedRepos[0]).toBe(`${home}/myrepo`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. runGrillRound
+// ---------------------------------------------------------------------------
+
+describe('runGrillRound', () => {
+  beforeEach(() => {
+    mockInvokeSkill.mockReset();
+  });
+
+  function baseInput() {
+    return {
+      workItem: testWorkItem(),
+      projectId: uniqueId(),
+      workItemId: 'wi-1',
+      runId: 'run-grill-1',
+      workflowRunId: 'wf-1',
+      worktreePath: '/wt/run-1',
+      priorReplies: [] as Array<{ role: 'user' | 'agent'; content: string }>,
+      projectContext: { stackSummary: '', contextMd: '', adrSummaries: [], claudeMd: '' },
+    };
+  }
+
+  it('returns question outcome when readyForPRD is false and question is present', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(
+        minimalGrillOutput({
+          readyForPRD: false,
+          questions: [{ text: 'What metric?', recommendedAnswer: 'Conversion rate.' }],
+          refinedIntent: 'Improve something.',
+        }),
+      ),
+    );
+
+    const result = await runGrillRound(baseInput());
+
+    expect(result.status).toBe('question');
+    if (result.status === 'question') {
+      expect(result.question).toBe('What metric?');
+      expect(result.recommendedAnswer).toBe('Conversion rate.');
+    }
+  });
+
+  it('returns ready outcome when readyForPRD is true', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(minimalGrillOutput({ readyForPRD: true, refinedIntent: 'Final intent.' })),
+    );
+
+    const result = await runGrillRound(baseInput());
+
+    expect(result.status).toBe('ready');
+    if (result.status === 'ready') {
+      expect(result.refinedIntent).toBe('Final intent.');
+    }
+  });
+
+  it('returns invalid when output has readyForPRD:false with no questions', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(minimalGrillOutput({ readyForPRD: false, questions: [] })),
+    );
+
+    const result = await runGrillRound(baseInput());
+
+    expect(result.status).toBe('invalid');
+    if (result.status === 'invalid') {
+      expect(result.error).toContain('readyForPRD:false with no questions');
+    }
+  });
+
+  it('forces ready at round 8 (roundNumber > 7)', async () => {
+    const priorReplies = Array.from({ length: 14 }, (_, i) =>
+      i % 2 === 0
+        ? { role: 'agent' as const, content: `Round ${Math.floor(i / 2) + 1}` }
+        : { role: 'user' as const, content: `Answer ${Math.floor(i / 2) + 1}` },
+    );
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(
+        minimalGrillOutput({
+          readyForPRD: false,
+          questions: [{ text: 'Still asking?' }],
+          refinedIntent: 'Partially refined.',
+        }),
+      ),
+    );
+
+    const result = await runGrillRound({ ...baseInput(), priorReplies });
+
+    expect(result.status).toBe('ready');
+    if (result.status === 'ready') {
+      expect(result.refinedIntent).toBe('Partially refined.');
+    }
+  });
+
+  it('returns failed on runtime error', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(new Error('network failure'));
+
+    const result = await runGrillRound(baseInput());
+
+    expect(result.status).toBe('failed');
+    if (result.status === 'failed') {
+      expect(result.error).toContain('network failure');
+    }
+  });
+
+  it('returns invalid on OutputValidationError', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new OutputValidationError(
+        [{ path: ['questions'], message: 'Required' }],
+        'grill-me',
+        'run-1',
+      ),
+    );
+
+    const result = await runGrillRound(baseInput());
+
+    expect(result.status).toBe('invalid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. runPrdDraft
+// ---------------------------------------------------------------------------
+
+describe('runPrdDraft', () => {
+  beforeEach(() => {
+    mockInvokeSkill.mockReset();
+  });
+
+  function baseInput() {
+    return {
+      workItem: testWorkItem(),
+      projectId: uniqueId(),
+      workItemId: 'wi-1',
+      runId: 'run-prd-1',
+      workflowRunId: 'wf-1',
+      refinedIntent: 'Do the thing.',
+      fullProjectContext: { stackSummary: '', contextMd: '', adrSummaries: [], claudeMd: '' },
+    };
+  }
+
+  it('returns ok with prdOutput on success', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(makeAgentResult(minimalPrdOutput()));
+
+    const result = await runPrdDraft(baseInput());
+
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.prdOutput.title).toBe('Test PRD');
+    }
+  });
+
+  it('returns invalid when output parse fails', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(makeAgentResult({ title: 'incomplete' }));
+
+    const result = await runPrdDraft(baseInput());
+
+    expect(result.status).toBe('invalid');
+  });
+
+  it('returns failed on runtime error', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(new Error('timeout'));
+
+    const result = await runPrdDraft(baseInput());
+
+    expect(result.status).toBe('failed');
+    if (result.status === 'failed') {
+      expect(result.error).toContain('timeout');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. runAdvisorReview
+// ---------------------------------------------------------------------------
+
+describe('runAdvisorReview', () => {
+  beforeEach(() => {
+    mockInvokeSkill.mockReset();
+  });
+
+  function baseInput(): Parameters<typeof runAdvisorReview>[0] {
+    return {
+      workItem: testWorkItem('high'),
+      projectId: uniqueId(),
+      workItemId: 'wi-1',
+      runId: 'run-advisor-1',
+      workflowRunId: 'wf-1',
+      prdOutput: minimalPrdOutput(),
+      projectConfig: projectConfigWithBudget(10),
+      totalSpendForSkill: vi.fn().mockReturnValue(0),
+    };
+  }
+
+  it('returns skipped with reason priority for low-priority item', async () => {
+    const result = await runAdvisorReview({ ...baseInput(), workItem: testWorkItem('low') });
+
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reason).toBe('priority');
+    }
+    expect(mockInvokeSkill).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped with reason budget when budget exceeded', async () => {
+    // FALLBACK_ADVISOR_BUDGET.maxBudgetUsd = 1.0; totalSpend = 9.5; perAdvisorMaxUsd = 10
+    // 9.5 + 1.0 = 10.5 > 10 → skip
+    const result = await runAdvisorReview({
+      ...baseInput(),
+      projectConfig: projectConfigWithBudget(10),
+      totalSpendForSkill: vi.fn().mockReturnValue(9.5),
+    });
+
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reason).toBe('budget');
+    }
+    expect(mockInvokeSkill).not.toHaveBeenCalled();
+  });
+
+  it('returns ok with merged revisedSections and concerns', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(
+        minimalAdvisorOutput({
+          verdict: 'revise',
+          concerns: ['Needs more detail.'],
+          revisedSections: { problem: 'Revised problem statement.' },
+          decisionSummaries: [{ kind: 'VERDICT', summary: 'Revised.' }],
+        }),
+      ),
+    );
+
+    const result = await runAdvisorReview(baseInput());
+
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect((result.prdOutput as { problem: string }).problem).toBe('Revised problem statement.');
+      expect(result.concerns).toEqual(['Needs more detail.']);
+    }
+  });
+
+  it('returns ok with null concerns when advisor returns empty concerns', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(
+        minimalAdvisorOutput({ verdict: 'approve', concerns: [], revisedSections: {} }),
+      ),
+    );
+
+    const result = await runAdvisorReview(baseInput());
+
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.concerns).toBeNull();
+    }
+  });
+
+  it('returns invalid on output parse failure', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(makeAgentResult({ verdict: 'unknown' }));
+
+    const result = await runAdvisorReview(baseInput());
+
+    expect(result.status).toBe('invalid');
+  });
+
+  it('returns failed on runtime error', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(new Error('advisor crash'));
+
+    const result = await runAdvisorReview(baseInput());
+
+    expect(result.status).toBe('failed');
+    if (result.status === 'failed') {
+      expect(result.error).toContain('advisor crash');
+    }
+  });
+});

--- a/core/workflows/grill-and-prd/grill-round.ts
+++ b/core/workflows/grill-and-prd/grill-round.ts
@@ -1,0 +1,112 @@
+import type { GrillMeOutput } from '../../../skills/grill-me/schema.js';
+import { GrillMeOutputSchema } from '../../../skills/grill-me/schema.js';
+import type { AgentRuntime } from '../../agent-runtime/interface.js';
+import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import type { ProjectConfig } from '../../types.js';
+import type { ProjectContextBundle } from '../grill-and-prd.js';
+
+export type GrillRoundOutcome =
+  | { status: 'question'; question: string; recommendedAnswer?: string; output: GrillMeOutput }
+  | { status: 'ready'; refinedIntent: string; output: GrillMeOutput }
+  | { status: 'invalid'; error: string }
+  | { status: 'failed'; error: string };
+
+export interface RunGrillRoundInput {
+  workItem: { id: string; title: string; body: string; externalId: string };
+  projectId: string;
+  workItemId: string;
+  runId: string;
+  workflowRunId: string;
+  worktreePath: string;
+  priorReplies: Array<{ role: 'user' | 'agent'; content: string; crystallized?: string }>;
+  projectContext: ProjectContextBundle;
+  projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
+  deps?: { runtime?: AgentRuntime };
+}
+
+export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRoundOutcome> {
+  const {
+    workItem,
+    projectId,
+    workItemId,
+    runId,
+    workflowRunId,
+    worktreePath,
+    priorReplies,
+    projectContext,
+    deps,
+  } = input;
+
+  const roundNumber =
+    priorReplies.filter((r) => r.role === 'agent' && !r.content.startsWith('<!-- factory:prd -->'))
+      .length + 1;
+
+  let result: Awaited<ReturnType<typeof invokeSkill>>;
+
+  try {
+    result = await invokeSkill({
+      skillName: 'grill-me',
+      projectId,
+      workItemId,
+      runId,
+      context: {
+        projectId,
+        workItemId,
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        priorReplies,
+        roundNumber,
+        projectContext,
+        worktreePath,
+      },
+      overrides: {
+        workspaceDir: worktreePath,
+        runtimeOverride: deps?.runtime,
+        extraEventPayload: { roundNumber, workflowRunId },
+      },
+    });
+  } catch (err) {
+    if (err instanceof OutputValidationError) {
+      return { status: 'invalid', error: err.message };
+    }
+    return { status: 'failed', error: String(err) };
+  }
+
+  const parsed = GrillMeOutputSchema.safeParse(result.output);
+  if (!parsed.success) {
+    return { status: 'invalid', error: parsed.error.message };
+  }
+
+  const grillOutput = parsed.data;
+
+  if (!grillOutput.readyForPRD && roundNumber > 7) {
+    const refinedIntent =
+      grillOutput.refinedIntent.trim() !== '' ? grillOutput.refinedIntent.trim() : workItem.body;
+    return {
+      status: 'ready',
+      refinedIntent,
+      output: { ...grillOutput, readyForPRD: true, refinedIntent },
+    };
+  }
+
+  if (!grillOutput.readyForPRD) {
+    const questionEntry = grillOutput.questions[0];
+    if (questionEntry == null || questionEntry.text.trim() === '') {
+      return {
+        status: 'invalid',
+        error: 'grill-me returned readyForPRD:false with no questions',
+      };
+    }
+    return {
+      status: 'question',
+      question: questionEntry.text,
+      recommendedAnswer: questionEntry.recommendedAnswer ?? undefined,
+      output: grillOutput,
+    };
+  }
+
+  return { status: 'ready', refinedIntent: grillOutput.refinedIntent, output: grillOutput };
+}

--- a/core/workflows/grill-and-prd/prd-draft.ts
+++ b/core/workflows/grill-and-prd/prd-draft.ts
@@ -1,0 +1,82 @@
+import type { PRDOutput } from '../../../skills/write-prd/schema.js';
+import { PRDOutputSchema } from '../../../skills/write-prd/schema.js';
+import type { AgentRuntime } from '../../agent-runtime/interface.js';
+import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import type { Priority } from '../../state-source/interface.js';
+import type { ProjectConfig } from '../../types.js';
+import type { ProjectContextBundle } from '../grill-and-prd.js';
+
+export type PrdDraftOutcome =
+  | { status: 'ok'; prdOutput: PRDOutput }
+  | { status: 'invalid'; error: string }
+  | { status: 'failed'; error: string };
+
+export interface RunPrdDraftInput {
+  workItem: { id: string; title: string; body: string; externalId: string; priority: Priority };
+  projectId: string;
+  workItemId: string;
+  runId: string;
+  workflowRunId: string;
+  refinedIntent: string;
+  fullProjectContext: ProjectContextBundle;
+  projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
+  priorReplies?: Array<{ role: 'user' | 'agent'; content: string; crystallized?: string }>;
+  priorPrd?: PRDOutput;
+  humanConcerns?: string[];
+  deps?: { runtime?: AgentRuntime };
+}
+
+export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutcome> {
+  const {
+    workItem,
+    projectId,
+    workItemId,
+    runId,
+    workflowRunId,
+    refinedIntent,
+    fullProjectContext,
+    priorReplies,
+    priorPrd,
+    humanConcerns,
+    deps,
+  } = input;
+
+  let result: Awaited<ReturnType<typeof invokeSkill>>;
+
+  try {
+    result = await invokeSkill({
+      skillName: 'write-prd',
+      projectId,
+      workItemId,
+      runId,
+      context: {
+        projectId,
+        workItemId,
+        workItem: {
+          title: workItem.title,
+          body: workItem.body,
+          number: Number(workItem.externalId),
+        },
+        refinedIntent,
+        priority: workItem.priority,
+        projectContext: fullProjectContext,
+        ...(priorReplies != null ? { priorReplies } : {}),
+        ...(priorPrd != null ? { priorPrd } : {}),
+        ...(humanConcerns != null ? { humanConcerns } : {}),
+      },
+      overrides: { runtimeOverride: deps?.runtime, extraEventPayload: { workflowRunId } },
+    });
+  } catch (err) {
+    if (err instanceof OutputValidationError) {
+      return { status: 'invalid', error: err.message };
+    }
+    return { status: 'failed', error: String(err) };
+  }
+
+  const parsed = PRDOutputSchema.safeParse(result.output);
+  if (!parsed.success) {
+    return { status: 'invalid', error: parsed.error.message };
+  }
+
+  return { status: 'ok', prdOutput: parsed.data };
+}

--- a/core/workflows/grill-and-prd/worktree-lifecycle.ts
+++ b/core/workflows/grill-and-prd/worktree-lifecycle.ts
@@ -1,0 +1,32 @@
+import { join } from 'node:path';
+import { cleanupWorktree, createWorktree } from '../../workspaces/worktree.js';
+
+export async function withManagedWorktree<T>(
+  repoPath: string,
+  runId: string,
+  body: (worktreePath: string) => Promise<T>,
+  onCleanupError: (error: unknown) => void,
+  deps?: {
+    createWorktreeImpl?: typeof createWorktree;
+    cleanupWorktreeImpl?: typeof cleanupWorktree;
+  },
+): Promise<T> {
+  const expanded = repoPath.startsWith('~/')
+    ? join(process.env.HOME ?? '/root', repoPath.slice(2))
+    : repoPath;
+
+  const createImpl = deps?.createWorktreeImpl ?? createWorktree;
+  const cleanupImpl = deps?.cleanupWorktreeImpl ?? cleanupWorktree;
+
+  const worktreePath = createImpl(expanded, runId);
+
+  try {
+    return await body(worktreePath);
+  } finally {
+    try {
+      cleanupImpl(runId);
+    } catch (err) {
+      onCleanupError(err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Split monolithic `runGrillAndPrdWorkflow` (1006 lines) into four focused sub-modules: `worktree-lifecycle`, `grill-round`, `prd-draft`, `advisor-review`
- All three skills (`grill-me`, `write-prd`, `advise-on-prd`) now invoke via `invokeSkill` instead of direct `runtime.run` — eliminating manual persona selection, budget resolution, prompt loading, and output schema wiring from the coordinator
- Coordinator reduced to orchestration: entry state validation, side effects, event emission, decision-summary reconciliation

## Test Plan

- [x] Existing 24-test slice contract (`slices/grill-and-prd/slice.test.ts`) passes unchanged
- [x] 20 new focused unit tests added covering: worktree lifecycle cleanup semantics, grill round outcomes and round-8 cap, PRD draft normal/revise context, advisor skip/run/merge behavior, invalid output vs runtime failure mapping
- [x] Typecheck clean
- [x] Biome lint/format clean