### PR TITLE
M7.XX: Sprint Review: M13: Discover Lane

### DIFF
--- a/core/bootstrap/stack-detector.ts
+++ b/core/bootstrap/stack-detector.ts
@@ -98,7 +98,8 @@ async function tryDetectNode(repoPath: string): Promise<NodeStackInfo | null> {
     if (scriptsRaw.test) scripts.test = scriptsRaw.test;
     if (scriptsRaw.lint) scripts.lint = scriptsRaw.lint;
     if (scriptsRaw.typecheck) scripts.typecheck = scriptsRaw.typecheck;
-    if (scriptsRaw.e2e) scripts.e2e = scriptsRaw.e2e;
+    const e2eScript = scriptsRaw.e2e ?? scriptsRaw['test:e2e'];
+    if (e2eScript) scripts.e2e = e2eScript;
   }
 
   // Detect package manager: packageManager field > lockfile presence

--- a/slices/stack-detector/fixtures/node-test-e2e/package.json
+++ b/slices/stack-detector/fixtures/node-test-e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "my-node-project-with-e2e-alias",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run",
+    "lint": "biome lint .",
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
+  },
+  "packageManager": "pnpm@8.0.0",
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/slices/stack-detector/slice.test.ts
+++ b/slices/stack-detector/slice.test.ts
@@ -30,6 +30,16 @@ describe('stack-detector slice', () => {
     });
   });
 
+  describe('Node/TypeScript stack with test:e2e script alias', () => {
+    const fixturePath = path.join(FIXTURES, 'node-test-e2e');
+
+    it('maps test:e2e onto the e2e script field', async () => {
+      const info = await detectStack(fixturePath);
+      if (info.type !== 'node') throw new Error('Expected node stack');
+      expect(info.scripts.e2e).toBe('playwright test');
+    });
+  });
+
   describe('Python stack (pyproject.toml with pytest + ruff)', () => {
     const fixturePath = path.join(FIXTURES, 'python');
 


### PR DESCRIPTION
## Summary

Sprint Review: M13: Discover Lane

## Files
- `core/bootstrap/stack-detector.ts` — map Node package.json `test:e2e` scripts into the detected `e2e` script field
- `slices/stack-detector/slice.test.ts` — regression coverage for the `test:e2e` alias detection path
- `slices/stack-detector/fixtures/node-test-e2e/package.json` — fixture package manifest exercising the `test:e2e` script alias

## Tests
- `slices/stack-detector/slice.test.ts` (1 cases)

Closes #791
