### PR TITLE
docs: Office Mode vertical-slice-v1 roadmap + phases 3–6

### DIFF
--- a/docs/design/office-mode/vertical-slice-v1/README.md
+++ b/docs/design/office-mode/vertical-slice-v1/README.md
@@ -1,0 +1,343 @@
+# Office Mode — Vertical Slice v1
+
+**Status:** Phases 1–2 merged. Phases 3–6 specified, not yet implemented.
+
+This directory is the authoritative implementation roadmap for the first
+cinematic vertical slice of Goose Hub Office Mode. Future sessions should
+start here.
+
+The slice is **deliberately narrow.** It exists to prove one cinematic
+journey end-to-end on one project floor, not to build the full operational
+office described in `docs/office-mode-operational-model.md`. Anything not
+called out below is out of scope.
+
+---
+
+## 1. What v1 proves
+
+A single WorkItem, observed at the office, traversing:
+
+```
+factory:triaging → triage room
+   → factory:investigating  → investigation room
+       → Wave 1 fan-out (3 scouts, sealed library)
+       → swarm.wave-completed
+   → factory:dev-ready / factory:in-progress → dev room
+       → builder seats; desk lamp on
+   → factory:needs-qa → qa room (sealed)
+       → qa.functional-failed (one retry)
+       → ticket reroutes to dev via red corridor pulse
+       → second pass passes
+   → factory:needs-review → review room (frosted)
+       → review.converged → door opens
+   → factory:done → done shelf
+       → mergeCelebration
+```
+
+This single journey, animated faithfully from real orchestration events on
+the SSE `/events` stream, is the v1 deliverable. Everything in this
+directory exists to deliver it.
+
+When a player runs the dev server, picks one project, and watches the
+office for the lifetime of one issue, they should see this journey as a
+coherent cinematic. Nothing more.
+
+---
+
+## 2. Documents in this directory
+
+| File                              | Phase | Scope                                                          | Status      |
+| --------------------------------- | ----- | -------------------------------------------------------------- | ----------- |
+| `phase-1-pure-refactor.md`        | 1     | Split `OfficeScene` into `FloorLayer` + `SpriteLayer`         | merged      |
+| `phase-2-rooms-and-anchors.md`*   | 2     | Adopt Board 02 canon: 6 rooms on a single 1280×384 floor       | merged      |
+| `phase-3-persona-ticket-split.md` | 3     | Split sprite rendering into `PersonaSprite` + `TicketSprite`   | specified   |
+| `phase-4-event-choreography.md`   | 4     | Add `ChoreographyPlayer` + lane model + SSE-driven intents     | specified   |
+| `phase-5-cinematics.md`           | 5     | Implement 4 canonical v1 cinematics                            | specified   |
+| `phase-6-runtime-hud.md`          | 6     | Minimum runtime overlays — physically integrated into the world | specified   |
+
+\* Phase 2 plan was not authored as a standalone file; its contract is the
+spec at `docs/design/office-mode/goose-hub-office-mode-design-pack/02-canonical-project-floor/design-spec.md`
+(Board 02). Phase 2 implementation landed in PR #770. Future phase docs
+should reference Board 02 for floor geometry rather than restating it.
+
+Each phase doc is self-contained and consumable in isolation. They share
+the invariants listed in §6.
+
+---
+
+## 3. Roadmap status table
+
+| Phase | Title                            | Output                                                   | Depends on |
+| ----- | -------------------------------- | -------------------------------------------------------- | ---------- |
+| 1     | Pure refactor                    | `FloorLayer`, `SpriteLayer` siblings; behaviour preserved | —          |
+| 2     | Rooms & anchors                  | `lib/rooms.ts`, 6-room single-floor geometry              | 1          |
+| 3     | Persona/ticket split             | `PersonaSprite`, `TicketSprite`, carry semantics          | 2          |
+| 4     | Event choreography               | `ChoreographyPlayer`, lanes, intent registry              | 3          |
+| 5     | Cinematics                       | 4 named cinematics: wave, qaFailed, reviewConverged, mergeCelebration | 4 |
+| 6     | Runtime HUD                      | Overlay layer integrated into the world                   | 5          |
+
+Each phase ships behind its own PR. Phases do not skip; phase 5 cannot
+land before phase 4 because it consumes the choreography player; phase 4
+cannot land before phase 3 because it dispatches intents to the persona /
+ticket sprite contracts.
+
+---
+
+## 4. The cinematic journey, in order of phase landing
+
+Phase 1 — refactor only; visually identical to M17.
+Phase 2 — the single-floor 6-room geography exists; tickets and personas
+still render as combined sprites; sprites still slide.
+Phase 3 — personas and tickets are visually separate; tickets follow
+personas via the carry contract; queue stacks read at each room doorway.
+Phase 4 — SSE events flow into intents flow into the player; the simplest
+intents (`walkToRoom`, `attachToDesk`) animate. No multi-step cinematics
+yet.
+Phase 5 — the four canonical cinematics run end-to-end on the v1 journey.
+Phase 6 — overlays surface hero labels, queue depth, retry counts,
+convergence progress, room pressure. The slice is shippable.
+
+---
+
+## 5. Architectural seams to preserve
+
+These seams exist because later milestones will expand them. Future
+sessions must not collapse them during v1 work.
+
+### 5.1 React ↔ Phaser boundary
+
+React owns:
+- Data ingestion (TanStack Query for issues, EventSource for SSE).
+- `activeProject` selection.
+- Derived `placements` (pure function of work items).
+- DOM-layer HUD (`FloorIndicator`, `DeskDetailPanel`).
+- Routing.
+
+Phaser owns:
+- Rendering only.
+- Scene-local sprite, layer, anchor, and effect state.
+- A scene `EventEmitter` for scene → React events (`'ready'`, `'desk-click'`, `'floor-change'`).
+
+React pushes via `applyProjects`, `applyPlacements`, `applyChoreography`*,
+`panToProject`. Phaser pushes back only via the emitter.
+
+\* `applyChoreography` is introduced in phase 4 as a new push channel for
+event-derived intents. It is parallel to `applyPlacements`, not a
+replacement.
+
+### 5.2 Scene-local ownership
+
+Each layer (`FloorLayer`, `SpriteLayer` → splitting in phase 3 to
+`PersonaLayer` + `TicketLayer`) owns its own containers, sprites, anchors,
+and event handlers. Cross-layer reads go through the scene; cross-layer
+writes do not exist. Layers do not import each other.
+
+### 5.3 Pure libs
+
+`lib/rooms.ts`, `lib/agent-positions.ts`, `lib/layout.ts`,
+`lib/pathfinding.ts`, `lib/state-indicators.ts`, `lib/state-to-room.ts`,
+`lib/persona-codenames.ts` are pure modules with no Phaser import. They
+are unit-tested in isolation in `slice.test.ts`. New choreography logic
+(phase 4) and HUD computation (phase 6) extend this pattern with new pure
+modules — they do not introduce Phaser into existing libs.
+
+### 5.4 Visualisation-only invariant
+
+The Phaser office reads orchestration truth and renders it. It does not
+mutate it. No scene method, layer method, sprite method, or choreography
+node may issue a `fetch`, `postMessage`, label write, or any other
+side-effecting call against workflow state. Click events emit on the
+scene emitter; React handles workflow-aware side effects.
+
+This invariant is enforced by Board 02 §1.5 and is restated in every
+later phase doc because it is the single most important constraint of
+the slice.
+
+### 5.5 Single project per scene
+
+`OfficeScene.applyProjects` accepts exactly one `OfficeProject` in v1.
+Multi-project rendering and cross-project navigation were valid M17
+behaviours; they are explicitly deferred (see §7). The mount and tab
+select `activeProject` upstream.
+
+### 5.6 Coordinates live in one place
+
+All world coordinates — room interior bounds, door centers, desks,
+station anchors, slot anchors (queue / exterior / interior), shelf
+slots, queue stack anchors, camera anchors — live in `lib/rooms.ts`.
+Scene, layer, and component code consume the table; no coordinate
+literal appears in `apps/web/src/components/office/{game,components}/`
+except via `lib/rooms.ts` import. Phase 4 and 5 add cinematic timings
+and event mappings; these live in their own pure module
+(`lib/choreography.ts`), not in `lib/rooms.ts`.
+
+---
+
+## 6. Invariants every phase must preserve
+
+Restated here so future sessions read them once, then again in each phase.
+
+1. **Office is visualisation only.** No scene/layer/sprite mutates
+   workflow state. See §5.4.
+2. **React ↔ Phaser boundary is one-way push + emitter-back.** See §5.1.
+3. **Scene-local ownership.** Layers don't import each other. See §5.2.
+4. **Pure libs stay pure.** No Phaser import in `lib/`. See §5.3.
+5. **Single project per scene.** See §5.5.
+6. **All coordinates in `lib/rooms.ts`.** See §5.6.
+7. **All cinematic timings / event mappings in `lib/choreography.ts`**
+   (introduced phase 4). Same single-source-of-truth rule as rooms.
+8. **No ECS.** The choreography system is a lightweight intent dispatcher
+   on top of Phaser's existing scene graph, not a generic entity-component
+   framework. Phase 4 spells this out.
+9. **Holdout sealing is visible.** Library, QA, and Review walls and
+   slots render their seal/frost. A persona never visually walks through
+   a sealed wall. Verdict scrolls and envelopes use slot anchors.
+10. **Phaser as renderer.** No game-logic AI, no agent autonomy inside
+    Phaser. Personas move because an intent told them to move; intents
+    come from events; events come from the server.
+
+If a future change makes any of these invariants harder to honour, the
+change is wrong, not the invariant. ADR it before proceeding.
+
+---
+
+## 7. Deferred systems
+
+Out of scope for v1. Each one is a real system in the operational model;
+none belongs in this slice.
+
+| System                              | Why deferred                                                |
+| ----------------------------------- | ----------------------------------------------------------- |
+| Multi-floor stacking                | One project at a time; floor nav unnecessary for slice      |
+| Building view (multiple projects)   | Same                                                        |
+| Lobby (inbox, courier, budget board) | Funnel visualisation is a later milestone                  |
+| Watchtower / auditor sprite         | Audit gate is a critical-lane slot but no anchors yet      |
+| Backstage corkboard / coach office  | Meta-loop visualisation requires Retro room first          |
+| Discovery sub-rooms                 | Grilling / PRD / decomposition fold into Triage in v1       |
+| Research lab                        | Folded into Investigation                                   |
+| Spec booth + builder board          | M19 parallel-build is a separate slice                      |
+| Dev-Review nook                     | Reserved tile bounds in Board 02; no v1 furniture          |
+| Retro room                          | Folds into Dev with a `retrospecting` indicator            |
+| Archive cabinet                     | `factory:archived` shares Done shelf                        |
+| Sprite-sheet walk cycles            | Sprites still slide                                         |
+| TDD-heartbeat glyphs (RED / GREEN / REFACTOR / LINT) | Tier-3 micro-animation; deferred             |
+| Tool-call micro-animations          | Same                                                        |
+| Full simulation AI / autonomous geese | Not in scope, ever — Phaser is renderer-only              |
+| Procedural generation               | Floors are hand-designed                                    |
+| Sound / ambient audio               | Deferred to atmospheric polish slice                        |
+| Ambient layer (non-work-item motion) | Atmospheric; not in cinematic core                         |
+| Cross-project WorkPackage tethers   | Parallel-build slice                                        |
+| Zoom modes beyond floor-overview + hero-ticket-follow | All room/persona-zoom anchors reserved     |
+| Multiplayer                         | Not in scope, ever                                          |
+| Cross-project building stacks       | Not in scope; v1 is one floor                               |
+
+These are intentionally deferred. The purpose of the slice is **implementation
+clarity, not exploration.** If a phase doc surfaces a useful follow-on,
+file it as a new milestone-scoped issue. Do not absorb it into v1.
+
+---
+
+## 8. Relationship between the canon documents
+
+This slice draws on three documents that future sessions must keep in
+sync:
+
+### 8.1 Operational model — `docs/office-mode-operational-model.md`
+
+The operational model describes the entire Goose Hub orchestration as a
+simulation: every entity class, every workflow phase, every archetype,
+every wave, every mode, every event tier, every visual abstraction the
+office *could* eventually render. It is intentionally larger than v1.
+
+The slice reads it for vocabulary and intent — for example, "ticket as a
+physical object that gets carried," "scout fan-out is the cinematic
+core," "QA is a sealed holdout." It does not read it for implementation
+detail; the slice implements a subset.
+
+### 8.2 Visual canon — the design pack
+
+`docs/design/office-mode/goose-hub-office-mode-design-pack/` holds 12
+boards. Of those, the slice consumes:
+
+- **Board 01 — Building blueprint.** Reference only. The slice does not
+  build the building; it builds one floor.
+- **Board 02 — Canonical project floor.** The **spatial canon for v1.**
+  Every coordinate the slice renders is bound to this spec. Phase 2 of
+  the roadmap consumed this directly; phases 3–6 honour it.
+- **Board 03 — Ticket lifecycle storyboard.** Reference for the journey;
+  the slice's cinematic sequencing must align panel-to-panel with this
+  board.
+- **Board 04 — Zoom semantics.** Reference only; v1 uses two camera
+  anchors (`floor-overview`, `hero-ticket-follow`) and reserves the
+  rest.
+- **Board 05 — Holdout chambers.** Reference for Library / QA / Review
+  seal semantics. Phase 5 cinematics consume the slot anchors.
+- **Boards 06 — Visual system.** Palette, iconography, animation
+  language. Style reference; not coordinate-bearing.
+- **Boards 07 — Dynamic choreography.** Reference for phase 4 and 5
+  movement grammar.
+- **Boards 08 — Runtime HUD.** Reference for phase 6 overlay design.
+- **Boards 09–12 — Atmospheric boards.** Reference only; v1 does not
+  implement atmospheric polish.
+
+When a coordinate, anchor, or sequencing rule is needed, **Board 02 is
+the source.** When a *meaning* is needed (why scouts are sealed in a
+library, why QA is holdout, why Review uses frosted glass), the
+operational model is the source.
+
+### 8.3 Spatial canon — `lib/rooms.ts`
+
+The pure-library form of Board 02. It is the only place in code that
+holds floor coordinates. Future phases extend (e.g. add cinematic
+durations) in a sibling module (`lib/choreography.ts`) — never duplicate
+coordinate literals.
+
+### 8.4 Implementation roadmap — these phase docs
+
+The phase docs in this directory are the **operational contract** for
+the slice. They describe what each phase produces, what it must not
+touch, what its acceptance criteria are, and what the next phase
+consumes. They reference the canon above but do not duplicate it.
+
+---
+
+## 9. How a future session continues safely
+
+When invoked to work on Office Mode v1:
+
+1. **Read this README.** Identify the current phase (the next one with
+   status "specified" and all prior phases "merged").
+2. **Read the phase doc for the current phase.** It is self-contained.
+3. **Read Board 02 spec** if the phase touches coordinates.
+4. **Read the operational model only for vocabulary**, never for
+   implementation detail.
+5. **Stay in scope.** Acceptance criteria are the contract. Anything
+   outside them is out of scope unless you file an ADR and adjust this
+   README first.
+6. **Honour the invariants in §6.** If a step in the phase doc seems to
+   conflict with an invariant, the invariant wins. Stop and surface the
+   conflict.
+7. **One PR per phase.** Phase docs explicitly forbid bundling.
+
+When a phase merges, mark its status in §2 and §3 of this README and
+proceed to the next.
+
+---
+
+## 10. What "done with v1" means
+
+The slice is complete when, in the dev server, picking one project that
+has an active WorkItem flowing through the canonical journey produces:
+
+- The full single-floor 6-room geography rendered (phase 2).
+- A `PersonaSprite` per active persona, named by codename when hero
+  (phase 3).
+- A `TicketSprite` carried correctly by personas, parked at desks, and
+  travelling through slots as scrolls and envelopes (phase 3).
+- The four canonical cinematics firing on real events from the server
+  (phases 4 + 5).
+- Queue stacks, retry counters, convergence counters, hero labels, and
+  the runtime event feed surfacing as overlays integrated into the
+  world (phase 6).
+
+Anything else is post-v1.

