### PR TITLE
M14: Changelog modal + grill-ready banner

### DIFF
--- a/apps/server/src/domains/changelog/router.test.ts
+++ b/apps/server/src/domains/changelog/router.test.ts
@@ -1,0 +1,84 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetChangelog } = vi.hoisted(() => ({
+  mockGetChangelog: vi.fn(),
+}));
+
+vi.mock('./service.js', async () => {
+  const actual = await vi.importActual<typeof import('./service.js')>('./service.js');
+  return {
+    ...actual,
+    getChangelog: mockGetChangelog,
+  };
+});
+
+import { changelogRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/api/changelog', changelogRouter);
+}
+
+describe('GET /api/changelog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns entries array on success', async () => {
+    mockGetChangelog.mockResolvedValue({
+      ok: true,
+      data: {
+        entries: [
+          {
+            number: 7,
+            title: 'A',
+            mergedAt: '2026-05-12T10:00:00Z',
+            url: 'u',
+            repo: 'o/r',
+            author: 'octocat',
+          },
+        ],
+      },
+    });
+    const app = makeApp();
+    const res = await app.request('/api/changelog?days=7');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(1);
+  });
+
+  it('defaults days to 7 when missing', async () => {
+    mockGetChangelog.mockResolvedValue({ ok: true, data: { entries: [] } });
+    const app = makeApp();
+    await app.request('/api/changelog');
+    expect(mockGetChangelog).toHaveBeenCalledWith(7);
+  });
+
+  it('forwards parsed days param when valid', async () => {
+    mockGetChangelog.mockResolvedValue({ ok: true, data: { entries: [] } });
+    const app = makeApp();
+    await app.request('/api/changelog?days=14');
+    expect(mockGetChangelog).toHaveBeenCalledWith(14);
+  });
+
+  it('clamps days outside range', async () => {
+    mockGetChangelog.mockResolvedValue({ ok: true, data: { entries: [] } });
+    const app = makeApp();
+    await app.request('/api/changelog?days=999');
+    expect(mockGetChangelog).toHaveBeenCalledWith(90);
+  });
+
+  it('returns 500 with error body when service fails', async () => {
+    mockGetChangelog.mockResolvedValue({
+      ok: false,
+      error: 'github-token-missing',
+      status: 500,
+    });
+    const app = makeApp();
+    const res = await app.request('/api/changelog');
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('github-token-missing');
+  });
+});

--- a/apps/server/src/domains/changelog/router.ts
+++ b/apps/server/src/domains/changelog/router.ts
@@ -1,0 +1,14 @@
+import { Hono } from 'hono';
+import { getChangelog, parseDays } from './service.js';
+
+const router = new Hono();
+
+router.get('/', async (c) => {
+  const days = parseDays(c.req.query('days'));
+  const result = await getChangelog(days);
+  return result.ok
+    ? c.json(result.data.entries)
+    : c.json({ error: result.error }, result.status as 500);
+});
+
+export { router as changelogRouter };

