### PR TITLE
Add QA verification summary harness

### DIFF
--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -67,6 +67,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'qa.functional-failed': 'QA functional failed',
   'qa.regression-passed': 'QA regression passed',
   'qa.regression-failed': 'QA regression failed',
+  'qa.verification-summary-built': 'QA verification summary built',
   'retrospective.completed': 'Retrospective completed',
   'grill.question-posted': 'Grill question posted',
   'grill.completed': 'Grill completed',

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -35,6 +35,7 @@ export type EventKind =
   | 'qa.functional-failed'
   | 'qa.regression-passed'
   | 'qa.regression-failed'
+  | 'qa.verification-summary-built'
   // M7 fix-issue workflow lifecycle (#183) + evidence-post wiring (#234)
   | 'agent.implement-complete'
   | 'pr.opened'

--- a/skills/qa/prompt.md
+++ b/skills/qa/prompt.md
@@ -18,9 +18,12 @@ If you find yourself reasoning about "why the developer did X", stop. Your job i
 
 ## Execution discipline
 
-- **Full output, no grep.** Run `testCommand` once. Read the complete output before drawing any conclusions. Do not re-run the suite more than once in a verification pass. Re-running speculatively wastes budget and does not produce new information.
+- **Start from `verificationSummary`.** It is workflow-owned ground truth for changed files, command choices, deterministic lint/typecheck/test results, e2e policy, evidence-post status, and developer targeted-test metadata. Use it before spending tool calls.
+- **Do not re-run deterministic checks that already ran.** When `verificationSummary.commands.lint`, `verificationSummary.commands.typecheck`, or `verificationSummary.testRun` are present, grade those results from the structured packet. Do not re-run `testCommand` when structured test results are present. Only run an isolated command if you have a specific uncertainty that the packet cannot answer.
+- **Full output, no grep.** If `testRun` and `verificationSummary.testRun` are both absent, run `testCommand` once. Read the complete output before drawing any conclusions. Do not re-run the suite more than once in a verification pass. Re-running speculatively wastes budget and does not produce new information.
 - **Verify the command first.** If `testRun` is absent from context, confirm the test command from `projectCommands` before running it. Do not assume `pnpm test` works — the project may require a workspace-specific invocation.
 - **Isolate sparingly.** Only re-run a single test file if you have a specific hypothesis about that file. State the hypothesis in a decision summary before running.
+- **Inspect changed files first.** Start with files listed in `verificationSummary.changedFiles.paths` and the PR diff. Inspect config or broader repository context only when a command failure, missing evidence, or explicit uncertainty justifies it. Record why broader inspection was needed in a decision summary.
 - **No shell syntax.** Never add `2>&1`, `&&`, `;`, or `|` — `shell: false` passes these as literal arguments, breaking the command. Example of what NOT to do: `pnpm biome check . | tail -20` — the pipe is banned AND `tail` silently discards earlier errors, making lint results unreliable.
 
 ## Input
@@ -29,6 +32,14 @@ The context contains a `<task>` block with:
 
 - `<workItem>` — JSON payload for the original GitHub issue, with `title`, `body`, and `number`
 - `<prDiff>` — complete git diff of the PR being reviewed
+- `<verificationSummary>` — compact workflow-owned verification packet:
+  - `changedFiles` — changed paths, count, diff character count, and diff stat
+  - `pr` — PR number, base branch, and head SHA when available
+  - `commands` — lint/typecheck/test/e2e commands chosen by the workflow and compact statuses
+  - `testRun` — pass/fail counts and failing suite names, never raw output
+  - `e2e` — policy mode, selected command, skipped/ran/failed status, and reason
+  - `evidence` — posted/skipped/failed/absent status, URL when posted, sanitized operational error when failed
+  - `devTestsRun` — targeted developer test metadata when available
 - `<projectCommands>` — JSON payload with `testCommand`, optional `lintCommand`, and optional `e2eCommand`
 - `<e2eDecision>` (optional) — JSON payload for e2e policy: `{ mode, command?, reason }`
 - `<sliceTests>` (optional) — JSON array of paths to slice-level test files
@@ -49,7 +60,7 @@ Run the tiers in order. If a tier fails, record all findings from that tier and 
 Purpose: Catch schema regressions, type errors, and lint violations.
 
 Steps:
-1. If `lintCommand` is provided, run it. Record any errors or warnings.
+1. If `verificationSummary.commands.lint` or `verificationSummary.commands.typecheck` is present, use those structured statuses directly. Otherwise, if `lintCommand` is provided, run it once and record any errors or warnings.
 2. Check that every changed TypeScript file (from the diff) type-checks correctly.
 3. If the PR introduces or modifies Zod schemas, verify that the schema exports are valid and correctly typed.
 4. Look for obvious anti-patterns in the diff: inline prompts instead of `prompt.md` files, imports between slices, missing `README.md` or `slice.test.ts` for new slices.
