### PR TITLE
M17: bridge Codex live decision summaries

### DIFF
--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -191,6 +191,33 @@ describe('groupEvents — run-group by runId', () => {
       expect(result[0].event.kind).toBe('agent.tool-call');
     }
   });
+
+  it('keeps live decision summaries inside the same run group as tool calls', () => {
+    const events: AgentEventDto[] = [
+      makeRunEvent(1, 'run-live', 'agent.run-started', 'implement'),
+      makeRunEvent(2, 'run-live', 'agent.tool-call'),
+      {
+        ...makeRunEvent(3, 'run-live', 'agent.decision-summary-live'),
+        payload: { kind: 'READ', summary: 'Searching app shell components', skill: 'implement' },
+      },
+      makeRunEvent(4, 'run-live', 'agent.tool-call'),
+    ];
+
+    const result = groupEvents(events);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('run-group');
+    if (result[0].kind === 'run-group') {
+      expect(result[0].runId).toBe('run-live');
+      expect(
+        result[0].items.map((item) => (item.kind === 'event' ? item.event.kind : item.kind)),
+      ).toEqual([
+        'agent.run-started',
+        'agent.tool-call',
+        'agent.decision-summary-live',
+        'agent.tool-call',
+      ]);
+    }
+  });
 });
 
 // ─── run-group metadata ───────────────────────────────────────────────────────

--- a/apps/web/src/components/detail/components/timeline/DecisionSummaryEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/DecisionSummaryEvents.tsx
@@ -1,5 +1,5 @@
 import type { AgentEventDto } from '@/lib/types';
