### PR TITLE
M7.XX: Change goose hub header 2

### DIFF
--- a/apps/web/e2e/issue-789.spec.ts
+++ b/apps/web/e2e/issue-789.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar branding reads GooseHUB in the expanded chrome', async ({ page }) => {
+  await page.goto('/projects/goose-hub-self');
+
+  const sidebar = page.getByTestId('sidebar');
+  await expect(sidebar).toBeVisible();
+
+  await page.getByRole('button', { name: 'Expand sidebar' }).click();
+
+  await expect(page.getByText('GooseHUB', { exact: true })).toBeVisible();
+  await expect(page.getByText('Goose Hub', { exact: true })).toHaveCount(0);
+
+  await page.screenshot({ path: 'evidence/issue-789/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,9 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Change goose hub header 2

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Change the visible sidebar brand label to GooseHUB.
- `apps/web/src/components/chrome/slice.test.ts` — Regress the brand-string assertion to expect GooseHUB and reject Goose Hub.
- `apps/web/e2e/issue-789.spec.ts` — Playwright evidence spec that opens the app, expands the sidebar, and screenshots the branding.

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (1 cases)
- `apps/web/e2e/issue-789.spec.ts` (1 cases)

Closes #789
