### PR TITLE
M17: dispatch triage after inbox promotion

### DIFF
--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -4,6 +4,10 @@ vi.mock('../../shared/source.js', () => ({
   getSourceForSlug: vi.fn(),
 }));
 
+vi.mock('../../shared/dispatch.js', () => ({
+  dispatchTriageBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('./repository.js', () => ({
   insertInboxItem: vi.fn(),
   listInboxItems: vi.fn().mockResolvedValue([]),
@@ -17,6 +21,7 @@ vi.mock('@goose-hub/core/db/db.js', () => ({
   },
 }));
 
+import { dispatchTriageBatch } from '#shared/dispatch.js';
 import { getSourceForSlug } from '#shared/source.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
 import {
@@ -84,6 +89,7 @@ describe('promoteInboxItem', () => {
     vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
     const result = await promoteInboxItem(1, 'unknown');
     expect(result).toEqual({ ok: false, error: 'project not found', status: 404 });
+    expect(dispatchTriageBatch).not.toHaveBeenCalled();
   });
 
   it('creates github issue and deletes inbox item on success', async () => {
@@ -94,6 +100,16 @@ describe('promoteInboxItem', () => {
       expect.objectContaining({ title: 'Fix bug' }),
     );
     expect(deleteInboxItem).toHaveBeenCalledWith(1);
+    expect(dispatchTriageBatch).toHaveBeenCalledWith('my-proj');
+  });
+
+  it('does not delete inbox item or dispatch triage when createIssue fails', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce(mockItem);
+    mockSource.createIssue.mockRejectedValueOnce(new Error('github unavailable'));
+
+    await expect(promoteInboxItem(1, 'my-proj')).rejects.toThrow('github unavailable');
+    expect(deleteInboxItem).not.toHaveBeenCalled();
+    expect(dispatchTriageBatch).not.toHaveBeenCalled();
   });
 
   it('still returns ok:true when deleteInboxItem throws (GitHub issue was created)', async () => {

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -2,6 +2,7 @@ import { db } from '@goose-hub/core/db/db.js';
 import { projectState } from '@goose-hub/core/db/schema.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { eq } from 'drizzle-orm';
+import { dispatchTriageBatch } from '#shared/dispatch.js';
 import type { Result } from '#shared/middleware.js';
 import { getSourceForSlug } from '#shared/source.js';
 import { runBugEnhance } from './enhance.js';
@@ -72,6 +73,7 @@ export async function promoteInboxItem(
     type: item.type as 'feature' | 'bug' | 'chore' | 'research',
     ...(effectiveMilestoneNumber != null ? { milestoneId: String(effectiveMilestoneNumber) } : {}),
   });
+  void dispatchTriageBatch(projectSlug);
 
   try {
     await repoDeleteInboxItem(id);


### PR DESCRIPTION
Summary:
- Trigger fire-and-forget triage dispatch after successful inbox issue creation.
- Cover success, project lookup failure, and createIssue failure in inbox service tests.

Verification:
- pnpm test apps/server/src/domains/inbox/service.test.ts
- pnpm test apps/server/src/domains/webhooks/handler.test.ts apps/server/src/shared/dispatch.test.ts
- pnpm exec biome check apps/server/src/domains/inbox/service.ts apps/server/src/domains/inbox/service.test.ts