### PR TITLE
M14: Work Mode Foundation (Jira + Bitbucket + Confluence) + ⌘K search

### DIFF
--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -5,6 +5,7 @@ import { STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { githubRepoRef } from '@goose-hub/core/types.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
 import { and, eq, gte, lt } from 'drizzle-orm';
 
@@ -31,7 +32,8 @@ export async function statusCommand(slug: string): Promise<void> {
     process.exit(1);
   }
 
-  const source = new GitHubLabelsSource(config.id, config.source.repo, token);
+  const repoRef = githubRepoRef(config.source);
+  const source = new GitHubLabelsSource(config.id, repoRef, token);
 
   let items: WorkItem[];
   let milestoneLabel: string | null = null;
@@ -57,7 +59,7 @@ export async function statusCommand(slug: string): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`${config.name} (${config.source.repo})`);
+  console.log(`${config.name} (${repoRef})`);
   if (milestoneLabel) {
     console.log(`Active milestone: ${milestoneLabel}`);
   }

--- a/apps/cli/src/commands/sweep.ts
+++ b/apps/cli/src/commands/sweep.ts
@@ -3,6 +3,7 @@ import { loadProjects } from '@goose-hub/core/projects/loader.js';
 import { TERMINAL_STATES } from '@goose-hub/core/state-machine/states.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { githubRepoRef } from '@goose-hub/core/types.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
 
 export async function sweepCommand(slug: string, milestoneArg: string): Promise<void> {
@@ -31,7 +32,7 @@ export async function sweepCommand(slug: string, milestoneArg: string): Promise<
     process.exit(1);
   }
 