@@ -69,7 +80,7 @@ Purpose: Catch behavior regressions and missing test coverage.
 **QA always runs the full suite.** The dev role only runs targeted tests for the surface it touched (#467). The workflow pre-runs the full `testCommand` and attaches results as `testRun` in your context — when it is present, grade the Functional tier from it directly. Cross-reference `devTestsRun.paths` (when present in context) against the full-suite results: failures **outside** dev's targeted set are the high-signal regressions and should be recorded as `error`-severity findings.
 
 Steps:
-1. If `testRun` is present in your context, use it as the test result — do not re-run `testCommand`. If `testRun` is absent or `null`, run the full `testCommand` yourself. If `sliceTests` are provided, run those first for targeted feedback before the full suite.
+1. If `verificationSummary.testRun` or `testRun` is present in your context, use it as the test result — do not re-run `testCommand`. If both are absent or null, run the full `testCommand` yourself. If `sliceTests` are provided, run those first for targeted feedback before the full suite.
 2. Check test output for failures, errors, and skipped tests.
    **Known worktree noise — do not report as findings:** Test files that fail with `ERR_DLOPEN_FAILED` or `Error: The module ... better-sqlite3 ...` are caused by the native module not being rebuilt for the worktree's Node version. These are pre-existing environment failures, not regressions introduced by the PR. Filter them out before assessing pass/fail. If ALL failures are of this type, record an `info`-severity finding noting the sqlite noise and mark the tier passed.
    **Pre-existing failures (non-sqlite).** If a test file fails but was NOT modified by this PR, it is likely pre-existing. Verify by searching `prDiff` for the test filename — one check, no git commands needed. Record pre-existing failures as `info`-severity ("pre-existing failure — file not modified by this PR") and exclude them from the pass/fail determination.
@@ -91,7 +102,7 @@ Record tier result with:
 Purpose: Catch UX regressions that only appear in end-to-end flows.
 
 Steps:
-1. If `e2eDecision.command` or `projectCommands.e2eCommand` is provided, run that command and record results. Do not invent or run an e2e command when no command is provided.
+1. If `verificationSummary.e2e` says e2e already ran or failed, grade from that structured status. If it was skipped but an `e2eDecision.command` or `projectCommands.e2eCommand` is provided, run that command and record results. Do not invent or run an e2e command when no command is provided.
 2. Read the diff and identify any UI surface changes (component changes, route changes, API changes visible to the frontend).
 3. **If no e2e command is provided:** treat the orchestrator's `e2eDecision.reason` as authoritative. Mark the tier passed with one `info`-severity finding such as `"e2e skipped by policy: <reason>"`. Do not return `partial` or `fail` solely because e2e was intentionally skipped.
 4. Check that any new UI paths introduced by the PR are reachable and render correctly (if e2e tests cover them).

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -88,6 +88,66 @@ export const TestRunSchema = z.object({
   suites: z.array(SuiteResultSchema),
 });
 
+const VerificationCommandStatusSchema = z.enum(['passed', 'failed', 'skipped']);
+
+export const VerificationCommandSummarySchema = z.object({
+  command: z.string(),
+  status: VerificationCommandStatusSchema,
+  exitCode: z.number().int().optional(),
+  durationMs: z.number().int().min(0).optional(),
+  error: z.string().optional(),
+});
+
+export const VerificationSummarySchema = z.object({
+  changedFiles: z.object({
+    paths: z.array(z.string()),
+    count: z.number().int().min(0),
+    diffCharCount: z.number().int().min(0),
+    diffStat: z.string().optional(),
+  }),
+  pr: z.object({
+    number: z.number().int().positive().optional(),
+    baseBranch: z.string().optional(),
+    headSha: z.string().optional(),
+  }),
+  commands: z.object({
+    lint: VerificationCommandSummarySchema.optional(),
+    typecheck: VerificationCommandSummarySchema.optional(),
+    test: VerificationCommandSummarySchema,
+    e2e: VerificationCommandSummarySchema.optional(),
+  }),
+  testRun: z
+    .object({
+      command: z.string(),
+      status: VerificationCommandStatusSchema,
+      wallTimeMs: z.number().int().min(0).optional(),
+      total: z.number().int().min(0),
+      passed: z.number().int().min(0),
+      failed: z.number().int().min(0),
+      skipped: z.number().int().min(0),
+      failingSuites: z.array(z.string()),
+    })
+    .optional(),
+  e2e: z.object({
+    mode: z.enum(['off', 'ui-changed', 'always']),
+    command: z.string().optional(),
+    status: z.enum(['ran', 'skipped', 'failed']),
+    reason: z.string(),
+  }),
+  evidence: z.object({
+    status: z.enum(['posted', 'skipped', 'failed', 'absent']),
+    url: z.string().url().optional(),
+    error: z.string().optional(),
+    reason: z.string().optional(),
+  }),
+  devTestsRun: z
+    .object({
+      command: z.string(),
+      paths: z.array(z.string()),
+    })
+    .optional(),
+});
+
 export const QualityScoresSchema = z.object({
   /** Open/Closed principle adherence — 0–20 pts */
   openClosed: z.number().int().min(0).max(20),
@@ -158,6 +218,8 @@ export type TierResult = z.infer<typeof TierResultSchema>;
 export type QualityScores = z.infer<typeof QualityScoresSchema>;
 export type SuiteResult = z.infer<typeof SuiteResultSchema>;
 export type TestRun = z.infer<typeof TestRunSchema>;
+export type VerificationCommandSummary = z.infer<typeof VerificationCommandSummarySchema>;
+export type VerificationSummary = z.infer<typeof VerificationSummarySchema>;
 export type CriteriaResult = z.infer<typeof CriteriaResultSchema>;
 export type QaOutput = z.infer<typeof QaOutputSchema>;
 

--- a/skills/qa/skill.config.ts
+++ b/skills/qa/skill.config.ts
@@ -1,6 +1,6 @@
 import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
 import { z } from 'zod';
-import { TestRunSchema } from './schema.js';
+import { TestRunSchema, VerificationSummarySchema } from './schema.js';
 
 /**
  * Context keys provided to the QA holdout agent, formatted as structured XML.
@@ -17,6 +17,7 @@ import { TestRunSchema } from './schema.js';
  *     <workItem>{"title":"...","body":"...","number":123}</workItem>
  *     <prDiff>...</prDiff>
  *     <projectCommands>{"testCommand":"...","lintCommand":"...","e2eCommand":"..."}</projectCommands>
+ *     <verificationSummary>{"changedFiles":...,"commands":...,"testRun":...}</verificationSummary>
  *     <sliceTests>["path/to/test.ts"]</sliceTests>
  *   </task>
  */
@@ -75,6 +76,11 @@ export const QaContextSchema = z.object({
     .optional(),
   /** Structured test results captured by the workflow before the QA agent starts. */
   testRun: TestRunSchema.nullable().optional(),
+  /**
+   * Compact workflow-owned verification packet. Contains deterministic command
+   * statuses and evidence metadata only, never implementation reasoning.
+   */
+  verificationSummary: VerificationSummarySchema.optional(),
 });
 
 const config: SkillConfig = {
@@ -114,6 +120,7 @@ const config: SkillConfig = {
     'verifyCommands',
     'devTestsRun',
     'testRun',
+    'verificationSummary',
   ],
 };
 

--- a/skills/qa/slice.test.ts
+++ b/skills/qa/slice.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { toJSONSchema } from 'zod';
 import {
@@ -6,6 +7,7 @@ import {
   QaOutputSchema,
   QualityScoresSchema,
   TierResultSchema,
+  VerificationSummarySchema,
   computeOverallScore,
 } from './schema.js';
 import config, { QaContextSchema } from './skill.config.js';
@@ -660,6 +662,52 @@ describe('qa skill config', () => {
     expect(config.contextAllowlist).toContain('devTestsRun');
   });
 
+  it('contextAllowlist contains verificationSummary', () => {
+    expect(config.contextAllowlist).toContain('verificationSummary');
+  });
+
+  it('contextSchema accepts compact verificationSummary', () => {
+    const verificationSummary = {
+      changedFiles: {
+        paths: ['slices/qa/workflow.ts'],
+        count: 1,
+        diffCharCount: 1024,
+        diffStat: 'slices/qa/workflow.ts | 10 +++++-----',
+      },
+      pr: { number: 813, baseBranch: 'main', headSha: 'abc1234' },
+      commands: {
+        lint: { command: 'pnpm lint', status: 'passed' },
+        typecheck: { command: 'pnpm typecheck', status: 'passed' },
+        test: { command: 'pnpm test --reporter=json', status: 'passed', durationMs: 1000 },
+      },
+      testRun: {
+        command: 'pnpm test --reporter=json',
+        status: 'passed',
+        wallTimeMs: 1000,
+        total: 10,
+        passed: 10,
+        failed: 0,
+        skipped: 0,
+        failingSuites: [],
+      },
+      e2e: { mode: 'ui-changed', status: 'skipped', reason: 'no significant UI changes detected' },
+      evidence: { status: 'absent' },
+      devTestsRun: {
+        command: 'pnpm vitest slices/qa/slice.test.ts',
+        paths: ['slices/qa/slice.test.ts'],
+      },
+    };
+
+    expect(VerificationSummarySchema.safeParse(verificationSummary).success).toBe(true);
+    const valid = QaContextSchema.safeParse({
+      workItem: { title: 't', body: 'b', number: 1 },
+      prDiff: 'diff',
+      projectCommands: { testCommand: 'pnpm test ' },
+      verificationSummary,
+    });
+    expect(valid.success).toBe(true);
+  });
+
   it('contextSchema accepts devTestsRun with command and paths (#467)', () => {
     const valid = QaContextSchema.safeParse({
       workItem: { title: 't', body: 'b', number: 1 },
@@ -671,6 +719,18 @@ describe('qa skill config', () => {
       },
     });
     expect(valid.success).toBe(true);
+  });
+});
+
+describe('qa prompt verificationSummary guidance', () => {
+  it('tells QA not to rerun the full suite when structured test results are present', () => {
+    const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+
+    expect(prompt).toContain('Start from `verificationSummary`');
+    expect(prompt).toContain(
+      'Do not re-run `testCommand` when structured test results are present',
+    );
+    expect(prompt).toContain('Inspect changed files first');
   });
 });
 

--- a/slices/qa/qa-helpers.ts
+++ b/slices/qa/qa-helpers.ts
@@ -58,6 +58,16 @@ export function getPrDiff(_workItem: WorkItem, workspaceDir?: string, baseBranch
   }
 }
 
+export function getPrDiffStat(workspaceDir?: string, baseBranch = 'main'): string {
+  if (workspaceDir == null) return '';
+  try {
+    const baseRef = diffBaseRef(baseBranch);
+    return runGit(workspaceDir, ['diff', '--stat', `${baseRef}...HEAD`]).trim();
+  } catch {
+    return '';
+  }
+}
+
 export function getChangedFilePaths(workspaceDir?: string, baseBranch = 'main'): string[] {
   if (workspaceDir == null) return [];
   try {
@@ -132,6 +142,8 @@ export interface PrOpenedHints {
   devRunId?: string;
   pipelineRunId?: string;
   baseBranch?: string;
+  prNumber?: number;
+  prHeadSha?: string;
 }
 
 export function findPrOpenedHints(workItemId: string): PrOpenedHints {
@@ -147,6 +159,13 @@ export function findPrOpenedHints(workItemId: string): PrOpenedHints {
     devRunId: typeof payload.devRunId === 'string' ? payload.devRunId : undefined,
     pipelineRunId: typeof payload.pipelineRunId === 'string' ? payload.pipelineRunId : undefined,
     baseBranch: typeof payload.baseBranch === 'string' ? payload.baseBranch : undefined,
+    prNumber: typeof payload.prNumber === 'number' ? payload.prNumber : undefined,
+    prHeadSha:
+      typeof payload.prHeadSha === 'string'
+        ? payload.prHeadSha
+        : typeof payload.headSha === 'string'
+          ? payload.headSha
+          : undefined,
   };
 }
 

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { AgentResult } from '@goose-hub/core/agent-runtime/interface.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -100,6 +104,29 @@ function makePassResult(): AgentResult {
     },
     decisionSummaries: [],
     events: [],
+  };
+}
+
+function makeSampleTestRun() {
+  return {
+    wallTimeMs: 7700,
+    total: 39,
+    passed: 38,
+    failed: 1,
+    skipped: 0,
+    success: false,
+    suites: [
+      {
+        name: 'cart.test.ts',
+        filePath: 'core/cart.test.ts',
+        total: 18,
+        passed: 17,
+        failed: 1,
+        skipped: 0,
+        durationMs: 412,
+        status: 'failed' as const,
+      },
+    ],
   };
 }
 
@@ -285,6 +312,119 @@ describe('qa helpers', () => {
     expect(
       classifyUiChanges(['docs/readme.md', 'apps/web/e2e/issue-42.spec.ts']).hasSignificantUiChange,
     ).toBe(false);
+  });
+});
+
+describe('verification summary harness', () => {
+  function makeGitFixture(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'qa-summary-'));
+    execFileSync('git', ['init'], { cwd: dir });
+    mkdirSync(join(dir, 'apps/web/src'), { recursive: true });
+    writeFileSync(join(dir, 'apps/web/src/foo.ts'), 'export const foo = 1;\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'base'],
+      { cwd: dir },
+    );
+    execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'HEAD'], { cwd: dir });
+    writeFileSync(join(dir, 'apps/web/src/foo.ts'), 'export const foo = 2;\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'change'],
+      { cwd: dir },
+    );
+    return dir;
+  }
+
+  it('builds changed-file, diff-stat, command, test, e2e, evidence, and dev-test metadata', async () => {
+    const dir = makeGitFixture();
+    try {
+      const { buildVerificationSummary } = await import('./verification-summary.js');
+      const sampleTestRun = makeSampleTestRun();
+      const runCommand = vi.fn(async (_cwd: string, command: string) => ({
+        command,
+        status: 'passed' as const,
+      }));
+
+      const result = await buildVerificationSummary({
+        workspaceDir: dir,
+        prHints: { baseBranch: 'main', prNumber: 99, prHeadSha: 'abc1234' },
+        prDiff: 'diff --git a/apps/web/src/foo.ts b/apps/web/src/foo.ts\n+export const foo = 2;\n',
+        qaE2eMode: 'ui-changed',
+        configuredE2eCommand: 'pnpm test:e2e:pipeline',
+        commands: {
+          lintCommand: 'pnpm lint',
+          typecheckCommand: 'pnpm typecheck',
+          testCommand: 'pnpm test --reporter=json',
+        },
+        priorEvents: [
+          {
+            id: 1,
+            projectId: 'test-project',
+            workItemId: 'github:owner/repo#42',
+            kind: 'evidence.posted',
+            payload: { commentUrl: 'https://github.com/owner/repo/issues/42#issuecomment-1' },
+            createdAt: '',
+          },
+        ],
+        devTestsRun: { command: 'pnpm vitest src/foo.test.ts', paths: ['src/foo.test.ts'] },
+        runTests: vi.fn().mockResolvedValue(sampleTestRun),
+        runCommand,
+      });
+
+      expect(result.verificationSummary.changedFiles.paths).toEqual(['apps/web/src/foo.ts']);
+      expect(result.verificationSummary.changedFiles.count).toBe(1);
+      expect(result.verificationSummary.changedFiles.diffCharCount).toBeGreaterThan(0);
+      expect(result.verificationSummary.changedFiles.diffStat).toContain('apps/web/src/foo.ts');
+      expect(result.verificationSummary.pr).toEqual({
+        number: 99,
+        baseBranch: 'main',
+        headSha: 'abc1234',
+      });
+      expect(result.verificationSummary.commands.lint?.status).toBe('passed');
+      expect(result.verificationSummary.commands.typecheck?.status).toBe('passed');
+      expect(result.verificationSummary.testRun?.failed).toBe(1);
+      expect(result.verificationSummary.testRun?.failingSuites).toEqual(['core/cart.test.ts']);
+      expect(result.verificationSummary.e2e.command).toBe('pnpm test:e2e:pipeline');
+      expect(result.verificationSummary.evidence.status).toBe('posted');
+      expect(result.verificationSummary.devTestsRun?.paths).toEqual(['src/foo.test.ts']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('summarizes failed evidence without copying non-operational payload fields', async () => {
+    const { buildVerificationSummary } = await import('./verification-summary.js');
+
+    const result = await buildVerificationSummary({
+      prHints: {},
+      prDiff: '',
+      qaE2eMode: 'off',
+      commands: { testCommand: 'pnpm test --reporter=json' },
+      priorEvents: [
+        {
+          id: 1,
+          projectId: 'test-project',
+          workItemId: 'github:owner/repo#42',
+          kind: 'evidence.post-failed',
+          payload: {
+            error: 'spawn failed\nat internal/path.ts:1',
+            developerReasoning: 'root cause analysis should not leak',
+          },
+          createdAt: '',
+        },
+      ],
+      runTests: vi.fn(),
+      runCommand: vi.fn(),
+    });
+
+    expect(result.verificationSummary.evidence).toEqual({
+      status: 'failed',
+      error: 'spawn failed at internal/path.ts:1',
+    });
+    expect(JSON.stringify(result.verificationSummary)).not.toContain('root cause analysis');
   });
 });
 
@@ -553,6 +693,103 @@ describe('runQaWorkflow', () => {
       expect(specUsed.contextAllowlist).toContain('workItem');
       expect(specUsed.contextAllowlist).toContain('prDiff');
       expect(specUsed.contextAllowlist).not.toContain('devDecisionSummaries');
+    });
+
+    it('passes verificationSummary into QA context and allowlist', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: {
+            prNumber: 99,
+            worktreePath: '/wt/abc',
+            baseBranch: 'develop',
+            prHeadSha: 'abc1234',
+          },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(makeSampleTestRun()),
+        runCommand: vi.fn(async (_cwd, command) => ({ command, status: 'passed' as const })),
+      });
+
+      const spec = mockRun.mock.calls[0][0] as {
+        context: Record<string, unknown>;
+        contextAllowlist: string[];
+      };
+      expect(spec.context.verificationSummary).toMatchObject({
+        pr: { number: 99, baseBranch: 'develop', headSha: 'abc1234' },
+        commands: {
+          lint: { command: 'pnpm biome check .', status: 'passed' },
+          test: { command: 'pnpm test --reporter=json', status: 'failed' },
+        },
+        testRun: {
+          failed: 1,
+          failingSuites: ['core/cart.test.ts'],
+        },
+      });
+      expect(spec.contextAllowlist).toContain('verificationSummary');
+    });
+
+    it('does not include forbidden holdout keys in QA context or allowlist', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const spec = mockRun.mock.calls[0][0] as {
+        context: Record<string, unknown>;
+        contextAllowlist: string[];
+      };
+      expect(spec.context.devDecisionSummaries).toBeUndefined();
+      expect(spec.context.investigationFindings).toBeUndefined();
+      expect(spec.contextAllowlist).not.toContain('devDecisionSummaries');
+      expect(spec.contextAllowlist).not.toContain('investigationFindings');
+    });
+
+    it('emits qa.verification-summary-built telemetry with compact statuses', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        { id: 1, kind: 'pr.opened', payload: { worktreePath: '/wt/abc' }, createdAt: '' },
+        {
+          id: 2,
+          kind: 'evidence.post-failed',
+          payload: { error: 'post failed' },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(makeSampleTestRun()),
+        runCommand: vi.fn(async (_cwd, command) => ({ command, status: 'passed' as const })),
+      });
+
+      const summaryEvent = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.verification-summary-built');
+      expect(summaryEvent).toBeDefined();
+      expect(summaryEvent?.[0].payload).toMatchObject({
+        lintStatus: 'passed',
+        typecheckStatus: 'skipped',
+        testStatus: 'failed',
+        e2eStatus: 'skipped',
+        evidenceStatus: 'failed',
+      });
+      expect(
+        (summaryEvent?.[0].payload as { contextByteSizeEstimate?: number }).contextByteSizeEstimate,
+      ).toBeGreaterThan(0);
     });
   });
 

