### PR TITLE
M7.XX: Goose hub header fix 18th may

### DIFF
--- a/apps/web/e2e/issue-811.spec.ts
+++ b/apps/web/e2e/issue-811.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar header shows GooseHUB', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.route('**/api/projects', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ projects: [] }),
+    });
+  });
+
+  await page.route('**/api/projects/configs', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configs: [] }),
+    });
+  });
+
+  await page.goto('/settings');
+
+  await expect(page.getByText('GooseHUB')).toBeVisible();
+  await page.screenshot({ path: 'evidence/issue-811/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher" />,
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  const localStorageMock = {
+    getItem: vi.fn(() => 'false'),
+    setItem: vi.fn(),
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: localStorageMock,
+  });
+});
+
+describe('Sidebar', () => {
+  it('renders the GooseHUB brand in the expanded header', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('GooseHUB')).toBeTruthy();
+  });
+
+  it('does not render the old Goose Hub spacing in the expanded header', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Goose Hub')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,8 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub header fix 18th may

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed the visible sidebar brand label to GooseHUB.
- `apps/web/src/components/chrome/slice.test.ts` — Updated the slice assertion to match the new branding string.
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Added jsdom coverage for the rendered sidebar header and a negative check for the old spelling.
- `apps/web/e2e/issue-811.spec.ts` — Added the Playwright evidence spec that proves GooseHUB renders in the browser.

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (6 cases)
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/e2e/issue-811.spec.ts` (1 cases)

Closes #811
