### PR TITLE
fix(investigate): reduce synthesis cost in wave-aware mode

### DIFF
--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -58,6 +58,8 @@ export type InvokeSkillInput = {
     runtimeOverride?: AgentRuntime;
     /** Pre-resolved project config. When provided, skips getProjectBySlug disk read. */
     projectConfigOverride?: Partial<ProjectConfig> | null;
+    /** Caller-supplied freshContext flag. When provided, overrides the skill config value. */
+    freshContextOverride?: boolean;
   };
 };
 
@@ -198,7 +200,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     skill: skillName,
     context: mergedContext,
     contextAllowlist: skillConfig.contextAllowlist,
-    freshContext: skillConfig.freshContext,
+    freshContext: overrides?.freshContextOverride ?? skillConfig.freshContext,
     toolBundles: skillConfig.toolBundles,
     toolExtras: [],
     budgets: resolved.budgets,

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -65,7 +65,7 @@ Emit: `[decision] READ: Issue #<number> — <one-sentence summary of the bug>`
 - Use search tools to locate files relevant to the symptom area
 - Read directory structure to understand the code organisation
 
-**Wave-aware mode:** if `<scout_reports>` is present in your context, read the cross-validated Wave-1 reports first; treat them as primary evidence and only re-investigate gaps. If `crossValidate` has flagged contradictions across scouts, surface them in `openQuestions`. Wave-1 partial-failure rules (informational — the orchestrator enforces them before you see the reports):
+**Wave-aware mode:** if `<scout_reports>` is present in your context, read the cross-validated Wave-1 reports first; treat them as complete, primary evidence. **Do not perform general code exploration.** You may make at most 2 targeted tool calls total — only to verify a specific file:line citation from the reports where your confidence in that citation is low. If `crossValidate` has flagged contradictions across scouts, surface them in `openQuestions` rather than re-investigating. Wave-1 partial-failure rules (informational — the orchestrator enforces them before you see the reports):
 - ≥3 scouts succeeded AND ≤1 failed → wave advanced; reports are usable.
 - 2+ scouts failed → orchestrator halted the wave and escalated; you should not be running.
 
@@ -78,7 +78,7 @@ Emit: `[decision] READ: Identified entry points — <comma-separated file or dir
 - Follow imports and function calls related to the reported symptom
 - Look for validation logic, error handling, or data transformation that could cause the bug
 
-**Wave-aware mode:** if Wave-2 deep-agent outputs are also present (`wave2-interface-designer` artefacts, `wave2-risk-analyst` risks), read them as the synthesis layer; do not re-derive what they already produced. Use the worktree only to verify their citations.
+**Wave-aware mode:** if Wave-2 deep-agent outputs are also present (`wave2-interface-designer` artefacts, `wave2-risk-analyst` risks), read them as the synthesis layer; do not re-derive what they already produced. Use at most 1 tool call to verify a Wave-2 citation if confidence is low. Do not explore beyond cited locations.
 
 Emit: `[decision] READ: Traced code path through <key files> — <one-sentence hypothesis>`
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -377,7 +377,8 @@ export async function runInvestigateWorkflow(
       overrides: {
         runtimeOverride: runtime,
         modelOverride: synthModelOverride,
-        freshContextOverride: investigationSwarmEnabled && allScoutReports != null ? true : undefined,
+        freshContextOverride:
+          investigationSwarmEnabled && allScoutReports != null ? true : undefined,
       },
     });
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -357,14 +357,28 @@ export async function runInvestigateWorkflow(
       investigateContext.scoutReports = allScoutReports;
     }
 
-    // Synthesis — invoke investigate skill with scout evidence when swarm is enabled
+    // Synthesis — invoke investigate skill with scout evidence when swarm is enabled.
+    // In wave-aware mode scouts have gathered all facts; synthesis only reads a JSON
+    // blob and writes findings, so we use a lighter model and fresh context (no
+    // accumulated conversation history needed).
+    const synthModelOverride =
+      investigationSwarmEnabled && allScoutReports != null
+        ? defaultModelForTierAndProvider(
+            'sonnet',
+            forcedRuntimeProvider ?? investigateRoleModel.provider,
+          )
+        : investigatorModelOverride;
     const synthResult = await invokeSkill({
       skillName: 'investigate',
       projectId,
       workItemId: workItem.id,
       runId,
       context: investigateContext,
-      overrides: { runtimeOverride: runtime, modelOverride: investigatorModelOverride },
+      overrides: {
+        runtimeOverride: runtime,
+        modelOverride: synthModelOverride,
+        freshContextOverride: investigationSwarmEnabled && allScoutReports != null ? true : undefined,
+      },
     });
 
     const findings = synthResult.output as InvestigateOutput;


### PR DESCRIPTION
## Summary

- Cap re-investigation in wave-aware mode to ≤2 tool calls (Wave-1) / ≤1 (Wave-2) for citation verification only; prohibit general code exploration
- Add `freshContextOverride` to `InvokeSkillInput` so callers can override a skill's `freshContext` per invocation
- When swarm ran successfully, invoke synthesis with `freshContextOverride: true` and a lighter model tier — scouts have gathered the facts; synthesis reads structured JSON and writes findings, so accumulated context history is unnecessary and a heavier model is overkill

Single-agent path (no `scoutReports` present) is unchanged.

## Test plan

- [ ] Existing investigate slice tests pass (3 pre-existing failures in `state-flows.test.ts` are unrelated to this change — missing mock for `getUseInvestigationSwarm`)
- [ ] TypeScript compiles clean (`pnpm tsc --noEmit`)
- [ ] Verify next wave-aware investigation run uses lighter model and completes in significantly fewer turns

https://claude.ai/code/session_01Vt2K8V7tDkk7UyNNGgQ92L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vt2K8V7tDkk7UyNNGgQ92L)_