-import { ChevronRight, Sparkles } from 'lucide-react';
+import { Radio, Sparkles } from 'lucide-react';
 import { getPayloadStr } from '../../lib/timeline';
 
 export function AgentDecisionSummaryEvent({ event }: { event: AgentEventDto }) {
@@ -45,28 +45,27 @@ export function AgentDecisionSummaryLiveEvent({ event }: { event: AgentEventDto 
   return (
     <li
       data-event-kind={event.kind}
-      className="rounded-md border border-line/50 bg-bg/40 px-4 py-2"
+      className="rounded-md border border-line/50 bg-bg/40 px-3 py-2"
     >
-      <details>
-        <summary className="flex items-center gap-1 cursor-pointer list-none font-mono text-[11.5px] select-none">
-          <ChevronRight size={12} />
-          <span className="text-[color:var(--accent)] shrink-0" title="Live decision marker">
-            💭
-          </span>
-          {kind != null && (
-            <span
-              data-testid="decision-kind-chip-live"
-              className="font-mono text-[9.5px] tracking-wider px-1 py-[1px] rounded bg-bg-elev-2 text-[color:var(--accent)] shrink-0"
-            >
-              {kind}
-            </span>
-          )}
-          <span className="truncate max-w-[460px]">{summary}</span>
-        </summary>
-        <div className="mt-1.5 text-[11px] text-fg-2 font-mono tnum pl-4">
-          {new Date(event.createdAt).toLocaleString()}
+      <div className="flex items-start gap-2">
+        <Radio size={12} className="mt-[2px] shrink-0 text-[color:var(--accent)]" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5 font-mono text-[10.5px] text-fg-3">
+            <span className="uppercase tracking-wider">Live decision</span>
+            {kind != null && (
+              <span
+                data-testid="decision-kind-chip-live"
+                className="shrink-0 rounded bg-bg-elev-2 px-1.5 py-[1px] font-mono text-[9.5px] tracking-wider text-[color:var(--accent)]"
+              >
+                {kind}
+              </span>
+            )}
+            <span aria-hidden className="h-[3px] w-[3px] rounded-full bg-fg-4" />
+            <span className="tnum">{new Date(event.createdAt).toLocaleTimeString()}</span>
+          </div>
+          <div className="mt-1 text-[12px] leading-snug text-fg-2">{summary}</div>
         </div>
-      </details>
+      </div>
     </li>
   );
 }

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -158,6 +158,158 @@ describe('CodexCliRuntime timeout handling', () => {
     );
   });
 
+  it('emits one live decision event from a streamed agent_message marker', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec({ skill: 'investigate' }));
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'msg_1',
+            type: 'agent_message',
+            text: '[decision] READ: Searching app shell components\n{"ok":true}',
+          },
+        })}\n`,
+      ),
+    );
+
+    const decisionCalls = mockEventStore.appendEvent.mock.calls.filter(
+      ([e]) => e.kind === 'agent.decision-summary-live',
+    );
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0][0]).toMatchObject({
+      projectId: 'test-project',
+      workItemId: 'github:owner/repo#1',
+      runId: 'run-codex',
+      personaId: 'test-project/developer/0',
+      payload: {
+        run_id: 'run-codex',
+        kind: 'READ',
+        summary: 'Searching app shell components',
+        skill: 'investigate',
+        personaId: 'test-project/developer/0',
+      },
+    });
+
+    child.emit('close', 0);
+    await expect(run).resolves.toMatchObject({ output: { ok: true } });
+  });
+
+  it('preserves live decision marker order from a single agent_message', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'msg_1',
+            type: 'agent_message',
+            text: [
+              '[decision] READ: Searching chrome coverage',
+              '[decision] UNCERTAINTY: Test target unclear',
+              '{"ok":true}',
+            ].join('\n'),
+          },
+        })}\n`,
+      ),
+    );
+    child.emit('close', 0);
+    await run;
+
+    const summaries = mockEventStore.appendEvent.mock.calls
+      .filter(([e]) => e.kind === 'agent.decision-summary-live')
+      .map(([e]) => (e.payload as { summary?: string }).summary);
+    expect(summaries).toEqual(['Searching chrome coverage', 'Test target unclear']);
+  });
+
+  it('does not double-emit markers when Codex replays cumulative assistant text', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        [
+          JSON.stringify({
+            type: 'item.updated',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.updated',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files\n[decision] INSIGHT: Found owner',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.completed',
+            item: { id: 'msg_2', type: 'agent_message', text: '{"ok":true}' },
+          }),
+          '',
+        ].join('\n'),
+      ),
+    );
+    child.emit('close', 0);
+    await run;
+
+    const summaries = mockEventStore.appendEvent.mock.calls
+      .filter(([e]) => e.kind === 'agent.decision-summary-live')
+      .map(([e]) => (e.payload as { summary?: string }).summary);
+    expect(summaries).toEqual(['Searching files', 'Found owner']);
+  });
+
+  it('normalizes invalid live decision marker kinds to UNKNOWN', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'msg_1',
+            type: 'agent_message',
+            text: '[decision] NOT_A_KIND: Still surface this progress\n{"ok":true}',
+          },
+        })}\n`,
+      ),
+    );
+    child.emit('close', 0);
+    await run;
+
+    const decisionCall = mockEventStore.appendEvent.mock.calls.find(
+      ([e]) => e.kind === 'agent.decision-summary-live',
+    );
+    expect(decisionCall?.[0].payload).toMatchObject({
+      kind: 'UNKNOWN',
+      summary: 'Still surface this progress',
+    });
+  });
+
   it('emits timeout and failed events, kills the process group, rejects, and ignores late close', async () => {
     vi.useFakeTimers();
     const child = makeHangingChild();

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -258,12 +258,16 @@ describe('CodexCliRuntime timeout handling', () => {
             item: {
               id: 'msg_1',
               type: 'agent_message',
-              text: '[decision] READ: Searching files\n[decision] INSIGHT: Found owner',
+              text: '[decision] READ: Searching files\n[decision] INSIGHT: Found owner\n',
             },
           }),
           JSON.stringify({
             type: 'item.completed',
-            item: { id: 'msg_2', type: 'agent_message', text: '{"ok":true}' },
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files\n[decision] INSIGHT: Found owner\n{"ok":true}',
+            },
           }),
           '',
         ].join('\n'),
@@ -276,6 +280,99 @@ describe('CodexCliRuntime timeout handling', () => {
       .filter(([e]) => e.kind === 'agent.decision-summary-live')
       .map(([e]) => (e.payload as { summary?: string }).summary);
     expect(summaries).toEqual(['Searching files', 'Found owner']);
+  });
+
+  it('does not emit partial updates or re-emit a marker whose line is later extended', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        [
+          JSON.stringify({
+            type: 'item.updated',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.updated',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files\n',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.updated',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files and confirming ownership\n',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.completed',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              text: '[decision] READ: Searching files and confirming ownership\n{"ok":true}',
+            },
+          }),
+          '',
+        ].join('\n'),
+      ),
+    );
+    child.emit('close', 0);
+    await run;
+
+    const summaries = mockEventStore.appendEvent.mock.calls
+      .filter(([e]) => e.kind === 'agent.decision-summary-live')
+      .map(([e]) => (e.payload as { summary?: string }).summary);
+    expect(summaries).toEqual(['Searching files']);
+  });
+
+  it('ignores raw delta chunks for live decision parsing', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        [
+          JSON.stringify({
+            type: 'item.delta',
+            item: {
+              id: 'msg_1',
+              type: 'agent_message',
+              delta: '[decision] READ: partial chunk',
+            },
+          }),
+          JSON.stringify({
+            type: 'item.completed',
+            item: { id: 'msg_1', type: 'agent_message', text: '{"ok":true}' },
+          }),
+          '',
+        ].join('\n'),
+      ),
+    );
+    child.emit('close', 0);
+    await run;
+
+    expect(
+      mockEventStore.appendEvent.mock.calls.filter(
+        ([e]) => e.kind === 'agent.decision-summary-live',
+      ),
+    ).toHaveLength(0);
   });
 
   it('normalizes invalid live decision marker kinds to UNKNOWN', async () => {

--- a/core/agent-runtime/codex-cli.test.ts
+++ b/core/agent-runtime/codex-cli.test.ts
@@ -4,6 +4,7 @@ import {
   extractResultJson,
   parseCodexEnvelope,
   pickCodexAgentMessageText,
+  pickCodexAssistantMessage,
 } from './codex-cli.js';
 
 const RUN_ID = 'test-run-id';
@@ -119,6 +120,16 @@ describe('parseCodexEnvelope', () => {
     expect(envelope?.result).toBeNull();
   });
 
+  it('does not synthesize final output from non-terminal assistant updates', () => {
+    const stdout = JSON.stringify({
+      type: 'item.updated',
+      item: { id: 'item_0', type: 'agent_message', text: '{"partial":true}' },
+    });
+    const envelope = parseCodexEnvelope(stdout);
+    expect(envelope).not.toBeNull();
+    expect(envelope?.result).toBeNull();
+  });
+
   it('leaves costUsd as null when no cost field is present in the envelope', () => {
     const stdout = [
       JSON.stringify({
@@ -151,6 +162,15 @@ describe('pickCodexAgentMessageText', () => {
     expect(pickCodexAgentMessageText({ type: 'thread.started', thread_id: 'abc' })).toBeNull();
   });
 
+  it('returns null for non-terminal item.updated assistant text', () => {
+    expect(
+      pickCodexAgentMessageText({
+        type: 'item.updated',
+        item: { type: 'agent_message', text: '{"partial":true}' },
+      }),
+    ).toBeNull();
+  });
+
   it('returns null for item.completed with non-agent_message item type', () => {
     const obj = { type: 'item.completed', item: { type: 'tool_call', text: '...' } };
     expect(pickCodexAgentMessageText(obj)).toBeNull();
@@ -165,6 +185,41 @@ describe('pickCodexAgentMessageText', () => {
       decisionSummaries: [],
     };
     expect(pickCodexAgentMessageText(obj)).toBeNull();
+  });
+});
+
+// ─── pickCodexAssistantMessage ───────────────────────────────────────────────
+
+describe('pickCodexAssistantMessage', () => {
+  it('extracts reconstructed assistant text from item.updated for live parsing', () => {
+    expect(
+      pickCodexAssistantMessage({
+        type: 'item.updated',
+        item: { id: 'item_0', type: 'agent_message', text: '[decision] READ: Searching files' },
+      }),
+    ).toEqual({
+      id: 'item_0',
+      text: '[decision] READ: Searching files',
+      terminal: false,
+    });
+  });
+
+  it('ignores raw item.delta chunks', () => {
+    expect(
+      pickCodexAssistantMessage({
+        type: 'item.delta',
+        item: { id: 'item_0', type: 'agent_message', delta: '[decision] READ: partial' },
+      }),
+    ).toBeNull();
+  });
+
+  it('marks item.completed assistant text as terminal', () => {
+    expect(
+      pickCodexAssistantMessage({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'agent_message', text: '{"ok":true}' },
+      }),
+    ).toEqual({ id: 'item_0', text: '{"ok":true}', terminal: true });
   });
 });
 

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -176,13 +176,15 @@ export class CodexCliRuntime implements AgentRuntime {
           if (assistantMessage != null) {
             const key = assistantMessage.id ?? '__default_assistant_message__';
             const previousOffset = assistantMarkerOffsets.get(key) ?? 0;
+            const scanText = assistantMessage.terminal
+              ? assistantMessage.text
+              : completeLinePrefix(assistantMessage.text);
             const safePreviousOffset =
-              assistantMessage.text.length < previousOffset ? 0 : previousOffset;
-            const markers = parseDecisionMarkersAfter(assistantMessage.text, safePreviousOffset);
-            assistantMarkerOffsets.set(
-              key,
-              Math.max(safePreviousOffset, assistantMessage.text.length),
-            );
+              scanText.length < previousOffset || assistantMessage.text.length < previousOffset
+                ? 0
+                : previousOffset;
+            const markers = parseDecisionMarkersAfter(scanText, safePreviousOffset);
+            assistantMarkerOffsets.set(key, Math.max(safePreviousOffset, scanText.length));
             for (const marker of markers) {
               const kind = isDecisionKind(marker.kind) ? marker.kind : 'UNKNOWN';
               eventStore.appendEvent({
@@ -464,4 +466,9 @@ export class CodexCliRuntime implements AgentRuntime {
       });
     });
   }
+}
+
+function completeLinePrefix(text: string): string {
+  const lastNewline = Math.max(text.lastIndexOf('\n'), text.lastIndexOf('\r'));
+  return lastNewline === -1 ? '' : text.slice(0, lastNewline + 1);
 }

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -23,9 +23,12 @@ import {
   extractResultJson,
   parseCodexEnvelope,
   pickCodexAgentMessageText,
+  pickCodexAssistantMessage,
   pickCodexToolCall,
 } from './codex-parser.js';
 import { assembleSpawnContext } from './context-assembly.js';
+import { parseDecisionMarkersAfter } from './decision-markers.js';
+import { isDecisionKind } from './decision-types.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { resolveMockOutput } from './mock-outputs.js';
 import { defaultModelForTierAndProvider, estimateCostUsd } from './models.js';
@@ -41,6 +44,7 @@ export {
 export {
   parseCodexEnvelope,
   extractResultJson,
+  pickCodexAssistantMessage,
   pickCodexAgentMessageText,
   pickCodexToolCall,
 } from './codex-parser.js';
@@ -160,13 +164,46 @@ export class CodexCliRuntime implements AgentRuntime {
       let truncated = false;
       let settled = false;
       let toolCallCount = 0;
+      const assistantMarkerOffsets = new Map<string, number>();
 
       const handleStdoutLine = (line: string) => {
         if (line.trim().length === 0) return;
         try {
           const parsed = JSON.parse(line) as unknown;
           if (parsed == null || typeof parsed !== 'object') return;
-          const toolCall = pickCodexToolCall(parsed as Record<string, unknown>);
+          const event = parsed as Record<string, unknown>;
+          const assistantMessage = pickCodexAssistantMessage(event);
+          if (assistantMessage != null) {
+            const key = assistantMessage.id ?? '__default_assistant_message__';
+            const previousOffset = assistantMarkerOffsets.get(key) ?? 0;
+            const safePreviousOffset =
+              assistantMessage.text.length < previousOffset ? 0 : previousOffset;
+            const markers = parseDecisionMarkersAfter(assistantMessage.text, safePreviousOffset);
+            assistantMarkerOffsets.set(
+              key,
+              Math.max(safePreviousOffset, assistantMessage.text.length),
+            );
+            for (const marker of markers) {
+              const kind = isDecisionKind(marker.kind) ? marker.kind : 'UNKNOWN';
+              eventStore.appendEvent({
+                projectId,
+                workItemId,
+                kind: 'agent.decision-summary-live',
+                payload: {
+                  run_id: runId,
+                  kind,
+                  summary: marker.summary,
+                  timestamp: new Date().toISOString(),
+                  skill: spec.skill,
+                  personaId,
+                },
+                runId,
+                personaId,
+              });
+            }
+          }
+
+          const toolCall = pickCodexToolCall(event);
           if (toolCall == null) return;
           toolCallCount += 1;
           eventStore.appendEvent({

--- a/core/agent-runtime/codex-parser.ts
+++ b/core/agent-runtime/codex-parser.ts
@@ -16,6 +16,7 @@ export interface CodexToolCall {
 export interface CodexAssistantMessage {
   id: string | null;
   text: string;
+  terminal: boolean;
 }
 
 /**
@@ -25,20 +26,29 @@ export interface CodexAssistantMessage {
  * Exported for unit testing.
  */
 export function pickCodexAgentMessageText(obj: Record<string, unknown>): string | null {
-  return pickCodexAssistantMessage(obj)?.text ?? null;
+  if (obj.type !== 'item.completed' || typeof obj.item !== 'object' || obj.item === null) {
+    return null;
+  }
+  const item = obj.item as Record<string, unknown>;
+  if (!isAssistantItem(item)) return null;
+  return pickAssistantText(item);
 }
 
 export function pickCodexAssistantMessage(
   obj: Record<string, unknown>,
 ): CodexAssistantMessage | null {
-  if (!isCodexItemEvent(obj.type) || typeof obj.item !== 'object' || obj.item === null) {
+  if (!isAssistantMessageEvent(obj.type) || typeof obj.item !== 'object' || obj.item === null) {
     return null;
   }
   const item = obj.item as Record<string, unknown>;
   if (!isAssistantItem(item)) return null;
   const text = pickAssistantText(item);
   if (text == null || text.length === 0) return null;
-  return { id: typeof item.id === 'string' ? item.id : null, text };
+  return {
+    id: typeof item.id === 'string' ? item.id : null,
+    text,
+    terminal: obj.type === 'item.completed',
+  };
 }
 
 /**
@@ -180,13 +190,8 @@ function pickString(obj: Record<string, unknown>, keys: string[]): string | null
   return null;
 }
 
-function isCodexItemEvent(type: unknown): boolean {
-  return (
-    type === 'item.started' ||
-    type === 'item.updated' ||
-    type === 'item.delta' ||
-    type === 'item.completed'
-  );
+function isAssistantMessageEvent(type: unknown): boolean {
+  return type === 'item.updated' || type === 'item.completed';
 }
 
 function isAssistantItem(item: Record<string, unknown>): boolean {
@@ -195,7 +200,7 @@ function isAssistantItem(item: Record<string, unknown>): boolean {
 }
 
 function pickAssistantText(item: Record<string, unknown>): string | null {
-  const direct = pickString(item, ['text', 'content', 'message', 'delta']);
+  const direct = pickString(item, ['text', 'content', 'message']);
   if (direct != null) return direct;
   if (Array.isArray(item.content)) {
     const parts = item.content

--- a/core/agent-runtime/codex-parser.ts
+++ b/core/agent-runtime/codex-parser.ts
@@ -13,6 +13,11 @@ export interface CodexToolCall {
   toolInput: Record<string, unknown>;
 }
 
+export interface CodexAssistantMessage {
+  id: string | null;
+  text: string;
+}
+
 /**
  * If `obj` is a Codex transport event of the form
  * `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`,
@@ -20,13 +25,20 @@ export interface CodexToolCall {
  * Exported for unit testing.
  */
 export function pickCodexAgentMessageText(obj: Record<string, unknown>): string | null {
-  if (obj.type === 'item.completed' && typeof obj.item === 'object' && obj.item !== null) {
-    const item = obj.item as Record<string, unknown>;
-    if (item.type === 'agent_message' && typeof item.text === 'string') {
-      return item.text;
-    }
+  return pickCodexAssistantMessage(obj)?.text ?? null;
+}
+
+export function pickCodexAssistantMessage(
+  obj: Record<string, unknown>,
+): CodexAssistantMessage | null {
+  if (!isCodexItemEvent(obj.type) || typeof obj.item !== 'object' || obj.item === null) {
+    return null;
   }
-  return null;
+  const item = obj.item as Record<string, unknown>;
+  if (!isAssistantItem(item)) return null;
+  const text = pickAssistantText(item);
+  if (text == null || text.length === 0) return null;
+  return { id: typeof item.id === 'string' ? item.id : null, text };
 }
 
 /**
@@ -164,6 +176,39 @@ function pickString(obj: Record<string, unknown>, keys: string[]): string | null
   for (const k of keys) {
     const v = obj[k];
     if (typeof v === 'string') return v;
+  }
+  return null;
+}
+
+function isCodexItemEvent(type: unknown): boolean {
+  return (
+    type === 'item.started' ||
+    type === 'item.updated' ||
+    type === 'item.delta' ||
+    type === 'item.completed'
+  );
+}
+
+function isAssistantItem(item: Record<string, unknown>): boolean {
+  if (item.type === 'agent_message' || item.type === 'assistant_message') return true;
+  return item.type === 'message' && item.role === 'assistant';
+}
+
+function pickAssistantText(item: Record<string, unknown>): string | null {
+  const direct = pickString(item, ['text', 'content', 'message', 'delta']);
+  if (direct != null) return direct;
+  if (Array.isArray(item.content)) {
+    const parts = item.content
+      .map((part) => {
+        if (typeof part === 'string') return part;
+        if (part != null && typeof part === 'object') {
+          const obj = part as Record<string, unknown>;
+          return pickString(obj, ['text', 'content']);
+        }
+        return null;
+      })
+      .filter((part): part is string => part != null);
+    if (parts.length > 0) return parts.join('');
   }
   return null;
 }

--- a/core/agent-runtime/decision-markers.test.ts
+++ b/core/agent-runtime/decision-markers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseDecisionMarkers, parseDecisionMarkersAfter } from './decision-markers.js';
+
+describe('parseDecisionMarkers', () => {
+  it('extracts typed live decision markers in source order', () => {
+    expect(
+      parseDecisionMarkers(
+        [
+          '[decision] READ: Searching app shell components to find the rendered header owner',
+          'ordinary text',
+          '[decision] INSIGHT: Sidebar.tsx owns the brand string',
+        ].join('\n'),
+      ).map(({ kind, summary }) => ({ kind, summary })),
+    ).toEqual([
+      {
+        kind: 'READ',
+        summary: 'Searching app shell components to find the rendered header owner',
+      },
+      { kind: 'INSIGHT', summary: 'Sidebar.tsx owns the brand string' },
+    ]);
+  });
+
+  it('keeps legacy untyped markers as UNKNOWN', () => {
+    expect(parseDecisionMarkers('[decision] a legacy progress marker')).toMatchObject([
+      { kind: 'UNKNOWN', summary: 'a legacy progress marker' },
+    ]);
+  });
+
+  it('keeps invalid typed kinds for caller-side normalization', () => {
+    expect(parseDecisionMarkers('[decision] NOT_A_KIND: still visible')).toMatchObject([
+      { kind: 'NOT_A_KIND', summary: 'still visible' },
+    ]);
+  });
+
+  it('ignores lowercase typed-looking markers as legacy text', () => {
+    expect(parseDecisionMarkers('[decision] read: lowercase kind')).toMatchObject([
+      { kind: 'UNKNOWN', summary: 'read: lowercase kind' },
+    ]);
+  });
+});
+
+describe('parseDecisionMarkersAfter', () => {
+  it('returns only markers not already covered by a previous cumulative text offset', () => {
+    const first = '[decision] READ: Searching files';
+    const cumulative = `${first}\n[decision] INSIGHT: Found the owner`;
+
+    expect(parseDecisionMarkersAfter(cumulative, first.length).map((m) => m.summary)).toEqual([
+      'Found the owner',
+    ]);
+  });
+});

--- a/core/agent-runtime/decision-markers.test.ts
+++ b/core/agent-runtime/decision-markers.test.ts
@@ -48,4 +48,12 @@ describe('parseDecisionMarkersAfter', () => {
       'Found the owner',
     ]);
   });
+
+  it('does not re-emit an already-started marker when cumulative text extends it', () => {
+    const cumulative = '[decision] READ: Searching files and confirming ownership';
+
+    expect(
+      parseDecisionMarkersAfter(cumulative, '[decision] READ: Searching files'.length),
+    ).toEqual([]);
+  });
 });

--- a/core/agent-runtime/decision-markers.ts
+++ b/core/agent-runtime/decision-markers.ts
@@ -30,5 +30,5 @@ export function parseDecisionMarkersAfter(
   text: string,
   previousEndOffset: number,
 ): DecisionMarker[] {
-  return parseDecisionMarkers(text).filter((marker) => marker.end > previousEndOffset);
+  return parseDecisionMarkers(text).filter((marker) => marker.start >= previousEndOffset);
 }

--- a/core/agent-runtime/decision-markers.ts
+++ b/core/agent-runtime/decision-markers.ts
@@ -1,0 +1,34 @@
+export interface DecisionMarker {
+  kind: string;
+  summary: string;
+  start: number;
+  end: number;
+}
+
+export const DECISION_MARKER_RE_SOURCE = '^\\[decision\\]\\s+(?:([A-Z_]+):\\s*(.+)|(.+))$';
+
+export function parseDecisionMarkers(text: string): DecisionMarker[] {
+  const re = new RegExp(DECISION_MARKER_RE_SOURCE, 'gm');
+  const markers: DecisionMarker[] = [];
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex iteration
+  while ((match = re.exec(text)) !== null) {
+    const kind = match[1] != null ? match[1].trim() : 'UNKNOWN';
+    const summary = (match[2] ?? match[3] ?? '').trim();
+    if (summary.length === 0) continue;
+    markers.push({
+      kind,
+      summary,
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  return markers;
+}
+
+export function parseDecisionMarkersAfter(
+  text: string,
+  previousEndOffset: number,
+): DecisionMarker[] {
+  return parseDecisionMarkers(text).filter((marker) => marker.end > previousEndOffset);
+}

--- a/core/tool-layer/post-tool-use-hook.ts
+++ b/core/tool-layer/post-tool-use-hook.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { DECISION_MARKER_RE_SOURCE } from '../agent-runtime/decision-markers.js';
 
 const HOOKS_DIR = join(homedir(), '.factory', 'hooks');
 
@@ -60,7 +61,7 @@ async function main() {
   // colon doesn't silently drop the marker. KIND is uppercase A-Z and
   // underscores; the server validates it against the canonical enum and
   // coerces unknown values to UNKNOWN.
-  const DECISION_RE = /^\\[decision\\]\\s+(?:([A-Z_]+):\\s*(.+)|(.+))$/gm;
+  const DECISION_RE = new RegExp(${JSON.stringify(DECISION_MARKER_RE_SOURCE)}, 'gm');
 
   const markers = [];
   let m;

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -269,4 +269,6 @@ Return a JSON object conforming to `ImplementSchema`. The orchestrator opens the
 
 Use uppercase enum values both in the JSON `kind` field and in the live `[decision] KIND: …` marker line. Free-text `step` strings are no longer accepted — schema validation rejects them.
 
-Live marker format: `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Example: `[decision] PLAN: Add helper in core/foo/bar.ts — mirrors existing baz pattern, avoids new abstraction`.
+Live markers are short progress/rationale markers, not raw thinking. Emit them before major search/read pivots, after important findings or test transitions, and on uncertainty/pivots. Do not emit before every command. Keep each marker to one sentence with no secrets, hidden reasoning, raw output, or file dumps.
+
+Live marker format: `[decision] KIND: <one sentence>`. Example: `[decision] PLAN: Adding helper in core/foo/bar.ts to mirror the existing baz pattern`.

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -142,20 +142,20 @@ Return a JSON object with this exact structure:
 
 ## Decision-summary pattern
 