--- a/docs/design/office-mode/vertical-slice-v1/phase-3-persona-ticket-split.md
+++ b/docs/design/office-mode/vertical-slice-v1/phase-3-persona-ticket-split.md
@@ -1,0 +1,678 @@
+# Office Mode Vertical Slice v1 — Phase 3: Persona / Ticket Split
+
+**Status:** Specified. Do not begin Phase 4 work in this phase.
+
+**Goal:** Split the single combined sprite (one body + one indicator)
+that Phase 2 inherits into two visually distinct renderables:
+
+- `PersonaSprite` — the goose carrying / working a WorkItem.
+- `TicketSprite` — the WorkItem itself, as a physical card / scroll / envelope.
+
+This is a **rendering split only.** It does not introduce SSE event
+handling, choreography intents, cinematic primitives, or any new event
+ingestion path. Phase 4 will introduce those; phase 3 leaves the data
+flow exactly as Phase 2 left it.
+
+The split exists so phases 4 and 5 can address persona movement and
+ticket movement as separate concerns without rewriting the sprite
+hierarchy under cinematic time pressure.
+
+---
+
+## 1. Scope
+
+### In scope
+
+- Two new layer files: `layers/PersonaLayer.ts`, `layers/TicketLayer.ts`,
+  replacing `SpriteLayer.ts`.
+- Two new sprite classes / entry records: `PersonaSprite`, `TicketSprite`.
+  Both are thin wrappers around a `Phaser.GameObjects.Container` plus
+  body / indicator / label children.
+- A `carry` contract describing how a `TicketSprite` follows a
+  `PersonaSprite` (or, when no carrier exists, owns its own position).
+- Queue stack rendering for tickets waiting at room doorways — depth
+  tiers per Board 02 §8.
+- Slot transit semantics for tickets crossing sealed-room slot anchors
+  (Library envelope-out, QA input/output, Review door) — geometric only;
+  the *triggering events* are phase 4.
+- Hero promotion interaction: when a ticket is "hero" (per Board 02
+  §11), it renders on layer `z=45` and its carrier persona renders a
+  codename label.
+- A deterministic stand-in persona name when no server-side `personaId`
+  exists, via `lib/persona-codenames.ts`.
+- New pure module: `lib/persona-codenames.ts` (per Board 02 §12.6).
+- New pure module: `lib/ticket-carry.ts` (carry-position math).
+
+### Out of scope (phase 4 and later)
+
+- SSE event-direct subscription. React Query invalidation continues to
+  drive `applyPlacements`.
+- `ChoreographyPlayer`, `Timeline`, lanes, intents, or any cinematic
+  primitive.
+- Verdict-scroll, envelope, glow-ring, particle, or convergence-ring
+  visuals. The ticket sprite has a single visual mode in phase 3 (a
+  card). Variants (scroll, envelope) land in phase 5.
+- Sprite-sheet walk cycles. Personas still slide.
+- TDD-heartbeat glyphs, tool-call micro-animations, monitor flicker.
+- Watchtower, backstage, lobby, multi-floor rendering.
+- Camera changes. `floor-overview` remains the only active camera anchor
+  in phase 3. `hero-ticket-follow` is allocated but **not switched to
+  yet**; phase 5 wires the cinematic camera switch.
+- Banner Hero-Ticket cell update mechanism. The cell exists from phase 2
+  and is set on hero promotion in phase 3 (one-way only — see §6.4).
+
+If you find yourself touching anything in "out of scope," stop.
+
+---
+
+## 2. Target file structure (after Phase 3)
+
+```
+apps/web/src/components/office/
+  components/
+    OfficePage.tsx               # unchanged
+    OfficeTab.tsx                # unchanged (or activeProject selection only)
+    OfficeGameMount.tsx          # unchanged
+    FloorIndicator.tsx           # unchanged
+    DeskDetailPanel.tsx          # unchanged
+  game/
+    OfficeScene.ts               # delegates to RoomLayer + PersonaLayer + TicketLayer
+    asset-loader.ts              # unchanged
+    textures.ts                  # new texture keys: ticket card body, queue-stack tiers
+    layers/
+      types.ts                   # extended: PersonaPlacement, TicketPlacement
+      RoomLayer.ts               # unchanged from phase 2
+      SpriteLayer.ts             # DELETED — replaced by PersonaLayer + TicketLayer
+      PersonaLayer.ts            # NEW — persona-only ownership
+      TicketLayer.ts             # NEW — ticket-only ownership; queue stacks; slot transit
+  lib/
+    rooms.ts                     # unchanged (read-only consumer)
+    agent-positions.ts           # ADJUSTED — emits { personas, tickets } pair
+    layout.ts                    # unchanged
+    pathfinding.ts               # unchanged (carry math is separate)
+    persona-codenames.ts         # NEW — deterministic codename derivation
+    ticket-carry.ts              # NEW — pure carry-position math
+    state-to-room.ts             # unchanged (phase 2 introduced this)
+    state-indicators.ts          # unchanged
+  slice.test.ts                  # extended for persona-codenames + ticket-carry + agent-positions
+```
+
+`SpriteLayer.ts` is deleted, not deprecated. Phase 3 is the breaking
+split. No callers should reach across the old name.
+
+---
+
+## 3. Sprite identity contracts
+
+### 3.1 `PersonaSprite`
+
+| Field         | Type                                          | Notes                                                    |
+| ------------- | --------------------------------------------- | -------------------------------------------------------- |
+| `personaId`   | `string`                                      | `${projectSlug}:${seed}`; v1 seed = ticket's `externalId` until server plumbs real persona ids |
+| `codename`    | `string`                                      | derived from `personaId` via `codenameFor`; stable per session |
+| `roomId`      | `RoomId`                                      | which room the persona occupies                          |
+| `deskSlot`    | `number` (room-local index)                   | which station / desk the persona is seated at, or `-1` if walking |
+| `container`   | `Phaser.GameObjects.Container`                | parent for body + indicator + label                      |
+| `body`        | `Phaser.GameObjects.Image`                    | role-keyed texture                                        |
+| `indicator`   | `Phaser.GameObjects.Image`                    | speech / thought / check / bang / question / null         |
+| `label?`      | `Phaser.GameObjects.Text`                     | codename pop; only present when hero                      |
+| `walkTween?`  | `Phaser.Tweens.Tween`                         | nullable; in-flight motion                                |
+| `silhouette`  | `boolean`                                     | dimmed render inside sealed rooms (Library / QA / Review) |
+| `state`       | `'idle' \| 'walking' \| 'working' \| 'frozen'`| pure read state; phase 3 sets `walking` / `idle`; phase 4+ adds `working` (during `agent.run-started`); phase 5 adds `frozen` (during `gate-pending`, `needs-human`) |
+
+Identity rule: a `PersonaSprite` is keyed by `personaId`. Two `PersonaSprite`s
+cannot share a `personaId`. A persona persists across walks; only its
+position, indicator, and label change.
+
+### 3.2 `TicketSprite`
+
+| Field         | Type                                                                      | Notes                                                    |
+| ------------- | ------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `ticketId`    | `string`                                                                  | `${projectSlug}:${externalId}` — same as M17's `spriteId` |
+| `carrierPersonaId?` | `string \| null`                                                    | nullable; null when ticket is in transit alone, queued, on shelf, in slot |
+| `position`    | `'carried' \| 'desk' \| 'queue' \| 'slot' \| 'shelf' \| 'free'`           | discriminator for current owner / location              |
+| `roomId?`     | `RoomId \| null`                                                          | room context for queue / shelf / slot positions          |
+| `slotId?`     | `string \| null`                                                          | e.g. `qa.input`, `qa.output`, `library.envelope-out`, `review.door` |
+| `shelfSlot?`  | `number \| null`                                                          | 0..4 for Done shelf                                      |
+| `container`   | `Phaser.GameObjects.Container`                                            | parent for body + badge                                  |
+| `body`        | `Phaser.GameObjects.Image`                                                | default texture: card; phase 5 swaps to scroll / envelope variants for slot transit |
+| `priorityTint`| `'critical' \| 'high' \| 'normal' \| 'low'`                              | applied as body modulation                                |
+| `hero`        | `boolean`                                                                 | hero promotion flag; affects z and adds glow             |
+| `glow?`       | `Phaser.GameObjects.Image`                                                | hero glow ring (z=50); present when `hero`                |
+
+Identity rule: a `TicketSprite` is keyed by `ticketId`. Two `TicketSprite`s
+cannot share a `ticketId`. A ticket persists across state transitions;
+its `position` and `roomId` change but the sprite instance does not.
+
+### 3.3 Joint identity invariant
+
+For any active WorkItem in a state mapped to a room:
+
+- Exactly one `TicketSprite` exists for it.
+- Either zero or one `PersonaSprite` is its carrier at any moment (the
+  `carrierPersonaId` field on the ticket).
+- A `PersonaSprite` may carry zero or one tickets at a time. (v1 does
+  not render multi-ticket personas; if data implies it, render only
+  the highest-priority and log a `system.note`-style console warning.)
+
+---
+
+## 4. Ownership rules
+
+### 4.1 Layer ownership
+
+| Layer        | Owns                                                            | Reads                                                  | Mutates                       |
+| ------------ | --------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------- |
+| `RoomLayer`  | room containers, walls, doors, desks, slot frames, shelf back, queue-stack containers | nothing from other layers | room z-layers only            |
+| `PersonaLayer` | persona sprites + their containers, codename labels, walk tweens | `lib/rooms.ts` anchors only; `RoomLayer.occupiedDeskKeys()` for stack offsets | persona z-layers only       |
+| `TicketLayer` | ticket sprites + their containers, carry offsets, queue stacks, slot tweens, shelf slot assignments | `PersonaLayer.getCarrierPosition(personaId)` for carried tickets; `lib/rooms.ts` anchors | ticket and ticket-hero z-layers only |
+
+A layer never reads from another layer's mutable internals. Cross-layer
+reads go through narrow, read-only methods like
+`PersonaLayer.getCarrierPosition`. Cross-layer writes do not exist.
+
+### 4.2 Scene-level ownership
+
+`OfficeScene` owns:
+
+- Construction order: `RoomLayer` → `PersonaLayer` → `TicketLayer` (in
+  ascending z-order). Construction happens before the first
+  `'ready'` emit.
+- The single emitter that all three layers share.
+- The `applyProjects(project)` → `RoomLayer.applyProject(project)`
+  delegation.
+- The `applyPlacements({ personas, tickets })` →
+  `PersonaLayer.applyPlacements(personas)` then
+  `TicketLayer.applyPlacements(tickets)` delegation **in that order**:
+  tickets read persona positions, so personas must settle first.
+
+### 4.3 Pure-lib ownership
+
+| Module                    | Owns                                                          |
+| ------------------------- | ------------------------------------------------------------- |
+| `lib/rooms.ts`            | all floor coordinates (read-only across the codebase)         |
+| `lib/agent-positions.ts`  | derives `{ personas: PersonaPlacement[], tickets: TicketPlacement[] }` from `WorkItemDto[]` |
+| `lib/state-to-room.ts`    | factory state → room id mapping                                |
+| `lib/state-indicators.ts` | factory state → indicator glyph mapping                        |
+| `lib/persona-codenames.ts`| deterministic codename hash + canonical pool                   |
+| `lib/ticket-carry.ts`     | offset math for `position='carried'` and `position='desk'`    |
+| `lib/pathfinding.ts`      | same-floor waypoint planning (unchanged)                       |
+
+No Phaser import in `lib/`.
+
+---
+
+## 5. Carried-ticket semantics
+
+A ticket whose `position='carried'` follows its carrier persona's
+**rendered** position. This is a render-time follow, not a tween, and
+must update every frame the persona moves.
+
+### 5.1 Carry offset
+
+Per Board 02 §5.3:
+
+- Offset is `(+10, −12)` relative to the persona container origin.
+- Origin convention: persona origin is `(0.5, 1)` (bottom-center);
+  ticket origin is `(0.5, 0.5)` (centered). The offset is computed
+  from the persona's container `x`, `y` directly.
+
+### 5.2 Follow implementation
+
+Option A (selected): parent the `TicketSprite.container` to the
+`PersonaSprite.container` when `position='carried'`; offset is the
+ticket container's local `x`, `y`. On `position` transition out of
+`'carried'`, re-parent to the scene root and snap to the new
+absolute position.
+
+Option B (rejected): per-frame copy in `update()`. Rejected because
+phase 3 must not introduce a per-frame update loop; Phaser parent-child
+positioning is free.
+
+### 5.3 Position transitions
+
+| From → To             | Trigger                                | Phaser action                                                  |
+| --------------------- | -------------------------------------- | -------------------------------------------------------------- |
+| `carried` → `desk`    | persona arrives at desk anchor          | re-parent to scene root; snap to desk's ticket-attach anchor   |
+| `desk` → `carried`    | persona leaves desk for another room    | re-parent to persona container with offset `(+10, −12)`        |
+| `carried` → `queue`   | (rare in phase 3; phase 4 will trigger when persona departs without ticket — not in v1) | not encountered in phase 3 |
+| `queue` → `carried`   | persona arrives at queue head, picks up | re-parent + offset                                             |
+| any → `slot`          | ticket enters a slot transit (phase 5)  | re-parent to scene root; deferred tween logic                  |
+| `slot` → any          | ticket leaves slot                      | re-parent + appropriate anchor                                 |
+| any → `shelf`         | `mergeCelebration` lands ticket (phase 5) | re-parent to scene root; snap to shelf-slot anchor          |
+| any → `free`          | brief in-transit between owners         | re-parent to scene root; held at last known anchor             |
+
+Phase 3 must implement `carried`, `desk`, `queue`, `shelf` transitions
+geometrically (snap or re-parent). Slot transits are **stubbed**: the
+ticket teleports to the destination anchor with no animation. Phase 5
+replaces the teleport with a real slot tween. Wiring is in place; tween
+is not.
+
+---
+
+## 6. Queue ownership
+
+Queue stacks render at the corridor side of every open-entry room
+(Triage, Investigation, Dev, QA-input, Review). Per Board 02 §8, depth
+ranges map to one of four texture tiers, plus a `+N` numeric badge for
+the highest tier.
+
+### 6.1 Queue owner
+
+`TicketLayer` owns queue stacks. They are not separate sprite classes;
+they are stack-anchor positions that `TicketLayer` writes a single
+texture-swapping sprite + optional text into per room.
+
+```
+TicketLayer.queueStacks: Map<RoomId, { stackSprite: Phaser.GameObjects.Image, badge?: Phaser.GameObjects.Text }>
+```
+
+### 6.2 Queue contents
+
+A ticket whose `position='queue'` and `roomId=R` is **counted** in the
+queue stack at room `R`'s queue anchor. It is **not** rendered as an
+independent sprite while queued: the stack texture *represents* it.
+
+Exception: the currently-hero ticket is never counted in a stack and is
+always rendered as its own sprite, regardless of position (per Board 02
+§8). When the hero ticket happens to be at a queue position, the stack
+depth is computed *excluding* it.
+
+### 6.3 Queue derivation
+
+`lib/agent-positions.ts` emits ticket placements with `position='queue'`
+when the work item is in a state mapped to a room but no persona is
+currently seated at any desk in that room with a matching room id, **and**
+the room is at capacity, **and** the work item is not the current hero.
+
+For v1 the "at capacity" rule simplifies to: queues exist only at
+Investigation (when wave is mid-flight) and Dev (when all 3 builder
+desks are occupied). All other rooms have no queue depth in the v1
+journey because only one ticket is in motion. Phase 4 / 5 do not change
+this; phase 6 may surface depth as an overlay regardless.
+
+### 6.4 Hero label and banner cell
+
+When a ticket becomes hero (per Board 02 §11), two side-effects occur:
+
+- The carrier `PersonaSprite` adds a codename `Phaser.GameObjects.Text`
+  label at `(persona.x, persona.y − 28)` on z=`persona-overlays`.
+- The Board 02 §3 banner's right-cell (Active Hero Ticket) updates to
+  `#{externalId} — {title|truncated}`.
+
+The banner update is a one-way write from the scene to its own banner
+text. Banner text is owned by `RoomLayer` (it was added during the
+phase 2 floor build); `RoomLayer` exposes a single method
+`RoomLayer.setHeroTicketCell(text: string | null)` that `TicketLayer`
+calls on hero promotion / release. This is the **one** cross-layer
+write path in phase 3 and is restricted to a string label — no game
+state.
+
+When hero releases (sticky timeout, click-elsewhere, or cinematic
+end), the codename label is destroyed and the banner cell is cleared.
+
+---
+
+## 7. Slot transit semantics (phase-3 stubs)
+
+Per Board 02 §9, slots have three anchors: `queueAnchor`,
+`exteriorAnchor`, `interiorAnchor`. A ticket "crosses a slot" by tweening
+through the three anchors in sequence.
+
+In phase 3, the **logic of when a ticket changes slot position is not
+wired to events.** Phase 4 introduces event-driven slot transit. Phase
+3 is purely structural:
+
+- `TicketLayer` exposes `setTicketSlotPosition(ticketId, slotId,
+  anchorKind)` where `anchorKind ∈ {'queue', 'exterior', 'interior'}`.
+- The method snaps (no tween) the ticket to the requested anchor.
+- A future caller (phase 4 choreography intent) will sequence three
+  calls 200ms apart to animate the transit. Phase 3 never calls these
+  in sequence from inside the scene.
+
+This separation matters because it isolates *geometry* (phase 3) from
+*timing* (phase 4). Both must be tested independently.
+
+---
+
+## 8. Hero promotion interaction
+
+Phase 3 implements hero promotion **only on click**. Other promotion
+triggers (lane-driven, transition-driven, sticky window) require the
+choreography player and are phase 5.
+
+### 8.1 Click promotion
+
+A ticket click handler (the per-sprite `pointerdown` registered in
+`TicketLayer.spawn`) does two things:
+
+1. Emits `'desk-click'` on the scene emitter (preserves M17 behaviour;
+   React routes this to the DeskDetailPanel).
+2. Promotes the ticket to hero locally for 10 seconds. After 10 s the
+   hero releases via a Phaser timer (`scene.time.delayedCall`).
+
+Re-click on the same ticket resets the 10s window. Click on a different
+ticket transfers hero (the previous hero releases immediately, the new
+one promotes). Click outside any ticket releases hero on the current
+sticky after the timer expires (no early release in phase 3 — that's a
+phase 4 lane interaction).
+
+### 8.2 Promotion side-effects
+
+On promote:
+- Ticket sprite moves to `z = ticket-hero` (45).
+- A `glow` image is added as a sibling at `z = effects` (50), parented
+  to the ticket container.
+- If the ticket has a carrier persona, the carrier gains a codename
+  label (see §6.4).
+- Banner Hero-Ticket cell updates.
+
+On release:
+- Reverse all of the above. Move ticket back to `z = tickets` (40).
+- Destroy the glow image.
+- Destroy the codename label.
+- Clear the banner cell.
+
+### 8.3 Camera
+
+Phase 3 **does not** switch camera to `hero-ticket-follow`. Camera
+remains at `floor-overview`. Phase 5 wires the camera switch as part
+of the primary-lane cinematic.
+
+---
+
+## 9. Layer / z-index expectations
+
+Inherit from Board 02 §7. Phase 3 adds nothing to the z-table.
+
+Layer construction order in `OfficeScene.create()`:
+
+```
+new RoomLayer(...)        // populates z=0..25
+new PersonaLayer(...)     // populates z=30..35
+new TicketLayer(...)      // populates z=40..50 (45 for hero; 50 for glow)
+```
+
+`TicketLayer.spawn()` must `setDepth(40)` on the container by default,
+and `setDepth(45)` on promotion. `PersonaLayer.spawn()` must
+`setDepth(30)` on the container; codename label, when present, is its
+own `Text` at `setDepth(35)`.
+
+The `canvas-hud` layer (z=60) is owned by `RoomLayer` for now (banner
++ static text). Phase 6 introduces real HUD overlays that may add new
+text at z=60; the layer is unchanged here.
+
+---
+
+## 10. Deterministic stand-in persona rules
+
+Until the server emits a `personaId` on each `WorkItemDto`, the slice
+derives a deterministic codename per work item. This is a visual
+stability shim — same input always yields the same name within a
+session, even though the name is fabricated.
+
+### 10.1 `lib/persona-codenames.ts`
+
+```ts
+export const CODENAME_POOL: readonly string[] = [
+  // ~30 entries, sourced from the operational-model canon
+  // e.g. "Grey Honker", "Cinder Drake", "Pale Tern", "Brass Magpie",
+  // "Iron Skua", "Slate Pelican", "Amber Heron", "Rust Cormorant", ...
+];
+
+export function codenameFor(seed: string): string {
+  // Deterministic 32-bit FNV-1a or similar → index into CODENAME_POOL.
+  // Must be pure and import-only (no Math.random, no Date.now).
+}
+```
+
+The exact hash is unconstrained; correctness is "deterministic +
+import-only." Tests assert:
+
+- `codenameFor('a') === codenameFor('a')`
+- `codenameFor` returns a string from `CODENAME_POOL`.
+- Reasonable distribution (e.g. 100 distinct seeds yield >20 distinct
+  names — soft assertion, not strict).
+
+### 10.2 Seed source
+
+v1 seed is `${projectSlug}:${externalId}`. The codename derives per
+**ticket**, not per persona, because v1 has no persona identity from
+the server. The mental model: "this issue's owner is always Grey
+Honker." When the server begins emitting `personaId`, the seed source
+swaps in `lib/agent-positions.ts`; the codename function and pool are
+unchanged.
+
+This is a deliberate **mis-modelling** (a codename per ticket, not per
+persona) to ship a stable visual without forcing the server to plumb
+identity now. Phase 4 does not depend on it. The right model lands
+later.
+
+### 10.3 No invented archetypes
+
+The codename is the only persona-stand-in render. Phase 3 does **not**:
+- Vary persona body texture per persona.
+- Vary persona pace per model tier.
+- Render persona stat badges, streaks, win counts.
+
+All of those exist in the operational model. None ships in v1.
+
+---
+
+## 11. Boundary preservation checks
+
+A future change in phase 3 that breaks any of the below is rejected.
+
+| Boundary                              | Check                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| React ↔ Phaser                        | `OfficeScene.applyPlacements` accepts `{ personas, tickets }` only; no event subscription in the scene |
+| Scene-local ownership                 | `PersonaLayer` and `TicketLayer` do not import each other                |
+| Pure libs                             | `lib/persona-codenames.ts` and `lib/ticket-carry.ts` have zero Phaser imports |
+| No mutation of workflow state         | Grep for `fetch(`, `postMessage(`, `mutateAsync` in `apps/web/src/components/office/game/` returns no matches |
+| One coordinate source                 | Grep for tile-pixel literals (16, 88, 112, 136, 168, 200, 232, 280, 288, ...) in `game/` returns only `lib/rooms.ts` imports |
+| Single project                        | `OfficeScene.applyProjects` signature is `(project: OfficeProject)`, not array; mount + tab unchanged |
+
+---
+
+## 12. What `lib/agent-positions.ts` looks like after phase 3
+
+Public signature:
+
+```ts
+export function placementsFromItems(items: readonly WorkItemDto[]): {
+  personas: PersonaPlacement[];
+  tickets: TicketPlacement[];
+};
+
+export interface PersonaPlacement {
+  personaId: string;
+  codename: string;
+  roomId: RoomId | null;     // null = freeze in place (needs-human / gate-pending)
+  deskSlot: number;          // -1 if walking / queued at door
+}
+
+export interface TicketPlacement {
+  ticketId: string;
+  externalId: number;
+  title: string;
+  priority: 'critical' | 'high' | 'normal' | 'low';
+  carrierPersonaId: string | null;
+  position: 'carried' | 'desk' | 'queue' | 'slot' | 'shelf' | 'free';
+  roomId: RoomId | null;
+  slotId: string | null;
+  shelfSlot: number | null;
+  indicator: IndicatorGlyph | null;  // existing M17 set
+}
+```
+
+`placementsFromItems` is a pure function. Its only inputs are the work
+items; its only outputs are the placements. Tests cover:
+
+- Each phase-A..I state in `state-to-room` maps to the correct room.
+- A `factory:investigating` item produces a persona at the investigation
+  lab lead-desk slot.
+- A `factory:in-progress` item produces a persona at one of the dev
+  desks (deterministic — same item ID always picks the same desk).
+- A ticket carried by an in-progress persona has
+  `position='carried'`, `carrierPersonaId=<that persona>`.
+- A ticket in `factory:done` has `position='shelf'`, `shelfSlot ∈ 0..4`.
+
+---
+
+## 13. Sequence of edits
+
+1. **Create `lib/persona-codenames.ts`** with `CODENAME_POOL` and
+   `codenameFor`. Add unit tests in `slice.test.ts`. Verify `pnpm test`.
+2. **Create `lib/ticket-carry.ts`** with `ticketCarryOffset(): {dx, dy}`,
+   `ticketAtDeskOffset(): {dx, dy}` (per Board 02 §5.3). Add unit tests.
+3. **Refactor `lib/agent-positions.ts`** to emit
+   `{ personas, tickets }`. Update tests for the new return type.
+   Other callers of `placementsFromItems` (only `OfficeScene` /
+   `SpriteLayer` consume it) tolerate the new shape behind a thin
+   adapter that flattens to the old `AgentPlacement[]` for one commit.
+4. **Create `layers/PersonaLayer.ts`.** Copy persona-handling code out
+   of `SpriteLayer` (spawn, walk, indicator update, destroy). Wire to
+   the scene. Behaviour must match `SpriteLayer` for personas. Verify.
+5. **Create `layers/TicketLayer.ts`.** Implement ticket sprite spawn /
+   destroy. Implement carry follow via container re-parenting. Implement
+   queue stack rendering at room queue anchors. Stub slot transit
+   (snap, no tween). Stub shelf landing (snap to shelf slot). Verify.
+6. **Delete `layers/SpriteLayer.ts`.** Remove the flatten adapter from
+   step 3. `OfficeScene.applyPlacements` now takes
+   `{ personas, tickets }`. Update `OfficeTab` to pass the destructured
+   value through `OfficeGameMount`.
+7. **Wire hero promotion on click** (per §8). Add `TicketLayer.promote`
+   / `release` methods; route per-sprite `pointerdown` through promote.
+   Add `RoomLayer.setHeroTicketCell` for the banner update.
+8. **Visual verification** — open the office tab in dev server, click
+   a ticket, observe glow + label + banner update; wait 10s, observe
+   release; click a different ticket, observe transfer.
+
+Each step compiles and passes tests. Do not batch.
+
+---
+
+## 14. Test surface
+
+### Unit tests (`apps/web/src/components/office/slice.test.ts`)
+
+Existing tests (rooms / layout / pathfinding / state-to-room /
+state-indicators) stay green untouched. New tests:
+
+- `persona-codenames`: determinism + pool membership + distribution.
+- `ticket-carry`: offset values match spec; result is pure.
+- `agent-positions` (rewritten): per-state placement assertions,
+  covering each room and each `position` discriminator.
+
+Target: existing 27 unit tests + ~15 new tests = ~42 total.
+
+### E2E tests
+
+- `office-click-through.spec.ts` must remain green.
+- Add a `phase-3` opt-in screenshot run (`RUN_SCREENSHOTS=1`) that
+  captures: floor with one queued ticket, click promotes to hero, hero
+  released after 10s. Not required for CI green.
+
+### Manual verification checklist
+
+Before opening the PR:
+
+- [ ] Office tab loads at `/projects/:slug/office` with no console errors.
+- [ ] Personas render at the correct rooms / desks for current state.
+- [ ] Tickets render as carded sprites at carry offsets when working;
+      at desk attach anchors when seated; at queue anchors when queued.
+- [ ] Queue stacks at room doorways swap texture tier as depth changes
+      (depth 0 → no sprite; depth 1..2 → 1-card; etc.).
+- [ ] Hero click promotes: glow appears, codename label appears, banner
+      Hero-Ticket cell updates.
+- [ ] Hero release after 10s: glow gone, label gone, banner clears.
+- [ ] Click another ticket: hero transfers.
+- [ ] FloorIndicator + DeskDetailPanel still work.
+- [ ] No layout jumps on browser resize.
+
+---
+
+## 15. Acceptance criteria
+
+The PR is mergeable iff:
+
+- [ ] `pnpm test` passes (~42 unit tests).
+- [ ] `pnpm typecheck` passes.
+- [ ] `pnpm lint` passes.
+- [ ] `office-click-through.spec.ts` passes in CI.
+- [ ] `layers/SpriteLayer.ts` is deleted.
+- [ ] `layers/PersonaLayer.ts` exists and is ≤ 250 lines.
+- [ ] `layers/TicketLayer.ts` exists and is ≤ 300 lines.
+- [ ] `lib/persona-codenames.ts` exists with `CODENAME_POOL` of
+      ≥ 24 entries and a pure `codenameFor`.
+- [ ] `lib/ticket-carry.ts` exists with pure offset functions.
+- [ ] No imports between `PersonaLayer` and `TicketLayer`.
+- [ ] No Phaser imports in `lib/`.
+- [ ] No coordinate literals in `game/` or `components/` outside
+      `lib/rooms.ts` imports (grep check from Board 02 §18).
+- [ ] No `fetch` / `postMessage` / label-write calls in
+      `apps/web/src/components/office/game/`.
+- [ ] Manual verification checklist all ticked.
+- [ ] No new dependencies in `apps/web/package.json`.
+
+---
+
+## 16. Stop conditions
+
+Stop and ask the human if any of the following occur:
+
+- Board 02 §1.5 ownership invariant becomes hard to honour. Example: you
+  find yourself wanting to write a label or `fetch` a state from inside
+  a layer. The architecture forbids it; do not work around it.
+- A test asserts behaviour that's actually a phase 4 concern (timing,
+  event handling, lane priority). Move the test out of phase 3.
+- The persona placement logic forces a "one persona per role" collapse
+  again. Phase 3 must support multiple personas per room; if the math
+  doesn't, the data model is wrong.
+- `lib/rooms.ts` requires a coordinate change. It shouldn't. If it
+  does, that's a Board 02 spec change; ADR before proceeding.
+- The carry-follow implementation needs a per-frame update loop. It
+  should not; Phaser parent-child positioning handles this for free.
+
+---
+
+## 17. Explicit non-goals
+
+Restated from §1 because they are the most common ways phase 3 work
+drifts into phase 4 / 5:
+
+- **No SSE event handling.** Tickets and personas update on
+  `applyPlacements` only.
+- **No choreography player, intents, lanes, or timelines.** All phase 4.
+- **No verdict scroll, envelope, particle, ring, or pulse visuals.**
+  Phase 5.
+- **No camera switching.** `floor-overview` only.
+- **No persona variants** (per-role textures already exist from M17;
+  no per-persona, per-tier, or per-stat variants).
+- **No TDD-heartbeat glyphs, monitor flicker, tool-call animations.**
+- **No queue interaction beyond a click that opens a panel** — the
+  panel itself is not in scope; the click zone is registered, the
+  React handler is phase 6.
+- **No sound. No ambience. No procedural anything.**
+
+If a future phase needs work that *feels* like it belongs in phase 3,
+move it. Phase 3 must stay narrow.
+
+---
+
+## 18. What happens after Phase 3
+
+Phase 4 (next session, after Phase 3 PR merges):
+
+- Add `EventSource('/events')` direct subscription in `OfficeTab` (in
+  parallel to the existing React Query invalidation, not in place of).
+- Author `lib/choreography.ts` — intent registry + lane assignments.
+- Add `ChoreographyPlayer` to `OfficeScene`; expose `applyChoreography`.
+- Implement `walkToRoom`, `attachToDesk`, `swapIndicator` as the first
+  three intents. They re-use phase 3's persona walk + ticket carry
+  primitives.
+
+Phase 5: the four cinematics.
+Phase 6: the HUD overlays.
+
+This plan only covers Phase 3.

