### PR TITLE
M17: skill runtime settings UI

### DIFF
--- a/apps/server/src/domains/inbox/enhance.ts
+++ b/apps/server/src/domains/inbox/enhance.ts
@@ -1,11 +1,8 @@
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
-import {
-  resolveBudgetsForProject,
-  resolveRoleModelForProject,
-} from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { BugEnhanceOutputSchema } from '@goose-hub/skills/bug-enhance/schema.js';
@@ -26,21 +23,18 @@ export async function runBugEnhance(
   body: string,
 ): Promise<string | null> {
   const projectConfig = await getProjectBySlug(projectId);
-  const bugEnhanceBudget = resolveBudgetsForProject('bug-enhance', undefined, projectId);
-  const bugEnhanceRoleModel = resolveRoleModelForProject({
-    role: 'triager',
-    projectId,
-    configRoleModel: projectConfig?.agentConfig?.rolesModels?.triager,
-    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+  const bugEnhanceRuntime = resolveSkillRuntimeForProject({
     skill: 'bug-enhance',
+    projectBudgets: projectConfig?.budgets,
+    projectId,
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    role: 'triager',
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
   });
-  const bugEnhanceModelOverride =
-    bugEnhanceRoleModel.source === 'db' || bugEnhanceRoleModel.source === 'config'
-      ? bugEnhanceRoleModel.modelId
-      : bugEnhanceBudget.modelOverride;
   const runtime = selectRuntime({
     configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-    model: bugEnhanceModelOverride,
+    model: bugEnhanceRuntime.modelOverride,
+    skillProvider: bugEnhanceRuntime.provider,
   });
   const runId = crypto.randomUUID();
   const { personaId } = selectPersona(projectId, 'triager');
@@ -64,8 +58,8 @@ export async function runBugEnhance(
       freshContext: false,
       toolBundles: [],
       toolExtras: [],
-      ...bugEnhanceBudget,
-      modelOverride: bugEnhanceModelOverride,
+      budgets: bugEnhanceRuntime.budgets,
+      modelOverride: bugEnhanceRuntime.modelOverride,
       personaId,
       outputJsonSchema: jsonSchema,
       appendSystemPrompt: prompt,

--- a/apps/server/src/domains/project-settings/router.test.ts
+++ b/apps/server/src/domains/project-settings/router.test.ts
@@ -1,0 +1,95 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockDeleteProjectSkillSetting,
+  mockGetProject,
+  mockReadProjectSettings,
+  mockReadProjectSkillSettings,
+  mockResetAllProjectBudgets,
+  mockWriteProjectSettings,
+  mockWriteProjectSkillSetting,
+} = vi.hoisted(() => ({
+  mockDeleteProjectSkillSetting: vi.fn(),
+  mockGetProject: vi.fn(),
+  mockReadProjectSettings: vi.fn(),
+  mockReadProjectSkillSettings: vi.fn(),
+  mockResetAllProjectBudgets: vi.fn(),
+  mockWriteProjectSettings: vi.fn(),
+  mockWriteProjectSkillSetting: vi.fn(),
+}));
+
+vi.mock('#shared/projects.js', () => ({
+  getProject: mockGetProject,
+}));
+
+vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
+  deleteProjectSkillSetting: mockDeleteProjectSkillSetting,
+  readProjectSettings: mockReadProjectSettings,
+  readProjectSkillSettings: mockReadProjectSkillSettings,
+  resetAllProjectBudgets: mockResetAllProjectBudgets,
+  writeProjectSettings: mockWriteProjectSettings,
+  writeProjectSkillSetting: mockWriteProjectSkillSetting,
+}));
+
+import { projectSettingsRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/projects', projectSettingsRouter);
+}
+
+function project() {
+  return {
+    id: 'goose-hub-self',
+    budgets: {},
+    agentConfig: {
+      runtime: 'auto',
+      allowHoldoutOverride: false,
+      rolesModels: {},
+    },
+  };
+}
+
+describe('project settings router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProject.mockResolvedValue(project());
+    mockReadProjectSettings.mockReturnValue(null);
+    mockReadProjectSkillSettings.mockReturnValue(new Map());
+  });
+
+  it('returns Codex provider defaults for provider-pinned skills', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      skillDefaults: Record<string, { modelProvider: string }>;
+      resolvedSkillRuntimes: Record<
+        string,
+        { effectiveProvider: string; resolvedPrimary: { modelId: string } }
+      >;
+    };
+
+    expect(body.skillDefaults['dev-review'].modelProvider).toBe('codex');
+    expect(body.resolvedSkillRuntimes['dev-review'].effectiveProvider).toBe('codex');
+    expect(body.resolvedSkillRuntimes['dev-review'].resolvedPrimary.modelId).toBe('gpt-5.4');
+  });
+
+  it('writes tier/provider patches to project_skill_settings model columns', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings/skills/repo-match', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modelTier: 'sonnet', provider: 'codex' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteProjectSkillSetting).toHaveBeenCalledWith(
+      'goose-hub-self',
+      'repo-match',
+      { modelTier: 'sonnet', modelProvider: 'codex' },
+      'ui',
+    );
+  });
+});

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -1,9 +1,8 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { SKILL_BUDGETS } from '@goose-hub/core/agent-runtime/budgets.js';
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
 import { deriveSkillRuntimeResponse } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
