### PR TITLE
M7.XX: Goose hub header fix

### DIFF
--- a/apps/web/e2e/issue-808.spec.ts
+++ b/apps/web/e2e/issue-808.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test('GooseHUB header is shown in the app shell', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('GooseHUB')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-808/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher" />,
+}));
+
+afterEach(cleanup);
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  });
+  localStorage.setItem('sidebar-collapsed', 'false');
+});
+
+describe('Sidebar', () => {
+  it('renders GooseHUB in the expanded header', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('GooseHUB')).toBeTruthy();
+  });
+
+  it('does not render the old Goose Hub spelling', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
+  });
+
+  it('sidebar header does not read "Goose Hub"', () => {
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub header fix

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed the visible sidebar brand label to GooseHUB
- `apps/web/src/components/chrome/slice.test.ts` — Updated the chrome slice contract to expect GooseHUB and reject the old Goose Hub spelling
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Added rendering coverage for the expanded sidebar header and the stale spelling regression
- `apps/web/e2e/issue-808.spec.ts` — Added Playwright evidence for the visible GooseHUB header in the app shell

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/e2e/issue-808.spec.ts` (1 cases)

Closes #808
