### PR TITLE
M7.XX: Change logo better

### DIFF
--- a/apps/web/e2e/issue-798.spec.ts
+++ b/apps/web/e2e/issue-798.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar wordmark shows Goosey Goose Hub branding', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem('sidebar-collapsed');
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await page.getByRole('button', { name: 'Expand sidebar' }).click();
+  await expect(page.getByText('Goosey Goose Hub')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-798/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Goosey Goose Hub
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "Goosey Goose Hub"', () => {
+    expect(sidebarSource).toContain('Goosey Goose Hub');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
-    const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+  it('sidebar header no longer renders the old "Goose Hub" wordmark', () => {
+    expect(sidebarSource).not.toMatch(/>\s*Goose Hub\s*<\/span>/);
   });
 });
 


### PR DESCRIPTION
## Summary

Change logo better

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Updated the shared chrome wordmark text to the requested Goosey Goose Hub branding.
- `apps/web/src/components/chrome/slice.test.ts` — Adjusted the chrome slice tests to assert the new wordmark and the removal of the old exact label.
- `apps/web/e2e/issue-798.spec.ts` — Added Playwright evidence coverage for the visible sidebar branding and screenshot capture.

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/e2e/issue-798.spec.ts` (1 cases)

Closes #798