-After each major investigation step, emit a line in your text turn:
+Emit sparse live markers in your text turn before major search/read pivots, after important findings, and when uncertainty changes the investigation path:
 
 ```
-[decision] KIND: what — why
+[decision] KIND: <one sentence>
 ```
 
 `KIND` is an uppercase value from the shared decision-kind enum (see `core/agent-runtime/decision-types.ts`). The investigator most commonly emits `READ` (issue/code reads), `INSIGHT` (root-cause hypothesis, open questions), and `UNCERTAINTY` (when evidence is thin).
 
-The ` — ` (space, em-dash, space) separates the decision (`what`) from its rationale (`why`). Both parts are required. These marker lines are parsed by the orchestrator and stored as `agent.decision-summary` events. They are NOT forwarded to QA or Reviewer agents. Keep each summary to a single sentence. Do not include credentials, file dumps, or raw chain-of-thought.
+These marker lines are parsed by the runtime and stored as `agent.decision-summary-live` events. They are short progress/rationale markers, not raw thinking. Do not emit before every command. Keep each summary to a single sentence. Do not include credentials, file dumps, secrets, PII, or hidden reasoning.
 
 Examples of good decision summaries:
-- `[decision] READ: Traced entry points to apps/server/src/routes/auth.ts — login endpoint reached via POST /auth/login`
-- `[decision] INSIGHT: Root cause in normaliseEmail() — URL-decode step strips plus signs before DB lookup`
-- `[decision] UNCERTAINTY: Cannot confirm fix without running integration tests — static analysis inconclusive`
+- `[decision] READ: Searching app shell components to find the rendered header owner`
+- `[decision] INSIGHT: Sidebar.tsx owns the brand string`
+- `[decision] UNCERTAINTY: Test target unclear, searching for chrome coverage`
 
 Bad decision summaries:
 - More than one sentence