--- a/apps/server/src/domains/changelog/service.test.ts
+++ b/apps/server/src/domains/changelog/service.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListProjectConfigs } = vi.hoisted(() => ({
+  mockListProjectConfigs: vi.fn(),
+}));
+
+vi.mock('#shared/projects.js', () => ({
+  listProjectConfigs: mockListProjectConfigs,
+}));
+
+vi.mock('@goose-hub/core/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { getChangelog, parseDays } from './service.js';
+
+const now = new Date('2026-05-13T12:00:00Z');
+
+function mockOk(prs: unknown[]): Response {
+  return new Response(JSON.stringify(prs), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function mockFail(status = 500): Response {
+  return new Response('boom', { status });
+}
+
+function pr(
+  over: Partial<{
+    number: number;
+    title: string;
+    merged_at: string | null;
+    html_url: string;
+    user: { login: string } | null;
+  }> = {},
+) {
+  return {
+    number: 1,
+    title: 'A PR',
+    merged_at: '2026-05-12T10:00:00Z',
+    html_url: 'https://github.com/o/r/pull/1',
+    user: { login: 'octocat' },
+    ...over,
+  };
+}
+
+describe('parseDays', () => {
+  it('returns default 7 when missing or unparseable', () => {
+    expect(parseDays(undefined)).toBe(7);
+    expect(parseDays('')).toBe(7);
+    expect(parseDays('abc')).toBe(7);
+    expect(parseDays('3.5')).toBe(7);
+  });
+  it('clamps to [1, 90]', () => {
+    expect(parseDays('0')).toBe(1);
+    expect(parseDays('-1')).toBe(1);
+    expect(parseDays('999')).toBe(90);
+    expect(parseDays('90')).toBe(90);
+  });
+  it('passes integers in range through', () => {
+    expect(parseDays('1')).toBe(1);
+    expect(parseDays('14')).toBe(14);
+  });
+});
+
+describe('getChangelog', () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = 'test-token';
+  });
+  afterAll(() => {
+    process.env.GITHUB_TOKEN = originalToken;
+  });
+
+  it('returns 500 when GITHUB_TOKEN is missing', async () => {
+    process.env.GITHUB_TOKEN = '';
+    mockListProjectConfigs.mockResolvedValue([]);
+    const fetchImpl = vi.fn();
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('github-token-missing');
+      expect(result.status).toBe(500);
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when no repos are configured', async () => {
+    mockListProjectConfigs.mockResolvedValue([]);
+    const fetchImpl = vi.fn();
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.entries).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('filters out PRs with null merged_at and entries older than the window', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+    ]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        mockOk([
+          pr({ number: 1, merged_at: '2026-05-12T10:00:00Z' }),
+          pr({ number: 2, merged_at: null }),
+          pr({ number: 3, merged_at: '2026-04-01T10:00:00Z' }),
+        ]),
+      );
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.entries).toHaveLength(1);
+      expect(result.data.entries[0]).toMatchObject({
+        number: 1,
+        repo: 'octo/repo',
+        author: 'octocat',
+        mergedAt: '2026-05-12T10:00:00Z',
+      });
+    }
+  });
+
+  it('returns ghost user as "unknown" when GitHub user is null', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+    ]);
+    const fetchImpl = vi.fn().mockResolvedValue(mockOk([pr({ number: 4, user: null })]));
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.entries[0].author).toBe('unknown');
+  });
+
+  it('deduplicates repos across multiple configs and source.repo', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+    ]);
+    const fetchImpl = vi.fn().mockResolvedValue(mockOk([pr({ number: 1 })]));
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('one repo fails: returns 200 with successes from other repos', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/good', 'octo/bad'], source: { kind: 'github', repo: 'octo/good' } },
+    ]);
+    const fetchImpl = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('octo/bad')) return Promise.resolve(mockFail(500));
+      return Promise.resolve(mockOk([pr({ number: 7 })]));
+    });
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.entries).toHaveLength(1);
+      expect(result.data.entries[0].number).toBe(7);
+    }
+  });
+
+  it('all repos fail: returns 500', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/a', 'octo/b'], source: { kind: 'github', repo: 'octo/a' } },
+    ]);
+    const fetchImpl = vi.fn().mockResolvedValue(mockFail(500));
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('all-repos-failed');
+      expect(result.status).toBe(500);
+    }
+  });
+
+  it('sorts entries by mergedAt descending', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+    ]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        mockOk([
+          pr({ number: 1, merged_at: '2026-05-08T10:00:00Z' }),
+          pr({ number: 2, merged_at: '2026-05-12T10:00:00Z' }),
+          pr({ number: 3, merged_at: '2026-05-10T10:00:00Z' }),
+        ]),
+      );
+    const result = await getChangelog(7, { fetchImpl, now });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.entries.map((e) => e.number)).toEqual([2, 3, 1]);
+    }
+  });
+
+  it('sends Bearer token in Authorization header', async () => {
+    mockListProjectConfigs.mockResolvedValue([
+      { repos: ['octo/repo'], source: { kind: 'github', repo: 'octo/repo' } },
+    ]);
+    const fetchImpl = vi.fn().mockResolvedValue(mockOk([]));
+    await getChangelog(7, { fetchImpl, now });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-token');
+  });
+});