--- a/slices/qa/verification-summary.ts
+++ b/slices/qa/verification-summary.ts
@@ -1,0 +1,278 @@
+import { spawn } from 'node:child_process';
+import type { QaE2eMode } from '@goose-hub/core/db/repositories/project-settings.js';
+import type { AgentEvent } from '@goose-hub/core/event-stream/store.js';
+import type {
+  TestRun,
+  VerificationCommandSummary,
+  VerificationSummary,
+} from '@goose-hub/skills/qa/schema.js';
+import {
+  type PrOpenedHints,
+  classifyUiChanges,
+  getChangedFilePaths,
+  getPrDiffStat,
+} from './qa-helpers.js';
+
+export type RunQaCommand = (cwd: string, command: string) => Promise<VerificationCommandSummary>;
+
+export interface VerificationSummaryInput {
+  workspaceDir?: string;
+  prHints: PrOpenedHints;
+  prDiff: string;
+  qaE2eMode: QaE2eMode;
+  configuredE2eCommand?: string;
+  commands: {
+    testCommand: string;
+    lintCommand?: string;
+    typecheckCommand?: string;
+  };
+  priorEvents: AgentEvent[];
+  devTestsRun?: { command: string; paths: string[] };
+  runTests: (cwd: string, command: string) => Promise<TestRun | null>;
+  runCommand?: RunQaCommand;
+}
+
+export interface VerificationSummaryResult {
+  verificationSummary: VerificationSummary;
+  testRun: TestRun | null;
+  e2eDecision: { mode: QaE2eMode; command?: string; reason: string };
+}
+
+const COMMAND_TIMEOUT_MS = 120_000;
+
+export async function defaultRunCommand(
+  cwd: string,
+  command: string,
+): Promise<VerificationCommandSummary> {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return { command, status: 'skipped', error: 'empty command' };
+  }
+
+  const started = Date.now();
+  return await new Promise((resolve) => {
+    let settled = false;
+    let child: ReturnType<typeof spawn> | undefined;
+    const finish = (summary: VerificationCommandSummary) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ ...summary, durationMs: Date.now() - started });
+    };
+    const timeout = setTimeout(() => {
+      child?.kill('SIGTERM');
+      finish({
+        command,
+        status: 'failed',
+        error: `command timed out after ${COMMAND_TIMEOUT_MS}ms`,
+      });
+    }, COMMAND_TIMEOUT_MS);
+
+    try {
+      child = spawn('sh', ['-c', trimmed], {
+        cwd,
+        env: { ...process.env, CI: 'true' },
+        stdio: ['ignore', 'ignore', 'ignore'],
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      finish({ command, status: 'failed', error: sanitizeOperationalMessage(error.message) });
+      return;
+    }
+
+    child.on('error', (err) => {
+      finish({ command, status: 'failed', error: sanitizeOperationalMessage(err.message) });
+    });
+    child.on('close', (code) => {
+      finish({
+        command,
+        status: code === 0 ? 'passed' : 'failed',
+        ...(code != null ? { exitCode: code } : {}),
+      });
+    });
+  });
+}
+
+export async function buildVerificationSummary(
+  input: VerificationSummaryInput,
+): Promise<VerificationSummaryResult> {
+  const runCommand = input.runCommand ?? defaultRunCommand;
+  const changedFilePaths = getChangedFilePaths(input.workspaceDir, input.prHints.baseBranch);
+  const diffStat = getPrDiffStat(input.workspaceDir, input.prHints.baseBranch);
+  const e2eDecision = decideE2e({
+    mode: input.qaE2eMode,
+    configuredE2eCommand: input.configuredE2eCommand,
+    changedFilePaths,
+  });
+
+  const lint = await runOptionalCommand(input.workspaceDir, input.commands.lintCommand, runCommand);
+  const typecheck = await runOptionalCommand(
+    input.workspaceDir,
+    input.commands.typecheckCommand,
+    runCommand,
+  );
+
+  const testRun =
+    input.workspaceDir != null
+      ? await input.runTests(input.workspaceDir, input.commands.testCommand)
+      : null;
+  const testStatus: VerificationCommandSummary['status'] =
+    input.workspaceDir == null ? 'skipped' : testRun?.success === true ? 'passed' : 'failed';
+
+  const verificationSummary: VerificationSummary = {
+    changedFiles: {
+      paths: changedFilePaths,
+      count: changedFilePaths.length,
+      diffCharCount: input.prDiff.length,
+      ...(diffStat.length > 0 ? { diffStat } : {}),
+    },
+    pr: {
+      ...(input.prHints.prNumber != null ? { number: input.prHints.prNumber } : {}),
+      ...(input.prHints.baseBranch != null ? { baseBranch: input.prHints.baseBranch } : {}),
+      ...(input.prHints.prHeadSha != null ? { headSha: input.prHints.prHeadSha } : {}),
+    },
+    commands: {
+      ...(lint != null ? { lint } : {}),
+      ...(typecheck != null ? { typecheck } : {}),
+      test: {
+        command: input.commands.testCommand,
+        status: testStatus,
+        ...(testRun != null ? { durationMs: testRun.wallTimeMs } : {}),
+      },
+      ...(e2eDecision.command != null
+        ? { e2e: { command: e2eDecision.command, status: 'skipped' as const } }
+        : {}),
+    },
+    testRun: compactTestRun(input.commands.testCommand, testStatus, testRun),
+    e2e: {
+      mode: e2eDecision.mode,
+      ...(e2eDecision.command != null ? { command: e2eDecision.command } : {}),
+      status: 'skipped',
+      reason:
+        e2eDecision.command != null
+          ? `${e2eDecision.reason}; harness did not run e2e`
+          : e2eDecision.reason,
+    },
+    evidence: summarizeEvidence(input.priorEvents),
+    ...(input.devTestsRun != null ? { devTestsRun: input.devTestsRun } : {}),
+  };
+
+  return { verificationSummary, testRun, e2eDecision };
+}
+
+export function estimateVerificationSummaryBytes(summary: VerificationSummary): number {
+  return Buffer.byteLength(JSON.stringify(summary), 'utf8');
+}
+
+function decideE2e(input: {
+  mode: QaE2eMode;
+  configuredE2eCommand?: string;
+  changedFilePaths: string[];
+}): { mode: QaE2eMode; command?: string; reason: string } {
+  const uiClassification = classifyUiChanges(input.changedFilePaths);
+  if (input.mode === 'off') {
+    return { mode: input.mode, reason: 'qa e2e disabled by project setting' };
+  }
+  if (input.mode === 'always') {
+    return input.configuredE2eCommand != null
+      ? { mode: input.mode, command: input.configuredE2eCommand, reason: 'qa e2e mode is always' }
+      : { mode: input.mode, reason: 'qa e2e mode is always but no command is configured' };
+  }
+  if (uiClassification.hasSignificantUiChange && input.configuredE2eCommand != null) {
+    return {
+      mode: input.mode,
+      command: input.configuredE2eCommand,
+      reason: uiClassification.reason,
+    };
+  }
+  return {
+    mode: input.mode,
+    reason:
+      input.configuredE2eCommand == null
+        ? 'qa e2e mode is ui-changed but no command is configured'
+        : uiClassification.reason,
+  };
+}
+
+function runOptionalCommand(
+  workspaceDir: string | undefined,
+  command: string | undefined,
+  runCommand: RunQaCommand,
+): Promise<VerificationCommandSummary | null> {
+  if (command == null || command.trim().length === 0) return Promise.resolve(null);
+  if (workspaceDir == null) {
+    return Promise.resolve({ command, status: 'skipped', error: 'no worktree available' });
+  }
+  return runCommand(workspaceDir, command);
+}
+
+function compactTestRun(
+  command: string,
+  status: VerificationCommandSummary['status'],
+  testRun: TestRun | null,
+): VerificationSummary['testRun'] {
+  if (testRun == null) {
+    return {
+      command,
+      status,
+      total: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      failingSuites: [],
+    };
+  }
+
+  return {
+    command,
+    status,
+    wallTimeMs: testRun.wallTimeMs,
+    total: testRun.total,
+    passed: testRun.passed,
+    failed: testRun.failed,
+    skipped: testRun.skipped,
+    failingSuites: testRun.suites
+      .filter((suite) => suite.status === 'failed' || suite.failed > 0)
+      .map((suite) => suite.filePath || suite.name),
+  };
+}
+
+function summarizeEvidence(events: AgentEvent[]): VerificationSummary['evidence'] {
+  const evidence = events
+    .slice()
+    .reverse()
+    .find((event) =>
+      [
+        'evidence.posted',
+        'evidence.post-failed',
+        'evidence.post-skipped',
+        'evidence.no-spec-declared',
+      ].includes(event.kind),
+    );
+  if (evidence == null) return { status: 'absent' };
+
+  const payload = evidence.payload as Record<string, unknown>;
+  if (evidence.kind === 'evidence.posted') {
+    return typeof payload.commentUrl === 'string'
+      ? { status: 'posted', url: payload.commentUrl }
+      : { status: 'posted' };
+  }
+  if (evidence.kind === 'evidence.post-failed') {
+    return {
+      status: 'failed',
+      error: sanitizeOperationalMessage(payload.error),
+    };
+  }
+  if (evidence.kind === 'evidence.post-skipped') {
+    return {
+      status: 'skipped',
+      reason: sanitizeOperationalMessage(payload.reason ?? 'evidence post skipped'),
+    };
+  }
+  return { status: 'skipped', reason: 'no evidence spec declared' };
+}
+
+function sanitizeOperationalMessage(value: unknown): string {
+  const message = typeof value === 'string' ? value : String(value ?? 'unknown error');
+  return message.replace(/\s+/g, ' ').trim().slice(0, 300);
+}

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -28,14 +28,13 @@ import {
   toAgentTierResults,
 } from './deterministic-tiers.js';
 export type { VerifyCommand } from './deterministic-tiers.js';