--- a/skills/qa/prompt.md
+++ b/skills/qa/prompt.md
@@ -287,13 +287,13 @@ Set `verdict` based on the following rules, in order:
 
 ## Decision-summary pattern
 
-After each major step, emit a line in your text turn:
+Emit sparse live markers in your text turn before major read/verification pivots, after important findings, and when uncertainty changes the QA path:
 
 ```
 [decision] KIND: <one sentence summary>
 ```
 
-`KIND` is an uppercase value from the shared decision-kind enum (see `core/agent-runtime/decision-types.ts`). The orchestrator parses these lines and stores them as `agent.decision-summary` events. Keep each to a single sentence. Do not include raw output, credentials, or implementation reasoning.
+`KIND` is an uppercase value from the shared decision-kind enum (see `core/agent-runtime/decision-types.ts`). The runtime parses these lines and stores them as `agent.decision-summary-live` events. Keep each to a single sentence. Do not emit before every command. Do not include raw output, credentials, implementation reasoning, secrets, or file dumps.
 
 Standard kinds for QA:
 

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -49,6 +49,6 @@ Return JSON conforming to `ScoutOutputSchema`:
 }
 ```
 
-Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a code-path scout are `READ` (you read a file or followed a call), `INSIGHT` (you noticed a branch or invariant worth flagging), `UNCERTAINTY` (the trace dead-ended or the symbol was not found).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a code-path scout are `READ` (you read a file or followed a call), `INSIGHT` (you noticed a branch or invariant worth flagging), `UNCERTAINTY` (the trace dead-ended or the symbol was not found). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -41,6 +41,6 @@ Return JSON conforming to `ScoutOutputSchema`:
 }
 ```
 
