### PR TITLE
Move model runtime settings to per-skill resolver

### DIFF
--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -1,4 +1,5 @@
 import { SKILL_BUDGETS } from '@goose-hub/core/agent-runtime/budgets.js';
+import { deriveSkillRuntimeResponse } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import {
   deleteProjectSkillSetting,
   readProjectSettings,
@@ -29,7 +30,19 @@ const SkillBudgetPatchSchema = z.object({
   maxTurns: z.number().int().min(1).max(500).nullable().optional(),
   maxBudgetUsd: z.number().min(0).max(100).nullable().optional(),
   timeoutMs: z.number().int().min(5_000).max(3_600_000).nullable().optional(),
+  modelTier: z.enum(['haiku', 'sonnet', 'opus']).nullable().optional(),
+  provider: z.enum(['claude', 'codex']).nullable().optional(),
 });
+
+function roleForSkill(skill: string): string | undefined {
+  if (skill === 'qa') return 'qa';
+  if (skill === 'review') return 'reviewer';
+  if (skill === 'implement' || skill === 'implement-wp') return 'developer';
+  if (skill === 'investigate' || skill === 'playwright-repro') return 'investigator';
+  if (skill.startsWith('scout-') || skill.startsWith('wave2-')) return 'investigator';
+  if (skill === 'repo-match' || skill === 'triage' || skill === 'bug-enhance') return 'triager';
+  return undefined;
+}
 
 /** GET /projects/:slug/settings — merged view of config + DB overrides */
 router.get('/:slug/settings', async (c) => {
@@ -46,6 +59,8 @@ router.get('/:slug/settings', async (c) => {
       maxTurns: number | null;
       maxBudgetUsd: number | null;
       timeoutMs: number | null;
+      modelTier: string | null;
+      provider: string | null;
       updatedAt: string | null;
     }
   > = {};
@@ -54,6 +69,8 @@ router.get('/:slug/settings', async (c) => {
       maxTurns: row.maxTurns ?? null,
       maxBudgetUsd: row.maxBudgetUsd ?? null,
       timeoutMs: row.timeoutMs ?? null,
+      modelTier: row.modelTier ?? null,
+      provider: row.modelProvider ?? null,
       updatedAt: row.updatedAt,
     };
   }
@@ -63,13 +80,50 @@ router.get('/:slug/settings', async (c) => {
   // "default" as placeholder text.
   const skillDefaults: Record<
     string,
-    { maxTurns: number; maxBudgetUsd: number; timeoutMs: number }
+    {
+      maxTurns: number;
+      maxBudgetUsd: number;
+      timeoutMs: number;
+      modelTier: string;
+      modelProvider: string;
+    }
   > = {};
   for (const [skill, budget] of Object.entries(SKILL_BUDGETS)) {
     skillDefaults[skill] = {
       maxTurns: budget.maxTurns,
       maxBudgetUsd: budget.maxBudgetUsd,
       timeoutMs: budget.timeoutMs,
+      modelTier: budget.modelTier,
+      modelProvider: 'claude',
+    };
+  }
+
+  const resolvedSkillRuntimes: Record<
+    string,
+    {
+      source: string;
+      effectiveTier: string;
+      effectiveProvider: string;
+      resolvedPrimary: unknown;
+      resolvedFallback: unknown;
+      resolvedAdvisor: unknown;
+    }
+  > = {};
+  for (const skill of Object.keys(SKILL_BUDGETS)) {
+    const resolved = deriveSkillRuntimeResponse({
+      skill,
+      row: skillRows.get(skill),
+      projectBudgets: project.budgets,
+      configRuntime: project.agentConfig.runtime,
+      role: roleForSkill(skill),
+    });
+    resolvedSkillRuntimes[skill] = {
+      source: resolved.source,
+      effectiveTier: resolved.tier,
+      effectiveProvider: resolved.provider,
+      resolvedPrimary: resolved.resolvedPrimary,
+      resolvedFallback: resolved.resolvedFallback,
+      resolvedAdvisor: resolved.resolvedAdvisor,
     };
   }
 
@@ -106,6 +160,7 @@ router.get('/:slug/settings', async (c) => {
     dbSkillOverrides: skillSettings,
     registeredSkills: Object.keys(SKILL_BUDGETS),
     skillDefaults,
+    resolvedSkillRuntimes,
   });
 });
 
@@ -157,7 +212,13 @@ router.patch('/:slug/settings/skills/:skill', async (c) => {
     return c.json({ error: 'invalid body', details: parsed.error.issues }, 422);
   }
 
-  writeProjectSkillSetting(project.id, skill, parsed.data, 'ui');
+  const { provider, ...patch } = parsed.data;
+  writeProjectSkillSetting(
+    project.id,
+    skill,
+    { ...patch, ...(provider !== undefined ? { modelProvider: provider } : {}) },
+    'ui',
+  );
   return c.json({ ok: true });
 });
 

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -116,6 +116,7 @@ router.get('/:slug/settings', async (c) => {
       projectBudgets: project.budgets,
       configRuntime: project.agentConfig.runtime,
       role: roleForSkill(skill),
+      allowHoldoutOverride: project.agentConfig.allowHoldoutOverride,
     });
     resolvedSkillRuntimes[skill] = {
       source: resolved.source,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -369,12 +369,34 @@ export interface ProjectSettingsDto {
       maxTurns: number | null;
       maxBudgetUsd: number | null;
       timeoutMs: number | null;
+      modelTier: ModelTier | null;
+      provider: ModelProvider | null;
       updatedAt: string;
     }
   >;
   registeredSkills: string[];
   /** SKILL_BUDGETS defaults — UX-3 hint surfaced under each per-skill input. */
-  skillDefaults: Record<string, { maxTurns: number; maxBudgetUsd: number; timeoutMs: number }>;
+  skillDefaults: Record<
+    string,
+    {
+      maxTurns: number;
+      maxBudgetUsd: number;
+      timeoutMs: number;
+      modelTier: ModelTier;
+      modelProvider: ModelProvider;
+    }
+  >;
+  resolvedSkillRuntimes?: Record<
+    string,
+    {
+      source: string;
+      effectiveTier: ModelTier;
+      effectiveProvider: ModelProvider;
+      resolvedPrimary: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
+      resolvedFallback: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
+      resolvedAdvisor: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
+    }
+  >;
 }
 
 export type ModelTier = 'haiku' | 'sonnet' | 'opus';

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -233,6 +233,8 @@ export interface DbSkillOverride {
   maxTurns?: number | null;
   maxBudgetUsd?: number | null;
   timeoutMs?: number | null;
+  modelTier?: ModelTier | string | null;
+  modelProvider?: string | null;
 }
 
 /**

--- a/core/agent-runtime/index.ts
+++ b/core/agent-runtime/index.ts
@@ -4,3 +4,11 @@ export {
   invokeSkill,
 } from './invoke-skill.js';
 export type { InvokeSkillInput } from './invoke-skill.js';
+export {
+  forcedProviderFromRuntime,
+  higherTier,
+  lowerTier,
+  resolveSkillRuntime,
+  resolveSkillRuntimeForProject,
+} from './skill-runtime-resolver.js';
+export type { ResolvedSkillRuntime, SkillRuntimeSource } from './skill-runtime-resolver.js';

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -115,6 +115,8 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     fallbackProvider: skillConfig.provider,
     callerModelOverride: overrides?.modelOverride,
     role,
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+    ignoreProviderOverride: overrides?.runtimeOverride != null && overrides?.modelOverride == null,
   });
   const modelOverride = resolved.modelOverride;
 

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -5,16 +5,11 @@ import { getProjectBySlug } from '../projects/loader.js';
 import type { ProjectConfig } from '../types.js';
 import type { ResolvedBudget } from './budgets.js';
 import type { AgentResult, AgentRuntime, SkillConfig } from './interface.js';
-import { defaultModelForTierAndProvider } from './models.js';
 import { readPromptWithContext } from './read-prompt.js';
-import {
-  resolveBudgetsForProject,
-  resolveRoleBudgetOverrideForProject,
-  resolveRoleModelForProject,
-} from './resolve-for-project.js';
 import { toJsonSchema } from './schema-bridge.js';
 import { selectPersona } from './select-persona.js';
 import { selectRuntime } from './select-runtime.js';
+import { resolveSkillRuntimeForProject } from './skill-runtime-resolver.js';
 
 export class ContextValidationError extends Error {
   issues: Array<{ path: Array<string | number>; message: string }>;
@@ -61,11 +56,6 @@ export type InvokeSkillInput = {
     /** Caller-supplied freshContext flag. When provided, overrides the skill config value. */
     freshContextOverride?: boolean;
   };
-};
-
-const FALLBACK_BUDGET: ResolvedBudget = {
-  budgets: { maxTurns: 25, maxBudgetUsd: 1.0, timeoutMs: 120_000 },
-  modelOverride: defaultModelForTierAndProvider('sonnet', 'claude'),
 };
 
 /**
@@ -115,61 +105,18 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     overrides?.projectConfigOverride !== undefined
       ? overrides.projectConfigOverride
       : await getProjectBySlug(projectId);
-  let resolved: ResolvedBudget;
-  try {
-    resolved = resolveBudgetsForProject(skillName, projectConfig?.budgets, projectId);
-  } catch {
-    resolved = {
-      ...FALLBACK_BUDGET,
-      modelOverride: defaultModelForTierAndProvider(
-        skillConfig.modelPin,
-        skillConfig.provider ?? 'claude',
-      ),
-    };
-  }
-
-  // 5b. Apply per-role budget overrides (maxTurns / timeoutMs) from DB on top of
-  //     the skill-level resolution. null means "no override — keep skill default".
-  //     Holdout gating is applied inside resolveRoleBudgetOverrideForProject.
-  const roleBudget = resolveRoleBudgetOverrideForProject(
+  const resolved: ResolvedBudget = resolveSkillRuntimeForProject({
+    skill: skillName,
+    projectBudgets: projectConfig?.budgets,
     projectId,
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    skillProvider: skillConfig.provider,
+    fallbackTier: skillConfig.modelPin,
+    fallbackProvider: skillConfig.provider,
+    callerModelOverride: overrides?.modelOverride,
     role,
-    projectConfig?.agentConfig?.allowHoldoutOverride,
-  );
-  resolved = {
-    ...resolved,
-    budgets: {
-      ...resolved.budgets,
-      ...(roleBudget.maxTurns != null && { maxTurns: roleBudget.maxTurns }),
-      ...(roleBudget.timeoutMs != null && { timeoutMs: roleBudget.timeoutMs }),
-    },
-  };
-
-  // 6. Resolve model — precedence: caller override > per-role override (DB / config) > skill budget default
-  // When runtimeOverride is supplied the caller owns the runtime; skip DB provider overrides so a
-  // codex-targeted DB row can't inject a Codex model ID into a ClaudeCliRuntime call.
-  let modelOverride: string;
-  if (overrides?.modelOverride != null) {
-    modelOverride = overrides.modelOverride;
-  } else if (overrides?.runtimeOverride != null) {
-    modelOverride = resolved.modelOverride;
-  } else {
-    const roleModel = resolveRoleModelForProject({
-      role,
-      projectId,
-      configRoleModel: projectConfig?.agentConfig?.rolesModels?.[role],
-      allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
-      skill: skillName,
-      skillProvider: skillConfig.provider,
-    });
-    // Use the role's resolved model when it differs from the skill-budget default
-    // (i.e. a DB or config override is active). Otherwise stick with the budget
-    // resolution so skill-pinned tiers still drive budget math correctly.
-    modelOverride =
-      roleModel.source === 'db' || roleModel.source === 'config'
-        ? roleModel.modelId
-        : resolved.modelOverride;
-  }
+  });
+  const modelOverride = resolved.modelOverride;
 
   // 7. Select runtime — runtimeOverride short-circuits for tests and bespoke callers
   const runtime =

--- a/core/agent-runtime/resolve-for-project.ts
+++ b/core/agent-runtime/resolve-for-project.ts
@@ -2,20 +2,17 @@ import {
   parseComplexityOverrides,
   readProjectModelSettingsForRole,
 } from '../db/repositories/project-model-settings.js';
-import {
-  readProjectSettings,
-  readProjectSkillSettings,
-} from '../db/repositories/project-settings.js';
+import { readProjectSettings } from '../db/repositories/project-settings.js';
 import type { ModelTier, Role, RoleModel } from '../types.js';
 import {
   type ResolvedBudget,
   type SkillBudgetOverride,
-  resolveBudgets,
   resolveEscalatedBudgets,
 } from './budgets.js';
 import type { ModelProvider } from './models.js';
 import { HOLDOUT_ROLES } from './roles.js';
 import { type SelectModelForRoleResult, selectModelForRole } from './select-model-for-role.js';
+import { resolveSkillRuntimeForProject } from './skill-runtime-resolver.js';
 
 /** Merged global settings: DB row wins over projectConfig value when non-null. */
 export interface EffectiveGlobalSettings {
@@ -80,15 +77,11 @@ export function resolveBudgetsForProject(
     | undefined,
   projectId: string,
 ): ResolvedBudget {
-  const skillRows = readProjectSkillSettings(projectId);
-  const globalRow = readProjectSettings(projectId);
-  return resolveBudgets(
+  return resolveSkillRuntimeForProject({
     skill,
     projectBudgets,
-    skillRows.get(skill),
-    globalRow?.perWorkflowMaxUsd,
-    globalRow?.perAgentMaxUsd,
-  );
+    projectId,
+  });
 }
 
 /**

--- a/core/agent-runtime/resolve-runtime-for-project.ts
+++ b/core/agent-runtime/resolve-runtime-for-project.ts
@@ -29,6 +29,8 @@ export function resolveProjectAgentExecution(input: {
     configRuntime,
     skillProvider: input.skillProvider,
     role: input.role,
+    allowHoldoutOverride: input.projectConfig?.agentConfig?.allowHoldoutOverride,
+    ignoreProviderOverride: input.injectedRuntime != null,
   });
 
   if (input.injectedRuntime != null) {

--- a/core/agent-runtime/resolve-runtime-for-project.ts
+++ b/core/agent-runtime/resolve-runtime-for-project.ts
@@ -1,19 +1,16 @@
 import type { ProjectConfig, Role } from '../types.js';
 import type { ResolvedBudget } from './budgets.js';
 import type { AgentRuntime } from './interface.js';
-import { type ModelProvider, defaultModelForTierAndProvider, tierOf } from './models.js';
-import { resolveBudgetsForProject, resolveRoleModelForProject } from './resolve-for-project.js';
+import type { ModelProvider } from './models.js';
 import { type ConfigRuntime, selectRuntime } from './select-runtime.js';
+import {
+  forcedProviderFromRuntime,
+  resolveSkillRuntimeForProject,
+} from './skill-runtime-resolver.js';
 
 export interface ProjectAgentExecution {
   runtime: AgentRuntime;
   resolvedBudget: ResolvedBudget;
-}
-
-function forcedProviderFromRuntime(configRuntime: ConfigRuntime): ModelProvider | null {
-  if (configRuntime === 'codex-cli') return 'codex';
-  if (configRuntime === 'claude-cli') return 'claude';
-  return null;
 }
 
 export function resolveProjectAgentExecution(input: {
@@ -24,37 +21,26 @@ export function resolveProjectAgentExecution(input: {
   injectedRuntime?: AgentRuntime;
   skillProvider?: ModelProvider;
 }): ProjectAgentExecution {
-  const resolvedBudget = resolveBudgetsForProject(
-    input.skill,
-    input.projectConfig?.budgets,
-    input.projectId,
-  );
+  const configRuntime = input.projectConfig?.agentConfig?.runtime ?? 'auto';
+  const resolvedBudget = resolveSkillRuntimeForProject({
+    skill: input.skill,
+    projectBudgets: input.projectConfig?.budgets,
+    projectId: input.projectId,
+    configRuntime,
+    skillProvider: input.skillProvider,
+    role: input.role,
+  });
 
   if (input.injectedRuntime != null) {
     return { runtime: input.injectedRuntime, resolvedBudget };
   }
 
-  const roleModel = resolveRoleModelForProject({
-    role: input.role,
-    projectId: input.projectId,
-    configRoleModel: input.projectConfig?.agentConfig?.rolesModels?.[input.role],
-    allowHoldoutOverride: input.projectConfig?.agentConfig?.allowHoldoutOverride,
-    skill: input.skill,
-    skillProvider: input.skillProvider,
-  });
-  const configRuntime = input.projectConfig?.agentConfig?.runtime ?? 'auto';
-  const provider =
-    forcedProviderFromRuntime(configRuntime) ??
-    (roleModel.source === 'db' || roleModel.source === 'config'
-      ? roleModel.provider
-      : (input.skillProvider ?? 'claude'));
-  const tier =
-    roleModel.source === 'db' || roleModel.source === 'config'
-      ? roleModel.tier
-      : tierOf(resolvedBudget.modelOverride);
-  const modelOverride = defaultModelForTierAndProvider(tier, provider);
   return {
-    runtime: selectRuntime({ configRuntime, model: modelOverride, skillProvider: provider }),
-    resolvedBudget: { ...resolvedBudget, modelOverride },
+    runtime: selectRuntime({
+      configRuntime,
+      model: resolvedBudget.modelOverride,
+      skillProvider: forcedProviderFromRuntime(configRuntime) ?? resolvedBudget.provider,
+    }),
+    resolvedBudget,
   };
 }

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -73,6 +73,7 @@ export interface RunOneScoutContext {
   projectId: string;
   workItemId?: string;
   runtime: AgentRuntime;
+  resolveScoutRuntime?: (resolvedBudget: ResolvedBudget, scoutName: string) => AgentRuntime;
   personaId: string;
   projectBudgets?: ScoutProjectBudgets;
   scoutTimeoutMs?: number;
@@ -163,7 +164,8 @@ export async function runOneScout(
   let errorReason: string | undefined;
 
   try {
-    result = await ctx.runtime.run(spawnSpec);
+    const runtime = ctx.resolveScoutRuntime?.(resolvedBudget, spec.scoutName) ?? ctx.runtime;
+    result = await runtime.run(spawnSpec);
   } catch (err) {
     if (isTimeoutError(err, budgets.timeoutMs)) {
       timedOut = true;

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { higherTier, lowerTier, resolveSkillRuntime } from './skill-runtime-resolver.js';
+
+describe('resolveSkillRuntime', () => {
+  it('lets a per-skill DB tier/provider override win over defaults', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { modelTier: 'sonnet', modelProvider: 'codex' },
+    });
+
+    expect(resolved.source).toBe('db');
+    expect(resolved.tier).toBe('sonnet');
+    expect(resolved.provider).toBe('codex');
+    expect(resolved.modelOverride).toBe('gpt-5.4');
+  });
+
+  it('uses project config skillBudgetOverrides before SKILL_BUDGETS', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'bug-enhance',
+      projectBudgets: { skillBudgetOverrides: { 'bug-enhance': { modelTier: 'opus' } } },
+    });
+
+    expect(resolved.source).toBe('config');
+    expect(resolved.modelOverride).toBe('claude-opus-4-7');
+  });
+
+  it('coerces provider when the project runtime is forced', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { modelTier: 'sonnet', modelProvider: 'claude' },
+      configRuntime: 'codex-cli',
+    });
+
+    expect(resolved.provider).toBe('codex');
+    expect(resolved.modelOverride).toBe('gpt-5.4');
+  });
+
+  it('keeps a caller concrete model override above forced runtime provider', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      callerModelOverride: 'claude-opus-4-7',
+      configRuntime: 'codex-cli',
+    });
+
+    expect(resolved.source).toBe('caller');
+    expect(resolved.provider).toBe('claude');
+    expect(resolved.modelOverride).toBe('claude-opus-4-7');
+  });
+
+  it('does not derive fallback/advisor models for holdouts', () => {
+    const resolved = resolveSkillRuntime({ skill: 'implement', role: 'qa' });
+
+    expect(resolved.resolvedFallback).toBeNull();
+    expect(resolved.resolvedAdvisor).toBeNull();
+  });
+});
+
+describe('tier helpers', () => {
+  it('floors lowerTier at haiku and caps higherTier at opus', () => {
+    expect(lowerTier('haiku')).toBe('haiku');
+    expect(lowerTier('sonnet')).toBe('haiku');
+    expect(higherTier('sonnet')).toBe('opus');
+    expect(higherTier('opus')).toBe('opus');
+  });
+});

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -53,6 +53,33 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.resolvedFallback).toBeNull();
     expect(resolved.resolvedAdvisor).toBeNull();
   });
+
+  it('ignores per-skill model overrides for holdouts unless explicitly allowed', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'qa',
+      role: 'qa',
+      dbOverride: { modelTier: 'haiku', modelProvider: 'codex' },
+      projectBudgets: { skillBudgetOverrides: { qa: { modelTier: 'haiku' } } },
+    });
+
+    expect(resolved.source).toBe('skill-default');
+    expect(resolved.tier).toBe('sonnet');
+    expect(resolved.provider).toBe('claude');
+    expect(resolved.modelOverride).toBe('claude-sonnet-4-6');
+  });
+
+  it('can ignore provider overrides for injected runtimes while keeping the tier', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { modelTier: 'sonnet', modelProvider: 'codex' },
+      configRuntime: 'codex-cli',
+      ignoreProviderOverride: true,
+    });
+
+    expect(resolved.tier).toBe('sonnet');
+    expect(resolved.provider).toBe('claude');
+    expect(resolved.modelOverride).toBe('claude-sonnet-4-6');
+  });
 });
 
 describe('tier helpers', () => {

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -1,0 +1,227 @@
+import type { ProjectSkillSettingsRow } from '../db/repositories/project-settings.js';
+import {
+  readProjectSettings,
+  readProjectSkillSettings,
+} from '../db/repositories/project-settings.js';
+import type { BudgetConfig, ModelProvider, ModelTier } from '../types.js';
+import type { ResolvedBudget, SkillBudgetOverride } from './budgets.js';
+import { SKILL_BUDGETS, resolveBudgets } from './budgets.js';
+import { defaultModelForTierAndProvider, providerOf, tierOf } from './models.js';
+import type { ConfigRuntime } from './select-runtime.js';
+
+export type SkillRuntimeSource = 'caller' | 'db' | 'config' | 'skill-default' | 'fallback';
+
+export interface SkillRuntimeDbOverride {
+  maxTurns?: number | null;
+  maxBudgetUsd?: number | null;
+  timeoutMs?: number | null;
+  modelTier?: ModelTier | string | null;
+  modelProvider?: ModelProvider | string | null;
+}
+
+export interface ResolvedDisplayModel {
+  tier: ModelTier;
+  provider: ModelProvider;
+  modelId: string;
+}
+
+export interface ResolvedSkillRuntime extends ResolvedBudget {
+  tier: ModelTier;
+  provider: ModelProvider;
+  source: SkillRuntimeSource;
+  resolvedPrimary: ResolvedDisplayModel;
+  resolvedFallback: ResolvedDisplayModel | null;
+  resolvedAdvisor: ResolvedDisplayModel | null;
+}
+
+const TIER_ORDER: ModelTier[] = ['haiku', 'sonnet', 'opus'];
+
+function isModelTier(value: unknown): value is ModelTier {
+  return value === 'haiku' || value === 'sonnet' || value === 'opus';
+}
+
+function isModelProvider(value: unknown): value is ModelProvider {
+  return value === 'claude' || value === 'codex';
+}
+
+export function lowerTier(tier: ModelTier): ModelTier {
+  const index = Math.max(0, TIER_ORDER.indexOf(tier) - 1);
+  return TIER_ORDER[index] ?? 'haiku';
+}
+
+export function higherTier(tier: ModelTier): ModelTier {
+  const index = Math.min(TIER_ORDER.length - 1, TIER_ORDER.indexOf(tier) + 1);
+  return TIER_ORDER[index] ?? 'opus';
+}
+
+export function forcedProviderFromRuntime(configRuntime: ConfigRuntime): ModelProvider | null {
+  if (configRuntime === 'codex-cli') return 'codex';
+  if (configRuntime === 'claude-cli') return 'claude';
+  return null;
+}
+
+function displayModel(tier: ModelTier, provider: ModelProvider): ResolvedDisplayModel {
+  return { tier, provider, modelId: defaultModelForTierAndProvider(tier, provider) };
+}
+
+function fallbackBudget(tier: ModelTier, provider: ModelProvider): ResolvedBudget {
+  return {
+    budgets: { maxTurns: 25, maxBudgetUsd: 1, timeoutMs: 120_000 },
+    modelOverride: defaultModelForTierAndProvider(tier, provider),
+  };
+}
+
+function sourceForSkill(
+  skill: string,
+  dbOverride?: SkillRuntimeDbOverride | null,
+): SkillRuntimeSource {
+  if (isModelTier(dbOverride?.modelTier) || isModelProvider(dbOverride?.modelProvider)) return 'db';
+  if (SKILL_BUDGETS[skill] != null) return 'skill-default';
+  return 'fallback';
+}
+
+function resolveTier(input: {
+  skill: string;
+  projectBudgets?: Pick<BudgetConfig, 'skillBudgetOverrides'>;
+  dbOverride?: SkillRuntimeDbOverride | null;
+  fallbackTier?: ModelTier;
+}): { tier: ModelTier; source: SkillRuntimeSource } {
+  if (isModelTier(input.dbOverride?.modelTier)) {
+    return { tier: input.dbOverride.modelTier, source: 'db' };
+  }
+
+  const configTier = input.projectBudgets?.skillBudgetOverrides?.[input.skill]?.modelTier;
+  if (isModelTier(configTier)) {
+    return { tier: configTier, source: 'config' };
+  }
+
+  const skillTier = SKILL_BUDGETS[input.skill]?.modelTier;
+  if (skillTier != null) {
+    return { tier: skillTier, source: sourceForSkill(input.skill, input.dbOverride) };
+  }
+
+  return { tier: input.fallbackTier ?? 'sonnet', source: 'fallback' };
+}
+
+export function resolveSkillRuntime(input: {
+  skill: string;
+  projectBudgets?: {
+    perWorkflowMaxUsd?: number;
+    perAgentMaxUsd?: number;
+    skillBudgetOverrides?: Record<string, SkillBudgetOverride>;
+  };
+  dbOverride?: SkillRuntimeDbOverride | null;
+  dbPerWorkflowMaxUsd?: number | null;
+  dbPerAgentMaxUsd?: number | null;
+  configRuntime?: ConfigRuntime;
+  skillProvider?: ModelProvider;
+  fallbackTier?: ModelTier;
+  fallbackProvider?: ModelProvider;
+  callerModelOverride?: string;
+  role?: string;
+}): ResolvedSkillRuntime {
+  const configRuntime = input.configRuntime ?? 'auto';
+  let resolvedBudget: ResolvedBudget;
+  try {
+    resolvedBudget = resolveBudgets(
+      input.skill,
+      input.projectBudgets,
+      input.dbOverride ?? undefined,
+      input.dbPerWorkflowMaxUsd,
+      input.dbPerAgentMaxUsd,
+    );
+  } catch {
+    resolvedBudget = fallbackBudget(
+      input.fallbackTier ?? 'sonnet',
+      forcedProviderFromRuntime(configRuntime) ??
+        (isModelProvider(input.dbOverride?.modelProvider)
+          ? input.dbOverride.modelProvider
+          : (input.skillProvider ?? input.fallbackProvider ?? 'claude')),
+    );
+  }
+
+  if (input.callerModelOverride != null) {
+    const tier = tierOf(input.callerModelOverride);
+    const provider = providerOf(input.callerModelOverride);
+    return {
+      ...resolvedBudget,
+      modelOverride: input.callerModelOverride,
+      tier,
+      provider,
+      source: 'caller',
+      resolvedPrimary: { tier, provider, modelId: input.callerModelOverride },
+      resolvedFallback: null,
+      resolvedAdvisor: null,
+    };
+  }
+
+  const tierResult = resolveTier({
+    skill: input.skill,
+    projectBudgets: input.projectBudgets,
+    dbOverride: input.dbOverride,
+    fallbackTier: input.fallbackTier,
+  });
+  const provider =
+    forcedProviderFromRuntime(configRuntime) ??
+    (isModelProvider(input.dbOverride?.modelProvider)
+      ? input.dbOverride.modelProvider
+      : (input.skillProvider ?? input.fallbackProvider ?? 'claude'));
+  const modelOverride = defaultModelForTierAndProvider(tierResult.tier, provider);
+  const isHoldout = input.role === 'qa' || input.role === 'reviewer';
+  const supportsFallback = SKILL_BUDGETS[input.skill]?.escalation != null;
+  const supportsAdvisor = input.skill === 'implement' || input.skill === 'write-prd';
+
+  return {
+    ...resolvedBudget,
+    modelOverride,
+    tier: tierResult.tier,
+    provider,
+    source: isModelProvider(input.dbOverride?.modelProvider) ? 'db' : tierResult.source,
+    resolvedPrimary: displayModel(tierResult.tier, provider),
+    resolvedFallback:
+      !isHoldout && supportsFallback ? displayModel(lowerTier(tierResult.tier), provider) : null,
+    resolvedAdvisor:
+      !isHoldout && supportsAdvisor ? displayModel(higherTier(tierResult.tier), provider) : null,
+  };
+}
+
+export function resolveSkillRuntimeForProject(input: {
+  skill: string;
+  projectBudgets?: {
+    perWorkflowMaxUsd?: number;
+    perAgentMaxUsd?: number;
+    skillBudgetOverrides?: Record<string, SkillBudgetOverride>;
+  };
+  projectId: string;
+  configRuntime?: ConfigRuntime;
+  skillProvider?: ModelProvider;
+  fallbackTier?: ModelTier;
+  fallbackProvider?: ModelProvider;
+  callerModelOverride?: string;
+  role?: string;
+}): ResolvedSkillRuntime {
+  const skillRows = readProjectSkillSettings(input.projectId);
+  const globalRow = readProjectSettings(input.projectId);
+  return resolveSkillRuntime({
+    ...input,
+    dbOverride: skillRows.get(input.skill),
+    dbPerWorkflowMaxUsd: globalRow?.perWorkflowMaxUsd,
+    dbPerAgentMaxUsd: globalRow?.perAgentMaxUsd,
+  });
+}
+
+export function deriveSkillRuntimeResponse(input: {
+  skill: string;
+  row?: ProjectSkillSettingsRow | null;
+  projectBudgets?: BudgetConfig;
+  configRuntime?: ConfigRuntime;
+  role?: string;
+}): ResolvedSkillRuntime {
+  return resolveSkillRuntime({
+    skill: input.skill,
+    projectBudgets: input.projectBudgets,
+    dbOverride: input.row,
+    configRuntime: input.configRuntime,
+    role: input.role,
+  });
+}

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -103,6 +103,18 @@ function resolveTier(input: {
   return { tier: input.fallbackTier ?? 'sonnet', source: 'fallback' };
 }
 
+function withoutConfigModelTier(
+  projectBudgets: Parameters<typeof resolveSkillRuntime>[0]['projectBudgets'],
+): Parameters<typeof resolveSkillRuntime>[0]['projectBudgets'] {
+  if (projectBudgets?.skillBudgetOverrides == null) return projectBudgets;
+  const skillBudgetOverrides: Record<string, SkillBudgetOverride> = {};
+  for (const [skill, override] of Object.entries(projectBudgets.skillBudgetOverrides)) {
+    const { modelTier: _modelTier, ...rest } = override;
+    skillBudgetOverrides[skill] = rest;
+  }
+  return { ...projectBudgets, skillBudgetOverrides };
+}
+
 export function resolveSkillRuntime(input: {
   skill: string;
   projectBudgets?: {
@@ -119,23 +131,36 @@ export function resolveSkillRuntime(input: {
   fallbackProvider?: ModelProvider;
   callerModelOverride?: string;
   role?: string;
+  allowHoldoutOverride?: boolean;
+  ignoreProviderOverride?: boolean;
 }): ResolvedSkillRuntime {
   const configRuntime = input.configRuntime ?? 'auto';
+  const isHoldout = input.role === 'qa' || input.role === 'reviewer';
+  const honourModelOverrides = !isHoldout || input.allowHoldoutOverride === true;
+  const dbOverride = honourModelOverrides
+    ? input.dbOverride
+    : input.dbOverride == null
+      ? input.dbOverride
+      : { ...input.dbOverride, modelTier: null, modelProvider: null };
+  const modelProjectBudgets = honourModelOverrides
+    ? input.projectBudgets
+    : withoutConfigModelTier(input.projectBudgets);
+  const providerConfigRuntime = input.ignoreProviderOverride ? 'auto' : configRuntime;
   let resolvedBudget: ResolvedBudget;
   try {
     resolvedBudget = resolveBudgets(
       input.skill,
       input.projectBudgets,
-      input.dbOverride ?? undefined,
+      dbOverride ?? undefined,
       input.dbPerWorkflowMaxUsd,
       input.dbPerAgentMaxUsd,
     );
   } catch {
     resolvedBudget = fallbackBudget(
       input.fallbackTier ?? 'sonnet',
-      forcedProviderFromRuntime(configRuntime) ??
-        (isModelProvider(input.dbOverride?.modelProvider)
-          ? input.dbOverride.modelProvider
+      forcedProviderFromRuntime(providerConfigRuntime) ??
+        (!input.ignoreProviderOverride && isModelProvider(dbOverride?.modelProvider)
+          ? dbOverride.modelProvider
           : (input.skillProvider ?? input.fallbackProvider ?? 'claude')),
     );
   }
@@ -157,17 +182,16 @@ export function resolveSkillRuntime(input: {
 
   const tierResult = resolveTier({
     skill: input.skill,
-    projectBudgets: input.projectBudgets,
-    dbOverride: input.dbOverride,
+    projectBudgets: modelProjectBudgets,
+    dbOverride,
     fallbackTier: input.fallbackTier,
   });
   const provider =
-    forcedProviderFromRuntime(configRuntime) ??
-    (isModelProvider(input.dbOverride?.modelProvider)
-      ? input.dbOverride.modelProvider
+    forcedProviderFromRuntime(providerConfigRuntime) ??
+    (!input.ignoreProviderOverride && isModelProvider(dbOverride?.modelProvider)
+      ? dbOverride.modelProvider
       : (input.skillProvider ?? input.fallbackProvider ?? 'claude'));
   const modelOverride = defaultModelForTierAndProvider(tierResult.tier, provider);
-  const isHoldout = input.role === 'qa' || input.role === 'reviewer';
   const supportsFallback = SKILL_BUDGETS[input.skill]?.escalation != null;
   const supportsAdvisor = input.skill === 'implement' || input.skill === 'write-prd';
 
@@ -176,7 +200,7 @@ export function resolveSkillRuntime(input: {
     modelOverride,
     tier: tierResult.tier,
     provider,
-    source: isModelProvider(input.dbOverride?.modelProvider) ? 'db' : tierResult.source,
+    source: isModelProvider(dbOverride?.modelProvider) ? 'db' : tierResult.source,
     resolvedPrimary: displayModel(tierResult.tier, provider),
     resolvedFallback:
       !isHoldout && supportsFallback ? displayModel(lowerTier(tierResult.tier), provider) : null,
@@ -199,6 +223,8 @@ export function resolveSkillRuntimeForProject(input: {
   fallbackProvider?: ModelProvider;
   callerModelOverride?: string;
   role?: string;
+  allowHoldoutOverride?: boolean;
+  ignoreProviderOverride?: boolean;
 }): ResolvedSkillRuntime {
   const skillRows = readProjectSkillSettings(input.projectId);
   const globalRow = readProjectSettings(input.projectId);
@@ -216,6 +242,7 @@ export function deriveSkillRuntimeResponse(input: {
   projectBudgets?: BudgetConfig;
   configRuntime?: ConfigRuntime;
   role?: string;
+  allowHoldoutOverride?: boolean;
 }): ResolvedSkillRuntime {
   return resolveSkillRuntime({
     skill: input.skill,
@@ -223,5 +250,6 @@ export function deriveSkillRuntimeResponse(input: {
     dbOverride: input.row,
     configRuntime: input.configRuntime,
     role: input.role,
+    allowHoldoutOverride: input.allowHoldoutOverride,
   });
 }

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -603,6 +603,49 @@ describe('swarm.dispatchWave', () => {
     expect(codePathSpec?.modelOverride).toBe('resolved-scout-code-path');
   });
 
+  it('can route child scout spawns through a runtime chosen from each resolved model', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const defaultSpecs: AgentSpec[] = [];
+    const perScoutSpecs: AgentSpec[] = [];
+    const runtime: AgentRuntime = {
+      async run(spec: AgentSpec): Promise<AgentResult> {
+        defaultSpecs.push(spec);
+        return okResult(spec.skill);
+      },
+    };
+    const perScoutRuntime: AgentRuntime = {
+      async run(spec: AgentSpec): Promise<AgentResult> {
+        perScoutSpecs.push(spec);
+        return okResult(spec.skill);
+      },
+    };
+
+    await dispatchWave({
+      parentRunId: 'parent-runtime',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: () => ({
+        budgets: { maxTurns: 20, maxBudgetUsd: 0.5, timeoutMs: 120_000 },
+        modelOverride: 'gpt-5.4-mini',
+      }),
+      resolveScoutRuntime: (resolvedBudget, scoutName) => {
+        expect(scoutName).toBe('scout-schema');
+        expect(resolvedBudget.modelOverride).toBe('gpt-5.4-mini');
+        return perScoutRuntime;
+      },
+    });
+
+    expect(defaultSpecs).toHaveLength(0);
+    expect(perScoutSpecs).toHaveLength(1);
+    expect(perScoutSpecs[0].modelOverride).toBe('gpt-5.4-mini');
+  });
+
   it('routes each child spawn through assembleSpawnContext (freshContext: true per scout)', async () => {
     const { fn: appendEvent } = makeFakeAppendEvent();
     const seenSpecs: AgentSpec[] = [];

--- a/core/agent-runtime/swarm.ts
+++ b/core/agent-runtime/swarm.ts
@@ -69,6 +69,11 @@ export interface DispatchWaveOptions {
   heartbeatIntervalMs?: number;
   /** Runtime — production: ClaudeCliRuntime; tests: stub. */
   runtime: AgentRuntime;
+  /** Optional runtime resolver for per-skill scout providers. */
+  resolveScoutRuntime?: (
+    resolvedBudget: ReturnType<ScoutBudgetResolver>,
+    scoutName: string,
+  ) => AgentRuntime;
   /** Persona attribution for scouts; reuses parent persona by convention. */
   personaId: string;
   /** Optional override (tests). Defaults to the real event store. */

--- a/core/db/migrations/0027_project_skill_settings_model.sql
+++ b/core/db/migrations/0027_project_skill_settings_model.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `project_skill_settings` ADD `model_tier` text;--> statement-breakpoint
+ALTER TABLE `project_skill_settings` ADD `model_provider` text;

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1778737181566,
       "tag": "0026_furry_umar",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1778817600000,
+      "tag": "0027_project_skill_settings_model",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/repositories/project-settings.ts
+++ b/core/db/repositories/project-settings.ts
@@ -24,6 +24,8 @@ export type SkillBudgetPatch = {
   maxTurns?: number | null;
   maxBudgetUsd?: number | null;
   timeoutMs?: number | null;
+  modelTier?: string | null;
+  modelProvider?: string | null;
 };
 
 export function readProjectSettings(projectId: string): ProjectSettingsRow | null {

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -290,6 +290,8 @@ export const projectSkillSettings = sqliteTable(
     maxTurns: integer('max_turns'),
     maxBudgetUsd: real('max_budget_usd'),
     timeoutMs: integer('timeout_ms'),
+    modelTier: text('model_tier'),
+    modelProvider: text('model_provider'),
     updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
     updatedBy: text('updated_by'),
   },

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -276,28 +276,6 @@ describe('runInvestigateWorkflow', () => {
     });
   });
 
-  describe('choosePlaywrightReproModelOverride', () => {
-    it('keeps the playwright-repro skill tier when investigator is configured for Codex', async () => {
-      const { choosePlaywrightReproModelOverride } = await import('./workflow.js');
-
-      const model = choosePlaywrightReproModelOverride({
-        resolvedBudget: {
-          budgets: { maxTurns: 60, maxBudgetUsd: 3, timeoutMs: 600_000 },
-          modelOverride: 'claude-sonnet-4-6',
-        },
-        investigatorRoleModel: {
-          tier: 'haiku',
-          provider: 'codex',
-          modelId: 'gpt-5.4-mini',
-          source: 'db',
-        },
-        forcedRuntimeProvider: null,
-      });
-
-      expect(model).toBe('gpt-5.4');
-    });
-  });
-
   describe('swarm dispatch — acceptance criterion 1', () => {
     it('calls dispatchWave exactly twice (Wave 1 then Wave 2)', async () => {
       const { runInvestigateWorkflow } = await import('./workflow.js');

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -233,62 +233,41 @@ beforeEach(() => {
 
 describe('runInvestigateWorkflow', () => {
   describe('chooseScoutModelOverride', () => {
-    it('hard-pins scout child agents to haiku even when investigator has a DB role override', async () => {
+    it('uses the per-skill scout model instead of investigator role rows', async () => {
       const { chooseScoutModelOverride } = await import('./workflow.js');
 
       const model = chooseScoutModelOverride({
-        skill: 'scout-schema',
         resolvedBudget: {
           budgets: { maxTurns: 20, maxBudgetUsd: 0.5, timeoutMs: 120_000 },
           modelOverride: 'claude-haiku-4-5-20251001',
         },
-        investigatorRoleModel: {
-          tier: 'sonnet',
-          provider: 'codex',
-          modelId: 'gpt-5.4',
-          source: 'db',
-        },
         forcedRuntimeProvider: null,
       });
 
-      expect(model).toBe('gpt-5.4-mini');
+      expect(model).toBe('claude-haiku-4-5-20251001');
     });
 
-    it('hard-pins wave2 child agents to haiku for the temporary scout rule', async () => {
+    it('uses the per-skill wave2 default instead of investigator role rows', async () => {
       const { chooseScoutModelOverride } = await import('./workflow.js');
 
       const model = chooseScoutModelOverride({
-        skill: 'wave2-risk-analyst',
         resolvedBudget: {
           budgets: { maxTurns: 30, maxBudgetUsd: 1.0, timeoutMs: 240_000 },
           modelOverride: 'claude-sonnet-4-6',
         },
-        investigatorRoleModel: {
-          tier: 'sonnet',
-          provider: 'codex',
-          modelId: 'gpt-5.4',
-          source: 'db',
-        },
         forcedRuntimeProvider: null,
       });
 
-      expect(model).toBe('gpt-5.4-mini');
+      expect(model).toBe('claude-sonnet-4-6');
     });
 
     it('coerces per-skill budget tier to a forced Codex runtime when no role override exists', async () => {
       const { chooseScoutModelOverride } = await import('./workflow.js');
 
       const model = chooseScoutModelOverride({
-        skill: 'playwright-repro',
         resolvedBudget: {
           budgets: { maxTurns: 20, maxBudgetUsd: 0.5, timeoutMs: 120_000 },
           modelOverride: 'claude-haiku-4-5-20251001',
-        },
-        investigatorRoleModel: {
-          tier: 'opus',
-          provider: 'claude',
-          modelId: 'claude-opus-4-7',
-          source: 'skill',
         },
         forcedRuntimeProvider: 'codex',
       });

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -222,6 +222,10 @@ export async function runInvestigateWorkflow(
         projectId,
         workItemId: workItem.id,
         runtime,
+        resolveScoutRuntime:
+          deps.runtime != null
+            ? undefined
+            : (resolved) => selectRuntime({ configRuntime, model: resolved.modelOverride }),
         personaId,
         maxScoutAgents: globalSettings.maxScoutAgents,
         projectBudgets: projectConfig?.budgets,
@@ -298,6 +302,10 @@ export async function runInvestigateWorkflow(
         projectId,
         workItemId: workItem.id,
         runtime,
+        resolveScoutRuntime:
+          deps.runtime != null
+            ? undefined
+            : (resolved) => selectRuntime({ configRuntime, model: resolved.modelOverride }),
         personaId,
         maxScoutAgents: globalSettings.maxScoutAgents,
         projectBudgets: projectConfig?.budgets,
@@ -387,7 +395,14 @@ export async function runInvestigateWorkflow(
           role: 'investigator',
         });
         const playwrightModelOverride = playwrightBudget.modelOverride;
-        const playwrightResult = await runtime.run({
+        const playwrightRuntime =
+          deps.runtime ??
+          selectRuntime({
+            configRuntime,
+            model: playwrightModelOverride,
+            skillProvider: forcedRuntimeProvider ?? playwrightBudget.provider,
+          });
+        const playwrightResult = await playwrightRuntime.run({
           runId: playwrightRunId,
           role: 'investigator',
           skill: 'playwright-repro',

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -9,16 +9,12 @@ import {
   tierOf,
 } from '@goose-hub/core/agent-runtime/models.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
-import {
-  resolveBudgetsForProject,
-  resolveGlobalSettingsForProject,
-  resolveRoleModelForProject,
-} from '@goose-hub/core/agent-runtime/resolve-for-project.js';
+import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
-import type { SelectModelForRoleResult } from '@goose-hub/core/agent-runtime/select-model-for-role.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import { type ScoutBudgetResolver, dispatchWave } from '@goose-hub/core/agent-runtime/swarm.js';
 import { getUseInvestigationSwarm } from '@goose-hub/core/db/repositories/project-settings.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
@@ -41,26 +37,10 @@ import { WAVE_1_SCOUTS, selectWave2Scouts } from './wave2-selection.js';
 type InvestigateOutput = z.infer<typeof InvestigateSchema>;
 
 export function chooseScoutModelOverride(input: {
-  skill: string;
   resolvedBudget: ResolvedBudget;
-  investigatorRoleModel: SelectModelForRoleResult;
   forcedRuntimeProvider: ModelProvider | null;
 }): string {
-  const { skill, resolvedBudget, investigatorRoleModel, forcedRuntimeProvider } = input;
-
-  if (skill.startsWith('scout-') || skill.startsWith('wave2-')) {
-    return defaultModelForTierAndProvider(
-      'haiku',
-      forcedRuntimeProvider ?? investigatorRoleModel.provider,
-    );
-  }
-
-  if (investigatorRoleModel.source === 'db' || investigatorRoleModel.source === 'config') {
-    return defaultModelForTierAndProvider(
-      investigatorRoleModel.tier,
-      forcedRuntimeProvider ?? investigatorRoleModel.provider,
-    );
-  }
+  const { resolvedBudget, forcedRuntimeProvider } = input;
 
   if (forcedRuntimeProvider != null) {
     return defaultModelForTierAndProvider(
@@ -70,19 +50,6 @@ export function chooseScoutModelOverride(input: {
   }
 
   return resolvedBudget.modelOverride;
-}
-
-export function choosePlaywrightReproModelOverride(input: {
-  resolvedBudget: ResolvedBudget;
-  investigatorRoleModel: SelectModelForRoleResult;
-  forcedRuntimeProvider: ModelProvider | null;
-}): string {
-  const provider =
-    input.forcedRuntimeProvider ??
-    (input.investigatorRoleModel.source === 'db' || input.investigatorRoleModel.source === 'config'
-      ? input.investigatorRoleModel.provider
-      : 'claude');
-  return defaultModelForTierAndProvider(tierOf(input.resolvedBudget.modelOverride), provider);
 }
 
 function buildSchemaScoutFocus(workItem: { title: string; body: string }): string {
@@ -151,37 +118,23 @@ export async function runInvestigateWorkflow(
     settingsProjectId,
     projectConfig?.investigationSwarm?.enabled ?? true,
   );
-  const investigateBudget = resolveBudgetsForProject(
-    'investigate',
-    projectConfig?.budgets,
-    projectId,
-  );
-  const investigateRoleModel = resolveRoleModelForProject({
-    role: 'investigator',
-    projectId,
-    configRoleModel: projectConfig?.agentConfig?.rolesModels?.investigator,
-    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
-    skill: 'investigate',
-  });
   const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
   const forcedRuntimeProvider: ModelProvider | null =
     configRuntime === 'codex-cli' ? 'codex' : configRuntime === 'claude-cli' ? 'claude' : null;
-  const configuredInvestigatorModelOverride =
-    investigateRoleModel.source === 'db' || investigateRoleModel.source === 'config'
-      ? investigateRoleModel.modelId
-      : investigateBudget.modelOverride;
-  const investigatorModelOverride =
-    forcedRuntimeProvider != null
-      ? defaultModelForTierAndProvider(
-          tierOf(configuredInvestigatorModelOverride),
-          forcedRuntimeProvider,
-        )
-      : configuredInvestigatorModelOverride;
+  const investigateBudget = resolveSkillRuntimeForProject({
+    skill: 'investigate',
+    projectBudgets: projectConfig?.budgets,
+    projectId,
+    configRuntime,
+    role: 'investigator',
+  });
+  const investigatorModelOverride = investigateBudget.modelOverride;
   const runtime =
     deps.runtime ??
     selectRuntime({
       configRuntime,
       model: investigatorModelOverride,
+      skillProvider: forcedRuntimeProvider ?? investigateBudget.provider,
     });
   const worktreePath = createWtFn(targetRepo, runId);
 
@@ -209,13 +162,17 @@ export async function runInvestigateWorkflow(
     projectBudgets,
     currentProjectId,
   ) => {
-    const resolved = resolveBudgetsForProject(skill, projectBudgets, currentProjectId);
+    const resolved = resolveSkillRuntimeForProject({
+      skill,
+      projectBudgets,
+      projectId: currentProjectId,
+      configRuntime,
+      role: 'investigator',
+    });
     return {
       ...resolved,
       modelOverride: chooseScoutModelOverride({
-        skill,
         resolvedBudget: resolved,
-        investigatorRoleModel: investigateRoleModel,
         forcedRuntimeProvider,
       }),
     };
@@ -394,7 +351,7 @@ export async function runInvestigateWorkflow(
       investigationSwarmEnabled && allScoutReports != null
         ? defaultModelForTierAndProvider(
             'sonnet',
-            forcedRuntimeProvider ?? investigateRoleModel.provider,
+            forcedRuntimeProvider ?? investigateBudget.provider,
           )
         : investigatorModelOverride;
     const synthResult = await invokeSkill({
@@ -422,16 +379,14 @@ export async function runInvestigateWorkflow(
       const playwrightRunId = crypto.randomUUID();
 
       try {
-        const playwrightBudget = resolveBudgetsForProject(
-          'playwright-repro',
-          projectConfig?.budgets,
+        const playwrightBudget = resolveSkillRuntimeForProject({
+          skill: 'playwright-repro',
+          projectBudgets: projectConfig?.budgets,
           projectId,
-        );
-        const playwrightModelOverride = choosePlaywrightReproModelOverride({
-          resolvedBudget: playwrightBudget,
-          investigatorRoleModel: investigateRoleModel,
-          forcedRuntimeProvider,
+          configRuntime,
+          role: 'investigator',
         });
+        const playwrightModelOverride = playwrightBudget.modelOverride;
         const playwrightResult = await runtime.run({
           runId: playwrightRunId,
           role: 'investigator',


### PR DESCRIPTION
## Summary
- port of #801 onto claude/milestone-17-setup-BRII1
- add per-skill model tier/provider columns and a shared skill runtime resolver
- route invokeSkill and project execution through per-skill runtime resolution instead of role model rows
- expose tier/provider and resolved primary/fallback/advisor values in the settings API
- update investigate scout/wave/playwright model selection to use skill runtime settings and matching runtime providers

## Port notes
- renumbered migration to 0027 because claude/milestone-17-setup-BRII1 already has 0026_furry_umar
- resolved investigate workflow conflict around the old playwright role-model helper by keeping the per-skill resolver/runtime path

## Verification
- pnpm run lint
- pnpm run typecheck
- pnpm test core/agent-runtime/skill-runtime-resolver.test.ts core/agent-runtime/swarm.test.ts slices/investigate/slice.test.ts core/agent-runtime/invoke-skill.test.ts --run