-import {
-  classifyUiChanges,
-  findDevTestsRun,
-  findPrOpenedHints,
-  getChangedFilePaths,
-  getPrDiff,
-} from './qa-helpers.js';
+import { findDevTestsRun, findPrOpenedHints, getPrDiff } from './qa-helpers.js';
 import { buildSyntheticQaOutput } from './synthetic-output.js';
+import {
+  type RunQaCommand,
+  buildVerificationSummary,
+  estimateVerificationSummaryBytes,
+} from './verification-summary.js';
 
 export interface QaWorkflowDeps {
   runtime?: AgentRuntime;
@@ -46,6 +45,8 @@ export interface QaWorkflowDeps {
    * QA agent still runs, just without real suite numbers in its context.
    */
   runTests?: (cwd: string, command: string) => Promise<TestRun | null>;
+  /** Inject for tests — run compact lint/typecheck command summaries. */
+  runCommand?: RunQaCommand;
   /** Per-AC verify commands extracted from the issue body before QA spawn. */
   verifyCommands?: VerifyCommand[];
   /** Inject for tests — return the spec for this work item, or null. */
@@ -90,6 +91,7 @@ export async function runQaWorkflow(
 ): Promise<void> {
   const runId = crypto.randomUUID();
   const runTests = deps.runTests ?? defaultRunTests;
+  const runCommand = deps.runCommand;
   const verifyCommands = deps.verifyCommands;
   const getSpec = deps.getEngineeringSpecImpl ?? defaultGetEngineeringSpec;
   const runTier = deps.runTierImpl ?? defaultRunTier;
@@ -239,33 +241,46 @@ export async function runQaWorkflow(
     // Run tests deterministically before invoking the QA agent so the agent
     // grades against real numbers instead of re-running the suite. Failures
     // here are non-fatal — the agent still runs without testRun.
-    const testCommand = DEFAULT_TEST_COMMAND;
-    const testRun = workspaceDir != null ? await runTests(workspaceDir, testCommand) : null;
+    const testCommand = projectConfig?.stack?.testCommand ?? DEFAULT_TEST_COMMAND;
+    const lintCommand = projectConfig?.stack?.lintCommand ?? 'pnpm biome check .';
+    const typecheckCommand = projectConfig?.stack?.typecheckCommand;
+    const configuredE2eCommand = projectConfig?.stack?.e2eCommand;
+    const { verificationSummary, testRun, e2eDecision } = await buildVerificationSummary({
+      workspaceDir,
+      prHints,
+      prDiff,
+      qaE2eMode,
+      configuredE2eCommand,
+      commands: {
+        testCommand,
+        lintCommand,
+        ...(typecheckCommand != null ? { typecheckCommand } : {}),
+      },
+      priorEvents,
+      devTestsRun,
+      runTests,
+      ...(runCommand != null ? { runCommand } : {}),
+    });
+
+    eventStore.appendEvent({
+      projectId: projectSlug,
+      workItemId: workItem.id,
+      kind: 'qa.verification-summary-built',
+      payload: {
+        changedFileCount: verificationSummary.changedFiles.count,
+        diffCharCount: verificationSummary.changedFiles.diffCharCount,
+        contextByteSizeEstimate: estimateVerificationSummaryBytes(verificationSummary),
+        lintStatus: verificationSummary.commands.lint?.status ?? 'skipped',
+        typecheckStatus: verificationSummary.commands.typecheck?.status ?? 'skipped',
+        testStatus: verificationSummary.commands.test.status,
+        e2eStatus: verificationSummary.e2e.status,
+        evidenceStatus: verificationSummary.evidence.status,
+      },
+      runId,
+    });
+
     const [webPort, apiPort] =
       workspaceDir != null ? await Promise.all([findFreePort(), findFreePort()]) : [null, null];
-    const changedFiles = getChangedFilePaths(workspaceDir, prHints.baseBranch);
-    const uiClassification = classifyUiChanges(changedFiles);
-    const configuredE2eCommand = projectConfig?.stack?.e2eCommand;
-    const e2eDecision =
-      qaE2eMode === 'off'
-        ? { mode: qaE2eMode, reason: 'qa e2e disabled by project setting' }
-        : qaE2eMode === 'always'
-          ? configuredE2eCommand != null
-            ? { mode: qaE2eMode, command: configuredE2eCommand, reason: 'qa e2e mode is always' }
-            : { mode: qaE2eMode, reason: 'qa e2e mode is always but no command is configured' }
-          : uiClassification.hasSignificantUiChange && configuredE2eCommand != null
-            ? {
-                mode: qaE2eMode,
-                command: configuredE2eCommand,
-                reason: uiClassification.reason,
-              }
-            : {
-                mode: qaE2eMode,
-                reason:
-                  configuredE2eCommand == null
-                    ? 'qa e2e mode is ui-changed but no command is configured'
-                    : uiClassification.reason,
-              };
 
     const deterministicTierResults = deterministic
       ? toAgentTierResults(deterministic.tierResults)
@@ -286,9 +301,10 @@ export async function runQaWorkflow(
         prDiff,
         projectCommands: {
           testCommand,
-          lintCommand: 'pnpm biome check .',
+          lintCommand,
           ...(e2eDecision.command != null ? { e2eCommand: e2eDecision.command } : {}),
         },
+        verificationSummary,
         e2eDecision,
         ...(verifyCommands != null && verifyCommands.length > 0 ? { verifyCommands } : {}),
         testRun,
@@ -300,6 +316,7 @@ export async function runQaWorkflow(
         'workItem',
         'prDiff',
         'projectCommands',
+        'verificationSummary',
         'e2eDecision',
         'testRun',
         'verifyCommands',


### PR DESCRIPTION
## Summary
- Add compact QA verificationSummary context with changed-file, command, test, e2e, evidence, and dev-test metadata
- Build workflow-owned deterministic verification summary before QA spawn and emit qa.verification-summary-built telemetry
- Update QA prompt/config/schema and focused tests for holdout-safe consumption

## Verification
- env PATH=/Users/shaunnesbitt/projects/goose-hub/node_modules/.bin:$PATH ../../node_modules/.bin/tsx scripts/run-vitest-with-db.ts slices/qa/slice.test.ts skills/qa/slice.test.ts apps/web/src/components/detail/lib/timeline.test.ts
- env PATH=/Users/shaunnesbitt/projects/goose-hub/node_modules/.bin:$PATH ../../node_modules/.bin/biome check skills/qa/schema.ts skills/qa/skill.config.ts skills/qa/prompt.md slices/qa/qa-helpers.ts slices/qa/verification-summary.ts slices/qa/workflow.ts slices/qa/slice.test.ts skills/qa/slice.test.ts core/event-stream/store.ts apps/web/src/components/detail/lib/timeline.ts

## Notes
- Full tsc --noEmit remains blocked in this worktree by missing server Hono dependencies.