### PR TITLE
M17.07: Office Phase 2.5 — visual canon adoption (Board 06 palette)

### DIFF
--- a/apps/web/src/components/office/README.md
+++ b/apps/web/src/components/office/README.md
@@ -12,14 +12,14 @@ Mounted at `/projects/:slug/office`. Sidebar entry "Office" between Kanban and I
 - `components/FloorIndicator.tsx` — out-of-canvas DOM overlay (floor number, project name, up/down buttons).
 - `components/DeskDetailPanel.tsx` — slide-in panel that opens when a desk is clicked. Links out to the full DetailPage.
 - `game/OfficeScene.ts` — the only Phaser scene. Owns the floors, desks, sprites, indicators, walks, click zones, stair navigation, camera pans.
-- `game/textures.ts` — procedural pixel-art generator (16×16 tiles, 32×24 desks, 12×16 sprites, 14×14–14×16 indicators). Used as the ground-truth fallback when no PNGs are present.
-- `game/asset-loader.ts` — optional preload of `/office/<key>.png` files; missing files are silently ignored so procedural textures take over.
+- `game/textures.ts` — canonical colour registry (`PALETTE` 13 entries, `ROLE_TINTS` 12 entries, `CINEMATIC_TINTS` 8 entries, `HUD_TINTS` 8 entries) plus `TEXTURE_KEYS` (20 entries) and procedural pixel-art fallback generators (16×16 tiles, 32×24 desks, 12×16 sprites, 14×14–14×16 indicators). All colours derived from the 28-code Board 06 visual system.
+- `game/asset-loader.ts` — optional preload of `/office/<key>.png` files via `pngManifest()` (20 entries, exported); missing files are silently ignored so procedural textures take over.
 - `lib/state-to-role.ts` — `factory:*` state → role-desk mapping; `shouldWalk()` predicate.
 - `lib/state-indicators.ts` — `factory:*` state → indicator glyph (speech / thought / question / coffee / bang / check).
 - `lib/layout.ts` — pure floor/desk/stairs world-coordinate math. Tiles are 16 px; floors are 30 × 12 tiles.
 - `lib/pathfinding.ts` — same-floor and cross-floor (via stairs) waypoint paths. `pathLength()` scales tween duration; `facingFromMovement()` flips the sprite.
 - `lib/agent-positions.ts` — derives one `AgentPlacement` per active issue from `WorkItemDto[]`.
-- `slice.test.ts` — 27 unit tests covering all pure logic. Phaser scene + React mount are exercised by Playwright e2e.
+- `slice.test.ts` — unit tests covering all pure logic including Phase 2.5 visual-canon assertions. Phaser scene + React mount are exercised by Playwright e2e.
 
 ## Data flow
 
