### PR TITLE
docs: senior-dev code review under review/

### DIFF
--- a/review/01-orientation.md
+++ b/review/01-orientation.md
@@ -1,0 +1,101 @@
+# Orientation — read this first
+
+## What Goose Hub is
+
+A personal command centre for AI-assisted software delivery. One operator
+(Shaun) runs it on his laptop. It picks up GitHub issues on registered
+target repos, sends them through a multi-agent SDLC pipeline, opens PRs,
+gates them with QA + Review holdouts, and merges on human approval.
+
+"Factory" is the engine **inside** Goose Hub — orchestrator, workflows,
+agent runtime, tool layer, workspaces. Don't confuse it with the
+unrelated SaaS product.
+
+## Mental model: the five-word elevator pitch
+
+> Webhook flips label → workflow runs → PR opens → holdouts approve → human merges.
+
+Everything else (skills, scouts, retros, the coach, parallel WP builders)
+is a refinement on that loop.
+
+## Core vocabulary cheat-sheet
+
+| Term | One-line meaning |
+|---|---|
+| **Target project** | A project Factory drives. Lives at `target-projects/<slug>/project.config.ts`. |
+| **Source of truth** | Where work-item state lives. v0: GitHub Issues (labels). |
+| **State** | The factory:* label currently on the issue. 28 of them; see `core/state-machine/states.ts`. |
+| **Work item** | A GitHub issue with factory labels (state, type, priority, schedule). |
+| **Workflow** | A TS module in `slices/<name>/` or `core/workflows/` that drives an issue from one state to another. |
+| **Skill** | A versioned `skills/<name>/` bundle: `prompt.md` + `schema.ts` + `skill.config.ts`. Atomic agent invocation unit. |
+| **Persona** | Named round-robin instance of a role. Stats accumulate per project+role. |
+| **Holdout** | An agent (QA, Reviewer) that runs in fresh context with no access to the developer's reasoning. Enforced by `contextAllowlist`. |
+| **Smoke gate** | Six non-skippable preflight checks (gh auth, git fsck, claude binary, sqlite, API key, budget) before any dispatch. |
+| **Advisor** | A higher-tier model that wraps a primary agent for high-priority work; verdict: proceed/revise/abort. |
+| **Decision summary** | One-sentence event an agent emits at decision points. Two streams: schema field (canonical) + `[decision] KIND: …` markers (live). |
+
+## What runs where
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  apps/web        Vite + React 19 + Tailwind. Kanban UI.     │
+│       │           Talks to apps/server over HTTP + SSE.     │
+│       ▼                                                     │
+│  apps/server     Hono. Receives GitHub webhooks. Runs per-  │
+│       │           project tick scheduler. Hosts SSE.        │
+│       ▼                                                     │
+│  core/*          Library code: state machine, event store,  │
+│       │           agent runtime, workflows, connectors.     │
+│       ▼                                                     │
+│  slices/*        Vertical features. One per workflow piece. │
+│       │           Each owns its own slice.test.ts.          │
+│       ▼                                                     │
+│  skills/*        Versioned prompts + Zod schemas. Spawned   │
+│                   as claude / codex CLI children.           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+State lives in two places, on purpose:
+
+- **GitHub** (source of truth): work-item state via labels. Survives an
+  orchestrator crash.
+- **SQLite** (`~/.factory/data/factory.db`, operational only): event
+  stream, persona stats, audit, governance, cost rows, archived
+  lifecycles. Never the authority for work-item state.
+
+## Things that surprise newcomers
+
+1. **Labels carry state, not PR titles.** `factory:needs-qa` is gospel.
+   PR labels are decorative.
+2. **The orchestrator is stateless across ticks.** Each per-project
+   `setInterval` re-derives everything from GitHub + SQLite.
+3. **Skills cannot import other skills.** They're invoked through
+   `invokeSkill()` in `core/agent-runtime/invoke-skill.ts`. That function
+   is the only entry point.
+4. **Holdouts have a runtime-enforced context allowlist.** Try to inject
+   the developer's plan into a QA prompt and you get a `tool.violation`
+   event, not a sneaky pass.
+5. **better-sqlite3 is synchronous.** Inside a single Node process the
+   event log is effectively single-threaded — that's why the
+   "single-writer chokepoint" claim holds. Across processes (e.g. CLI vs
+   server on the same DB) it doesn't.
+6. **`pnpm test` writes per-worker DB files.** See
+   `scripts/run-vitest-with-db.ts`. Don't try to share a DB across vitest
+   workers, the migration race will bite.
+
+## Where to read next
+
+- New to the dispatch path → [`03-flows.md`](./03-flows.md).
+- Need to add a table or query → [`04-data-model.md`](./04-data-model.md).
+- Hunting a bug → [`05-findings.md`](./05-findings.md).
+- Need a 2-hour win → [`07-quick-wins.md`](./07-quick-wins.md).
+
+## Files every newcomer should open once
+
+1. `CLAUDE.md` — agent-facing orientation; still useful for humans.
+2. `CONTEXT.md` — resolved decisions, "how is this wired?" answers.
+3. `FACTORY_RULES.md` — non-negotiables (numbered 1–33).
+4. `docs/inventory.md` — auto-generated map; run `pnpm manifest` after
+   touching the catalogue.
+5. `core/types.ts` — canonical role union, role-model shape, project config.
+6. `core/event-stream/store.ts` — the spinal cord.

--- a/review/02-architecture.md
+++ b/review/02-architecture.md
@@ -1,0 +1,159 @@
+# Architecture
+
+## Layer map
+
+```
+┌──────────────────────────── apps/ ────────────────────────────┐
+│                                                               │
+│   apps/web (React 19, Vite, Tailwind 4, React Router 6)       │
+│      ├── components/board     Kanban (SSE → live patches)     │
+│      ├── components/detail    Issue detail, tabs              │
+│      ├── components/roster    Persona stats, playbooks        │
+│      ├── components/settings  Project budgets, model router   │
+│      └── lib/api/             Fetch wrappers (typed)          │
+│                                                               │
+│   apps/server (Hono, @hono/node-server)                       │
+│      ├── domains/<slice>/     Routers, services, repositories │
+│      └── shared/dispatch-*    Webhook label → workflow router │
+│                                                               │
+│   apps/cli (tsx-runnable)                                     │
+│      └── commands/            goose status / sweep / run-agent│
+│                                                               │
+└───────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────── core/ ────────────────────────────┐
+│                                                               │
+│   agent-runtime/   invokeSkill() entry, claude-cli / codex-cli│
+│                    runtimes, persona selection, budget math   │
+│   event-stream/    Single-writer EventStore (SQLite + emitter)│
+│   db/              Drizzle schema + better-sqlite3 connection │
+│   orchestrator/    Smoke gate (6-check preflight)             │
+│   projects/        Loader, per-project tick scheduler, locks  │
+│   state-machine/   28-state graph, legal-targets table        │
+│   state-source/    GitHub Issues adapter (labels ↔ WorkItem)  │
+│   connectors/      GitHub PR ops, retry, timeout              │
+│   tool-layer/      Sandbox, deny list, PreToolUse/Stop hooks  │
+│   workflows/       Cross-cutting: bootstrap, grill+prd,       │
+│                    decompose-prd, retro, cross-run-retro      │
+│   cost/, persona/, retry/, findings/, retrospective/, etc.    │
+│                                                               │
+└───────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────── slices/ (vertical features, one folder each) ────────────┐
+│                                                                      │
+│   fix-issue, qa, review, retro, investigate, grill-and-prd,          │
+│   decompose-prd, bootstrap-project, parallel-implement, ...          │
+│                                                                      │
+│   Each slice: workflow.ts + slice.test.ts + README.md (+ ui.tsx if   │
+│   it ships UI). Slices may not import from other slices.             │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────── skills/ (versioned agent capabilities) ────────────┐
+│                                                                │
+│   triage, investigate, implement, qa, review, retrospective-*, │
+│   grill-me, write-prd, decompose-issues, scout-*, wave2-*, ... │
+│                                                                │
+│   Each skill: prompt.md + schema.ts + skill.config.ts          │
+│              + slice.test.ts (+ README.md, eval/eval.json)     │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Boundaries (the rules that actually matter)
+
+1. **Slices import core through public interfaces only.** No reaching
+   into another slice. Enforced by review, not lint.
+2. **Skills are invoked only through `invokeSkill()`.** That function is
+   the gate where context validation, persona selection, budget
+   resolution, model selection, and output validation happen. See
+   `core/agent-runtime/invoke-skill.ts:81`.
+3. **One writer for `events` table.** Anything that wants to record
+   something calls `eventStore.appendEvent()`. CI lints for direct
+   `events` inserts.
+4. **State labels live on issues, not PRs.** PR labels exist; they're
+   decorative. Anything reading PR labels is wrong.
+5. **Governance files are immutable from agent PRs.** `MISSION.md`,
+   `FACTORY_RULES.md`, `CLAUDE.md`, project configs, personas. Only
+   bootstrap-tagged PRs may create them.
+
+## How a webhook becomes a merge
+
+A `factory:dev-ready` label flip is the canonical entry. The chain:
+
+```
+GitHub Issues
+   │  webhook (label changed)
+   ▼
+apps/server  webhooks/handler.ts
+   │  verify signature, route by event type
+   ▼
+apps/server/shared/dispatch-routing.ts
+   │  label → dispatchFn (factory:dev-ready → dispatchFixIssue)
+   ▼
+slices/fix-issue/workflow.ts
+   │  acquire parallel lock → smoke gate → workspace prep
+   ├──→ skills/investigate (if not already done)
+   ├──→ (priority:high|critical) skills/advise-on-plan
+   ├──→ skills/implement   (TDD-first, opens PR via connectors/github)
+   ├──→ skills/evidence-post   (best-effort screenshots)
+   └──→ source.transitionState(issue, factory:needs-qa)
+   ▼
+GitHub label flips to factory:needs-qa → webhook fires again →
+   dispatchQa → slices/qa/workflow.ts → skills/qa (HOLDOUT)
+   │  three-tier verification (lint, tests, e2e)
+   ▼
+factory:needs-review → dispatchReview → skills/review (HOLDOUT)
+   │  diff vs issue ACs, per-criterion verdict
+   ▼
+factory:approved → human clicks Approve in web UI
+   │
+   ▼
+apps/server merges PR via connectors/github → factory:retrospecting →
+   slices/retro → factory:done.
+```
+
+Every step emits events to the event stream. The UI tails it over SSE
+and patches React Query caches in place — no polling on the board.
+
+## What lives where (quick lookup)
+
+| Need to … | Open … |
+|---|---|
+| Add a new factory state | `core/state-machine/states.ts` + transitions.ts |
+| Wire a new label → workflow | `apps/server/src/shared/dispatch-routing.ts` |
+| Add a new skill | `skills/<name>/{prompt.md, schema.ts, skill.config.ts}` |
+| Add a DB table | `core/db/schema.ts` + `pnpm db:generate` |
+| Add an SSE event kind | `core/event-stream/store.ts` (EventKind union) |
+| Change a budget default | `core/agent-runtime/budgets.ts` (SKILL_BUDGETS) |
+| Add a new role | `core/types.ts` (Role union) + audit-docs check |
+| Add a hook the agent runs | `hooks/<name>.sh` (NOT `.claude/hooks/` — see CLAUDE.md) |
+
+## Process model
+
+- **Single Node process** per orchestrator run. Per-project ticks are
+  independent `setInterval` loops in that same process. No worker
+  threads; no clustering.
+- **Child processes** for agents: `claude` or `codex` CLI spawned per
+  skill invocation. `shell: false`, minimal env, 30 s timeout (rule 32).
+- **SQLite, WAL mode.** All operational state. `busy_timeout = 5000`
+  for the vitest case.
+- **Workspaces are git worktrees** under `~/.factory/workspaces/<runId>/`.
+  Sandboxed via `.claude/settings.local.json` written by
+  `core/tool-layer/sandbox.ts`.
+
+## Cross-cutting concerns
+
+- **Event audit trail.** Every meaningful action is an event. Replay is
+  cheap; SSE consumers use Last-Event-ID for resumption.
+- **Cost accounting.** Every agent run writes one row to `agent_run_costs`,
+  with `costLabel ∈ { 'estimated', 'exact' }` so the UI can be honest
+  about which figures are real.
+- **Holdout enforcement.** `contextAllowlist` declared on each skill;
+  runtime drops disallowed keys at spawn time. Regression tested in
+  `slices/holdout-boundary-test/`.
+- **Secret redaction.** All event payloads go through `redactSecrets()`
+  before serialisation (`core/event-stream/store.ts:170`).

--- a/review/03-flows.md
+++ b/review/03-flows.md
@@ -1,0 +1,229 @@
+# Flows
+
+Mermaid diagrams for the loops you actually care about.
+
+## 1. Webhook → workflow dispatch
+
+```mermaid
+flowchart TB
+    GH[GitHub webhook: label changed] --> H[apps/server webhooks/handler.ts]
+    H -->|verify signature| R{dispatch-routing.ts<br/>label switch}
+
+    R -->|factory:triaging| TR[dispatchTriageBatch]
+    R -->|factory:investigating| IN[dispatchInvestigate]
+    R -->|factory:dev-ready| FX[dispatchFixIssue]
+    R -->|factory:spec-ready| PI[dispatchParallelImplement]
+    R -->|factory:needs-qa| QA[dispatchQa]
+    R -->|factory:needs-review| RV[dispatchReview]
+    R -->|factory:retrospecting| RT[dispatchRetro]
+    R -->|factory:qa-failed| QF[dispatchQaFailed]
+    R -->|factory:needs-fix| NF[dispatchNeedsFix]
+    R -->|factory:grilling| GR[dispatchGrillAndPrd]
+    R -->|factory:decomposing| DC[dispatchDecomposePrd]
+    R -->|factory:merge-conflict| MC[dispatchResolveConflict]
+    R -->|factory:archived /<br/>factory:rejected| TL[dispatchTerminalLabel<br/>fires sprint-review trigger]
+    R -->|unknown label| NOOP[logger.info, no-op]
+
+    FX --> L[withParallelLock<br/>per-issue lock + maxParallelAgents cap]
+    L -->|locked| W[workflow body]
+    L -->|cap full| Q[enqueueWorkflow<br/>drains on release]
+    L -->|already in-flight| D[drop duplicate]
+```
+
+Key file: `apps/server/src/shared/dispatch-routing.ts:60` (`dispatchForLabel`).
+Lock: `apps/server/src/shared/dispatch-lock.ts:58` (`withParallelLock`).
+
+## 2. fix-issue workflow (the dev-side happy path)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Tick (or webhook)
+    participant Disp as dispatchFixIssue
+    participant Smk as runSmoke
+    participant Ws as workspaces.ts
+    participant Adv as advise-on-plan (advisor)
+    participant Imp as skills/implement
+    participant Gh as connectors/github
+    participant Ev as skills/evidence-post
+    participant Src as state-source (GitHub)
+
+    T->>Disp: slug, issueNumber
+    Disp->>Smk: 6-check preflight (cached 60s)
+    Smk-->>Disp: ok / fail (event: workflow.smoke-failed)
+    Disp->>Ws: prepare worktree<br/>(git fetch + checkout branch)
+    Note over Disp: priority:high|critical only
+    Disp->>Adv: invokeSkill(advise-on-plan)
+    Adv-->>Disp: { verdict: proceed|revise|abort }
+    Disp->>Imp: invokeSkill(implement)
+    Imp-->>Disp: { filesChanged, testCommands, plan }
+    Disp->>Gh: openPullRequest(branch, base)
+    Gh-->>Disp: { url, number }
+    Disp->>Ev: invokeSkill(evidence-post) (best-effort)
+    Disp->>Src: transitionState(factory:needs-qa)
+    Src-->>Src: label flip on GitHub → webhook → dispatchQa
+```
+
+Skipped here for compactness: dev-review (Codex pre-QA), parallel WP
+builders (M19.03 path via `factory:spec-ready`), retry counters, and
+budget gating. All happen between steps 5 and 7.
+
+Key files: `slices/fix-issue/workflow.ts`, `apps/server/src/shared/dispatch-dev.ts`.
+
+## 3. QA → Review → approval gate
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Disp as dispatchQa
+    participant V as core/verify (deterministic)
+    participant Qa as skills/qa (HOLDOUT)
+    participant Rv as skills/review (HOLDOUT)
+    participant Src as state-source
+    participant UI as web UI (banner)
+    participant H as Human
+    participant Gh as connectors/github
+
+    Disp->>V: lint + typecheck + tests
+    V-->>Disp: structural pass/fail
+    Note over Disp,Qa: skip Qa if structural fails — go straight to qa-failed
+    Disp->>Qa: invokeSkill(qa) — fresh context, no dev reasoning
+    Qa-->>Disp: { verdict: pass|fail|partial, tiers, findings }
+    alt pass
+        Disp->>Src: transitionState(factory:needs-review)
+        Src-->>Rv: dispatchReview
+        Rv->>Rv: invokeSkill(review) — fresh context
+        Rv-->>Src: transitionState(factory:approved)
+        Src->>UI: SSE state.transitioned event
+        UI->>H: Approve / Reject banner
+        H->>UI: click Approve
+        UI->>Gh: mergePR
+        Gh-->>UI: 200 → factory:retrospecting (auto)
+    else fail / partial
+        Disp->>Src: transitionState(factory:qa-failed)
+        Src-->>Disp: webhook → dispatchQaFailed
+        Disp->>Disp: increment retry counter
+        alt retries < max
+            Disp->>Src: transitionState(factory:needs-fix)
+        else retries exhausted
+            Disp->>Src: transitionState(factory:needs-human)
+        end
+    end
+```
+
+Key files: `slices/qa/workflow.ts`, `slices/review/workflow.ts`,
+`core/retry/retry-counter.ts`, `apps/server/src/domains/issues/transitions.ts`.
+
+## 4. State machine (the happy path is just one slice of this)
+
+```mermaid
+stateDiagram-v2
+    [*] --> factory_triaging : new issue
+    factory_triaging --> factory_accepted : triage skill
+    factory_accepted --> factory_investigating : type:bug | type:chore
+    factory_accepted --> factory_grilling : vague feature
+    factory_grilling --> factory_prd_drafting : grill complete
+    factory_prd_drafting --> factory_decomposing : prd approved
+    factory_decomposing --> factory_dev_ready : sub-issues filed
+    factory_investigating --> factory_investigation_complete
+    factory_investigation_complete --> factory_dev_ready
+    factory_dev_ready --> factory_in_progress : fix-issue picks up
+    factory_dev_ready --> factory_spec_ready : M19 spec-author path
+    factory_spec_ready --> factory_in_progress : parallel-implement
+    factory_in_progress --> factory_needs_qa
+    factory_needs_qa --> factory_needs_review : qa pass
+    factory_needs_qa --> factory_qa_failed : qa fail
+    factory_qa_failed --> factory_needs_fix : retries remaining
+    factory_qa_failed --> factory_needs_human : retries exhausted
+    factory_needs_fix --> factory_needs_qa : fix-feedback loop
+    factory_needs_review --> factory_approved : review pass
+    factory_needs_review --> factory_needs_fix : review needs-fix
+    factory_needs_review --> factory_needs_human : review unsure
+    factory_approved --> factory_retrospecting : human merges
+    factory_approved --> factory_merge_conflict : merge 405
+    factory_merge_conflict --> factory_retrospecting : resolve-conflict OK
+    factory_merge_conflict --> factory_needs_human : resolve fails
+    factory_retrospecting --> factory_done : retro completes
+    factory_done --> factory_archived
+    factory_needs_human --> [*] : manual
+    factory_rejected --> [*] : manual
+```
+
+Canonical: `core/state-machine/states.ts`, `transitions.ts`.
+28 states; terminal: `done`, `archived`, `rejected`. Diagram omits a
+couple of admin states for clarity.
+
+## 5. Per-project tick scheduler
+
+```mermaid
+sequenceDiagram
+    participant S as startPerProjectScheduler
+    participant P1 as Project A interval (60s)
+    participant P2 as Project B interval (60s)
+    participant Tk as dispatchTriageBatch
+    participant Sm as runSmoke
+    participant Db as project_state.last_tick_at
+
+    S->>P1: setInterval(tick, A.tickIntervalSeconds * 1000)
+    S->>P2: setInterval(tick, B.tickIntervalSeconds * 1000)
+
+    par independent loops
+        P1->>Sm: smoke gate (cached 60s per slug)
+        Sm-->>P1: ok
+        P1->>Tk: dispatchTriageBatch(A.slug)
+        Tk-->>Db: update last_tick_at
+    and
+        P2->>Sm: smoke gate
+        Sm-->>P2: ok (separate cache key)
+        P2->>Tk: dispatchTriageBatch(B.slug)
+    end
+```
+
+A crash in project A's tick does not stop project B. Each tick re-derives
+state from GitHub + SQLite (rule 7: stateless across ticks).
+
+Key files: `core/projects/scheduler.ts`, `core/orchestrator/smoke.ts`,
+`apps/server/src/shared/dispatch.ts`.
+
+## 6. Event store fan-out
+
+```mermaid
+flowchart LR
+    Caller[any core/slice] -->|appendEvent| ES[EventStore]
+    ES -->|JSON.stringify + redact| Ins[(SQLite INSERT)]
+    Ins -->|RETURNING row| ES
+    ES -->|emit 'event'| Emit[EventEmitter]
+    Emit --> Sub1[SSE buildSseStream → web client]
+    Emit --> Sub2[Other subscribers: retro trigger, sprint review, etc.]
+
+    classDef wrap fill:#fee,stroke:#900,color:#900
+    note1[safeListener wraps subscribers:<br/>thrown errors are caught + logged<br/>once per error shape, process-lifetime]:::wrap
+    Sub1 -.- note1
+    Sub2 -.- note1
+```
+
+`core/event-stream/store.ts:169` is the only writer.
+`closeOrphanedRuns()` (line 300) runs on startup to emit synthetic
+`agent.run-failed` for any `agent.run-started` without a matching
+`run-completed` / `run-failed`.
+
+## 7. Retro + learning loop (M9 + M11)
+
+```mermaid
+flowchart TB
+    M[PR merged, factory:retrospecting] --> Pol{retrospectivePolicy<br/>+ deep triggers fired?}
+    Pol -->|light| RL[skills/retrospective-light<br/>3-bullet summary]
+    Pol -->|deep| RD[skills/retrospective-deep<br/>full analysis + scores]
+    RL --> AR[(archived_lifecycles<br/>+ decision_patterns)]
+    RD --> AR
+    AR --> CM{lifecycleCount >= 3<br/>AND consistency >= 0.8?}
+    CM -->|yes| CR[skills/retrospective-cross-run<br/>PlaybookManifest]
+    CR --> IC[(improvement_candidates)]
+    IC --> CG{coachPolicy.enabled<br/>AND not forbidden target?}
+    CG -->|yes| SK[skills/skill-coach<br/>proposes diff to prompt.md]
+    SK --> Iss[Factory GitHub issue<br/>type:improvement]
+    Iss --> H[Human approves<br/>before any merge]
+```
+
+Forbidden coach targets are hard-coded: `qa`, `review`, all retros,
+`skill-coach` itself. See ADR 0025.

--- a/review/04-data-model.md
+++ b/review/04-data-model.md
@@ -1,0 +1,117 @@
+# Data model
+
+`core/db/schema.ts` is the source of truth. This page is the
+human-friendly summary.
+
+## ER overview (selected tables)
+
+```mermaid
+erDiagram
+    PROJECT_STATE ||--o{ EVENTS : "logs to"
+    PROJECT_STATE ||--o{ AGENT_RUNS : "owns"
+    PROJECT_STATE ||--o{ AGENT_RUN_COSTS : "owns"
+    PROJECT_STATE ||--o{ ARCHIVED_LIFECYCLES : "archives"
+    PROJECT_STATE ||--o{ DECISION_PATTERNS : "mines"
+    PROJECT_STATE ||--o{ PLAYBOOKS : "exports"
+    PROJECT_STATE ||--|| PROJECT_SETTINGS : "overrides"
+    PROJECT_STATE ||--o{ PROJECT_SKILL_SETTINGS : "skill overrides"
+    PROJECT_STATE ||--o{ PROJECT_MODEL_SETTINGS : "model overrides"
+
+    PERSONA_NAMES ||--o{ PERSONA_ROUTING : "slot lookup"
+    PERSONA_NAMES ||--o{ PERSONA_STATS : "accumulates"
+    PERSONA_STATS ||--o{ IMPROVEMENT_CANDIDATES : "files"
+    AGENT_RUNS }o--|| PERSONA_STATS : "updates"
+    AGENT_RUN_COSTS }o--|| AGENT_RUNS : "1:1 by runId"
+
+    EVENTS }o..o{ AGENT_RUNS : "runId (soft FK)"
+
+    ENGINEERING_SPECS ||--o{ RUN_QUALITY_SCORES : "by pipelineRunId"
+    WP_ITERATIONS }o--|| AGENT_RUNS : "WP run history"
+    AGENT_DECISIONS }o--|| AGENT_RUNS : "decision records"
+
+    INBOX_ITEMS {
+        int id PK
+        text title
+        text body
+        text type
+    }
+
+    GOVERNANCE_AUDIT {
+        int id PK
+        text pr_url
+        int  ok
+        text violations
+    }
+```
+
+> **Note.** SQLite FKs are not enforced at the database level (PRAGMA
+> off — see Finding F-8). The diagram shows logical relationships; the
+> code is the actual enforcer.
+
+## Tables, in order of importance
+
+| Table | Purpose | Hot read pattern | Indexes |
+|---|---|---|---|
+| `events` | Append-only audit log. Single writer. | `(projectId, workItemId, ?kind)` ascending by id | `(project_id, created_at)`, `(work_item_id, id)` — see F-9 |
+| `project_state` | Per-project tick metadata, active milestone | by `project_id` | PK |
+| `agent_runs` | One row per agent invocation, outcome only | by `run_id`, `project_id`, `persona_id` | runId uniq + 2 |
+| `agent_run_costs` | One row per run, tokens + USD | by `project_id` over `created_at`; per `work_item_id` for issue page | runId uniq + 2 |
+| `persona_stats` | Round-robin persona quality + run counts | `(persona_name, role)` for stats; by `role` for ranking | uniq on (name, role) — see F-9 |
+| `persona_routing` | `lastIndex` for round-robin | `(project_id, role)` | composite PK |
+| `persona_names` | Codename per (project, role, slot) | `(project_id, role, slot_index)` | uniq |
+| `improvement_candidates` | Retro-flagged changes pending human approval | by `persona_name + status` | composite |
+| `archived_lifecycles` | One JSON blob per closed work item | by `project_id` over `closed_at` | composite + (project, work_item) |
+| `decision_patterns` | Mined convergent patterns (cross-run learning) | `(project_id, kind, role)` | uniq + project |
+| `playbooks` | Exported PlaybookManifest snapshots | by `project_id` over `created_at` | composite |
+| `run_quality_scores` | Per-run QualityScore (M19.08+) | by `pipeline_run_id`, `project_id` over `ts` | uniq + 2 |
+| `engineering_specs` | EngineeringSpec JSON per work item (M19.17) | `(project_id, work_item_id)` | uniq |
+| `wp_iterations` | Per-WP outcome rows (M19.03 parallel builder) | `(run_id, wp_id)` | uniq + 1 |
+| `agent_decisions` | Decision capture (M19.06) | by `run_id` | uniq + 1 |
+| `scout_reports` | Wave-1 scout JSON outputs | `(project_id, work_item_id, run_id)` | uniq + 1 |
+| `governance_audit` | Per-PR governance check verdicts | by `pr_url` | PK only |
+| `inbox_items` | Raw notes pending promotion to an issue | by id | PK |
+| `project_settings`, `project_skill_settings`, `project_model_settings`, `project_dev_review_settings`, `project_review_settings` | Per-project override layers | by project | PKs |
+
+## Two-place state split
+
+| What | Where | Why |
+|---|---|---|
+| Work-item state, type, priority, schedule | GitHub Issue **labels** | Survives orchestrator crash; UI on github.com is the canonical view |
+| Events, costs, persona stats, archives, audits | SQLite | Operational; regeneratable from events if needed |
+| Project config (budgets, rolesModels, governance) | `target-projects/<slug>/project.config.ts` | Versioned in git; DB rows in `project_*_settings` are **overrides** on top |
+
+This is rule 7: the orchestrator is stateless across ticks. The DB never
+"owns" work-item state.
+
+## Override precedence (model + budget resolution)
+
+When `invokeSkill()` resolves a model and budget for a run:
+
+1. **Caller override** (e.g. test seam, advisor wrapping) — wins.
+2. **DB row override** in `project_model_settings` / `project_skill_settings`.
+3. **`project.config.ts`** declared overrides.
+4. **`SKILL_BUDGETS` defaults** in `core/agent-runtime/budgets.ts`.
+5. **Skill `modelPin`** as the final fallback.
+
+Code: `core/agent-runtime/resolve-for-project.ts`.
+
+Holdout protection: if `allowHoldoutOverride !== true`, any override
+attempt against `qa` / `reviewer` is **silently dropped** (not errored).
+That keeps QA/Reviewer at the project's declared tier.
+
+## Migration story
+
+- Drizzle migrations live in `core/db/migrations/`.
+- `migrate()` runs on every server start (see `core/db/db.ts:54`).
+  Idempotent (drizzle tracks applied migrations).
+- Vitest workers each get their own DB file. The migration race is real
+  if you ever try to share a DB across workers — `scripts/run-vitest-with-db.ts`
+  is the workaround.
+
+## Things deliberately NOT in the DB
+
+- Work-item state (GitHub).
+- Agent prompts (versioned files under `skills/`).
+- Decision-summary text beyond the run window (archived only).
+- Worktree contents (`~/.factory/workspaces/<runId>/`, ephemeral).
+- Symbol index (`~/.factory/symbol-index.db`, regenerable, gitignored).

--- a/review/05-findings.md
+++ b/review/05-findings.md
@@ -1,0 +1,576 @@
+# Findings
+
+Concrete bugs, smells, and refactor candidates. Each finding includes
+file:line, why it matters, and a one-line fix sketch.
+
+Severity legend:
+- **H** — observable bug or correctness risk under normal use.
+- **M** — latent bug, perf cliff, or significant maintainability cost.
+- **L** — nit / polish / minor smell.
+
+Numbering is stable so PRs can cite `F-3` etc.
+
+---
+
+## H — High
+
+### F-1 — Persona round-robin has a non-atomic read/modify/write
+
+**Where:** `core/agent-runtime/select-persona.ts:26-50`
+
+The function reads `lastIndex`, computes the next, writes it back, all
+as three separate Drizzle statements. better-sqlite3 is synchronous so
+within a single Node process this is effectively atomic — **but** the
+moment a second process touches the same DB (CLI command, vitest worker
+in CI, or a hypothetical second server), two concurrent callers see the
+same `lastIndex` and assign the same slot. Round-robin invariant breaks
+silently.
+
+The same shape repeats for `personaNames` codename allocation on first
+seed (lines 53-69): if two callers race on slot 0 they both compute
+`totalSlots` identically and the unique index will fire — but only the
+loser fails noisily. That's actually fine; the round-robin one is the
+real problem.
+
+**Fix sketch.** Wrap the routing block in `db.transaction(() => { ... })`,
+or use `UPDATE persona_routing SET last_index = ((last_index + 1) % 3)
+WHERE … RETURNING last_index` to fold read+write into one statement.
+
+---
+
+### F-2 — `parseDependencies` accepts unsafe issue numbers
+
+**Where:** `core/state-source/dependency-parser.ts:31`
+
+`Number.parseInt(m[2], 10)` happily parses `#9999999999999999` into a
+non-safe-integer that GitHub will reject downstream — but only after the
+scheduler has already filtered the issue with a `schedule:blocked-by`
+label. Worse: nothing caps `issueNumber` to GitHub's 1-2^31 range. A
+malicious or buggy issue body containing `Depends on #99...` (any
+digits) makes the issue parse but the resolver fail every tick.
+
+The regex also matches `#0`, which is never a valid GitHub issue
+number.
+
+**Fix sketch.**
+
+```ts
+if (!Number.isSafeInteger(issueNumber) || issueNumber < 1 || issueNumber > 2 ** 31 - 1) continue;
+```
+
+Two lines, in the for-loop body. No tests need to change; add one for
+the boundary.
+
+---
+
+### F-3 — Event subscribers can leak if the unsubscribe handle is dropped
+
+**Where:** `core/event-stream/store.ts:158, 263-279`
+
+`setMaxListeners(0)` disables the Node EventEmitter warning that would
+normally tell you "you have 50 listeners on this emitter, that's
+suspicious." The store hands out subscriptions as closures returned from
+`subscribe(listener)`. If a caller forgets to call the returned
+unsubscribe function — long-lived SSE handlers do this correctly, but
+any future ad-hoc subscriber (or a hot-reloaded dev session) is a
+candidate — listeners accumulate for process lifetime.
+
+There's no audit of how many subscribers are currently attached. There's
+no TTL.
+
+**Fix sketch.** Either:
+1. Drop `setMaxListeners(0)` and keep the warning. 50 is a generous
+   ceiling for a local-first single-user tool. The warning will catch
+   leaks early.
+2. Or expose `eventStore.listenerCount()` and add a startup log line.
+
+---
+
+### F-4 — `appendEvent` does not guard against unserialisable payloads
+
+**Where:** `core/event-stream/store.ts:170-171`
+
+```ts
+const redacted = redactSecrets(input.payload);
+const payload = JSON.stringify(redacted ?? {});
+```
+
+If `redacted` contains a circular reference or a `BigInt`, `JSON.stringify`
+throws. That throw escapes `appendEvent`, which is called from inside
+every dispatcher's try/finally. The current event is lost and the caller
+may continue believing it was recorded — there's no return-channel for
+"event dropped."
+
+This is unlikely under normal use (payloads are plain JSON-ish objects
+shaped by Zod schemas), but a future tool-call audit payload that
+includes a non-serialisable object would silently kill events.
+
+**Fix sketch.**
+
+```ts
+let payload: string;
+try {
+  payload = JSON.stringify(redacted ?? {});
+} catch (err) {
+  logger.error('appendEvent: payload not serialisable', { kind: input.kind, err: String(err) });
+  payload = JSON.stringify({ __error: 'payload_not_serialisable', kind: input.kind });
+}
+```
+
+---
+
+### F-5 — Listener safe-wrap dedupes errors **process-lifetime**
+
+**Where:** `core/event-stream/store.ts:264-274`
+
+```ts
+const seenErrorShapes = new Set<string>();
+// ...
+if (!seenErrorShapes.has(shape)) { seenErrorShapes.add(shape); console.error(...); }
+```
+
+The dedup set is per-subscription and grows forever. Each unique
+`name + message` shape accumulates. For a long-lived server process
+(>weeks) seeing diverse errors this grows unbounded. More importantly,
+"once-per-error-shape per process" means a real recurring problem
+becomes invisible after the first occurrence. The docstring acknowledges
+this trade-off, but it's worth re-litigating: a TTL or a low-water-mark
+flush (e.g. 1 hour) gives you both noise reduction and visibility.
+
+**Fix sketch.** Use a `Map<string, { lastLoggedAt: number, count: number }>`
+and re-log when `now - lastLoggedAt > 1h` or `count` crosses a power of
+ten. Log the cumulative count when you do.
+
+---
+
+### F-6 — `extractResultJson` falls back to returning a raw string
+
+**Where:** `core/agent-runtime/claude-cli.ts:68-113`
+
+Tries five different JSON parse strategies. If all fail, returns the raw
+string and emits a `console.error` preview. The schema validator at the
+end of `invokeSkill()` (line 213) catches this and throws
+`OutputValidationError`, so it's not a silent corruption. But:
+
+1. The error message the operator sees says "output validation failed"
+   when the real problem is "agent didn't emit JSON at all."
+2. The `console.error` preview is the only signal of what actually
+   happened — and it's gone the moment logs rotate.
+
+**Fix sketch.** Emit a typed event when the fallback fires, e.g.
+`agent.json-parse-failed`, with the truncated preview. Then
+`OutputValidationError` can read the run's last event to give a useful
+error. Cheap.
+
+---
+
+### F-7 — `dispatchTerminalLabel` proceeds even when source.getItem returns minimal data
+
+**Where:** `apps/server/src/shared/dispatch-routing.ts:41-50`
+
+If `getItem` succeeds but `item.milestoneId` is null *and*
+`item.milestoneTitle` is null (legitimate for unscheduled archives), the
+code logs `info` and returns. That's correct. But the call to
+`source.getItem` itself can throw (network error, GitHub 5xx) — the
+caller is `dispatchForLabel`, which awaits this without a try/catch and
+will propagate the error all the way up to the webhook handler. A 500
+back to GitHub may or may not be desired here.
+
+This is a moderate concern: webhook failures cause GitHub to retry, and
+flaky GitHub reads at the moment a label flips will produce phantom
+retries. Better to log + swallow at the dispatch boundary.
+
+**Fix sketch.** Wrap the body of `dispatchTerminalLabel` in
+`try/catch` and log on failure. Same for every leaf `dispatch*` —
+some already do, some don't.
+
+---
+
+## M — Medium
+
+### F-8 — SQLite foreign keys are off
+
+**Where:** `core/db/db.ts:44-50`
+
+SQLite ships with `PRAGMA foreign_keys = OFF` by default. The schema
+defines no explicit FKs anyway — the columns are typed but
+unconstrained. As long as nothing relies on FK cascade behaviour, this
+is fine. The risk: orphaned rows accumulate (e.g. `persona_stats` rows
+referencing a deleted persona). For a local-first tool that's tolerable;
+for anyone forking this and adding multi-tenancy, it bites.
+
+**Fix sketch.** Either (a) document the choice in `core/db/README.md`
+("we don't use FKs; relationships are enforced in code"), or (b) add
+`sqlite.pragma('foreign_keys = ON')` and rerun the migration set against
+explicit FKs. Option (a) is what the codebase wants today.
+
+---
+
+### F-9 — Missing index on `events` for the common `(projectId, kind)` filter
+
+**Where:** `core/db/schema.ts:32-35`
+
+`events_project_created_idx` is `(project_id, created_at)`; `events_work_item_idx`
+is `(work_item_id, id)`. The `replay()` method (line 205) accepts a `kind`
+filter and many callers use `kind` alone, sometimes with `projectId`.
+Examples: cross-run retro queries all `qa.completed` events per project;
+sprint-review trigger replays multiple kinds. These queries scan the
+projectId index and filter rows in memory.
+
+For a single-user local DB this is invisible. After ~100k events it
+won't be. Cost-free to add now.
+
+**Fix sketch.** Add `events_project_kind_idx ON events(project_id, kind, id)`
+in a new migration.
+
+---
+
+### F-10 — `replay()` returns all events with no default limit
+
+**Where:** `core/event-stream/store.ts:205-251`
+
+`limit` is optional and unbounded by default. SSE replay (with
+`sinceId`) is bounded by event growth between disconnections (fine for
+short outages). Anything that calls `replay({ projectId })` with no
+filter (and a few do: see `dispatchResumeIssue` at line 205 which
+queries all events per work item — bounded) will pull the entire row
+set into memory.
+
+Two cases worth tightening: `dispatchResumeIssue` (work-item filtered,
+fine) and any future "show me everything for this project" caller (not
+fine).
+
+**Fix sketch.** Make `limit` required with a sane default (e.g. 5000),
+or add an internal `MAX_REPLAY = 50_000` that logs a warning when hit.
+
+---
+
+### F-11 — `dispatchResumeIssue` reads state, then does work without re-checking
+
+**Where:** `apps/server/src/shared/dispatch-routing.ts:185-355`
+
+`item.state` is read at line 200, then used to drive the entire resume
+logic. Between that read and the eventual dispatch, a webhook can flip
+the label (human action on github.com, or a competing workflow). The
+parallel lock (line 186) protects against the *same* dispatch running
+twice, but not against the underlying state being different by the time
+the dispatch runs.
+
+In practice this is rare; the resume path is a recovery flow. But if it
+ever does fire wrong, debugging it from logs alone is painful because
+the dispatch happens far from the state read.
+
+**Fix sketch.** Re-fetch state immediately before the final
+`await entry.dispatch(...)` call and log if it differs. Or just log the
+read state into the event stream so you can correlate later.
+
+---
+
+### F-12 — `withParallelLock` ignores errors thrown by the post-lock thunk
+
+**Where:** `apps/server/src/shared/dispatch-lock.ts:87-89`
+
+```ts
+if (postLock != null) {
+  await postLock();
+}
+```
+
+The post-lock thunk runs *after* `finally` released the lock. If it
+throws, the error propagates to the original caller — typically the
+webhook handler — and the chained workflow (e.g.
+`dispatchInvestigationComplete` after `dispatchInvestigate`) is lost
+with no retry. There's no event emitted.
+
+The wrapper deliberately runs the thunk outside the lock so it can
+re-acquire. That's correct. But a logged catch around `await postLock()`
+would make failures visible.
+
+**Fix sketch.**
+
+```ts
+if (postLock != null) {
+  try { await postLock(); }
+  catch (err) { logger.error('withParallelLock: post-lock thunk failed', { slug, issueNumber, err: String(err) }); }
+}
+```
+
+---
+
+### F-13 — Hook scripts assume bash + GNU `grep`/`jq` and don't quote `$RUN_ID`
+
+**Where:** `hooks/require-spec.sh`, `hooks/stop-verify-ac.sh`
+
+- `RUN_ID` is treated as safe (UUID-shaped). It is, today. If a caller
+  ever puts a space or a glob char in there, `slices/${RUN_ID}/spec.ts`
+  expands wrongly. Two-character fix.
+- `grep -c '\[ \]' "$SPEC_FILE" 2>/dev/null || echo 0` swallows the
+  difference between "no matches" (exit 1) and "file unreadable" (exit
+  2). The AC-completeness gate silently passes if the spec file is
+  permission-denied.
+- Both scripts require `jq` and a recent bash. macOS ships bash 3.2;
+  there's no shebang guard. Document it or switch to `/usr/bin/env -S bash`.
+
+**Fix sketch.**
+```sh
+SPEC_TS="slices/${RUN_ID:?missing FACTORY_RUN_ID}/spec.ts"
+if [ -e "$SPEC_FILE" ] && [ ! -r "$SPEC_FILE" ]; then
+  printf "stop-verify-ac: spec file unreadable: %s\n" "$SPEC_FILE" >&2
+  exit 2
+fi
+UNCHECKED=$(grep -c -- '\[ \]' "$SPEC_FILE" 2>/dev/null || echo 0)
+```
+
+---
+
+### F-14 — `costFromCliEnvelope` silently records zero on a malformed envelope
+
+**Where:** `core/agent-runtime/claude-cli.ts:353, 358-371`
+
+```ts
+const usage = envelope ? costFromCliEnvelope(envelope) : null;
+// ...
+costUsd: usage?.costUsd ?? 0,
+costLabel: usage?.costLabel ?? 'estimated',
+```
+
+When the envelope is missing required fields, `usage` is null and the
+row records `costUsd: 0, costLabel: 'estimated'`. No warning. Per-project
+daily-token budgets that drive scheduling decisions silently undercount.
+A run that consumed real tokens but had a parsing hiccup looks free.
+
+The cost dashboard correctly labels `~$` for estimated figures, so the
+UI is honest — but the **budget enforcement** path doesn't distinguish
+"zero because cheap" from "zero because we couldn't read it."
+
+**Fix sketch.** When `usage == null` but the run otherwise succeeded,
+emit `agent.cost-unknown` event and let the budget code decide whether
+to treat that as a budget hit. At minimum log a warning.
+
+---
+
+### F-15 — `MCP_CONFIG_PATH` is overwritten every run
+
+**Where:** `core/agent-runtime/claude-cli.ts:127`
+
+```ts
+writeFileSync(MCP_CONFIG_PATH, '{"mcpServers":{}}', { flag: 'w' });
+```
+
+Every agent run writes the global `~/.factory/mcp-config.json` to an
+empty server set, before `resolveMcpConfigPath()` may pick a
+workspace-relative MCP file. If two runs race (parallel-implement
+dispatches multiple WP builders), they both clobber the same file with
+the same content — harmless, but the unconditional write is unnecessary
+I/O and a footgun the day someone adds a real MCP server to that file
+expecting it to persist.
+
+**Fix sketch.** Skip the write when the file already exists with
+content `{"mcpServers":{}}`. Or move the empty default to a per-run
+temp file.
+
+---
+
+### F-16 — `replay({ runId })` is called inside the run-completed event payload assembly
+
+**Where:** `core/agent-runtime/claude-cli.ts:435`
+
+```ts
+resolve({
+  output: extractResultJson(...),
+  decisionSummaries: [],
+  events: eventStore.replay({ runId }),
+});
+```
+
+This re-queries the events table just to package the run's own event
+stream into the result. The result object is then consumed by
+`invokeSkill()` which doesn't actually use `events`. Caller drops it.
+
+Two small wins: (a) drop the field entirely if no callers consume it
+(check first), or (b) keep it but document that it triggers an extra
+SQL query per spawn.
+
+**Fix sketch.** Grep the codebase for `.events` on `AgentResult`. If
+unused, delete the field and the query.
+
+---
+
+### F-17 — `dispatchForLabel` is a 60-line if-chain
+
+**Where:** `apps/server/src/shared/dispatch-routing.ts:60-123`
+
+Twelve consecutive `if (labelName === 'factory:X') { await dispatchY; return; }`
+branches. Functional and readable, but every new state adds another
+branch and a new test in dispatch-routing.test.ts. A label → dispatch
+table would compress this and make adding states one line.
+
+**Fix sketch.**
+
+```ts
+const LABEL_DISPATCH: Record<string, (s: string, n: number) => Promise<void>> = {
+  'factory:triaging':     (slug) => dispatchTriageBatch(slug),
+  'factory:investigating': dispatchInvestigate,
+  // ...
+};
+const fn = LABEL_DISPATCH[labelName];
+if (fn) return fn(slug, issueNumber);
+if (labelName === 'factory:archived' || labelName === 'factory:rejected') return dispatchTerminalLabel(slug, issueNumber);
+logger.info('dispatchForLabel: no workflow for label', { slug, labelName });
+```
+
+---
+
+## L — Low / nits
+
+### F-18 — `process.env` reads scattered through `claude-cli.ts`
+
+**Where:** `core/agent-runtime/claude-cli.ts:198-225`
+
+Five different `process.env.X ?? fallback` reads inline. Move them to a
+typed `loadAgentEnv()` helper at the top of the file. Same module reads
+`FACTORY_SERVER_PORT` with a hardcoded fallback of `3001` — that magic
+number deserves a constant.
+
+### F-19 — `closeOrphanedRuns()` swallows orphaned `agent.run-started` events with `runId == null`
+
+**Where:** `core/event-stream/store.ts:300-340`
+
+```ts
+.where(and(eq(events.kind, 'agent.run-started'), isNotNull(events.runId)))
+```
+
+Correct, but means any run-started emitted without a runId is invisible
+forever. There are no callers today that omit `runId` for run-started,
+but a regression here is silent. Add an `assert(input.runId != null)`
+inside `appendEvent` when `kind === 'agent.run-started'`.
+
+### F-20 — `replay()` returns `kind: r.kind as EventKind`
+
+**Where:** `core/event-stream/store.ts:245`
+
+Casts a string column to the EventKind union with no validation. If the
+DB has an old event kind no longer in the union (after a refactor),
+consumers receive an `EventKind` value that fails downstream type
+narrowing. Switch to a `validateEventKind(s): EventKind | 'unknown'`
+helper, or drop the cast and surface `string` to consumers that don't
+care.
+
+### F-21 — `dependencies.events` referenced as a soft FK; no cleanup
+
+**Where:** `core/event-stream/store.ts:290-293` (`deleteByWorkItem`)
+
+The escape hatch deletes events for a work item. Documented as test-only.
+Worth a runtime check that `process.env.VITEST != null` (or similar) to
+prevent accidental production calls.
+
+### F-22 — `ProjectModelPanel.tsx` is 759 lines
+
+**Where:** `apps/web/src/components/settings/ProjectModelPanel.tsx`
+
+Already split into subcomponents but the parent file is still long.
+Pull the role row, the dev-review panel, the codex auth panel, and the
+complexity-overrides table out into their own files.
+
+### F-23 — `BootstrapWizard.tsx` is 654 lines
+
+**Where:** `apps/web/src/components/bootstrap/BootstrapWizard.tsx`
+
+Multi-step wizards naturally grow. Lift each step's render block into
+`StepN.tsx` siblings, keep the parent as state machine + step dispatch.
+
+### F-24 — `grill-and-prd.ts` workflow is 739 lines
+
+**Where:** `core/workflows/grill-and-prd.ts`
+
+Two skills' worth of orchestration packed into one file. Split into
+`grill-loop.ts` (the question/answer cycle) and `prd-author.ts` (the
+hand-off + advisor wrap) — both already conceptually separate.
+
+### F-25 — `apps/server/src/domains/issues/transitions.ts` is 319 lines
+
+**Where:** `apps/server/src/domains/issues/transitions.ts`
+
+This is the transition router for manual/forced state changes from the
+UI. Worth scanning for TOCTOU between "read current state from GitHub"
+and "post new label." Probably fine because GitHub label updates are
+PUT-idempotent, but a paragraph in the file's header docstring
+explaining the race model would help future readers.
+
+### F-26 — `scripts/run-vitest-with-db.ts` does not clean up temp DBs on crash
+
+**Where:** `scripts/run-vitest-with-db.ts`
+
+The script writes per-worker DBs under the OS tempdir. If vitest is
+killed (Ctrl-C, OOM), the files linger. `process.on('exit', () => rmSync(dir, { recursive: true }))`
+plus an explicit cleanup on `SIGINT` covers the gap.
+
+### F-27 — `dispatchResumeIssue` calls `eventStore.replay` three times
+
+**Where:** `apps/server/src/shared/dispatch-routing.ts:205, 242, 303`
+
+Three separate replays of the same work-item's full event history. Each
+queries the events table independently. Replays once into a local
+`const allEvents`, walk it three times.
+
+### F-28 — `core/event-stream/store.ts` mixes EventKind union with a wide replay filter
+
+The 90+ EventKind values are an enum, but `replay()` accepts
+`filter.kind: string`. Tighten to `EventKind` so the typechecker catches
+typos in callers.
+
+### F-29 — Inventory marks four target-projects as "missing README"
+
+**Where:** `docs/inventory.md:130-138`
+
+`target-projects/*` lacks READMEs. Per the audit doc rule, this should
+either be excluded from the inventory check or each project should get
+a one-paragraph stub.
+
+### F-30 — `apps/web/src/lib/dependency-parser.ts` is a client mirror of the server parser
+
+**Where:** `apps/web/src/lib/dependency-parser.ts`
+
+CLAUDE.md notes the mirror. Risk: the server parser changes, the client
+doesn't, and `useHasOpenDep` shows a different result than the
+scheduler. There's no cross-test pinning the two implementations to the
+same fixtures. A shared `core/state-source/dependency-parser.ts` import
+from the web build (via the workspace package) would be safer, or at
+minimum a snapshot test that runs the same fixture through both.
+
+---
+
+## Summary table
+
+| ID | Severity | Area | One-line summary |
+|---|---|---|---|
+| F-1 | H | agent-runtime | Persona round-robin non-atomic across processes |
+| F-2 | H | state-source | `parseDependencies` accepts unsafe issue numbers |
+| F-3 | H | event-stream | Subscriber list unbounded if unsub handles are dropped |
+| F-4 | H | event-stream | `appendEvent` crashes on unserialisable payloads |
+| F-5 | H | event-stream | Error dedup is process-lifetime; recurring errors invisible |
+| F-6 | H | agent-runtime | JSON-parse fallback to raw string emits no event |
+| F-7 | H | dispatch | `dispatchTerminalLabel` doesn't swallow getItem errors |
+| F-8 | M | db | Foreign keys off; document or enable |
+| F-9 | M | db | Missing index `events(project_id, kind, id)` |
+| F-10 | M | event-stream | `replay()` has no default limit |
+| F-11 | M | dispatch | TOCTOU on resume between state read and dispatch |
+| F-12 | M | dispatch | Post-lock thunk errors disappear |
+| F-13 | M | hooks | Shell hooks don't quote `$RUN_ID`; AC gate swallows grep errors |
+| F-14 | M | agent-runtime | Cost recorded as zero on missing envelope; budget undercounts |
+| F-15 | M | agent-runtime | MCP config file rewritten every spawn |
+| F-16 | M | agent-runtime | `replay({ runId })` packed into AgentResult; check if consumed |
+| F-17 | M | dispatch | `dispatchForLabel` if-chain → table |
+| F-18 | L | agent-runtime | env reads scattered; introduce typed helper |
+| F-19 | L | event-stream | `agent.run-started` with null runId silently ignored |
+| F-20 | L | event-stream | `kind: r.kind as EventKind` cast unchecked |
+| F-21 | L | event-stream | `deleteByWorkItem` lacks production-guard |
+| F-22 | L | web | `ProjectModelPanel.tsx` 759 lines |
+| F-23 | L | web | `BootstrapWizard.tsx` 654 lines |
+| F-24 | L | workflows | `grill-and-prd.ts` 739 lines |
+| F-25 | L | server | `domains/issues/transitions.ts` lacks race-model doc |
+| F-26 | L | scripts | `run-vitest-with-db.ts` doesn't clean temp DBs |
+| F-27 | L | dispatch | Triple-replay in `dispatchResumeIssue` |
+| F-28 | L | event-stream | `replay({ kind })` accepts string instead of EventKind |
+| F-29 | L | docs | `target-projects/*` missing READMEs |
+| F-30 | L | web | Dependency parser client/server mirror has no cross-test |

--- a/review/06-performance.md
+++ b/review/06-performance.md
@@ -1,0 +1,105 @@
+# Performance notes
+
+The system is local-first, single-user, and event-driven. Most of it
+doesn't need optimisation. This is the short list of places that
+**will** matter once the event log grows past ~100k rows.
+
+## Hot paths today
+
+| Path | Frequency | Cost shape |
+|---|---|---|
+| `eventStore.appendEvent()` | Every event (~10s of events per agent run, dozens of runs/day) | One SQLite insert + N synchronous subscriber calls. ~1ms. Cheap. |
+| `eventStore.replay()` | Every SSE connection, every resume, every retro mining | One indexed SELECT. Cheap for now; see below. |
+| `invokeSkill()` | Once per agent invocation | Bound by the child process. The SQL inside is <5ms. |
+| `runSmoke()` | Every project tick (cached 60s) | Five child processes when uncached; near-free when cached. |
+| Per-project tick | Configurable (`tickIntervalSeconds`, default 60s) | One `gh issue list` + dependency resolution per tick. GitHub API rate is the bottleneck, not SQL. |
+| Web Kanban | One initial REST + one SSE per route mount | React Query caches; cleanup hooks fire correctly. |
+
+## Where indexes will start to bite
+
+The `events` table is the only one that grows monotonically. At
+~100k rows the missing `(project_id, kind, id)` index becomes a
+noticeable cliff for these queries:
+
+- Cross-run retro: `WHERE project_id = ? AND kind IN ('qa.completed', 'review.completed', 'retrospective.completed')`
+- Sprint-review trigger: `WHERE project_id = ? AND kind = 'state.transitioned' AND created_at > ?`
+- Dispatch resume: `WHERE project_id = ? AND work_item_id = ?` (already indexed; fine)
+
+**Recommendation.** Add `events_project_kind_idx ON events(project_id, kind, id)`
+in a new migration. Cheap; you'll be glad later. (Finding F-9.)
+
+## Caches that exist and work
+
+- **Smoke gate**, per-slug, 60s TTL. Result cached on success only; failures
+  re-checked next tick.
+- **React Query**, default 5-minute stale time except Board which uses
+  `gcTime: 0` (live).
+- **Project config**, loaded once on server start. Reloaded only when the
+  Settings page "Reload" button is clicked.
+
+## Caches I would NOT add
+
+- **`getItem` / `replaceFactoryStateAtomic`** — these are GitHub
+  round-trips. Caching them invites the TOCTOU class of bugs we already
+  see in F-11. Pay the network cost; it's <200ms.
+- **Skill config / prompt** — `readPromptWithContext()` reads three small
+  files. Sub-millisecond.
+- **Event payload JSON parse** — `JSON.parse` on a few-KB string is
+  ~10µs. Don't cache.
+
+## Caches I'd consider
+
+- **`computeAllowlist(spec)`** in `core/tool-layer/allowlist.ts`. The
+  result depends only on `(role, toolBundles)` which are static per
+  skill. Memoising by stringified key would save a few ms per spawn —
+  trivially small but reduces a hot read of `skills/<name>/skill.config.ts`.
+  Probably not worth it; mention because it's the obvious next step
+  someone might try.
+- **`loadProjects()`** is already once-on-boot. If the project count
+  ever grows past ~50, the linear scan in `getProjectBySlug()` could
+  become a map lookup.
+
+## Long-running concerns
+
+- **`agent_run_costs` and `events` are append-only.** No retention.
+  After ~6 months of daily use on a busy project this DB gets sizable
+  (rough order: 1-10 GB). Two options when it matters:
+  1. Periodic archive to a sidecar DB (`factory-archive-<year-month>.db`).
+  2. SQLite `VACUUM INTO` for compaction; not necessary as long as WAL
+     is checkpointing.
+- **`archived_lifecycles`** stores JSON blobs. If lifecycles get big
+  (decision summaries + learning entries), this can be a per-row cost.
+  Today it's fine.
+
+## Concurrency cliffs
+
+- **Per-project parallel-agents cap defaults to 1.** Raising it (project
+  config `budgets.maxParallelAgents`) means multiple `claude` child
+  processes running at once. Each child can use ~1-2 GB resident; check
+  RAM before raising past 3-4. The lock module enforces the cap correctly
+  (`core/projects/parallel-lock.ts:32`).
+- **Per-issue scout fan-out (`maxScoutAgents`, default 6).** Multiplied
+  by `maxParallelAgents` this can be 6 × N children at once.
+  Worth a comment in `project.config.ts` examples.
+
+## SSE specifics
+
+The SSE channel does the right things:
+
+- `buildSseStream` replays since `Last-Event-ID` then tails.
+- 15s heartbeat keeps proxies happy.
+- One `EventSource` per page mount, cleanup in effect return.
+
+No issues. The thing to watch is the **number of concurrent SSE
+clients**: each adds an EventEmitter subscriber (F-3). A single-user
+tool will have 1-3 tabs open; not a problem unless someone opens
+hundreds.
+
+## What to leave alone
+
+- Drizzle ORM call sites. The query shapes are fine.
+- React rendering (the components are small and React 19 handles the
+  rest).
+- The Hono server. Hono is fast; nothing in the route handlers blocks.
+- Better-sqlite3 sync calls. The whole event-log story depends on them.
+  Switching to an async client would break the single-writer guarantee.

--- a/review/07-quick-wins.md
+++ b/review/07-quick-wins.md
@@ -1,0 +1,98 @@
+# Quick wins
+
+Two-hour pickups, ordered by leverage. Each links back to the finding
+that motivates it.
+
+## ≤ 30 minutes
+
+1. **Add `events_project_kind_idx` migration.** (F-9) Two-line schema
+   change + `pnpm db:generate`. Prevents the 100k-row cliff in retro
+   mining queries.
+
+2. **Bounds-check issue numbers in `parseDependencies`.** (F-2)
+   Two lines. Stops bad bodies from looping the scheduler.
+
+3. **Wrap `JSON.stringify` in `appendEvent`.** (F-4) Five lines.
+   Removes a class of cascading crash.
+
+4. **Log + swallow in leaf dispatch handlers.** (F-7, F-12) A pattern
+   already partly applied — finish it: `dispatchTerminalLabel` and
+   `withParallelLock` post-thunk should both catch and log.
+
+5. **Quote `$RUN_ID` and check readability in hook scripts.** (F-13)
+   Two scripts, four lines each.
+
+6. **Drop or document `setMaxListeners(0)`.** (F-3) One line. Either
+   remove and accept the warning at 11 subscribers, or add a comment
+   citing the trade-off and a startup log of `listenerCount`.
+
+7. **`replay({ kind })` should take `EventKind`, not `string`.** (F-28)
+   Type-only change, catches typos.
+
+## 30–90 minutes
+
+8. **Atomic persona round-robin via SQL.** (F-1) Single `UPDATE … RETURNING`
+   replaces three statements. Add a unit test with parallel callers in
+   a single transaction.
+
+9. **Index audit on hot tables.** (F-9 + scan): take `events`,
+   `agent_run_costs`, `archived_lifecycles`, `decision_patterns`. Plot
+   the EXPLAIN QUERY PLAN of each known caller. Add missing composites.
+   90 min including the writeup.
+
+10. **Default limit on `replay()`.** (F-10) Add `MAX_REPLAY = 50_000`,
+    warn-and-truncate when exceeded. Update tests.
+
+11. **Split `dispatchForLabel` into a table.** (F-17) Pure refactor,
+    keep tests green. Improves readability + makes new states a
+    one-liner.
+
+12. **Cost-unknown event + warning when envelope missing.** (F-14) One
+    new EventKind + an emit branch. Budget enforcement gets a real
+    signal instead of silently undercounting.
+
+13. **Cleanup hook for vitest temp DBs.** (F-26) Register `exit` +
+    `SIGINT` handlers in `scripts/run-vitest-with-db.ts`.
+
+## 90 minutes – half a day
+
+14. **Cross-test the client + server dependency parsers.** (F-30) Add a
+    fixture in `core/state-source/dependency-parser.fixtures.ts`, run
+    the same expectation list through both implementations. Or
+    eliminate the mirror by importing the core function from the web
+    build.
+
+15. **Pull subcomponents out of `ProjectModelPanel.tsx`.** (F-22)
+    No behaviour change; just file hygiene. Ditto `BootstrapWizard.tsx`
+    (F-23) and `grill-and-prd.ts` (F-24).
+
+16. **`agent.json-parse-failed` event + better error.** (F-6) Plumb the
+    runId-scoped event so `OutputValidationError` can include the
+    raw-string preview in its message.
+
+17. **Add READMEs for `target-projects/*`.** (F-29) Either real ones
+    explaining each project's purpose, or update `docs/inventory.md`'s
+    drift check to exempt target-project dirs.
+
+## Pick of the day
+
+If you only have an hour, do 1, 3, and 5. Two indexed queries, one
+crash class, and two shell-quoting nits. Net effect: visibly cheaper
+retros and a noticeably more robust event pipeline.
+
+## Pick of the week
+
+Add #8 (atomic persona selection) and #14 (parser cross-test). The
+first removes a real correctness risk if anyone ever runs the CLI
+against the same DB as the server. The second prevents a quiet UI
+divergence the day the parser is touched.
+
+## Don't bother
+
+- Refactoring `core/agent-runtime/claude-cli.ts` for "readability."
+  It's long because it has a lot of legitimate complexity (env, hooks,
+  truncation, cost, two SQL writes). Surgical fixes only.
+- "Replace EventEmitter with a real pub-sub library." No. Single-user
+  local-first tool. The standard library is fine.
+- Caching skill prompts or allowlists. Sub-millisecond reads. Save the
+  budget for the indexes that actually matter.

--- a/review/README.md
+++ b/review/README.md
@@ -1,0 +1,35 @@
+# Goose Hub — Code Review
+
+A senior-developer pass over the codebase: how it's wired, where the rough
+edges are, and what to fix first. Skim `01-orientation.md` if you're new.
+
+| File | Purpose |
+|---|---|
+| [`01-orientation.md`](./01-orientation.md) | One-page tour for a new dev: vocabulary, what runs where, what to read next. |
+| [`02-architecture.md`](./02-architecture.md) | Layer map (apps / core / slices / skills) + how a webhook becomes a PR. |
+| [`03-flows.md`](./03-flows.md) | Mermaid flow diagrams: dispatch routing, fix-issue, QA→Review→approval, retro. |
+| [`04-data-model.md`](./04-data-model.md) | DB schema diagram + table-by-table notes. |
+| [`05-findings.md`](./05-findings.md) | Concrete bugs, smells, and refactors. Prioritised. |
+| [`06-performance.md`](./06-performance.md) | Hot paths, indexes, where to add caching, what to leave alone. |
+| [`07-quick-wins.md`](./07-quick-wins.md) | Two-hour pickups that improve correctness or readability now. |
+
+## How this review was scoped
+
+- Read on the `claude/code-review-documentation-xoWCG` branch.
+- Survey-first: `apps/`, `core/`, `slices/`, `skills/`, `docs/inventory.md`,
+  `CLAUDE.md`, `CONTEXT.md`, `FACTORY_RULES.md`.
+- Targeted reads of high-leverage modules: `event-stream/store.ts`,
+  `agent-runtime/{claude-cli,invoke-skill,select-persona}.ts`,
+  `db/{db,schema}.ts`, `projects/parallel-lock.ts`, `shared/dispatch-*.ts`,
+  `state-source/{dependency-parser,github-labels}.ts`, hooks.
+- No code changes shipped — this is documentation only. Each finding has a
+  one-line fix sketch so the next dev can land it without a re-read.
+
+## Two-sentence verdict
+
+The architecture is honest: vertical slices, single-writer event log,
+stateless ticks, holdouts enforced at the runtime layer. Most issues are
+small (missing indexes, brittle parsers, a couple of TOCTOUs around DB
+counters), and the only thing that really wants attention is the
+listener-leak / orphan-run interaction in `event-stream/store.ts` if this
+ever runs >1 process against the same DB.


### PR DESCRIPTION
## Summary

Adds eight short documents under `review/` orienting new developers and flagging concrete bugs, smells, and quick wins. Documentation-only — no code changes.

- `01-orientation.md` — vocabulary, what runs where, what to read next.
- `02-architecture.md` — layer map + webhook → merge walkthrough.
- `03-flows.md` — Mermaid diagrams: dispatch, fix-issue, QA→Review, state machine, tick scheduler, event fan-out, retro loop.
- `04-data-model.md` — schema diagram + table notes + override precedence.
- `05-findings.md` — 30 numbered findings (7 H / 10 M / 13 L) with file:line and fix sketches.
- `06-performance.md` — hot paths, missing indexes, what to leave alone.
- `07-quick-wins.md` — two-hour pickups ranked by leverage.

## Highest-impact findings

- **F-1** Persona round-robin is not atomic across processes (`core/agent-runtime/select-persona.ts:26-50`).
- **F-2** `parseDependencies` accepts unsafe issue numbers (`core/state-source/dependency-parser.ts:31`).
- **F-4** `appendEvent` crashes on unserialisable payloads (`core/event-stream/store.ts:170`).
- **F-9** Missing `events(project_id, kind, id)` index; cliff at ~100k rows.
- **F-13** Hook scripts don't quote `$RUN_ID` and the AC gate swallows grep errors.

## Test plan

- [ ] Confirm Mermaid diagrams render on GitHub (open the PR's Files view and scroll `03-flows.md` / `04-data-model.md`).
- [ ] Spot-check 2-3 file:line references in `05-findings.md` to confirm they point at the right code.

https://claude.ai/code/session_01FrykeE1hxbQeeZs8t7KqiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrykeE1hxbQeeZs8t7KqiV)_