### PR TITLE
M7.XX: Change goose hub header

### DIFF
--- a/apps/web/e2e/issue-783.spec.ts
+++ b/apps/web/e2e/issue-783.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar header shows GooseHUB branding on the home route', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByText('GooseHUB')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-783/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
+  });
+
+  it('sidebar header does not read "Goose Hub"', () => {
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Change goose hub header

## Files
- `apps/web/src/components/chrome/slice.test.ts` — updated regression coverage for the sidebar brand copy
- `apps/web/src/components/chrome/Sidebar.tsx` — changed the visible header wordmark to GooseHUB
- `apps/web/e2e/issue-783.spec.ts` — added Playwright evidence coverage for the renamed header

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/e2e/issue-783.spec.ts` (1 cases)

Closes #783