--- a/apps/server/src/domains/changelog/service.ts
+++ b/apps/server/src/domains/changelog/service.ts
@@ -1,0 +1,110 @@
+import { logger } from '@goose-hub/core/logger.js';
+import type { Result } from '#shared/middleware.js';
+import { listProjectConfigs } from '#shared/projects.js';
+
+export interface ChangelogEntry {
+  number: number;
+  title: string;
+  mergedAt: string;
+  url: string;
+  repo: string;
+  author: string;
+}
+
+interface GitHubPullSummary {
+  number: number;
+  title: string;
+  merged_at: string | null;
+  html_url: string;
+  user: { login: string } | null;
+}
+
+const DEFAULT_DAYS = 7;
+const MIN_DAYS = 1;
+const MAX_DAYS = 90;
+
+export function parseDays(raw: string | undefined): number {
+  if (raw == null || raw === '') return DEFAULT_DAYS;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return DEFAULT_DAYS;
+  if (n < MIN_DAYS) return MIN_DAYS;
+  if (n > MAX_DAYS) return MAX_DAYS;
+  return n;
+}
+
+export async function getChangelog(
+  days: number,
+  opts?: { fetchImpl?: typeof fetch; now?: Date },
+): Promise<Result<{ entries: ChangelogEntry[] }>> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const now = opts?.now ?? new Date();
+  const token = process.env.GITHUB_TOKEN ?? '';
+  if (token.length === 0) return { ok: false, error: 'github-token-missing', status: 500 };
+
+  const configs = await listProjectConfigs();
+  const repos = new Set<string>();
+  for (const cfg of configs) {
+    for (const repo of cfg.repos ?? []) repos.add(repo);
+    if (cfg.source.kind === 'github') repos.add(cfg.source.repo);
+  }
+
+  if (repos.size === 0) return { ok: true, data: { entries: [] } };
+
+  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+  const results = await Promise.all(
+    Array.from(repos).map(async (repo) => {
+      try {
+        const entries = await fetchMergedPullsForRepo(repo, token, cutoff, fetchImpl);
+        return { ok: true as const, repo, entries };
+      } catch (err) {
+        logger.warn('changelog: repo fetch failed', {
+          repo,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { ok: false as const, repo };
+      }
+    }),
+  );
+
+  const successes = results.filter((r) => r.ok);
+  if (successes.length === 0) return { ok: false, error: 'all-repos-failed', status: 500 };
+
+  const entries = successes.flatMap((r) => r.entries);
+  entries.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+  return { ok: true, data: { entries } };
+}
+
+async function fetchMergedPullsForRepo(
+  repo: string,
+  token: string,
+  cutoffMs: number,
+  fetchImpl: typeof fetch,
+): Promise<ChangelogEntry[]> {
+  const url = `https://api.github.com/repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=50`;
+  const res = await fetchImpl(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} for ${repo}`);
+  }
+  const pulls = (await res.json()) as GitHubPullSummary[];
+  const entries: ChangelogEntry[] = [];
+  for (const p of pulls) {
+    if (p.merged_at == null) continue;
+    const mergedMs = Date.parse(p.merged_at);
+    if (Number.isNaN(mergedMs) || mergedMs < cutoffMs) continue;
+    entries.push({
+      number: p.number,
+      title: p.title,
+      mergedAt: p.merged_at,
+      url: p.html_url,
+      repo,
+      author: p.user?.login ?? 'unknown',
+    });
+  }
+  return entries;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,6 +2,7 @@ import { logger } from '@goose-hub/core/logger.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { bootstrapRouter } from './domains/bootstrap/router.js';
+import { changelogRouter } from './domains/changelog/router.js';
 import { costsRouter } from './domains/costs/router.js';
 import { decisionsRouter } from './domains/decisions/router.js';
 import { eventsRouter } from './domains/events/router.js';
@@ -43,5 +44,6 @@ app.route('/roster', rosterRouter); // GET /roster/**
 app.route('/events', eventsRouter); // GET /events
 app.route('/webhooks', webhooksRouter); // POST /webhooks/github
 app.route('/api/decisions', decisionsRouter); // POST /api/decisions (M19.23)
+app.route('/api/changelog', changelogRouter); // GET /api/changelog?days=7 (M14.XX)
 
 export { app };

--- a/apps/web/src/components/chrome/ChangelogModal.test.tsx
+++ b/apps/web/src/components/chrome/ChangelogModal.test.tsx
@@ -1,0 +1,155 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChangelogModal, formatRelative } from './ChangelogModal';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function entry(
+  overrides: Partial<{
+    number: number;
+    title: string;
+    mergedAt: string;
+    url: string;
+    repo: string;
+    author: string;
+  }> = {},
+) {
+  return {
+    number: 1,
+    title: 'Some PR',
+    mergedAt: '2026-05-12T10:00:00Z',
+    url: 'https://github.com/o/r/pull/1',
+    repo: 'o/r',
+    author: 'octocat',
+    ...overrides,
+  };
+}
+
+describe('ChangelogModal', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
+  });
+
+  it('does not render when open=false', () => {
+    render(<ChangelogModal open={false} onClose={() => {}} />);
+    expect(screen.queryByTestId('changelog-modal')).toBeNull();
+  });
+
+  it('renders Last 7 days heading when open', () => {
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    expect(screen.getByText('Last 7 days')).toBeTruthy();
+  });
+
+  it('shows loading state while fetch is pending', () => {
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    expect(screen.getByTestId('changelog-loading')).toBeTruthy();
+  });
+
+  it('renders entries grouped by repo on successful fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          entry({ number: 1, repo: 'o/a', title: 'First', mergedAt: '2026-05-10T10:00:00Z' }),
+          entry({ number: 2, repo: 'o/a', title: 'Second', mergedAt: '2026-05-12T10:00:00Z' }),
+          entry({ number: 3, repo: 'o/b', title: 'Third', mergedAt: '2026-05-11T10:00:00Z' }),
+        ]),
+        { status: 200 },
+      ),
+    );
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-list')).toBeTruthy();
+    });
+    const items = screen.getAllByTestId('changelog-entry');
+    expect(items).toHaveLength(3);
+    expect(screen.getByText('o/a')).toBeTruthy();
+    expect(screen.getByText('o/b')).toBeTruthy();
+  });
+
+  it('within each repo group, entries are sorted newest first', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          entry({ number: 1, repo: 'o/a', title: 'Older', mergedAt: '2026-05-08T10:00:00Z' }),
+          entry({ number: 2, repo: 'o/a', title: 'Newer', mergedAt: '2026-05-12T10:00:00Z' }),
+        ]),
+        { status: 200 },
+      ),
+    );
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-list')).toBeTruthy();
+    });
+    const items = screen.getAllByTestId('changelog-entry');
+    expect(items[0].textContent).toContain('Newer');
+    expect(items[1].textContent).toContain('Older');
+  });
+
+  it('renders empty state when fetch returns []', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-empty')).toBeTruthy();
+    });
+    expect(screen.getByText('No merged PRs in the last 7 days.')).toBeTruthy();
+  });
+
+  it('renders error state on non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-error')).toBeTruthy();
+    });
+    expect(screen.getByText('Could not load changelog.')).toBeTruthy();
+  });
+
+  it('renders error state when fetch throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-error')).toBeTruthy();
+    });
+  });
+
+  it('PR links open in new tab with safe rel attributes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([entry()]), { status: 200 }),
+    );
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('changelog-list')).toBeTruthy();
+    });
+    const link = screen.getByRole('link') as HTMLAnchorElement;
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toContain('noopener');
+    expect(link.rel).toContain('noreferrer');
+  });
+
+  it('fetches /api/changelog?days=7 when modal opens', () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
+    render(<ChangelogModal open={true} onClose={() => {}} />);
+    expect(spy).toHaveBeenCalledWith('/api/changelog?days=7');
+  });
+});
+
+describe('formatRelative', () => {
+  it('returns "yesterday"-style copy for ~1 day ago', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    expect(formatRelative('2026-05-12T12:00:00Z', now)).toMatch(/day/);
+  });
+
+  it('returns hour-scale copy for sub-day deltas', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    expect(formatRelative('2026-05-13T09:00:00Z', now)).toMatch(/hour/);
+  });
+
+  it('returns input verbatim for unparseable dates', () => {
+    expect(formatRelative('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/apps/web/src/components/chrome/ChangelogModal.tsx
+++ b/apps/web/src/components/chrome/ChangelogModal.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+
+interface ChangelogEntry {
+  number: number;
+  title: string;
+  mergedAt: string;
+  url: string;
+  repo: string;
+  author: string;
+}
+
+interface ChangelogModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'loaded'; entries: ChangelogEntry[] }
+  | { status: 'error' };
+
+export function ChangelogModal({ open, onClose }: ChangelogModalProps) {
+  const [state, setState] = useState<FetchState>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setState({ status: 'loading' });
+    fetch('/api/changelog?days=7')
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const entries = (await res.json()) as ChangelogEntry[];
+        if (!cancelled) setState({ status: 'loaded', entries });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="changelog-modal"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.45)',
+      }}
+      onClick={onClose}
+      onKeyDown={(e) => e.key === 'Escape' && onClose()}
+    >
+      <div
+        style={{
+          background: 'var(--bg-elev)',
+          border: '1px solid var(--line)',
+          borderRadius: 8,
+          padding: '24px',
+          width: '100%',
+          maxWidth: 560,
+          maxHeight: '80vh',
+          overflowY: 'auto',
+          color: 'var(--fg)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
+      >
+        <h2
+          style={{
+            margin: '0 0 16px',
+            fontSize: 15,
+            fontWeight: 600,
+            color: 'var(--fg)',
+          }}
+        >
+          Last 7 days
+        </h2>
+
+        {state.status === 'loading' && (
+          <p data-testid="changelog-loading" style={{ fontSize: 13, color: 'var(--fg-2)' }}>
+            Loading…
+          </p>
+        )}
+
+        {state.status === 'error' && (
+          <p data-testid="changelog-error" style={{ fontSize: 13, color: 'var(--fg-2)' }}>
+            Could not load changelog.
+          </p>
+        )}
+
+        {state.status === 'loaded' && state.entries.length === 0 && (
+          <p data-testid="changelog-empty" style={{ fontSize: 13, color: 'var(--fg-2)' }}>
+            No merged PRs in the last 7 days.
+          </p>
+        )}
+
+        {state.status === 'loaded' && state.entries.length > 0 && (
+          <ChangelogList entries={state.entries} />
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
+          <button
+            type="button"
+            data-testid="changelog-close"
+            onClick={onClose}
+            style={{
+              padding: '5px 14px',
+              borderRadius: 6,
+              border: '1px solid var(--line)',
+              background: 'var(--bg)',
+              color: 'var(--fg-2)',
+              fontSize: 13,
+              cursor: 'pointer',
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChangelogList({ entries }: { entries: ChangelogEntry[] }) {
+  const groups = groupByRepo(entries);
+  return (
+    <div data-testid="changelog-list" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {groups.map(([repo, items]) => (
+        <section key={repo}>
+          <h3 style={{ margin: '0 0 6px', fontSize: 12, fontWeight: 600, color: 'var(--fg-2)' }}>
+            {repo}
+          </h3>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {items.map((e) => (
+              <li
+                key={`${e.repo}#${e.number}`}
+                data-testid="changelog-entry"
+                style={{ padding: '4px 0', fontSize: 13 }}
+              >
+                <a
+                  href={e.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--fg)', textDecoration: 'none' }}
+                >
+                  #{e.number} {e.title}
+                </a>
+                <span style={{ marginLeft: 8, color: 'var(--fg-2)', fontSize: 12 }}>
+                  {e.author} · {formatRelative(e.mergedAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function groupByRepo(entries: ChangelogEntry[]): Array<[string, ChangelogEntry[]]> {
+  const map = new Map<string, ChangelogEntry[]>();
+  for (const entry of entries) {
+    const arr = map.get(entry.repo) ?? [];
+    arr.push(entry);
+    map.set(entry.repo, arr);
+  }
+  for (const arr of map.values()) {
+    arr.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+  }
+  return Array.from(map.entries());
+}
+
+const RELATIVE_UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; seconds: number }> = [
+  { unit: 'year', seconds: 60 * 60 * 24 * 365 },
+  { unit: 'month', seconds: 60 * 60 * 24 * 30 },
+  { unit: 'week', seconds: 60 * 60 * 24 * 7 },
+  { unit: 'day', seconds: 60 * 60 * 24 },
+  { unit: 'hour', seconds: 60 * 60 },
+  { unit: 'minute', seconds: 60 },
+];
+
+export function formatRelative(iso: string, now: Date = new Date()): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return iso;
+  const diffSeconds = Math.round((ms - now.getTime()) / 1000);
+  const abs = Math.abs(diffSeconds);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  for (const { unit, seconds } of RELATIVE_UNITS) {
+    if (abs >= seconds) {
+      return rtf.format(Math.round(diffSeconds / seconds), unit);
+    }
+  }
+  return rtf.format(diffSeconds, 'second');
+}

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -1,6 +1,7 @@
 import { CaptureModal } from '@/components/ui/CaptureModal';
-import { Plus, Search, Terminal } from 'lucide-react';
+import { Plus, ScrollText, Search } from 'lucide-react';
 import { useState } from 'react';
+import { ChangelogModal } from './ChangelogModal';
 
 interface TopBarProps {
   breadcrumb?: React.ReactNode;
@@ -8,6 +9,7 @@ interface TopBarProps {
 
 export function TopBar({ breadcrumb }: TopBarProps) {
   const [showCapture, setShowCapture] = useState(false);
+  const [showChangelog, setShowChangelog] = useState(false);
 
   return (
     <>
@@ -17,6 +19,16 @@ export function TopBar({ breadcrumb }: TopBarProps) {
       >
         <div className="text-[12.5px] text-fg-2 min-w-0 truncate">{breadcrumb}</div>
         <span className="grow" />
+        <button
+          type="button"
+          data-testid="changelog-button"
+          onClick={() => setShowChangelog(true)}
+          title="What shipped in the last 7 days"
+          className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
+        >
+          <ScrollText size={13} />
+          <span>Changelog</span>
+        </button>
         <button
           type="button"
           data-testid="capture-button"
@@ -38,6 +50,7 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         </button>
       </header>
       <CaptureModal open={showCapture} onClose={() => setShowCapture(false)} />
+      <ChangelogModal open={showChangelog} onClose={() => setShowChangelog(false)} />
     </>
   );
 }

--- a/apps/web/src/components/detail/components/GatePendingBanner.test.tsx
+++ b/apps/web/src/components/detail/components/GatePendingBanner.test.tsx
@@ -2,6 +2,7 @@
 import { fetchEvents, transitionState } from '@/lib/api';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GatePendingBanner } from './GatePendingBanner';
 
@@ -14,7 +15,11 @@ vi.mock('@/lib/api', () => ({
 
 function render_(jsx: React.ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}>{jsx}</QueryClientProvider>);
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{jsx}</QueryClientProvider>
+    </MemoryRouter>,
+  );
 }
 
 const DECISION_SUMMARY_EVENT = {
@@ -115,5 +120,32 @@ describe('GatePendingBanner — factory:needs-human', () => {
         'factory:triaging',
       );
     });
+  });
+});
+
+describe('GatePendingBanner — factory:gate-pending', () => {
+  it('renders info-variant banner with "Question ready — grill" message', () => {
+    render_(<GatePendingBanner state="factory:gate-pending" projectSlug="proj" id="42" />);
+    const banner = screen.getByTestId('gate-pending-banner');
+    expect(banner.getAttribute('data-variant')).toBe('info');
+    expect(banner.textContent).toContain('Question ready');
+  });
+
+  it('renders Grill link pointing at the grill section of this issue', () => {
+    render_(<GatePendingBanner state="factory:gate-pending" projectSlug="proj" id="42" />);
+    const grill = screen.getByTestId('gate-action-grill') as HTMLAnchorElement;
+    expect(grill).toBeTruthy();
+    expect(grill.getAttribute('href')).toBe('/projects/proj/items/42/grill');
+  });
+
+  it('does not render needs-human action buttons in gate-pending variant', () => {
+    render_(<GatePendingBanner state="factory:gate-pending" projectSlug="proj" id="42" />);
+    expect(screen.queryByTestId('gate-action-send-to-triage')).toBeNull();
+    expect(screen.queryByTestId('gate-action-reject')).toBeNull();
+  });
+
+  it('omits Grill link when projectSlug/id are absent', () => {
+    render_(<GatePendingBanner state="factory:gate-pending" />);
+    expect(screen.queryByTestId('gate-action-grill')).toBeNull();
   });
 });