--- a/docs/design/office-mode/vertical-slice-v1/phase-4-event-choreography.md
+++ b/docs/design/office-mode/vertical-slice-v1/phase-4-event-choreography.md
@@ -1,0 +1,804 @@
+# Office Mode Vertical Slice v1 — Phase 4: Event Choreography
+
+**Status:** Specified. Do not begin Phase 5 work in this phase.
+
+**Goal:** Introduce the lightweight event → choreography pipeline that
+takes orchestration events from the SSE stream, maps them to declarative
+**intents**, and dispatches those intents to the `PersonaLayer` and
+`TicketLayer` primitives that phase 3 produced.
+
+Phase 4 is the **glue** between server events and rendered motion. It
+does not introduce the four named cinematics (those are phase 5); it
+introduces the *machinery* that phase 5's cinematics compose against.
+
+The system is deliberately **lightweight and deterministic.** It is
+not an ECS, not a behaviour tree, not a generic timeline framework.
+It is a small intent dispatcher with three priority lanes, a single
+queue per lane, and a 1-frame coalescing window.
+
+---
+
+## 1. Scope
+
+### In scope
+
+- A direct SSE subscription in the scene (or in the tab and forwarded to
+  the scene — see §5). React Query invalidation continues to drive
+  data; phase 4 adds an event-direct path **in parallel**.
+- `lib/choreography.ts` — pure module defining the intent registry,
+  event-to-intent mapping table, lane assignment, and timing constants.
+- `ChoreographyPlayer` — a scene-owned dispatcher that runs intents on
+  three lanes with deterministic priority + queueing.
+- `Timeline` — a simple sequenced container of intents. Phase 4
+  supports timelines with at most 3 sequenced steps; phase 5 may extend
+  to longer cinematics in code (each cinematic is itself ≤10 steps).
+- A v1 event catalogue: a fixed allowlist of event kinds the player
+  reacts to. Other event kinds are ignored.
+- Three concrete intent implementations:
+  - `walkToRoom(personaId, destRoomId)` — wraps phase 3's persona walk.
+  - `attachToDesk(personaId, deskSlot)` — wraps phase 3's seat-at-desk.
+  - `swapIndicator(personaId | ticketId, glyph)` — wraps phase 3's
+    indicator update.
+- Interruption + queueing semantics per lane.
+- A scene → React channel for **per-intent observability** (for the
+  phase 6 event feed). Lane-name + intent-name + status only; no
+  workflow reasoning.
+
+### Out of scope (phase 5 and later)
+
+- The four named cinematics (`investigationWave`, `qaFailed`,
+  `reviewConverged`, `mergeCelebration`). Phase 4 ships the runtime
+  for them; phase 5 ships the cinematics themselves.
+- Verdict scrolls, envelopes, particles, glow rings, convergence rings,
+  corridor pulses. Phase 5 visuals.
+- Camera switches. The `floor-overview` → `hero-ticket-follow`
+  transition is a phase 5 concern. Phase 4 may *expose* a camera intent
+  in the registry but does not fire one.
+- Tier-3 micro-animations (TDD glyphs, tool-call flickers).
+- Door-state animation on the Review chamber. The `door.open` /
+  `door.close` intents are placeholders in the registry; they snap-on /
+  snap-off in phase 4 and animate in phase 5.
+- HUD overlays. Phase 6.
+- Sound, ambience, atmospheric polish.
+- Multi-floor, building view, lobby, watchtower, backstage.
+- Procedural generation, simulation AI, ECS-style world model.
+
+If you find yourself touching anything in "out of scope," stop.
+
+---
+
+## 2. Target file structure (after Phase 4)
+
+```
+apps/web/src/components/office/
+  components/
+    OfficeTab.tsx                # ADJUSTED — adds SSE subscription wiring (see §5)
+    OfficeGameMount.tsx          # ADJUSTED — exposes new applyChoreography channel
+    OfficePage.tsx, FloorIndicator.tsx, DeskDetailPanel.tsx   # unchanged
+  game/
+    OfficeScene.ts               # ADJUSTED — adds ChoreographyPlayer; exposes applyChoreography
+    asset-loader.ts              # unchanged
+    textures.ts                  # unchanged (phase 5 adds scroll / envelope)
+    choreography/                # NEW DIRECTORY
+      ChoreographyPlayer.ts      # NEW — lane dispatcher, ~250 lines
+      Timeline.ts                # NEW — sequence container, ~120 lines
+      intents/
+        walkToRoom.ts            # NEW — wraps PersonaLayer.walk
+        attachToDesk.ts          # NEW — wraps PersonaLayer.seat
+        swapIndicator.ts         # NEW — wraps swap
+    layers/
+      RoomLayer.ts               # unchanged
+      PersonaLayer.ts            # ADJUSTED — exposes seat(personaId, deskSlot) primitive
+      TicketLayer.ts             # unchanged (phase 5 adds slot transit)
+      types.ts                   # ADJUSTED — adds IntentResult, IntentStatus
+  lib/
+    choreography.ts              # NEW — intent registry, event→intent map, lane table, timings
+    rooms.ts                     # unchanged
+    agent-positions.ts           # unchanged
+    state-to-room.ts             # unchanged
+    state-indicators.ts          # unchanged
+    persona-codenames.ts         # unchanged
+    ticket-carry.ts              # unchanged
+    pathfinding.ts               # unchanged
+  slice.test.ts                  # extended for choreography + event→intent map
+```
+
+Total new code budget: ~700 lines including tests. If a phase 4 file
+exceeds ~300 lines, split it before merging.
+
+---
+
+## 3. Choreography timeline model
+
+### 3.1 The smallest unit: `Intent`
+
+```ts
+export type LaneId = 'critical' | 'primary' | 'ambient';
+
+export interface IntentBase {
+  id: IntentName;            // 'walkToRoom' | 'attachToDesk' | 'swapIndicator' | (phase 5 adds more)
+  target: { kind: 'persona' | 'ticket' | 'room' | 'door' | 'camera'; id: string };
+  params: Record<string, unknown>;  // intent-specific
+  lane: LaneId;
+  ttlMs: number;             // hard upper bound on running time
+}
+
+export type IntentStatus = 'pending' | 'running' | 'completed' | 'cancelled' | 'failed';
+export interface IntentResult { status: IntentStatus; reason?: string; }
+```
+
+A single intent describes one declarative motion: "walk persona X to
+room R," "attach ticket T to desk D," "swap indicator on persona P to
+`speech`."
+
+Intents are **never created inside Phaser.** They are created by
+`lib/choreography.ts` from incoming events and pushed to the player.
+
+### 3.2 The composition unit: `Timeline`
+
+```ts
+export interface Timeline {
+  id: string;                  // unique per timeline instance
+  lane: LaneId;
+  ticketId: string | null;     // hero subject if any (drives hero promotion in phase 5)
+  steps: Intent[];             // sequenced; one runs at a time
+  onComplete?: () => void;     // optional; phase 5 cinematics use this
+  source: 'event' | 'placement' | 'click';   // diagnostic only
+  startedAt?: number;          // ms timestamp; set by player
+}
+```
+
+In phase 4, timelines are **at most 3 steps long**:
+
+- For `state.transitioned`: a single step — `walkToRoom`.
+- For `agent.run-started`: 2 steps — `attachToDesk` + `swapIndicator`.
+- For `agent.run-completed`: 2 steps — `swapIndicator(check)` then a
+  delayed `swapIndicator(null)` (250ms tween-as-delay).
+
+Phase 5 cinematics extend this to ≤ 10 steps each. The model does not
+change; the depth of the step list does.
+
+### 3.3 Determinism
+
+The player runs intents in **stable order** within a lane:
+
+1. By lane priority: `critical` > `primary` > `ambient`.
+2. Within a lane: by `startedAt` ascending (earlier first).
+3. Within identical `startedAt` (same SSE tick): by `id` string sort.
+
+There is no per-frame randomness. There is no animation easing variance.
+A given input event stream always produces the same intent order.
+
+### 3.4 What a timeline is *not*
+
+- Not an ECS. Intents do not declare components on entities; they call
+  named methods on layer primitives.
+- Not a state machine. Intents do not transition between states; they
+  run to completion or cancel.
+- Not a tween graph. Each intent owns its own tween (or none) via the
+  layer primitive it wraps.
+- Not a generic effect system. Each intent has a single, fixed,
+  declarative motion. New motions require new intents in the registry.
+
+This is intentional. v1 needs four cinematics, not a framework.
+
+---
+
+## 4. `ChoreographyPlayer` responsibilities
+
+The player is a single class instantiated by `OfficeScene` in `create()`,
+**after** the three layers exist.
+
+### 4.1 Responsibilities
+
+- Receive `Timeline` instances via `scene.applyChoreography(timelines)`.
+- Assign each timeline to its lane queue (declared on the timeline).
+- Run each lane's queue head:
+  - Run the first `Intent`; await completion or `ttlMs` timeout.
+  - Advance to the next step. Repeat until the timeline has no more
+    steps; emit `IntentResult{ status: 'completed' }` on its
+    `onComplete`.
+- Coalesce timelines arriving within the same SSE tick: see §4.4.
+- Honour interruption rules per lane: see §4.5.
+- Emit per-intent observability events on the scene emitter
+  (`'choreo.intent-started'`, `'choreo.intent-completed'`,
+  `'choreo.intent-cancelled'`). These carry only:
+  `{ lane, intentName, target: {kind, id}, status }`. No reasoning,
+  no workflow content. Phase 6 consumes them for the event feed.
+
+### 4.2 Lane queues
+
+```ts
+class ChoreographyPlayer {
+  private queues: Record<LaneId, Timeline[]>;
+  private active: Record<LaneId, Timeline | null>;
+  // ...
+}
+```
+
+Three queues, one active timeline per lane. Lanes are independent:
+- `critical` can preempt `primary` and `ambient` (see §4.5).
+- `primary` and `ambient` run concurrently. A primary intent on
+  persona P and an ambient indicator swap on the same persona do not
+  conflict if they target different sub-renderables; if they conflict
+  (both target `persona.position`), primary wins, ambient is
+  cancelled.
+
+Concurrency rule simplified for v1: **each persona / ticket sprite has
+at most one active position-changing intent at a time.** The player
+tracks a per-sprite "owned by lane" flag; conflicting intents are
+either queued behind the current owner (same lane) or preempt (higher
+lane).
+
+### 4.3 Per-intent execution
+
+Each intent module exports:
+
+```ts
+export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult>;
+export function cancel(intent: Intent, ctx: ChoreographyCtx): void;
+```
+
+`ChoreographyCtx` holds references to the three layers (read + narrow
+write) and the scene timer. The `run` function wires up a tween or
+single-call mutation, returns a promise that resolves on tween-complete
+or `ttlMs` timeout. `cancel` aborts the in-flight tween cleanly.
+
+Intent implementations live in `game/choreography/intents/`. Each is
+≤ 50 lines and references only its layer + `lib/rooms.ts`.
+
+### 4.4 Coalescing window
+
+The player coalesces multiple `applyChoreography` calls within the same
+animation frame. If the React side dispatches 3 timelines in rapid
+succession (e.g. an SSE event arrives, React Query refetches, both
+push within ms), the player merges them in a single tick. Coalescing
+rules:
+
+- Within a tick, multiple timelines on the **same lane targeting the
+  same sprite** drop all but the latest. (Latest wins.)
+- Within a tick, timelines on the **same lane targeting different
+  sprites** all enqueue.
+- Across ticks, no merging — separate `applyChoreography` calls in
+  different frames produce separate enqueues even on the same target.
+
+Coalescing prevents jitter when state and event arrive within ms of
+each other.
+
+### 4.5 Interruption semantics
+
+| Active lane | Incoming lane | Action                                                                   |
+| ----------- | ------------- | ------------------------------------------------------------------------ |
+| critical    | critical      | enqueue incoming behind active; FIFO                                     |
+| critical    | primary       | enqueue incoming on the primary lane queue; do not preempt critical     |
+| critical    | ambient       | enqueue incoming on the ambient lane queue; do not preempt              |
+| primary     | critical      | **preempt** primary: cancel active primary intent; primary timeline pauses at the current step; critical runs; on critical completion, primary resumes (re-runs the cancelled step from scratch) |
+| primary     | primary       | enqueue incoming; FIFO                                                   |
+| primary     | ambient       | enqueue incoming                                                         |
+| ambient     | critical      | preempt and cancel ambient; ambient does not resume (it's ambient)       |
+| ambient     | primary       | preempt and cancel ambient                                               |
+| ambient     | ambient       | enqueue if targeting a different sprite; coalesce / drop if same         |
+
+Rules of thumb:
+- **Critical is sacred.** It runs immediately and to completion.
+- **Primary is resumable.** Cancelled steps re-run from scratch on
+  resume.
+- **Ambient is disposable.** Cancelled, never resumed.
+
+### 4.6 Queueing semantics
+
+Within a lane queue:
+
+- FIFO by `startedAt`.
+- A queued timeline may be **dropped** before it ever runs if a coalesce
+  rule (§4.4) replaces it.
+- Maximum queue depth per lane in v1: **8**. Beyond 8, oldest pending
+  timeline drops with `IntentResult{ status: 'cancelled', reason:
+  'queue-overflow' }`. Should not occur on a single-ticket journey;
+  if it does, log it.
+
+### 4.7 TTL behaviour
+
+Every intent declares a `ttlMs`. If `run` does not resolve within `ttlMs`,
+the player calls `cancel` and emits
+`IntentResult{ status: 'failed', reason: 'ttl-exceeded' }`. The
+containing timeline then aborts (no remaining steps run); its
+`onComplete` is *not* called. This is a safety hatch, not a feature —
+v1 does not depend on it firing.
+
+Suggested baselines:
+- `walkToRoom`: `ttlMs = 5000`.
+- `attachToDesk`: `ttlMs = 1000`.
+- `swapIndicator`: `ttlMs = 500`.
+
+---
+
+## 5. SSE subscription wiring
+
+### 5.1 Current state after phase 3
+
+`OfficeTab` opens `EventSource('/events')` and uses each event purely
+to invalidate React Query for the affected project. The scene reacts
+only to the resulting `applyPlacements` diff.
+
+### 5.2 Phase 4 wiring
+
+Phase 4 **does not remove** the React Query invalidation path. It is
+the data-truth path; it stays.
+
+In **parallel**, the same `EventSource` handler invokes a new pure
+function:
+
+```ts
+// lib/choreography.ts
+export function timelinesForEvent(
+  event: OrchestrationEvent,
+  context: { hero: string | null; rooms: typeof ROOM_IDS; }
+): Timeline[];
+```
+
+The returned timelines are pushed to the scene via
+`scene.applyChoreography(timelines)`. The scene's `ChoreographyPlayer`
+consumes them.
+
+This dual path is deliberate:
+- React Query holds the **state**.
+- The choreography player holds the **motion**.
+- A reconciliation pass (the next `applyPlacements`) corrects the scene
+  if the choreography missed an event or got a stale state.
+
+### 5.3 Where the subscription lives
+
+Two acceptable approaches; pick one in implementation:
+
+- **Tab-driven (default):** `OfficeTab.tsx` continues to own the
+  `EventSource`. It calls `timelinesForEvent` and routes the result
+  through `OfficeGameMount` → `scene.applyChoreography`. Keeps the
+  scene boundary clean.
+- **Scene-driven (rejected for v1):** the scene opens its own
+  EventSource. Rejected because it duplicates connections and crosses
+  the React ↔ Phaser boundary in a new direction. Do not implement.
+
+### 5.4 Event ordering
+
+Events arrive in stream order. `timelinesForEvent` is pure and stateless,
+so it cannot reorder them. The player processes them in arrival order
+within each lane (see §3.3 determinism).
+
+If two events arrive in the same React batch (rare), they both produce
+timelines; both enqueue; lane priority resolves their interleaving.
+
+---
+
+## 6. Lane system
+
+### 6.1 `critical`
+
+**Purpose:** events that interrupt the player's attention. The lane
+preempts primary and cancels ambient.
+
+**v1 driver events:**
+- `qa.functional-failed` — surfaces a red verdict scroll exit + corridor
+  pulse + retry counter bump. Wires the qaFailed cinematic in phase 5.
+- `gate.awaiting-human` — freeze persona in place with `?` indicator;
+  ambient dimming overlay (phase 6).
+- `audit.autonomy-gate-fired` — placeholder. Anchors reserved (Board
+  02 §15). Phase 4 ignores; phase 5+ may wire when the watchtower
+  exists.
+
+**Lane characteristics:**
+- Max one active intent at a time (cannot subdivide critical events).
+- Runs to completion even if higher-priority data arrives.
+- TTL strict: a critical intent that times out logs a system note;
+  recovery is automatic via next `applyPlacements`.
+
+### 6.2 `primary`
+
+**Purpose:** events that drive the **current hero ticket's** journey.
+Visible, narrative motion. Camera focus moves with primary lane in
+phase 5.
+
+**v1 driver events:**
+- `state.transitioned` for the hero ticket → produces `walkToRoom`.
+- `agent.run-started` on the hero ticket's persona → produces
+  `attachToDesk` + `swapIndicator(speech)`.
+- `agent.run-completed` on the hero ticket's persona → produces
+  `swapIndicator(check)` + delayed `swapIndicator(null)`.
+- `swarm.wave-started`, `swarm.scout-completed`, `swarm.wave-completed`
+  — produce timelines for the `investigationWave` cinematic (phase 5
+  consumes; phase 4 maps to placeholder intents that snap until phase 5).
+- `review.converged` — produces a placeholder timeline (snap door open /
+  closed; phase 5 animates).
+- `pr.merged` for the hero — placeholder; phase 5 mergeCelebration.
+
+**Lane characteristics:**
+- Can be preempted by critical; cancelled steps re-run from scratch.
+- Sole owner of camera-anchor changes (phase 5).
+- Hero promotion bound to whichever ticket is the subject of the
+  current primary timeline (phase 5 implements this binding; phase 4
+  only marks the `ticketId` field on the timeline so phase 5 has the
+  hook).
+
+### 6.3 `ambient`
+
+**Purpose:** motion that should be visible but never demands attention.
+Cancelled freely.
+
+**v1 driver events:**
+- `state.transitioned` for any ticket that is **not** the current hero
+  → `walkToRoom` on ambient lane.
+- `agent.run-started` / `-completed` for non-hero personas →
+  `swapIndicator` on ambient lane.
+
+**Lane characteristics:**
+- May be cancelled at any time, never resumes.
+- No camera changes.
+- No hero promotion.
+- Coalesces aggressively (latest indicator swap on a given target wins).
+
+### 6.4 Lane assignment table
+
+`lib/choreography.ts` exports the canonical mapping:
+
+```ts
+export const LANE_FOR_EVENT: Record<OrchestrationEventKind, LaneId | null> = {
+  'qa.functional-failed': 'critical',
+  'gate.awaiting-human': 'critical',
+  'audit.autonomy-gate-fired': 'critical',          // phase 5+ may map
+  'state.transitioned': 'primary',                   // demoted to ambient if non-hero
+  'agent.run-started': 'primary',                    // demoted to ambient if non-hero
+  'agent.run-completed': 'primary',                  // demoted to ambient if non-hero
+  'swarm.wave-started': 'primary',
+  'swarm.scout-completed': 'primary',
+  'swarm.wave-completed': 'primary',
+  'review.converged': 'primary',
+  'pr.merged': 'primary',
+  // all other event kinds → null (ignored in v1)
+};
+```
+
+The "demoted to ambient if non-hero" rule is implemented in
+`timelinesForEvent` by inspecting `context.hero`.
+
+---
+
+## 7. Supported v1 event catalogue
+
+The fixed allowlist of events the player reacts to. Anything not in
+this table is ignored.
+
+| Event kind                       | Lane     | Resulting timeline                                                    |
+| -------------------------------- | -------- | --------------------------------------------------------------------- |
+| `state.transitioned` (hero)      | primary  | `walkToRoom(persona, destRoomId)`                                     |
+| `state.transitioned` (non-hero)  | ambient  | `walkToRoom(persona, destRoomId)`                                     |
+| `agent.run-started` (hero)       | primary  | `attachToDesk(persona, deskSlot)` → `swapIndicator(persona, speech)`  |
+| `agent.run-started` (non-hero)   | ambient  | `swapIndicator(persona, speech)`                                      |
+| `agent.run-completed` (hero)     | primary  | `swapIndicator(persona, check)` → delay → `swapIndicator(persona, null)` |
+| `agent.run-completed` (non-hero) | ambient  | `swapIndicator(persona, check)` → delay → `swapIndicator(persona, null)` |
+| `qa.functional-failed`           | critical | (phase 5 fills cinematic; phase 4: `swapIndicator(ticket, bang)`)     |
+| `gate.awaiting-human`            | critical | `swapIndicator(persona, question)` + freeze flag                       |
+| `swarm.wave-started`             | primary  | (phase 5; phase 4: no-op timeline; logged)                            |
+| `swarm.scout-completed`          | primary  | (phase 5; phase 4: no-op)                                              |
+| `swarm.wave-completed`           | primary  | (phase 5; phase 4: snap `swapIndicator(ticket, check)`)               |
+| `review.converged`               | primary  | (phase 5 animates door; phase 4: snap door open/closed)               |
+| `pr.merged`                      | primary  | (phase 5; phase 4: snap ticket to shelf via `TicketLayer` primitive)  |
+
+**Everything else** — `agent.tool-call`, `agent.decision-summary-live`,
+`agent.log`, `tool.*`, `coach.*`, `retrospective.*`, `decompose.*`,
+`prd.*`, `grill.*`, `merge.conflict*`, `parallel-implement.*`,
+`audit.*`, `cost.*`, `project.*` — is **ignored** by the player in v1.
+React Query invalidation still runs for these (data path).
+
+The ignored set is intentionally large. The slice is one ticket
+through one journey; nothing else needs choreographing.
+
+---
+
+## 8. Sequencing model
+
+### 8.1 Timeline construction (per-event, pure)
+
+```ts
+function timelinesForEvent(event, context) {
+  // 1. Look up lane (LANE_FOR_EVENT).
+  // 2. If hero context matters, demote to ambient if event.ticketId !== context.hero.
+  // 3. Map (event.kind, event.payload) to a sequence of intent specs.
+  // 4. Wrap as Timeline { id: uuid, lane, ticketId, steps, source: 'event' }.
+  // 5. Return.
+}
+```
+
+Pure. No side effects. Tests assert: same event + context → same
+timeline sequence (id is mockable for tests).
+
+### 8.2 Player loop
+
+```
+on applyChoreography(timelines):
+  for each timeline:
+    coalesce(timeline) into queues[lane]
+  process()
+
+process():
+  for each lane in [critical, primary, ambient]:
+    if active[lane] is null and queue[lane] is non-empty:
+      active[lane] = queue[lane].shift()
+      runNextStep(active[lane])
+
+runNextStep(timeline):
+  step = timeline.steps[i]
+  if no step: complete(timeline); active[lane]=null; process()
+  intent.run(step).then(result => {
+    if result.cancelled: handlePreempt(timeline); return
+    if result.failed: abort(timeline); return
+    advance; runNextStep(timeline)
+  })
+```
+
+This is the entire player. ~80 lines. Anything more elaborate is
+overdesign for v1.
+
+### 8.3 Lane preemption flow
+
+```
+critical timeline arrives:
+  if active[primary] exists:
+    save (timeline, stepIndex) for resume
+    intent.cancel(active[primary].steps[stepIndex])
+    active[primary] = null
+  if active[ambient] exists:
+    intent.cancel(active[ambient])
+    active[ambient] = null  // no resume save
+  enqueue critical, process()
+
+on critical completion:
+  if saved primary exists:
+    primary queue.unshift(saved)
+    process()
+```
+
+### 8.4 Timing ownership
+
+The player **does not own animation durations.** Each intent runs its
+own Phaser tween with its own duration. The player only knows:
+- Did the tween resolve, or did it not?
+- Did ttlMs elapse?
+
+Animation timing values live in `lib/choreography.ts` constants
+(per-intent). Each intent imports its own duration constant; the player
+is opaque to them.
+
+This separation lets phase 5 tune cinematic timing without touching the
+player.
+
+---
+
+## 9. Ownership boundaries
+
+| Concern                              | Owner                                | Reads from                          |
+| ------------------------------------ | ------------------------------------ | ----------------------------------- |
+| SSE connection                       | `OfficeTab` (React)                   | `/events`                            |
+| Event → Timeline mapping             | `lib/choreography.ts` (pure)          | event payload + hero context        |
+| Timeline → Player dispatch           | `OfficeScene.applyChoreography`       | React calls                         |
+| Lane queueing, coalescing            | `ChoreographyPlayer`                  | own state                            |
+| Intent execution                     | `game/choreography/intents/*.ts`      | layer primitives + `lib/rooms.ts`   |
+| Persona walk tween                   | `PersonaLayer`                        | `lib/pathfinding.ts`, `lib/rooms.ts` |
+| Ticket carry follow                  | `TicketLayer`                         | `PersonaLayer.getCarrierPosition`    |
+| Indicator swap                       | `PersonaLayer` / `TicketLayer`        | `lib/state-indicators.ts`            |
+| Camera                               | `OfficeScene` (unchanged from phase 3)| —                                    |
+
+**Phaser tween ownership** rule: a tween is created and destroyed by the
+layer that owns the sprite it animates. The player never creates a
+tween directly; intents create tweens by calling layer methods. This
+keeps tween lifetimes scoped to sprite lifetimes (a destroyed sprite
+auto-cancels its tweens).
+
+---
+
+## 10. Event → intent mapping (detailed)
+
+The mapping in `lib/choreography.ts` is a single exported table plus
+small per-event functions for non-trivial payload-derived intent
+parameters. The functions are pure.
+
+Example:
+
+```ts
+function intentsForStateTransitioned(event, context): Intent[] {
+  const isHero = event.ticketId === context.hero;
+  const lane: LaneId = isHero ? 'primary' : 'ambient';
+  const destRoom = stateToRoom(event.toState);
+  if (destRoom == null) return [];
+  return [{
+    id: 'walkToRoom',
+    target: { kind: 'persona', id: event.personaId },
+    params: { destRoomId: destRoom },
+    lane,
+    ttlMs: 5000,
+  }];
+}
+```
+
+All such functions live next to the table. No conditional logic outside
+this file decides lane assignments or intent shapes. Tests cover each
+function with at least: hero case, non-hero case, missing payload case
+(returns empty array).
+
+---
+
+## 11. Acceptance criteria
+
+The PR is mergeable iff:
+
+- [ ] `pnpm test` passes. New tests cover lib + player + intents.
+- [ ] `pnpm typecheck` passes.
+- [ ] `pnpm lint` passes.
+- [ ] `office-click-through.spec.ts` passes in CI.
+- [ ] `game/choreography/ChoreographyPlayer.ts` exists; ≤ 300 lines.
+- [ ] `game/choreography/Timeline.ts` exists; ≤ 150 lines.
+- [ ] `game/choreography/intents/` contains three intent modules:
+      `walkToRoom.ts`, `attachToDesk.ts`, `swapIndicator.ts`. Each ≤
+      80 lines.
+- [ ] `lib/choreography.ts` exists with `timelinesForEvent`,
+      `LANE_FOR_EVENT`, and per-event helper functions. Pure (no
+      Phaser imports).
+- [ ] `OfficeScene` exposes `applyChoreography(timelines: Timeline[])`.
+- [ ] `OfficeTab` opens SSE, calls `timelinesForEvent`, dispatches
+      through `OfficeGameMount`. React Query invalidation **also**
+      still happens for the same events.
+- [ ] No imports between `ChoreographyPlayer` and `PersonaLayer` /
+      `TicketLayer` directly — intents go through layer primitive
+      methods only.
+- [ ] No Phaser imports in `lib/choreography.ts`.
+- [ ] No event-kind strings appear in code outside
+      `lib/choreography.ts` (single source of truth for event names
+      the scene cares about).
+- [ ] Per-intent observability events (`'choreo.intent-started'`,
+      `'choreo.intent-completed'`, `'choreo.intent-cancelled'`) emit
+      on the scene emitter. They carry only `{ lane, intentName,
+      target: {kind, id}, status }`.
+- [ ] **No mutation of workflow state.** Grep for `fetch`, `postMessage`,
+      label-write calls in `apps/web/src/components/office/game/`
+      returns no matches.
+- [ ] **No coordinate literals** in `game/` outside `lib/rooms.ts`
+      imports (grep check from Board 02 §18).
+- [ ] No new dependencies in `apps/web/package.json`.
+- [ ] Manual verification (§13) all ticked.
+
+---
+
+## 12. Test surface
+
+### Unit tests (`slice.test.ts`)
+
+- `timelinesForEvent`:
+  - `state.transitioned` hero → primary `walkToRoom`.
+  - `state.transitioned` non-hero → ambient `walkToRoom`.
+  - `agent.run-started` hero → primary `attachToDesk` + `swapIndicator`.
+  - `qa.functional-failed` → critical.
+  - Unsupported event kind → empty array.
+- `LANE_FOR_EVENT` allowlist is the only declaration; assertion that
+  every event handled in tests is in the table.
+- Coalescing: two timelines on the same lane targeting the same sprite
+  in one tick collapse to the latter.
+
+### Integration / player tests
+
+- Player runs a single primary timeline to completion → emits
+  `intent-started` → `intent-completed` events in order.
+- Critical preempts primary: primary step cancels, critical runs,
+  primary resumes from same step.
+- Ambient cancelled by critical does not resume.
+- TTL exceeded → intent failed → timeline aborts.
+
+Phaser tween calls can be mocked. The player itself does not need a
+running scene to test.
+
+### E2E
+
+- `office-click-through.spec.ts` continues to pass.
+- Optional: an opt-in spec that emits a synthetic SSE event through
+  the dev EventSource shim and asserts the scene moved a persona.
+  Not required for CI.
+
+---
+
+## 13. Manual verification checklist
+
+Before opening the PR, in the dev server:
+
+- [ ] Office tab loads without console errors.
+- [ ] Trigger a state transition (manually label an issue
+      `factory:in-progress`). Expected: persona walks into Dev room
+      via the corridor; ticket follows (carry contract from phase 3).
+- [ ] Trigger `agent.run-started`. Expected: persona seats at a dev
+      desk; indicator becomes `speech`.
+- [ ] Trigger `agent.run-completed`. Expected: indicator briefly
+      becomes `check`, then clears after ~250ms.
+- [ ] Trigger `qa.functional-failed`. Expected (phase-4 placeholder):
+      ticket gets `bang` indicator immediately; critical-lane event is
+      visible via the per-intent observability emitter (DevTools shows
+      `choreo.intent-completed` for `swapIndicator` on the critical
+      lane). No cinematic yet.
+- [ ] Trigger two transitions in rapid succession on the same persona.
+      Expected: coalescing — only the second walk plays; the first is
+      dropped or shadowed.
+- [ ] Trigger `qa.functional-failed` while a primary walk is in flight.
+      Expected: primary walk pauses (its step cancels); critical runs;
+      primary resumes (re-walks from start). Visible as a single
+      restart at the persona's starting position.
+- [ ] Verify SSE subscription is alive after 5 minutes idle (the
+      EventSource auto-reconnects per existing M17 wiring; nothing to
+      add in phase 4 beyond preserving it).
+
+If any behaviour differs, fix it. Do not ratify in tests.
+
+---
+
+## 14. Stop conditions
+
+Stop and ask the human if any of the following occur:
+
+- The lane-priority rule produces visible jitter (e.g. primary keeps
+  preempt-resuming on every critical event). The rule is right; if it
+  fights the data, the data interpretation is wrong. Surface and
+  re-think.
+- You find yourself wanting to add per-frame `update()` loops.
+  Choreography is intent-driven, not frame-driven. If the design needs
+  per-frame logic, restate the design.
+- `timelinesForEvent` becomes longer than ~300 lines including
+  per-event helpers. The event allowlist is small; the file should be
+  small.
+- You need to introduce a new event kind not in the allowlist for the
+  v1 journey. Ask first; the allowlist is deliberately narrow.
+- The intent registry grows beyond the three v1 intents in phase 4. New
+  intents are a phase 5 concern.
+
+---
+
+## 15. Explicit non-goals
+
+Restated for clarity:
+
+- **No full ECS.** Intents are not components; entities are not
+  registered.
+- **No generic effect framework.** Each intent is a fixed wrapper
+  around a layer primitive.
+- **No camera intent firing.** A `cameraTo(anchor)` intent may exist
+  in the registry to make the phase 5 type signatures cleaner, but
+  phase 4 never enqueues it.
+- **No door animations.** Snap on/off only.
+- **No verdict scrolls, envelopes, particles, glow rings,** convergence
+  rings, corridor pulses.
+- **No HUD rendering.** Phase 6.
+- **No sound. No ambience.**
+- **No multi-floor, watchtower, lobby, corkboard.**
+- **No simulation AI, autonomous behaviour, procedural movement.**
+- **No mutation of workflow state.** Restated again because it remains
+  the load-bearing invariant.
+
+If a future phase needs work that *feels* like it belongs in phase 4,
+move it. Phase 4 must stay narrow.
+
+---
+
+## 16. What happens after Phase 4
+
+Phase 5 (next session, after Phase 4 PR merges):
+
+- Author the four cinematics (`investigationWave`, `qaFailed`,
+  `reviewConverged`, `mergeCelebration`) as composed `Timeline`s of
+  new + existing intents.
+- Add new intents: `slotTransit` (3-anchor tween), `spawnVerdictScroll`,
+  `spawnScoutEnvelope`, `cameraTo`, `doorState`, `corridorPulse`,
+  `glowRing`, `particleBurst`, `shelfLand`.
+- Switch camera to `hero-ticket-follow` during primary cinematics; back
+  to `floor-overview` at completion.
+- Ambient suppression: while a critical cinematic is in flight, ambient
+  lane is paused.
+
+Phase 6: HUD overlays consume the per-intent observability events to
+power the event feed; queue depth, retry counters, convergence counters,
+hero labels surface as canvas-hud or DOM-hud per Board 02 §7.
+
+This plan only covers Phase 4.

--- a/docs/design/office-mode/vertical-slice-v1/phase-5-cinematics.md
+++ b/docs/design/office-mode/vertical-slice-v1/phase-5-cinematics.md
@@ -1,0 +1,709 @@
+# Office Mode Vertical Slice v1 — Phase 5: Cinematics
+
+**Status:** Specified. Do not begin Phase 6 work in this phase.
+
+**Goal:** Implement the four canonical v1 cinematics on the
+choreography player that phase 4 produced.
+
+The cinematics are:
+
+1. `investigationWave` — Wave 1 scout fan-out + convergence.
+2. `qaFailed` — verdict-scroll exit + corridor pulse + rerouted ticket.
+3. `reviewConverged` — review door opens, ticket walks out to corridor.
+4. `mergeCelebration` — ticket lands on Done shelf with green pulse.
+
+Each cinematic is a single composed `Timeline` (a few extend to ≤ 10
+intents). They consume the lane / preemption / coalescing system from
+phase 4 unchanged. They add new intents (verdict scroll, slot transit,
+camera, door, pulse, particle) and use existing intents from phase 4.
+
+Phase 5 is the **payoff phase** for the slice. After phase 5, the v1
+cinematic journey runs end-to-end. Phase 6 then adds runtime
+observability on top.
+
+---
+
+## 1. Scope
+
+### In scope
+
+- Four named cinematics, each as a composed `Timeline` produced by
+  `lib/choreography.ts` when the relevant trigger event fires.
+- New intents (one file each in `game/choreography/intents/`):
+  - `slotTransit` — three-anchor sequenced tween through a slot.
+  - `spawnVerdictScroll` — creates a `TicketSprite` visual variant
+    (scroll texture) at a slot interior anchor.
+  - `spawnScoutEnvelope` — creates an envelope visual at the Library
+    south slot.
+  - `corridorPulse` — east- or west-bound coloured pulse along
+    `corridorY=88`.
+  - `doorState` — Review chamber door open/close animation (1.2s
+    cycle).
+  - `glowRing` — radial glow effect at a target anchor.
+  - `particleBurst` — small particle effect at a target anchor.
+  - `shelfLand` — snaps a ticket to a Done shelf slot and shifts
+    neighbours outward.
+  - `cameraTo` — pans camera to a Board 02 §6 anchor.
+  - `swapWallTint` — frosted/sealed wall tint change for the
+    duration of a cinematic (used by qaFailed + investigationWave for
+    ambient dimming).
+- Sprite texture variants for ticket: `card`, `scroll`, `envelope`.
+- Hero promotion driven by primary-lane timelines (the `ticketId`
+  field on `Timeline` from phase 4 now drives promotion).
+- Ambient suppression: while a critical cinematic runs, the ambient
+  lane pauses fully (no new ambient intents start; in-flight ambient
+  cancels).
+- Rollback expectation: each cinematic ends with the scene in a
+  reconcilable state — the next `applyPlacements` corrects any drift.
+
+### Out of scope (phase 6 and later)
+
+- Runtime HUD overlays: hero labels (above sprite — partially in phase
+  3 already; banner cell stays), queue depth badges, retry counter
+  rendering, convergence counter rendering, room pressure overlays,
+  blocked-state overlays, runtime event feed. **All phase 6.**
+- TDD-heartbeat glyphs (RED / GREEN / REFACTOR / LINT) — Tier 3,
+  deferred indefinitely.
+- Tool-call micro-animations — Tier 3, deferred.
+- Watchtower beacon, audit cinematic — Board 02 §15 reserves the
+  critical-lane slot but no anchors.
+- Sound / ambience — deferred.
+- Atmospheric polish boards (09–12) — separate slice.
+- Multi-floor, lobby, backstage, corkboard, building view — deferred.
+- Persona variants beyond the M17 role-keyed body — deferred.
+- Cross-project / WorkPackage tethers — separate slice.
+- Generalised cinematic framework. The four cinematics are
+  hand-composed. **Do not extract a "cinematic DSL."** v1 has four;
+  YAGNI.
+
+If you find yourself touching anything in "out of scope," stop.
+
+---
+
+## 2. Target file structure (after Phase 5)
+
+```
+apps/web/src/components/office/
+  game/
+    OfficeScene.ts               # may grow slightly to expose hero-promotion to player
+    choreography/
+      ChoreographyPlayer.ts      # ADJUSTED — adds ambient suppression flag
+      Timeline.ts                # unchanged
+      cinematics/                # NEW DIRECTORY
+        investigationWave.ts     # NEW — Timeline factory
+        qaFailed.ts              # NEW — Timeline factory
+        reviewConverged.ts       # NEW — Timeline factory
+        mergeCelebration.ts      # NEW — Timeline factory
+      intents/
+        walkToRoom.ts            # unchanged
+        attachToDesk.ts          # unchanged
+        swapIndicator.ts         # unchanged
+        slotTransit.ts           # NEW
+        spawnVerdictScroll.ts    # NEW
+        spawnScoutEnvelope.ts    # NEW
+        corridorPulse.ts         # NEW
+        doorState.ts             # NEW
+        glowRing.ts              # NEW
+        particleBurst.ts         # NEW
+        shelfLand.ts             # NEW
+        cameraTo.ts              # NEW
+        swapWallTint.ts          # NEW
+    layers/
+      RoomLayer.ts               # ADJUSTED — exposes door state primitive, wall-tint primitive
+      PersonaLayer.ts            # ADJUSTED — exposes freezePersona / unfreezePersona
+      TicketLayer.ts             # ADJUSTED — exposes setVariant('card'|'scroll'|'envelope'), shelf primitives
+      types.ts                   # ADJUSTED — adds cinematic-related type aliases
+  lib/
+    choreography.ts              # ADJUSTED — adds cinematic factories to event→timeline map
+    cinematic-timings.ts         # NEW — constants only (durations, easings); pure
+  slice.test.ts                  # extended for cinematic factories + new intents
+```
+
+New code budget for phase 5: ~1200 lines including tests. If any
+single intent grows past ~120 lines, split or simplify it before
+merging.
+
+---
+
+## 3. The four cinematics
+
+Each cinematic is defined here at the level of "what runs, in what
+order, against which anchors, for how long." Implementation detail —
+which Phaser tween calls produce which motion — lives in the intent
+modules and is interchangeable as long as the visible result matches.
+
+All timings are from `lib/cinematic-timings.ts`. All coordinates are
+from `lib/rooms.ts` (per Board 02 §18). No literals appear in
+cinematic factory code.
+
+### 3.1 `investigationWave`
+
+**Trigger:** `swarm.wave-started` event on the hero ticket. Lane:
+`primary`.
+
+**Subject:** the hero ticket. The cinematic must promote the ticket to
+hero on entry (if not already).
+
+**Sequence:**
+
+| Step | Intent                  | Target                                | Duration | Notes                                                       |
+| ---- | ----------------------- | ------------------------------------- | -------- | ----------------------------------------------------------- |
+| 1    | `cameraTo`              | `library-zoom` anchor reserved? **No.** Use `room-investigation` only when phase 6 zoom lands. Phase 5 stays at `hero-ticket-follow` centered on lead investigator. | 600ms ease | Camera follows hero. |
+| 2    | `attachToDesk`          | lead investigator desk `(280, 280)` (Board 02 §4.2) | 800ms     | Lead persona walks from corridor → lab → desk.            |
+| 3    | `swapIndicator`         | lead persona → `thought` glyph        | 0ms      | Snap.                                                       |
+| 4..6 | `spawnScoutEnvelope`×3 (parallel via Timeline.parallel — see §6) | Library scout slots 1, 2, 3 | 100ms stagger per scout | Each scout's "appearance" is rendering an `envelope`-textured ticket-prop at the scout desk. |
+| 7..9 | `swapIndicator`×3       | each scout → `speech`                 | 0ms      | Indicates active scout run.                                 |
+| 10   | (await `swarm.scout-completed` ×3 OR ttlMs cap) | —                       | up to 8s   | Player awaits; each scout-completed advances internal step counter (see §3.1.1). |
+| 11..13 | `slotTransit` (south) | each envelope through `library.envelope-out` slot `(288, 200) → (288, 224)` | 600ms each | Envelopes emerge from Library through south slot. |
+| 14   | `glowRing`              | lead investigator desk `(280, 280)`   | 800ms    | Convergence ring at the lead desk on `swarm.wave-completed`. |
+| 15   | `swapIndicator`         | hero ticket → `check`                 | 0ms      | Signals investigation complete (ticket gets check glyph briefly). |
+
+**Ambient suppression:** off (this is primary, not critical).
+**Hero promotion:** on entry; release at step 15 +500ms.
+**Camera:** stays on `hero-ticket-follow` throughout.
+**Rollback:** if any step exceeds its TTL, the timeline aborts. Next
+`applyPlacements` re-establishes the correct state (scouts disappear,
+indicator clears, ticket re-positions per server state).
+
+#### 3.1.1 Handling the await on `swarm.scout-completed`
+
+The cinematic cannot block on external events from inside an intent —
+intents are run-to-completion. To handle Wave-1 convergence, phase 5
+introduces a small pattern: **incremental cinematic continuation.**
+
+- The `investigationWave` factory in `lib/choreography.ts` runs at
+  `swarm.wave-started` and produces steps 1..6 only.
+- Each subsequent `swarm.scout-completed` event produces a small
+  follow-up `Timeline` containing steps 11..13 for that single scout
+  (one `slotTransit`), enqueued on the same lane.
+- `swarm.wave-completed` produces steps 14..15.
+
+The player's existing lane queue + preemption machinery handles this
+naturally: serial timelines on the primary lane against the same hero
+ticket complete in arrival order.
+
+The factory module composes the cinematic; phase 5 does not extend the
+player.
+
+### 3.2 `qaFailed`
+
+**Trigger:** `qa.functional-failed` event for the hero ticket (or for
+a ticket that promotes to hero on this event — see §5). Lane:
+`critical`.
+
+**Subject:** the hero ticket.
+
+**Sequence:** (timings strictly bounded; total ≤ 3.5s per Board 02 §14.1)
+
+| Step | Intent                  | Target                                | Duration | Notes                                                       |
+| ---- | ----------------------- | ------------------------------------- | -------- | ----------------------------------------------------------- |
+| 1    | (hero promotion)        | ticket                                | 0ms      | If not already hero, promote now. Camera switches to `hero-ticket-follow` centered on QA output slot. |
+| 2    | `spawnVerdictScroll`    | QA output interior anchor `(856, 136)` | 0ms      | Red-tinted scroll variant of `TicketSprite`. The ticket sprite swaps its body texture for the duration of this cinematic. |
+| 3    | `slotTransit`           | scroll through `qa.output` (`856, 136 → 96 → 88`) | 600ms | Three-anchor sequence: interior → exterior → queue. |
+| 4    | `corridorPulse`         | east-to-west, from `tx=854` to `tx=36`, along `py=88` | 1000ms | Red, 1-second sweep. Layer: `effects` (z=50). |
+| 5    | (parallel) `swapWallTint` | `room.review` north wall tint dim 20% for 3500ms | 0ms enter, restore on cinematic end | Subtle ambient dim. Auto-restores when cinematic ends. |
+| 6    | `walkToRoom`            | ticket — follows corridor pulse west; sub-step: corridor → dev door descent | 1200ms | Implemented as a single `walkToRoom` with destRoomId='dev'; layer fills in the corridor + descent. |
+| 7    | (parallel) `swapIndicator` | hero ticket → `bang`               | 0ms      | Snap.                                                       |
+| 8    | desk-lamp re-light at dev desk | (handled by layer primitive triggered by `attachToDesk` re-fire, no separate intent) | 200ms flicker | Phaser tween on lamp brightness. Implemented inside `attachToDesk` when target desk already has lamp on. |
+| 9    | hero release            | ticket                                | 0ms after step 8 | Camera returns to `floor-overview` over 800ms via a follow-up `cameraTo` step. |
+
+**Ambient suppression:** **on** for the duration. The ambient lane
+queue continues to grow but does not run; resumes after step 9.
+**Hero promotion:** force-promote at step 1; release at step 9 +500ms.
+**Camera:** `floor-overview` → `hero-ticket-follow` at step 1; back at
+step 9.
+**Retry counter:** **not rendered in phase 5.** The counter is a phase
+6 overlay. Phase 5 may emit a `'choreo.retry-incremented'` event on the
+scene emitter so phase 6 hook can listen — but phase 5 does not render
+the badge.
+**Tier-disagreement light:** not wired (Board 02 §16 still-open
+question; phase 5 leaves the anchor unused).
+**Rollback:** if total exceeds 3.5s TTL, abort. The scene reconciles
+on next placement diff. The wall-tint must restore on abort.
+
+### 3.3 `reviewConverged`
+
+**Trigger:** `review.converged` event for the hero ticket. Lane:
+`primary`.
+
+**Subject:** the hero ticket.
+
+**Sequence:** (total ~1.2s per Board 02 §14.1)
+
+| Step | Intent          | Target                                  | Duration | Notes                                          |
+| ---- | --------------- | --------------------------------------- | -------- | ---------------------------------------------- |
+| 1    | `doorState`     | `room.review.door`: `closed → opening`  | 200ms    | Tween door alpha + position.                   |
+| 2    | (hold open)     | door: `open`                            | 800ms    | Implemented as a delay step (a `swapIndicator` no-op or explicit `delay` intent — see §6.2). |
+| 3    | `slotTransit`   | hero ticket through `review.door` slot: interior `(1016, 136)` → exterior `(1016, 96)` → queue `(1016, 88)` | 600ms | Three-anchor sequenced tween. |
+| 4    | `walkToRoom`    | hero ticket continues east in corridor toward `room.done` door `(1192, 88)` | 1000ms | Implemented as `walkToRoom(destRoomId='done')` on the ticket sprite (no carrier; ticket is autonomous in this phase per Board 02 §1.5). |
+| 5    | `doorState`     | `room.review.door`: `open → closing`    | 200ms    | Door closes.                                   |
+
+**Ambient suppression:** off (primary).
+**Hero promotion:** the ticket is hero throughout; release on
+`mergeCelebration` (which may follow within seconds, or never — if
+the journey ends here, release at step 5 +500ms).
+**Camera:** stays at `hero-ticket-follow` (already centered on
+review door because the ticket has been hero since the wave).
+**Convergence counter:** **not rendered in phase 5.** Phase 6.
+**Rollback:** if door fails to open within TTL, abort; ticket remains
+in `review` room visually. Next placement diff corrects.
+
+### 3.4 `mergeCelebration`
+
+**Trigger:** `pr.merged` event for the hero ticket. Lane: `primary`
+(non-hero merges run on ambient — see §3.4.1).
+
+**Subject:** the hero ticket.
+
+**Sequence:** (total ~1.6s per Board 02 §14.1)
+
+| Step | Intent           | Target                                  | Duration | Notes                                          |
+| ---- | ---------------- | --------------------------------------- | -------- | ---------------------------------------------- |
+| 1    | `walkToRoom`     | hero ticket from done door `(1192, 88)` descends to shelf slot 3 `(1192, 168)` | 600ms | Implemented as a vertical tween; layer handles. |
+| 2    | `shelfLand`      | hero ticket → shelf slot 3 `(1192, 168)`; existing tickets shift outward; off-shelf tickets fade outward (800ms) | 800ms | Per Board 02 §4.6. |
+| 3    | `glowRing`       | shelf slot 3 `(1192, 168)`              | 600ms    | Green pulse.                                   |
+| 4    | `particleBurst`  | shelf slot 3 `(1192, 168)`              | 800ms    | 8 particles, fade.                             |
+| 5    | (Done-day counter increment) | Done-day badge anchor `(1184, 296)` | 0ms      | **Phase 6 renders the badge.** Phase 5 fires a `'choreo.merge-celebrated'` event on the emitter; phase 6 reads it. Phase 5 does not draw the counter. |
+| 6    | hero release     | ticket                                  | 0ms after step 4 | Camera returns to `floor-overview` over 800ms. |
+
+#### 3.4.1 Non-hero merges
+
+A `pr.merged` event for a ticket that is **not** the current hero
+produces a smaller ambient timeline:
+
+| Step | Intent          | Target                                  | Duration | Notes                                    |
+| ---- | --------------- | --------------------------------------- | -------- | ---------------------------------------- |
+| 1    | `shelfLand`     | non-hero ticket → next available slot   | 400ms    | Faster than hero version.                |
+| 2    | `particleBurst` | shelf landing slot                      | 600ms    | Smaller, lower-z particle effect.        |
+
+No glow, no camera move, no hero promotion. Pure ambient.
+
+**Ambient suppression:** off (primary for hero; ambient for non-hero).
+**Hero promotion:** force-promote at step 1 for the hero version;
+release at step 6.
+**Rollback:** if shelf positions can't be computed (e.g. shelf already
+full and the new ticket has lower priority), the ticket snaps directly
+into slot 3 and existing tickets fade out per the §4.6 overflow rule.
+
+---
+
+## 4. Timing ownership
+
+Every duration above is a constant in `lib/cinematic-timings.ts`. Each
+cinematic factory imports the constants it needs:
+
+```ts
+export const TIMING = {
+  cameraEase: 400,
+  cameraEaseSlow: 800,
+  walkRoomMs: 800,
+  walkCorridorMs: 1200,
+  slotTransit3AnchorMs: 600,
+  doorOpenMs: 200,
+  doorHoldMs: 800,
+  doorCloseMs: 200,
+  corridorPulseMs: 1000,
+  shelfLandHeroMs: 800,
+  shelfLandAmbientMs: 400,
+  glowRingMs: 600,
+  particleBurstMs: 800,
+  wallTintRestoreMs: 0,         // restore is part of cinematic-end, not its own tween
+  qaFailedHardCapMs: 3500,
+} as const;
+```
+
+No literal millisecond values anywhere in cinematic factory or intent
+code. Pure module. Tests can import it for assertions.
+
+Easings:
+- All cinematic tweens use `Phaser.Math.Easing.Cubic.InOut` by default.
+- Camera pans use the same.
+- Particle alphas use `Quad.Out`.
+
+This is fixed in `lib/cinematic-timings.ts`. Do not introduce
+per-cinematic ease overrides unless a Board 02 §14 sequence demands it
+(it does not).
+
+---
+
+## 5. Hero promotion behaviour
+
+Phase 3 implemented click-driven sticky promotion (10s window). Phase
+5 adds **cinematic-driven** promotion:
+
+- A `Timeline` with non-null `ticketId` whose lane is `primary` or
+  `critical` causes the ChoreographyPlayer to call
+  `TicketLayer.promote(ticketId)` on timeline start and
+  `TicketLayer.release(ticketId)` on timeline complete (or abort).
+- Cinematic-driven promotion **overrides** click-sticky promotion. If
+  click-sticky is active on a different ticket, that ticket releases
+  immediately and the cinematic's subject promotes.
+- After the cinematic completes, the player does **not** re-promote the
+  previous click-sticky ticket. Click was a fleeting interaction; the
+  cinematic event is the system's authoritative focus.
+- Two simultaneous cinematics targeting different tickets is impossible
+  by lane construction (one critical max, primary may queue but only
+  one active). The active timeline's subject is always the unique hero.
+- Banner Hero-Ticket cell (Board 02 §3 right cell) updates with the
+  current hero — single source of truth via
+  `RoomLayer.setHeroTicketCell` exactly as in phase 3. The player calls
+  it, not React.
+
+---
+
+## 6. Composing cinematic timelines
+
+### 6.1 Sequenced steps
+
+Phase 4 timelines run steps strictly sequentially. Phase 5 keeps that
+model.
+
+### 6.2 Delay steps
+
+Some cinematics include a "hold" (e.g. `reviewConverged` step 2:
+hold the door open for 800ms after it finishes opening). Two options:
+
+- **Option A (selected):** add a `delay(ms)` intent that resolves after
+  `ms` via `scene.time.delayedCall`. Lightweight; ≤ 30 lines.
+- **Option B (rejected):** extend `Timeline` to support inter-step
+  delays declaratively. Rejected because it makes timelines
+  serialisable in a way nothing else uses. Adding a `delay` intent is
+  cheaper.
+
+Implement Option A as a new intent in `game/choreography/intents/delay.ts`.
+It is the simplest possible intent: `run = ({ ms }) =>
+new Promise(r => scene.time.delayedCall(ms, r))`. `cancel` clears the
+delayedCall.
+
+### 6.3 Parallel steps
+
+Some cinematics need parallel intent execution (e.g. `qaFailed` runs
+the corridor pulse and the ticket walk concurrently; `investigationWave`
+spawns 3 scout envelopes in parallel).
+
+Phase 5 introduces a thin **timeline composition primitive**:
+`Timeline.parallel(steps)` returns a single composite step that the
+player runs as: dispatch all sub-steps simultaneously; resolve when the
+last sub-step completes (or any sub-step cancels).
+
+This is the **only** extension to the phase-4 player model. ~30 lines
+in `Timeline.ts`. Tests cover: 3-parallel completion, 1-of-3 cancel,
+ttl exceeded.
+
+`Timeline.parallel` is **not** a generic concurrency primitive — it is
+a specific composition rule. It does not nest indefinitely; cinematics
+in phase 5 use at most one level of parallelism per timeline.
+
+### 6.4 Cinematic factory shape
+
+Each cinematic lives in its own module:
+
+```ts
+// game/choreography/cinematics/qaFailed.ts
+import { TIMING } from '../../../lib/cinematic-timings';
+import { roomDoor, roomSlotAnchors } from '../../../lib/rooms';
+
+export function qaFailedTimeline(ticketId: string, devDeskSlot: number): Timeline {
+  return {
+    id: makeId(),
+    lane: 'critical',
+    ticketId,
+    source: 'event',
+    steps: [
+      { id: 'cameraTo', target: { kind: 'camera', id: 'hero-ticket-follow' }, params: {} , lane: 'critical', ttlMs: TIMING.cameraEase + 100 },
+      { id: 'spawnVerdictScroll', /* ... */ },
+      { id: 'slotTransit', /* ... */ },
+      // ...
+    ],
+  };
+}
+```
+
+Factories are pure. They take the trigger event's payload and produce
+a deterministic timeline. Tests cover each factory.
+
+`lib/choreography.ts` imports the four factories and dispatches per
+`timelinesForEvent`. The event allowlist grows:
+
+| Event kind                | Maps to                                 |
+| ------------------------- | --------------------------------------- |
+| `swarm.wave-started`      | `investigationWaveTimeline()` part 1    |
+| `swarm.scout-completed`   | `investigationWaveTimeline()` part 2 (per-scout follow-up) |
+| `swarm.wave-completed`    | `investigationWaveTimeline()` part 3    |
+| `qa.functional-failed`    | `qaFailedTimeline()`                    |
+| `review.converged`        | `reviewConvergedTimeline()`             |
+| `pr.merged` (hero)        | `mergeCelebrationTimeline()`            |
+| `pr.merged` (non-hero)    | `mergeCelebrationAmbientTimeline()`     |
+
+All others — same as phase 4 — produce phase-4 timelines or are
+ignored.
+
+---
+
+## 7. Ambient suppression rules
+
+While a **critical** cinematic is active:
+
+- New incoming ambient timelines do not start. They enqueue.
+- Active ambient timelines are cancelled immediately. They do not
+  resume.
+- This is enforced by the `ChoreographyPlayer` checking a single
+  `criticalActive` flag set by the lane state.
+
+While a **primary** cinematic is active:
+
+- Ambient continues to run.
+- Existing primary cinematics (none active because primary has one
+  slot) are preempted by critical only.
+
+Restoration:
+- When the critical timeline completes (or aborts), the
+  `criticalActive` flag clears, and the player resumes the ambient
+  queue head normally.
+
+Phase 5 implements the `criticalActive` gating in
+`ChoreographyPlayer.process()`. ~10 lines.
+
+---
+
+## 8. Rollback expectations
+
+Each cinematic ends in one of three states:
+
+1. **Completed.** All steps ran. Camera at floor-overview (or
+   hero-ticket-follow if a primary handoff is queued). All temporary
+   visuals destroyed. Wall tints restored.
+2. **Aborted (TTL).** A step exceeded its `ttlMs`. Player cancels the
+   timeline. Cinematic factory must register a cleanup callback
+   (`Timeline.onAbort?: () => void`) that:
+   - Destroys any spawned scrolls / envelopes / glow rings / particles.
+   - Restores wall tints.
+   - Restores door state to closed.
+   - Resets the camera to `floor-overview` over 400ms.
+3. **Preempted (critical interrupt).** A primary cinematic was running
+   when a critical event arrived. Active step cancels; the primary
+   timeline pauses. The cleanup callback **does not** run on
+   preemption — only on full abort.
+
+After any of these end states, **the next `applyPlacements` is
+authoritative.** It resets sprite positions per server truth, clears
+indicators per current state, and re-renders queue stacks. This is the
+final safety net; cinematics do not need to be exhaustively
+"undoable" on their own.
+
+`Timeline.onAbort` is the second of two extensions to the phase-4
+timeline shape (the first was the optional `onComplete`).
+
+---
+
+## 9. Acceptance criteria
+
+The PR is mergeable iff:
+
+- [ ] `pnpm test` passes.
+- [ ] `pnpm typecheck` passes.
+- [ ] `pnpm lint` passes.
+- [ ] `office-click-through.spec.ts` passes in CI.
+- [ ] Four cinematic factories exist in `game/choreography/cinematics/`,
+      each pure, each ≤ 200 lines.
+- [ ] New intent modules exist in `game/choreography/intents/`:
+      `slotTransit`, `spawnVerdictScroll`, `spawnScoutEnvelope`,
+      `corridorPulse`, `doorState`, `glowRing`, `particleBurst`,
+      `shelfLand`, `cameraTo`, `swapWallTint`, `delay`. Each ≤ 120
+      lines.
+- [ ] `lib/cinematic-timings.ts` exists with all durations as named
+      constants. No literal `ms` values appear in cinematic factory or
+      intent code.
+- [ ] `Timeline.parallel` exists and is unit-tested.
+- [ ] `Timeline.onAbort` exists and is invoked exactly on full aborts,
+      never on preemption.
+- [ ] Player's `criticalActive` flag implements ambient suppression.
+- [ ] Banner Hero-Ticket cell updates from primary / critical timelines.
+- [ ] Hero promotion is driven by `Timeline.ticketId` on the player.
+- [ ] **No mutation of workflow state.** Grep across `game/` returns
+      no `fetch`, `postMessage`, label-write calls.
+- [ ] **No coordinate literals** in `game/` outside `lib/rooms.ts`
+      imports.
+- [ ] **No literal timing values** in `game/` outside `lib/cinematic-timings.ts`
+      imports.
+- [ ] No new dependencies in `apps/web/package.json` (Phaser's existing
+      particle system suffices; if it doesn't, surface before adding
+      anything).
+- [ ] Manual verification (§11) all ticked.
+
+---
+
+## 10. Test surface
+
+### Unit tests (`slice.test.ts`)
+
+- Each cinematic factory:
+  - Produces the expected sequence of intent ids in order.
+  - Pulls anchors from `lib/rooms.ts` (mockable to assert).
+  - Pulls timings from `lib/cinematic-timings.ts`.
+  - Marks correct lane (`critical` for qaFailed; `primary` for the
+    others).
+- `Timeline.parallel`:
+  - 3 sub-steps, all resolve → composite resolves.
+  - 1 sub-step cancels → composite cancels.
+  - ttl exceeded on one sub-step → composite cancels.
+- Player ambient suppression:
+  - Critical cinematic active → new ambient timeline does not start.
+  - Critical completes → ambient queue resumes.
+- Player onAbort:
+  - TTL exceeded → `onAbort` runs.
+  - Preempted by higher lane → `onAbort` does not run.
+- Event → cinematic map:
+  - `qa.functional-failed` → qaFailed factory called.
+  - `swarm.scout-completed` → per-scout follow-up factory.
+  - `pr.merged` hero / non-hero branches.
+
+### Integration tests
+
+- A scripted sequence of events: `state.transitioned(investigating)` →
+  `swarm.wave-started` → 3× `swarm.scout-completed` →
+  `swarm.wave-completed` → `state.transitioned(in-progress)` →
+  `agent.run-started` → `agent.run-completed` →
+  `state.transitioned(needs-qa)` → `qa.functional-failed` →
+  `state.transitioned(in-progress)` → ... → `pr.merged`. Assert that
+  the player's lane activity follows the expected pattern (intent
+  observability events emitted in the expected order).
+
+Phaser tween calls are mocked at the layer boundary — phase 5 tests
+do not require a real WebGL context.
+
+### E2E
+
+- `office-click-through.spec.ts` continues to pass.
+- Optional: a `phase-5-cinematics` opt-in spec
+  (`RUN_SCREENSHOTS=1`) that runs the v1 journey end-to-end and
+  captures screenshots at: investigation wave mid-fan-out, qaFailed
+  corridor pulse, review door open, shelf landing. Not required for
+  CI green.
+
+---
+
+## 11. Manual verification checklist
+
+Before opening the PR, run a full v1 journey in the dev server:
+
+- [ ] `factory:triaging` → ticket appears in Triage room with a persona.
+- [ ] Transition to `factory:investigating`: persona walks across
+      corridor to investigation lab; ticket follows (carry).
+- [ ] Emit `swarm.wave-started`: 3 scout envelopes spawn at Library
+      slots. Indicators light up.
+- [ ] Emit `swarm.scout-completed` ×3: each envelope tweens south
+      through the library slot to the lead investigator desk.
+- [ ] Emit `swarm.wave-completed`: convergence glow at lead desk;
+      ticket gets `check` glyph.
+- [ ] Transition to `factory:dev-ready`: persona walks to Dev room;
+      ticket follows.
+- [ ] Emit `agent.run-started`: persona seats at a dev desk; indicator
+      `speech`; desk lamp on.
+- [ ] Emit `agent.run-completed`: indicator briefly `check`, then
+      clears.
+- [ ] Transition to `factory:needs-qa`: persona walks to QA queue
+      anchor; ticket transits through QA input slot (queue → exterior →
+      interior).
+- [ ] Emit `qa.functional-failed`:
+  - Red verdict scroll exits QA output slot.
+  - Red corridor pulse sweeps east-to-west.
+  - Review wall dims briefly.
+  - Ticket returns to a dev desk.
+  - Indicator becomes `bang`.
+  - Camera centers on QA output at start; returns to floor-overview
+    after.
+  - Total ≤ 3.5s.
+- [ ] During the qaFailed cinematic, fire a `state.transitioned` on
+      another ticket (non-hero). Expected: it does not animate during
+      critical; resumes after qaFailed ends.
+- [ ] Transition through second QA pass, then `factory:needs-review`:
+      persona walks to Review queue anchor; ticket waits (no door
+      transit yet because Review is gated).
+- [ ] Emit `review.converged`:
+  - Review door opens.
+  - Ticket transits through door slot.
+  - Ticket walks east in corridor to Done door.
+  - Door closes.
+- [ ] Emit `pr.merged`:
+  - Ticket descends to shelf slot 3.
+  - Existing shelf tickets shift outward; off-shelf items fade.
+  - Green glow + particle burst.
+  - Camera returns to `floor-overview`.
+  - Banner Hero-Ticket cell clears.
+- [ ] No console errors throughout the journey.
+- [ ] All intent observability events visible in DevTools
+      (`scene.events_().on('choreo.intent-started', ...)` callable).
+
+If a step fails visually, fix it. Do not ratify in tests.
+
+---
+
+## 12. Stop conditions
+
+Stop and ask the human if any of the following occur:
+
+- A cinematic exceeds its hard timing cap (qaFailed > 3.5s,
+  mergeCelebration > 2s, etc.). The cap is the contract; speed up the
+  implementation, do not raise the cap.
+- The four cinematics share enough structure that a "cinematic DSL"
+  starts to feel necessary. v1 has four; YAGNI. Surface and ask before
+  abstracting.
+- Phaser particles or graphics primitives do not suffice for a step
+  (e.g. you find yourself wanting a shader). Surface — this is a v1
+  scope-limit problem, not an implementation problem.
+- Cinematic factories grow past ~200 lines each. They should not;
+  most of the logic is in intents.
+- An intent module needs to read from another layer it does not own.
+  Restate the design — intents should call narrow primitive methods on
+  exactly one layer.
+- Hero promotion conflicts between click-sticky and cinematic produce
+  visible flicker. Specifically: rapid cinematic start, end, click,
+  cinematic start on a 3rd ticket. The override rule in §5 should
+  produce a clean handoff; if it does not, debug before adding new
+  rules.
+
+---
+
+## 13. Explicit non-goals
+
+Restated:
+
+- **No generalised cinematic framework.** Four named cinematics, hand
+  composed.
+- **No HUD overlays.** Hero label *above* a persona sprite exists from
+  phase 3; the banner cell exists from phase 2; nothing new beyond
+  that in phase 5.
+- **No retry / convergence counter rendering.** Phase 5 emits the
+  events; phase 6 draws the badges.
+- **No watchtower / audit cinematic.** Critical lane has the slot but
+  no anchors.
+- **No TDD glyphs, monitor flicker, tool-call micro-animations.**
+- **No sound, ambience, atmospheric polish.**
+- **No multi-floor, building view, lobby, backstage, corkboard.**
+- **No persona variants, no tier badges, no streaks / win counters.**
+- **No procedural ambient motion** (janitor goose, coffee machine,
+  etc.). These are atmospheric polish.
+- **No new event kinds beyond the v1 catalogue.**
+- **No mutation of workflow state.** Restated again because cinematic
+  code is the place this invariant is most likely to be casually
+  violated ("just emit a label write on merge complete..." — no.)
+
+---
+
+## 14. What happens after Phase 5
+
+Phase 6 (next session, after Phase 5 PR merges):
+
+- Author `lib/hud-overlays.ts` — pure module computing overlay state
+  from current `applyPlacements` + intent observability events.
+- Add a `HudLayer` (or extend `RoomLayer`'s canvas-hud band) for
+  in-world overlays: queue depth badges, retry counter at QA, round
+  counter at Review, QualityScore dial readout, Done-day badge.
+- Add the runtime event feed: a small DOM-side feed (React) that
+  subscribes to `'choreo.intent-started'` / `'choreo.intent-completed'`
+  events on the scene emitter and renders a scrolling 5-line log.
+- Surface room pressure overlays + blocked-state spotlight.
+- Hero ticket camera state badge.
+
+This plan only covers Phase 5.

--- a/docs/design/office-mode/vertical-slice-v1/phase-6-runtime-hud.md
+++ b/docs/design/office-mode/vertical-slice-v1/phase-6-runtime-hud.md
@@ -1,0 +1,668 @@
+# Office Mode Vertical Slice v1 — Phase 6: Runtime HUD
+
+**Status:** Specified. Last phase of the slice. After this merges, v1
+is shippable.
+
+**Goal:** Add the minimum runtime observability overlays the slice
+needs so a player watching the office can read what's happening
+without parsing motion alone.
+
+The HUD must feel **physically integrated into the world** — labels
+above heads, counters mounted on doors, depth badges at room
+thresholds, a dial on the Review chamber. Not a generic dashboard
+pasted over the canvas.
+
+This is the office-first principle: the office is the dashboard.
+
+---
+
+## 1. Scope
+
+### In scope
+
+- **Hero labels** — codename above the carrier persona of the current
+  hero ticket; issue id + truncated title in the banner Hero-Ticket
+  cell. (Phase 3 already implemented codename pop + banner cell; phase
+  6 polishes them and adds priority tinting.)
+- **Queue overlays** — depth badges at room doorways (the `+N`
+  variant for tier-4 stacks from Board 02 §8) and a click-to-list
+  panel for queued items.
+- **Retry counter** — numeric badge on the QA chamber, increments on
+  `qa.functional-failed` events (which phase 5 already emits
+  `'choreo.retry-incremented'` for).
+- **Convergence counter** — round counter on the Review chamber door.
+- **QualityScore dial readout** — small numeric label below the dial
+  on the Review door frame (Board 02 §4.5 reserves the dial anchor).
+- **Room pressure overlays** — subtle room-floor tint that warms as
+  in-flight ticket count climbs in that room.
+- **Blocked-state overlays** — spotlight effect + bell icon on
+  `gate-pending` / `needs-human` personas (phase 5 already freezes them
+  with `swapIndicator(question)`).
+- **Done-day badge** — small "+N today" counter below the Done shelf;
+  increments on `'choreo.merge-celebrated'` event from phase 5.
+- **Runtime event feed** — a small DOM-side React component that
+  subscribes to the scene emitter and renders the last ~5 lines of
+  high-tier choreography activity ("Wave started", "Review converged",
+  "QA failed", "Merged: #1234").
+- **Hero-ticket camera-state indicator** — a tiny "Following" icon /
+  text in the top-left of the canvas when camera is on
+  `hero-ticket-follow`; absent when on `floor-overview`.
+
+### Out of scope (post-v1)
+
+- Zoom mode HUD (`building`, `room`, `persona` indicators) — Board 02
+  §6 reserves the anchors; v1 has only `floor-overview` and
+  `hero-ticket-follow`.
+- Budget / token gauge — operationally important but lives in the
+  lobby (not in scope). Phase 6 does not surface it.
+- Room load *heatmap* (Board 08 brief mentions one) — replaced by
+  subtle floor tinting per §3.4. No multi-color heatmap.
+- TDD heartbeat glyphs.
+- Tool-call micro-animations.
+- Watchtower / auditor sprite + beacon. Critical-lane anchor reserved;
+  not in v1.
+- Tier-disagreement light at the QA chamber. Anchor reserved (Board 02
+  §16 still-open), not wired in v1.
+- Wave-glyph aggregated overlay (the "6 scouts ×" flock-badge at floor
+  zoom). v1 always shows individual scouts.
+- Sound, ambient audio, weather, rain, night-mode lighting changes.
+- Mode (`interactive` / `supervised` / `autonomous`) tinting beyond
+  the static badge in the banner's middle cell. Per-mode global
+  palette is deferred.
+- Persona stat badges, streak counters, win counts.
+- WorkPackage tethers.
+- Generic event-log expansion beyond the 5-line feed.
+
+If you find yourself touching anything in "out of scope," stop.
+
+---
+
+## 2. Target file structure (after Phase 6)
+
+```
+apps/web/src/components/office/
+  components/
+    OfficePage.tsx               # unchanged
+    OfficeTab.tsx                # ADJUSTED — instantiates HudFeed; passes event subscription
+    OfficeGameMount.tsx          # unchanged
+    FloorIndicator.tsx           # unchanged
+    DeskDetailPanel.tsx          # unchanged
+    HudFeed.tsx                  # NEW — DOM event feed, ~80 lines
+  game/
+    OfficeScene.ts               # ADJUSTED — instantiates HudLayer
+    asset-loader.ts              # unchanged
+    textures.ts                  # extended for badge / dial / spotlight textures (procedural)
+    choreography/                # unchanged
+    layers/
+      RoomLayer.ts               # ADJUSTED — exposes hud-friendly anchor lookups for HudLayer
+      PersonaLayer.ts            # unchanged
+      TicketLayer.ts             # unchanged
+      HudLayer.ts                # NEW — canvas-hud renderable; ~280 lines
+      types.ts                   # ADJUSTED — adds HudState type
+  lib/
+    rooms.ts                     # ADJUSTED — adds two new anchor lookups:
+                                 #   hudAnchor('retry-counter' | 'round-counter' | 'quality-score' | 'done-day' | 'camera-state' | etc.)
+                                 #   pressureColorForCount(n: number): ColorString  (pure)
+    hud-state.ts                 # NEW — pure derivation of HudState from placements + recent events
+    ...                          # all other libs unchanged
+  slice.test.ts                  # extended for hud-state + room pressure
+```
+
+New code budget: ~700 lines including tests.
+
+---
+
+## 3. The HUD components
+
+Each component has a single source of truth — usually
+`HudLayer.update(state: HudState)` driven by `hud-state.ts`. State
+flows in once per `applyPlacements` or per choreography observability
+event, never per frame.
+
+### 3.1 Hero labels
+
+**Where:** above the carrier persona of the current hero ticket, plus
+in the Board 02 §3 banner Hero-Ticket cell.
+
+**What phase 3 / 5 already built:**
+- Codename pop above persona at `(persona.x, persona.y − 28)`. Owned
+  by `PersonaLayer`.
+- Banner cell text. Owned by `RoomLayer`.
+
+**What phase 6 adds:**
+- Priority tinting on the codename label: `critical` → red,
+  `high` → amber, `normal` → cyan, `low` → grey. Single text colour
+  per priority. The tint comes from `lib/rooms.ts` →
+  `priorityTintColor(priority)` (pure). The carrier persona's
+  priority is the priority of its carried ticket.
+- Truncation rule for banner: `#${externalId} — ${title.slice(0, 36)}…`.
+- A tiny **issue-priority dot** rendered to the left of the banner
+  Hero-Ticket cell text, sized 6px square, coloured per priority.
+
+`PersonaLayer.setHeroCodename(personaId, codename, priority)` replaces
+the simpler `setHeroCodename(personaId, codename)` from phase 3.
+
+### 3.2 Queue depth badges
+
+**Where:** beside each room queue stack (per Board 02 §8). Existing
+queue stack texture tiers already encode depth 0..15 visually. Phase 6
+adds the **numeric badge** for tier-4 stacks (depth 16+).
+
+**Implementation:** `HudLayer.applyQueueDepths(perRoom: Record<RoomId,
+number>)`. For each room with depth ≥ 16, render a
+`Phaser.GameObjects.Text` at `(stack.x + 12, stack.y − 18)` showing
+`+${depth - 15}`. For depth < 16, no badge.
+
+**Z-layer:** `canvas-hud` (z=60).
+
+**Cadence:** updated once per `applyPlacements`. No per-frame work.
+
+**Click behaviour:** the existing room queue click zone (Board 02
+§10) opens a "Queued at <room>" panel. **The panel itself is a DOM
+component**; v1 ships the panel as a simple `<aside>` listing item ids
+and titles, similar to `DeskDetailPanel`. Single screen, no
+pagination, no filters. Implemented as `components/QueuePanel.tsx`,
+opened via React in response to the existing scene `'queue-click'`
+emitter event (which `RoomLayer` already emits per phase 2). If the
+emitter event does not yet exist, phase 6 adds it — single
+`stopPropagation`-aware click handler on `zone.queue.*` rects.
+
+### 3.3 Retry counter
+
+**Where:** corridor side of the QA chamber, anchor
+`hudAnchor('retry-counter')` = Board 02 §4.4 `(784, 96)`.
+
+**Visual:** small numeric badge "×N" with a single-digit cap (rare;
+≥10 retries surface as "9+"). Default value: `0`. Hidden when value is
+0.
+
+**Update rule:**
+- Phase 5 emits `'choreo.retry-incremented'` on
+  `qa.functional-failed`. Phase 6's `HudLayer` listens for this and
+  increments a per-ticket counter (`Map<ticketId, number>`).
+- The counter for the **hero ticket** is rendered. Counters for
+  non-hero tickets are tracked but invisible until they become hero.
+- Counter resets when the ticket transitions to `factory:done` /
+  `factory:archived` / `factory:rejected` (observed via
+  `applyPlacements`).
+
+**Bounce:** on increment, the badge runs a 200ms `Quad.Out` scale
+bounce (1.0 → 1.4 → 1.0), per Board 02 §14.1 step 4 of `qaFailed`.
+
+### 3.4 Convergence counter (Review)
+
+**Where:** corridor side of the Review chamber, anchor
+`hudAnchor('round-counter')` = Board 02 §4.5 `(1024, 96)`.
+
+**Visual:** "rN" where N is the current convergence round. Default `r1`
+when the ticket enters Review for the first time. Increments on each
+`review.escalated` event (deferred from the v1 cinematic catalogue but
+the *counter* still surfaces it — minimal HUD wiring, no cinematic).
+
+If the hero is not in Review (or no hero exists), the counter is
+hidden.
+
+### 3.5 QualityScore dial readout
+
+**Where:** beside the dial face, anchor `hudAnchor('quality-score')` =
+Board 02 §4.5 `(1064, 104)`.
+
+**Visual:** numeric text `0..100` beneath the dial frame, monospace,
+12px. Phase 6 does **not** animate a dial needle — the needle is a
+later atmospheric concern; phase 6 only renders the numeric.
+
+**Update rule:**
+- Read from `WorkItemDto` if the server includes
+  `qualityScore?: number` on issues. If not, read from a
+  `qualityScore` field on the hero ticket only.
+- Update on `applyPlacements`. No event-driven path; the score is
+  data, not motion.
+- Hidden when no hero or no score.
+
+If the field is not yet plumbed in `WorkItemDto`, phase 6 leaves the
+anchor unused. Do not block phase 6 on a server-side change; surface
+in the PR description.
+
+### 3.6 Room pressure overlay
+
+**Where:** floor tiles inside each room.
+
+**Visual:** a single tile-tint modulation applied per room. As
+"in-flight tickets in this room" increases, the room's interior tint
+shifts from neutral cyan toward warm amber (pressure). Mapping (from
+`lib/rooms.ts → pressureColorForCount(n)`):
+
+| In-flight tickets | Tint           |
+| ----------------- | -------------- |
+| 0                 | neutral cyan   |
+| 1..3              | neutral        |
+| 4..7              | slight amber   |
+| 8..15             | amber          |
+| 16+               | warm amber     |
+
+For the v1 single-ticket journey, all rooms stay at 0..1 most of the
+time; pressure surfaces only during the Wave (3 scouts in Library) or
+parallel-build (out of v1 scope). Implementation must work for higher
+counts but v1 visual budget is the 0..3 range.
+
+**Implementation:** `HudLayer` does not own this — `RoomLayer.applyPressure(perRoom: Record<RoomId, number>)`
+takes the count map and tints the floor-tile group inside each room.
+This is the **only** HUD-driven write phase 6 makes into `RoomLayer`,
+done via a single primitive method, not a layer boundary violation.
+
+**Cadence:** once per `applyPlacements`. No per-frame work.
+
+### 3.7 Blocked-state overlay
+
+**Where:** above and around a frozen persona (one with
+`factory:needs-human` or `factory:gate-pending`).
+
+**Visual:** a soft spotlight ring at `(persona.x, persona.y − 6)`
+radius 28px (z=`effects` 50). Plus a small bell icon at
+`(persona.x + 16, persona.y − 32)` (z=`canvas-hud` 60) when the state
+is `gate-pending` only. `needs-human` shows a `?` indicator (already
+swapped by phase 5) plus the spotlight; no bell.
+
+**Implementation:** `HudLayer.applyBlocked(personaIds: Set<string>,
+modes: Map<string, 'gate-pending' | 'needs-human'>)`. Spotlight and
+bell are per-persona; cleaned up when the persona transitions out.
+
+**Cadence:** once per `applyPlacements`.
+
+### 3.8 Done-day badge
+
+**Where:** below the Done shelf, anchor `hudAnchor('done-day')` =
+Board 02 §4.6 `(1184, 296)`.
+
+**Visual:** "+N today" text. `N` increments on every
+`'choreo.merge-celebrated'` event from phase 5.
+
+**Reset rule:** on midnight (browser-local). Implement with a
+`setInterval` set in `HudLayer.create()` that checks the current date
+once per minute; on date change, the counter resets to 0.
+
+(This is the one place phase 6 introduces a tiny timer that ticks
+without an event. It is bounded — one timer, one check per minute,
+not a per-frame update.)
+
+### 3.9 Runtime event feed
+
+**Where:** **DOM**, not canvas. Top-right of the office viewport,
+below the existing `FloorIndicator`. Component:
+`components/HudFeed.tsx`.
+
+**Visual:** a fixed 200×120px panel showing the last 5 lines of
+high-tier choreography activity, scrolling from the bottom. Each line:
+- Small priority dot.
+- Event verb ("Wave started", "QA failed", "Review converged",
+  "Merged").
+- Ticket id `#1234`.
+
+**Data source:** subscribes to scene events:
+- `'choreo.intent-started'` filtered by cinematic boundaries (only
+  the *first* intent of each cinematic produces a feed line, identified
+  by name match: `cameraTo` is a follower, ignored; `spawnVerdictScroll`
+  is qaFailed; `attachToDesk` + `swapIndicator(thought)` at lead-desk
+  is investigationWave; etc.).
+- Better approach: phase 5's `ChoreographyPlayer` is extended to emit
+  `'choreo.cinematic-started'` and `'choreo.cinematic-completed'`
+  events whenever a cinematic-named timeline starts / completes. Phase
+  6 listens for **`'choreo.cinematic-started'` only.**
+
+If extending the player conflicts with the phase 5 acceptance criteria
+("`ChoreographyPlayer` ≤ 300 lines"), then the alternative is: phase
+6 inspects intent names heuristically. Pick the cleaner one;
+extending the player by ~10 lines is preferred.
+
+**Feed line lifetime:**
+- Each new event prepends a line to the feed.
+- Lines older than 30 seconds fade out (opacity 0 over 1s); then
+  disappear from the DOM.
+- The feed never exceeds 5 visible lines; older lines drop on
+  insertion of a new one if at max.
+
+**Cadence:** event-driven only. No polling.
+
+**No filters.** No expansion. No detail view. v1 is a 5-line ticker.
+
+### 3.10 Hero-ticket camera state indicator
+
+**Where:** top-left of the canvas, anchor
+`hudAnchor('camera-state')` = `(8, 8)` (added to `lib/rooms.ts` for
+this phase).
+
+**Visual:** a small text "FOLLOWING #1234" when camera anchor is
+`hero-ticket-follow`; absent when `floor-overview`. Text is white,
+8px, monospace; renders on `canvas-hud` (z=60).
+
+**Update rule:** `HudLayer.applyCameraState({ anchor: AnchorName,
+ticketId?: string })`. Called by `OfficeScene` whenever the camera
+anchor changes (which phase 5 already does at cinematic start /
+end).
+
+---
+
+## 4. `HudLayer` responsibilities
+
+The `HudLayer` is a single layer instance owned by `OfficeScene`.
+Construction order:
+
+```
+new RoomLayer(...)
+new PersonaLayer(...)
+new TicketLayer(...)
+new HudLayer(...)        // last — sits at top of z-stack
+```
+
+`HudLayer` owns:
+
+- All canvas-hud children listed in §3 (queue badges, retry counter,
+  round counter, score readout, done-day badge, camera state text,
+  blocked-state spotlight + bell).
+- A single subscription to the scene emitter for
+  `'choreo.cinematic-started'`, `'choreo.retry-incremented'`,
+  `'choreo.merge-celebrated'`.
+- A single `applyHud(state: HudState)` method called by `OfficeScene`
+  whenever `applyPlacements` updates derive a new HUD state.
+
+It does **not** own:
+
+- Hero codename labels above personas (that's `PersonaLayer`, set by
+  phase 3 and extended by phase 6 for priority tinting only).
+- Banner Hero-Ticket cell (that's `RoomLayer`'s banner text from phase
+  2).
+- Room pressure tinting (that's `RoomLayer.applyPressure`, called from
+  the scene with the same `HudState` payload).
+- The DOM event feed (that's `HudFeed.tsx`).
+
+This split — `HudLayer` for canvas-hud, `HudFeed.tsx` for DOM — is
+deliberate. The feed is a scrolling text widget; DOM is the right
+medium. The badges, counters, dials, and spotlights are world-anchored;
+Phaser is the right medium.
+
+---
+
+## 5. `lib/hud-state.ts` — pure derivation
+
+```ts
+export interface HudState {
+  hero: {
+    ticketId: string;
+    personaId: string | null;
+    priority: 'critical' | 'high' | 'normal' | 'low';
+    bannerLabel: string;       // "#1234 — title…"
+    qualityScore: number | null;
+  } | null;
+  queues: Record<RoomId, number>;          // depth per room
+  pressure: Record<RoomId, number>;        // in-flight per room
+  retry: Record<string, number>;           // ticket id → retry count
+  reviewRound: number | null;
+  blocked: Array<{ personaId: string; mode: 'gate-pending' | 'needs-human' }>;
+  camera: { anchor: 'floor-overview' | 'hero-ticket-follow'; ticketId?: string };
+  doneToday: number;
+}
+```
+
+Pure derivation:
+
+```ts
+export function hudStateFromPlacements(
+  personas: PersonaPlacement[],
+  tickets: TicketPlacement[],
+  prev: HudState | null,             // for retry / doneToday accumulators
+  events: { retryIncremented: string[]; mergedCelebrated: string[] }
+): HudState;
+```
+
+Tests cover every field. The function is the single source of truth for
+"what does the HUD show right now?" `OfficeScene` calls it on every
+`applyPlacements` and pushes the result to `HudLayer`, `RoomLayer`
+(for pressure), and `HudFeed.tsx` (via emitter).
+
+---
+
+## 6. Layering rules
+
+Inherit Board 02 §7. Phase 6 sits at z=60 (`canvas-hud`).
+
+| Phase 6 surface             | Layer (z)        | Belongs to                |
+| --------------------------- | ---------------- | ------------------------- |
+| Hero codename label         | 35 (persona-overlays) | `PersonaLayer`          |
+| Banner text (3 cells)       | 60 (canvas-hud)  | `RoomLayer`               |
+| Queue depth badge `+N`      | 60 (canvas-hud)  | `HudLayer`                |
+| Retry counter               | 60 (canvas-hud)  | `HudLayer`                |
+| Round counter               | 60 (canvas-hud)  | `HudLayer`                |
+| QualityScore readout        | 60 (canvas-hud)  | `HudLayer`                |
+| Done-day badge              | 60 (canvas-hud)  | `HudLayer`                |
+| Camera-state text           | 60 (canvas-hud)  | `HudLayer`                |
+| Blocked spotlight ring      | 50 (effects)     | `HudLayer`                |
+| Blocked bell icon           | 60 (canvas-hud)  | `HudLayer`                |
+| Room pressure tile tint     | 0 (floor-tiles, modulated) | `RoomLayer`     |
+| HudFeed (event log)         | DOM              | `HudFeed.tsx`             |
+
+No new z values are introduced. The `canvas-hud` band remains
+single-layered; insertion order within it does not matter visually
+because no two HUD elements overlap.
+
+---
+
+## 7. Update cadence
+
+**Per `applyPlacements`:**
+- Recompute `HudState` via `hudStateFromPlacements`.
+- Push to `HudLayer.applyHud(state)` → updates badges, counters,
+  readouts, spotlights.
+- Push to `RoomLayer.applyPressure(state.pressure)`.
+- Push to `HudFeed.tsx` via React state.
+
+**Per choreography event:**
+- `'choreo.retry-incremented'` → accumulator updates retry map,
+  `HudLayer` re-renders the relevant badge with a bounce.
+- `'choreo.merge-celebrated'` → accumulator increments `doneToday`.
+- `'choreo.cinematic-started'` → `HudFeed` prepends a line.
+
+**Per minute:**
+- `HudLayer` checks browser date; if rolled over, reset `doneToday`.
+
+**No per-frame update.** No `scene.update()` work. Phase 6 must not
+introduce a per-frame tick.
+
+---
+
+## 8. Interaction rules
+
+| Element                    | Click behaviour                                                 |
+| -------------------------- | --------------------------------------------------------------- |
+| Queue badge `+N`           | Opens `QueuePanel.tsx` (DOM) listing queued items for that room |
+| Retry counter              | No click; informational only                                    |
+| Round counter              | No click                                                        |
+| QualityScore readout       | No click in v1 (would link to detail panel later)               |
+| Done-day badge             | No click in v1                                                  |
+| Blocked spotlight / bell   | Click on the persona opens the existing `DeskDetailPanel` (per phase 3); the bell itself does not have its own zone |
+| Camera-state text          | No click in v1 (clicking it could swap camera back; deferred)  |
+| HudFeed lines              | Hovering a line shows a tiny title-tooltip via the `title=`     |
+|                            | attribute (browser-native); clicking is no-op in v1             |
+
+All clicks emit through React handlers, not the scene. The scene
+remains visualisation-only.
+
+---
+
+## 9. Acceptance criteria
+
+The PR is mergeable iff:
+
+- [ ] `pnpm test` passes.
+- [ ] `pnpm typecheck` passes.
+- [ ] `pnpm lint` passes.
+- [ ] `office-click-through.spec.ts` passes in CI.
+- [ ] `layers/HudLayer.ts` exists; ≤ 320 lines.
+- [ ] `components/HudFeed.tsx` exists; ≤ 100 lines.
+- [ ] `components/QueuePanel.tsx` exists; ≤ 100 lines.
+- [ ] `lib/hud-state.ts` exists; pure; ≤ 200 lines including tests
+      target.
+- [ ] `lib/rooms.ts` extended with `hudAnchor`, `priorityTintColor`,
+      `pressureColorForCount`. No tile-pixel literals in any file
+      outside `lib/rooms.ts`.
+- [ ] `HudLayer` listens to `'choreo.cinematic-started'`,
+      `'choreo.retry-incremented'`, `'choreo.merge-celebrated'` —
+      and nothing else.
+- [ ] **No per-frame update logic** added to `HudLayer` or any
+      adjacent layer.
+- [ ] **No mutation of workflow state.** Grep across `game/` returns
+      no `fetch`, `postMessage`, label-write calls.
+- [ ] No new dependencies in `apps/web/package.json`.
+- [ ] Manual verification (§11) all ticked.
+
+---
+
+## 10. Test surface
+
+### Unit tests (`slice.test.ts`)
+
+- `hudStateFromPlacements`:
+  - With no hero → `hero: null`.
+  - With a hero carrying a critical ticket → priority `'critical'`.
+  - With retry events accumulated → `retry[ticketId]` matches count.
+  - With blocked personas → `blocked[]` has the right modes.
+  - Done-today increments on each merged event in the input batch.
+- `priorityTintColor(priority)` → returns expected colour per priority.
+- `pressureColorForCount(n)` → returns expected colour per bucket.
+- `hudAnchor(name)` → returns the expected `(x, y)` per Board 02 anchor
+  table.
+
+### Integration tests
+
+- A scripted set of placements + events feeds `hudStateFromPlacements`
+  then asserts `HudLayer.applyHud` was called with the right state.
+  Phaser tween calls and text widgets mocked at the layer boundary.
+- `HudFeed` snapshot test: 5 cinematic-started events fed in produce
+  5 visible lines in the expected order.
+
+### E2E
+
+- `office-click-through.spec.ts` continues to pass.
+- Optional opt-in spec for the HUD: scripted journey via the
+  EventSource shim emits all four cinematics and asserts:
+  - Hero label appears on the carrier persona.
+  - Retry counter shows `1` after `qa.functional-failed`.
+  - Done-day badge shows `1` after `pr.merged`.
+  - HudFeed shows 4 lines.
+
+---
+
+## 11. Manual verification checklist
+
+Before opening the PR, in the dev server:
+
+- [ ] With no hero ticket, no codename pop, no banner Hero-Ticket cell,
+      no retry / round counters, no QualityScore readout, no Done-day
+      badge.
+- [ ] Click a ticket: codename appears above carrier, priority tinted.
+      Banner shows id + title + priority dot.
+- [ ] Run the v1 journey end-to-end:
+  - Investigation wave: 3 scouts visible; Library room pressure tint
+    warms briefly.
+  - Dev: no special HUD beyond hero label.
+  - QA failure: retry counter at QA chamber shows `1` with bounce
+    animation. Critical lane suppresses HudFeed line burst (only one
+    feed line per cinematic, not per intent).
+  - Review: round counter shows `r1`. (If `review.escalated` is
+    emitted, round increments to `r2` etc.)
+  - Merge: shelf landing + Done-day badge ticks to `1`.
+- [ ] HudFeed shows lines for: "Wave started #N", "QA failed #N",
+      "Review converged #N", "Merged #N". Each line carries a small
+      priority dot.
+- [ ] Open the office tab, wait > 30s, verify oldest HudFeed line
+      fades out and disappears.
+- [ ] Resize browser: queue badges, counters, dial readout, Done-day
+      badge stay anchored to their world positions (they're canvas-hud,
+      not DOM). HudFeed stays anchored to the viewport corner (it is
+      DOM).
+- [ ] Block a ticket: set `factory:gate-pending` on the hero — the
+      spotlight ring appears around its carrier, a bell icon
+      appears at top-right of the persona. Indicator is `?` (already
+      from phase 5).
+- [ ] No console errors.
+
+---
+
+## 12. Stop conditions
+
+Stop and ask the human if any of the following occur:
+
+- A HUD element starts wanting a per-frame tick. None of the v1
+  elements should. If you find yourself wiring `scene.update()`,
+  restate the design.
+- Queue depth requires aggregation that doesn't exist in `tickets[]`
+  (e.g. you need a count of items in `factory:in-progress` for a
+  room — but the room has multiple desks). The `placementsFromItems`
+  function should produce the per-room count for free; if it doesn't,
+  extend that pure function rather than adding a side-channel.
+- Two HUD elements overlap visually at the default scale. Each anchor
+  in Board 02 was selected to avoid overlap, but if it happens at
+  certain depths, surface — do not silently relocate anchors.
+- The event feed begins to need filtering, expansion, or pagination.
+  v1 is a 5-line ticker. Anything more is a different milestone.
+- The QualityScore field is not on `WorkItemDto`. Surface — do not
+  guess at where to source the value.
+- Phase 5's `ChoreographyPlayer` does not emit
+  `'choreo.cinematic-started'` events. Phase 5's acceptance criteria
+  expect the per-intent observability emit; check whether the
+  cinematic-level event was added or whether phase 6 needs the
+  extension. Either is fine; pick the cleaner one.
+
+---
+
+## 13. Explicit non-goals
+
+Restated:
+
+- **No generic dashboard.** Everything in phase 6 anchors into the
+  world geometry, except the 5-line event feed (intentionally DOM
+  because it scrolls).
+- **No zoom-mode HUD.** Single zoom level in v1.
+- **No budget / token gauges.** Lobby concern.
+- **No multi-color heatmaps.** Single-axis pressure tint per room.
+- **No watchtower beacon.** Anchor reserved; not in v1.
+- **No tier-disagreement light at QA.** Anchor reserved; not in v1.
+- **No expanded event log.** 5 lines, fade after 30s.
+- **No HUD interaction beyond two narrow click paths**: queue badges
+  open a panel; blocked persona clicks open DeskDetailPanel.
+- **No sound, no audio.**
+- **No atmospheric polish** (night palette, rain, mode-driven global
+  tints).
+- **No persona stats** beyond the codename label + priority colour.
+- **No mutation of workflow state from any HUD element.** Restated:
+  this is the load-bearing invariant. HUD click handlers route through
+  React; React handlers route to the existing workflow paths or to no
+  side effects at all.
+
+---
+
+## 14. What happens after Phase 6
+
+After phase 6 merges:
+
+- The slice is **shippable.** A player can pick a project, watch one
+  ticket traverse the v1 journey, and read both the motion and the
+  HUD overlays to understand what's happening.
+- Open follow-on slices (post-v1 milestones), each with its own
+  ADR / spec:
+  - Atmospheric polish (Boards 09–12): night palette, mode-driven
+    global tint, ambient janitor / coffee machine.
+  - Watchtower + auditor cinematic.
+  - Tier-3 micro-animations: TDD glyphs, tool-call flickers, monitor
+    flicker on desk lamps.
+  - Sound / ambience.
+  - Multi-floor / building view.
+  - Lobby + courier + budget board.
+  - Backstage corkboard + retro room.
+  - M19 parallel-build cinematic + WorkPackage tethers.
+  - Persona variants, stat badges, streaks.
+  - Zoom modes (`building`, `room`, `persona`) — Board 02 anchors
+    already reserved.
+
+None of those are in scope for v1. They are the next slices.
+
+This plan only covers Phase 6.


### PR DESCRIPTION
## Summary

Formalises the remaining implementation-canon documents for Goose Hub
Office Mode Vertical Slice v1. The architecture direction, visual canon
(Board 02), and Phase 1 / Phase 2 sequencing are already established and
landed; this PR codifies the rest of the roadmap so future Claude
sessions don't re-derive intent.

No code changes — documentation only.

## What's authored

- `docs/design/office-mode/vertical-slice-v1/README.md` — authoritative
  roadmap: cinematic journey, phase ordering, preserved architectural
  seams, deferred systems, canon-document relationships, exit criteria.
- `phase-3-persona-ticket-split.md` — `PersonaSprite` / `TicketSprite`
  split, carry semantics, queue ownership, click-driven hero promotion,
  deterministic codename shim. Visual/runtime ownership only — no
  choreography engine, no SSE event handling yet.
- `phase-4-event-choreography.md` — `ChoreographyPlayer` + `Timeline` +
  three-lane model (critical / primary / ambient), v1 event allowlist,
  three intents (`walkToRoom`, `attachToDesk`, `swapIndicator`).
  Lightweight + deterministic. **Not** an ECS.
- `phase-5-cinematics.md` — four canonical cinematics:
  `investigationWave`, `qaFailed`, `reviewConverged`,
  `mergeCelebration`. Ambient suppression, rollback expectations, hero
  promotion via primary/critical timelines. No generalised cinematic
  framework — four hand-composed timelines.
- `phase-6-runtime-hud.md` — minimum world-anchored runtime overlays:
  hero labels, queue depth badges, retry/round counters, QualityScore
  readout, room pressure tinting, blocked-state spotlight, Done-day
  badge, DOM event feed, camera-state indicator. Office-first: the
  office is the dashboard.

## Invariants every phase doc preserves

- Office is visualisation only (Board 02 §1.5).
- React ↔ Phaser boundary: one-way push + emitter-back.
- Scene-local ownership; layers don't import each other.
- Pure libs stay pure (no Phaser in `lib/`).
- Single project per scene; coordinate literals only in `lib/rooms.ts`.
- No ECS, no full simulation AI, no procedural generation.
- Holdout sealing is visible (Library / QA / Review).

## Out of scope (deferred, called out in every phase doc)

Multiplayer, ECS, full simulation AI, procedural generation, advanced
zoom systems, sound, ambience, cross-project building stacks,
watchtower, lobby, backstage corkboard, atmospheric polish, M19
parallel-build cinematic, tool-call micro-animations, TDD heartbeat
glyphs.

## Test plan

- [ ] Verify the README links resolve to the new phase files.
- [ ] Verify Phase 3 doc reads as self-contained when read cold.
- [ ] Verify Phase 4 doc's lane / preemption table matches Board 02 §14
      lane mapping.
- [ ] Verify Phase 5 timing constants all reference Board 02 §14.1
      cinematic durations.
- [ ] Verify Phase 6 anchors all reference Board 02 §4 anchor table.
- [ ] Confirm no governance file modified.

https://claude.ai/code/session_01NxDqzBnoN6kyApZTSFA7aj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxDqzBnoN6kyApZTSFA7aj)_