### PR TITLE
fix: address codex review comments from PR #803

### DIFF
--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -142,9 +142,6 @@ router.get('/:slug/settings', async (c) => {
       globalRow.maxScoutAgents,
       globalRow.maxRetries,
       globalRow.perBashCommandMaxSeconds,
-      globalRow.qaE2eMode,
-      globalRow.playwrightReproEnabled,
-      globalRow.evidencePostEnabled,
     ].some((value) => value != null)
       ? {
           perWorkflowMaxUsd: globalRow.perWorkflowMaxUsd,
@@ -155,11 +152,17 @@ router.get('/:slug/settings', async (c) => {
           maxScoutAgents: globalRow.maxScoutAgents,
           maxRetries: globalRow.maxRetries,
           perBashCommandMaxSeconds: globalRow.perBashCommandMaxSeconds,
-          qaE2eMode: globalRow.qaE2eMode,
-          playwrightReproEnabled: globalRow.playwrightReproEnabled,
-          evidencePostEnabled: globalRow.evidencePostEnabled,
           updatedAt: globalRow.updatedAt,
           updatedBy: globalRow.updatedBy,
+        }
+      : null;
+
+  const dbPipelineFlags =
+    globalRow != null
+      ? {
+          qaE2eMode: globalRow.qaE2eMode ?? null,
+          playwrightReproEnabled: globalRow.playwrightReproEnabled ?? null,
+          evidencePostEnabled: globalRow.evidencePostEnabled ?? null,
         }
       : null;
 
@@ -167,6 +170,7 @@ router.get('/:slug/settings', async (c) => {
     projectId: project.id,
     configBudgets: project.budgets,
     dbGlobalOverrides,
+    dbPipelineFlags,
     dbSkillOverrides: skillSettings,
     registeredSkills: Object.keys(SKILL_BUDGETS),
     skillDefaults,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -363,6 +363,11 @@ export interface ProjectSettingsDto {
     updatedAt: string;
     updatedBy: string | null;
   } | null;
+  dbPipelineFlags: {
+    qaE2eMode: string | null;
+    playwrightReproEnabled: number | null;
+    evidencePostEnabled: number | null;
+  } | null;
   dbSkillOverrides: Record<
     string,
     {

--- a/slices/fix-issue/pr-helpers.ts
+++ b/slices/fix-issue/pr-helpers.ts
@@ -44,8 +44,9 @@ export interface RunEvidencePostInput {
  */
 export async function runEvidencePost(input: RunEvidencePostInput): Promise<void> {
   const projectConfig = await getProjectBySlug(input.projectId);
+  const settingsProjectId = projectConfig?.id ?? input.projectId;
   const evidencePostEnabled = getEvidencePostEnabled(
-    input.projectId,
+    settingsProjectId,
     projectConfig?.evidencePostEnabled ?? true,
   );
   if (!evidencePostEnabled) {

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -115,11 +115,11 @@ export async function runInvestigateWorkflow(
   const runId = crypto.randomUUID();
   const { personaId } = selectPersona(projectId, 'investigator');
   const projectConfig = await getProjectBySlug(projectId);
+  const settingsProjectId = projectConfig?.id ?? projectId;
   const playwrightReproEnabled = getPlaywrightReproEnabled(
-    projectId,
+    settingsProjectId,
     projectConfig?.playwrightReproEnabled ?? true,
   );
-  const settingsProjectId = projectConfig?.id ?? projectId;
   const globalSettings = resolveGlobalSettingsForProject(settingsProjectId, projectConfig?.budgets);
   const investigationSwarmEnabled = getUseInvestigationSwarm(
     settingsProjectId,

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -6,7 +6,10 @@ import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconc
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
-import { getQaE2eMode } from '@goose-hub/core/db/repositories/project-settings.js';
+import {
+  getQaE2eMode,
+  type QaE2eMode,
+} from '@goose-hub/core/db/repositories/project-settings.js';
 import { getEngineeringSpec as defaultGetEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
@@ -108,7 +111,10 @@ export async function runQaWorkflow(
   const workspaceDir = prHints.worktreePath;
   const prDiff = getPrDiff(workItem, workspaceDir, prHints.baseBranch);
   const regressionPolicy: RegressionPolicy = projectConfig?.regressionPolicy ?? 'escalate';
-  const qaE2eMode = getQaE2eMode(projectSlug, projectConfig?.qaE2eMode ?? 'off');
+  const settingsProjectId = projectConfig?.id ?? projectSlug;
+  const e2eConfigDefault: QaE2eMode =
+    projectConfig?.qaE2eMode ?? (projectConfig?.stack?.e2eCommand != null ? 'ui-changed' : 'off');
+  const qaE2eMode = getQaE2eMode(settingsProjectId, e2eConfigDefault);
 
   // Snapshot prior events BEFORE this run's outcome is appended.
   // shouldEscalateQa uses this count to decide: Nth failure = N-1 priors.


### PR DESCRIPTION
Closes codex review threads on #803.

## Changes

**P1 — `slices/qa/workflow.ts`**
- `qaE2eMode` fallback changed from `'off'` to `'ui-changed'` when `stack.e2eCommand` is present. Projects that have an e2e command but no explicit `qaE2eMode` no longer silently drop browser coverage after the PR #803 change.
- `getQaE2eMode` now keyed by `settingsProjectId` (config `id`) rather than `projectSlug`.

**P2 — `slices/investigate/workflow.ts`**
- `settingsProjectId` derivation moved before `getPlaywrightReproEnabled` so the DB lookup uses the project config `id` rather than the slug. Fixes silent DB override miss when slug ≠ id.

**P2 — `slices/fix-issue/pr-helpers.ts`**
- `getEvidencePostEnabled` now keyed by `settingsProjectId` (config `id`). Same slug/id alignment fix.

**P2 — `apps/server/src/domains/project-settings/router.ts`**
- `dbGlobalOverrides` null-check now only considers budget columns. `qaE2eMode`, `playwrightReproEnabled`, `evidencePostEnabled` are moved to a new `dbPipelineFlags` response field so the budget panel reset sentinel (`dbGlobalOverrides != null`) is not permanently stuck when only pipeline flags are set.

**`apps/web/src/lib/types.ts`**
- Added `dbPipelineFlags` to `ProjectSettingsDto` to match the new router shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuJcG3stx81XvTJjK6HS1r)_