--- a/apps/web/src/components/detail/components/GatePendingBanner.tsx
+++ b/apps/web/src/components/detail/components/GatePendingBanner.tsx
@@ -3,8 +3,9 @@ import { cn } from '@/lib/cn';
 import { GATE_STATES } from '@/lib/constants';
 import type { AgentEventDto } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
-import { ShieldAlert } from 'lucide-react';
+import { Info, MessageCircleQuestion, ShieldAlert } from 'lucide-react';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 export { GATE_STATES } from '@/lib/constants';
 
@@ -61,6 +62,7 @@ export function GatePendingBanner({
   const [error, setError] = useState<string | null>(null);
 
   const isNeedsHuman = state === 'factory:needs-human';
+  const isGatePending = state === 'factory:gate-pending';
 
   const { data: events = [] } = useQuery({
     queryKey: ['events', projectSlug, id],
@@ -94,26 +96,52 @@ export function GatePendingBanner({
     }
   };
 
-  const isDanger = isNeedsHuman;
+  const variant: 'danger' | 'warning' | 'info' = isNeedsHuman
+    ? 'danger'
+    : isGatePending
+      ? 'info'
+      : 'warning';
 
   return (
     <div
       data-testid="gate-pending-banner"
+      data-variant={variant}
       className={cn(
         'flex flex-col px-6 py-2.5 shrink-0',
         'border-b',
         'text-[12.5px] font-medium',
-        isDanger
-          ? 'border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 text-[color:var(--danger)]'
-          : 'border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+        variant === 'danger' &&
+          'border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 text-[color:var(--danger)]',
+        variant === 'warning' &&
+          'border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+        variant === 'info' &&
+          'border-[color:var(--info)]/40 bg-[color:var(--info)]/10 text-[color:var(--info)]',
       )}
     >
       <div className="flex items-center gap-2.5">
-        <ShieldAlert size={14} className="shrink-0" />
+        {variant === 'info' ? (
+          <Info size={14} className="shrink-0" />
+        ) : (
+          <ShieldAlert size={14} className="shrink-0" />
+        )}
         <span>{message}</span>
         {error && <span className="text-[color:var(--danger)] ml-2">{error}</span>}
         <span className="grow" />
         <span className="flex items-center gap-2">
+          {isGatePending && projectSlug && id && (
+            <Link
+              to={`/projects/${projectSlug}/items/${id}/grill`}
+              data-testid="gate-action-grill"
+              className={cn(
+                'flex items-center gap-1 h-6 px-2.5 rounded text-[11.5px] font-medium border',
+                'border-[color:var(--info)]/60 text-[color:var(--info)]',
+                'hover:bg-[color:var(--info)]/20',
+              )}
+            >
+              <MessageCircleQuestion size={12} />
+              Grill
+            </Link>
+          )}
           {actions.sendToTriage && (
             <button
               type="button"

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -82,6 +82,10 @@ describe('GatePendingBanner — gate state map', () => {
     expect(GATE_STATES['factory:needs-human']).toBe('Human intervention required');
   });
 
+  it('returns banner text for gate-pending grill state', () => {
+    expect(GATE_STATES['factory:gate-pending']).toBe('Question ready — grill');
+  });
+
   it('does not include non-gate states', () => {
     expect(GATE_STATES['factory:in-progress']).toBeUndefined();
     expect(GATE_STATES['factory:triaging']).toBeUndefined();

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -89,6 +89,7 @@ export const GATE_STATES: Record<string, string> = {
   'factory:prd-review': 'PRD Review pending — human approval required',
   'factory:needs-review': 'Code Review pending — human approval required',
   'factory:needs-human': 'Human intervention required',
+  'factory:gate-pending': 'Question ready — grill',
 };
 
 export const PENDING_NEXT_RUN_STATES: Record<string, string> = {


### PR DESCRIPTION
## Summary

Closes the two open, unblocked work items in milestone **M14: Work Mode Foundation**:

- **#751 / #749 / #750 — Changelog feature.** Adds `GET /api/changelog?days=N` on the server (new `domains/changelog/` module) that aggregates merged PRs across all configured target-project repos, plus a `Changelog` button in `TopBar` that opens a `ChangelogModal` listing the last 7 days of merged PRs grouped by repo. Loading, empty, and error states are all covered.
- **#753 — Grill-ready banner.** Adds an info-styled variant of `GatePendingBanner` for `factory:gate-pending`, the state grill-me enters when it has a question waiting for the human. Reads "Question ready — grill" and links to the issue's grill section.

## Files

Server
- `apps/server/src/domains/changelog/{service,router,service.test,router.test}.ts` (new)
- `apps/server/src/server.ts` — registers `/api/changelog`

Web
- `apps/web/src/components/chrome/{ChangelogModal,ChangelogModal.test}.tsx` (new)
- `apps/web/src/components/chrome/TopBar.tsx` — Changelog button left of Capture
- `apps/web/src/lib/constants.ts` — adds `factory:gate-pending` → "Question ready — grill" to `GATE_STATES`
- `apps/web/src/components/detail/components/GatePendingBanner.tsx` — adds info variant + Grill link action
- `apps/web/src/components/detail/components/GatePendingBanner.test.tsx` — adds 4 tests for the new variant
- `apps/web/src/components/detail/slice.test.ts` — updates GATE_STATES contract

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `apps/server/src/domains/changelog/*` — 17 tests (server)
- [x] `apps/web/src/components/chrome/ChangelogModal.test.tsx` — 13 tests
- [x] `apps/web/src/components/detail/components/GatePendingBanner.test.tsx` — 11 tests (4 new)
- [x] Existing `apps/web/src/components/detail/*` slice — 258 tests still passing

Closes #749
Closes #750
Closes #751
Closes #753

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3prAiKqXt4RKQvsZkpY4G)_