-Emit `[decision] KIND: <one sentence>` markers at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a dependency scout are `READ` (you read a file), `INSIGHT` (you noticed a structural or import-rule concern), `UNCERTAINTY` (the dependency graph is incomplete or ambiguous).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a dependency scout are `READ` (you read a file), `INSIGHT` (you noticed a structural or import-rule concern), `UNCERTAINTY` (the dependency graph is incomplete or ambiguous). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -50,6 +50,6 @@ Return JSON conforming to `ScoutOutputSchema`:
 }
 ```
 
-Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a pattern scout are `READ` (you read a file), `INSIGHT` (you noticed a pattern or notable absence), `UNCERTAINTY` (the pattern is ambiguous or inconclusive).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a pattern scout are `READ` (you read a file), `INSIGHT` (you noticed a pattern or notable absence), `UNCERTAINTY` (the pattern is ambiguous or inconclusive). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -73,6 +73,6 @@ Return a JSON object with this exact shape (validated by `ScoutOutputSchema`):
 
 ## Decision summaries
 
-Emit `[decision] KIND: <one sentence>` lines in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a schema scout are `READ` (you read a file), `INSIGHT` (you noticed something), `UNCERTAINTY` (the evidence is thin).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a schema scout are `READ` (you read a file), `INSIGHT` (you noticed something), `UNCERTAINTY` (the evidence is thin). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -41,6 +41,6 @@ Return JSON conforming to `ScoutOutputSchema`:
 }
 ```
 
