### PR TITLE
M7.XX: goose hub headeer 4

### DIFF
--- a/apps/web/e2e/issue-794.spec.ts
+++ b/apps/web/e2e/issue-794.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar brand reads GooseHUB', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByText('GooseHUB')).toBeVisible();
+  await page.screenshot({ path: 'evidence/issue-794/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { ActiveProjectProvider } from '@/state/active-project';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  });
+});
+
+function renderSidebar() {
+  render(
+    <MemoryRouter>
+      <ActiveProjectProvider initialSlug="goose-hub-self">
+        <Sidebar />
+      </ActiveProjectProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Sidebar', () => {
+  it('shows the GooseHUB wordmark when expanded', () => {
+    vi.mocked(localStorage.getItem).mockReturnValue('false');
+    renderSidebar();
+
+    expect(screen.getByText('GooseHUB')).toBeTruthy();
+  });
+
+  it('does not show the wordmark when collapsed by default', () => {
+    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    renderSidebar();
+
+    expect(screen.queryByText('GooseHUB')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
+  });
+
+  it('sidebar header does not read "Goose Hub"', () => {
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

goose hub headeer 4

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed the visible sidebar wordmark to GooseHUB.
- `apps/web/src/components/chrome/slice.test.ts` — Updated the slice assertions to lock in the GooseHUB spelling.
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Added component-level regression coverage for expanded and collapsed sidebar branding.
- `apps/web/e2e/issue-794.spec.ts` — Added Playwright evidence coverage for the visible header branding and screenshot.

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/src/components/chrome/slice.test.ts` (3 cases)
- `apps/web/e2e/issue-794.spec.ts` (1 cases)

Closes #794
