### PR TITLE
fix: address codex review comments from PR #802 (per-skill runtime resolver)

### DIFF
--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -97,7 +97,7 @@ router.get('/:slug/settings', async (c) => {
       maxBudgetUsd: budget.maxBudgetUsd,
       timeoutMs: budget.timeoutMs,
       modelTier: budget.modelTier,
-      modelProvider: 'claude',
+      modelProvider: budget.provider ?? 'claude',
     };
   }
 
@@ -120,6 +120,7 @@ router.get('/:slug/settings', async (c) => {
       configRuntime: project.agentConfig.runtime,
       role: roleForSkill(skill),
       allowHoldoutOverride: project.agentConfig.allowHoldoutOverride,
+      skillProvider: SKILL_BUDGETS[skill]?.provider,
     });
     resolvedSkillRuntimes[skill] = {
       source: resolved.source,

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -1,4 +1,4 @@
-import type { ModelTier } from '../types.js';
+import type { ModelProvider, ModelTier } from '../types.js';
 import type { AgentBudgets } from './interface.js';
 import { defaultModelForTierAndProvider } from './models.js';
 
@@ -7,6 +7,8 @@ export interface SkillBudget {
   maxBudgetUsd: number;
   timeoutMs: number;
   modelTier: ModelTier;
+  /** Default provider for this skill. Omit for Claude (the default). */
+  provider?: ModelProvider;
   /**
    * Escalation policy for schema-validation failures. When present,
    * `runWithEscalation` may retry once at the escalated tier with the
@@ -194,6 +196,7 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     maxBudgetUsd: 2.0,
     timeoutMs: 180_000,
     modelTier: 'sonnet',
+    provider: 'codex',
   },
   // M19.12 — Developer response to dev-review findings. One revision turn
   // in the integration worktree; sonnet-tier matches dev-review.
@@ -220,6 +223,8 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     timeoutMs: 480_000,
     modelTier: 'opus',
   },
+  // Test / eval harness skill — not used in production workflows.
+  'echo-test': { maxTurns: 5, maxBudgetUsd: 0.1, timeoutMs: 30_000, modelTier: 'sonnet' },
 };
 
 export interface ResolvedBudget {

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -6,6 +6,7 @@ import type { ProjectConfig } from '../types.js';
 import type { ResolvedBudget } from './budgets.js';
 import type { AgentResult, AgentRuntime, SkillConfig } from './interface.js';
 import { readPromptWithContext } from './read-prompt.js';
+import { resolveRoleBudgetOverrideForProject } from './resolve-for-project.js';
 import { toJsonSchema } from './schema-bridge.js';
 import { selectPersona } from './select-persona.js';
 import { selectRuntime } from './select-runtime.js';
@@ -120,6 +121,19 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
   });
   const modelOverride = resolved.modelOverride;
 
+  // 5c. Apply per-role budget overrides (maxTurns / timeoutMs) from DB on top of
+  //     the per-skill runtime resolution. null means "no override — keep skill default".
+  const roleBudgetOverride = resolveRoleBudgetOverrideForProject(
+    projectId,
+    role,
+    projectConfig?.agentConfig?.allowHoldoutOverride,
+  );
+  const effectiveBudgets = {
+    ...resolved.budgets,
+    ...(roleBudgetOverride.maxTurns != null && { maxTurns: roleBudgetOverride.maxTurns }),
+    ...(roleBudgetOverride.timeoutMs != null && { timeoutMs: roleBudgetOverride.timeoutMs }),
+  };
+
   // 7. Select runtime — runtimeOverride short-circuits for tests and bespoke callers
   const runtime =
     overrides?.runtimeOverride ??
@@ -152,7 +166,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     freshContext: overrides?.freshContextOverride ?? skillConfig.freshContext,
     toolBundles: skillConfig.toolBundles,
     toolExtras: [],
-    budgets: resolved.budgets,
+    budgets: effectiveBudgets,
     personaId,
     workItemId,
     modelOverride,

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -64,13 +64,6 @@ function displayModel(tier: ModelTier, provider: ModelProvider): ResolvedDisplay
   return { tier, provider, modelId: defaultModelForTierAndProvider(tier, provider) };
 }
 
-function fallbackBudget(tier: ModelTier, provider: ModelProvider): ResolvedBudget {
-  return {
-    budgets: { maxTurns: 25, maxBudgetUsd: 1, timeoutMs: 120_000 },
-    modelOverride: defaultModelForTierAndProvider(tier, provider),
-  };
-}
-
 function sourceForSkill(
   skill: string,
   dbOverride?: SkillRuntimeDbOverride | null,
@@ -146,24 +139,13 @@ export function resolveSkillRuntime(input: {
     ? input.projectBudgets
     : withoutConfigModelTier(input.projectBudgets);
   const providerConfigRuntime = input.ignoreProviderOverride ? 'auto' : configRuntime;
-  let resolvedBudget: ResolvedBudget;
-  try {
-    resolvedBudget = resolveBudgets(
-      input.skill,
-      input.projectBudgets,
-      dbOverride ?? undefined,
-      input.dbPerWorkflowMaxUsd,
-      input.dbPerAgentMaxUsd,
-    );
-  } catch {
-    resolvedBudget = fallbackBudget(
-      input.fallbackTier ?? 'sonnet',
-      forcedProviderFromRuntime(providerConfigRuntime) ??
-        (!input.ignoreProviderOverride && isModelProvider(dbOverride?.modelProvider)
-          ? dbOverride.modelProvider
-          : (input.skillProvider ?? input.fallbackProvider ?? 'claude')),
-    );
-  }
+  const resolvedBudget: ResolvedBudget = resolveBudgets(
+    input.skill,
+    input.projectBudgets,
+    dbOverride ?? undefined,
+    input.dbPerWorkflowMaxUsd,
+    input.dbPerAgentMaxUsd,
+  );
 
   if (input.callerModelOverride != null) {
     const tier = tierOf(input.callerModelOverride);
@@ -243,6 +225,7 @@ export function deriveSkillRuntimeResponse(input: {
   configRuntime?: ConfigRuntime;
   role?: string;
   allowHoldoutOverride?: boolean;
+  skillProvider?: ModelProvider;
 }): ResolvedSkillRuntime {
   return resolveSkillRuntime({
     skill: input.skill,
@@ -251,5 +234,6 @@ export function deriveSkillRuntimeResponse(input: {
     configRuntime: input.configRuntime,
     role: input.role,
     allowHoldoutOverride: input.allowHoldoutOverride,
+    skillProvider: input.skillProvider,
   });
 }


### PR DESCRIPTION
## Summary

Addresses the 4 unresolved Codex review comments on #802.

- **P1 — Preserve role max-turn/timeout overrides in invokeSkill**: Restores the `resolveRoleBudgetOverrideForProject` call in `invokeSkill` to apply per-role `maxTurns`/`timeoutMs` DB overrides on top of the per-skill runtime resolution. Projects with role-level budget caps in `project_model_settings` now have those limits honoured again.

- **P2 — Use actual default provider in `skillDefaults`**: Adds an optional `provider` field to `SkillBudget` and sets `provider: 'codex'` for `dev-review`. The settings endpoint now uses `budget.provider ?? 'claude'` instead of a hardcoded `'claude'` for all skills.

- **P2 — Fail fast on budget errors**: Removes the silent catch block in `resolveSkillRuntime` that substituted a generic fallback budget on any `resolveBudgets` failure. Misconfigured or unregistered skills now surface an actionable error rather than silently running with 25-turn/$1 defaults. `echo-test` is registered in `SKILL_BUDGETS` (it was relying on the now-removed fallback).

- **P2 — Pass skill provider hints to `deriveSkillRuntimeResponse`**: Adds a `skillProvider` parameter to `deriveSkillRuntimeResponse` and passes `SKILL_BUDGETS[skill]?.provider` from the settings route, so `effectiveProvider` in `/projects/:slug/settings` is correct for Codex-pinned skills like `dev-review`.

## Verification

- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm test core/agent-runtime/skill-runtime-resolver.test.ts core/agent-runtime/invoke-skill.test.ts core/agent-runtime/swarm.test.ts slices/investigate/slice.test.ts --run` — 79/79 passed

https://claude.ai/code/session_01UrKqFmJ9C5rapxzyrtjfGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKqFmJ9C5rapxzyrtjfGe)_