-Emit `[decision] KIND: <one sentence>` markers in your text turn. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a test-inventory scout are `READ` (you read a file), `INSIGHT` (you noticed something notable about test coverage), `UNCERTAINTY` (the evidence is thin or ambiguous).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a test-inventory scout are `READ` (you read a file), `INSIGHT` (you noticed something notable about test coverage), `UNCERTAINTY` (the evidence is thin or ambiguous). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -41,6 +41,6 @@ Return JSON conforming to `ScoutOutputSchema`:
 }
 ```
 
-Emit `[decision] KIND: <one sentence>` markers in your text turn at major checkpoints. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a user-journey scout are `READ` (you read a component or route file), `INSIGHT` (you noticed a notable UI state, label, or branch), `UNCERTAINTY` (the flow was incomplete or ambiguous in the code).
+Emit sparse `[decision] KIND: <one sentence>` live markers before major read/search pivots, after important findings, and on uncertainty. Use the canonical `DecisionKindSchema` enum (`core/agent-runtime/decision-types.ts`). The most useful kinds for a user-journey scout are `READ` (you read a component or route file), `INSIGHT` (you noticed a notable UI state, label, or branch), `UNCERTAINTY` (the flow was incomplete or ambiguous in the code). Do not emit before every command; never include raw thinking, secrets, or file dumps.
 
 You must include **at least one** `decisionSummaries` entry in the JSON output. The orchestrator never synthesises decisions on your behalf; only the ones you emit are recorded against your `runId`.

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -185,7 +185,9 @@ Return a single JSON object conforming to `EngineeringSpecSchema`. Do not includ
 
 `decisionSummaries` must have at least one entry. Use the canonical `DecisionKindSchema` enum (`READ`, `PLAN`, `INSIGHT`, `UNCERTAINTY`, etc.).
 
-Live markers use the format `[decision] KIND: what — why` where ` — ` (space, em-dash, space) separates the decision from its rationale. Example: `[decision] PLAN: Defined 5 falsifiable ACs — one per journey step, all with verifyCommand`.
+Live markers are short progress/rationale markers, not raw thinking. Emit them before major evidence reads, after important spec-shaping findings, and on uncertainty/pivots. Do not emit before every command. Keep each marker to one sentence with no secrets, hidden reasoning, raw output, or file dumps.
+
+Live marker format: `[decision] KIND: <one sentence>`. Example: `[decision] PLAN: Defining falsifiable ACs around the checkout journey and verifyCommand coverage`.
 
 ## Failure modes (the validator will catch)
 

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -21,6 +21,7 @@ const mockGetUseInvestigationSwarm = vi.fn();
 const mockReadProjectSettings = vi.fn();
 const mockReadProjectSkillSettings = vi.fn();
 const mockReadProjectModelSettingsForRole = vi.fn();
+const mockReconcileDecisionSummaries = vi.fn();
 
 vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
   dispatchWave: (...args: unknown[]) => mockDispatchWave(...args),
@@ -37,6 +38,10 @@ vi.mock('@goose-hub/core/agent-runtime/cross-validate.js', () => ({
 
 vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
   invokeSkill: (...args: unknown[]) => mockInvokeSkill(...args),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/reconcile-decisions.js', () => ({
+  reconcileDecisionSummaries: (...args: unknown[]) => mockReconcileDecisionSummaries(...args),
 }));
 
 vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
@@ -881,6 +886,26 @@ describe('runInvestigateWorkflow', () => {
         .mock.calls.find(([e]) => e.kind === 'agent.investigation-complete');
       const payload = call?.[0].payload as { investigate: unknown };
       expect(payload.investigate).toBeDefined();
+    });
+
+    it('reconciles terminal decision summaries before completing the investigation', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const completeCallIndex = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.findIndex(([e]) => e.kind === 'agent.investigation-complete');
+      expect(mockReconcileDecisionSummaries).toHaveBeenCalledWith(
+        expect.any(String),
+        'goose-hub-self',
+        'github:shaunnez/goose-hub#42',
+        'investigate',
+        makeInvestigateOutput().decisionSummaries,
+      );
+      expect(mockReconcileDecisionSummaries.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(eventStore.appendEvent).mock.invocationCallOrder[completeCallIndex],
+      );
     });
 
     it('transitions to factory:investigation-complete on success', async () => {

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -9,6 +9,7 @@ import {
   tierOf,
 } from '@goose-hub/core/agent-runtime/models.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
@@ -424,6 +425,13 @@ export async function runInvestigateWorkflow(
     });
 
     const findings = synthResult.output as InvestigateOutput;
+    reconcileDecisionSummaries(
+      runId,
+      projectId,
+      workItem.id,
+      'investigate',
+      findings.decisionSummaries,
+    );
 
     // Playwright repro for browser-manifesting bugs
     let reproOutput: PlaywrightReproOutput | undefined;


### PR DESCRIPTION
## Summary
- add a shared live decision marker parser and reuse its grammar from the PostToolUse hook
- bridge Codex assistant JSONL messages into agent.decision-summary-live events with replay dedupe and kind normalization
- keep investigate terminal decision summaries reconciled, tighten standard-flow prompt guidance, and render live timeline notes as compact visible rows

## Verification
- pnpm lint
- pnpm exec tsc --noEmit
- DB_PATH=/private/tmp/goose-hub-decision-summary-live-test.db pnpm exec vitest run core/agent-runtime/decision-markers.test.ts core/agent-runtime/codex-cli-runtime.test.ts core/tool-layer/post-tool-use-hook.test.ts apps/web/src/components/detail/components/TimelineSection.test.ts slices/investigate/slice.test.ts
- codex exec --json shape check: observed item.completed agent_message text before turn.completed
- isolated real Codex runtime smoke: run 14830a88-c2e3-4bff-83f7-6b994bf0e212 produced agent.tool-call, interleaved agent.decision-summary-live, agent.run-completed, agent.decision-summary, and agent.investigation-complete rows in /private/tmp/goose-hub-manual-decision-live.db

## Notes
- Full pnpm test was attempted, but the wrapper ran the entire suite and hit existing state-flows mock drift: @goose-hub/core/workspaces/worktree.js mock lacks resolveWorkflowBase.