@@ -74,7 +74,7 @@ To upgrade visual quality with PixelLab:
 3. Run `pnpm gen:office-assets`. PNGs land in `apps/web/public/office/` (also gitignored — they're regenerable).
 4. Reload the Office tab — the scene's preload pulls PNGs from `/office/<key>.png` and skips the procedural fallback for any key that loaded successfully.
 
-The 11-asset manifest is in `scripts/generate-office-assets.ts`. Edit prompts there if you want a different style.
+The 20-asset manifest (`MANIFEST`, exported) is in `scripts/generate-office-assets.ts`. Every prompt references at least one Board 06 hex code. Edit prompts there if you want a different style. The 3 Phase 2.5 additions are `wall-frosted-blue.png`, `wall-frosted-grey.png`, and `scout-desk.png`.
 
 ## Phaser version
 

--- a/apps/web/src/components/office/components/HudFeed.tsx
+++ b/apps/web/src/components/office/components/HudFeed.tsx
@@ -6,6 +6,7 @@
 import type Phaser from 'phaser';
 import { useEffect, useRef, useState } from 'react';
 import { priorityTintColor } from '../lib/rooms';
+import { HUD_TINTS } from '../game/textures';
 
 interface FeedLine {
   id: number;
@@ -77,7 +78,7 @@ export function HudFeed({ sceneEmitter }: HudFeedProps) {
             key={line.id}
             title={line.text}
             className="flex items-center gap-1 mb-0.5 text-[9px] font-mono"
-            style={{ opacity, transition: 'opacity 1s', color: '#c7b8ff' }}
+            style={{ opacity, transition: 'opacity 1s', color: HUD_TINTS.hudFeedLineText }}
           >
             <span
               className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"

--- a/apps/web/src/components/office/components/QueuePanel.tsx
+++ b/apps/web/src/components/office/components/QueuePanel.tsx
@@ -50,27 +50,27 @@ export function QueuePanel({ roomId, items, onClose }: QueuePanelProps) {
       />
       <aside
         data-testid="queue-panel"
-        className="absolute top-4 right-4 z-50 w-64 rounded-md border border-[#4a3a5e] bg-[#1a1622ee] text-[#c7b8ff] shadow-xl"
+        className="absolute top-4 right-4 z-50 w-64 rounded-md border border-[#2B2D42] bg-[#2B2D42EE] text-[#D68FD6] shadow-xl"
         style={{ maxHeight: '50vh', overflowY: 'auto' }}
       >
-        <div className="flex items-center justify-between border-b border-[#4a3a5e] px-3 py-2">
+        <div className="flex items-center justify-between border-b border-[#2B2D42] px-3 py-2">
           <span className="text-[11px] font-mono font-semibold">Queued at {label}</span>
           <button
             type="button"
             onClick={onClose}
-            className="text-[#9ca3af] hover:text-white text-xs leading-none"
+            className="text-[#D68FD6] hover:text-white text-xs leading-none"
             aria-label="Close"
           >
             ×
           </button>
         </div>
         {items.length === 0 ? (
-          <p className="px-3 py-3 text-[10px] text-[#9ca3af]">Nothing queued.</p>
+          <p className="px-3 py-3 text-[10px] text-[#D68FD6]">Nothing queued.</p>
         ) : (
-          <ul className="divide-y divide-[#2a2333]">
+          <ul className="divide-y divide-[#3A3D5C]">
             {items.map((item) => (
               <li key={item.ticketId} className="px-3 py-2 text-[10px] font-mono">
-                <span className="text-[#9ca3af] mr-1">#{item.externalId}</span>
+                <span className="text-[#D68FD6] mr-1">#{item.externalId}</span>
                 <span className="truncate">{item.title || '(untitled)'}</span>
               </li>
             ))}

--- a/apps/web/src/components/office/game/asset-loader.ts
+++ b/apps/web/src/components/office/game/asset-loader.ts
@@ -20,19 +20,28 @@ interface AssetEntry {
   url: string;
 }
 
-function pngManifest(): AssetEntry[] {
+export function pngManifest(): AssetEntry[] {
   return [
     { key: TEXTURE_KEYS.floorTile, url: `${ASSET_BASE}/floor-tile.png` },
     { key: TEXTURE_KEYS.floorTileAlt, url: `${ASSET_BASE}/floor-tile-alt.png` },
     { key: TEXTURE_KEYS.wallTile, url: `${ASSET_BASE}/wall-tile.png` },
     { key: TEXTURE_KEYS.desk, url: `${ASSET_BASE}/desk.png` },
     { key: TEXTURE_KEYS.stairs, url: `${ASSET_BASE}/stairs.png` },
+    { key: TEXTURE_KEYS.spriteBase, url: `${ASSET_BASE}/sprite.png` },
     { key: TEXTURE_KEYS.indicatorSpeech, url: `${ASSET_BASE}/indicator-speech.png` },
     { key: TEXTURE_KEYS.indicatorThought, url: `${ASSET_BASE}/indicator-thought.png` },
     { key: TEXTURE_KEYS.indicatorQuestion, url: `${ASSET_BASE}/indicator-question.png` },
     { key: TEXTURE_KEYS.indicatorCoffee, url: `${ASSET_BASE}/indicator-coffee.png` },
     { key: TEXTURE_KEYS.indicatorBang, url: `${ASSET_BASE}/indicator-bang.png` },
     { key: TEXTURE_KEYS.indicatorCheck, url: `${ASSET_BASE}/indicator-check.png` },
+    { key: TEXTURE_KEYS.ticket, url: `${ASSET_BASE}/ticket.png` },
+    { key: TEXTURE_KEYS.queueStackMany, url: `${ASSET_BASE}/queue-stack-many.png` },
+    { key: TEXTURE_KEYS.ticketGlow, url: `${ASSET_BASE}/ticket-glow.png` },
+    { key: TEXTURE_KEYS.ticketScroll, url: `${ASSET_BASE}/ticket-scroll.png` },
+    { key: TEXTURE_KEYS.ticketEnvelope, url: `${ASSET_BASE}/ticket-envelope.png` },
+    { key: TEXTURE_KEYS.wallFrostedBlue, url: `${ASSET_BASE}/wall-frosted-blue.png` },
+    { key: TEXTURE_KEYS.wallFrostedGrey, url: `${ASSET_BASE}/wall-frosted-grey.png` },
+    { key: TEXTURE_KEYS.scoutDesk, url: `${ASSET_BASE}/scout-desk.png` },
   ];
 }
 

--- a/apps/web/src/components/office/game/choreography/cinematics/investigationWave.ts
+++ b/apps/web/src/components/office/game/choreography/cinematics/investigationWave.ts
@@ -20,6 +20,7 @@ import { TIMING } from '../../../lib/cinematic-timings';
 import { floorOriginY } from '../../../lib/layout';
 import { CORRIDOR_WALK_Y, roomDeskAnchors, roomSlotAnchors } from '../../../lib/rooms';
 import { Timeline as TL } from '../Timeline';
+import { CINEMATIC_TINTS } from '../../textures';
 
 let _seq = 0;
 function nextId(suffix: string): string {
@@ -176,7 +177,7 @@ export function investigationWavePart3Timeline(ticketId: string, floorIndex: num
         worldX: glowX,
         worldY: glowY,
         durationMs: TIMING.glowRingMs,
-        color: 0x88aaff,
+        color: CINEMATIC_TINTS.glowRingWave,
         effectId: `wave-glow-${ticketId}`,
       },
       lane: LANE,

--- a/apps/web/src/components/office/game/choreography/cinematics/mergeCelebration.ts
+++ b/apps/web/src/components/office/game/choreography/cinematics/mergeCelebration.ts
@@ -20,6 +20,7 @@ import { TIMING } from '../../../lib/cinematic-timings';
 import { floorOriginY } from '../../../lib/layout';
 import { CORRIDOR_WALK_Y, roomDeskAnchors, roomDoor } from '../../../lib/rooms';
 import { Timeline as TL } from '../Timeline';
+import { CINEMATIC_TINTS } from '../../textures';
 
 let _seq = 0;
 function nextId(): string {
@@ -81,7 +82,7 @@ export function mergeCelebrationTimeline(
             worldX: shelfWorldX,
             worldY: shelfWorldY,
             durationMs: TIMING.glowRingMs,
-            color: 0x00ff88,
+            color: CINEMATIC_TINTS.pulseSuccess,
             effectId: `merge-glow-${ticketId}`,
           },
           lane: 'primary',
@@ -94,7 +95,7 @@ export function mergeCelebrationTimeline(
             worldX: shelfWorldX,
             worldY: shelfWorldY,
             durationMs: TIMING.particleBurstMs,
-            color: 0x00ff88,
+            color: CINEMATIC_TINTS.particleBurstDefault,
             effectId: `merge-burst-${ticketId}`,
           },
           lane: 'primary',
@@ -146,7 +147,7 @@ export function mergeCelebrationAmbientTimeline(ticketId: string, floorIndex: nu
         worldX: shelfWorldX,
         worldY: shelfWorldY,
         durationMs: TIMING.particleBurstMs,
-        color: 0x88ffaa,
+        color: CINEMATIC_TINTS.particleBurstDefault,
         effectId: `merge-burst-ambient-${ticketId}`,
       },
       lane: 'ambient',

--- a/apps/web/src/components/office/game/choreography/cinematics/qaFailed.ts
+++ b/apps/web/src/components/office/game/choreography/cinematics/qaFailed.ts
@@ -22,6 +22,7 @@ import { TIMING } from '../../../lib/cinematic-timings';
 import { floorOriginY } from '../../../lib/layout';
 import { CORRIDOR_WALK_Y, roomSlotAnchors } from '../../../lib/rooms';
 import { Timeline as TL } from '../Timeline';
+import { CINEMATIC_TINTS } from '../../textures';
 
 let _seq = 0;
 function nextId(): string {
@@ -89,7 +90,7 @@ export function qaFailedTimeline(
             toWorldX: 36,
             worldY: corridorY,
             durationMs: TIMING.corridorPulseMs,
-            color: 0xff4444,
+            color: CINEMATIC_TINTS.pulseFail,
             effectId: `qa-pulse-${ticketId}`,
           },
           lane: 'critical',

--- a/apps/web/src/components/office/game/choreography/intents/corridorPulse.ts
+++ b/apps/web/src/components/office/game/choreography/intents/corridorPulse.ts
@@ -10,6 +10,7 @@
 
 import type { Intent } from '../../../lib/choreography';
 import type { IntentResult } from '../../layers/types';
+import { CINEMATIC_TINTS } from '../../textures';
 import type { ChoreographyCtx } from '../Timeline';
 
 const inflightCancels = new Map<Intent, () => void>();
@@ -19,7 +20,7 @@ export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult>
   const toWorldX = typeof intent.params.toWorldX === 'number' ? intent.params.toWorldX : 0;
   const worldY = typeof intent.params.worldY === 'number' ? intent.params.worldY : 0;
   const durationMs = typeof intent.params.durationMs === 'number' ? intent.params.durationMs : 1000;
-  const color = typeof intent.params.color === 'number' ? intent.params.color : 0xff4444;
+  const color = typeof intent.params.color === 'number' ? intent.params.color : CINEMATIC_TINTS.pulseFail;
   const effectId =
     typeof intent.params.effectId === 'string' ? intent.params.effectId : intent.target.id;
 

--- a/apps/web/src/components/office/game/choreography/intents/glowRing.ts
+++ b/apps/web/src/components/office/game/choreography/intents/glowRing.ts
@@ -8,6 +8,7 @@
 
 import type { Intent } from '../../../lib/choreography';
 import type { IntentResult } from '../../layers/types';
+import { CINEMATIC_TINTS } from '../../textures';
 import type { ChoreographyCtx } from '../Timeline';
 
 const inflightCancels = new Map<Intent, () => void>();
@@ -16,7 +17,7 @@ export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult>
   const worldX = typeof intent.params.worldX === 'number' ? intent.params.worldX : 0;
   const worldY = typeof intent.params.worldY === 'number' ? intent.params.worldY : 0;
   const durationMs = typeof intent.params.durationMs === 'number' ? intent.params.durationMs : 600;
-  const color = typeof intent.params.color === 'number' ? intent.params.color : 0x00ff88;
+  const color = typeof intent.params.color === 'number' ? intent.params.color : CINEMATIC_TINTS.glowRingDefault;
   const effectId =
     typeof intent.params.effectId === 'string' ? intent.params.effectId : intent.target.id;
 

--- a/apps/web/src/components/office/game/choreography/intents/particleBurst.ts
+++ b/apps/web/src/components/office/game/choreography/intents/particleBurst.ts
@@ -8,6 +8,7 @@
 
 import type { Intent } from '../../../lib/choreography';
 import type { IntentResult } from '../../layers/types';
+import { CINEMATIC_TINTS } from '../../textures';
 import type { ChoreographyCtx } from '../Timeline';
 
 const inflightCancels = new Map<Intent, () => void>();
@@ -16,7 +17,7 @@ export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult>
   const worldX = typeof intent.params.worldX === 'number' ? intent.params.worldX : 0;
   const worldY = typeof intent.params.worldY === 'number' ? intent.params.worldY : 0;
   const durationMs = typeof intent.params.durationMs === 'number' ? intent.params.durationMs : 800;
-  const color = typeof intent.params.color === 'number' ? intent.params.color : 0x00ff88;
+  const color = typeof intent.params.color === 'number' ? intent.params.color : CINEMATIC_TINTS.particleBurstDefault;
   const effectId =
     typeof intent.params.effectId === 'string' ? intent.params.effectId : intent.target.id;
 

--- a/apps/web/src/components/office/game/choreography/intents/spawnVerdictScroll.ts
+++ b/apps/web/src/components/office/game/choreography/intents/spawnVerdictScroll.ts
@@ -12,7 +12,7 @@
 
 import type { Intent } from '../../../lib/choreography';
 import type { IntentResult } from '../../layers/types';
-import { TEXTURE_KEYS } from '../../textures';
+import { CINEMATIC_TINTS, TEXTURE_KEYS } from '../../textures';
 import type { ChoreographyCtx } from '../Timeline';
 
 export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult> {
@@ -21,7 +21,7 @@ export function run(intent: Intent, ctx: ChoreographyCtx): Promise<IntentResult>
   const worldY = typeof intent.params.worldY === 'number' ? intent.params.worldY : 0;
   const spriteId =
     typeof intent.params.spriteId === 'string' ? intent.params.spriteId : `scroll-${ticketId}`;
-  const tint = 0xff6666; // red tint for failed verdict
+  const tint = CINEMATIC_TINTS.verdictScrollFail;
 
   ctx.ticketLayer.setVariant(ticketId, 'scroll');
   ctx.ticketLayer.spawnTempSprite(spriteId, TEXTURE_KEYS.ticketScroll, worldX, worldY, tint);

--- a/apps/web/src/components/office/game/layers/HudLayer.ts
+++ b/apps/web/src/components/office/game/layers/HudLayer.ts
@@ -7,6 +7,7 @@ import type { HudState } from '../../lib/hud-state';
 import { resetDoneToday } from '../../lib/hud-state';
 import { floorOriginY } from '../../lib/layout';
 import { type HudAnchorName, type RoomId, hudAnchor, roomQueueAnchor } from '../../lib/rooms';
+import { HUD_TINTS } from '../textures';
 
 const HUD_DEPTH = 60;
 const SPOTLIGHT_DEPTH = 50;
@@ -14,22 +15,22 @@ const MONO = 'JetBrains Mono, monospace';
 const BADGE_STYLE = {
   fontFamily: MONO,
   fontSize: '8px',
-  color: '#ffd700',
-  backgroundColor: '#1a162299',
+  color: HUD_TINTS.hudBadgeText,
+  backgroundColor: HUD_TINTS.hudPanelBgDark,
   padding: { left: 3, right: 3, top: 1, bottom: 1 },
 } as const;
 const CTR_STYLE = {
   fontFamily: MONO,
   fontSize: '9px',
-  color: '#c7b8ff',
-  backgroundColor: '#1a162299',
+  color: HUD_TINTS.hudCounterText,
+  backgroundColor: HUD_TINTS.hudPanelBgDark,
   padding: { left: 3, right: 3, top: 1, bottom: 1 },
 } as const;
 const CAM_STYLE = {
   fontFamily: MONO,
   fontSize: '8px',
-  color: '#ffffff',
-  backgroundColor: '#00000066',
+  color: HUD_TINTS.hudCameraStateText,
+  backgroundColor: HUD_TINTS.hudShadowOverlay,
   padding: { left: 3, right: 3, top: 1, bottom: 1 },
 } as const;
 const ROOM_IDS: RoomId[] = ['triage', 'investigation', 'dev', 'qa', 'review', 'done'];
@@ -245,7 +246,7 @@ export class HudLayer {
     for (const { personaId, mode } of state.blocked) {
       if (this.spotlights.has(personaId)) continue;
       const circle = this.scene.add
-        .arc(0, 0, 28, 0, 360, false, 0xffffff, 0.12)
+        .arc(0, 0, 28, 0, 360, false, HUD_TINTS.hudSpotlight, 0.12)
         .setDepth(SPOTLIGHT_DEPTH)
         .setVisible(false);
       const entry: SpotlightEntry = { circle };

--- a/apps/web/src/components/office/game/layers/PersonaLayer.ts
+++ b/apps/web/src/components/office/game/layers/PersonaLayer.ts
@@ -15,10 +15,23 @@ import { facingFromMovement, pathLength, planWalk } from '../../lib/pathfinding'
 import { type Priority, priorityTintColor, roomDeskAnchors } from '../../lib/rooms';
 import type { IndicatorKind } from '../../lib/state-indicators';
 import {
+  HUD_TINTS,
+  PALETTE,
+  ROLE_TINTS,
+  TEXTURE_KEYS,
   applyOfficeTextureDisplaySize,
   indicatorTextureKey,
-  spriteTextureKeyForRole,
 } from '../textures';
+
+// Derive default role tint from room for spriteBase colouring
+const ROOM_DEFAULT_ROLE: Record<string, string> = {
+  triage: 'triager',
+  investigation: 'investigator',
+  dev: 'developer',
+  qa: 'qa',
+  review: 'reviewer',
+  done: 'retrospector',
+};
 import type { DeskClickPayload, IntentResult, OfficeProject } from './types';
 
 const WALK_PIXELS_PER_MS = 0.35;
@@ -146,13 +159,13 @@ export class PersonaLayer {
   addCodenameLabel(personaId: string, priority?: Priority): void {
     const e = this.personas.get(personaId);
     if (e == null || e.label != null) return;
-    const color = priority != null ? priorityTintColor(priority) : '#ffd700';
+    const color = priority != null ? priorityTintColor(priority) : HUD_TINTS.hudBadgeText;
     // Parented to the container so it follows walk tweens and restack moves.
     const label = this.scene.add.text(0, -28, e.codename, {
       fontFamily: 'JetBrains Mono, monospace',
       fontSize: '7px',
       color,
-      backgroundColor: '#1a162299',
+      backgroundColor: HUD_TINTS.hudPanelBgDark,
       padding: { left: 3, right: 3, top: 1, bottom: 1 },
     });
     label.setOrigin(0.5, 1);
@@ -380,8 +393,10 @@ export class PersonaLayer {
     const container = this.scene.add.container(pos.x, pos.y - TILE_SIZE);
     container.setDepth(PERSONA_DEPTH);
 
-    const body = this.scene.add.image(0, 0, spriteTextureKeyForRole('developer'));
+    const body = this.scene.add.image(0, 0, TEXTURE_KEYS.spriteBase);
     body.setOrigin(0.5, 1);
+    const role = p.roomId != null ? (ROOM_DEFAULT_ROLE[p.roomId] ?? 'developer') : 'developer';
+    body.setTint(ROLE_TINTS[role] ?? PALETTE.amber);
     container.add(body);
 
     const indicator = this.scene.add.image(0, -TILE_SIZE - 4, indicatorTextureKey(p.indicator));

--- a/apps/web/src/components/office/game/layers/PersonaLayer.ts
+++ b/apps/web/src/components/office/game/layers/PersonaLayer.ts
@@ -395,6 +395,7 @@ export class PersonaLayer {
 
     const body = this.scene.add.image(0, 0, TEXTURE_KEYS.spriteBase);
     body.setOrigin(0.5, 1);
+    applyOfficeTextureDisplaySize(body, TEXTURE_KEYS.spriteBase);
     const role = p.roomId != null ? (ROOM_DEFAULT_ROLE[p.roomId] ?? 'developer') : 'developer';
     body.setTint(ROLE_TINTS[role] ?? PALETTE.amber);
     container.add(body);
@@ -512,6 +513,10 @@ export class PersonaLayer {
         entry.roomId = p.roomId;
         entry.deskSlot = p.deskSlot;
         entry.floorIndex = toFloorIndex;
+        if (p.roomId != null) {
+          const newRole = ROOM_DEFAULT_ROLE[p.roomId] ?? 'developer';
+          entry.body.setTint(ROLE_TINTS[newRole] ?? PALETTE.amber);
+        }
         this.updateIndicator(entry, p);
         this.restackAtSharedDesks();
       },

--- a/apps/web/src/components/office/game/layers/RoomLayer.ts
+++ b/apps/web/src/components/office/game/layers/RoomLayer.ts
@@ -24,7 +24,7 @@ import {
   roomDoor,
   roomQueueAnchor,
 } from '../../lib/rooms';
-import { TEXTURE_KEYS, applyOfficeTextureDisplaySize } from '../textures';
+import { HUD_TINTS, PALETTE, TEXTURE_KEYS, applyOfficeTextureDisplaySize } from '../textures';
 import type { IntentResult, OfficeProject } from './types';
 
 interface RoomLayerCallbacks {
@@ -452,7 +452,7 @@ export class RoomLayer {
       return entry;
     }
     const g = this.scene.add.graphics();
-    g.fillStyle(0x6a4a8e, 1);
+    g.fillStyle(PALETTE.reviewWall, 1);
     g.fillRect(door.x - DOOR_WIDTH / 2, originY + door.y, DOOR_WIDTH, TILE_SIZE);
     g.setDepth(35); // above room overlays
     const entry: DoorEntry = { graphics: g };
@@ -464,7 +464,7 @@ export class RoomLayer {
     const originY = floorOriginY(floorIndex);
     const bounds = roomBounds(roomId);
     const g = this.scene.add.graphics();
-    g.fillStyle(0x000000, 1);
+    g.fillStyle(PALETTE.wall, 1);
     g.fillRect(bounds.x1, originY + bounds.y1, bounds.x2 - bounds.x1, bounds.y2 - bounds.y1);
     g.setAlpha(0);
     g.setDepth(52); // above standard overlays
@@ -493,17 +493,17 @@ export class RoomLayer {
 
   private drawBase(container: Phaser.GameObjects.Container, originY: number): void {
     const bg = this.scene.add.graphics();
-    bg.fillStyle(0x2a2333, 1);
+    bg.fillStyle(PALETTE.floor, 1);
     bg.fillRect(0, originY, FLOOR_WORLD.width, FLOOR_WORLD.height);
     container.add(bg);
 
     const corridor = this.scene.add.graphics();
-    corridor.fillStyle(0x322a3e, 1);
+    corridor.fillStyle(PALETTE.floorAlt, 1);
     corridor.fillRect(0, originY + ROW_CORRIDOR_TOP, FLOOR_WORLD.width, TILE_SIZE * 3);
     container.add(corridor);
 
     const bannerBg = this.scene.add.graphics();
-    bannerBg.fillStyle(0x1a1622, 1);
+    bannerBg.fillStyle(PALETTE.wall, 1);
     bannerBg.fillRect(0, originY + ROW_BANNER_TOP, FLOOR_WORLD.width, TILE_SIZE * 3);
     container.add(bannerBg);
   }
@@ -511,7 +511,7 @@ export class RoomLayer {
   private drawWalls(container: Phaser.GameObjects.Container, originY: number): void {
     const W = FLOOR_WORLD.width;
     const walls = this.scene.add.graphics();
-    walls.fillStyle(0x4a3a5e, 1);
+    walls.fillStyle(PALETTE.wall, 1);
 
     walls.fillRect(0, originY + ROW_TOP_WALL, W, TILE_SIZE);
     walls.fillRect(0, originY + ROW_BOTTOM_WALL, W, TILE_SIZE);
@@ -557,13 +557,13 @@ export class RoomLayer {
     const roomH = ROW_ROOM_BOTTOM - ROW_ROOM_TOP;
     const overlays = this.scene.add.graphics();
 
-    overlays.fillStyle(0x0a1a3a, 0.45);
+    overlays.fillStyle(PALETTE.qaWall, 0.45);
     overlays.fillRect(736, originY + ROW_ROOM_TOP, 192, roomH);
 
-    overlays.fillStyle(0x1a1a2a, 0.35);
+    overlays.fillStyle(PALETTE.reviewWall, 0.35);
     overlays.fillRect(944, originY + ROW_ROOM_TOP, 160, roomH);
 
-    overlays.fillStyle(0x0e0b18, 0.55);
+    overlays.fillStyle(PALETTE.wall, 0.55);
     overlays.fillRect(
       LIBRARY_BOUNDS.x1,
       originY + LIBRARY_BOUNDS.y1,
@@ -571,7 +571,7 @@ export class RoomLayer {
       LIBRARY_BOUNDS.y2 - LIBRARY_BOUNDS.y1,
     );
 
-    overlays.lineStyle(1, 0x6b4a8e, 1);
+    overlays.lineStyle(1, PALETTE.reviewWall, 1);
     overlays.strokeRect(
       LIBRARY_BOUNDS.x1,
       originY + LIBRARY_BOUNDS.y1,
@@ -584,9 +584,9 @@ export class RoomLayer {
 
   private drawDoneShelf(container: Phaser.GameObjects.Container, originY: number): void {
     const shelf = this.scene.add.graphics();
-    shelf.fillStyle(0x5c3a1e, 1);
+    shelf.fillStyle(PALETTE.desk, 1);
     shelf.fillRect(1120, originY + 160, 143, 8);
-    shelf.fillStyle(0x8a6541, 1);
+    shelf.fillStyle(PALETTE.deskTop, 1);
     shelf.fillRect(1120, originY + 160, 143, 2);
     container.add(shelf);
   }
@@ -605,8 +605,8 @@ export class RoomLayer {
       {
         fontFamily: 'JetBrains Mono, monospace',
         fontSize: '10px',
-        color: '#c7b8ff',
-        backgroundColor: '#1a1622',
+        color: HUD_TINTS.hudCounterText,
+        backgroundColor: '#2B2D42',
         padding: { left: 6, right: 6, top: 2, bottom: 2 },
       },
     );
@@ -621,8 +621,8 @@ export class RoomLayer {
       {
         fontFamily: 'JetBrains Mono, monospace',
         fontSize: '9px',
-        color: '#ffd700',
-        backgroundColor: '#1a1622',
+        color: HUD_TINTS.hudBadgeText,
+        backgroundColor: '#2B2D42',
         padding: { left: 4, right: 4, top: 2, bottom: 2 },
       },
     );
@@ -635,7 +635,7 @@ export class RoomLayer {
 
   private drawRoomLabels(container: Phaser.GameObjects.Container, originY: number): void {
     const labelY = originY + ROW_CEILING + TILE_SIZE * 2;
-    const style = { fontFamily: 'JetBrains Mono, monospace', fontSize: '8px', color: '#8877aa' };
+    const style = { fontFamily: 'JetBrains Mono, monospace', fontSize: '8px', color: HUD_TINTS.hudCounterText };
     const labels = [
       { x: 96, text: 'TRIAGE' },
       { x: 312, text: 'INVESTIGATION' },
@@ -697,7 +697,7 @@ export class RoomLayer {
     }
 
     const dots = this.scene.add.graphics();
-    dots.fillStyle(0x6655aa, 0.4);
+    dots.fillStyle(PALETTE.reviewWall, 0.4);
     for (const id of ROOM_IDS) {
       const qa = roomQueueAnchor(id as RoomId);
       if (qa) dots.fillCircle(qa.x, originY + qa.y, 3);

--- a/apps/web/src/components/office/game/layers/TicketLayer.ts
+++ b/apps/web/src/components/office/game/layers/TicketLayer.ts
@@ -182,6 +182,7 @@ export class TicketLayer {
     // Glow ring
     const glow = this.scene.add.image(0, 0, TEXTURE_KEYS.ticketGlow);
     glow.setOrigin(0.5, 0.5);
+    applyOfficeTextureDisplaySize(glow, TEXTURE_KEYS.ticketGlow);
     glow.setDepth(GLOW_DEPTH);
     entry.container.add(glow);
     entry.glow = glow;
@@ -250,10 +251,13 @@ export class TicketLayer {
     if (entry == null) return;
     if (variant === 'scroll') {
       entry.body.setTexture(TEXTURE_KEYS.ticketScroll);
+      applyOfficeTextureDisplaySize(entry.body, TEXTURE_KEYS.ticketScroll);
     } else if (variant === 'envelope') {
       entry.body.setTexture(TEXTURE_KEYS.ticketEnvelope);
+      applyOfficeTextureDisplaySize(entry.body, TEXTURE_KEYS.ticketEnvelope);
     } else {
       entry.body.setTexture(TEXTURE_KEYS.ticket);
+      applyOfficeTextureDisplaySize(entry.body, TEXTURE_KEYS.ticket);
     }
   }
 
@@ -410,6 +414,7 @@ export class TicketLayer {
     container.setDepth(TICKET_HERO_DEPTH + 1);
     const img = this.scene.add.image(0, 0, textureKey);
     img.setOrigin(0.5, 0.5);
+    applyOfficeTextureDisplaySize(img, textureKey);
     if (tint != null) img.setTint(tint);
     container.add(img);
     this.tempSprites.set(id, { container });
@@ -501,6 +506,7 @@ export class TicketLayer {
 
     const body = this.scene.add.image(0, 0, TEXTURE_KEYS.ticket);
     body.setOrigin(0.5, 0.5);
+    applyOfficeTextureDisplaySize(body, TEXTURE_KEYS.ticket);
     this.applyPriorityTint(body, p.priority);
     container.add(body);
 
@@ -696,6 +702,7 @@ export class TicketLayer {
       if (qs == null) {
         const sprite = this.scene.add.image(qa.x, oy + qa.y, TEXTURE_KEYS.queueStackMany);
         sprite.setOrigin(0.5, 0.5);
+        applyOfficeTextureDisplaySize(sprite, TEXTURE_KEYS.queueStackMany);
         sprite.setDepth(TICKET_DEPTH - 1);
         qs = { sprite };
         this.queueStacks.set(storeKey, qs);

--- a/apps/web/src/components/office/game/layers/TicketLayer.ts
+++ b/apps/web/src/components/office/game/layers/TicketLayer.ts
@@ -19,7 +19,7 @@ import { roomDeskAnchors, roomQueueAnchor, roomSlotAnchors } from '../../lib/roo
 import type { RoomId } from '../../lib/rooms';
 import type { IndicatorKind } from '../../lib/state-indicators';
 import { ticketCarryOffset } from '../../lib/ticket-carry';
-import { TEXTURE_KEYS, applyOfficeTextureDisplaySize, indicatorTextureKey } from '../textures';
+import { HUD_TINTS, PALETTE, TEXTURE_KEYS, applyOfficeTextureDisplaySize, indicatorTextureKey } from '../textures';
 import type { PersonaLayer } from './PersonaLayer';
 import type { DeskClickPayload, IntentResult } from './types';
 
@@ -640,12 +640,12 @@ export class TicketLayer {
 
   private applyPriorityTint(body: Phaser.GameObjects.Image, priority: string): void {
     const tints: Record<string, number> = {
-      critical: 0xff4444,
-      high: 0xff9900,
-      normal: 0xffffff,
-      low: 0x88bbff,
+      critical: PALETTE.fail,
+      high: PALETTE.amber,
+      normal: PALETTE.amber,
+      low: PALETTE.cyan,
     };
-    body.setTint(tints[priority] ?? 0xffffff);
+    body.setTint(tints[priority] ?? PALETTE.amber);
   }
 
   private updateQueueStacks(placements: readonly TicketPlacement[]): void {
@@ -694,7 +694,7 @@ export class TicketLayer {
       let qs = this.queueStacks.get(storeKey);
 
       if (qs == null) {
-        const sprite = this.scene.add.image(qa.x, oy + qa.y, TEXTURE_KEYS.queueStack1);
+        const sprite = this.scene.add.image(qa.x, oy + qa.y, TEXTURE_KEYS.queueStackMany);
         sprite.setOrigin(0.5, 0.5);
         sprite.setDepth(TICKET_DEPTH - 1);
         qs = { sprite };
@@ -704,23 +704,15 @@ export class TicketLayer {
       qs.sprite.setVisible(depth > 0);
       qs.sprite.setPosition(qa.x, oy + qa.y);
 
-      if (depth >= 4) {
-        qs.sprite.setTexture(TEXTURE_KEYS.queueStackMany);
-      } else if (depth >= 3) {
-        qs.sprite.setTexture(TEXTURE_KEYS.queueStack3);
-      } else if (depth >= 2) {
-        qs.sprite.setTexture(TEXTURE_KEYS.queueStack2);
-      } else {
-        qs.sprite.setTexture(TEXTURE_KEYS.queueStack1);
-      }
+      qs.sprite.setTexture(TEXTURE_KEYS.queueStackMany);
 
       if (depth >= 4) {
         if (qs.badge == null) {
           qs.badge = this.scene.add.text(qa.x + 6, oy + qa.y - 4, '', {
             fontFamily: 'JetBrains Mono, monospace',
             fontSize: '6px',
-            color: '#ffffff',
-            backgroundColor: '#6b4a8e',
+            color: HUD_TINTS.hudBadgeText,
+            backgroundColor: '#473A55',
             padding: { left: 1, right: 1, top: 0, bottom: 0 },
           });
           qs.badge.setOrigin(0.5, 1);

--- a/apps/web/src/components/office/game/textures.ts
+++ b/apps/web/src/components/office/game/textures.ts
@@ -2,8 +2,7 @@
 //
 // Why procedural rather than PNGs in /public? Two reasons:
 //   1. The repo ships with zero binary assets — runtime-generated textures
-//      mean the Office tab works in fresh checkouts without an asset-build
-//      step.
+//      mean the Office tab works in fresh checkouts without an asset-build step.
 //   2. PixelLab generation runs offline (`pnpm gen:office-assets`) and writes
 //      to `/public/office/`; the loader (see `loadOfficeAssets`) prefers PNGs
 //      from disk when present and falls back to procedural otherwise.
@@ -14,31 +13,61 @@
 import type Phaser from 'phaser';
 import type { IndicatorKind } from '../lib/state-indicators';
 
-const PALETTE = {
-  floor: 0x2a2333,
-  floorAlt: 0x312a3d,
-  wall: 0x4a3a5e,
-  desk: 0x6b4a2e,
-  deskTop: 0x8a6541,
-  monitor: 0x101820,
-  monitorOn: 0x4ea1ff,
-  stairs: 0x8a7355,
-  stairsRail: 0x5c4a30,
-  bannerBg: 0x1a1622,
-  bannerFg: 0xc7b8ff,
-  // Sprite colors per role (so it's glanceable at low resolution)
-  spriteBody: 0xe6c285,
-  spriteHead: 0xf5d9a8,
-  spriteTriager: 0xa78bfa,
-  spriteGriller: 0xf97316,
-  spritePrdWriter: 0xeab308,
-  spriteDecomposer: 0x84cc16,
-  spriteResearcher: 0x06b6d4,
-  spriteInvestigator: 0x3b82f6,
-  spriteDeveloper: 0x10b981,
-  spriteQa: 0xec4899,
-  spriteReviewer: 0xf59e0b,
-  spriteRetrospector: 0x8b5cf6,
+// §4.0 Board 06 canonical palette (8 base + 3 derived shades + 2 derived blends = 13)
+export const PALETTE = {
+  wall: 0x2B2D42,
+  floor: 0x3A3D5C,
+  desk: 0x6B4F3B,
+  cyan: 0x6FE7FF,
+  amber: 0xF2CC8F,
+  fail: 0xFF6B6B,
+  success: 0x8BD17C,
+  purple: 0xD68FD6,
+  floorAlt: 0x42466A,
+  wallTop: 0x3B3D55,
+  deskTop: 0x85694F,
+  qaWall: 0x3F6B80,
+  reviewWall: 0x473A55,
+} as const;
+
+// §5.3 Per-role runtime tint applied via setTint() to spriteBase
+export const ROLE_TINTS: Record<string, number> = {
+  triager: 0xA78BFA,
+  griller: 0xF2CC8F,
+  'prd-writer': 0xF59E0B,
+  decomposer: 0x8BD17C,
+  researcher: 0x6FE7FF,
+  investigator: 0x7DD3FC,
+  developer: 0x34D399,
+  'dev-reviewer': 0xA7F3D0,
+  qa: 0xFF6B6B,
+  reviewer: 0xD68FD6,
+  retrospector: 0xC084FC,
+  auditor: 0xFBBF24,
+};
+
+// §5.4 Named bindings for choreography intent colours (all reuse canonical hues)
+export const CINEMATIC_TINTS = {
+  pulseFail: 0xFF6B6B,
+  pulseSuccess: 0x8BD17C,
+  glowRingDefault: 0x8BD17C,
+  glowRingFail: 0xFF6B6B,
+  glowRingWave: 0x6FE7FF,
+  particleBurstDefault: 0x8BD17C,
+  verdictScrollFail: 0xFF6B6B,
+  scoutEnvelopeSeal: 0x6FE7FF,
+} as const;
+
+// §5.5 Named bindings for HUD elements (5 opaque CSS + 1 Phaser number + 2 alpha CSS = 8)
+export const HUD_TINTS = {
+  hudBadgeText: '#F2CC8F',
+  hudCounterText: '#D68FD6',
+  hudCameraStateText: '#6FE7FF',
+  hudSpotlight: 0x6FE7FF as number,
+  hudFeedLineText: '#F2CC8F',
+  hudPanelBgDark: '#2B2D4299',
+  hudPanelBgDarker: '#2B2D42EE',
+  hudShadowOverlay: '#00000066',
 } as const;
 
 export const TEXTURE_KEYS = {
@@ -48,23 +77,20 @@ export const TEXTURE_KEYS = {
   desk: 'office:desk',
   stairs: 'office:stairs',
   spriteBase: 'office:sprite',
-  // Indicator keys mirror the IndicatorKind values
   indicatorSpeech: 'office:indicator-speech',
   indicatorThought: 'office:indicator-thought',
   indicatorQuestion: 'office:indicator-question',
   indicatorCoffee: 'office:indicator-coffee',
   indicatorBang: 'office:indicator-bang',
   indicatorCheck: 'office:indicator-check',
-  // Phase-3 ticket and queue-stack textures
   ticket: 'office:ticket',
-  queueStack1: 'office:queue-stack-1',
-  queueStack2: 'office:queue-stack-2',
-  queueStack3: 'office:queue-stack-3',
   queueStackMany: 'office:queue-stack-many',
   ticketGlow: 'office:ticket-glow',
-  // Phase-5 cinematic texture variants
   ticketScroll: 'office:ticket-scroll',
   ticketEnvelope: 'office:ticket-envelope',
+  wallFrostedBlue: 'office:wall-frosted-blue',
+  wallFrostedGrey: 'office:wall-frosted-grey',
+  scoutDesk: 'office:scout-desk',
 } as const;
 
 interface TextureDisplaySize {
@@ -114,21 +140,9 @@ export function indicatorTextureKey(kind: IndicatorKind): string {
   }
 }
 
-const ROLE_COLOR: Record<string, number> = {
-  triager: PALETTE.spriteTriager,
-  griller: PALETTE.spriteGriller,
-  'prd-writer': PALETTE.spritePrdWriter,
-  decomposer: PALETTE.spriteDecomposer,
-  researcher: PALETTE.spriteResearcher,
-  investigator: PALETTE.spriteInvestigator,
-  developer: PALETTE.spriteDeveloper,
-  qa: PALETTE.spriteQa,
-  reviewer: PALETTE.spriteReviewer,
-  retrospector: PALETTE.spriteRetrospector,
-};
-
-export function spriteTextureKeyForRole(role: string): string {
-  return `${TEXTURE_KEYS.spriteBase}-${role}`;
+/** Returns the base sprite texture key. Role tint is applied at runtime via setTint(ROLE_TINTS[role]). */
+export function spriteTextureKeyForRole(_role: string): string {
+  return TEXTURE_KEYS.spriteBase;
 }
 
 /**
@@ -142,13 +156,11 @@ export function ensureOfficeTextures(scene: Phaser.Scene): void {
   generateWallTile(scene);
   generateDesk(scene);
   generateStairs(scene);
-  for (const role of Object.keys(ROLE_COLOR)) {
-    generateSprite(scene, role, ROLE_COLOR[role]);
-  }
+  generateSprite(scene);
   generateTicket(scene);
   generateTicketScroll(scene);
   generateTicketEnvelope(scene);
-  generateQueueStacks(scene);
+  generateQueueStackMany(scene);
   generateTicketGlow(scene);
   generateSpeechBubble(scene);
   generateThoughtBubble(scene);
@@ -156,6 +168,9 @@ export function ensureOfficeTextures(scene: Phaser.Scene): void {
   generateCoffeeIcon(scene);
   generateBangIcon(scene);
   generateCheckIcon(scene);
+  generateWallFrostedBlue(scene);
+  generateWallFrostedGrey(scene);
+  generateScoutDesk(scene);
 }
 
 function generateFloorTile(scene: Phaser.Scene, key: string, color: number): void {
@@ -163,7 +178,6 @@ function generateFloorTile(scene: Phaser.Scene, key: string, color: number): voi
   const g = scene.add.graphics({ x: 0, y: 0 });
   g.fillStyle(color, 1);
   g.fillRect(0, 0, 16, 16);
-  // Subtle scuff in the corners for a "tiled" feel
   g.fillStyle(color === PALETTE.floor ? PALETTE.floorAlt : PALETTE.floor, 0.15);
   g.fillRect(0, 0, 1, 1);
   g.fillRect(15, 15, 1, 1);
@@ -177,7 +191,7 @@ function generateWallTile(scene: Phaser.Scene): void {
   const g = scene.add.graphics({ x: 0, y: 0 });
   g.fillStyle(PALETTE.wall, 1);
   g.fillRect(0, 0, 16, 16);
-  g.fillStyle(0x000000, 0.25);
+  g.fillStyle(PALETTE.wall, 0.5);
   g.fillRect(0, 14, 16, 2);
   g.generateTexture(key, 16, 16);
   g.destroy();
@@ -187,18 +201,14 @@ function generateDesk(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.desk;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Desk base
   g.fillStyle(PALETTE.desk, 1);
   g.fillRect(0, 14, 32, 10);
-  // Desktop
   g.fillStyle(PALETTE.deskTop, 1);
   g.fillRect(0, 12, 32, 4);
-  // Monitor
-  g.fillStyle(PALETTE.monitor, 1);
+  g.fillStyle(PALETTE.wall, 1);
   g.fillRect(8, 2, 16, 11);
-  g.fillStyle(PALETTE.monitorOn, 1);
+  g.fillStyle(PALETTE.cyan, 1);
   g.fillRect(10, 4, 12, 7);
-  // Monitor stand
   g.fillStyle(PALETTE.desk, 1);
   g.fillRect(14, 13, 4, 2);
   g.generateTexture(key, 32, 24);
@@ -209,10 +219,9 @@ function generateStairs(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.stairs;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  g.fillStyle(PALETTE.stairs, 1);
+  g.fillStyle(PALETTE.deskTop, 1);
   g.fillRect(0, 0, 32, 32);
-  // Stair lines
-  g.lineStyle(1, PALETTE.stairsRail, 1);
+  g.lineStyle(1, PALETTE.desk, 1);
   for (let i = 4; i < 32; i += 4) {
     g.beginPath();
     g.moveTo(0, i);
@@ -223,25 +232,25 @@ function generateStairs(scene: Phaser.Scene): void {
   g.destroy();
 }
 
-function generateSprite(scene: Phaser.Scene, role: string, accent: number): void {
-  const key = spriteTextureKeyForRole(role);
+function generateSprite(scene: Phaser.Scene): void {
+  const key = TEXTURE_KEYS.spriteBase;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Body (shirt) — accent color identifies the role
-  g.fillStyle(accent, 1);
+  // Body — role tint applied at runtime via body.setTint(ROLE_TINTS[role])
+  g.fillStyle(PALETTE.wallTop, 1);
   g.fillRect(2, 9, 8, 7);
   // Head
-  g.fillStyle(PALETTE.spriteHead, 1);
+  g.fillStyle(PALETTE.deskTop, 1);
   g.fillRect(3, 2, 6, 7);
-  // Hair top
-  g.fillStyle(0x1f1726, 1);
+  // Hair
+  g.fillStyle(PALETTE.wall, 1);
   g.fillRect(3, 1, 6, 2);
-  // Eyes (single dark pixel each)
-  g.fillStyle(0x101010, 1);
+  // Eyes
+  g.fillStyle(PALETTE.wall, 1);
   g.fillRect(4, 5, 1, 1);
   g.fillRect(7, 5, 1, 1);
-  // Arms / legs hint
-  g.fillStyle(accent, 1);
+  // Arms
+  g.fillStyle(PALETTE.wallTop, 1);
   g.fillRect(1, 9, 1, 5);
   g.fillRect(10, 9, 1, 5);
   g.generateTexture(key, 12, 16);
@@ -249,14 +258,13 @@ function generateSprite(scene: Phaser.Scene, role: string, accent: number): void
 }
 
 function makeBubbleBg(g: Phaser.GameObjects.Graphics): void {
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRoundedRect(0, 0, 14, 12, 3);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.strokeRoundedRect(0, 0, 14, 12, 3);
-  // Tail
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillTriangle(4, 12, 8, 12, 5, 15);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.beginPath();
   g.moveTo(4, 12);
   g.lineTo(5, 15);
@@ -270,7 +278,7 @@ function generateSpeechBubble(scene: Phaser.Scene): void {
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
   makeBubbleBg(g);
-  g.fillStyle(0x1a1622, 1);
+  g.fillStyle(PALETTE.wall, 1);
   g.fillRect(4, 5, 1, 1);
   g.fillRect(7, 5, 1, 1);
   g.fillRect(10, 5, 1, 1);
@@ -282,19 +290,17 @@ function generateThoughtBubble(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.indicatorThought;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Cloud-shaped bubble
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillCircle(4, 5, 4);
   g.fillCircle(9, 4, 4);
   g.fillCircle(7, 8, 4);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.strokeCircle(4, 5, 4);
   g.strokeCircle(9, 4, 4);
   g.strokeCircle(7, 8, 4);
-  // Trailing dots
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillCircle(5, 13, 1.5);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.strokeCircle(5, 13, 1.5);
   g.generateTexture(key, 14, 16);
   g.destroy();
@@ -305,8 +311,7 @@ function generateQuestionBubble(scene: Phaser.Scene): void {
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
   makeBubbleBg(g);
-  // ?
-  g.fillStyle(0x1a1622, 1);
+  g.fillStyle(PALETTE.wall, 1);
   g.fillRect(5, 3, 4, 1);
   g.fillRect(8, 4, 1, 2);
   g.fillRect(6, 6, 2, 1);
@@ -320,16 +325,13 @@ function generateCoffeeIcon(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.indicatorCoffee;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Mug
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRect(2, 5, 8, 7);
-  g.fillStyle(0x6b4a2e, 1);
+  g.fillStyle(PALETTE.desk, 1);
   g.fillRect(3, 6, 6, 5);
-  // Handle
-  g.lineStyle(1, 0xffffff, 1);
+  g.lineStyle(1, PALETTE.amber, 1);
   g.strokeRect(10, 6, 2, 4);
-  // Steam
-  g.fillStyle(0xb8b8b8, 0.7);
+  g.fillStyle(PALETTE.wallTop, 0.7);
   g.fillRect(4, 1, 1, 3);
   g.fillRect(7, 1, 1, 3);
   g.generateTexture(key, 14, 14);
@@ -340,13 +342,11 @@ function generateBangIcon(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.indicatorBang;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Red triangle
-  g.fillStyle(0xef4444, 1);
+  g.fillStyle(PALETTE.fail, 1);
   g.fillTriangle(7, 1, 13, 13, 1, 13);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.strokeTriangle(7, 1, 13, 13, 1, 13);
-  // !
-  g.fillStyle(0xffffff, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRect(6, 5, 2, 4);
   g.fillRect(6, 10, 2, 2);
   g.generateTexture(key, 14, 14);
@@ -357,13 +357,11 @@ function generateCheckIcon(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.indicatorCheck;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Green circle
-  g.fillStyle(0x22c55e, 1);
+  g.fillStyle(PALETTE.success, 1);
   g.fillCircle(7, 7, 7);
-  g.lineStyle(1, 0x1a1622, 1);
+  g.lineStyle(1, PALETTE.wall, 1);
   g.strokeCircle(7, 7, 7);
-  // Tick
-  g.lineStyle(2, 0xffffff, 1);
+  g.lineStyle(2, PALETTE.amber, 1);
   g.beginPath();
   g.moveTo(3, 7);
   g.lineTo(6, 10);
@@ -377,16 +375,13 @@ function generateTicket(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.ticket;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Card body
-  g.fillStyle(0xf5f0e8, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRoundedRect(0, 0, 14, 10, 2);
-  g.lineStyle(1, 0x8a7355, 1);
+  g.lineStyle(1, PALETTE.deskTop, 1);
   g.strokeRoundedRect(0, 0, 14, 10, 2);
-  // Priority tint strip at top
-  g.fillStyle(0x6b4a8e, 1);
+  g.fillStyle(PALETTE.reviewWall, 1);
   g.fillRect(0, 0, 14, 2);
-  // Text lines
-  g.fillStyle(0x4a3a5e, 0.5);
+  g.fillStyle(PALETTE.wall, 0.5);
   g.fillRect(2, 4, 8, 1);
   g.fillRect(2, 6, 6, 1);
   g.generateTexture(key, 14, 10);
@@ -397,17 +392,14 @@ function generateTicketScroll(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.ticketScroll;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Scroll body — taller, parchment colour
-  g.fillStyle(0xf5e8c8, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRoundedRect(0, 0, 10, 16, 1);
-  g.lineStyle(1, 0xb88a3a, 1);
+  g.lineStyle(1, PALETTE.deskTop, 1);
   g.strokeRoundedRect(0, 0, 10, 16, 1);
-  // Rolled-up ends (dark band)
-  g.fillStyle(0x8a6020, 0.8);
+  g.fillStyle(PALETTE.desk, 0.8);
   g.fillRect(0, 0, 10, 2);
   g.fillRect(0, 14, 10, 2);
-  // Text lines
-  g.fillStyle(0x4a3020, 0.4);
+  g.fillStyle(PALETTE.wall, 0.4);
   g.fillRect(2, 4, 6, 1);
   g.fillRect(2, 7, 5, 1);
   g.fillRect(2, 10, 6, 1);
@@ -419,53 +411,87 @@ function generateTicketEnvelope(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.ticketEnvelope;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  // Envelope body
-  g.fillStyle(0xf0eadc, 1);
+  g.fillStyle(PALETTE.amber, 1);
   g.fillRect(0, 0, 14, 10);
-  g.lineStyle(1, 0x8a7355, 1);
+  g.lineStyle(1, PALETTE.deskTop, 1);
   g.strokeRect(0, 0, 14, 10);
-  // V-flap line
-  g.lineStyle(1, 0x8a7355, 0.6);
+  g.lineStyle(1, PALETTE.deskTop, 0.6);
   g.lineBetween(0, 0, 7, 5);
   g.lineBetween(14, 0, 7, 5);
-  // Seal dot
-  g.fillStyle(0x6b4a8e, 1);
+  // Seal dot: scout envelope seal colour per CINEMATIC_TINTS
+  g.fillStyle(PALETTE.cyan, 1);
   g.fillCircle(7, 5, 2);
   g.generateTexture(key, 14, 10);
   g.destroy();
 }
 
-function generateQueueStacks(scene: Phaser.Scene): void {
-  const configs = [
-    { key: TEXTURE_KEYS.queueStack1, count: 1 },
-    { key: TEXTURE_KEYS.queueStack2, count: 2 },
-    { key: TEXTURE_KEYS.queueStack3, count: 3 },
-    { key: TEXTURE_KEYS.queueStackMany, count: 4 },
-  ];
-  for (const { key, count } of configs) {
-    if (scene.textures.exists(key)) continue;
-    const g = scene.add.graphics({ x: 0, y: 0 });
-    for (let i = count - 1; i >= 0; i--) {
-      const ox = i * 2;
-      const oy = i * 2;
-      g.fillStyle(0xf5f0e8, 1);
-      g.fillRoundedRect(ox, oy, 14, 10, 2);
-      g.lineStyle(1, 0x8a7355, 1);
-      g.strokeRoundedRect(ox, oy, 14, 10, 2);
-    }
-    g.generateTexture(key, 14 + 6, 10 + 6);
-    g.destroy();
+function generateQueueStackMany(scene: Phaser.Scene): void {
+  const key = TEXTURE_KEYS.queueStackMany;
+  if (scene.textures.exists(key)) return;
+  const g = scene.add.graphics({ x: 0, y: 0 });
+  for (let i = 3; i >= 0; i--) {
+    const ox = i * 2;
+    const oy = i * 2;
+    g.fillStyle(PALETTE.amber, 1);
+    g.fillRoundedRect(ox, oy, 14, 10, 2);
+    g.lineStyle(1, PALETTE.deskTop, 1);
+    g.strokeRoundedRect(ox, oy, 14, 10, 2);
   }
+  g.generateTexture(key, 14 + 6, 10 + 6);
+  g.destroy();
 }
 
 function generateTicketGlow(scene: Phaser.Scene): void {
   const key = TEXTURE_KEYS.ticketGlow;
   if (scene.textures.exists(key)) return;
   const g = scene.add.graphics({ x: 0, y: 0 });
-  g.fillStyle(0xffd700, 0.25);
+  g.fillStyle(PALETTE.amber, 0.25);
   g.fillRoundedRect(0, 0, 20, 16, 4);
-  g.lineStyle(1, 0xffd700, 0.6);
+  g.lineStyle(1, PALETTE.amber, 0.6);
   g.strokeRoundedRect(0, 0, 20, 16, 4);
   g.generateTexture(key, 20, 16);
+  g.destroy();
+}
+
+function generateWallFrostedBlue(scene: Phaser.Scene): void {
+  const key = TEXTURE_KEYS.wallFrostedBlue;
+  if (scene.textures.exists(key)) return;
+  const g = scene.add.graphics({ x: 0, y: 0 });
+  g.fillStyle(PALETTE.qaWall, 1);
+  g.fillRect(0, 0, 16, 16);
+  g.fillStyle(PALETTE.cyan, 0.2);
+  g.fillRect(0, 0, 16, 16);
+  g.generateTexture(key, 16, 16);
+  g.destroy();
+}
+
+function generateWallFrostedGrey(scene: Phaser.Scene): void {
+  const key = TEXTURE_KEYS.wallFrostedGrey;
+  if (scene.textures.exists(key)) return;
+  const g = scene.add.graphics({ x: 0, y: 0 });
+  g.fillStyle(PALETTE.wallTop, 1);
+  g.fillRect(0, 0, 16, 16);
+  g.fillStyle(PALETTE.wall, 0.3);
+  g.fillRect(0, 14, 16, 2);
+  g.generateTexture(key, 16, 16);
+  g.destroy();
+}
+
+function generateScoutDesk(scene: Phaser.Scene): void {
+  const key = TEXTURE_KEYS.scoutDesk;
+  if (scene.textures.exists(key)) return;
+  const g = scene.add.graphics({ x: 0, y: 0 });
+  g.fillStyle(PALETTE.desk, 1);
+  g.fillRect(0, 14, 32, 10);
+  g.fillStyle(PALETTE.deskTop, 1);
+  g.fillRect(0, 12, 32, 4);
+  g.fillStyle(PALETTE.wall, 1);
+  g.fillRect(8, 2, 16, 11);
+  g.fillStyle(PALETTE.cyan, 1);
+  g.fillRect(10, 4, 12, 7);
+  // Report on desk surface
+  g.fillStyle(PALETTE.amber, 1);
+  g.fillRect(2, 14, 5, 3);
+  g.generateTexture(key, 32, 24);
   g.destroy();
 }

--- a/apps/web/src/components/office/game/textures.ts
+++ b/apps/web/src/components/office/game/textures.ts
@@ -110,6 +110,12 @@ const OFFICE_TEXTURE_DISPLAY_SIZES: Record<string, TextureDisplaySize> = {
   [TEXTURE_KEYS.indicatorCoffee]: { width: 14, height: 14 },
   [TEXTURE_KEYS.indicatorBang]: { width: 14, height: 14 },
   [TEXTURE_KEYS.indicatorCheck]: { width: 14, height: 14 },
+  [TEXTURE_KEYS.spriteBase]: { width: 12, height: 16 },
+  [TEXTURE_KEYS.ticket]: { width: 14, height: 10 },
+  [TEXTURE_KEYS.ticketScroll]: { width: 10, height: 16 },
+  [TEXTURE_KEYS.ticketEnvelope]: { width: 14, height: 10 },
+  [TEXTURE_KEYS.queueStackMany]: { width: 20, height: 16 },
+  [TEXTURE_KEYS.ticketGlow]: { width: 20, height: 16 },
 };
 
 export function applyOfficeTextureDisplaySize(

--- a/apps/web/src/components/office/slice.test.ts
+++ b/apps/web/src/components/office/slice.test.ts
@@ -5,6 +5,9 @@
 // (apps/web/e2e/m17-office-tab.spec.ts) — they need a real browser canvas and
 // won't run in jsdom.
 
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { ChoreographyPlayer } from './game/choreography/ChoreographyPlayer';
 import type { ChoreographyCtx } from './game/choreography/Timeline';
@@ -56,6 +59,14 @@ import {
 import { IDLE_INDICATOR, indicatorForState } from './lib/state-indicators';
 import { deskForState, shouldWalk } from './lib/state-to-role';
 import { ticketAtDeskOffset, ticketCarryOffset } from './lib/ticket-carry';
+import { pngManifest } from './game/asset-loader';
+import {
+  CINEMATIC_TINTS,
+  HUD_TINTS,
+  PALETTE,
+  ROLE_TINTS,
+  TEXTURE_KEYS,
+} from './game/textures';
 
 describe('state → desk role mapping', () => {
   it('maps every lane state to a valid role', () => {
@@ -1359,5 +1370,105 @@ describe('hudStateFromPlacements', () => {
       mergedCelebrated: [],
     });
     expect(state.pressure.done).toBe(0);
+  });
+});
+
+describe('Phase 2.5 — visual canon', () => {
+  const BOARD06_HEX = [
+    '#2B2D42', '#3A3D5C', '#6B4F3B', '#6FE7FF',
+    '#F2CC8F', '#FF6B6B', '#8BD17C', '#D68FD6',
+    '#42466A', '#3B3D55', '#85694F', '#3F6B80', '#473A55',
+  ];
+
+  it('PALETTE has exactly 13 entries', () => {
+    expect(Object.keys(PALETTE)).toHaveLength(13);
+  });
+
+  it('ROLE_TINTS covers every OFFICE_ROLES entry', () => {
+    for (const role of OFFICE_ROLES) {
+      expect(ROLE_TINTS).toHaveProperty(role);
+    }
+  });
+
+  it('CINEMATIC_TINTS has exactly 8 entries', () => {
+    expect(Object.keys(CINEMATIC_TINTS)).toHaveLength(8);
+  });
+
+  it('HUD_TINTS has exactly 8 entries', () => {
+    expect(Object.keys(HUD_TINTS)).toHaveLength(8);
+  });
+
+  it('TEXTURE_KEYS has exactly 20 entries', () => {
+    expect(Object.keys(TEXTURE_KEYS)).toHaveLength(20);
+  });
+
+  it('pngManifest keys match all TEXTURE_KEYS values', () => {
+    const manifestKeys = new Set(pngManifest().map((e) => e.key));
+    const textureValues = new Set(Object.values(TEXTURE_KEYS));
+    expect(manifestKeys).toEqual(textureValues);
+  });
+
+  it('MANIFEST has 20 entries matching TEXTURE_KEYS count', async () => {
+    const { MANIFEST } = await import('../../../../../scripts/generate-office-assets');
+    expect(MANIFEST).toHaveLength(20);
+    expect(MANIFEST.length).toBe(Object.keys(TEXTURE_KEYS).length);
+  });
+
+  it('every MANIFEST prompt contains at least one Board 06 hex code', async () => {
+    const { MANIFEST } = await import('../../../../../scripts/generate-office-assets');
+    const hexPattern = /#[0-9A-Fa-f]{6}/g;
+    for (const spec of MANIFEST) {
+      const found = spec.prompt.match(hexPattern) ?? [];
+      const hasCanonical = found.some((h) => BOARD06_HEX.includes(h.toUpperCase()));
+      expect(hasCanonical, `Prompt for ${spec.file} has no Board 06 hex: "${spec.prompt}"`).toBe(true);
+    }
+  });
+
+  it('no non-canonical hex literals in game/ or components/', () => {
+    const officeDir = join(process.cwd(), 'apps', 'web', 'src', 'components', 'office');
+    const canonicalNums = new Set<number>([
+      ...Object.values(PALETTE) as number[],
+      ...Object.values(ROLE_TINTS) as number[],
+      ...Object.values(CINEMATIC_TINTS).filter((v): v is number => typeof v === 'number'),
+      ...Object.values(HUD_TINTS).filter((v): v is number => typeof v === 'number'),
+    ]);
+
+    function collectFiles(dir: string): string[] {
+      const files: string[] = [];
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          files.push(...collectFiles(full));
+        } else if (full.endsWith('.ts') || full.endsWith('.tsx')) {
+          files.push(full);
+        }
+      }
+      return files;
+    }
+
+    const dirsToScan = [join(officeDir, 'game'), join(officeDir, 'components')];
+    const allFiles: string[] = [];
+    for (const d of dirsToScan) {
+      allFiles.push(...collectFiles(d));
+    }
+
+    const hexLiteralPattern = /0x([0-9A-Fa-f]{6})\b/g;
+    const violations: string[] = [];
+
+    for (const file of allFiles) {
+      if (file.endsWith('textures.ts')) continue;
+      const src = readFileSync(file, 'utf8');
+      let m: RegExpExecArray | null;
+      while ((m = hexLiteralPattern.exec(src)) !== null) {
+        const val = parseInt(m[1], 16);
+        if (!canonicalNums.has(val)) {
+          const rel = file.replace(officeDir + '/', '');
+          violations.push(`${rel}: 0x${m[1]}`);
+        }
+      }
+      hexLiteralPattern.lastIndex = 0;
+    }
+
+    expect(violations, `Non-canonical hex literals found:\n${violations.join('\n')}`).toHaveLength(0);
   });
 });

--- a/scripts/generate-office-assets.ts
+++ b/scripts/generate-office-assets.ts
@@ -41,75 +41,132 @@ interface AssetSpec {
   height: number;
 }
 
-const MANIFEST: AssetSpec[] = [
+export const MANIFEST: AssetSpec[] = [
   // Tiles
   {
     file: 'floor-tile.png',
-    prompt: 'top-down dark purple office carpet tile, seamless, pixel art, 16x16',
+    prompt: 'top-down office carpet tile colour #3A3D5C dark slate-blue, seamless, pixel art, 16x16',
     width: 16,
     height: 16,
   },
   {
     file: 'floor-tile-alt.png',
-    prompt: 'top-down dark indigo office carpet tile, slightly lighter, seamless, pixel art, 16x16',
+    prompt: 'top-down office carpet tile colour #42466A slightly lighter slate-blue, seamless, pixel art, 16x16',
     width: 16,
     height: 16,
   },
   {
     file: 'wall-tile.png',
-    prompt: 'top-down purple office wall tile with shadow at base, pixel art, 16x16',
+    prompt: 'top-down office wall tile colour #2B2D42 dark navy with shadow at base, pixel art, 16x16',
     width: 16,
     height: 16,
   },
   // Furniture
   {
     file: 'desk.png',
-    prompt: 'top-down pixel art office desk with monitor showing blue screen, brown wood, 32x24',
+    prompt: 'top-down pixel art office desk wood #6B4F3B with monitor showing cyan #6FE7FF screen glow, 32x24',
     width: 32,
     height: 24,
   },
   {
     file: 'stairs.png',
-    prompt: 'top-down pixel art staircase with wooden steps and dark rail, isometric hint, 32x32',
+    prompt: 'top-down pixel art staircase wooden steps #85694F with dark rail #6B4F3B, isometric hint, 32x32',
     width: 32,
     height: 32,
   },
-  // Indicators (speech / thought / question / coffee / bang / check)
+  // Sprite
+  {
+    file: 'sprite.png',
+    prompt: 'top-down pixel art office goose character neutral pose, body colour #3B3D55, skin #85694F, 12x16, transparent bg',
+    width: 16,
+    height: 16,
+  },
+  // Indicators
   {
     file: 'indicator-speech.png',
-    prompt: 'pixel art white speech bubble with three small black dots, 14x16, transparent bg',
+    prompt: 'pixel art speech bubble colour #F2CC8F amber with three dark #2B2D42 dots, 14x16, transparent bg',
     width: 14,
     height: 16,
   },
   {
     file: 'indicator-thought.png',
-    prompt: 'pixel art white cloud thought bubble with trailing dot, 14x16, transparent bg',
+    prompt: 'pixel art cloud thought bubble colour #F2CC8F amber with trailing dot, outline #2B2D42, 14x16, transparent bg',
     width: 14,
     height: 16,
   },
   {
     file: 'indicator-question.png',
-    prompt: 'pixel art white speech bubble with bold black question mark, 14x16, transparent bg',
+    prompt: 'pixel art speech bubble #F2CC8F amber with bold #2B2D42 question mark, 14x16, transparent bg',
     width: 14,
     height: 16,
   },
   {
     file: 'indicator-coffee.png',
-    prompt: 'pixel art white coffee mug with steam wisps, brown coffee inside, 14x14, transparent bg',
+    prompt: 'pixel art coffee mug #F2CC8F amber with steam wisps, brown coffee #6B4F3B inside, 14x14, transparent bg',
     width: 14,
     height: 14,
   },
   {
     file: 'indicator-bang.png',
-    prompt: 'pixel art red warning triangle with white exclamation mark, 14x14, transparent bg',
+    prompt: 'pixel art red #FF6B6B warning triangle with #F2CC8F exclamation mark, outline #2B2D42, 14x14, transparent bg',
     width: 14,
     height: 14,
   },
   {
     file: 'indicator-check.png',
-    prompt: 'pixel art green circle with white checkmark, 14x14, transparent bg',
+    prompt: 'pixel art green #8BD17C circle with #F2CC8F checkmark, outline #2B2D42, 14x14, transparent bg',
     width: 14,
     height: 14,
+  },
+  // Ticket variants
+  {
+    file: 'ticket.png',
+    prompt: 'pixel art work ticket card #F2CC8F amber body with #473A55 priority strip, outline #85694F, 14x10, transparent bg',
+    width: 14,
+    height: 16,
+  },
+  {
+    file: 'queue-stack-many.png',
+    prompt: 'pixel art stack of 4 staggered #F2CC8F amber cards with #85694F outlines, 20x16, transparent bg',
+    width: 20,
+    height: 16,
+  },
+  {
+    file: 'ticket-glow.png',
+    prompt: 'pixel art glowing halo #F2CC8F amber rounded rect glow effect, 20x16, transparent bg',
+    width: 20,
+    height: 16,
+  },
+  {
+    file: 'ticket-scroll.png',
+    prompt: 'pixel art parchment scroll #F2CC8F amber with dark #6B4F3B rolled ends and text lines, 10x16, transparent bg',
+    width: 10,
+    height: 16,
+  },
+  {
+    file: 'ticket-envelope.png',
+    prompt: 'pixel art envelope #F2CC8F amber with V-flap and #6FE7FF cyan wax seal dot, 14x10, transparent bg',
+    width: 14,
+    height: 16,
+  },
+  // Phase 2.5 wall variants
+  {
+    file: 'wall-frosted-blue.png',
+    prompt: 'top-down office wall tile #3F6B80 teal with subtle #6FE7FF cyan frost, pixel art, 16x16',
+    width: 16,
+    height: 16,
+  },
+  {
+    file: 'wall-frosted-grey.png',
+    prompt: 'top-down office wall tile #3B3D55 muted blue-grey with shadow at base, pixel art, 16x16',
+    width: 16,
+    height: 16,
+  },
+  {
+    file: 'scout-desk.png',
+    prompt: 'top-down pixel art scout desk wood #6B4F3B with #6FE7FF cyan monitor and #F2CC8F report on surface, 32x24',
+    width: 32,
+    height: 24,
   },
 ];
 
@@ -166,7 +223,10 @@ async function main(): Promise<void> {
   console.log('Done. Restart the dev server to pick up new assets.');
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run when invoked directly (not when imported as a module in tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #782

## Summary

- Collapses ~72 ad-hoc hex literals across the Office slice to 28 enumerated codes from the Board 06 visual system spec. Pure colour registry retrofit — no behaviour, geometry, or architecture changes.
- `game/textures.ts` rewritten with `PALETTE` (13 entries), `ROLE_TINTS` (12 entries), `CINEMATIC_TINTS` (8 entries), `HUD_TINTS` (8 entries); `TEXTURE_KEYS` expanded to 20 entries adding `wallFrostedBlue`, `wallFrostedGrey`, `scoutDesk`; `spriteTextureKeyForRole` returns `spriteBase` for all roles; procedural fallbacks use only canonical colours.
- 13-file drift sweep: `HudLayer`, `PersonaLayer`, `RoomLayer`, `TicketLayer`, `HudFeed.tsx`, `QueuePanel.tsx`, three cinematics, four intents — all ad-hoc hex replaced with named imports from `textures.ts`.
- `asset-loader.ts`: `pngManifest()` exported, expanded 11→20 entries matching full `TEXTURE_KEYS`.
- `generate-office-assets.ts`: `MANIFEST` exported, expanded 11→20 entries with Board 06 hex codes in every prompt; `main()` guarded so the file is safe to import as a module.
- `slice.test.ts`: 9 new Phase 2.5 visual-canon assertions (palette counts, role tint coverage, filesystem hex sweep).
- `README.md`: updated asset count and palette constants documentation.

## §9.1 Sandbox exception

PixelLab was not run in this environment (no outbound HTTPS). The Office tab operates on the procedural fallback as normal. Run `pnpm gen:office-assets` locally to generate PNGs.

## Test plan

- [ ] `pnpm test` — all 131 office slice tests pass including 9 new Phase 2.5 assertions
- [ ] No non-canonical hex literals remain in `game/` or `components/` (enforced by filesystem scan test)
- [ ] `TEXTURE_KEYS` count 20, `PALETTE` count 13, `CINEMATIC_TINTS` count 8, `HUD_TINTS` count 8 (all enumerated by tests)
- [ ] Office tab renders with procedural fallback textures (no visual regressions in Playwright e2e)

https://claude.ai/code/session_014En3ebgMoxKZ3yLtG8JHWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014En3ebgMoxKZ3yLtG8JHWV)_