-  const source = new GitHubLabelsSource(config.id, config.source.repo, token);
+  const source = new GitHubLabelsSource(config.id, githubRepoRef(config.source), token);
 
   let allOpen: WorkItem[];
   try {

--- a/apps/cli/src/commands/task-move.ts
+++ b/apps/cli/src/commands/task-move.ts
@@ -7,6 +7,7 @@ import {
 } from '@goose-hub/core/projects/move-with-deps.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { githubRepoRef } from '@goose-hub/core/types.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
 
 export async function taskMoveCommand(rawArgs: string[]): Promise<void> {
@@ -46,7 +47,8 @@ export async function taskMoveCommand(rawArgs: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const source = new GitHubLabelsSource(config.id, config.source.repo, token);
+  const repoRef = githubRepoRef(config.source);
+  const source = new GitHubLabelsSource(config.id, repoRef, token);
   let item: WorkItem;
   try {
     item = await source.getItem(id);
@@ -92,7 +94,7 @@ export async function taskMoveCommand(rawArgs: string[]): Promise<void> {
   try {
     result = await moveIssueToCurrent(
       item.body,
-      config.source.repo,
+      repoRef,
       Number(item.externalId),
       mode,
       fetchLifecycle,

--- a/apps/cli/src/commands/work.README.md
+++ b/apps/cli/src/commands/work.README.md
@@ -1,0 +1,16 @@
+# `goose work` CLI namespace (M14.08 / #329)
+
+Work-mode subcommands. Every command short-circuits with a non-zero exit code unless `WORK_MACHINE=true` is set in the environment.
+
+## Commands
+
+- `goose work status` — list active Work (Jira-backed) projects and the current `factory:*` state of their open tickets. Read-only.
+- `goose work investigate <project-slug> <jira-key>` — trigger an investigation run for the named ticket. Resolves the project and ticket up-front so the user gets fast feedback on bad input.
+
+## Gating
+
+The single gate is `WORK_MACHINE=true`. It matches the same gate enforced by `core/projects/loader.ts` (#325) and `core/projects/scheduler.ts` so the user gets a consistent "Work is hidden here" signal from every surface. The CLI top-level `goose help` only lists the `work` namespace when the gate is open.
+
+## Tests
+
+`work.test.ts` covers the WORK_MACHINE rejection path for every subcommand, the unknown-slug failure, and the happy-path output for both `status` and `investigate` against mocked `loadProjects` + `JiraStateSource`.

--- a/apps/cli/src/commands/work.test.ts
+++ b/apps/cli/src/commands/work.test.ts
@@ -1,0 +1,170 @@
+import type { ProjectConfig } from '@goose-hub/core/types.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type WorkCommandIo,
+  workCommand,
+  workHelpLines,
+  workInvestigateCommand,
+  workStatusCommand,
+} from './work.js';
+
+function mkIo(env: Record<string, string> = {}): WorkCommandIo & {
+  out: string[];
+  err: string[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    write: (line: string) => out.push(line),
+    writeErr: (line: string) => err.push(line),
+    env,
+    out,
+    err,
+  };
+}
+
+vi.mock('@goose-hub/core/projects/loader.js', async () => {
+  const actual = await vi.importActual<typeof import('@goose-hub/core/projects/loader.js')>(
+    '@goose-hub/core/projects/loader.js',
+  );
+  return {
+    ...actual,
+    loadProjects: vi.fn(),
+  };
+});
+
+vi.mock('@goose-hub/core/state-source/jira.js', () => ({
+  JiraStateSource: vi.fn().mockImplementation(() => ({
+    listOpenWork: vi.fn().mockResolvedValue([
+      {
+        externalId: 'PAY-1',
+        state: 'factory:accepted',
+        title: 'Idempotency keys',
+      },
+      {
+        externalId: 'PAY-2',
+        state: 'factory:in-progress',
+        title: 'Charge retry storm',
+      },
+    ]),
+    getItem: vi.fn(async (key: string) => ({
+      id: `jira:PAY#${key}`,
+      externalId: key,
+      title: 'A ticket',
+    })),
+  })),
+}));
+
+import { loadProjects } from '@goose-hub/core/projects/loader.js';
+
+const mockedLoadProjects = vi.mocked(loadProjects);
+
+beforeEach(() => {
+  mockedLoadProjects.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('workCommand — WORK_MACHINE gate', () => {
+  it('rejects every subcommand when WORK_MACHINE is unset', async () => {
+    const io = mkIo({});
+    const exit = await workCommand(['status'], io);
+    expect(exit).toBe(1);
+    expect(io.err.join('\n')).toContain('WORK_MACHINE is not set');
+  });
+
+  it('rejects `investigate` when WORK_MACHINE is unset', async () => {
+    const io = mkIo({});
+    const exit = await workInvestigateCommand(['my-slug', 'PAY-1'], io);
+    expect(exit).toBe(1);
+    expect(io.err.join('\n')).toContain('WORK_MACHINE is not set');
+  });
+
+  it('returns 1 with a usage line for unknown subcommands when gated open', async () => {
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workCommand(['nope'], io);
+    expect(exit).toBe(1);
+    expect(io.err.join('\n')).toContain('Usage: goose work');
+  });
+});
+
+describe('workStatusCommand — WORK_MACHINE=true happy path', () => {
+  it('lists Work projects and their open Jira tickets', async () => {
+    mockedLoadProjects.mockResolvedValue([
+      {
+        slug: 'pay',
+        name: 'Payments',
+        id: 'pay',
+        source: { kind: 'jira', projectKey: 'PAY' },
+      } as unknown as ProjectConfig,
+      {
+        slug: 'gh-only',
+        source: { kind: 'github', repo: 'shaunnez/x' },
+      } as unknown as ProjectConfig,
+    ]);
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workStatusCommand(io);
+    expect(exit).toBe(0);
+    const all = io.out.join('\n');
+    expect(all).toContain('Payments (PAY)');
+    expect(all).toContain('PAY-1');
+    expect(all).toContain('factory:accepted');
+    expect(all).toContain('PAY-2');
+    expect(all).not.toContain('gh-only');
+  });
+
+  it('reports "no Work projects registered" gracefully', async () => {
+    mockedLoadProjects.mockResolvedValue([
+      {
+        slug: 'gh-only',
+        source: { kind: 'github', repo: 'shaunnez/x' },
+      } as unknown as ProjectConfig,
+    ]);
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workStatusCommand(io);
+    expect(exit).toBe(0);
+    expect(io.out.join('\n')).toContain('No Work projects registered');
+  });
+});
+
+describe('workInvestigateCommand — WORK_MACHINE=true happy path', () => {
+  it('requires slug + jira-key', async () => {
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workInvestigateCommand([], io);
+    expect(exit).toBe(1);
+    expect(io.err.join('\n')).toContain('Usage: goose work investigate');
+  });
+
+  it('rejects an unknown slug', async () => {
+    mockedLoadProjects.mockResolvedValue([]);
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workInvestigateCommand(['missing', 'PAY-1'], io);
+    expect(exit).toBe(1);
+    expect(io.err.join('\n')).toContain('No Work project registered with slug "missing"');
+  });
+
+  it('triggers investigation for a known Work slug + Jira key', async () => {
+    mockedLoadProjects.mockResolvedValue([
+      {
+        slug: 'pay',
+        name: 'Payments',
+        id: 'pay',
+        source: { kind: 'jira', projectKey: 'PAY' },
+      } as unknown as ProjectConfig,
+    ]);
+    const io = mkIo({ WORK_MACHINE: 'true' });
+    const exit = await workInvestigateCommand(['pay', 'PAY-7'], io);
+    expect(exit).toBe(0);
+    expect(io.out.join('\n')).toContain('Triggering investigation for PAY-7');
+  });
+});
+
+describe('workHelpLines', () => {
+  it('returns at least the documented commands', () => {
+    const lines = workHelpLines();
+    expect(lines.join('\n')).toContain('work status');
+    expect(lines.join('\n')).toContain('work investigate');
+  });
+});

--- a/apps/cli/src/commands/work.ts
+++ b/apps/cli/src/commands/work.ts
@@ -1,0 +1,144 @@
+/**
+ * `goose work` CLI namespace (M14.08 / #329).
+ *
+ * Houses Work-mode subcommands: `goose work status`, `goose work
+ * investigate <issue>`. Gated by `WORK_MACHINE=true`. Each subcommand
+ * short-circuits with a clear error message and a non-zero exit code on
+ * machines where the env var is unset, mirroring the loader/scheduler
+ * gates so the user gets the same "Work is hidden here" signal from
+ * every surface.
+ */
+
+import { logger } from '@goose-hub/core/logger.js';
+import { isWorkMachine, loadProjects } from '@goose-hub/core/projects/loader.js';
+import { JiraStateSource } from '@goose-hub/core/state-source/jira.js';
+import type { JiraSourceConfig, ProjectConfig } from '@goose-hub/core/types.js';
+import { targetProjectsRoot } from '@goose-hub/target-projects';
+
+export interface WorkCommandIo {
+  write: (line: string) => void;
+  writeErr: (line: string) => void;
+  env: NodeJS.ProcessEnv;
+}
+
+const DEFAULT_IO: WorkCommandIo = {
+  write: (line) => process.stdout.write(`${line}\n`),
+  writeErr: (line) => process.stderr.write(`${line}\n`),
+  env: process.env,
+};
+
+const WORK_GATE_MESSAGE =
+  'WORK_MACHINE is not set — Work commands are unavailable on this machine.';
+
+function requireWorkMachine(io: WorkCommandIo): boolean {
+  if (isWorkMachine(io.env)) return true;
+  io.writeErr(WORK_GATE_MESSAGE);
+  return false;
+}
+
+function isJiraProject(cfg: ProjectConfig): cfg is ProjectConfig & { source: JiraSourceConfig } {
+  return cfg.source.kind === 'jira';
+}
+
+/**
+ * `goose work status` — list Work projects + the current state of their
+ * open Jira tickets. Read-only.
+ */
+export async function workStatusCommand(io: WorkCommandIo = DEFAULT_IO): Promise<number> {
+  if (!requireWorkMachine(io)) return 1;
+
+  const projects = await loadProjects(targetProjectsRoot);
+  const work = projects.filter(isJiraProject);
+  if (work.length === 0) {
+    io.write('No Work projects registered.');
+    return 0;
+  }
+  for (const project of work) {
+    io.write(`${project.name} (${project.source.projectKey})`);
+    io.write('─'.repeat(60));
+    try {
+      const source = new JiraStateSource(project.id, project.source.projectKey, {
+        issueTypes: project.source.issueTypes,
+        statusMap: project.source.statusMap,
+      });
+      const items = await source.listOpenWork();
+      if (items.length === 0) {
+        io.write('  (no open Jira issues)');
+      } else {
+        for (const item of items) {
+          io.write(`  ${item.externalId.padEnd(12)}  ${item.state.padEnd(28)}  ${item.title}`);
+        }
+      }
+    } catch (err) {
+      io.writeErr(`  error: ${(err as Error).message}`);
+    }
+    io.write('');
+  }
+  return 0;
+}
+
+/**
+ * `goose work investigate <project-slug> <jira-key>` — manually trigger
+ * an investigation against a specific Jira ticket. The actual workflow
+ * dispatch lives in `apps/server`; this CLI surfaces the trigger by
+ * resolving the project + ticket and writing an event the server can
+ * pick up. M14 ships the surface; the wiring to dispatch is incremental.
+ */
+export async function workInvestigateCommand(
+  args: string[],
+  io: WorkCommandIo = DEFAULT_IO,
+): Promise<number> {
+  if (!requireWorkMachine(io)) return 1;
+  const [slug, jiraKey] = args;
+  if (slug == null || jiraKey == null) {
+    io.writeErr('Usage: goose work investigate <project-slug> <jira-key>');
+    return 1;
+  }
+  const projects = await loadProjects(targetProjectsRoot);
+  const project = projects.find((p) => p.slug === slug);
+  if (project == null || !isJiraProject(project)) {
+    io.writeErr(`No Work project registered with slug "${slug}".`);
+    return 1;
+  }
+  try {
+    const source = new JiraStateSource(project.id, project.source.projectKey, {
+      issueTypes: project.source.issueTypes,
+      statusMap: project.source.statusMap,
+    });
+    const item = await source.getItem(jiraKey);
+    io.write(`Triggering investigation for ${item.externalId}: ${item.title}`);
+    logger.info('work.investigate-triggered', {
+      projectId: project.id,
+      itemId: item.id,
+    });
+    return 0;
+  } catch (err) {
+    io.writeErr(`Failed to load ticket ${jiraKey}: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+/** Help text — listed under `goose help` only when WORK_MACHINE=true. */
+export function workHelpLines(): string[] {
+  return [
+    '  work status                       List active Work projects and Jira issue states',
+    '  work investigate <slug> <key>     Trigger an investigation run for a Jira ticket',
+  ];
+}
+
+/**
+ * Top-level dispatcher for `goose work <subcommand>`. Returns the exit
+ * code so the CLI entrypoint can pass it to `process.exit`.
+ */
+export async function workCommand(args: string[], io: WorkCommandIo = DEFAULT_IO): Promise<number> {
+  const [sub, ...rest] = args;
+  switch (sub) {
+    case 'status':
+      return workStatusCommand(io);
+    case 'investigate':
+      return workInvestigateCommand(rest, io);
+    default:
+      io.writeErr('Usage: goose work <status|investigate>');
+      return 1;
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import 'dotenv/config';
+import { isWorkMachine } from '@goose-hub/core/projects/loader.js';
 import { bootstrapProject } from '@goose-hub/core/workflows/bootstrap-project.js';
 import { bootstrapCommand } from './bootstrap-command.js';
 import { runAgentCommand } from './commands/agent.js';
@@ -8,6 +9,7 @@ import { skillCommand } from './commands/skill.js';
 import { statusCommand } from './commands/status.js';
 import { sweepCommand } from './commands/sweep.js';
 import { taskMoveCommand } from './commands/task-move.js';
+import { workCommand, workHelpLines } from './commands/work.js';
 
 const [, , command, ...args] = process.argv;
 
@@ -37,6 +39,11 @@ switch (command) {
   case 'skill':
     await skillCommand(args);
     break;
+  case 'work': {
+    const exitCode = await workCommand(args);
+    process.exit(exitCode);
+    break;
+  }
   case 'project':
     if (args[0] === 'bootstrap') {
       const exitCode = await bootstrapCommand({
@@ -66,5 +73,8 @@ switch (command) {
     console.error('  playbook export|import <project-slug> [--json]');
     console.error('  skill triggers <skill-name> [--json]');
     console.error('  project bootstrap <owner>/<repo>  Bootstrap a new project into Factory');
+    if (isWorkMachine()) {
+      for (const line of workHelpLines()) console.error(line);
+    }
     process.exit(1);
 }

--- a/apps/server/src/domains/projects/router.ts
+++ b/apps/server/src/domains/projects/router.ts
@@ -1,3 +1,4 @@
+import { makeConfluenceFetcher } from '@goose-hub/core/connectors/confluence.js';
 import { Hono } from 'hono';
 import { listProjectConfigsService, listProjectsService } from './service.js';
 
@@ -13,6 +14,27 @@ router.get('/projects', async (c) => {
 router.get('/projects/configs', async (c) => {
   const result = await listProjectConfigsService();
   return c.json(result);
+});
+
+// M14.05 / #324 — return a Confluence page title for a given pageId. Used
+// by the task detail panel's Confluence-links section to render labelled
+// links rather than raw URLs. Returns `{ title: null }` when credentials
+// are not configured so the client knows to fall back to the URL slug.
+router.get('/confluence/title', async (c) => {
+  const pageId = c.req.query('pageId');
+  if (pageId == null || !/^\d+$/.test(pageId)) {
+    return c.json({ title: null, error: 'invalid pageId' }, 400);
+  }
+  const fetcher = makeConfluenceFetcher();
+  if (fetcher == null) {
+    return c.json({ title: null, available: false });
+  }
+  try {
+    const title = await fetcher.fetchTitle(pageId);
+    return c.json({ title, available: true });
+  } catch {
+    return c.json({ title: null, available: true });
+  }
 });
 
 export { router as projectsRouter };

--- a/apps/server/src/domains/projects/service.ts
+++ b/apps/server/src/domains/projects/service.ts
@@ -8,6 +8,11 @@ export async function listProjectsService(): Promise<{ projects: unknown[] }> {
 export interface ProjectConfigDto {
   slug: string;
   name: string;
+  /**
+   * `repo` carries `<owner>/<repo>` for github sources or the Jira project
+   * key for jira sources. The DTO is intentionally flat so existing
+   * consumers don't have to branch on `kind`.
+   */
   source: { kind: string; repo: string };
   activeMilestone: string | null;
   colorStripe: string;
@@ -20,7 +25,10 @@ export async function listProjectConfigsService(): Promise<{ configs: ProjectCon
   const configs: ProjectConfigDto[] = projects.map((p) => ({
     slug: p.slug,
     name: p.name,
-    source: p.source,
+    source: {
+      kind: p.source.kind,
+      repo: p.source.kind === 'github' ? p.source.repo : p.source.projectKey,
+    },
     activeMilestone: p.activeMilestone ?? null,
     colorStripe: p.colorStripe,
     budgets: {

--- a/apps/server/src/domains/roster/service.ts
+++ b/apps/server/src/domains/roster/service.ts
@@ -143,7 +143,8 @@ export async function approveCandidate(
       return { ok: true, data: { candidate: updated ?? candidate } };
     }
 
-    const issueUrl = await createGithubImprovementIssue(cfg.source.repo, token, existing);
+    const githubRepo = cfg.source.repo;
+    const issueUrl = await createGithubImprovementIssue(githubRepo, token, existing);
     const updated = await updateCandidateGithubIssue(id, issueUrl, null);
     return { ok: true, data: { candidate: updated ?? candidate } };
   } catch (err) {

--- a/apps/server/src/shared/dispatch-dev.ts
+++ b/apps/server/src/shared/dispatch-dev.ts
@@ -176,7 +176,8 @@ export async function dispatchSpecAuthor(slug: string, issueNumber: number): Pro
     if (depProjectConfig != null) {
       const fetchTarget = await createProjectAwareTargetSource();
       const { eligible } = await filterEligibleByDependencies([item], {
-        currentRepo: depProjectConfig.source.repo,
+        currentRepo:
+          depProjectConfig.source.kind === 'github' ? depProjectConfig.source.repo : slug,
         fetchTarget,
         source,
       });
@@ -252,7 +253,8 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
     if (depProjectConfig != null) {
       const fetchTarget = await createProjectAwareTargetSource();
       const { eligible } = await filterEligibleByDependencies([item], {
-        currentRepo: depProjectConfig.source.repo,
+        currentRepo:
+          depProjectConfig.source.kind === 'github' ? depProjectConfig.source.repo : slug,
         fetchTarget,
         source,
       });

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -316,7 +316,7 @@ describe('dispatchFixIssue', () => {
     mockGetSourceForSlug.mockResolvedValue(mockSource);
     mockGetProject.mockResolvedValue({
       budgets: { maxParallelAgents: 1 },
-      source: { repo: 'shaunnez/goose-hub', type: 'github' },
+      source: { kind: 'github', repo: 'shaunnez/goose-hub' },
     });
     mockFilterEligibleByDependencies.mockResolvedValue({
       eligible: [],
@@ -355,7 +355,7 @@ describe('dispatchFixIssue', () => {
     mockGetSourceForSlug.mockResolvedValue(mockSource);
     mockGetProject.mockResolvedValue({
       budgets: { maxParallelAgents: 1 },
-      source: { repo: 'shaunnez/goose-hub', type: 'github' },
+      source: { kind: 'github', repo: 'shaunnez/goose-hub' },
     });
     mockFilterEligibleByDependencies.mockResolvedValue({
       eligible: [mockItem],
@@ -501,7 +501,7 @@ describe('dispatchFixIssue: bug routing', () => {
     mockGetProject.mockResolvedValue({
       id: 'slug',
       budgets: { maxParallelAgents: 1 },
-      source: { repo: 'shaunnez/goose-hub', type: 'github' },
+      source: { kind: 'github', repo: 'shaunnez/goose-hub' },
     });
     const bugItem = {
       id: 'item-bug',
@@ -564,7 +564,7 @@ describe('dispatchFixIssue: bug routing', () => {
     mockGetProject.mockResolvedValue({
       id: 'slug',
       budgets: { maxParallelAgents: 1 },
-      source: { repo: 'shaunnez/goose-hub', type: 'github' },
+      source: { kind: 'github', repo: 'shaunnez/goose-hub' },
     });
     const featureItem = {
       id: 'item-feat',

--- a/apps/web/src/components/chrome/SearchModal.tsx
+++ b/apps/web/src/components/chrome/SearchModal.tsx
@@ -1,0 +1,235 @@
+import { fetchIssues, fetchProjects } from '@/lib/api';
+import type { ProjectSummary, WorkItemDto } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface SearchModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface SearchHit {
+  slug: string;
+  projectName: string;
+  item: WorkItemDto;
+}
+
+async function fetchAllIssues(): Promise<SearchHit[]> {
+  const projects: ProjectSummary[] = await fetchProjects();
+  const results = await Promise.all(
+    projects.map(async (p) => {
+      const items = await fetchIssues(p.slug).catch(() => [] as WorkItemDto[]);
+      return items.map((item) => ({ slug: p.slug, projectName: p.name, item }));
+    }),
+  );
+  return results.flat();
+}
+
+function matches(query: string, hit: SearchHit): boolean {
+  if (query.length === 0) return true;
+  const q = query.toLowerCase();
+  return (
+    hit.item.title.toLowerCase().includes(q) ||
+    `#${hit.item.externalId}`.toLowerCase().includes(q) ||
+    hit.item.externalId.toLowerCase().includes(q)
+  );
+}
+
+const PLACEHOLDER = 'Start typing to search…';
+
+export function SearchModal({ open, onClose }: SearchModalProps) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+
+  const { data: hits = [], isLoading } = useQuery<SearchHit[]>({
+    queryKey: ['all-issues'],
+    queryFn: fetchAllIssues,
+    staleTime: 60_000,
+    enabled: open,
+  });
+
+  const filtered = useMemo(() => {
+    if (query.length === 0) {
+      return [...hits]
+        .sort((a, b) => Number(b.item.externalId) - Number(a.item.externalId))
+        .slice(0, 20);
+    }
+    return hits.filter((h) => matches(query, h)).slice(0, 50);
+  }, [hits, query]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on query/hits change is the intent
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query, hits]);
+
+  useEffect(() => {
+    if (open) {
+      // Defer focus so the input has mounted before we grab it.
+      const id = setTimeout(() => inputRef.current?.focus(), 10);
+      return () => clearTimeout(id);
+    }
+    setQuery('');
+    setSelectedIndex(0);
+    return undefined;
+  }, [open]);
+
+  if (!open) return null;
+
+  const select = (hit: SearchHit) => {
+    navigate(`/projects/${hit.slug}/items/${hit.item.externalId}`);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(filtered.length - 1, i + 1));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+    if (e.key === 'Enter' && filtered[selectedIndex]) {
+      e.preventDefault();
+      select(filtered[selectedIndex]);
+    }
+  };
+
+  return (
+    <div
+      data-testid="search-modal"
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> on flex layout doesn't slot the same; using role
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search issues"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.45)',
+        paddingTop: 80,
+      }}
+      onClick={onClose}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        style={{
+          background: 'var(--bg-elev)',
+          border: '1px solid var(--line)',
+          borderRadius: 8,
+          width: '100%',
+          maxWidth: 640,
+          maxHeight: '70vh',
+          display: 'flex',
+          flexDirection: 'column',
+          color: 'var(--fg)',
+          overflow: 'hidden',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <input
+          ref={inputRef}
+          data-testid="search-modal-input"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={PLACEHOLDER}
+          style={{
+            background: 'var(--bg)',
+            color: 'var(--fg)',
+            border: 'none',
+            borderBottom: '1px solid var(--line)',
+            padding: '14px 16px',
+            fontSize: 14,
+            outline: 'none',
+          }}
+        />
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+          }}
+          data-testid="search-modal-results"
+        >
+          {isLoading && <div className="px-4 py-3 text-[12.5px] text-fg-3">Loading…</div>}
+          {!isLoading && filtered.length === 0 && (
+            <div className="px-4 py-6 text-[12.5px] text-fg-3" data-testid="search-modal-empty">
+              {query.length === 0 ? PLACEHOLDER : 'No issues found'}
+            </div>
+          )}
+          {filtered.map((hit, idx) => {
+            const selected = idx === selectedIndex;
+            return (
+              <button
+                key={`${hit.slug}/${hit.item.externalId}`}
+                type="button"
+                data-testid="search-modal-result"
+                data-slug={hit.slug}
+                data-external-id={hit.item.externalId}
+                onClick={() => select(hit)}
+                onMouseEnter={() => setSelectedIndex(idx)}
+                style={{
+                  display: 'flex',
+                  width: '100%',
+                  textAlign: 'left',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: '10px 16px',
+                  background: selected ? 'var(--bg-elev-2)' : 'transparent',
+                  border: 'none',
+                  color: 'var(--fg)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                }}
+              >
+                <span className="font-mono" style={{ color: 'var(--fg-3)', minWidth: 56 }}>
+                  #{hit.item.externalId}
+                </span>
+                <span
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {hit.item.title}
+                </span>
+                <span className="font-mono" style={{ color: 'var(--fg-3)', fontSize: 11.5 }}>
+                  {hit.slug}
+                </span>
+                <span
+                  style={{
+                    color: 'var(--fg-2)',
+                    fontSize: 11.5,
+                    padding: '2px 8px',
+                    borderRadius: 999,
+                    background: 'var(--bg)',
+                    border: '1px solid var(--line)',
+                  }}
+                >
+                  {hit.item.state.replace('factory:', '')}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chrome/SearchModal.tsx
+++ b/apps/web/src/components/chrome/SearchModal.tsx
@@ -53,8 +53,16 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
 
   const filtered = useMemo(() => {
     if (query.length === 0) {
+      // Mixed sources (GitHub numeric ids + Jira keys like PAY-42) — sort
+      // by createdAt desc (most recent first), falling back to a string
+      // compare so the order stays deterministic when timestamps tie.
       return [...hits]
-        .sort((a, b) => Number(b.item.externalId) - Number(a.item.externalId))
+        .sort((a, b) => {
+          const at = new Date(a.item.createdAt).getTime();
+          const bt = new Date(b.item.createdAt).getTime();
+          if (bt !== at) return bt - at;
+          return a.item.externalId.localeCompare(b.item.externalId);
+        })
         .slice(0, 20);
     }
     return hits.filter((h) => matches(query, h)).slice(0, 50);
@@ -125,6 +133,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
       onClick={onClose}
       onKeyDown={handleKeyDown}
     >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keydown is handled on the parent backdrop; this inner stopPropagation prevents bubbling */}
       <div
         style={{
           background: 'var(--bg-elev)',
@@ -139,7 +148,6 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
           overflow: 'hidden',
         }}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
       >
         <input
           ref={inputRef}

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -1,6 +1,7 @@
+import { SearchModal } from '@/components/chrome/SearchModal';
 import { CaptureModal } from '@/components/ui/CaptureModal';
-import { Plus, Search, Terminal } from 'lucide-react';
-import { useState } from 'react';
+import { Plus, Search } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 interface TopBarProps {
   breadcrumb?: React.ReactNode;
@@ -8,6 +9,19 @@ interface TopBarProps {
 
 export function TopBar({ breadcrumb }: TopBarProps) {
   const [showCapture, setShowCapture] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+
+  // ⌘K / Ctrl+K opens the search modal globally (#603).
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setShowSearch(true);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   return (
     <>
@@ -29,15 +43,23 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         </button>
         <button
           type="button"
-          disabled
-          title="Search — available later"
-          className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg cursor-not-allowed"
+          data-testid="search-button"
+          onClick={() => setShowSearch(true)}
+          title="Search issues (⌘K)"
+          className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Search size={13} />
           <span>Search</span>
+          <span
+            aria-hidden
+            className="ml-1 hidden sm:inline-flex items-center gap-0.5 text-[10.5px] text-fg-3 font-mono"
+          >
+            ⌘K
+          </span>
         </button>
       </header>
       <CaptureModal open={showCapture} onClose={() => setShowCapture(false)} />
+      <SearchModal open={showSearch} onClose={() => setShowSearch(false)} />
     </>
   );
 }

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -53,3 +53,46 @@ describe('chrome slice — deferred surfaces config', () => {
     expect(collapsed).toBe(false);
   });
 });
+
+describe('chrome slice — search modal (#603)', () => {
+  const topBarSource = readFileSync(join(import.meta.dirname, 'TopBar.tsx'), 'utf-8');
+  const searchModalSource = readFileSync(join(import.meta.dirname, 'SearchModal.tsx'), 'utf-8');
+
+  it('TopBar imports the SearchModal', () => {
+    expect(topBarSource).toContain('SearchModal');
+    expect(topBarSource).toContain("from '@/components/chrome/SearchModal'");
+  });
+
+  it('TopBar wires a ⌘K / Ctrl+K keyboard shortcut', () => {
+    expect(topBarSource).toContain('metaKey');
+    expect(topBarSource).toContain('ctrlKey');
+    expect(topBarSource).toMatch(/key.*toLowerCase\(\).*===.*'k'/);
+  });
+
+  it('TopBar no longer renders the disabled search button', () => {
+    expect(topBarSource).not.toContain('Search — available later');
+    expect(topBarSource).toContain('data-testid="search-button"');
+  });
+
+  it('SearchModal exposes test-ids the e2e suite hooks into', () => {
+    for (const id of [
+      '"search-modal"',
+      '"search-modal-input"',
+      '"search-modal-results"',
+      '"search-modal-empty"',
+      '"search-modal-result"',
+    ]) {
+      expect(searchModalSource).toContain(id);
+    }
+  });
+
+  it('SearchModal navigates to /projects/:slug/items/:id on select', () => {
+    expect(searchModalSource).toMatch(/\/projects\/\$\{[^}]+\}\/items\/\$\{[^}]+\}/);
+    expect(searchModalSource).toContain('useNavigate');
+  });
+
+  it('SearchModal closes on Escape', () => {
+    expect(searchModalSource).toContain("e.key === 'Escape'");
+    expect(searchModalSource).toContain('onClose');
+  });
+});

--- a/apps/web/src/components/detail/components/ConfluenceLinksSection.tsx
+++ b/apps/web/src/components/detail/components/ConfluenceLinksSection.tsx
@@ -1,0 +1,103 @@
+import { fetchComments } from '@/lib/api';
+import type { IssueCommentDto } from '@/lib/types';
+import {
+  type ConfluencePageRef,
+  extractConfluenceLinks,
+  labelForConfluenceRef,
+} from '@goose-hub/core/connectors/confluence.js';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+interface ConfluenceLinksSectionProps {
+  body: string | undefined;
+  projectSlug: string;
+  externalId: string;
+}
+
+interface ConfluenceTitleResponse {
+  title: string | null;
+  available?: boolean;
+}
+
+async function fetchConfluenceTitle(pageId: string): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/confluence/title?pageId=${encodeURIComponent(pageId)}`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as ConfluenceTitleResponse;
+    return data.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function ConfluenceLinksSection({
+  body,
+  projectSlug,
+  externalId,
+}: ConfluenceLinksSectionProps) {
+  const { data: comments = [] } = useQuery<IssueCommentDto[]>({
+    queryKey: ['comments', projectSlug, externalId],
+    queryFn: () => fetchComments(projectSlug, externalId),
+    staleTime: 30_000,
+  });
+
+  const refs: ConfluencePageRef[] = useMemo(() => {
+    const combined = [body ?? '', ...comments.map((c) => c.body)].join('\n');
+    return extractConfluenceLinks(combined);
+  }, [body, comments]);
+
+  const { data: titles = {} } = useQuery<Record<string, string | null>>({
+    queryKey: [
+      'confluence-titles',
+      refs
+        .map((r) => r.pageId)
+        .sort()
+        .join(','),
+    ],
+    queryFn: async () => {
+      const entries = await Promise.all(
+        refs.map(async (ref) => [ref.pageId, await fetchConfluenceTitle(ref.pageId)] as const),
+      );
+      return Object.fromEntries(entries);
+    },
+    enabled: refs.length > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  if (refs.length === 0) return null;
+
+  return (
+    <div
+      data-testid="confluence-links-section"
+      className="rounded-lg border border-line bg-bg-elev overflow-hidden"
+    >
+      <div className="px-4 py-3 border-b border-line bg-bg-elev-2">
+        <div className="text-[10.5px] uppercase tracking-wider text-fg-2">
+          Confluence references
+        </div>
+      </div>
+      <ul className="px-4 py-3 space-y-2 text-[13px]">
+        {refs.map((ref) => {
+          const title = titles[ref.pageId] ?? null;
+          const label = labelForConfluenceRef(ref, title);
+          return (
+            <li key={ref.url}>
+              <a
+                href={ref.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-accent hover:underline"
+                data-testid="confluence-link"
+                data-page-id={ref.pageId}
+              >
+                {label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'react-router-dom';
 import { parseDiff } from '../lib/code-diff';
 import { useIssueCostsBreakdown } from '../lib/costs';
 import { CommentsSection } from './CommentsSection';
+import { ConfluenceLinksSection } from './ConfluenceLinksSection';
 import { DependenciesSection } from './DependenciesSection';
 import { StatCard } from './StatCard';
 
@@ -129,6 +130,16 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
         {/* Dependencies */}
         {item != null && projectSlug != null && (
           <DependenciesSection item={item} projectSlug={projectSlug} />
+        )}
+
+        {/* Confluence references (M14.05 / #324) — appears only when the
+            body or comments contain Confluence URLs. */}
+        {item != null && projectSlug != null && (
+          <ConfluenceLinksSection
+            body={item.body}
+            projectSlug={projectSlug}
+            externalId={item.externalId}
+          />
         )}
 
         {/* Comments card */}

--- a/core/connectors/README.md
+++ b/core/connectors/README.md
@@ -8,6 +8,13 @@ External-system adapters. Each subdirectory wraps one external API behind a narr
 |---|---|
 | `github/` | Open a PR (`open-pr.ts`) and merge a PR (`merge-pr.ts`) via the GitHub REST API. Defines `MergeConflictError` so callers can dispatch the resolve-conflict workflow when GitHub returns HTTP 405. See `github/README.md`. |
 
+## Top-level adapters
+
+| File | Purpose |
+|---|---|
+| `bitbucket.ts` (M14.03 / #323) | Read-only Bitbucket Cloud connector — `getFile`, `searchCode`, `listPullRequests`, plus `getRepoMetadata` / `listWorkspaceRepos` used by the matcher. Reads `BITBUCKET_USER` / `BITBUCKET_APP_PASSWORD` (HTTP Basic). Constructor throws if either is unset. Also exports `parseBitbucketCloneUrl` for SSH + HTTPS URL parsing. |
+| `bitbucket-matcher.ts` (M14.04 / #326) | Repo-matching adapter — `matchRepo(issue, connector)` returns the top-3 Bitbucket candidates ranked by project-key overlap, keyword similarity, and prior selections. Score `>= 0.7` is auto-selected; lower confidence surfaces the choices via `factory:gate-pending`. Sticky behaviour: prior selections persist in a self-bootstrapping `bitbucket_repo_matches` SQLite table (no drizzle migration). |
+
 ## Adding a new connector
 
 1. New directory under `core/connectors/<name>/`.

--- a/core/connectors/bitbucket-matcher.ts
+++ b/core/connectors/bitbucket-matcher.ts
@@ -1,0 +1,263 @@
+import type Database from 'better-sqlite3';
+import { db } from '../db/db.js';
+import { logger } from '../logger.js';
+import type { WorkItem } from '../state-source/interface.js';
+import type { BitbucketConnector, BitbucketRepoRef } from './bitbucket.js';
+
+/**
+ * Repo-matching adapter for Jira issues (#326). Given a Jira `WorkItem`
+ * and a set of Bitbucket workspaces to consider, rank candidate repos by
+ * project key, keyword overlap with the issue summary/description, and
+ * past selections recorded in SQLite (so user choices "stick" across
+ * subsequent triage runs).
+ *
+ * The matcher self-bootstraps its persistence table on first call — no
+ * drizzle migration is required because the table is isolated from the
+ * rest of the schema and only consumed here.
+ */
+
+export interface MatchCandidate {
+  ref: BitbucketRepoRef;
+  /** Score between 0 and 1; >= 0.7 is auto-selectable. */
+  score: number;
+  /** Human-friendly explanation of how the score was computed. */
+  reason: string;
+}
+
+export interface MatchResult {
+  /** Top-3 candidates by score, highest first. */
+  candidates: MatchCandidate[];
+  /** True when the top candidate scored >= 0.7. */
+  autoSelected: boolean;
+  /** The top candidate, if any. */
+  topCandidate: MatchCandidate | null;
+}
+
+export interface BitbucketMatcherOptions {
+  /** Override the default better-sqlite3 connection (test injection). */
+  database?: Database.Database;
+  /**
+   * Comma-separated list of Bitbucket workspace slugs to consider. Defaults
+   * to `BITBUCKET_WORKSPACES`. Empty values short-circuit to "no candidates".
+   */
+  workspaces?: string[];
+}
+
+const TABLE_DDL = `
+  CREATE TABLE IF NOT EXISTS bitbucket_repo_matches (
+    project_id TEXT NOT NULL,
+    issue_key TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    repo_slug TEXT NOT NULL,
+    score REAL NOT NULL,
+    selected_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (project_id, issue_key)
+  );
+  CREATE INDEX IF NOT EXISTS bitbucket_repo_matches_workspace_idx
+    ON bitbucket_repo_matches (workspace, repo_slug);
+`;
+
+const tableInitialised = new WeakSet<Database.Database>();
+
+function ensureTable(database: Database.Database): void {
+  if (tableInitialised.has(database)) return;
+  database.exec(TABLE_DDL);
+  tableInitialised.add(database);
+}
+
+function getDb(options: BitbucketMatcherOptions): Database.Database {
+  // Drizzle wraps better-sqlite3; the raw instance lives behind .$client
+  // in current drizzle-orm versions. We type-pun rather than depend on a
+  // private API path because the matcher only needs prepare/exec.
+  const fromDrizzle = (db as unknown as { $client?: Database.Database }).$client;
+  return options.database ?? fromDrizzle ?? (db as unknown as Database.Database);
+}
+
+function resolveWorkspaces(options: BitbucketMatcherOptions): string[] {
+  if (options.workspaces != null) return options.workspaces.filter((w) => w.length > 0);
+  const env = process.env.BITBUCKET_WORKSPACES ?? '';
+  return env
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Score a single candidate repo against the issue. Three signals are
+ * combined with documented weights:
+ *
+ * - project-key overlap (repo slug contains the Jira project key) → 0.4
+ * - keyword overlap between issue summary/description and repo name +
+ *   description → 0.15 per overlapping token, capped at 0.5
+ * - previously selected (in SQLite) → 0.9 boost — large enough to make a
+ *   sticky pick dominate fresh matches even when the fresh match has both
+ *   project-key and keyword signals
+ *
+ * Sum is capped at 1.0. A confident key + keyword match clears the 0.7
+ * auto-select bar without requiring prior history.
+ */
+export function scoreCandidate(
+  issue: WorkItem,
+  repo: BitbucketRepoRef,
+  repoDescription = '',
+  priorMatch = false,
+): { score: number; reason: string } {
+  const reasons: string[] = [];
+  let score = 0;
+
+  // 1) Jira project key vs repo slug.
+  const projectKey = issue.repoRef.split('/').pop() ?? issue.repoRef;
+  const slugLower = repo.repoSlug.toLowerCase();
+  if (projectKey.length > 0 && slugLower.includes(projectKey.toLowerCase())) {
+    score += 0.4;
+    reasons.push(`slug contains project key "${projectKey}"`);
+  }
+
+  // 2) Keyword overlap. Tokenise summary + body, intersect with repo
+  // slug + description tokens.
+  const issueTokens = tokenise(`${issue.title} ${issue.body}`);
+  const repoTokens = tokenise(`${repo.repoSlug} ${repoDescription}`);
+  const overlap = countOverlap(issueTokens, repoTokens);
+  if (overlap > 0) {
+    const keywordScore = Math.min(0.5, overlap * 0.15);
+    score += keywordScore;
+    reasons.push(`${overlap} keyword overlap`);
+  }
+
+  // 3) Prior-match boost — dominates over a single tick's signals so a
+  // user's selection sticks across reruns.
+  if (priorMatch) {
+    score += 0.9;
+    reasons.push('prior selection on this issue');
+  }
+
+  score = Math.min(1, score);
+  const reason = reasons.length > 0 ? reasons.join('; ') : 'no signals matched';
+  return { score, reason };
+}
+
+function tokenise(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w.length >= 3),
+  );
+}
+
+function countOverlap(a: Set<string>, b: Set<string>): number {
+  let n = 0;
+  for (const w of a) if (b.has(w)) n += 1;
+  return n;
+}
+
+/**
+ * Look up a previously selected repo for an issue. Returns null if none
+ * recorded. Backed by the bootstrap table above.
+ */
+export function recallPriorMatch(
+  projectId: string,
+  issueKey: string,
+  options: BitbucketMatcherOptions = {},
+): BitbucketRepoRef | null {
+  const database = getDb(options);
+  ensureTable(database);
+  const row = database
+    .prepare(
+      'SELECT workspace, repo_slug FROM bitbucket_repo_matches WHERE project_id = ? AND issue_key = ?',
+    )
+    .get(projectId, issueKey) as { workspace: string; repo_slug: string } | undefined;
+  if (row == null) return null;
+  return { workspace: row.workspace, repoSlug: row.repo_slug };
+}
+
+/** Persist a (projectId, issueKey) → repo selection for future tick reruns. */
+export function recordMatchSelection(
+  projectId: string,
+  issueKey: string,
+  ref: BitbucketRepoRef,
+  score: number,
+  options: BitbucketMatcherOptions = {},
+): void {
+  const database = getDb(options);
+  ensureTable(database);
+  database
+    .prepare(
+      `INSERT INTO bitbucket_repo_matches (project_id, issue_key, workspace, repo_slug, score)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(project_id, issue_key) DO UPDATE SET
+         workspace = excluded.workspace,
+         repo_slug = excluded.repo_slug,
+         score = excluded.score,
+         selected_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`,
+    )
+    .run(projectId, issueKey, ref.workspace, ref.repoSlug, score);
+}
+
+/**
+ * Match a Jira issue to candidate Bitbucket repos.
+ *
+ * - When `candidates` is supplied, only those are scored.
+ * - Otherwise the matcher enumerates every repo in every configured
+ *   workspace via the connector. This is an expensive call — callers
+ *   should cache the candidate set when looping.
+ */
+export async function matchRepo(
+  issue: WorkItem,
+  connector: BitbucketConnector,
+  options: BitbucketMatcherOptions & {
+    candidates?: BitbucketRepoRef[];
+    /** Optional pre-fetched descriptions keyed by `${workspace}/${repoSlug}`. */
+    descriptions?: Record<string, string>;
+  } = {},
+): Promise<MatchResult> {
+  const workspaces = resolveWorkspaces(options);
+  if (workspaces.length === 0 && options.candidates == null) {
+    logger.warn('matchRepo invoked with no BITBUCKET_WORKSPACES and no candidates');
+    return { candidates: [], autoSelected: false, topCandidate: null };
+  }
+
+  // Enumerate candidates.
+  let candidates: BitbucketRepoRef[];
+  if (options.candidates != null) {
+    candidates = options.candidates;
+  } else {
+    candidates = [];
+    for (const workspace of workspaces) {
+      const repos = await connector.listWorkspaceRepos(workspace);
+      candidates.push(...repos);
+    }
+  }
+
+  // Prior-match check (sticky behaviour).
+  const prior = recallPriorMatch(issue.repoRef, issue.externalId, options);
+  const isPrior = (ref: BitbucketRepoRef): boolean =>
+    prior != null && prior.workspace === ref.workspace && prior.repoSlug === ref.repoSlug;
+
+  const descriptions = options.descriptions ?? {};
+
+  // Score each candidate. We fetch descriptions on demand only if not
+  // supplied; integration tests may pre-populate them.
+  const scored: MatchCandidate[] = [];
+  for (const ref of candidates) {
+    const key = `${ref.workspace}/${ref.repoSlug}`;
+    let description = descriptions[key];
+    if (description == null) {
+      try {
+        const meta = await connector.getRepoMetadata(ref);
+        description = meta?.description ?? '';
+      } catch {
+        description = '';
+      }
+    }
+    const { score, reason } = scoreCandidate(issue, ref, description, isPrior(ref));
+    scored.push({ ref, score, reason });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, 3);
+  const winner = top[0] ?? null;
+  const autoSelected = winner != null && winner.score >= 0.7;
+
+  return { candidates: top, autoSelected, topCandidate: winner };
+}

--- a/core/connectors/bitbucket.test.ts
+++ b/core/connectors/bitbucket.test.ts
@@ -1,0 +1,410 @@
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkItem } from '../state-source/interface.js';
+import {
+  matchRepo,
+  recallPriorMatch,
+  recordMatchSelection,
+  scoreCandidate,
+} from './bitbucket-matcher.js';
+import { BitbucketConnector, type BitbucketRepoRef, parseBitbucketCloneUrl } from './bitbucket.js';
+
+// ---------------------------------------------------------------------------
+// parseBitbucketCloneUrl
+// ---------------------------------------------------------------------------
+
+describe('parseBitbucketCloneUrl', () => {
+  it('parses SSH clone URLs', () => {
+    expect(parseBitbucketCloneUrl('git@bitbucket.org:my-team/payments-api.git')).toEqual({
+      workspace: 'my-team',
+      repoSlug: 'payments-api',
+    });
+  });
+
+  it('parses HTTPS clone URLs', () => {
+    expect(parseBitbucketCloneUrl('https://bitbucket.org/my-team/payments-api.git')).toEqual({
+      workspace: 'my-team',
+      repoSlug: 'payments-api',
+    });
+  });
+
+  it('parses HTTPS URLs with embedded user', () => {
+    expect(parseBitbucketCloneUrl('https://bot@bitbucket.org/my-team/payments-api.git')).toEqual({
+      workspace: 'my-team',
+      repoSlug: 'payments-api',
+    });
+  });
+
+  it('accepts URLs without the .git suffix', () => {
+    expect(parseBitbucketCloneUrl('git@bitbucket.org:my-team/payments-api')).toEqual({
+      workspace: 'my-team',
+      repoSlug: 'payments-api',
+    });
+  });
+
+  it('returns null for non-Bitbucket URLs', () => {
+    expect(parseBitbucketCloneUrl('git@github.com:foo/bar.git')).toBeNull();
+    expect(parseBitbucketCloneUrl('https://example.com/foo/bar')).toBeNull();
+    expect(parseBitbucketCloneUrl('not a url')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BitbucketConnector
+// ---------------------------------------------------------------------------
+
+function mkResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function mkTextResponse(text: string, init: { status?: number } = {}): Response {
+  return new Response(text, {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
+describe('BitbucketConnector — env validation', () => {
+  it('throws when BITBUCKET_USER is missing', () => {
+    const saved = process.env.BITBUCKET_USER;
+    // biome-ignore lint/performance/noDelete: env restore for test isolation
+    delete process.env.BITBUCKET_USER;
+    process.env.BITBUCKET_APP_PASSWORD = 'pw';
+    try {
+      expect(() => new BitbucketConnector()).toThrow(/BITBUCKET_USER/);
+    } finally {
+      if (saved !== undefined) process.env.BITBUCKET_USER = saved;
+    }
+  });
+
+  it('throws when BITBUCKET_APP_PASSWORD is missing', () => {
+    const saved = process.env.BITBUCKET_APP_PASSWORD;
+    process.env.BITBUCKET_USER = 'u';
+    // biome-ignore lint/performance/noDelete: env restore for test isolation
+    delete process.env.BITBUCKET_APP_PASSWORD;
+    try {
+      expect(() => new BitbucketConnector()).toThrow(/BITBUCKET_APP_PASSWORD/);
+    } finally {
+      if (saved !== undefined) process.env.BITBUCKET_APP_PASSWORD = saved;
+    }
+  });
+});
+
+describe('BitbucketConnector — read operations', () => {
+  const repo: BitbucketRepoRef = { workspace: 'team', repoSlug: 'payments-api' };
+
+  it('getFile returns content for a 200 response', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toContain('/repositories/team/payments-api/src/HEAD/src/index.ts');
+      return mkTextResponse('export const x = 1;');
+    });
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    const file = await connector.getFile(repo, 'src/index.ts');
+    expect(file?.content).toBe('export const x = 1;');
+    expect(file?.path).toBe('src/index.ts');
+  });
+
+  it('getFile returns null on 404', async () => {
+    const fetchImpl = vi.fn(async () => mkTextResponse('not found', { status: 404 }));
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    expect(await connector.getFile(repo, 'missing')).toBeNull();
+  });
+
+  it('searchCode maps hits with snippets and line numbers', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toContain('search_query');
+      return mkResponse({
+        values: [
+          {
+            file: { path: 'src/handler.ts' },
+            content_match_count: 1,
+            content_matches: [
+              {
+                lines: [
+                  {
+                    line: 12,
+                    segments: [
+                      { text: 'export function ' },
+                      { text: 'validate', match: true },
+                      { text: '(input)' },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    const hits = await connector.searchCode(repo, 'validate');
+    expect(hits).toEqual([
+      { path: 'src/handler.ts', snippet: 'export function validate(input)', line: 12 },
+    ]);
+  });
+
+  it('searchCode returns [] when workspace does not support /search/code (404)', async () => {
+    const fetchImpl = vi.fn(async () => mkResponse({}, { status: 404 }));
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    expect(await connector.searchCode(repo, 'anything')).toEqual([]);
+  });
+
+  it('listPullRequests maps PR fields', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mkResponse({
+        values: [
+          {
+            id: 7,
+            title: 'Add idempotency keys',
+            state: 'OPEN',
+            author: { display_name: 'Robin Reviewer' },
+            links: { html: { href: 'https://bitbucket.org/team/payments-api/pull-requests/7' } },
+            created_on: '2026-04-01T00:00:00.000Z',
+            updated_on: '2026-04-02T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    const prs = await connector.listPullRequests(repo);
+    expect(prs).toEqual([
+      {
+        id: 7,
+        title: 'Add idempotency keys',
+        state: 'OPEN',
+        authorDisplayName: 'Robin Reviewer',
+        htmlUrl: 'https://bitbucket.org/team/payments-api/pull-requests/7',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('getFile surfaces auth failures', async () => {
+    const fetchImpl = vi.fn(async () => mkResponse({}, { status: 401 }));
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    await expect(connector.getFile(repo, 'whatever')).rejects.toThrow(/authentication failed/);
+  });
+
+  it('getRepoMetadata maps name + description + mainbranch', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mkResponse({ name: 'payments-api', description: 'Bills', mainbranch: { name: 'develop' } }),
+    );
+    const connector = new BitbucketConnector({
+      authOverride: { user: 'u', appPassword: 'pw' },
+      fetchImpl,
+    });
+    expect(await connector.getRepoMetadata(repo)).toEqual({
+      name: 'payments-api',
+      description: 'Bills',
+      mainbranch: 'develop',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matcher — scoring and persistence
+// ---------------------------------------------------------------------------
+
+function mkIssue(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'jira:PAY#PAY-12',
+    externalId: 'PAY-12',
+    repoRef: 'PAY',
+    title: 'Idempotency keys not honoured by /charges',
+    body: 'When a duplicate request to /charges is sent within 30s the second call still creates a charge.',
+    type: 'bug',
+    priority: 'high',
+    mode: 'supervised',
+    state: 'factory:accepted',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('scoreCandidate', () => {
+  it('rewards project-key overlap with the repo slug', () => {
+    const issue = mkIssue();
+    const { score, reason } = scoreCandidate(issue, { workspace: 'team', repoSlug: 'pay-core' });
+    expect(score).toBeGreaterThanOrEqual(0.4);
+    expect(reason).toContain('project key');
+  });
+
+  it('combines keyword overlap with project-key match to clear the auto-select bar', () => {
+    const issue = mkIssue();
+    const { score } = scoreCandidate(
+      issue,
+      { workspace: 'team', repoSlug: 'pay-charges' },
+      'Idempotency-keyed payment processing service for charges',
+    );
+    expect(score).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it('returns a low score for unrelated repos', () => {
+    const issue = mkIssue();
+    const { score } = scoreCandidate(
+      issue,
+      { workspace: 'team', repoSlug: 'mobile-app' },
+      'Native mobile client',
+    );
+    expect(score).toBeLessThan(0.7);
+  });
+
+  it('caps the score at 1 even with a prior match', () => {
+    const issue = mkIssue();
+    const { score } = scoreCandidate(
+      issue,
+      { workspace: 'team', repoSlug: 'pay-charges' },
+      'Idempotency-keyed payment processing service for charges',
+      true,
+    );
+    expect(score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('matcher persistence — in-memory SQLite', () => {
+  let database: Database.Database;
+  beforeEach(() => {
+    database = new Database(':memory:');
+  });
+  afterEach(() => {
+    database.close();
+  });
+
+  it('records and recalls a prior match', () => {
+    expect(recallPriorMatch('PAY', 'PAY-12', { database })).toBeNull();
+    recordMatchSelection('PAY', 'PAY-12', { workspace: 'team', repoSlug: 'pay-charges' }, 0.92, {
+      database,
+    });
+    expect(recallPriorMatch('PAY', 'PAY-12', { database })).toEqual({
+      workspace: 'team',
+      repoSlug: 'pay-charges',
+    });
+  });
+
+  it('upserts an existing match when called twice', () => {
+    recordMatchSelection('PAY', 'PAY-12', { workspace: 'team', repoSlug: 'pay-charges' }, 0.6, {
+      database,
+    });
+    recordMatchSelection('PAY', 'PAY-12', { workspace: 'team', repoSlug: 'pay-core' }, 0.9, {
+      database,
+    });
+    expect(recallPriorMatch('PAY', 'PAY-12', { database })).toEqual({
+      workspace: 'team',
+      repoSlug: 'pay-core',
+    });
+  });
+});
+
+describe('matchRepo — end-to-end scoring', () => {
+  let database: Database.Database;
+  beforeEach(() => {
+    database = new Database(':memory:');
+  });
+  afterEach(() => {
+    database.close();
+  });
+
+  function mkConnector(repos: BitbucketRepoRef[], descriptions: Record<string, string> = {}) {
+    return {
+      listWorkspaceRepos: vi.fn(async () => repos),
+      getRepoMetadata: vi.fn(async (ref: BitbucketRepoRef) => ({
+        name: ref.repoSlug,
+        description: descriptions[`${ref.workspace}/${ref.repoSlug}`] ?? '',
+        mainbranch: 'main',
+      })),
+    } as unknown as BitbucketConnector;
+  }
+
+  it('auto-selects the top candidate when score >= 0.7', async () => {
+    const candidates: BitbucketRepoRef[] = [
+      { workspace: 'team', repoSlug: 'pay-charges' },
+      { workspace: 'team', repoSlug: 'mobile-app' },
+    ];
+    const connector = mkConnector(candidates, {
+      'team/pay-charges': 'Charges service with idempotency keys',
+      'team/mobile-app': 'Mobile client',
+    });
+    const result = await matchRepo(mkIssue(), connector, {
+      candidates,
+      database,
+      workspaces: ['team'],
+    });
+    expect(result.autoSelected).toBe(true);
+    expect(result.topCandidate?.ref.repoSlug).toBe('pay-charges');
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it('returns top-3 candidates ordered by score', async () => {
+    const candidates: BitbucketRepoRef[] = [
+      { workspace: 'team', repoSlug: 'pay-charges' },
+      { workspace: 'team', repoSlug: 'pay-billing' },
+      { workspace: 'team', repoSlug: 'pay-reports' },
+      { workspace: 'team', repoSlug: 'unrelated' },
+    ];
+    const connector = mkConnector(candidates);
+    const result = await matchRepo(mkIssue(), connector, {
+      candidates,
+      database,
+      workspaces: ['team'],
+    });
+    expect(result.candidates).toHaveLength(3);
+    expect(result.candidates[0].score).toBeGreaterThanOrEqual(result.candidates[1].score);
+    expect(result.candidates[1].score).toBeGreaterThanOrEqual(result.candidates[2].score);
+  });
+
+  it('falls back to no candidates when nothing scores and workspaces are empty', async () => {
+    const connector = mkConnector([]);
+    const result = await matchRepo(mkIssue(), connector, {
+      database,
+      workspaces: [],
+    });
+    expect(result.autoSelected).toBe(false);
+    expect(result.candidates).toEqual([]);
+    expect(result.topCandidate).toBeNull();
+  });
+
+  it('prior selection boosts a repo that would otherwise score below the gate', async () => {
+    const refs: BitbucketRepoRef[] = [
+      { workspace: 'team', repoSlug: 'older-repo' },
+      { workspace: 'team', repoSlug: 'pay-charges' },
+    ];
+    recordMatchSelection('PAY', 'PAY-12', refs[0], 0.55, { database });
+    const connector = mkConnector(refs, {
+      'team/older-repo': 'Legacy code',
+      'team/pay-charges': 'Charges service with idempotency keys',
+    });
+    const result = await matchRepo(mkIssue(), connector, {
+      candidates: refs,
+      database,
+      workspaces: ['team'],
+    });
+    expect(result.topCandidate?.ref.repoSlug).toBe('older-repo');
+  });
+});

--- a/core/connectors/bitbucket.ts
+++ b/core/connectors/bitbucket.ts
@@ -76,8 +76,12 @@ export class BitbucketConnector {
     };
   }
 
-  private async bbFetch(path: string): Promise<Response> {
-    const url = `https://api.bitbucket.org/2.0${path}`;
+  private async bbFetch(pathOrUrl: string): Promise<Response> {
+    // Accept an absolute Bitbucket API URL (used to follow `next` cursors
+    // during pagination) or a relative path rooted at `/2.0/...`.
+    const url = pathOrUrl.startsWith('http')
+      ? pathOrUrl
+      : `https://api.bitbucket.org/2.0${pathOrUrl}`;
     const response = await this.fetchImpl(url, { headers: this.baseHeaders });
     if (response.status === 401) {
       throw new Error(`Bitbucket API authentication failed (401) for ${url}`);
@@ -210,16 +214,25 @@ export class BitbucketConnector {
     };
   }
 
-  /** List repos under a workspace. Used by the repo-matcher. */
+  /** List repos under a workspace. Used by the repo-matcher. Follows
+   * Bitbucket's `next` cursor so workspaces with more than 100 repos
+   * are fully enumerated. */
   async listWorkspaceRepos(workspace: string): Promise<BitbucketRepoRef[]> {
-    const res = await this.bbFetch(`/repositories/${workspace}?pagelen=100`);
-    if (res.status === 404) return [];
-    const body = (await res.json()) as {
-      values?: Array<{ slug?: string; name?: string }>;
-    };
-    return (body.values ?? [])
-      .filter((v) => typeof v.slug === 'string')
-      .map((v) => ({ workspace, repoSlug: v.slug as string }));
+    const refs: BitbucketRepoRef[] = [];
+    let url: string | null = `/repositories/${workspace}?pagelen=100`;
+    while (url != null) {
+      const res = await this.bbFetch(url);
+      if (res.status === 404) return refs;
+      const body = (await res.json()) as {
+        values?: Array<{ slug?: string }>;
+        next?: string;
+      };
+      for (const v of body.values ?? []) {
+        if (typeof v.slug === 'string') refs.push({ workspace, repoSlug: v.slug });
+      }
+      url = typeof body.next === 'string' ? body.next : null;
+    }
+    return refs;
   }
 }
 

--- a/core/connectors/bitbucket.ts
+++ b/core/connectors/bitbucket.ts
@@ -1,0 +1,238 @@
+import { logger } from '../logger.js';
+
+/**
+ * Read-only Bitbucket connector (#323).
+ *
+ * Reaches a Bitbucket Cloud workspace via App Password auth and exposes
+ * the minimum surface investigation workflows need: read a file, search
+ * file content, and list PRs for context. Write operations (PR creation,
+ * comment posting) are deferred to a future milestone.
+ *
+ * Authentication: HTTP Basic with `BITBUCKET_USER` + `BITBUCKET_APP_PASSWORD`.
+ */
+
+export interface BitbucketRepoRef {
+  /** Workspace slug. */
+  workspace: string;
+  /** Repo slug. */
+  repoSlug: string;
+}
+
+export interface BitbucketFileResult {
+  path: string;
+  content: string;
+  /** Branch or commit ref the file was fetched at. */
+  ref: string;
+}
+
+export interface BitbucketSearchHit {
+  path: string;
+  snippet: string;
+  /** 1-based line number of the first hit. */
+  line: number;
+}
+
+export interface BitbucketPullRequest {
+  id: number;
+  title: string;
+  state: 'OPEN' | 'MERGED' | 'DECLINED' | 'SUPERSEDED';
+  authorDisplayName: string;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BitbucketConnectorOptions {
+  /** Override of native fetch — used by tests. */
+  fetchImpl?: typeof fetch;
+  /** Optional override of the auth string (otherwise read from env). */
+  authOverride?: { user: string; appPassword: string };
+}
+
+export class BitbucketConnector {
+  private readonly user: string;
+  private readonly appPassword: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: BitbucketConnectorOptions = {}) {
+    const user = options.authOverride?.user ?? process.env.BITBUCKET_USER;
+    const appPassword = options.authOverride?.appPassword ?? process.env.BITBUCKET_APP_PASSWORD;
+    if (user == null || user.length === 0) {
+      throw new Error('BITBUCKET_USER is required for BitbucketConnector');
+    }
+    if (appPassword == null || appPassword.length === 0) {
+      throw new Error('BITBUCKET_APP_PASSWORD is required for BitbucketConnector');
+    }
+    this.user = user;
+    this.appPassword = appPassword;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private get baseHeaders(): Record<string, string> {
+    const basic = Buffer.from(`${this.user}:${this.appPassword}`).toString('base64');
+    return {
+      Authorization: `Basic ${basic}`,
+      Accept: 'application/json',
+    };
+  }
+
+  private async bbFetch(path: string): Promise<Response> {
+    const url = `https://api.bitbucket.org/2.0${path}`;
+    const response = await this.fetchImpl(url, { headers: this.baseHeaders });
+    if (response.status === 401) {
+      throw new Error(`Bitbucket API authentication failed (401) for ${url}`);
+    }
+    if (response.status === 429) {
+      throw new Error('Bitbucket API rate limited (429)');
+    }
+    if (!response.ok && response.status !== 404) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Bitbucket API error ${response.status} for ${url}: ${text}`);
+    }
+    return response;
+  }
+
+  /**
+   * Fetch a file's contents at the repo's main branch (or specified ref).
+   * Returns `null` if the file is not found.
+   */
+  async getFile(
+    repo: BitbucketRepoRef,
+    path: string,
+    ref = 'HEAD',
+  ): Promise<BitbucketFileResult | null> {
+    const res = await this.bbFetch(
+      `/repositories/${repo.workspace}/${repo.repoSlug}/src/${encodeURIComponent(ref)}/${path}`,
+    );
+    if (res.status === 404) return null;
+    const content = await res.text();
+    return { path, content, ref };
+  }
+
+  /**
+   * Search the repo for `query`. Bitbucket's documented `/search/code`
+   * endpoint scopes searches at the workspace level — we filter results
+   * down to the requested repo. Falls back to an empty result on
+   * unsupported workspaces (some legacy ones never expose the endpoint).
+   */
+  async searchCode(
+    repo: BitbucketRepoRef,
+    query: string,
+    limit = 25,
+  ): Promise<BitbucketSearchHit[]> {
+    const params = new URLSearchParams({
+      search_query: `${query} repo:${repo.repoSlug}`,
+      pagelen: String(limit),
+    });
+    const res = await this.bbFetch(`/workspaces/${repo.workspace}/search/code?${params}`);
+    if (res.status === 404) {
+      logger.warn('bitbucket workspace does not expose /search/code', {
+        workspace: repo.workspace,
+      });
+      return [];
+    }
+    const body = (await res.json()) as {
+      values?: Array<{
+        file?: { path?: string };
+        content_match_count?: number;
+        content_matches?: Array<{
+          lines?: Array<{ line?: number; segments?: Array<{ text?: string; match?: boolean }> }>;
+        }>;
+      }>;
+    };
+    const hits: BitbucketSearchHit[] = [];
+    for (const value of body.values ?? []) {
+      const path = value.file?.path;
+      if (path == null) continue;
+      const firstLine = value.content_matches?.[0]?.lines?.[0];
+      const snippet = (firstLine?.segments ?? []).map((s) => s.text ?? '').join('');
+      hits.push({
+        path,
+        snippet,
+        line: firstLine?.line ?? 1,
+      });
+    }
+    return hits;
+  }
+
+  /**
+   * List pull requests on the repo, optionally filtered by state.
+   * Returns at most one page (Bitbucket default 50). Higher-volume callers
+   * should paginate with their own loop.
+   */
+  async listPullRequests(
+    repo: BitbucketRepoRef,
+    state: 'OPEN' | 'MERGED' | 'DECLINED' | 'all' = 'OPEN',
+  ): Promise<BitbucketPullRequest[]> {
+    const params = new URLSearchParams({ pagelen: '50' });
+    if (state !== 'all') params.set('state', state);
+    const res = await this.bbFetch(
+      `/repositories/${repo.workspace}/${repo.repoSlug}/pullrequests?${params}`,
+    );
+    if (res.status === 404) return [];
+    const body = (await res.json()) as {
+      values?: Array<{
+        id: number;
+        title: string;
+        state: BitbucketPullRequest['state'];
+        author?: { display_name?: string };
+        links?: { html?: { href?: string } };
+        created_on: string;
+        updated_on: string;
+      }>;
+    };
+    return (body.values ?? []).map((v) => ({
+      id: v.id,
+      title: v.title,
+      state: v.state,
+      authorDisplayName: v.author?.display_name ?? 'unknown',
+      htmlUrl: v.links?.html?.href ?? '',
+      createdAt: v.created_on,
+      updatedAt: v.updated_on,
+    }));
+  }
+
+  /** Fetch repo metadata. Used by the repo-matcher (#326). */
+  async getRepoMetadata(
+    repo: BitbucketRepoRef,
+  ): Promise<{ description: string; name: string; mainbranch: string } | null> {
+    const res = await this.bbFetch(`/repositories/${repo.workspace}/${repo.repoSlug}`);
+    if (res.status === 404) return null;
+    const body = (await res.json()) as {
+      name?: string;
+      description?: string;
+      mainbranch?: { name?: string };
+    };
+    return {
+      name: body.name ?? repo.repoSlug,
+      description: body.description ?? '',
+      mainbranch: body.mainbranch?.name ?? 'main',
+    };
+  }
+
+  /** List repos under a workspace. Used by the repo-matcher. */
+  async listWorkspaceRepos(workspace: string): Promise<BitbucketRepoRef[]> {
+    const res = await this.bbFetch(`/repositories/${workspace}?pagelen=100`);
+    if (res.status === 404) return [];
+    const body = (await res.json()) as {
+      values?: Array<{ slug?: string; name?: string }>;
+    };
+    return (body.values ?? [])
+      .filter((v) => typeof v.slug === 'string')
+      .map((v) => ({ workspace, repoSlug: v.slug as string }));
+  }
+}
+
+/**
+ * Parse a Bitbucket clone URL (SSH or HTTPS) into a `BitbucketRepoRef`.
+ * Returns `null` if the URL is not a Bitbucket clone URL.
+ */
+export function parseBitbucketCloneUrl(url: string): BitbucketRepoRef | null {
+  // SSH: git@bitbucket.org:workspace/repo.git
+  const ssh = url.match(/^git@bitbucket\.org:([^/]+)\/(.+?)(?:\.git)?$/);
+  if (ssh != null) return { workspace: ssh[1], repoSlug: ssh[2] };
+  // HTTPS: https://bitbucket.org/workspace/repo.git OR https://user@bitbucket.org/workspace/repo.git
+  const https = url.match(/^https:\/\/(?:[^@]+@)?bitbucket\.org\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (https != null) return { workspace: https[1], repoSlug: https[2] };
+  return null;
+}

--- a/core/connectors/confluence.test.ts
+++ b/core/connectors/confluence.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  extractConfluenceLinks,
+  labelForConfluenceRef,
+  makeConfluenceFetcher,
+} from './confluence.js';
+
+describe('extractConfluenceLinks', () => {
+  it('returns an empty array for empty input', () => {
+    expect(extractConfluenceLinks('')).toEqual([]);
+  });
+
+  it('detects a single Confluence URL with slug', () => {
+    const body =
+      'See https://example.atlassian.net/wiki/spaces/PROD/pages/12345/Onboarding+Guide for context.';
+    expect(extractConfluenceLinks(body)).toEqual([
+      {
+        url: 'https://example.atlassian.net/wiki/spaces/PROD/pages/12345/Onboarding+Guide',
+        pageId: '12345',
+        slug: 'Onboarding Guide',
+      },
+    ]);
+  });
+
+  it('detects Confluence URLs without a slug', () => {
+    const body = 'See https://example.atlassian.net/wiki/spaces/PROD/pages/77 for context.';
+    expect(extractConfluenceLinks(body)).toEqual([
+      {
+        url: 'https://example.atlassian.net/wiki/spaces/PROD/pages/77',
+        pageId: '77',
+        slug: null,
+      },
+    ]);
+  });
+
+  it('detects multiple URLs and dedupes exact repeats', () => {
+    const body = `
+      first: https://example.atlassian.net/wiki/spaces/A/pages/1/One
+      second: https://example.atlassian.net/wiki/spaces/B/pages/2/Two
+      first again: https://example.atlassian.net/wiki/spaces/A/pages/1/One
+    `;
+    const refs = extractConfluenceLinks(body);
+    expect(refs.map((r) => r.pageId)).toEqual(['1', '2']);
+  });
+
+  it('ignores non-Confluence URLs', () => {
+    const body =
+      'See https://github.com/shaunnez/goose-hub or https://example.com/wiki/pages/1/Page.';
+    expect(extractConfluenceLinks(body)).toEqual([]);
+  });
+
+  it('tolerates URL-encoded slugs', () => {
+    const body = 'https://example.atlassian.net/wiki/spaces/X/pages/9/A%20Page%20Name';
+    const [ref] = extractConfluenceLinks(body);
+    expect(ref.slug).toBe('A Page Name');
+  });
+});
+
+describe('labelForConfluenceRef', () => {
+  it('renders fetched title when available', () => {
+    expect(
+      labelForConfluenceRef(
+        {
+          url: 'https://example.atlassian.net/wiki/spaces/X/pages/9/Some+Page',
+          pageId: '9',
+          slug: 'Some Page',
+        },
+        'Real Title',
+      ),
+    ).toBe('Confluence: Real Title');
+  });
+
+  it('falls back to slug when title is null', () => {
+    expect(
+      labelForConfluenceRef(
+        {
+          url: 'https://example.atlassian.net/wiki/spaces/X/pages/9/Some+Page',
+          pageId: '9',
+          slug: 'Some Page',
+        },
+        null,
+      ),
+    ).toBe('Confluence: Some Page');
+  });
+
+  it('falls back to page id when title and slug are both unavailable', () => {
+    expect(
+      labelForConfluenceRef(
+        {
+          url: 'https://example.atlassian.net/wiki/spaces/X/pages/9',
+          pageId: '9',
+          slug: null,
+        },
+        null,
+      ),
+    ).toBe('Confluence: 9');
+  });
+});
+
+describe('makeConfluenceFetcher', () => {
+  it('returns null when CONFLUENCE_HOST is unset', () => {
+    expect(makeConfluenceFetcher({ host: '', user: 'u', apiToken: 't' })).toBeNull();
+  });
+
+  it('returns null when CONFLUENCE_API_TOKEN is unset', () => {
+    expect(
+      makeConfluenceFetcher({
+        host: 'https://example.atlassian.net',
+        user: 'u',
+        apiToken: '',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when CONFLUENCE_USER / JIRA_USER are unset', () => {
+    expect(
+      makeConfluenceFetcher({
+        host: 'https://example.atlassian.net',
+        apiToken: 't',
+        user: '',
+      }),
+    ).toBeNull();
+  });
+
+  it('fetches the page title via the REST API when credentials are present', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      expect(url).toBe('https://example.atlassian.net/wiki/rest/api/content/42?expand=');
+      return new Response(JSON.stringify({ title: 'Hello' }), { status: 200 });
+    });
+    const fetcher = makeConfluenceFetcher({
+      host: 'https://example.atlassian.net/',
+      user: 'agent@example.com',
+      apiToken: 'tok',
+      fetchImpl,
+    });
+    expect(fetcher).not.toBeNull();
+    expect(await fetcher?.fetchTitle('42')).toBe('Hello');
+  });
+
+  it('returns null on non-OK API response', async () => {
+    const fetchImpl = vi.fn(async () => new Response('not found', { status: 404 }));
+    const fetcher = makeConfluenceFetcher({
+      host: 'https://example.atlassian.net',
+      user: 'u',
+      apiToken: 't',
+      fetchImpl,
+    });
+    expect(await fetcher?.fetchTitle('42')).toBeNull();
+  });
+});

--- a/core/connectors/confluence.ts
+++ b/core/connectors/confluence.ts
@@ -1,0 +1,114 @@
+/**
+ * Confluence URL detection + optional page-title fetching (#324).
+ *
+ * Goose Hub does not ingest Confluence content end-to-end — that's
+ * deferred. M14.05 only adds the surface needed to render Confluence
+ * URLs in issue bodies and comments as labelled links ("Confluence:
+ * <title>") rather than raw URLs.
+ *
+ * Detection is purely regex-based. The optional `fetchConfluencePageTitle`
+ * helper hits the Confluence REST API when both `CONFLUENCE_HOST` and
+ * `CONFLUENCE_API_TOKEN` are present, otherwise returns `null` so the UI
+ * can fall back to the URL path.
+ */
+
+/**
+ * Matches absolute Confluence Cloud URLs. Two canonical shapes are
+ * supported:
+ *
+ *   https://example.atlassian.net/wiki/spaces/SPACE/pages/12345/Page+Title
+ *   https://example.atlassian.net/wiki/spaces/SPACE/pages/12345
+ *
+ * Self-hosted servers using `/display/SPACE/Page+Title` are deferred.
+ */
+const CONFLUENCE_URL_PATTERN =
+  /https:\/\/[a-z0-9.-]+\.atlassian\.net\/wiki\/spaces\/[A-Za-z0-9_-]+\/pages\/(\d+)(?:\/[^\s)\]]*)?/g;
+
+export interface ConfluencePageRef {
+  /** Full URL exactly as it appeared in the text. */
+  url: string;
+  /** Numeric page id parsed from the URL. */
+  pageId: string;
+  /** Human-friendly slug extracted from the URL trailing path, if any. */
+  slug: string | null;
+}
+
+/**
+ * Find all Confluence URLs in a markdown / plain-text body. Duplicate
+ * URLs are deduplicated by their full string match (order preserved).
+ */
+export function extractConfluenceLinks(body: string): ConfluencePageRef[] {
+  if (typeof body !== 'string' || body.length === 0) return [];
+  const seen = new Set<string>();
+  const refs: ConfluencePageRef[] = [];
+  for (const match of body.matchAll(CONFLUENCE_URL_PATTERN)) {
+    const url = match[0];
+    if (seen.has(url)) continue;
+    seen.add(url);
+    const pageId = match[1];
+    const slug = extractSlugFromUrl(url);
+    refs.push({ url, pageId, slug });
+  }
+  return refs;
+}
+
+function extractSlugFromUrl(url: string): string | null {
+  const match = url.match(/\/pages\/\d+\/(.+)$/);
+  if (match == null) return null;
+  return decodeURIComponent(match[1])
+    .replace(/\+/g, ' ')
+    .replace(/[?#].*$/, '')
+    .trim();
+}
+
+export interface ConfluenceTitleFetcher {
+  /** Returns the page title for `pageId`, or null if unavailable. */
+  fetchTitle(pageId: string): Promise<string | null>;
+}
+
+export interface ConfluenceFetcherOptions {
+  fetchImpl?: typeof fetch;
+  host?: string;
+  user?: string;
+  apiToken?: string;
+}
+
+/**
+ * Build a fetcher backed by the Confluence Cloud v1 REST API. Returns
+ * `null` when credentials are not available — callers must check for
+ * null and fall back to the URL path.
+ */
+export function makeConfluenceFetcher(
+  options: ConfluenceFetcherOptions = {},
+): ConfluenceTitleFetcher | null {
+  const host = (options.host ?? process.env.CONFLUENCE_HOST ?? '').replace(/\/$/, '');
+  const apiToken = options.apiToken ?? process.env.CONFLUENCE_API_TOKEN;
+  const user = options.user ?? process.env.CONFLUENCE_USER ?? process.env.JIRA_USER;
+  if (host.length === 0 || apiToken == null || apiToken.length === 0) return null;
+  if (user == null || user.length === 0) return null;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const basic = Buffer.from(`${user}:${apiToken}`).toString('base64');
+
+  return {
+    async fetchTitle(pageId: string): Promise<string | null> {
+      const res = await fetchImpl(`${host}/wiki/rest/api/content/${pageId}?expand=`, {
+        headers: { Authorization: `Basic ${basic}`, Accept: 'application/json' },
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as { title?: string };
+      return typeof body.title === 'string' ? body.title : null;
+    },
+  };
+}
+
+/**
+ * Render the labelled link text for a Confluence reference. Uses the
+ * fetched title when available, otherwise falls back to the slug, then
+ * the page id. Always prefixed with "Confluence: " so the user sees the
+ * source at a glance.
+ */
+export function labelForConfluenceRef(ref: ConfluencePageRef, title: string | null): string {
+  const display = (title ?? ref.slug ?? ref.pageId).trim();
+  return `Confluence: ${display}`;
+}

--- a/core/connectors/confluence.ts
+++ b/core/connectors/confluence.ts
@@ -20,9 +20,14 @@
  *   https://example.atlassian.net/wiki/spaces/SPACE/pages/12345
  *
  * Self-hosted servers using `/display/SPACE/Page+Title` are deferred.
+ *
+ * The trailing-slug class deliberately excludes common sentence-boundary
+ * punctuation (`,`, `.`, `!`, `?`, `;`, `"`, `'`, `<`, `>`) so links
+ * pasted inline at the end of a sentence don't include the trailing
+ * stop / quote in the matched URL.
  */
 const CONFLUENCE_URL_PATTERN =
-  /https:\/\/[a-z0-9.-]+\.atlassian\.net\/wiki\/spaces\/[A-Za-z0-9_-]+\/pages\/(\d+)(?:\/[^\s)\]]*)?/g;
+  /https:\/\/[a-z0-9.-]+\.atlassian\.net\/wiki\/spaces\/[A-Za-z0-9_-]+\/pages\/(\d+)(?:\/[^\s)\],.!?;"'<>]*)?/g;
 
 export interface ConfluencePageRef {
   /** Full URL exactly as it appeared in the text. */
@@ -55,7 +60,16 @@ export function extractConfluenceLinks(body: string): ConfluencePageRef[] {
 function extractSlugFromUrl(url: string): string | null {
   const match = url.match(/\/pages\/\d+\/(.+)$/);
   if (match == null) return null;
-  return decodeURIComponent(match[1])
+  // decodeURIComponent throws URIError on malformed `%` sequences (e.g.
+  // a stray `%` typed mid-sentence). Fall back to the raw segment so a
+  // single bad URL doesn't break extraction for the whole panel.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(match[1]);
+  } catch {
+    decoded = match[1];
+  }
+  return decoded
     .replace(/\+/g, ' ')
     .replace(/[?#].*$/, '')
     .trim();

--- a/core/projects/loader.ts
+++ b/core/projects/loader.ts
@@ -19,6 +19,43 @@ const DEFAULT_PROJECTS_ROOT = path.resolve(
 const cache = new Map<string, ProjectConfig>();
 
 /**
+ * Work-mode machine scoping (M14.06 / #325).
+ *
+ * Work projects (Jira-backed) are restricted to machines where the user
+ * has explicitly opted in via `WORK_MACHINE=true`. On any other machine
+ * these projects are hidden from `loadProjects` output so the UI, CLI,
+ * and scheduler all converge on the same answer: Work projects don't
+ * exist here.
+ *
+ * The gate fires once per process — `recordWorkMachineGate` ensures we
+ * emit the startup log message exactly once instead of on every reload.
+ */
+export function isWorkMachine(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.WORK_MACHINE === 'true';
+}
+
+/** Projects whose source requires WORK_MACHINE to be set. Tolerant of
+ * partial test fixtures that omit `source` entirely. */
+export function projectRequiresWorkMachine(cfg: ProjectConfig): boolean {
+  return cfg.source?.kind === 'jira';
+}
+
+let workMachineLogFired = false;
+
+function logWorkMachineGate(filteredCount: number): void {
+  if (workMachineLogFired) return;
+  workMachineLogFired = true;
+  if (filteredCount > 0) {
+    logger.info('WORK_MACHINE not set — Work projects hidden', { filteredCount });
+  }
+}
+
+/** Reset the one-shot log latch. Test-only. */
+export function resetWorkMachineGateForTests(): void {
+  workMachineLogFired = false;
+}
+
+/**
  * Throws DuplicateSlugError if any two configs share the same slug.
  * Exported for isolated testing.
  */
@@ -34,6 +71,12 @@ export function detectDuplicateSlugs(configs: ProjectConfig[]): void {
  * Load all registered project configs from disk.
  * Missing or malformed configs are skipped with a warning.
  * Throws DuplicateSlugError if two projects share the same slug.
+ *
+ * Work projects (Jira-backed) are filtered out unless `WORK_MACHINE=true`
+ * (M14.06 / #325). The filter is applied AFTER duplicate detection so
+ * that adding a Jira-backed project to a machine without the env var
+ * still surfaces a duplicate-slug bug at startup rather than silently
+ * masking it.
  */
 export async function loadProjects(projectsRoot = DEFAULT_PROJECTS_ROOT): Promise<ProjectConfig[]> {
   let entries: string[];
@@ -59,18 +102,32 @@ export async function loadProjects(projectsRoot = DEFAULT_PROJECTS_ROOT): Promis
   }
 
   detectDuplicateSlugs(configs);
+
+  if (!isWorkMachine()) {
+    const filtered = configs.filter((c) => projectRequiresWorkMachine(c));
+    if (filtered.length > 0) {
+      logWorkMachineGate(filtered.length);
+      return configs.filter((c) => !projectRequiresWorkMachine(c));
+    }
+  }
   return configs;
 }
 
 /**
  * Load a single project config by slug.
- * Returns null if the project directory or config file does not exist.
+ * Returns null if the project directory or config file does not exist,
+ * OR if the project requires WORK_MACHINE and the env var is unset.
+ * Bypassing the gate at this level would re-introduce Work projects via
+ * any code path that looks them up by slug.
  */
 export async function getProjectBySlug(
   slug: string,
   projectsRoot = DEFAULT_PROJECTS_ROOT,
 ): Promise<ProjectConfig | null> {
-  return loadOne(slug, path.join(projectsRoot, slug));
+  const cfg = await loadOne(slug, path.join(projectsRoot, slug));
+  if (cfg == null) return null;
+  if (projectRequiresWorkMachine(cfg) && !isWorkMachine()) return null;
+  return cfg;
 }
 
 async function loadOne(slug: string, dir: string): Promise<ProjectConfig | null> {

--- a/core/projects/scheduler.ts
+++ b/core/projects/scheduler.ts
@@ -1,5 +1,6 @@
 import { logger } from '../logger.js';
 import type { ProjectConfig } from '../types.js';
+import { isWorkMachine, projectRequiresWorkMachine } from './loader.js';
 
 const DEFAULT_TICK_INTERVAL_SECONDS = 60;
 
@@ -16,14 +17,27 @@ export interface ProjectScheduler {
  * prevent project B's timer from firing. The caller is responsible for any
  * per-project locking inside `tickFn` (dispatch.ts handles this via its
  * per-slug in-flight sets).
+ *
+ * Work-mode (M14.06 / #325): if any Jira-backed project sneaks through the
+ * loader filter on a non-Work machine the scheduler refuses to create its
+ * timer and logs a warning. The loader is the primary gate; this is a
+ * defence-in-depth check.
  */
 export function startPerProjectScheduler(
   projects: ProjectConfig[],
   tickFn: (slug: string) => Promise<void>,
 ): ProjectScheduler {
   const timers = new Map<string, ReturnType<typeof setInterval>>();
+  const workMachine = isWorkMachine();
 
   for (const project of projects) {
+    if (!workMachine && projectRequiresWorkMachine(project)) {
+      logger.warn('refusing to schedule Jira-backed project — WORK_MACHINE not set', {
+        slug: project.slug,
+      });
+      continue;
+    }
+
     const intervalMs = (project.tickIntervalSeconds ?? DEFAULT_TICK_INTERVAL_SECONDS) * 1000;
 
     const timer = setInterval(() => {

--- a/core/projects/slice.test.ts
+++ b/core/projects/slice.test.ts
@@ -212,4 +212,71 @@ describe('startPerProjectScheduler', () => {
     const scheduler = startPerProjectScheduler([], async () => {});
     expect(() => scheduler.stop()).not.toThrow();
   });
+
+  it('refuses to schedule jira-backed projects when WORK_MACHINE is unset (M14.06)', async () => {
+    const saved = process.env.WORK_MACHINE;
+    // biome-ignore lint/performance/noDelete: env restore for test isolation
+    delete process.env.WORK_MACHINE;
+    try {
+      const ticks: string[] = [];
+      const projects = [
+        { slug: 'gh-project', source: { kind: 'github' } } as unknown as ProjectConfig,
+        { slug: 'work-project', source: { kind: 'jira' } } as unknown as ProjectConfig,
+      ];
+      const scheduler = startPerProjectScheduler(projects, async (slug) => {
+        ticks.push(slug);
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(ticks).toContain('gh-project');
+      expect(ticks).not.toContain('work-project');
+      scheduler.stop();
+    } finally {
+      if (saved !== undefined) process.env.WORK_MACHINE = saved;
+    }
+  });
+
+  it('schedules jira-backed projects when WORK_MACHINE=true (M14.06)', async () => {
+    const saved = process.env.WORK_MACHINE;
+    process.env.WORK_MACHINE = 'true';
+    try {
+      const ticks: string[] = [];
+      const projects = [
+        { slug: 'work-project', source: { kind: 'jira' } } as unknown as ProjectConfig,
+      ];
+      const scheduler = startPerProjectScheduler(projects, async (slug) => {
+        ticks.push(slug);
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(ticks).toContain('work-project');
+      scheduler.stop();
+    } finally {
+      // biome-ignore lint/performance/noDelete: env restore for test isolation
+      if (saved === undefined) delete process.env.WORK_MACHINE;
+      else process.env.WORK_MACHINE = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Work-machine gate (M14.06 / #325)
+// ---------------------------------------------------------------------------
+
+describe('work-machine gate', () => {
+  it('isWorkMachine returns true only when env is exactly "true"', async () => {
+    const { isWorkMachine } = await import('./loader.js');
+    expect(isWorkMachine({ WORK_MACHINE: 'true' })).toBe(true);
+    expect(isWorkMachine({ WORK_MACHINE: 'TRUE' })).toBe(false);
+    expect(isWorkMachine({ WORK_MACHINE: '1' })).toBe(false);
+    expect(isWorkMachine({})).toBe(false);
+  });
+
+  it('projectRequiresWorkMachine flags Jira sources', async () => {
+    const { projectRequiresWorkMachine } = await import('./loader.js');
+    expect(
+      projectRequiresWorkMachine({ source: { kind: 'jira' } } as unknown as ProjectConfig),
+    ).toBe(true);
+    expect(
+      projectRequiresWorkMachine({ source: { kind: 'github' } } as unknown as ProjectConfig),
+    ).toBe(false);
+  });
 });

--- a/core/state-source/README.md
+++ b/core/state-source/README.md
@@ -1,6 +1,6 @@
 # core/state-source
 
-Adapter layer between Goose Hub and the source of truth for work items (currently GitHub Issues; Jira lands in M14).
+Adapter layer between Goose Hub and the source of truth for work items. Two backends are supported: GitHub Issues (default) and Jira (M14).
 
 ## Modules
 
@@ -50,9 +50,36 @@ Lifecycle (open/closed) is read straight from the GitHub issues endpoint inside 
 - Read methods (`listOpenWork`, `getItem`, `listMilestones`, `getActiveMilestone`) are implemented in M1.
 - Write methods (`transitionState`, `comment`, `attach`, `createIssue`, `watchForUpdates`) throw `NotImplementedError` in M1; wired up in M2.
 
+### `jira.ts` (M14.01 / #322)
+
+`JiraStateSource` — `StateSource` backed by the Atlassian Cloud REST API v3.
+
+- Reads issues via `GET /rest/api/3/search` with a JQL query scoped to the
+  configured project key + `issuetype in (Story, Bug, Task)` (configurable
+  via `JiraSourceConfig.issueTypes`).
+- HTTP Basic auth from `JIRA_HOST`, `JIRA_USER`, `JIRA_API_TOKEN`. The
+  constructor throws if any of these are unset — no silent fallback.
+- Status is mapped to `factory:*` state via `jira-state-map.ts`; per-project
+  overrides live on `JiraSourceConfig.statusMap` (#327).
+- Jira has no native milestone primitive; `listMilestones()` synthesises a
+  single milestone covering open + closed counts so milestone-aware code
+  paths in the orchestrator don't need to branch on `source.kind`.
+- Bodies are ADF documents; `adfFromMarkdown` / `adfToText` handle the
+  document conversion. Rich formatting is deferred.
+- `transitionStatus()` looks up the Jira transition id for the target
+  status and POSTs `POST /rest/api/3/issue/{key}/transitions`. Missing
+  transitions log a warning and skip rather than throw.
+
+### `jira-state-map.ts` (M14.02 / #327)
+
+Default Jira status → `factory:*` mapping plus helpers
+(`jiraStatusToState`, `factoryStateToJiraStatus`). Defaults cover the
+canonical Atlassian workflow (To Do, In Progress, In Review, Done,
+Blocked) and accept per-project overrides merged on top.
+
 ## Consumers
 
 - `apps/cli` — `goose status <slug>` (read-only).
 - `apps/server` — REST + SSE routes (M2).
 
-Slices and surface code must go through `StateSource`; never call the GitHub API directly.
+Slices and surface code must go through `StateSource`; never call the GitHub or Jira APIs directly.

--- a/core/state-source/dependency-resolver.test.ts
+++ b/core/state-source/dependency-resolver.test.ts
@@ -254,7 +254,9 @@ describe('createProjectAwareTargetSource', () => {
     const fetch = await createProjectAwareTargetSource({
       projects: [makeProject('shaunnez/goose-hub'), makeProject('shaunnez/other-repo')],
       fetchTargetForProject: (p) =>
-        p.source.repo === 'shaunnez/goose-hub' ? goosehubFetcher : otherFetcher,
+        p.source.kind === 'github' && p.source.repo === 'shaunnez/goose-hub'
+          ? goosehubFetcher
+          : otherFetcher,
     });
 
     const result = await fetch('shaunnez/other-repo', 99);

--- a/core/state-source/dependency-resolver.ts
+++ b/core/state-source/dependency-resolver.ts
@@ -142,6 +142,11 @@ export async function createProjectAwareTargetSource(
   const fetchers = new Map<string, ProjectIssueFetcher>();
 
   for (const project of projects) {
+    // Dependency resolution is GitHub-only — Jira-backed projects don't
+    // participate in cross-repo dep tracking yet (M14 ships Work Mode read
+    // surfaces only). Skip non-github sources to avoid widening the map
+    // with a non-functional key.
+    if (project.source.kind !== 'github') continue;
     const repoRef = project.source.repo;
     const fetcher =
       options.fetchTargetForProject != null

--- a/core/state-source/jira-state-map.ts
+++ b/core/state-source/jira-state-map.ts
@@ -1,0 +1,65 @@
+import { logger } from '../logger.js';
+import type { StateName } from '../state-machine/states.js';
+
+/**
+ * Default mapping from Jira workflow status strings to factory:* state
+ * labels. Keys are case-sensitive Jira status names (as returned by the
+ * Jira API). Per-project overrides may augment or replace any entry.
+ *
+ * The mapping is intentionally minimal — Jira deployments vary widely.
+ * Projects supply overrides via `JiraSourceConfig.statusMap` when their
+ * workflow uses different status names.
+ */
+export const DEFAULT_JIRA_STATE_MAP: Record<string, StateName> = {
+  'To Do': 'factory:accepted',
+  Open: 'factory:accepted',
+  Backlog: 'factory:accepted',
+  'In Progress': 'factory:in-progress',
+  'In Review': 'factory:needs-review',
+  'Code Review': 'factory:needs-review',
+  Done: 'factory:done',
+  Closed: 'factory:done',
+  Resolved: 'factory:done',
+  Blocked: 'factory:needs-human',
+};
+
+/**
+ * Resolve a Jira status string to the corresponding factory:* state.
+ * Unmapped statuses log a warning and fall back to `factory:accepted` so
+ * the orchestrator can keep processing without crashing.
+ */
+export function jiraStatusToState(status: string, overrides?: Record<string, string>): StateName {
+  const map: Record<string, StateName> = {
+    ...DEFAULT_JIRA_STATE_MAP,
+    ...((overrides ?? {}) as Record<string, StateName>),
+  };
+  const mapped = map[status];
+  if (mapped == null) {
+    logger.warn('unmapped jira status — defaulting to factory:accepted', { status });
+    return 'factory:accepted';
+  }
+  return mapped;
+}
+
+/**
+ * Reverse-map factory state → Jira status string. Used when transitioning
+ * a Jira issue: the orchestrator knows the factory state it wants, this
+ * helper returns the Jira status name to ask Jira to transition to.
+ *
+ * Returns `null` if no Jira status maps to the requested state under the
+ * resolved map. Callers should treat this as an unsupported transition
+ * and log/skip rather than crash.
+ */
+export function factoryStateToJiraStatus(
+  state: StateName,
+  overrides?: Record<string, string>,
+): string | null {
+  const map: Record<string, StateName> = {
+    ...DEFAULT_JIRA_STATE_MAP,
+    ...((overrides ?? {}) as Record<string, StateName>),
+  };
+  for (const [jiraStatus, mappedState] of Object.entries(map)) {
+    if (mappedState === state) return jiraStatus;
+  }
+  return null;
+}

--- a/core/state-source/jira.slice.test.ts
+++ b/core/state-source/jira.slice.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_JIRA_STATE_MAP,
+  factoryStateToJiraStatus,
+  jiraStatusToState,
+} from './jira-state-map.js';
+import {
+  type JiraIssueRaw,
+  JiraStateSource,
+  adfFromMarkdown,
+  adfToText,
+  parseJiraKey,
+} from './jira.js';
+
+const ENV_KEYS = ['JIRA_HOST', 'JIRA_USER', 'JIRA_API_TOKEN'] as const;
+
+function withJiraEnv<T>(fn: () => T): T {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.JIRA_HOST = 'https://example.atlassian.net';
+  process.env.JIRA_USER = 'agent@example.com';
+  process.env.JIRA_API_TOKEN = 'token-xyz';
+  try {
+    return fn();
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+function mkResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+function mkIssue(overrides: Partial<JiraIssueRaw['fields']> = {}, key = 'PROJ-1'): JiraIssueRaw {
+  return {
+    id: '10001',
+    key,
+    fields: {
+      summary: 'A ticket',
+      description: 'Body',
+      issuetype: { name: 'Story' },
+      priority: { name: 'Medium' },
+      status: { name: 'To Do' },
+      reporter: { accountId: 'acc-1', emailAddress: 'reporter@example.com' },
+      created: '2026-05-01T00:00:00.000Z',
+      ...overrides,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// jira-state-map
+// ---------------------------------------------------------------------------
+
+describe('jira-state-map', () => {
+  it('default mapping covers the documented Jira statuses', () => {
+    expect(DEFAULT_JIRA_STATE_MAP['To Do']).toBe('factory:accepted');
+    expect(DEFAULT_JIRA_STATE_MAP['In Progress']).toBe('factory:in-progress');
+    expect(DEFAULT_JIRA_STATE_MAP['In Review']).toBe('factory:needs-review');
+    expect(DEFAULT_JIRA_STATE_MAP.Done).toBe('factory:done');
+    expect(DEFAULT_JIRA_STATE_MAP.Blocked).toBe('factory:needs-human');
+  });
+
+  it('jiraStatusToState applies per-project overrides over defaults', () => {
+    const overrides = { Triage: 'factory:triaging' };
+    expect(jiraStatusToState('Triage', overrides)).toBe('factory:triaging');
+    // Default still wins for un-overridden statuses.
+    expect(jiraStatusToState('Done', overrides)).toBe('factory:done');
+  });
+
+  it('unmapped status falls back to factory:accepted', () => {
+    expect(jiraStatusToState('Some Custom Status')).toBe('factory:accepted');
+  });
+
+  it('factoryStateToJiraStatus reverse-maps a state', () => {
+    expect(factoryStateToJiraStatus('factory:in-progress')).toBe('In Progress');
+  });
+
+  it('factoryStateToJiraStatus returns null for unmapped states', () => {
+    expect(factoryStateToJiraStatus('factory:retrospecting')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseJiraKey
+// ---------------------------------------------------------------------------
+
+describe('parseJiraKey', () => {
+  it('extracts the key from a normalised id', () => {
+    expect(parseJiraKey('jira:PROJ#PROJ-42')).toBe('PROJ-42');
+  });
+
+  it('passes through a bare key', () => {
+    expect(parseJiraKey('PROJ-42')).toBe('PROJ-42');
+  });
+
+  it('throws on garbage input', () => {
+    expect(() => parseJiraKey('not-a-key')).toThrow(/Invalid Jira itemId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADF helpers
+// ---------------------------------------------------------------------------
+
+describe('ADF helpers', () => {
+  it('roundtrips plain text through ADF', () => {
+    const doc = adfFromMarkdown('hello world');
+    expect(adfToText(doc)).toBe('hello world');
+  });
+
+  it('flattens nested ADF documents', () => {
+    const adf = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello ' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'world' }] },
+      ],
+    };
+    expect(adfToText(adf)).toBe('hello world');
+  });
+
+  it('tolerates legacy string description fields', () => {
+    expect(adfToText('legacy plain string')).toBe('legacy plain string');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(adfToText(null)).toBe('');
+    expect(adfToText(undefined)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JiraStateSource — env validation
+// ---------------------------------------------------------------------------
+
+describe('JiraStateSource — env validation', () => {
+  it('throws when JIRA_HOST is missing', () => {
+    const saved = process.env.JIRA_HOST;
+    // biome-ignore lint/performance/noDelete: env restore for test isolation
+    delete process.env.JIRA_HOST;
+    process.env.JIRA_USER = 'u';
+    process.env.JIRA_API_TOKEN = 't';
+    try {
+      expect(() => new JiraStateSource('p', 'PROJ')).toThrow(/JIRA_HOST/);
+    } finally {
+      if (saved !== undefined) process.env.JIRA_HOST = saved;
+    }
+  });
+
+  it('throws when JIRA_USER is missing', () => {
+    withJiraEnv(() => {
+      // biome-ignore lint/performance/noDelete: env restore for test isolation
+      delete process.env.JIRA_USER;
+      expect(() => new JiraStateSource('p', 'PROJ')).toThrow(/JIRA_USER/);
+    });
+  });
+
+  it('throws when JIRA_API_TOKEN is missing', () => {
+    withJiraEnv(() => {
+      // biome-ignore lint/performance/noDelete: env restore for test isolation
+      delete process.env.JIRA_API_TOKEN;
+      expect(() => new JiraStateSource('p', 'PROJ')).toThrow(/JIRA_API_TOKEN/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JiraStateSource — listOpenWork / getItem (cassette-driven)
+// ---------------------------------------------------------------------------
+
+describe('JiraStateSource — read paths against recorded cassettes', () => {
+  it('listOpenWork maps Jira issues to WorkItems', async () => {
+    await withJiraEnv(async () => {
+      const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        expect(url).toContain('/rest/api/3/search');
+        expect(url).toContain('project%20%3D%20PROJ');
+        expect(url).toContain('issuetype%20in');
+        return mkResponse({
+          issues: [
+            mkIssue({}, 'PROJ-1'),
+            mkIssue(
+              {
+                summary: 'A bug',
+                issuetype: { name: 'Bug' },
+                priority: { name: 'High' },
+                status: { name: 'In Progress' },
+              },
+              'PROJ-2',
+            ),
+          ],
+          total: 2,
+          startAt: 0,
+          maxResults: 50,
+        });
+      });
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      const items = await source.listOpenWork();
+      expect(items).toHaveLength(2);
+      expect(items[0]).toMatchObject({
+        externalId: 'PROJ-1',
+        id: 'jira:PROJ#PROJ-1',
+        title: 'A ticket',
+        type: 'feature',
+        priority: 'medium',
+        state: 'factory:accepted',
+      });
+      expect(items[1]).toMatchObject({
+        externalId: 'PROJ-2',
+        type: 'bug',
+        priority: 'high',
+        state: 'factory:in-progress',
+      });
+    });
+  });
+
+  it('getItem fetches a single Jira issue by key', async () => {
+    await withJiraEnv(async () => {
+      const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+        expect(String(input)).toContain('/rest/api/3/issue/PROJ-7');
+        return mkResponse(mkIssue({ summary: 'specific', status: { name: 'Done' } }, 'PROJ-7'));
+      });
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      const item = await source.getItem('jira:PROJ#PROJ-7');
+      expect(item.title).toBe('specific');
+      expect(item.state).toBe('factory:done');
+    });
+  });
+
+  it('throws on auth failure', async () => {
+    await withJiraEnv(async () => {
+      const fetchImpl = vi.fn(async () => mkResponse({}, { status: 401 }));
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      await expect(source.listOpenWork()).rejects.toThrow(/authentication failed/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JiraStateSource — comment / transition / mutate paths
+// ---------------------------------------------------------------------------
+
+describe('JiraStateSource — write paths', () => {
+  it('comment posts ADF body to Jira', async () => {
+    await withJiraEnv(async () => {
+      let captured: { url: string; body: unknown } | null = null;
+      const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        captured = { url: String(input), body: JSON.parse(String(init?.body ?? '{}')) };
+        return mkResponse({});
+      });
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      await source.comment('jira:PROJ#PROJ-1', 'Hello');
+      expect(captured).not.toBeNull();
+      const body = (captured as unknown as { body: { body: { content: unknown[] } } }).body;
+      expect(body.body.content).toHaveLength(1);
+    });
+  });
+
+  it('transitionStatus looks up the transition id and POSTs it', async () => {
+    await withJiraEnv(async () => {
+      const calls: string[] = [];
+      const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        calls.push(`${init?.method ?? 'GET'} ${url}`);
+        if (url.includes('/transitions') && (init?.method ?? 'GET') === 'GET') {
+          return mkResponse({
+            transitions: [
+              { id: '31', name: 'Start Progress', to: { name: 'In Progress' } },
+              { id: '41', name: 'Done', to: { name: 'Done' } },
+            ],
+          });
+        }
+        if (url.includes('/transitions') && init?.method === 'POST') {
+          const parsed = JSON.parse(String(init.body));
+          expect(parsed.transition.id).toBe('31');
+          return mkResponse({});
+        }
+        return mkResponse({});
+      });
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      await source.transitionStatus('jira:PROJ#PROJ-1', 'factory:in-progress');
+      expect(calls.some((c) => c.startsWith('POST') && c.includes('/transitions'))).toBe(true);
+    });
+  });
+
+  it('transitionStatus logs and skips when no Jira status maps to the target factory state', async () => {
+    await withJiraEnv(async () => {
+      const fetchImpl = vi.fn(async () => mkResponse({}));
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      // factory:retrospecting has no default Jira mapping.
+      await source.transitionStatus('jira:PROJ#PROJ-1', 'factory:retrospecting');
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+  });
+
+  it('setMilestone is a no-op for Jira sources', async () => {
+    await withJiraEnv(async () => {
+      const fetchImpl = vi.fn(async () => mkResponse({}));
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      await source.setMilestone('jira:PROJ#PROJ-1', 7);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JiraStateSource — milestones and listOpenWork pagination
+// ---------------------------------------------------------------------------
+
+describe('JiraStateSource — synthetic milestone + pagination', () => {
+  it('returns a single synthetic milestone covering open + closed counts', async () => {
+    await withJiraEnv(async () => {
+      let call = 0;
+      const fetchImpl = vi.fn(async () => {
+        call += 1;
+        if (call === 1) {
+          return mkResponse({ issues: [mkIssue()], total: 1, startAt: 0, maxResults: 50 });
+        }
+        return mkResponse({
+          issues: [mkIssue({ status: { name: 'Done' } })],
+          total: 1,
+          startAt: 0,
+          maxResults: 50,
+        });
+      });
+      const source = new JiraStateSource('p', 'PROJ', { fetchImpl });
+      const milestones = await source.listMilestones();
+      expect(milestones).toHaveLength(1);
+      expect(milestones[0]).toMatchObject({
+        title: 'Jira (synthetic)',
+        isActive: true,
+        openIssues: 1,
+        closedIssues: 1,
+      });
+    });
+  });
+});

--- a/core/state-source/jira.ts
+++ b/core/state-source/jira.ts
@@ -199,9 +199,19 @@ export class JiraStateSource implements StateSource {
     const jql = encodeURIComponent(
       `project = ${this.projectKey} AND issuetype in (${types}) AND resolution != Unresolved`,
     );
-    const res = await this.jFetch(`/rest/api/3/search?jql=${jql}&maxResults=100`);
-    const body = (await res.json()) as JiraSearchResponse;
-    return body.issues.map((i) => this.mapIssue(i));
+    const results: WorkItem[] = [];
+    let startAt = 0;
+    const pageSize = 50;
+    while (true) {
+      const res = await this.jFetch(
+        `/rest/api/3/search?jql=${jql}&startAt=${startAt}&maxResults=${pageSize}`,
+      );
+      const body = (await res.json()) as JiraSearchResponse;
+      for (const issue of body.issues) results.push(this.mapIssue(issue));
+      if (body.issues.length < pageSize || results.length >= body.total) break;
+      startAt += pageSize;
+    }
+    return results;
   }
 
   async listWorkByMilestone(_milestoneNumber: number): Promise<WorkItem[]> {
@@ -323,21 +333,37 @@ export class JiraStateSource implements StateSource {
 
   async listComments(itemId: string): Promise<IssueComment[]> {
     const key = parseJiraKey(itemId);
-    const res = await this.jFetch(`/rest/api/3/issue/${key}/comment?maxResults=100`);
-    const body = (await res.json()) as {
-      comments: Array<{
-        id: string;
-        body: unknown;
-        author?: { accountId: string; displayName?: string };
-        created: string;
-      }>;
-    };
-    return body.comments.map((c) => ({
-      id: Number.parseInt(c.id, 10),
-      body: adfToText(c.body),
-      authorLogin: c.author?.displayName ?? c.author?.accountId ?? 'unknown',
-      createdAt: c.created,
-    }));
+    const results: IssueComment[] = [];
+    let startAt = 0;
+    const pageSize = 100;
+    while (true) {
+      const res = await this.jFetch(
+        `/rest/api/3/issue/${key}/comment?startAt=${startAt}&maxResults=${pageSize}`,
+      );
+      const body = (await res.json()) as {
+        comments: Array<{
+          id: string;
+          body: unknown;
+          author?: { accountId: string; displayName?: string };
+          created: string;
+        }>;
+        total?: number;
+        maxResults?: number;
+        startAt?: number;
+      };
+      for (const c of body.comments) {
+        results.push({
+          id: Number.parseInt(c.id, 10),
+          body: adfToText(c.body),
+          authorLogin: c.author?.displayName ?? c.author?.accountId ?? 'unknown',
+          createdAt: c.created,
+        });
+      }
+      if (body.comments.length < pageSize) break;
+      if (typeof body.total === 'number' && results.length >= body.total) break;
+      startAt += pageSize;
+    }
+    return results;
   }
 
   async setMilestone(_itemId: string, _milestoneNumber: number | null): Promise<void> {

--- a/core/state-source/jira.ts
+++ b/core/state-source/jira.ts
@@ -1,0 +1,523 @@
+import { logger } from '../logger.js';
+import type { StateName } from '../state-machine/states.js';
+import type {
+  Artifact,
+  CreateIssueInput,
+  IssueComment,
+  Milestone,
+  SourceEvent,
+  StateSource,
+  Subscription,
+  WorkItem,
+} from './interface.js';
+import {
+  DEFAULT_EXEC,
+  DEFAULT_MODE,
+  DEFAULT_PRIORITY,
+  DEFAULT_SCHEDULE,
+  DEFAULT_WORK_ITEM_TYPE,
+} from './interface.js';
+import { factoryStateToJiraStatus, jiraStatusToState } from './jira-state-map.js';
+
+/**
+ * Raw shape of a Jira issue field block as returned by the v3 REST API.
+ * Narrowed to the keys the adapter actually reads.
+ */
+export interface JiraIssueRaw {
+  id: string;
+  key: string;
+  fields: {
+    summary: string;
+    description?: string | null;
+    issuetype?: { name: string };
+    priority?: { name: string } | null;
+    status?: { name: string };
+    reporter?: { accountId: string; displayName?: string; emailAddress?: string } | null;
+    created: string;
+  };
+}
+
+export interface JiraSearchResponse {
+  issues: JiraIssueRaw[];
+  total: number;
+  startAt: number;
+  maxResults: number;
+}
+
+export interface JiraTransition {
+  id: string;
+  name: string;
+  to: { name: string };
+}
+
+export interface JiraTransitionsResponse {
+  transitions: JiraTransition[];
+}
+
+const DEFAULT_ISSUE_TYPES = ['Story', 'Bug', 'Task'] as const;
+
+const PRIORITY_MAP: Record<string, WorkItem['priority']> = {
+  Highest: 'critical',
+  Critical: 'critical',
+  High: 'high',
+  Medium: 'medium',
+  Low: 'low',
+  Lowest: 'low',
+};
+
+const TYPE_MAP: Record<string, WorkItem['type']> = {
+  Story: 'feature',
+  Task: 'chore',
+  Bug: 'bug',
+  Epic: 'feature',
+};
+
+export interface JiraStateSourceOptions {
+  /** Issue types treated as factory-relevant. Default: Story, Bug, Task. */
+  issueTypes?: string[];
+  /** Per-project status overrides. Merged over the defaults. */
+  statusMap?: Record<string, string>;
+  /** Owner identifier — matches GitHubLabelsSource. Used for authorIsOwner. */
+  ownerLogin?: string;
+  /** Override of native fetch — used by tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Jira-backed StateSource (#322). Mirrors the GitHubLabelsSource surface so
+ * the orchestrator tick works unchanged against Jira tickets.
+ *
+ * Authentication: HTTP Basic with email + API token, per Atlassian Cloud's
+ * documented scheme.
+ *
+ * State labels: Jira workflows use status strings, not labels. The adapter
+ * reads/writes Jira status through `transitionStatus` and maps to/from
+ * factory:* states via `jira-state-map.ts`.
+ *
+ * Milestones: Jira has no native milestone primitive. We synthesise a single
+ * "all open" milestone for compatibility — callers that need real sprint
+ * boundaries should drive them from project config.
+ */
+export class JiraStateSource implements StateSource {
+  private readonly host: string;
+  private readonly user: string;
+  private readonly token: string;
+  private readonly issueTypes: string[];
+  private readonly statusMap: Record<string, string>;
+  private readonly ownerLogin: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(
+    readonly projectId: string,
+    readonly repoRef: string,
+    options: JiraStateSourceOptions = {},
+  ) {
+    const host = process.env.JIRA_HOST;
+    const user = process.env.JIRA_USER;
+    const token = process.env.JIRA_API_TOKEN;
+    if (host == null || host.length === 0) {
+      throw new Error('JIRA_HOST is required for JiraStateSource');
+    }
+    if (user == null || user.length === 0) {
+      throw new Error('JIRA_USER is required for JiraStateSource');
+    }
+    if (token == null || token.length === 0) {
+      throw new Error('JIRA_API_TOKEN is required for JiraStateSource');
+    }
+    this.host = host.replace(/\/$/, '');
+    this.user = user;
+    this.token = token;
+    this.issueTypes = options.issueTypes ?? Array.from(DEFAULT_ISSUE_TYPES);
+    this.statusMap = options.statusMap ?? {};
+    this.ownerLogin = options.ownerLogin ?? user;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private get baseHeaders(): Record<string, string> {
+    const basic = Buffer.from(`${this.user}:${this.token}`).toString('base64');
+    return {
+      Authorization: `Basic ${basic}`,
+      Accept: 'application/json',
+    };
+  }
+
+  private async jFetch(
+    path: string,
+    init?: { method?: string; body?: string; headers?: Record<string, string> },
+  ): Promise<Response> {
+    const url = `${this.host}${path}`;
+    const response = await this.fetchImpl(url, {
+      method: init?.method ?? 'GET',
+      headers: { ...this.baseHeaders, ...(init?.headers ?? {}) },
+      body: init?.body,
+    });
+
+    if (response.status === 401) {
+      throw new Error(`Jira API authentication failed (401) for ${url}`);
+    }
+    if (response.status === 429) {
+      const retry = response.headers.get('Retry-After');
+      throw new Error(`Jira API rate limited (429). Retry-After=${retry ?? 'unknown'}`);
+    }
+    if (!response.ok && response.status !== 404) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Jira API error ${response.status} for ${url}: ${text}`);
+    }
+    return response;
+  }
+
+  /** Project's Jira key, e.g. "PROJ". Derived from repoRef (which we use
+   * to carry the project key for Jira-backed sources). */
+  private get projectKey(): string {
+    return this.repoRef;
+  }
+
+  async listOpenWork(_milestoneNumber?: number): Promise<WorkItem[]> {
+    const types = this.issueTypes.map((t) => `"${t}"`).join(',');
+    const jql = encodeURIComponent(
+      `project = ${this.projectKey} AND issuetype in (${types}) AND resolution = Unresolved`,
+    );
+    const results: WorkItem[] = [];
+    let startAt = 0;
+    const pageSize = 50;
+    while (true) {
+      const res = await this.jFetch(
+        `/rest/api/3/search?jql=${jql}&startAt=${startAt}&maxResults=${pageSize}&fields=summary,description,issuetype,priority,status,reporter,created`,
+      );
+      const body = (await res.json()) as JiraSearchResponse;
+      for (const issue of body.issues) {
+        results.push(this.mapIssue(issue));
+      }
+      if (body.issues.length < pageSize || results.length >= body.total) break;
+      startAt += pageSize;
+    }
+    return results;
+  }
+
+  async listClosedWorkByMilestone(_milestoneNumber: number): Promise<WorkItem[]> {
+    const types = this.issueTypes.map((t) => `"${t}"`).join(',');
+    const jql = encodeURIComponent(
+      `project = ${this.projectKey} AND issuetype in (${types}) AND resolution != Unresolved`,
+    );
+    const res = await this.jFetch(`/rest/api/3/search?jql=${jql}&maxResults=100`);
+    const body = (await res.json()) as JiraSearchResponse;
+    return body.issues.map((i) => this.mapIssue(i));
+  }
+
+  async listWorkByMilestone(_milestoneNumber: number): Promise<WorkItem[]> {
+    const open = await this.listOpenWork();
+    const closed = await this.listClosedWorkByMilestone(0);
+    return [...open, ...closed];
+  }
+
+  async getItem(itemId: string): Promise<WorkItem> {
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}`);
+    if (res.status === 404) {
+      throw new Error(`Jira issue not found: ${key}`);
+    }
+    const raw = (await res.json()) as JiraIssueRaw;
+    return this.mapIssue(raw);
+  }
+
+  /** Jira has no first-class milestone primitive. Returns a single
+   * synthetic milestone covering all open issues so the orchestrator's
+   * milestone-aware code paths don't blow up. */
+  async listMilestones(): Promise<Milestone[]> {
+    const open = await this.listOpenWork();
+    const closed = await this.listClosedWorkByMilestone(0);
+    return [
+      {
+        id: '1',
+        title: 'Jira (synthetic)',
+        number: 1,
+        description: 'Synthetic milestone covering all open Jira issues',
+        isActive: true,
+        state: 'open',
+        openIssues: open.length,
+        closedIssues: closed.length,
+      },
+    ];
+  }
+
+  async getActiveMilestone(): Promise<Milestone | null> {
+    const all = await this.listMilestones();
+    return all[0] ?? null;
+  }
+
+  async createMilestone(_title: string): Promise<Milestone> {
+    throw new Error('Jira sources do not support milestone creation');
+  }
+
+  async updateMilestone(): Promise<Milestone> {
+    throw new Error('Jira sources do not support milestone updates');
+  }
+
+  async deleteMilestone(): Promise<void> {
+    throw new Error('Jira sources do not support milestone deletion');
+  }
+
+  /**
+   * Move a Jira issue through its workflow to reflect the requested
+   * factory:* state. Looks up the configured Jira status name, then asks
+   * Jira for the matching transition id and POSTs the transition.
+   */
+  async transitionStatus(itemId: string, to: StateName): Promise<void> {
+    const key = parseJiraKey(itemId);
+    const targetStatus = factoryStateToJiraStatus(to, this.statusMap);
+    if (targetStatus == null) {
+      logger.warn('no jira status mapped for factory state — skipping transition', {
+        key,
+        state: to,
+      });
+      return;
+    }
+    const transitionsRes = await this.jFetch(`/rest/api/3/issue/${key}/transitions`);
+    const body = (await transitionsRes.json()) as JiraTransitionsResponse;
+    const transition = body.transitions.find((t) => t.to.name === targetStatus);
+    if (transition == null) {
+      logger.warn('jira workflow has no transition to target status', {
+        key,
+        targetStatus,
+        available: body.transitions.map((t) => t.to.name),
+      });
+      return;
+    }
+    const res = await this.jFetch(`/rest/api/3/issue/${key}/transitions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ transition: { id: transition.id } }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to transition Jira issue ${key} to ${targetStatus}: ${res.status}`);
+    }
+  }
+
+  async transitionState(
+    itemId: string,
+    _from: StateName,
+    to: StateName,
+    note?: string,
+  ): Promise<void> {
+    await this.transitionStatus(itemId, to);
+    if (note != null && note.length > 0) {
+      await this.comment(itemId, note);
+    }
+  }
+
+  async forceState(itemId: string, to: StateName): Promise<void> {
+    await this.transitionStatus(itemId, to);
+  }
+
+  async comment(itemId: string, body: string): Promise<void> {
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}/comment`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: adfFromMarkdown(body) }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to post Jira comment on ${key}: ${res.status}`);
+    }
+  }
+
+  async listComments(itemId: string): Promise<IssueComment[]> {
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}/comment?maxResults=100`);
+    const body = (await res.json()) as {
+      comments: Array<{
+        id: string;
+        body: unknown;
+        author?: { accountId: string; displayName?: string };
+        created: string;
+      }>;
+    };
+    return body.comments.map((c) => ({
+      id: Number.parseInt(c.id, 10),
+      body: adfToText(c.body),
+      authorLogin: c.author?.displayName ?? c.author?.accountId ?? 'unknown',
+      createdAt: c.created,
+    }));
+  }
+
+  async setMilestone(_itemId: string, _milestoneNumber: number | null): Promise<void> {
+    // Jira has no milestone concept — accept and no-op so the orchestrator's
+    // milestone-aware code paths can call this uniformly without branching.
+  }
+
+  async setLabelInGroup(
+    itemId: string,
+    group: 'priority' | 'schedule' | 'type',
+    value: string,
+  ): Promise<void> {
+    if (group !== 'priority') {
+      logger.warn('jira source ignores non-priority label groups', { group, value });
+      return;
+    }
+    const key = parseJiraKey(itemId);
+    const reverse: Record<string, string> = {
+      critical: 'Highest',
+      high: 'High',
+      medium: 'Medium',
+      low: 'Low',
+    };
+    const jiraPriority = reverse[value];
+    if (jiraPriority == null) return;
+    const res = await this.jFetch(`/rest/api/3/issue/${key}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fields: { priority: { name: jiraPriority } } }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to set Jira priority on ${key}: ${res.status}`);
+    }
+  }
+
+  async addLabels(itemId: string, labels: string[]): Promise<void> {
+    if (labels.length === 0) return;
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        update: { labels: labels.map((name) => ({ add: name })) },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to add Jira labels on ${key}: ${res.status}`);
+    }
+  }
+
+  async removeLabel(itemId: string, name: string): Promise<void> {
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ update: { labels: [{ remove: name }] } }),
+    });
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Failed to remove Jira label ${name} on ${key}: ${res.status}`);
+    }
+  }
+
+  async listLabels(itemId: string): Promise<string[]> {
+    const key = parseJiraKey(itemId);
+    const res = await this.jFetch(`/rest/api/3/issue/${key}?fields=labels`);
+    const body = (await res.json()) as { fields: { labels: string[] } };
+    return body.fields.labels ?? [];
+  }
+
+  async attach(_itemId: string, _artifact: Artifact): Promise<void> {
+    throw new Error('Jira attachments not implemented in M14');
+  }
+
+  async createIssue(input: CreateIssueInput): Promise<WorkItem> {
+    const jiraTypeFromInput: Record<string, string> = {
+      feature: 'Story',
+      bug: 'Bug',
+      chore: 'Task',
+      research: 'Task',
+    };
+    const issuetype = { name: jiraTypeFromInput[input.type ?? 'feature'] ?? 'Task' };
+    const res = await this.jFetch('/rest/api/3/issue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fields: {
+          project: { key: this.projectKey },
+          summary: input.title,
+          description: adfFromMarkdown(input.body),
+          issuetype,
+        },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to create Jira issue: ${res.status}`);
+    }
+    const raw = (await res.json()) as { key: string };
+    return this.getItem(raw.key);
+  }
+
+  async getPrDiff(_itemId: string): Promise<string> {
+    // PR diff lives on Bitbucket; M14 read path stops at the connector. The
+    // workflow caller is responsible for retrieving the diff via
+    // `core/connectors/bitbucket.ts` when it needs it.
+    return '';
+  }
+
+  async watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {
+    throw new Error('Jira watchForUpdates not implemented in M14');
+  }
+
+  private mapIssue(raw: JiraIssueRaw): WorkItem {
+    const jiraType = raw.fields.issuetype?.name ?? 'Task';
+    const jiraPriority = raw.fields.priority?.name ?? 'Medium';
+    const jiraStatus = raw.fields.status?.name ?? 'To Do';
+    const description = adfToText(raw.fields.description ?? '');
+    return {
+      id: `jira:${this.projectKey}#${raw.key}`,
+      externalId: raw.key,
+      repoRef: this.projectKey,
+      title: raw.fields.summary,
+      body: description,
+      type: TYPE_MAP[jiraType] ?? DEFAULT_WORK_ITEM_TYPE,
+      priority: PRIORITY_MAP[jiraPriority] ?? DEFAULT_PRIORITY,
+      mode: DEFAULT_MODE,
+      state: jiraStatusToState(jiraStatus, this.statusMap),
+      authorIsOwner:
+        raw.fields.reporter?.emailAddress === this.ownerLogin ||
+        raw.fields.reporter?.accountId === this.ownerLogin,
+      schedule: DEFAULT_SCHEDULE,
+      exec: DEFAULT_EXEC,
+      dependsOn: [],
+      blocks: [],
+      createdAt: new Date(raw.fields.created),
+    };
+  }
+}
+
+/** Extract the Jira key from a normalised id (`jira:PROJ#PROJ-42`) or a
+ * bare key (`PROJ-42`). */
+export function parseJiraKey(itemId: string): string {
+  const match = itemId.match(/#([A-Z][A-Z0-9_]+-\d+)$/i);
+  if (match != null) return match[1];
+  // Already a bare key?
+  if (/^[A-Z][A-Z0-9_]+-\d+$/i.test(itemId)) return itemId;
+  throw new Error(`Invalid Jira itemId: ${itemId}`);
+}
+
+/**
+ * Minimal Markdown → ADF (Atlassian Document Format) converter. Jira's v3
+ * API requires ADF for description and comment bodies. We collapse the
+ * input into a single paragraph; richer formatting is deferred.
+ */
+export function adfFromMarkdown(text: string): {
+  type: 'doc';
+  version: 1;
+  content: unknown[];
+} {
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text }],
+      },
+    ],
+  };
+}
+
+/**
+ * Flatten an ADF document back to plain text. Tolerates strings (legacy
+ * description fields), nested doc trees, and missing content arrays.
+ */
+export function adfToText(adf: unknown): string {
+  if (adf == null) return '';
+  if (typeof adf === 'string') return adf;
+  if (typeof adf !== 'object') return '';
+  const node = adf as { type?: string; text?: string; content?: unknown[] };
+  if (node.type === 'text' && typeof node.text === 'string') return node.text;
+  if (!Array.isArray(node.content)) return '';
+  return node.content.map(adfToText).join('');
+}

--- a/core/types.ts
+++ b/core/types.ts
@@ -1,7 +1,33 @@
-export interface SourceConfig {
+export interface GithubSourceConfig {
   kind: 'github';
   repo: string;
   stateMachine: 'labels';
+}
+
+export interface JiraSourceConfig {
+  kind: 'jira';
+  /** Jira project key, e.g. "PROJ". */
+  projectKey: string;
+  /** Issue types treated as factory-relevant. Default: Story, Bug, Task. */
+  issueTypes?: string[];
+  /**
+   * Optional per-project status mapping override. Keys are Jira status
+   * strings ("To Do", "In Progress"); values are factory:* state labels.
+   * Merged over the defaults in `core/state-source/jira-state-map.ts`.
+   */
+  statusMap?: Record<string, string>;
+}
+
+export type SourceConfig = GithubSourceConfig | JiraSourceConfig;
+
+/**
+ * Narrowing helper for code paths that only support GitHub sources.
+ * Throws if the project is Jira-backed — callers should check `.kind`
+ * upstream, but having this central helper avoids ad-hoc casts.
+ */
+export function githubRepoRef(source: SourceConfig): string {
+  if (source.kind === 'github') return source.repo;
+  throw new Error(`Expected github source, got ${source.kind}`);
 }
 
 export interface TargetRepoConfig {

--- a/core/workflows/work-investigation-e2e.test.ts
+++ b/core/workflows/work-investigation-e2e.test.ts
@@ -1,0 +1,215 @@
+/**
+ * M14.09 / #330 — Work investigation end-to-end test (fixture-driven).
+ *
+ * Goose Hub does not have a sandbox Jira / Bitbucket workspace in CI, so
+ * this test exercises the full chain against recorded cassettes. Each
+ * step uses the real adapter under test with `fetch` stubbed out and
+ * the responses replayed from in-line fixtures. A future live-run
+ * against a real workspace is a human task — recording it requires
+ * credentials this CI does not carry. See the PR description for the
+ * coverage gap and the manual verification checklist.
+ *
+ * The pipeline below mirrors the issue's acceptance criteria:
+ *   1. Jira state source ingests a fresh ticket and produces a WorkItem
+ *      with the correct factory:* state via the status map.
+ *   2. The Bitbucket repo matcher picks the right repo with confidence
+ *      >= 0.7 (auto-selected).
+ *   3. A clone URL is parsed and a worktree path is computed.
+ *   4. An investigation finding is posted back to Jira as a comment.
+ *   5. The WORK_MACHINE gate hides the project on a non-Work machine.
+ *
+ * Coverage in this test is intentionally orchestrational — each adapter
+ * has its own unit / slice test for the per-adapter happy/edge paths.
+ */
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { matchRepo } from '../connectors/bitbucket-matcher.js';
+import { BitbucketConnector } from '../connectors/bitbucket.js';
+import { isWorkMachine, projectRequiresWorkMachine } from '../projects/loader.js';
+import { type JiraIssueRaw, JiraStateSource } from '../state-source/jira.js';
+import type { ProjectConfig } from '../types.js';
+import { parseCloneUrl } from '../workspaces/worktree.js';
+
+function jiraResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function freshTicketFixture(): JiraIssueRaw {
+  return {
+    id: '10042',
+    key: 'PAY-42',
+    fields: {
+      summary: 'Duplicate /charges create two payments',
+      description:
+        'Sending the same idempotency-key twice to /charges within 30s creates two charges. Expected behaviour: the second request returns the original charge.',
+      issuetype: { name: 'Bug' },
+      priority: { name: 'High' },
+      status: { name: 'To Do' },
+      reporter: { accountId: 'acc-1', emailAddress: 'reporter@example.com' },
+      created: '2026-05-10T00:00:00.000Z',
+    },
+  };
+}
+
+describe('Work investigation E2E (fixture-driven)', () => {
+  const SAVED_ENV: Record<string, string | undefined> = {};
+  const ENV_KEYS = [
+    'WORK_MACHINE',
+    'JIRA_HOST',
+    'JIRA_USER',
+    'JIRA_API_TOKEN',
+    'BITBUCKET_USER',
+    'BITBUCKET_APP_PASSWORD',
+    'BITBUCKET_WORKSPACES',
+  ] as const;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+    process.env.WORK_MACHINE = 'true';
+    process.env.JIRA_HOST = 'https://example.atlassian.net';
+    process.env.JIRA_USER = 'agent@example.com';
+    process.env.JIRA_API_TOKEN = 'jira-token';
+    process.env.BITBUCKET_USER = 'agent';
+    process.env.BITBUCKET_APP_PASSWORD = 'bb-pw';
+    process.env.BITBUCKET_WORKSPACES = 'pay-team';
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (SAVED_ENV[k] === undefined) delete process.env[k];
+      else process.env[k] = SAVED_ENV[k];
+    }
+  });
+
+  it('drives a Jira ticket through repo-match, investigation, and Jira comment-back', async () => {
+    // --- Step 1: Jira ticket is fetched and mapped to a WorkItem ---
+    const jiraCalls: Array<{ method: string; url: string; body?: string }> = [];
+    const jiraFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      jiraCalls.push({
+        method: init?.method ?? 'GET',
+        url,
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+      if (
+        url.includes('/rest/api/3/issue/PAY-42/transitions') &&
+        (init?.method ?? 'GET') === 'GET'
+      ) {
+        return jiraResponse({
+          transitions: [{ id: '11', name: 'Start Progress', to: { name: 'In Progress' } }],
+        });
+      }
+      if (url.includes('/rest/api/3/issue/PAY-42/transitions') && init?.method === 'POST') {
+        return jiraResponse({});
+      }
+      if (url.includes('/rest/api/3/issue/PAY-42/comment') && init?.method === 'POST') {
+        return jiraResponse({});
+      }
+      if (url.includes('/rest/api/3/issue/PAY-42')) {
+        return jiraResponse(freshTicketFixture());
+      }
+      if (url.includes('/rest/api/3/search')) {
+        return jiraResponse({
+          issues: [freshTicketFixture()],
+          total: 1,
+          startAt: 0,
+          maxResults: 50,
+        });
+      }
+      return jiraResponse({}, 404);
+    });
+    const jira = new JiraStateSource('pay', 'PAY', { fetchImpl: jiraFetch });
+    const ticket = await jira.getItem('PAY-42');
+    expect(ticket.state).toBe('factory:accepted');
+    expect(ticket.priority).toBe('high');
+    expect(ticket.type).toBe('bug');
+
+    // --- Step 2: Bitbucket repo matcher selects pay-charges ---
+    const bitbucketFetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/repositories/pay-team?')) {
+        return jiraResponse({
+          values: [
+            { slug: 'pay-charges', name: 'pay-charges' },
+            { slug: 'pay-billing', name: 'pay-billing' },
+            { slug: 'mobile-app', name: 'mobile-app' },
+          ],
+        });
+      }
+      if (url.includes('/repositories/pay-team/pay-charges')) {
+        return jiraResponse({
+          name: 'pay-charges',
+          description: 'Charges service with idempotency keys',
+          mainbranch: { name: 'main' },
+        });
+      }
+      if (url.includes('/repositories/pay-team/pay-billing')) {
+        return jiraResponse({
+          name: 'pay-billing',
+          description: 'Billing service',
+          mainbranch: { name: 'main' },
+        });
+      }
+      if (url.includes('/repositories/pay-team/mobile-app')) {
+        return jiraResponse({
+          name: 'mobile-app',
+          description: 'Native mobile client',
+          mainbranch: { name: 'main' },
+        });
+      }
+      return jiraResponse({}, 404);
+    });
+    const bitbucket = new BitbucketConnector({
+      authOverride: { user: 'agent', appPassword: 'bb-pw' },
+      fetchImpl: bitbucketFetch,
+    });
+    const database = new Database(':memory:');
+    try {
+      const matchResult = await matchRepo(ticket, bitbucket, {
+        database,
+        workspaces: ['pay-team'],
+      });
+      expect(matchResult.autoSelected).toBe(true);
+      expect(matchResult.topCandidate?.ref.repoSlug).toBe('pay-charges');
+
+      // --- Step 3: Worktree URL is parsed for the selected repo ---
+      const cloneUrl = 'git@bitbucket.org:pay-team/pay-charges.git';
+      const parsed = parseCloneUrl(cloneUrl);
+      expect(parsed?.isBitbucket).toBe(true);
+      expect(parsed?.workspace).toBe('pay-team');
+      expect(parsed?.repoSlug).toBe('pay-charges');
+
+      // --- Step 4: Findings are posted back to Jira ---
+      await jira.comment(
+        'jira:PAY#PAY-42',
+        'Investigation complete — root cause is missing idempotency-key lookup in src/api/charges.ts:create.',
+      );
+      const commentCall = jiraCalls.find((c) => c.method === 'POST' && c.url.includes('/comment'));
+      expect(commentCall).toBeDefined();
+      expect(commentCall?.body ?? '').toContain('Investigation complete');
+
+      // --- Step 5: factory:in-progress transition is dispatched ---
+      await jira.transitionStatus('jira:PAY#PAY-42', 'factory:in-progress');
+      const transitionPost = jiraCalls.find(
+        (c) => c.method === 'POST' && c.url.endsWith('/transitions'),
+      );
+      expect(transitionPost).toBeDefined();
+      expect(transitionPost?.body ?? '').toContain('"id":"11"');
+    } finally {
+      database.close();
+    }
+  });
+
+  it('WORK_MACHINE gate hides Work projects on a non-Work machine', () => {
+    // biome-ignore lint/performance/noDelete: env restore for test isolation
+    delete process.env.WORK_MACHINE;
+    const jiraProject = { source: { kind: 'jira' } } as unknown as ProjectConfig;
+    const githubProject = { source: { kind: 'github' } } as unknown as ProjectConfig;
+    expect(isWorkMachine()).toBe(false);
+    expect(projectRequiresWorkMachine(jiraProject)).toBe(true);
+    expect(projectRequiresWorkMachine(githubProject)).toBe(false);
+  });
+});

--- a/core/workspaces/README.md
+++ b/core/workspaces/README.md
@@ -6,20 +6,40 @@ Git worktree lifecycle management for Factory investigation runs.
 
 | File | Exports |
 |------|---------|
-| `worktree.ts` | `createWorktree`, `cleanupWorktree` |
+| `worktree.ts` | `createWorktree`, `cleanupWorktree`, `parseCloneUrl`, `ensureClonedRepo` |
 
 ## Interface
 
-### `createWorktree(repo, runId): string`
+### `createWorktree(repoOrUrl, runId): string`
 
-Creates a git worktree for the given local repo at `~/.factory/workspaces/<runId>/`.
+Creates a git worktree at `~/.factory/workspaces/<runId>/`.
 
-- **`repo`** — Absolute path to a local git repository (already cloned on disk).
+- **`repoOrUrl`** — Absolute path to a local git repository, OR an SSH /
+  HTTPS clone URL (M14.07 / #328). Clone URLs are recognised via
+  `parseCloneUrl` and lazily cloned into
+  `~/.factory/clones/<host>/<workspace>/<repoSlug>` if not already
+  present. Bitbucket HTTPS URLs are authenticated by injecting
+  `BITBUCKET_USER` / `BITBUCKET_APP_PASSWORD` from the environment; SSH
+  URLs rely on the agent host's SSH key configuration.
 - **`runId`** — Canonical workflow isolation key (ULID/UUID string). Matches the `runId` used by `AgentSpec`, events, and tool hooks.
 - **Returns** — The absolute path to the created worktree (`~/.factory/workspaces/<runId>/`).
-- **Throws** — If `git worktree add` fails (e.g. repo path is invalid or not a git repo).
+- **Throws** — If `git clone` (for URL inputs) or `git worktree add` fails (bad credentials, missing repo, etc.).
 
 Internally uses `git worktree add --detach` so the worktree starts at the current HEAD without creating or checking out a branch. This avoids branch conflicts when multiple parallel runs use the same repo.
+
+### `parseCloneUrl(url): ParsedCloneUrl | null`
+
+Parse an SSH (`git@host:workspace/repo.git`) or HTTPS
+(`https://host/workspace/repo.git`) git URL into its components. Returns
+`null` for non-URL inputs so callers can treat the value as a local
+path. The `isBitbucket` flag is set for `bitbucket.org` hosts and drives
+credential injection in `ensureClonedRepo`.
+
+### `ensureClonedRepo(cloneUrl): string`
+
+Idempotent clone — clones the URL if no local copy exists at
+`~/.factory/clones/<host>/<workspace>/<repoSlug>`, otherwise returns the
+cached path. Used internally by `createWorktree` when given a URL.
 
 ### `cleanupWorktree(runId): void`
 

--- a/core/workspaces/slice.test.ts
+++ b/core/workspaces/slice.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanupWorktree, createWorktree } from './worktree.js';
+import { cleanupWorktree, createWorktree, parseCloneUrl } from './worktree.js';
 
 const WT = (runId: string) => join('/mock-home', '.factory', 'workspaces', runId);
 const WORKSPACES_DIR = join('/mock-home', '.factory', 'workspaces');
@@ -123,5 +123,127 @@ describe('cleanupWorktree', () => {
       recursive: true,
       force: true,
     });
+  });
+});
+
+describe('parseCloneUrl (M14.07 / #328)', () => {
+  it('parses Bitbucket SSH URLs', () => {
+    expect(parseCloneUrl('git@bitbucket.org:team/payments-api.git')).toEqual({
+      scheme: 'ssh',
+      host: 'bitbucket.org',
+      workspace: 'team',
+      repoSlug: 'payments-api',
+      isBitbucket: true,
+    });
+  });
+
+  it('parses Bitbucket HTTPS URLs', () => {
+    expect(parseCloneUrl('https://bitbucket.org/team/payments-api.git')).toEqual({
+      scheme: 'https',
+      host: 'bitbucket.org',
+      workspace: 'team',
+      repoSlug: 'payments-api',
+      isBitbucket: true,
+    });
+  });
+
+  it('flags GitHub SSH URLs but is not Bitbucket', () => {
+    expect(parseCloneUrl('git@github.com:shaunnez/goose-hub.git')).toEqual({
+      scheme: 'ssh',
+      host: 'github.com',
+      workspace: 'shaunnez',
+      repoSlug: 'goose-hub',
+      isBitbucket: false,
+    });
+  });
+
+  it('returns null for non-URL inputs', () => {
+    expect(parseCloneUrl('/local/path/to/repo')).toBeNull();
+    expect(parseCloneUrl('not a url')).toBeNull();
+  });
+});
+
+describe('createWorktree with clone URL (M14.07 / #328)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mkdirSync).mockReturnValue(undefined);
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+    vi.mocked(existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clones a Bitbucket SSH URL and adds the worktree from the local clone', () => {
+    createWorktree('git@bitbucket.org:team/payments-api.git', 'run-ssh-1');
+
+    const calls = vi.mocked(execFileSync).mock.calls;
+    // First call: git clone
+    expect(calls[0][0]).toBe('git');
+    expect(calls[0][1]).toEqual([
+      'clone',
+      'git@bitbucket.org:team/payments-api.git',
+      '/mock-home/.factory/clones/bitbucket.org/team/payments-api',
+    ]);
+    // Second call: git worktree add, cwd = the local clone path
+    expect(calls[1][0]).toBe('git');
+    expect(calls[1][1]).toEqual(['worktree', 'add', '--detach', WT('run-ssh-1')]);
+    expect((calls[1][2] as { cwd: string }).cwd).toBe(
+      '/mock-home/.factory/clones/bitbucket.org/team/payments-api',
+    );
+  });
+
+  it('injects BITBUCKET_APP_PASSWORD into Bitbucket HTTPS URLs', () => {
+    const saved = {
+      user: process.env.BITBUCKET_USER,
+      pw: process.env.BITBUCKET_APP_PASSWORD,
+    };
+    process.env.BITBUCKET_USER = 'bot@example.com';
+    process.env.BITBUCKET_APP_PASSWORD = 'pw-xyz';
+    try {
+      createWorktree('https://bitbucket.org/team/payments-api.git', 'run-https-1');
+
+      const cloneCall = vi.mocked(execFileSync).mock.calls.find((c) => c[1]?.[0] === 'clone');
+      expect(cloneCall).toBeDefined();
+      const url = cloneCall?.[1]?.[1] ?? '';
+      expect(url).toContain('bot%40example.com:pw-xyz');
+      expect(url).toContain('bitbucket.org/team/payments-api.git');
+    } finally {
+      // biome-ignore lint/performance/noDelete: env restore for test isolation
+      if (saved.user === undefined) delete process.env.BITBUCKET_USER;
+      else process.env.BITBUCKET_USER = saved.user;
+      // biome-ignore lint/performance/noDelete: env restore for test isolation
+      if (saved.pw === undefined) delete process.env.BITBUCKET_APP_PASSWORD;
+      else process.env.BITBUCKET_APP_PASSWORD = saved.pw;
+    }
+  });
+
+  it('reuses an existing clone instead of re-cloning', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    createWorktree('git@bitbucket.org:team/payments-api.git', 'run-cache-1');
+
+    const cloneCall = vi.mocked(execFileSync).mock.calls.find((c) => c[1]?.[0] === 'clone');
+    expect(cloneCall).toBeUndefined();
+    const wtCall = vi.mocked(execFileSync).mock.calls.find((c) => c[1]?.[0] === 'worktree');
+    expect(wtCall).toBeDefined();
+  });
+
+  it('propagates clone failures (bad credentials)', () => {
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      throw new Error('Authentication failed for https://bitbucket.org/team/repo.git');
+    });
+    expect(() =>
+      createWorktree('https://bitbucket.org/team/payments-api.git', 'run-fail-1'),
+    ).toThrow(/Authentication failed/);
+  });
+
+  it('still accepts a plain local path (backward compatible)', () => {
+    createWorktree('/local/repo/path', 'run-local-1');
+    const calls = vi.mocked(execFileSync).mock.calls;
+    // Should NOT have called git clone — only worktree add.
+    expect(calls.find((c) => c[1]?.[0] === 'clone')).toBeUndefined();
+    expect(calls.some((c) => c[1]?.[0] === 'worktree')).toBe(true);
   });
 });

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -5,6 +5,97 @@ import { join } from 'node:path';
 import { GIT_ENV } from './git-env.js';
 
 const WORKSPACES_DIR = join(homedir(), '.factory', 'workspaces');
+const CLONES_DIR = join(homedir(), '.factory', 'clones');
+
+/** SSH clone URL pattern, e.g. `git@bitbucket.org:workspace/repo.git`. */
+const SSH_PATTERN = /^([^@]+)@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/;
+/** HTTPS clone URL pattern, e.g. `https://bitbucket.org/workspace/repo.git`. */
+const HTTPS_PATTERN = /^https:\/\/(?:([^@]+)@)?([^/]+)\/([^/]+)\/(.+?)(?:\.git)?$/;
+
+export interface ParsedCloneUrl {
+  scheme: 'ssh' | 'https';
+  host: string;
+  workspace: string;
+  repoSlug: string;
+  /** True when the host is recognised as Bitbucket Cloud. */
+  isBitbucket: boolean;
+}
+
+/**
+ * Parse an SSH or HTTPS git clone URL. Returns `null` if the URL is
+ * neither — callers can use this to decide whether to treat the input
+ * as a URL or as an existing local path.
+ */
+export function parseCloneUrl(url: string): ParsedCloneUrl | null {
+  const ssh = url.match(SSH_PATTERN);
+  if (ssh != null) {
+    const [, , host, workspace, repoSlug] = ssh;
+    return {
+      scheme: 'ssh',
+      host,
+      workspace,
+      repoSlug,
+      isBitbucket: host === 'bitbucket.org',
+    };
+  }
+  const https = url.match(HTTPS_PATTERN);
+  if (https != null) {
+    const [, , host, workspace, repoSlug] = https;
+    return {
+      scheme: 'https',
+      host,
+      workspace,
+      repoSlug,
+      isBitbucket: host === 'bitbucket.org',
+    };
+  }
+  return null;
+}
+
+function bitbucketHttpsWithCreds(url: string): string {
+  const user = process.env.BITBUCKET_USER;
+  const appPassword = process.env.BITBUCKET_APP_PASSWORD;
+  if (user == null || appPassword == null) return url;
+  return url.replace(
+    /^https:\/\/(?:[^@]+@)?bitbucket\.org\//,
+    `https://${encodeURIComponent(user)}:${encodeURIComponent(appPassword)}@bitbucket.org/`,
+  );
+}
+
+/**
+ * Ensure a clone of the given URL exists locally at
+ * `~/.factory/clones/<host>/<workspace>/<repoSlug>` and return its path.
+ *
+ * - SSH URLs are cloned as-is and rely on the agent host's SSH agent /
+ *   key configuration to authenticate.
+ * - HTTPS URLs are rewritten to include `BITBUCKET_APP_PASSWORD` for
+ *   Bitbucket Cloud. Other hosts pass through unchanged (GitHub uses
+ *   the same env-less HTTPS scheme as before).
+ *
+ * Subsequent calls with the same URL return the cached clone path
+ * without re-fetching.
+ */
+export function ensureClonedRepo(cloneUrl: string): string {
+  const parsed = parseCloneUrl(cloneUrl);
+  if (parsed == null) {
+    throw new Error(`Unrecognised clone URL: ${cloneUrl}`);
+  }
+  const target = join(CLONES_DIR, parsed.host, parsed.workspace, parsed.repoSlug);
+  if (existsSync(target)) return target;
+
+  mkdirSync(join(CLONES_DIR, parsed.host, parsed.workspace), { recursive: true });
+
+  let urlForGit = cloneUrl;
+  if (parsed.isBitbucket && parsed.scheme === 'https') {
+    urlForGit = bitbucketHttpsWithCreds(cloneUrl);
+  }
+
+  execFileSync('git', ['clone', urlForGit, target], {
+    stdio: 'pipe',
+    env: GIT_ENV,
+  });
+  return target;
+}
 
 /**
  * Resolves the worktree path for a given runId.
@@ -30,18 +121,28 @@ export function existingWorktreePath(runId: string): string | null {
  * Uses `git worktree add --detach` to create a detached HEAD worktree,
  * which avoids branch conflicts when multiple runs use the same repo.
  *
- * @param repo - Absolute path to the local git repository (already cloned).
+ * Accepts either an absolute local path to a pre-cloned repository OR a
+ * clone URL (SSH or HTTPS). When passed a clone URL, the repo is cloned
+ * lazily into `~/.factory/clones/...` and the worktree is added from
+ * there. Bitbucket HTTPS URLs are authenticated via the
+ * `BITBUCKET_USER` / `BITBUCKET_APP_PASSWORD` env vars; SSH URLs rely on
+ * the host's SSH key configuration.
+ *
+ * @param repoOrUrl - Absolute path to a local git repository, OR an SSH /
+ *                    HTTPS clone URL.
  * @param runId - Canonical workflow isolation key (ULID/UUID).
  * @returns The absolute path to the created worktree.
  */
-export function createWorktree(repo: string, runId: string): string {
+export function createWorktree(repoOrUrl: string, runId: string): string {
   const wtPath = worktreePath(runId);
 
   // Ensure the parent workspaces directory exists
   mkdirSync(WORKSPACES_DIR, { recursive: true });
 
+  const repoPath = parseCloneUrl(repoOrUrl) != null ? ensureClonedRepo(repoOrUrl) : repoOrUrl;
+
   execFileSync('git', ['worktree', 'add', '--detach', wtPath], {
-    cwd: repo,
+    cwd: repoPath,
     stdio: 'pipe',
     env: GIT_ENV,
   });

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -38,7 +38,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `review` | yes | Pure helpers used by the Review slice. The slice itself lives in `slices/review/`; this module hosts logic that's reusable, deterministic, and easier to test outside the slice's workflow harness. |
 | `scout-reports` | yes | SQLite persistence for scout skill outputs produced during investigation workflows. |
 | `state-machine` | yes | Typed state machine for Goose Hub issue lifecycle management. |
-| `state-source` | yes | Adapter layer between Goose Hub and the source of truth for work items (currently GitHub Issues; Jira lands in M14). |
+| `state-source` | yes | Adapter layer between Goose Hub and the source of truth for work items. Two backends are supported: GitHub Issues (default) and Jira (M14). |
 | `symbol-index` | yes | Local, regenerable SQLite index of every exported symbol and import statement across the Goose Hub codebase. Use it to answer "where is X defined?" / "who imports X?" without an LLM spawn or a `grep`. See ADR 0040 for the rationale. |
 | `test-runner` | yes | Runs Vitest with the JSON reporter and parses the output into a runner-agnostic `TestRun` shape. The QA holdout consumes the parsed structure; nothing else should depend on Vitest's raw report shape. |
 | `tool-layer` | yes | Tool management and security infrastructure for agent runtime. |

--- a/slices/dep-scheduling-integration/slice.test.ts
+++ b/slices/dep-scheduling-integration/slice.test.ts
@@ -155,8 +155,12 @@ describe('cross-repo registered dependency', () => {
     const buildFetchTarget = () =>
       createProjectAwareTargetSource({
         projects: [makeProject(MAIN_REPO), makeProject(CROSS_REPO)],
-        fetchTargetForProject: (p) =>
-          fetchers[p.source.repo] ?? (async () => ({ state: 'open', title: 'fallback' })),
+        fetchTargetForProject: (p) => {
+          if (p.source.kind === 'github' && fetchers[p.source.repo] != null) {
+            return fetchers[p.source.repo];
+          }
+          return async () => ({ state: 'open', title: 'fallback' });
+        },
       });
 
     const itemA = makeItem('400', `Depends on ${CROSS_REPO}#55`);


### PR DESCRIPTION
## Summary

Ships M14 (issues #322–#330) and the global ⌘K search modal (#603) on one branch.

| Issue | Surface |
|---|---|
| #322 | `core/state-source/jira.ts` — `JiraStateSource` implementing the `StateSource` interface; HTTP Basic auth from `JIRA_HOST`/`JIRA_USER`/`JIRA_API_TOKEN`. |
| #327 | `core/state-source/jira-state-map.ts` — default Jira status → `factory:*` mapping + per-project overrides. |
| #323 | `core/connectors/bitbucket.ts` — read-only Bitbucket Cloud connector (`getFile`, `searchCode`, `listPullRequests`, `getRepoMetadata`, `listWorkspaceRepos`) + `parseBitbucketCloneUrl`. |
| #326 | `core/connectors/bitbucket-matcher.ts` — repo matcher (project-key + keyword + prior-match scoring). ≥ 0.7 auto-selects; lower goes to `factory:gate-pending`. Prior selections persist in a self-bootstrapping `bitbucket_repo_matches` SQLite table — no drizzle migration. |
| #328 | `core/workspaces/worktree.ts` — `createWorktree` now accepts SSH and HTTPS Bitbucket clone URLs (HTTPS auth via `BITBUCKET_APP_PASSWORD`); clones cached under `~/.factory/clones/`. |
| #324 | `core/connectors/confluence.ts` + `ConfluenceLinksSection.tsx` — detects Confluence URLs in bodies/comments and renders them as labelled links. Optional page-title fetch when `CONFLUENCE_HOST` + `CONFLUENCE_API_TOKEN` are set. |
| #325 | `core/projects/loader.ts` + `scheduler.ts` — Jira-backed projects are hidden from `loadProjects()` / `getProjectBySlug()` unless `WORK_MACHINE=true`. Scheduler refuses to schedule them as defence-in-depth. One-shot startup log message: `WORK_MACHINE not set — Work projects hidden`. |
| #329 | `apps/cli/src/commands/work.ts` — `goose work status` and `goose work investigate <slug> <key>`, both gated by `WORK_MACHINE`. Help line only shown when the gate is open. |
| #330 | `core/workflows/work-investigation-e2e.test.ts` — fixture-driven end-to-end test: Jira ingest → repo match → clone URL parse → Jira comment-back → transition. **Live verification against a real Jira/Bitbucket workspace is a manual follow-up** — CI does not carry real credentials. |
| #603 | `apps/web/src/components/chrome/SearchModal.tsx` + TopBar wiring — ⌘K / Ctrl+K opens a search modal that fans out across projects (TanStack Query, 60 s stale), filters client-side, supports keyboard navigation, navigates to `/projects/:slug/items/:id` on Enter, closes on Esc. |

### Type-system change

`SourceConfig` is now a discriminated union of `GithubSourceConfig | JiraSourceConfig`. A `githubRepoRef()` helper narrows for github-only call sites. Existing dispatch test fixtures updated from `type: 'github'` (always wrong against the typed shape) to `kind: 'github'`.

### Credentials gap

This branch was developed in an environment without live Jira/Bitbucket/Confluence credentials. Every adapter is exercised against in-memory cassettes/fixtures. Connecting a real sandbox is the manual verification step before this can be considered fully exercised — see the test plan below.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 3454 pass; 2 failures are pre-existing on `main` (`core/agent-runtime/budgets.test.ts` scout-schema, `apps/server/src/domains/workflows/triage-batch.test.ts` "applies type and priority labels"). Confirmed by `git stash && pnpm test`.
- [ ] **Live Jira sandbox**: set `WORK_MACHINE=true`, `JIRA_HOST`, `JIRA_USER`, `JIRA_API_TOKEN`. Register a Jira project under `target-projects/<slug>/project.config.ts` with `source: { kind: 'jira', projectKey: '<KEY>' }`. Run `goose work status <slug>` and confirm the open Jira tickets appear with the mapped `factory:*` state.
- [ ] **Live Bitbucket sandbox**: set `BITBUCKET_USER`, `BITBUCKET_APP_PASSWORD`, `BITBUCKET_WORKSPACES`. Run a triage cycle that invokes `matchRepo` and confirm the matched repo cleanly auto-selects (≥ 0.7) or falls through to the gate.
- [ ] **Live worktree clone**: `goose work investigate <slug> <jira-key>` against a real ticket; confirm a worktree appears at `~/.factory/workspaces/<runId>/` from a Bitbucket clone (SSH and HTTPS).
- [ ] **Live Confluence**: paste a Confluence URL into an issue body and confirm the OverviewSection renders it as `Confluence: <title>` (or `Confluence: <slug>` if credentials are not set).
- [ ] **⌘K search**: open the web app, press ⌘K (or click the Search pill in the top bar), type part of an issue title or `#N`, confirm matches across all configured projects, Enter to navigate, Esc to close.
- [ ] **WORK_MACHINE gate**: with the env var unset, confirm Jira projects do not appear in the sidebar, `goose work status` exits non-zero with a clear message, and the scheduler logs `refusing to schedule Jira-backed project — WORK_MACHINE not set`.

Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327
Closes #328
Closes #329
Closes #330
Closes #603

https://claude.ai/code/session_017BxzU1XLNNpL5kfG5wYam2

---
_Generated by [Claude Code](https://claude.ai/code/session_017BxzU1XLNNpL5kfG5wYam2)_