-import {
-  type ProjectModelSettingsRow,
-  readProjectModelSettings,
-} from '@goose-hub/core/db/repositories/project-model-settings.js';
 import {
   deleteProjectSkillSetting,
   readProjectSettings,
@@ -12,7 +11,8 @@ import {
   writeProjectSettings,
   writeProjectSkillSetting,
 } from '@goose-hub/core/db/repositories/project-settings.js';
-import type { Role } from '@goose-hub/core/types.js';
+import type { ModelProvider, ModelTier, Role } from '@goose-hub/core/types.js';
+import { skillsRoot } from '@goose-hub/skills';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { parseBody } from '#shared/middleware.js';
@@ -76,6 +76,27 @@ function roleForSkill(skill: string): Role | undefined {
   return undefined;
 }
 
+async function loadSkillRuntimeHint(skill: string): Promise<{
+  role?: Role;
+  modelTier?: ModelTier;
+  provider?: ModelProvider;
+}> {
+  try {
+    const configPath = join(skillsRoot, skill, 'skill.config.ts');
+    // Cross-package boundary at runtime path: skill configs live in @goose-hub/skills.
+    const mod = (await import(pathToFileURL(configPath).href)) as { default?: unknown };
+    if (mod.default == null || typeof mod.default !== 'object') return {};
+    const config = mod.default as Partial<SkillConfig>;
+    return {
+      role: config.role,
+      modelTier: config.modelPin,
+      provider: config.provider,
+    };
+  } catch {
+    return {};
+  }
+}
+
 /** GET /projects/:slug/settings — merged view of config + DB overrides */
 router.get('/:slug/settings', async (c) => {
   const slug = c.req.param('slug');
@@ -84,7 +105,10 @@ router.get('/:slug/settings', async (c) => {
 
   const globalRow = readProjectSettings(project.id);
   const skillRows = readProjectSkillSettings(project.id);
-  const roleRows = readProjectModelSettings(project.id);
+  const skillRuntimeHints = new Map<string, Awaited<ReturnType<typeof loadSkillRuntimeHint>>>();
+  for (const skill of Object.keys(SKILL_BUDGETS)) {
+    skillRuntimeHints.set(skill, await loadSkillRuntimeHint(skill));
+  }
 
   const skillSettings: Record<
     string,
@@ -122,12 +146,13 @@ router.get('/:slug/settings', async (c) => {
     }
   > = {};
   for (const [skill, budget] of Object.entries(SKILL_BUDGETS)) {
+    const hint = skillRuntimeHints.get(skill);
     skillDefaults[skill] = {
       maxTurns: budget.maxTurns,
       maxBudgetUsd: budget.maxBudgetUsd,
       timeoutMs: budget.timeoutMs,
       modelTier: budget.modelTier,
-      modelProvider: budget.provider ?? 'claude',
+      modelProvider: hint?.provider ?? budget.provider ?? 'claude',
     };
   }
 
@@ -143,17 +168,18 @@ router.get('/:slug/settings', async (c) => {
     }
   > = {};
   for (const skill of Object.keys(SKILL_BUDGETS)) {
-    const role = roleForSkill(skill);
+    const hint = skillRuntimeHints.get(skill);
+    const role = hint?.role ?? roleForSkill(skill);
     const resolved = deriveSkillRuntimeResponse({
       skill,
       row: skillRows.get(skill),
       projectBudgets: project.budgets,
       configRuntime: project.agentConfig.runtime,
       role,
-      configRoleModel: role != null ? project.agentConfig.rolesModels?.[role] : undefined,
-      dbRoleModel: role != null ? (roleRows.get(role) as ProjectModelSettingsRow | null) : null,
       allowHoldoutOverride: project.agentConfig.allowHoldoutOverride,
-      skillProvider: SKILL_BUDGETS[skill]?.provider,
+      skillProvider: hint?.provider ?? SKILL_BUDGETS[skill]?.provider,
+      fallbackTier: hint?.modelTier,
+      fallbackProvider: hint?.provider,
     });
     resolvedSkillRuntimes[skill] = {
       source: resolved.source,

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -1,14 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
-import {
-  resolveBudgetsForProject,
-  resolveGlobalSettingsForProject,
-  resolveRoleModelForProject,
-} from '@goose-hub/core/agent-runtime/resolve-for-project.js';
+import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
@@ -112,21 +109,18 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
     const { personaId: triagerPersonaId } = selectPersona(projectId, 'triager');
 
     // Run triage skill
-    const triageBudget = resolveBudgetsForProject('triage', projectConfig?.budgets, projectId);
-    const triageRoleModel = resolveRoleModelForProject({
-      role: 'triager',
-      projectId,
-      configRoleModel: projectConfig?.agentConfig?.rolesModels?.triager,
-      allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+    const triageBudget = resolveSkillRuntimeForProject({
       skill: 'triage',
+      projectBudgets: projectConfig?.budgets,
+      projectId,
+      configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+      role: 'triager',
+      allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
     });
-    const triageModelOverride =
-      triageRoleModel.source === 'db' || triageRoleModel.source === 'config'
-        ? triageRoleModel.modelId
-        : triageBudget.modelOverride;
     const triageRuntime = selectRuntime({
       configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-      model: triageModelOverride,
+      model: triageBudget.modelOverride,
+      skillProvider: triageBudget.provider,
     });
     logger.info('triage-batch running triage skill', { slug, workItemId, runId });
     const triageResult = await triageRuntime.run({
@@ -142,8 +136,8 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       freshContext: false,
       toolBundles: [],
       toolExtras: [],
-      ...triageBudget,
-      modelOverride: triageModelOverride,
+      budgets: triageBudget.budgets,
+      modelOverride: triageBudget.modelOverride,
       personaId: triagerPersonaId,
       outputJsonSchema: triageJsonSchema,
       appendSystemPrompt: triagePrompt,
@@ -198,25 +192,18 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
     // Run repo-match skill
     const repoMatchRunId = crypto.randomUUID();
     const { personaId: researcherPersonaId } = selectPersona(projectId, 'researcher');
-    const repoMatchBudget = resolveBudgetsForProject(
-      'repo-match',
-      projectConfig?.budgets,
-      projectId,
-    );
-    const repoMatchRoleModel = resolveRoleModelForProject({
-      role: 'triager',
-      projectId,
-      configRoleModel: projectConfig?.agentConfig?.rolesModels?.triager,
-      allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+    const repoMatchBudget = resolveSkillRuntimeForProject({
       skill: 'repo-match',
+      projectBudgets: projectConfig?.budgets,
+      projectId,
+      configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+      role: 'researcher',
+      allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
     });
-    const repoMatchModelOverride =
-      repoMatchRoleModel.source === 'db' || repoMatchRoleModel.source === 'config'
-        ? repoMatchRoleModel.modelId
-        : repoMatchBudget.modelOverride;
     const repoMatchRuntime = selectRuntime({
       configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-      model: repoMatchModelOverride,
+      model: repoMatchBudget.modelOverride,
+      skillProvider: repoMatchBudget.provider,
     });
     logger.info('triage-batch running repo-match skill', {
       slug,
@@ -237,8 +224,8 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       freshContext: false,
       toolBundles: [],
       toolExtras: [],
-      ...repoMatchBudget,
-      modelOverride: repoMatchModelOverride,
+      budgets: repoMatchBudget.budgets,
+      modelOverride: repoMatchBudget.modelOverride,
       personaId: researcherPersonaId,
       outputJsonSchema: repoMatchJsonSchema,
       appendSystemPrompt: repoMatchPrompt,

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -5,7 +5,7 @@ import {
   patchSkillBudgetSetting,
   resetAllProjectBudgets,
 } from '@/lib/api';
-import type { ProjectSettingsDto } from '@/lib/types';
+import type { ModelProvider, ModelTier, ProjectSettingsDto } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { RotateCcw, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -53,6 +53,9 @@ const GLOBAL_FIELDS: Array<{
     notYetEnforced: true,
   },
 ];
+
+const TIERS: ModelTier[] = ['haiku', 'sonnet', 'opus'];
+const PROVIDERS: ModelProvider[] = ['claude', 'codex'];
 
 function NumericInput({
   value,
@@ -109,6 +112,62 @@ function NumericInput({
   );
 }
 
+function RuntimeSelect({
+  value,
+  options,
+  defaultValue,
+  overridden,
+  onCommit,
+}: {
+  value: string | null;
+  options: string[];
+  defaultValue?: string;
+  overridden: boolean;
+  onCommit: (val: string | null) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-1">
+        <select
+          value={value ?? ''}
+          onChange={(event) => onCommit(event.target.value === '' ? null : event.target.value)}
+          className={[
+            'w-24 rounded border px-2 py-0.5 text-[12px] bg-bg text-fg',
+            overridden ? 'border-accent' : 'border-line',
+          ].join(' ')}
+        >
+          <option value="">{defaultValue ?? 'default'}</option>
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        {overridden && <span className="text-[10px] text-accent font-medium">override</span>}
+      </div>
+      {defaultValue != null && (
+        <span className="text-[10px] text-fg-3 font-mono">default: {defaultValue}</span>
+      )}
+    </div>
+  );
+}
+
+function RuntimeModelCell({
+  value,
+}: {
+  value: { tier: ModelTier; provider: ModelProvider; modelId: string } | null | undefined;
+}) {
+  if (value == null) return <span className="text-fg-3">—</span>;
+  return (
+    <div className="flex flex-col gap-0.5 min-w-32">
+      <span className="font-mono text-fg">{value.modelId}</span>
+      <span className="text-[10px] text-fg-3 font-mono">
+        {value.provider}:{value.tier}
+      </span>
+    </div>
+  );
+}
+
 export function ProjectBudgetPanel({ slug }: Props) {
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery<ProjectSettingsDto>({
@@ -123,8 +182,13 @@ export function ProjectBudgetPanel({ slug }: Props) {
   });
 
   const patchSkill = useMutation({
-    mutationFn: ({ skill, patch }: { skill: string; patch: Record<string, number | null> }) =>
-      patchSkillBudgetSetting(slug, skill, patch),
+    mutationFn: ({
+      skill,
+      patch,
+    }: {
+      skill: string;
+      patch: Parameters<typeof patchSkillBudgetSetting>[2];
+    }) => patchSkillBudgetSetting(slug, skill, patch),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['project-settings', slug] }),
   });
 
@@ -150,7 +214,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
   function confirmReset() {
     if (!hasAnyOverride) return;
     const ok = window.confirm(
-      'Reset all budget overrides for this project? Global caps and every per-skill override will be cleared. The project will fall back to config and SKILL_BUDGETS defaults.',
+      'Reset all skill runtime overrides for this project? Global caps and every per-skill override will be cleared. The project will fall back to config and skill defaults.',
     );
     if (ok) resetAll.mutate();
   }
@@ -161,7 +225,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
       <section>
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2">
-            Global budget caps
+            Global runtime caps
           </h3>
           {hasAnyOverride && (
             <button
@@ -169,7 +233,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
               onClick={confirmReset}
               disabled={resetAll.isPending}
               className="flex items-center gap-1 text-[11px] text-fg-3 hover:text-danger border border-line/60 rounded-full px-2.5 py-0.5 transition-colors disabled:opacity-40"
-              title="Clear ALL budget overrides (global + per-skill)"
+              title="Clear all skill runtime overrides"
             >
               <RotateCcw size={11} />
               Reset all to defaults
@@ -210,19 +274,24 @@ export function ProjectBudgetPanel({ slug }: Props) {
       {/* Per-skill overrides */}
       <section>
         <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2 mb-3">
-          Per-skill budget overrides
+          Skill runtime settings
         </h3>
         <p className="text-[11px] text-fg-3 mb-4">
-          Leave fields blank to inherit from config or SKILL_BUDGETS defaults. Changes take effect
-          on the next agent dispatch.
+          Leave fields blank to inherit from config or skill defaults. Changes take effect on the
+          next agent dispatch. Primary, fallback, and advisor are derived read-only values.
         </p>
         <table className="w-full text-[12px]">
           <thead>
             <tr className="text-fg-3 text-left border-b border-line">
               <th className="pb-2 font-medium">Skill</th>
               <th className="pb-2 font-medium px-2">Max turns</th>
-              <th className="pb-2 font-medium px-2">Max budget (USD)</th>
-              <th className="pb-2 font-medium px-2">Timeout (ms)</th>
+              <th className="pb-2 font-medium px-2">Max budget</th>
+              <th className="pb-2 font-medium px-2">Timeout</th>
+              <th className="pb-2 font-medium px-2">Tier</th>
+              <th className="pb-2 font-medium px-2">Provider</th>
+              <th className="pb-2 font-medium px-2">Primary</th>
+              <th className="pb-2 font-medium px-2">Fallback</th>
+              <th className="pb-2 font-medium px-2">Advisor</th>
               <th className="pb-2 w-6" />
             </tr>
           </thead>
@@ -230,12 +299,17 @@ export function ProjectBudgetPanel({ slug }: Props) {
             {data.registeredSkills.map((skill) => {
               const row = data.dbSkillOverrides[skill] ?? null;
               const defaults = skillDefaults[skill];
+              const resolved = data.resolvedSkillRuntimes?.[skill];
               const hasAny =
                 row != null &&
-                (row.maxTurns != null || row.maxBudgetUsd != null || row.timeoutMs != null);
+                (row.maxTurns != null ||
+                  row.maxBudgetUsd != null ||
+                  row.timeoutMs != null ||
+                  row.modelTier != null ||
+                  row.provider != null);
               return (
                 <tr key={skill} className="border-b border-line/50 hover:bg-bg-hover align-top">
-                  <td className="py-1.5 font-mono text-fg">{skill}</td>
+                  <td className="py-1.5 font-mono text-fg whitespace-nowrap">{skill}</td>
                   <td className="py-1.5 px-2">
                     <NumericInput
                       value={row?.maxTurns ?? null}
@@ -265,6 +339,40 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       subtitle={defaults != null ? `default: ${defaults.timeoutMs} ms` : null}
                       onCommit={(val) => patchSkill.mutate({ skill, patch: { timeoutMs: val } })}
                     />
+                  </td>
+                  <td className="py-1.5 px-2">
+                    <RuntimeSelect
+                      value={row?.modelTier ?? null}
+                      options={TIERS}
+                      defaultValue={defaults?.modelTier}
+                      overridden={row?.modelTier != null}
+                      onCommit={(val) =>
+                        patchSkill.mutate({ skill, patch: { modelTier: val as ModelTier | null } })
+                      }
+                    />
+                  </td>
+                  <td className="py-1.5 px-2">
+                    <RuntimeSelect
+                      value={row?.provider ?? null}
+                      options={PROVIDERS}
+                      defaultValue={defaults?.modelProvider}
+                      overridden={row?.provider != null}
+                      onCommit={(val) =>
+                        patchSkill.mutate({
+                          skill,
+                          patch: { provider: val as ModelProvider | null },
+                        })
+                      }
+                    />
+                  </td>
+                  <td className="py-1.5 px-2">
+                    <RuntimeModelCell value={resolved?.resolvedPrimary} />
+                  </td>
+                  <td className="py-1.5 px-2">
+                    <RuntimeModelCell value={resolved?.resolvedFallback} />
+                  </td>
+                  <td className="py-1.5 px-2">
+                    <RuntimeModelCell value={resolved?.resolvedAdvisor} />
                   </td>
                   <td className="py-1.5 pl-1">
                     {hasAny && (

--- a/apps/web/src/components/settings/components/ProjectModelPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectModelPanel.tsx
@@ -219,13 +219,11 @@ function RoleRow({
   slug,
   data,
   allowHoldoutOverride,
-  codexAvailable,
 }: {
   role: string;
   slug: string;
   data: RoleModelDto;
   allowHoldoutOverride: boolean;
-  codexAvailable: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const qc = useQueryClient();
@@ -254,12 +252,7 @@ function RoleRow({
 
   const db = data.dbRoleModel;
   const hasDbOverride =
-    db != null &&
-    (db.primaryModel != null ||
-      db.fallbackModel != null ||
-      db.advisorModel != null ||
-      db.maxTurns != null ||
-      db.timeoutMs != null);
+    db != null && (db.primaryModel != null || db.maxTurns != null || db.timeoutMs != null);
   const hasComplexity = Object.keys(data.dbComplexityOverrides).length > 0;
 
   // Local state for budget inputs — PATCH on blur, not on every keystroke.
@@ -277,8 +270,6 @@ function RoleRow({
   }, [db?.timeoutMs]);
 
   const configPrimary = (data.configRoleModel?.primary as ModelTier) ?? null;
-  const codexDisabled = !codexAvailable;
-
   return (
     <>
       <tr className="border-b border-line/50 hover:bg-bg-hover">
@@ -314,40 +305,6 @@ function RoleRow({
             }
           />
         </td>
-        <td className="py-1.5 px-2 align-top">
-          <TierProviderSelect
-            tier={db?.fallbackModel ?? null}
-            provider={db?.fallbackProvider ?? null}
-            overridden={db?.fallbackModel != null}
-            placeholder={data.configRoleModel?.fallback ?? '—'}
-            disabled={locked}
-            codexDisabled={codexDisabled}
-            subtitle={null}
-            onChange={(next) =>
-              patchRole.mutate({
-                fallbackModel: next.tier,
-                fallbackProvider: next.tier == null ? null : next.provider,
-              })
-            }
-          />
-        </td>
-        <td className="py-1.5 px-2 align-top">
-          <TierProviderSelect
-            tier={db?.advisorModel ?? null}
-            provider={db?.advisorProvider ?? null}
-            overridden={db?.advisorModel != null}
-            placeholder={data.configRoleModel?.advisor ?? '—'}
-            disabled={locked}
-            codexDisabled={codexDisabled}
-            subtitle={null}
-            onChange={(next) =>
-              patchRole.mutate({
-                advisorModel: next.tier,
-                advisorProvider: next.tier == null ? null : next.provider,
-              })
-            }
-          />
-        </td>
         <td className="py-1.5 pl-1">
           {(hasDbOverride || hasComplexity) && (
             <button
@@ -363,7 +320,7 @@ function RoleRow({
       </tr>
       {expanded && (
         <tr className="border-b border-line/30">
-          <td colSpan={5} className="py-2 px-2">
+          <td colSpan={3} className="py-2 px-2">
             {locked ? (
               <p className="text-[11px] text-fg-3 ml-4">
                 Holdout role — set <code>agentConfig.allowHoldoutOverride: true</code> in project
@@ -681,7 +638,7 @@ export function ProjectModelPanel({ slug }: Props) {
       <div>
         <div className="flex items-center justify-between mb-1">
           <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2">
-            Role model assignments
+            Advanced role settings
           </h3>
           <div className="flex items-center gap-2">
             <button
@@ -718,21 +675,15 @@ export function ProjectModelPanel({ slug }: Props) {
           </div>
         </div>
         <p className="text-[11px] text-fg-3 mb-4">
-          DB overrides win over project config <code>rolesModels</code> and skill defaults. Clear a
-          field to revert to config. Expand a row to set complexity-based rules. The model ID below
-          each primary select is the resolved dispatch target.
-        </p>
-        <p className="text-[11px] text-fg-3 mb-4">
-          To switch to codex/claude there must be an entry in the db. So change the "tier" first
-          then the "model" e.g. Haiku then Codex
+          Compatibility controls for role-level persona and internal policy experiments. Normal
+          skill dispatch uses Skill runtime settings; role rows are not a fallback/advisor control
+          surface for ordinary runs.
         </p>
         <table className="w-full text-[12px]">
           <thead>
             <tr className="text-fg-3 text-left border-b border-line">
               <th className="pb-2 font-medium">Role</th>
               <th className="pb-2 font-medium px-2">Primary</th>
-              <th className="pb-2 font-medium px-2">Fallback</th>
-              <th className="pb-2 font-medium px-2">Advisor</th>
               <th className="pb-2 w-6" />
             </tr>
           </thead>
@@ -744,7 +695,6 @@ export function ProjectModelPanel({ slug }: Props) {
                 slug={slug}
                 data={data.roles[role]}
                 allowHoldoutOverride={data.allowHoldoutOverride}
-                codexAvailable={codexAvailable}
               />
             ))}
           </tbody>

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -11,7 +11,16 @@ import { ProjectConfigPanel } from './ProjectConfigPanel';
 import { ProjectModelPanel } from './ProjectModelPanel';
 import { ReviewPanel } from './ReviewPanel';
 
-type Tab = 'config' | 'budgets' | 'models' | 'pipeline' | 'review' | 'dev-review';
+type Tab = 'config' | 'runtime' | 'advanced-roles' | 'pipeline' | 'review' | 'dev-review';
+
+const TAB_LABELS: Record<Tab, string> = {
+  config: 'Config',
+  runtime: 'Skill runtime',
+  'advanced-roles': 'Advanced roles',
+  pipeline: 'Pipeline',
+  review: 'Review',
+  'dev-review': 'Dev-review',
+};
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
@@ -92,32 +101,32 @@ export function SettingsPage() {
 
         {/* Tab bar */}
         <div className="flex gap-1 mb-6 border-b border-line">
-          {(['config', 'budgets', 'models', 'pipeline', 'review', 'dev-review'] as Tab[]).map(
-            (t) => (
-              <button
-                key={t}
-                type="button"
-                onClick={() => setTab(t)}
-                className={[
-                  'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
-                  tab === t
-                    ? 'border-accent text-fg font-medium'
-                    : 'border-transparent text-fg-2 hover:text-fg',
-                ].join(' ')}
-              >
-                {t}
-              </button>
-            ),
-          )}
+          {(
+            ['config', 'runtime', 'advanced-roles', 'pipeline', 'review', 'dev-review'] as Tab[]
+          ).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={[
+                'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
+                tab === t
+                  ? 'border-accent text-fg font-medium'
+                  : 'border-transparent text-fg-2 hover:text-fg',
+              ].join(' ')}
+            >
+              {TAB_LABELS[t]}
+            </button>
+          ))}
         </div>
 
         {tab === 'config' && selectedConfig != null && (
           <ProjectConfigPanel config={selectedConfig} />
         )}
-        {tab === 'budgets' && selectedConfig != null && (
+        {tab === 'runtime' && selectedConfig != null && (
           <ProjectBudgetPanel slug={selectedConfig.slug} />
         )}
-        {tab === 'models' && selectedConfig != null && (
+        {tab === 'advanced-roles' && selectedConfig != null && (
           <ProjectModelPanel slug={selectedConfig.slug} />
         )}
         {tab === 'pipeline' && selectedConfig != null && (

--- a/apps/web/src/components/settings/slice.test.ts
+++ b/apps/web/src/components/settings/slice.test.ts
@@ -20,6 +20,11 @@ describe('settings slice', () => {
     expect(typeof mod.PipelinePanel).toBe('function');
   });
 
+  it('exports ProjectBudgetPanel', async () => {
+    const mod = await import('./components/ProjectBudgetPanel');
+    expect(typeof mod.ProjectBudgetPanel).toBe('function');
+  });
+
   it('exports DevReviewPanel', async () => {
     const mod = await import('./components/DevReviewPanel');
     expect(typeof mod.DevReviewPanel).toBe('function');

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -28,7 +28,13 @@ export async function patchGlobalBudgetSettings(
 export async function patchSkillBudgetSetting(
   slug: string,
   skill: string,
-  patch: Record<string, number | null>,
+  patch: Partial<{
+    maxTurns: number | null;
+    maxBudgetUsd: number | null;
+    timeoutMs: number | null;
+    modelTier: ModelTier | null;
+    provider: ModelProvider | null;
+  }>,
 ): Promise<void> {
   await patchJson(`/projects/${slug}/settings/skills/${encodeURIComponent(skill)}`, patch);
 }

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -6,7 +6,6 @@ import type { ProjectConfig } from '../types.js';
 import type { ResolvedBudget } from './budgets.js';
 import type { AgentResult, AgentRuntime, SkillConfig } from './interface.js';
 import { readPromptWithContext } from './read-prompt.js';
-import { resolveRoleBudgetOverrideForProject } from './resolve-for-project.js';
 import { toJsonSchema } from './schema-bridge.js';
 import { selectPersona } from './select-persona.js';
 import { selectRuntime } from './select-runtime.js';
@@ -112,7 +111,6 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     projectId,
     configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
     skillProvider: skillConfig.provider,
-    configRoleModel: projectConfig?.agentConfig?.rolesModels?.[role],
     fallbackTier: skillConfig.modelPin,
     fallbackProvider: skillConfig.provider,
     callerModelOverride: overrides?.modelOverride,
@@ -121,19 +119,6 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     ignoreProviderOverride: overrides?.runtimeOverride != null && overrides?.modelOverride == null,
   });
   const modelOverride = resolved.modelOverride;
-
-  // 5c. Apply per-role budget overrides (maxTurns / timeoutMs) from DB on top of
-  //     the per-skill runtime resolution. null means "no override — keep skill default".
-  const roleBudgetOverride = resolveRoleBudgetOverrideForProject(
-    projectId,
-    role,
-    projectConfig?.agentConfig?.allowHoldoutOverride,
-  );
-  const effectiveBudgets = {
-    ...resolved.budgets,
-    ...(roleBudgetOverride.maxTurns != null && { maxTurns: roleBudgetOverride.maxTurns }),
-    ...(roleBudgetOverride.timeoutMs != null && { timeoutMs: roleBudgetOverride.timeoutMs }),
-  };
 
   // 7. Select runtime — runtimeOverride short-circuits for tests and bespoke callers
   const runtime =
@@ -167,7 +152,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     freshContext: overrides?.freshContextOverride ?? skillConfig.freshContext,
     toolBundles: skillConfig.toolBundles,
     toolExtras: [],
-    budgets: effectiveBudgets,
+    budgets: resolved.budgets,
     personaId,
     workItemId,
     modelOverride,

--- a/core/agent-runtime/resolve-runtime-for-project.ts
+++ b/core/agent-runtime/resolve-runtime-for-project.ts
@@ -28,7 +28,6 @@ export function resolveProjectAgentExecution(input: {
     projectId: input.projectId,
     configRuntime,
     skillProvider: input.skillProvider,
-    configRoleModel: input.projectConfig?.agentConfig?.rolesModels?.[input.role],
     role: input.role,
     allowHoldoutOverride: input.projectConfig?.agentConfig?.allowHoldoutOverride,
     ignoreProviderOverride: input.injectedRuntime != null,

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -1,25 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ProjectModelSettingsRow } from '../db/repositories/project-model-settings.js';
 import { higherTier, lowerTier, resolveSkillRuntime } from './skill-runtime-resolver.js';
-
-function roleRow(overrides: Partial<ProjectModelSettingsRow>): ProjectModelSettingsRow {
-  return {
-    projectId: 'project',
-    role: 'role',
-    primaryModel: null,
-    fallbackModel: null,
-    advisorModel: null,
-    complexityOverridesJson: null,
-    updatedAt: 'now',
-    updatedBy: null,
-    primaryProvider: null,
-    fallbackProvider: null,
-    advisorProvider: null,
-    maxTurns: null,
-    timeoutMs: null,
-    ...overrides,
-  };
-}
 
 describe('resolveSkillRuntime', () => {
   it('lets a per-skill DB tier/provider override win over defaults', () => {
@@ -64,31 +44,11 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.modelOverride).toBe('claude-opus-4-7');
   });
 
-  it('uses role-level DB model/provider before skill defaults', () => {
-    const resolved = resolveSkillRuntime({
-      skill: 'investigate',
-      role: 'investigator',
-      dbRoleModel: roleRow({
-        primaryModel: 'sonnet',
-        primaryProvider: 'codex',
-      }),
-    });
-
-    expect(resolved.source).toBe('db');
-    expect(resolved.tier).toBe('sonnet');
-    expect(resolved.provider).toBe('codex');
-    expect(resolved.modelOverride).toBe('gpt-5.4');
-  });
-
-  it('lets per-skill DB model/provider override role-level settings', () => {
+  it('lets per-skill DB model/provider override skill defaults', () => {
     const resolved = resolveSkillRuntime({
       skill: 'investigate',
       role: 'investigator',
       dbOverride: { modelTier: 'opus', modelProvider: 'claude' },
-      dbRoleModel: roleRow({
-        primaryModel: 'sonnet',
-        primaryProvider: 'codex',
-      }),
     });
 
     expect(resolved.source).toBe('db');
@@ -97,19 +57,14 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.modelOverride).toBe('claude-opus-4-7');
   });
 
-  it('uses role-level project config before skill defaults when no DB role row exists', () => {
+  it('uses the skill provider hint for provider-pinned defaults like dev-review', () => {
     const resolved = resolveSkillRuntime({
-      skill: 'investigate',
-      role: 'investigator',
-      configRoleModel: {
-        primary: 'sonnet',
-        primaryProvider: 'codex',
-        fallback: null,
-        advisor: null,
-      },
+      skill: 'dev-review',
+      role: 'dev-reviewer',
+      skillProvider: 'codex',
     });
 
-    expect(resolved.source).toBe('config');
+    expect(resolved.source).toBe('skill-default');
     expect(resolved.tier).toBe('sonnet');
     expect(resolved.provider).toBe('codex');
     expect(resolved.modelOverride).toBe('gpt-5.4');

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -1,15 +1,12 @@
-import type { ProjectModelSettingsRow } from '../db/repositories/project-model-settings.js';
-import { readProjectModelSettingsForRole } from '../db/repositories/project-model-settings.js';
 import type { ProjectSkillSettingsRow } from '../db/repositories/project-settings.js';
 import {
   readProjectSettings,
   readProjectSkillSettings,
 } from '../db/repositories/project-settings.js';
-import type { BudgetConfig, ModelProvider, ModelTier, Role, RoleModel } from '../types.js';
+import type { BudgetConfig, ModelProvider, ModelTier, Role } from '../types.js';
 import type { ResolvedBudget, SkillBudgetOverride } from './budgets.js';
 import { SKILL_BUDGETS, resolveBudgets } from './budgets.js';
 import { defaultModelForTierAndProvider, providerOf, tierOf } from './models.js';
-import { selectModelForRole } from './select-model-for-role.js';
 import type { ConfigRuntime } from './select-runtime.js';
 
 export type SkillRuntimeSource = 'caller' | 'db' | 'config' | 'skill-default' | 'fallback';
@@ -127,8 +124,6 @@ export function resolveSkillRuntime(input: {
   fallbackProvider?: ModelProvider;
   callerModelOverride?: string;
   role?: Role;
-  configRoleModel?: RoleModel;
-  dbRoleModel?: ProjectModelSettingsRow | null;
   allowHoldoutOverride?: boolean;
   ignoreProviderOverride?: boolean;
 }): ResolvedSkillRuntime {
@@ -173,39 +168,19 @@ export function resolveSkillRuntime(input: {
     dbOverride,
     fallbackTier: input.fallbackTier,
   });
-  const roleModel =
-    input.role != null
-      ? selectModelForRole({
-          role: input.role,
-          configRoleModel: input.configRoleModel,
-          allowHoldoutOverride: input.allowHoldoutOverride,
-          dbRow: input.dbRoleModel,
-          skill: input.skill,
-          skillProvider: input.skillProvider,
-        })
-      : null;
-  const roleModelWins =
-    tierResult.source !== 'db' &&
-    tierResult.source !== 'config' &&
-    (roleModel?.source === 'db' || roleModel?.source === 'config');
-  const roleOverrideSource: SkillRuntimeSource | null =
-    roleModelWins && roleModel != null ? (roleModel.source === 'db' ? 'db' : 'config') : null;
-  const tier = roleModelWins ? roleModel.tier : tierResult.tier;
+  const tier = tierResult.tier;
   const provider =
     forcedProviderFromRuntime(providerConfigRuntime) ??
     (!input.ignoreProviderOverride && isModelProvider(dbOverride?.modelProvider)
       ? dbOverride.modelProvider
-      : roleModelWins
-        ? roleModel.provider
-        : (input.skillProvider ?? input.fallbackProvider ?? 'claude'));
+      : (input.skillProvider ??
+        SKILL_BUDGETS[input.skill]?.provider ??
+        input.fallbackProvider ??
+        'claude'));
   const modelOverride = defaultModelForTierAndProvider(tier, provider);
   const supportsFallback = SKILL_BUDGETS[input.skill]?.escalation != null;
   const supportsAdvisor = input.skill === 'implement' || input.skill === 'write-prd';
-  const source = isModelProvider(dbOverride?.modelProvider)
-    ? 'db'
-    : roleOverrideSource != null
-      ? roleOverrideSource
-      : tierResult.source;
+  const source = isModelProvider(dbOverride?.modelProvider) ? 'db' : tierResult.source;
 
   return {
     ...resolvedBudget,
@@ -231,7 +206,6 @@ export function resolveSkillRuntimeForProject(input: {
   projectId: string;
   configRuntime?: ConfigRuntime;
   skillProvider?: ModelProvider;
-  configRoleModel?: RoleModel;
   fallbackTier?: ModelTier;
   fallbackProvider?: ModelProvider;
   callerModelOverride?: string;
@@ -240,13 +214,10 @@ export function resolveSkillRuntimeForProject(input: {
   ignoreProviderOverride?: boolean;
 }): ResolvedSkillRuntime {
   const skillRows = readProjectSkillSettings(input.projectId);
-  const roleRow =
-    input.role != null ? readProjectModelSettingsForRole(input.projectId, input.role) : null;
   const globalRow = readProjectSettings(input.projectId);
   return resolveSkillRuntime({
     ...input,
     dbOverride: skillRows.get(input.skill),
-    dbRoleModel: roleRow,
     dbPerWorkflowMaxUsd: globalRow?.perWorkflowMaxUsd,
     dbPerAgentMaxUsd: globalRow?.perAgentMaxUsd,
   });
@@ -260,18 +231,18 @@ export function deriveSkillRuntimeResponse(input: {
   role?: Role;
   allowHoldoutOverride?: boolean;
   skillProvider?: ModelProvider;
-  configRoleModel?: RoleModel;
-  dbRoleModel?: ProjectModelSettingsRow | null;
+  fallbackTier?: ModelTier;
+  fallbackProvider?: ModelProvider;
 }): ResolvedSkillRuntime {
   return resolveSkillRuntime({
     skill: input.skill,
     projectBudgets: input.projectBudgets,
     dbOverride: input.row,
-    configRoleModel: input.configRoleModel,
-    dbRoleModel: input.dbRoleModel,
     configRuntime: input.configRuntime,
     role: input.role,
     allowHoldoutOverride: input.allowHoldoutOverride,
     skillProvider: input.skillProvider,
+    fallbackTier: input.fallbackTier,
+    fallbackProvider: input.fallbackProvider,
   });
 }

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -6,20 +6,10 @@ import {
   pathsTouchInvestigationSurface,
   toolCallsTouchInvestigationSurface,
 } from '@goose-hub/core/agent-runtime/investigation-context.js';
-import { selectModel } from '@goose-hub/core/agent-runtime/model-router.js';
-import {
-  type ModelProvider,
-  type ModelTier,
-  defaultModelForTierAndProvider,
-  tierOf,
-} from '@goose-hub/core/agent-runtime/models.js';
+import type { ModelTier } from '@goose-hub/core/agent-runtime/models.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
-import {
-  resolveBudgetsForProject,
-  resolveComplexityOverridesForProject,
-  resolveRoleModelForProject,
-} from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import { runWithEscalation } from '@goose-hub/core/agent-runtime/with-escalation.js';
 import type { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
@@ -51,7 +41,7 @@ export interface RunImplementInput {
 export interface ImplementExecution {
   runtime: AgentRuntime;
   projectConfig: Awaited<ReturnType<typeof getProjectBySlug>>;
-  budgets: ReturnType<typeof resolveBudgetsForProject>['budgets'];
+  budgets: ReturnType<typeof resolveSkillRuntimeForProject>['budgets'];
   modelOverride: string;
   selectedTier: ModelTier;
   selectionReason: string;
@@ -124,73 +114,46 @@ export function emitWrongSurfaceGuardForRun(input: {
   });
 }
 
-function forcedProviderFromRuntime(configRuntime: string | undefined): ModelProvider | null {
-  if (configRuntime === 'codex-cli') return 'codex';
-  if (configRuntime === 'claude-cli') return 'claude';
-  return null;
-}
-
 export async function resolveImplementExecution(input: {
   projectId: string;
   workItem: WorkItem;
   injectedRuntime?: AgentRuntime;
 }): Promise<ImplementExecution> {
   const projectConfig = await getProjectBySlug(input.projectId);
-  const { budgets, modelOverride: budgetModelOverride } = resolveBudgetsForProject(
-    'implement',
-    projectConfig?.budgets,
-    input.projectId,
-  );
-
-  const dbComplexityOverrides = resolveComplexityOverridesForProject(
-    'developer',
-    input.projectId,
-    projectConfig?.agentConfig?.modelRouter?.overrides,
-  );
-  const routerResult = selectModel({
-    workItem: input.workItem,
-    role: 'developer',
+  const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
+  const resolvedRuntime = resolveSkillRuntimeForProject({
+    skill: 'implement',
+    projectBudgets: projectConfig?.budgets,
     projectId: input.projectId,
-    modelRouterConfig: projectConfig?.agentConfig?.modelRouter,
-    dbComplexityOverrides,
+    configRuntime,
+    role: 'developer',
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
   });
-  const selectedTier = routerResult?.tier ?? tierOf(budgetModelOverride);
 
   if (input.injectedRuntime != null) {
     return {
       runtime: input.injectedRuntime,
       projectConfig,
-      budgets,
-      modelOverride:
-        routerResult != null
-          ? defaultModelForTierAndProvider(routerResult.tier, 'claude')
-          : budgetModelOverride,
-      selectedTier,
-      selectionReason: routerResult?.reason ?? 'budget-default',
+      budgets: resolvedRuntime.budgets,
+      modelOverride: resolvedRuntime.modelOverride,
+      selectedTier: resolvedRuntime.tier,
+      selectionReason: resolvedRuntime.source,
     };
   }
 
-  const roleModel = resolveRoleModelForProject({
-    role: 'developer',
-    projectId: input.projectId,
-    configRoleModel: projectConfig?.agentConfig?.rolesModels?.developer,
-    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
-    skill: 'implement',
+  const runtime = selectRuntime({
+    configRuntime,
+    model: resolvedRuntime.modelOverride,
+    skillProvider: resolvedRuntime.provider,
   });
-  const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
-  const provider =
-    forcedProviderFromRuntime(configRuntime) ??
-    (roleModel.source === 'db' || roleModel.source === 'config' ? roleModel.provider : 'claude');
-  const modelOverride = defaultModelForTierAndProvider(selectedTier, provider);
-  const runtime = selectRuntime({ configRuntime, model: modelOverride });
 
   return {
     runtime,
     projectConfig,
-    budgets,
-    modelOverride,
-    selectedTier,
-    selectionReason: routerResult?.reason ?? 'budget-default',
+    budgets: resolvedRuntime.budgets,
+    modelOverride: resolvedRuntime.modelOverride,
+    selectedTier: resolvedRuntime.tier,
+    selectionReason: resolvedRuntime.source,
   };
 }
 

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -2,10 +2,11 @@ import type { AgentResult, AgentRuntime } from '@goose-hub/core/agent-runtime/in
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+let mockProjectSkillSettings = new Map<string, Record<string, unknown>>();
 vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
   getEvidencePostEnabled: vi.fn((_projectId: string, configDefault = true) => configDefault),
   readProjectSettings: vi.fn().mockReturnValue(null),
-  readProjectSkillSettings: vi.fn().mockReturnValue(new Map()),
+  readProjectSkillSettings: vi.fn(() => mockProjectSkillSettings),
 }));
 let mockProjectModelSettingsRow: Record<string, unknown> | null = null;
 vi.mock('@goose-hub/core/db/repositories/project-model-settings.js', () => ({
@@ -196,6 +197,7 @@ function makeImplementOutput(overrides: Record<string, unknown> = {}) {
 
 function resetRuntimeRoutingMocks(): void {
   mockProjectModelSettingsRow = null;
+  mockProjectSkillSettings = new Map();
   mockProjectConfig = {
     agentConfig: { runtime: 'auto' },
     budgets: undefined,
@@ -213,6 +215,7 @@ describe('runFixIssueWorkflow — default deps (lines 68-73 ?? fallbacks)', () =
     resetEventStoreMocks();
     mockAccumulatePersonaStats.mockClear();
     resetRuntimeRoutingMocks();
+    mockProjectSkillSettings = new Map();
     process.env.GITHUB_TOKEN = 'ghp_test';
     mockClaudeCliRun.mockResolvedValueOnce({
       output: makeImplementOutput(),
@@ -262,12 +265,23 @@ describe('runFixIssueWorkflow — provider-aware runtime dispatch', () => {
     process.env.GITHUB_TOKEN = undefined;
   });
 
-  it('uses CodexCliRuntime and a gpt model when DB developer provider is codex', async () => {
+  it('uses CodexCliRuntime and a gpt model when per-skill provider is codex', async () => {
+    mockProjectSkillSettings = new Map([
+      [
+        'implement',
+        {
+          projectId: 'proj',
+          skillName: 'implement',
+          modelTier: 'haiku',
+          modelProvider: 'codex',
+        },
+      ],
+    ]);
     mockProjectModelSettingsRow = {
       projectId: 'proj',
       role: 'developer',
-      primaryModel: 'haiku',
-      primaryProvider: 'codex',
+      primaryModel: 'sonnet',
+      primaryProvider: 'claude',
     };
     const item = makeWorkItem({ priority: 'medium', type: 'chore' });
     const source = makeStateSource();
@@ -321,7 +335,7 @@ describe('runFixIssueWorkflow — provider-aware runtime dispatch', () => {
 
     expect(mockCodexCliRun).toHaveBeenCalledTimes(1);
     const spec = mockCodexCliRun.mock.calls[0][0] as { modelOverride?: string };
-    expect(spec.modelOverride).toBe('gpt-5.4');
+    expect(spec.modelOverride).toBe('gpt-5.4-mini');
   });
 
   it('keeps an injected runtime instead of replacing it with provider dispatch', async () => {
@@ -367,13 +381,18 @@ describe('runFixIssueWorkflow — provider-aware runtime dispatch', () => {
     expect(mockClaudeCliRun).not.toHaveBeenCalled();
   });
 
-  it('maps implement router type:bug -> haiku onto Codex haiku when provider is Codex', async () => {
-    mockProjectModelSettingsRow = {
-      projectId: 'proj',
-      role: 'developer',
-      primaryModel: 'sonnet',
-      primaryProvider: 'codex',
-    };
+  it('maps per-skill DB tier/provider to the concrete Codex model', async () => {
+    mockProjectSkillSettings = new Map([
+      [
+        'implement',
+        {
+          projectId: 'proj',
+          skillName: 'implement',
+          modelTier: 'haiku',
+          modelProvider: 'codex',
+        },
+      ],
+    ]);
 
     const { runFixIssueWorkflow } = await import('./workflow.js');
     await runFixIssueWorkflow(

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -315,7 +315,7 @@ describe('runInvestigateWorkflow', () => {
       );
     });
 
-    it('uses the investigator role provider for synthesis model routing', async () => {
+    it('ignores investigator role provider rows for synthesis model routing', async () => {
       mockReadProjectModelSettingsForRole.mockReturnValue({
         projectId: 'goose-hub-self',
         role: 'investigator',
@@ -334,7 +334,7 @@ describe('runInvestigateWorkflow', () => {
         expect.objectContaining({
           skillName: 'investigate',
           overrides: expect.objectContaining({
-            modelOverride: 'gpt-5.4',
+            modelOverride: 'claude-sonnet-4-6',
           }),
         }),
       );

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -173,7 +173,6 @@ export async function runInvestigateWorkflow(
     projectId,
     configRuntime,
     role: 'investigator',
-    configRoleModel: projectConfig?.agentConfig?.rolesModels?.investigator,
   });
   const investigatorModelOverride = investigateBudget.modelOverride;
   const runtime =
@@ -216,7 +215,6 @@ export async function runInvestigateWorkflow(
       projectId: currentProjectId,
       configRuntime,
       role: 'investigator',
-      configRoleModel: projectConfig?.agentConfig?.rolesModels?.investigator,
     });
     return {
       ...resolved,
@@ -478,7 +476,6 @@ export async function runInvestigateWorkflow(
             projectId,
             configRuntime,
             role: 'investigator',
-            configRoleModel: projectConfig?.agentConfig?.rolesModels?.investigator,
           });
           const playwrightModelOverride = playwrightBudget.modelOverride;
           const playwrightRuntime =


### PR DESCRIPTION
## Summary
- Move normal runtime model selection to per-skill tier/provider settings.
- Surface skill runtime settings with derived primary/fallback/advisor display.
- Demote role model settings to advanced role configuration.

## Verification
- pnpm run lint
- pnpm run typecheck
- pnpm tsx scripts/run-vitest-with-db.ts core/agent-runtime/skill-runtime-resolver.test.ts core/agent-runtime/invoke-skill.test.ts apps/server/src/domains/project-settings/router.test.ts apps/web/src/components/settings/slice.test.ts slices/fix-issue/slice.test.ts slices/investigate/slice.test.ts