### PR TITLE
M7.XX: Goose hub logo fix

### DIFF
--- a/apps/web/e2e/issue-813.spec.ts
+++ b/apps/web/e2e/issue-813.spec.ts
@@ -1,0 +1,17 @@
+import { mkdir } from 'node:fs/promises';
+import { expect, test } from '@playwright/test';
+
+test('Goose hub header branding reads GooseHUB', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('GooseHUB')).toBeVisible();
+  await expect(page.getByText('Goose Hub')).toHaveCount(0);
+
+  await mkdir('evidence/issue-813', { recursive: true });
+  await page.screenshot({ path: 'evidence/issue-813/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GooseHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,13 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GooseHUB"', () => {
+    expect(sidebarSource).toContain('GooseHUB');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
+  it('sidebar header does not read "Goose Hub"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
   });
 });
 


### PR DESCRIPTION
## Summary

Goose hub logo fix

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Update the sidebar brand label from Goose Hub to GooseHUB.
- `apps/web/src/components/chrome/slice.test.ts` — Update the regression assertions to match the new branding and guard against the old copy.
- `apps/web/e2e/issue-813.spec.ts` — Add browser evidence for the expanded sidebar brand and screenshot.

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/e2e/issue-813.spec.ts` (1 cases)

Closes #813
