### PR TITLE
M17: add settings workflow map

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -9,6 +9,7 @@ API + SSE host for the Goose Hub web UI. Stands up the server process the UI tal
 | GET | `/health` | liveness |
 | GET | `/projects` | lists projects from `target-projects/*/project.config.ts` |
 | GET | `/projects/configs` | returns full `ProjectConfigDto[]` for all registered projects (used by Settings UI) |
+| GET | `/workflow-catalog` | returns the maintained workflow map catalog used by Settings |
 | GET | `/projects/:slug/issues` | proxies `StateSource.listOpenWork()` |
 | GET | `/projects/:slug/issues/:id` | proxies `StateSource.getItem()` |
 | GET | `/projects/:slug/milestones` | proxies `StateSource.listMilestones()` |

--- a/apps/server/src/domains/projects/router.ts
+++ b/apps/server/src/domains/projects/router.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_CATALOG } from '@goose-hub/core/workflows/workflow-catalog.js';
 import { Hono } from 'hono';
 import { listProjectConfigsService, listProjectsService } from './service.js';
 
@@ -13,6 +14,10 @@ router.get('/projects', async (c) => {
 router.get('/projects/configs', async (c) => {
   const result = await listProjectConfigsService();
   return c.json(result);
+});
+
+router.get('/workflow-catalog', (c) => {
+  return c.json({ catalog: WORKFLOW_CATALOG });
 });
 
 export { router as projectsRouter };

--- a/apps/server/src/domains/workflows/state-flows.test.ts
+++ b/apps/server/src/domains/workflows/state-flows.test.ts
@@ -85,6 +85,11 @@ vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   createWorktree: vi.fn().mockReturnValue('/mock/worktree'),
   cleanupWorktree: vi.fn(),
   prewarmWorktree: vi.fn(),
+  resolveWorkflowBase: vi.fn().mockReturnValue({
+    branch: 'main',
+    ref: 'origin/main',
+    source: 'fallback-main',
+  }),
   resolveWorktreeHeadSha: vi.fn().mockReturnValue('mock-sha-abc123'),
 }));
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -10,8 +10,8 @@ import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-tra
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
-import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
+import { targetStateForTriage } from '@goose-hub/core/workflows/triage-routing.js';
 import { RepoMatchOutputSchema } from '@goose-hub/skills/repo-match/schema.js';
 import { TriageOutputSchema } from '@goose-hub/skills/triage/schema.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
@@ -321,33 +321,8 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       runId,
     });
 
-    // Determine whether this item carries factory:from-prd (decomposed child)
-    const isFromPrd = itemLabels.includes('factory:from-prd');
-
-    let finalState: StateName;
-    if (triageOutput.type === 'bug') {
-      await stateSource.transitionState(
-        item.externalId,
-        'factory:accepted',
-        'factory:investigating',
-      );
-      finalState = 'factory:investigating';
-    } else if (triageOutput.type === 'research') {
-      await stateSource.transitionState(
-        item.externalId,
-        'factory:accepted',
-        'factory:research-pending',
-      );
-      finalState = 'factory:research-pending';
-    } else if (triageOutput.type === 'feature' && !isFromPrd) {
-      // Fresh feature (not from decompose-prd): route to Discover Lane grilling
-      await stateSource.transitionState(item.externalId, 'factory:accepted', 'factory:grilling');
-      finalState = 'factory:grilling';
-    } else {
-      // Chore, or feature with factory:from-prd (decomposed child): skip grilling
-      await stateSource.transitionState(item.externalId, 'factory:accepted', 'factory:dev-ready');
-      finalState = 'factory:dev-ready';
-    }
+    const finalState = targetStateForTriage(triageOutput.type, itemLabels);
+    await stateSource.transitionState(item.externalId, 'factory:accepted', finalState);
     emitStateTransitionEvent({
       projectId,
       workItemId,

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -10,12 +10,21 @@ import { ProjectBudgetPanel } from './ProjectBudgetPanel';
 import { ProjectConfigPanel } from './ProjectConfigPanel';
 import { ProjectModelPanel } from './ProjectModelPanel';
 import { ReviewPanel } from './ReviewPanel';
+import { WorkflowMapPanel } from './WorkflowMapPanel';
 
-type Tab = 'config' | 'runtime' | 'advanced-roles' | 'pipeline' | 'review' | 'dev-review';
+type Tab =
+  | 'config'
+  | 'runtime'
+  | 'workflow-map'
+  | 'advanced-roles'
+  | 'pipeline'
+  | 'review'
+  | 'dev-review';
 
 const TAB_LABELS: Record<Tab, string> = {
   config: 'Config',
   runtime: 'Skill runtime',
+  'workflow-map': 'Workflow map',
   'advanced-roles': 'Advanced roles',
   pipeline: 'Pipeline',
   review: 'Review',
@@ -102,7 +111,15 @@ export function SettingsPage() {
         {/* Tab bar */}
         <div className="flex flex-wrap gap-1 mb-6 border-b border-line">
           {(
-            ['config', 'runtime', 'advanced-roles', 'pipeline', 'review', 'dev-review'] as Tab[]
+            [
+              'config',
+              'runtime',
+              'workflow-map',
+              'advanced-roles',
+              'pipeline',
+              'review',
+              'dev-review',
+            ] as Tab[]
           ).map((t) => (
             <button
               key={t}
@@ -125,6 +142,9 @@ export function SettingsPage() {
         )}
         {tab === 'runtime' && selectedConfig != null && (
           <ProjectBudgetPanel slug={selectedConfig.slug} />
+        )}
+        {tab === 'workflow-map' && selectedConfig != null && (
+          <WorkflowMapPanel slug={selectedConfig.slug} />
         )}
         {tab === 'advanced-roles' && selectedConfig != null && (
           <ProjectModelPanel slug={selectedConfig.slug} />

--- a/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
@@ -1,0 +1,183 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WorkflowMapPanel } from './WorkflowMapPanel';
+
+vi.mock('@/lib/api', () => ({
+  fetchProjectSettings: vi.fn().mockResolvedValue({
+    projectId: 'goose-hub-self',
+    configBudgets: {},
+    dbGlobalOverrides: null,
+    dbPipelineFlags: null,
+    dbSkillOverrides: {},
+    registeredSkills: ['triage', 'qa', 'dev-review'],
+    skillMetadata: {
+      triage: {
+        description: 'Classifies incoming work.',
+        dependencies: ['workItem'],
+        callers: ['triage-batch workflow'],
+      },
+      qa: {
+        description: 'Holdout QA check.',
+        dependencies: ['prDiff'],
+        callers: ['post-implementation QA gate'],
+      },
+      'dev-review': {
+        description: 'Codex pre-QA diff review.',
+        dependencies: ['prDiff'],
+        callers: ['developer pre-QA advisor'],
+      },
+    },
+    skillDefaults: {
+      triage: {
+        maxTurns: 25,
+        maxBudgetUsd: 1,
+        timeoutMs: 120000,
+        modelTier: 'haiku',
+        modelProvider: 'claude',
+      },
+      qa: {
+        maxTurns: 100,
+        maxBudgetUsd: 3,
+        timeoutMs: 600000,
+        modelTier: 'sonnet',
+        modelProvider: 'claude',
+      },
+      'dev-review': {
+        maxTurns: 20,
+        maxBudgetUsd: 2,
+        timeoutMs: 180000,
+        modelTier: 'sonnet',
+        modelProvider: 'codex',
+      },
+    },
+    resolvedSkillRuntimes: {
+      triage: {
+        source: 'default',
+        effectiveTier: 'haiku',
+        effectiveProvider: 'claude',
+        resolvedPrimary: { tier: 'haiku', provider: 'claude', modelId: 'claude-haiku' },
+        resolvedFallback: null,
+        resolvedAdvisor: null,
+      },
+      qa: {
+        source: 'default',
+        effectiveTier: 'sonnet',
+        effectiveProvider: 'claude',
+        resolvedPrimary: { tier: 'sonnet', provider: 'claude', modelId: 'claude-sonnet' },
+        resolvedFallback: null,
+        resolvedAdvisor: null,
+      },
+      'dev-review': {
+        source: 'default',
+        effectiveTier: 'sonnet',
+        effectiveProvider: 'codex',
+        resolvedPrimary: { tier: 'sonnet', provider: 'codex', modelId: 'gpt-5.4' },
+        resolvedFallback: null,
+        resolvedAdvisor: null,
+      },
+    },
+  }),
+  fetchWorkflowCatalog: vi.fn().mockResolvedValue({
+    catalog: [
+      {
+        kind: 'bug',
+        title: 'Bug workflow',
+        description: 'Bug path.',
+        normalPath: ['triaging', 'accepted', 'needs-qa'],
+        nodes: [
+          { id: 'triaging', label: 'Triage', state: 'factory:triaging' },
+          { id: 'accepted', label: 'Accepted', state: 'factory:accepted' },
+          { id: 'needs-qa', label: 'QA', state: 'factory:needs-qa' },
+          {
+            id: 'triage-skill',
+            label: 'triage',
+            skill: 'triage',
+            role: 'triager',
+            state: 'factory:triaging',
+          },
+          {
+            id: 'qa-skill',
+            label: 'qa',
+            skill: 'qa',
+            role: 'qa',
+            state: 'factory:needs-qa',
+          },
+          {
+            id: 'dev-review-skill',
+            label: 'dev-review',
+            skill: 'dev-review',
+            role: 'dev-reviewer',
+            state: 'factory:accepted',
+          },
+        ],
+        edges: [
+          { from: 'triaging', to: 'accepted', kind: 'primary' },
+          { from: 'accepted', to: 'needs-qa', kind: 'primary' },
+          { from: 'needs-qa', to: 'accepted', label: 'Repair', kind: 'retry' },
+        ],
+      },
+      {
+        kind: 'feature',
+        title: 'Feature workflow',
+        description: 'Feature path.',
+        normalPath: ['triaging'],
+        nodes: [{ id: 'triaging', label: 'Triage', state: 'factory:triaging' }],
+        edges: [],
+      },
+      {
+        kind: 'chore',
+        title: 'Chore workflow',
+        description: 'Chore path.',
+        normalPath: ['triaging'],
+        nodes: [{ id: 'triaging', label: 'Triage', state: 'factory:triaging' }],
+        edges: [],
+      },
+      {
+        kind: 'research',
+        title: 'Research workflow',
+        description: 'Research path.',
+        normalPath: ['triaging'],
+        nodes: [{ id: 'triaging', label: 'Triage', state: 'factory:triaging' }],
+        edges: [],
+      },
+    ],
+  }),
+}));
+
+function renderPanel() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <WorkflowMapPanel slug="goose-hub-self" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('WorkflowMapPanel', () => {
+  it('renders catalog-backed states, skill chips, and branch rows', async () => {
+    renderPanel();
+
+    expect(await screen.findByText('Bug workflow')).toBeTruthy();
+    expect(screen.getByText('triage')).toBeTruthy();
+    expect(screen.getByText('qa')).toBeTruthy();
+    expect(screen.getByText('Repair')).toBeTruthy();
+    expect(screen.getAllByTestId('workflow-state-node')).toHaveLength(3);
+  });
+
+  it('switches workflow kinds and shows skill details from settings metadata', async () => {
+    renderPanel();
+
+    fireEvent.click(await screen.findByText('triage'));
+    expect(screen.getByTestId('skill-detail').textContent).toContain('Classifies incoming work.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Feature' }));
+    expect(await screen.findByText('Feature workflow')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/settings/components/WorkflowMapPanel.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapPanel.tsx
@@ -1,0 +1,360 @@
+import { fetchProjectSettings, fetchWorkflowCatalog } from '@/lib/api';
+import type {
+  ProjectSettingsDto,
+  WorkflowCatalogEntryDto,
+  WorkflowEdgeDto,
+  WorkflowKind,
+  WorkflowNodeDto,
+} from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowRight, GitBranch, Info, RotateCcw, ShieldCheck } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+
+const WORKFLOW_KINDS: WorkflowKind[] = ['bug', 'feature', 'chore', 'research'];
+
+const KIND_LABELS: Record<WorkflowKind, string> = {
+  bug: 'Bug',
+  feature: 'Feature',
+  chore: 'Chore',
+  research: 'Research',
+};
+
+interface WorkflowMapPanelProps {
+  slug: string;
+}
+
+export function WorkflowMapPanel({ slug }: WorkflowMapPanelProps) {
+  const [kind, setKind] = useState<WorkflowKind>('bug');
+  const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
+
+  const catalogQuery = useQuery({
+    queryKey: ['workflow-catalog'],
+    queryFn: ({ signal }) => fetchWorkflowCatalog(signal),
+  });
+  const settingsQuery = useQuery<ProjectSettingsDto>({
+    queryKey: ['project-settings', slug],
+    queryFn: ({ signal }) => fetchProjectSettings(slug, signal),
+  });
+
+  const entry = catalogQuery.data?.catalog.find((candidate) => candidate.kind === kind) ?? null;
+  const selectedSkillNode = entry?.nodes.find((node) => node.skill === selectedSkill) ?? null;
+
+  return (
+    <div className="min-w-0 max-w-6xl overflow-x-hidden">
+      <section className="mb-5">
+        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2 mb-3">
+          Workflow map
+        </h3>
+        <div className="flex w-full flex-wrap gap-1 rounded-md border border-line bg-bg-subtle p-1">
+          {WORKFLOW_KINDS.map((candidate) => (
+            <button
+              key={candidate}
+              type="button"
+              onClick={() => {
+                setKind(candidate);
+                setSelectedSkill(null);
+              }}
+              className={[
+                'min-w-20 flex-1 rounded px-3 py-1.5 text-[12px] transition-colors',
+                kind === candidate
+                  ? 'bg-accent-soft text-fg font-medium'
+                  : 'text-fg-2 hover:bg-bg-hover hover:text-fg',
+              ].join(' ')}
+            >
+              {KIND_LABELS[candidate]}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {catalogQuery.isLoading && <p className="text-[12px] text-fg-3">Loading workflow map...</p>}
+      {catalogQuery.error && (
+        <p className="text-[12px] text-danger">Failed to load workflow map.</p>
+      )}
+
+      {entry != null && (
+        <>
+          <section className="mb-5">
+            <div className="mb-3 flex min-w-0 flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h4 className="text-[14px] font-semibold text-fg">{entry.title}</h4>
+                <p className="mt-1 max-w-3xl text-[12px] leading-relaxed text-fg-2">
+                  {entry.description}
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-1.5">
+                <MapBadge icon={<ShieldCheck size={12} />} label="QA/review holdouts" />
+                <MapBadge icon={<Info size={12} />} label="dev-review codex" />
+              </div>
+            </div>
+            <StateLane
+              entry={entry}
+              settings={settingsQuery.data}
+              onSelectSkill={setSelectedSkill}
+              selectedSkill={selectedSkill}
+            />
+          </section>
+
+          <section className="mb-5">
+            <h4 className="mb-2 text-[12px] font-semibold uppercase tracking-wider text-fg-2">
+              Conditional paths
+            </h4>
+            <BranchList entry={entry} />
+          </section>
+
+          {selectedSkillNode != null && (
+            <SkillDetail node={selectedSkillNode} settings={settingsQuery.data} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function StateLane({
+  entry,
+  settings,
+  selectedSkill,
+  onSelectSkill,
+}: {
+  entry: WorkflowCatalogEntryDto;
+  settings: ProjectSettingsDto | undefined;
+  selectedSkill: string | null;
+  onSelectSkill: (skill: string) => void;
+}) {
+  const nodesById = useMemo(() => new Map(entry.nodes.map((node) => [node.id, node])), [entry]);
+  const skillsByState = useMemo(() => {
+    const grouped = new Map<string, WorkflowNodeDto[]>();
+    for (const node of entry.nodes) {
+      if (node.skill == null || node.state == null) continue;
+      const bucket = grouped.get(node.state) ?? [];
+      bucket.push(node);
+      grouped.set(node.state, bucket);
+    }
+    return grouped;
+  }, [entry]);
+
+  return (
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-2">
+      {entry.normalPath.map((nodeId, index) => {
+        const node = nodesById.get(nodeId);
+        if (node == null) return null;
+        const stateSkills = node.state != null ? (skillsByState.get(node.state) ?? []) : [];
+        return (
+          <div
+            key={nodeId}
+            className="min-w-0 rounded-md border border-line bg-bg-subtle p-3"
+            data-testid="workflow-state-node"
+          >
+            <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+              <div className="min-w-0">
+                <div className="text-[10px] uppercase text-fg-3">Step {index + 1}</div>
+                <div className="truncate text-[12px] font-medium text-fg">{node.label}</div>
+              </div>
+              {index < entry.normalPath.length - 1 && (
+                <ArrowRight className="shrink-0 text-fg-3" size={13} />
+              )}
+            </div>
+            {node.state != null && (
+              <div className="mb-2 break-all font-mono text-[10px] text-fg-3">
+                {shortState(node.state)}
+              </div>
+            )}
+            <div className="flex min-w-0 flex-wrap gap-1.5">
+              {stateSkills.map((skillNode) => (
+                <SkillChip
+                  key={skillNode.id}
+                  node={skillNode}
+                  settings={settings}
+                  selected={selectedSkill === skillNode.skill}
+                  onSelect={() => skillNode.skill != null && onSelectSkill(skillNode.skill)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SkillChip({
+  node,
+  settings,
+  selected,
+  onSelect,
+}: {
+  node: WorkflowNodeDto;
+  settings: ProjectSettingsDto | undefined;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const skill = node.skill ?? '';
+  const metadata = settings?.skillMetadata?.[skill];
+  const runtime = settings?.resolvedSkillRuntimes?.[skill];
+  const isHoldout = skill === 'qa' || skill === 'review';
+  const provider = runtime?.effectiveProvider ?? settings?.skillDefaults?.[skill]?.modelProvider;
+  const titleParts = [
+    metadata?.description,
+    metadata?.dependencies?.length ? `Depends: ${metadata.dependencies.join(', ')}` : null,
+    metadata?.callers?.length ? `Called by: ${metadata.callers.join(', ')}` : null,
+  ].filter(Boolean);
+
+  return (
+    <button
+      type="button"
+      title={titleParts.join('\n') || skill}
+      onClick={onSelect}
+      className={[
+        'min-w-0 max-w-full rounded border px-2 py-1 text-left font-mono text-[10px] leading-tight transition-colors',
+        selected
+          ? 'border-accent bg-accent-soft text-fg'
+          : 'border-line bg-bg-elev text-fg-2 hover:border-accent/70 hover:text-fg',
+      ].join(' ')}
+    >
+      <span className="break-all">{skill}</span>
+      {(isHoldout || provider === 'codex') && (
+        <span className="ml-1 inline-flex rounded bg-bg-subtle px-1 text-[9px] text-fg-3">
+          {isHoldout ? 'holdout' : 'codex'}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function BranchList({ entry }: { entry: WorkflowCatalogEntryDto }) {
+  const nodesById = new Map(entry.nodes.map((node) => [node.id, node]));
+  const branches = entry.edges.filter((edge) => edge.kind === 'optional' || edge.kind === 'retry');
+
+  if (branches.length === 0) {
+    return <p className="text-[12px] text-fg-3">No conditional branches recorded.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-2">
+      {branches.map((edge) => (
+        <BranchRow
+          key={`${edge.from}-${edge.to}-${edge.label ?? ''}`}
+          edge={edge}
+          from={nodesById.get(edge.from)}
+          to={nodesById.get(edge.to)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function BranchRow({
+  edge,
+  from,
+  to,
+}: {
+  edge: WorkflowEdgeDto;
+  from: WorkflowNodeDto | undefined;
+  to: WorkflowNodeDto | undefined;
+}) {
+  const Icon = edge.kind === 'retry' ? RotateCcw : GitBranch;
+  return (
+    <div className="min-w-0 rounded-md border border-line/70 bg-bg-subtle px-3 py-2">
+      <div className="flex min-w-0 items-start gap-2">
+        <Icon className="mt-0.5 shrink-0 text-fg-3" size={13} />
+        <div className="min-w-0">
+          <div className="text-[11px] font-medium text-fg">
+            <span className="break-words">{from?.label ?? edge.from}</span>
+            <span className="mx-1 text-fg-3">to</span>
+            <span className="break-words">{to?.label ?? edge.to}</span>
+          </div>
+          {(edge.label != null || edge.condition != null) && (
+            <div className="mt-1 text-[10px] leading-snug text-fg-3">
+              {[edge.label, edge.condition].filter(Boolean).join(' / ')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkillDetail({
+  node,
+  settings,
+}: {
+  node: WorkflowNodeDto;
+  settings: ProjectSettingsDto | undefined;
+}) {
+  const skill = node.skill ?? '';
+  const metadata = settings?.skillMetadata?.[skill];
+  const defaults = settings?.skillDefaults?.[skill];
+  const runtime = settings?.resolvedSkillRuntimes?.[skill];
+
+  return (
+    <section className="rounded-md border border-line bg-bg-subtle p-4" data-testid="skill-detail">
+      <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2">
+        <h4 className="break-all font-mono text-[13px] font-semibold text-fg">{skill}</h4>
+        {node.role != null && <MapBadge label={node.role} />}
+        {runtime?.effectiveProvider === 'codex' && <MapBadge label="codex" />}
+      </div>
+      {metadata?.description != null && metadata.description !== '' && (
+        <p className="mb-3 max-w-3xl text-[12px] leading-relaxed text-fg-2">
+          {metadata.description}
+        </p>
+      )}
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-3 text-[11px]">
+        <DetailBlock label="Depends on" values={metadata?.dependencies ?? []} />
+        <DetailBlock label="Called by" values={metadata?.callers ?? []} />
+        <DetailBlock
+          label="Runtime default"
+          values={[
+            defaults != null
+              ? `${defaults.modelProvider} ${defaults.modelTier}, ${defaults.maxTurns} turns, $${defaults.maxBudgetUsd.toFixed(2)}`
+              : 'Not registered',
+          ]}
+        />
+        <DetailBlock
+          label="Resolved primary"
+          values={[
+            runtime?.resolvedPrimary != null
+              ? `${runtime.resolvedPrimary.provider} ${runtime.resolvedPrimary.modelId}`
+              : 'Inherits default',
+          ]}
+        />
+      </div>
+    </section>
+  );
+}
+
+function DetailBlock({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div className="min-w-0">
+      <div className="mb-1 text-[10px] uppercase text-fg-3">{label}</div>
+      <div className="flex min-w-0 flex-wrap gap-1">
+        {values.length === 0 ? (
+          <span className="text-fg-3">None</span>
+        ) : (
+          values.map((value) => (
+            <span
+              key={value}
+              className="max-w-full break-all rounded border border-line bg-bg-elev px-1.5 py-0.5 text-fg-2"
+            >
+              {value}
+            </span>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MapBadge({ label, icon }: { label: string; icon?: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded border border-line bg-bg-elev px-2 py-1 text-[10px] text-fg-2">
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+function shortState(state: string): string {
+  return state.replace('factory:', '');
+}

--- a/apps/web/src/components/settings/slice.test.ts
+++ b/apps/web/src/components/settings/slice.test.ts
@@ -29,4 +29,9 @@ describe('settings slice', () => {
     const mod = await import('./components/DevReviewPanel');
     expect(typeof mod.DevReviewPanel).toBe('function');
   });
+
+  it('exports WorkflowMapPanel', async () => {
+    const mod = await import('./components/WorkflowMapPanel');
+    expect(typeof mod.WorkflowMapPanel).toBe('function');
+  });
 });

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -8,6 +8,7 @@ import type {
   ProjectSettingsDto,
   ReviewSettingsDto,
   ReviewerSlot,
+  WorkflowCatalogDto,
 } from '../types.js';
 import { deleteRequest, getJson, patchJson } from './client.js';
 
@@ -145,6 +146,10 @@ export async function fetchReviewSettings(
   signal?: AbortSignal,
 ): Promise<ReviewSettingsDto> {
   return getJson<ReviewSettingsDto>(`/projects/${slug}/settings/review`, signal);
+}
+
+export async function fetchWorkflowCatalog(signal?: AbortSignal): Promise<WorkflowCatalogDto> {
+  return getJson<WorkflowCatalogDto>('/workflow-catalog', signal);
 }
 
 export async function patchReviewSettings(

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -412,6 +412,40 @@ export interface ProjectSettingsDto {
   >;
 }
 
+export type WorkflowKind = 'bug' | 'feature' | 'chore' | 'research';
+export type WorkflowEdgeKind = 'primary' | 'optional' | 'retry' | 'summary';
+
+export interface WorkflowNodeDto {
+  id: string;
+  label: string;
+  state?: string;
+  skill?: string;
+  role?: string;
+  notes?: string;
+}
+
+export interface WorkflowEdgeDto {
+  from: string;
+  to: string;
+  label?: string;
+  condition?: string;
+  kind?: WorkflowEdgeKind;
+  virtual?: boolean;
+}
+
+export interface WorkflowCatalogEntryDto {
+  kind: WorkflowKind;
+  title: string;
+  description: string;
+  nodes: WorkflowNodeDto[];
+  edges: WorkflowEdgeDto[];
+  normalPath: string[];
+}
+
+export interface WorkflowCatalogDto {
+  catalog: WorkflowCatalogEntryDto[];
+}
+
 export type ModelTier = 'haiku' | 'sonnet' | 'opus';
 export type ModelProvider = 'claude' | 'codex';
 

--- a/core/workflows/README.md
+++ b/core/workflows/README.md
@@ -2,6 +2,13 @@
 
 Orchestration workflows that compose skills, persist results, and transition work-item state.
 
+## workflow-catalog.ts
+
+Maintained catalog for the Settings Workflow map. This is the canonical visual
+map source for normal bug, feature, chore, and research paths. Older ASCII or
+Mermaid-style diagrams in slice docs are historical notes, not the source of
+truth for the current cross-workflow map.
+
 ## retrospective.ts
 
 Runs after every successful merge. Selects the retrospective tier (light or deep) and calls the appropriate skill.

--- a/core/workflows/triage-routing.ts
+++ b/core/workflows/triage-routing.ts
@@ -1,0 +1,22 @@
+import type { StateName } from '../state-machine/states.js';
+import type { WorkItemType } from '../state-source/interface.js';
+
+export const TRIAGE_ROUTE_TARGETS = Object.freeze({
+  bug: 'factory:investigating',
+  research: 'factory:research-pending',
+  freshFeature: 'factory:grilling',
+  chore: 'factory:dev-ready',
+  prdFeature: 'factory:dev-ready',
+} satisfies Record<string, StateName>);
+
+export function targetStateForTriage(
+  type: WorkItemType,
+  labels: readonly string[] = [],
+): StateName {
+  if (type === 'bug') return TRIAGE_ROUTE_TARGETS.bug;
+  if (type === 'research') return TRIAGE_ROUTE_TARGETS.research;
+  if (type === 'feature' && !labels.includes('factory:from-prd')) {
+    return TRIAGE_ROUTE_TARGETS.freshFeature;
+  }
+  return TRIAGE_ROUTE_TARGETS.chore;
+}

--- a/core/workflows/workflow-catalog.test.ts
+++ b/core/workflows/workflow-catalog.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { SKILL_BUDGETS } from '../agent-runtime/budgets.js';
+import { STATES } from '../state-machine/states.js';
+import { isLegalTransition } from '../state-machine/transitions.js';
+import { targetStateForTriage } from './triage-routing.js';
+import { WORKFLOW_CATALOG, type WorkflowCatalogEntry } from './workflow-catalog.js';
+
+const stateSet = new Set<string>(STATES);
+const registeredSkillSet = new Set<string>(Object.keys(SKILL_BUDGETS));
+
+function byKind(kind: WorkflowCatalogEntry['kind']): WorkflowCatalogEntry {
+  const entry = WORKFLOW_CATALOG.find((candidate) => candidate.kind === kind);
+  if (entry == null) throw new Error(`missing catalog entry for ${kind}`);
+  return entry;
+}
+
+function hasEdge(entry: WorkflowCatalogEntry, from: string, toState: string): boolean {
+  const nodesById = new Map(entry.nodes.map((node) => [node.id, node]));
+  return entry.edges.some(
+    (edge) => edge.from === from && nodesById.get(edge.to)?.state === toState,
+  );
+}
+
+describe('workflow catalog', () => {
+  it('covers the normal workflow kinds', () => {
+    expect(WORKFLOW_CATALOG.map((entry) => entry.kind)).toStrictEqual([
+      'bug',
+      'feature',
+      'chore',
+      'research',
+    ]);
+  });
+
+  it('keeps triage routing assumptions aligned with the runtime route helper', () => {
+    expect(targetStateForTriage('bug')).toBe('factory:investigating');
+    expect(targetStateForTriage('research')).toBe('factory:research-pending');
+    expect(targetStateForTriage('feature')).toBe('factory:grilling');
+    expect(targetStateForTriage('chore')).toBe('factory:dev-ready');
+
+    expect(hasEdge(byKind('bug'), 'accepted', targetStateForTriage('bug'))).toBe(true);
+    expect(hasEdge(byKind('research'), 'accepted', targetStateForTriage('research'))).toBe(true);
+    expect(hasEdge(byKind('feature'), 'accepted', targetStateForTriage('feature'))).toBe(true);
+    expect(hasEdge(byKind('chore'), 'accepted', targetStateForTriage('chore'))).toBe(true);
+    expect(targetStateForTriage('feature', ['factory:from-prd'])).toBe('factory:dev-ready');
+  });
+
+  it('references only state names from the state-machine registry', () => {
+    for (const entry of WORKFLOW_CATALOG) {
+      for (const node of entry.nodes) {
+        if (node.state != null) {
+          expect(stateSet.has(node.state), `${entry.kind}:${node.id} state`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('uses legal state transitions unless an edge is marked virtual', () => {
+    for (const entry of WORKFLOW_CATALOG) {
+      const nodesById = new Map(entry.nodes.map((node) => [node.id, node]));
+      for (const edge of entry.edges) {
+        const from = nodesById.get(edge.from);
+        const to = nodesById.get(edge.to);
+        expect(from, `${entry.kind}:${edge.from}`).toBeDefined();
+        expect(to, `${entry.kind}:${edge.to}`).toBeDefined();
+
+        if (edge.virtual || from?.state == null || to?.state == null || from.state === to.state) {
+          continue;
+        }
+
+        expect(
+          isLegalTransition(from.state, to.state),
+          `${entry.kind}:${from.state} -> ${to.state}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('references only registered runtime skills', () => {
+    for (const entry of WORKFLOW_CATALOG) {
+      for (const node of entry.nodes) {
+        if (node.skill != null) {
+          expect(registeredSkillSet.has(node.skill), `${entry.kind}:${node.skill}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('keeps node ids and normal paths internally consistent', () => {
+    for (const entry of WORKFLOW_CATALOG) {
+      const ids = entry.nodes.map((node) => node.id);
+      expect(new Set(ids).size, `${entry.kind} duplicate node ids`).toBe(ids.length);
+      for (const id of entry.normalPath) {
+        expect(ids.includes(id), `${entry.kind}:${id} normal path`).toBe(true);
+      }
+    }
+  });
+});

--- a/core/workflows/workflow-catalog.ts
+++ b/core/workflows/workflow-catalog.ts
@@ -1,0 +1,405 @@
+import type { StateName } from '../state-machine/states.js';
+import type { Role } from '../types.js';
+
+export type WorkflowKind = 'bug' | 'feature' | 'chore' | 'research';
+
+export type WorkflowEdgeKind = 'primary' | 'optional' | 'retry' | 'summary';
+
+export type WorkflowNode = {
+  id: string;
+  label: string;
+  state?: StateName;
+  skill?: string;
+  role?: Role;
+  notes?: string;
+};
+
+export type WorkflowEdge = {
+  from: string;
+  to: string;
+  label?: string;
+  condition?: string;
+  kind?: WorkflowEdgeKind;
+  /**
+   * True when the edge is a UI summary or branch annotation rather than a
+   * direct state-machine transition.
+   */
+  virtual?: boolean;
+};
+
+export type WorkflowCatalogEntry = {
+  kind: WorkflowKind;
+  title: string;
+  description: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  normalPath: string[];
+};
+
+const stateNode = (id: string, label: string, state: StateName, notes?: string): WorkflowNode => ({
+  id,
+  label,
+  state,
+  notes,
+});
+
+const skillNode = (
+  id: string,
+  label: string,
+  skill: string,
+  role: Role,
+  state: StateName,
+  notes?: string,
+): WorkflowNode => ({
+  id,
+  label,
+  skill,
+  role,
+  state,
+  notes,
+});
+
+const primary = (from: string, to: string, label?: string): WorkflowEdge => ({
+  from,
+  to,
+  label,
+  kind: 'primary',
+});
+
+const optional = (
+  from: string,
+  to: string,
+  label: string,
+  condition?: string,
+  virtual = false,
+): WorkflowEdge => ({
+  from,
+  to,
+  label,
+  condition,
+  kind: 'optional',
+  virtual,
+});
+
+const retry = (from: string, to: string, label: string): WorkflowEdge => ({
+  from,
+  to,
+  label,
+  kind: 'retry',
+});
+
+const summary = (from: string, to: string, label?: string): WorkflowEdge => ({
+  from,
+  to,
+  label,
+  kind: 'summary',
+  virtual: true,
+});
+
+const triageNodes: WorkflowNode[] = [
+  stateNode('triaging', 'Triage', 'factory:triaging'),
+  stateNode('accepted', 'Accepted', 'factory:accepted'),
+  skillNode('triage-skill', 'triage', 'triage', 'triager', 'factory:triaging'),
+  skillNode('repo-match-skill', 'repo-match', 'repo-match', 'researcher', 'factory:triaging'),
+];
+
+const deliveryNodes: WorkflowNode[] = [
+  stateNode('dev-ready', 'Dev ready', 'factory:dev-ready'),
+  stateNode('spec-ready', 'Spec ready', 'factory:spec-ready', 'M19 parallel path only.'),
+  stateNode('in-progress', 'In progress', 'factory:in-progress'),
+  stateNode('needs-qa', 'QA', 'factory:needs-qa', 'Holdout gate.'),
+  stateNode('qa-failed', 'QA failed', 'factory:qa-failed'),
+  stateNode('needs-fix', 'Needs fix', 'factory:needs-fix'),
+  stateNode('needs-review', 'Review', 'factory:needs-review', 'Holdout gate.'),
+  stateNode('approved', 'Approved', 'factory:approved'),
+  stateNode('merge-conflict', 'Conflict', 'factory:merge-conflict'),
+  stateNode('retrospecting', 'Retro', 'factory:retrospecting'),
+  stateNode('needs-human', 'Needs human', 'factory:needs-human'),
+  stateNode('done', 'Done', 'factory:done'),
+  skillNode(
+    'advise-on-plan-skill',
+    'advise-on-plan',
+    'advise-on-plan',
+    'researcher',
+    'factory:dev-ready',
+  ),
+  skillNode('spec-author-skill', 'spec-author', 'spec-author', 'developer', 'factory:dev-ready'),
+  skillNode('implement-skill', 'implement', 'implement', 'developer', 'factory:dev-ready'),
+  skillNode(
+    'implement-wp-skill',
+    'implement-wp',
+    'implement-wp',
+    'developer',
+    'factory:spec-ready',
+  ),
+  skillNode(
+    'dev-review-skill',
+    'dev-review',
+    'dev-review',
+    'dev-reviewer',
+    'factory:in-progress',
+    'Codex provider by default.',
+  ),
+  skillNode(
+    'dev-review-response-skill',
+    'dev-review-response',
+    'dev-review-response',
+    'developer',
+    'factory:in-progress',
+  ),
+  skillNode(
+    'evidence-post-skill',
+    'evidence-post',
+    'evidence-post',
+    'developer',
+    'factory:in-progress',
+    'Best-effort evidence path.',
+  ),
+  skillNode('qa-skill', 'qa', 'qa', 'qa', 'factory:needs-qa', 'Holdout.'),
+  skillNode('review-skill', 'review', 'review', 'reviewer', 'factory:needs-review', 'Holdout.'),
+  skillNode(
+    'resolve-conflict-skill',
+    'resolve-conflict',
+    'resolve-conflict',
+    'developer',
+    'factory:merge-conflict',
+  ),
+  skillNode(
+    'retro-light-skill',
+    'retrospective-light',
+    'retrospective-light',
+    'retrospector',
+    'factory:retrospecting',
+  ),
+  skillNode(
+    'retro-deep-skill',
+    'retrospective-deep',
+    'retrospective-deep',
+    'retrospector',
+    'factory:retrospecting',
+  ),
+];
+
+const deliveryEdges: WorkflowEdge[] = [
+  primary('dev-ready', 'in-progress'),
+  optional('dev-ready', 'spec-ready', 'M19 spec-author', 'multi-agent pipeline enabled'),
+  primary('spec-ready', 'in-progress'),
+  primary('in-progress', 'needs-qa'),
+  primary('needs-qa', 'needs-review', 'QA pass'),
+  primary('needs-review', 'approved', 'Review approve'),
+  primary('approved', 'retrospecting'),
+  primary('retrospecting', 'done'),
+  retry('needs-qa', 'qa-failed', 'QA fail'),
+  retry('qa-failed', 'needs-fix', 'Queue repair'),
+  retry('needs-review', 'needs-fix', 'Request changes'),
+  retry('needs-fix', 'in-progress', 'Repair'),
+  optional('approved', 'merge-conflict', 'Merge conflict'),
+  optional('merge-conflict', 'retrospecting', 'Resolved'),
+  optional('merge-conflict', 'needs-human', 'Cannot resolve'),
+  optional('dev-ready', 'needs-human', 'Workflow failure'),
+  optional('spec-ready', 'needs-human', 'Spec failure'),
+  optional('in-progress', 'needs-human', 'Implementation failure'),
+  optional('needs-qa', 'needs-human', 'QA escalation'),
+  optional('qa-failed', 'needs-human', 'Retry cap'),
+  optional('needs-review', 'needs-human', 'Reviewer escalation'),
+  optional('needs-fix', 'needs-human', 'Repair escalation'),
+  optional('approved', 'needs-human', 'Post-approval failure'),
+  summary('dev-ready', 'advise-on-plan-skill', 'high/critical legacy advisor'),
+  summary('dev-ready', 'spec-author-skill', 'parallel path'),
+  summary('spec-author-skill', 'spec-ready'),
+  summary('spec-ready', 'implement-wp-skill', 'parallel WPs'),
+  summary('dev-ready', 'implement-skill', 'legacy dev path'),
+  summary('in-progress', 'dev-review-skill', 'pre-QA advisor'),
+  summary('dev-review-skill', 'dev-review-response-skill', 'one repair turn'),
+  summary('in-progress', 'evidence-post-skill', 'best effort'),
+  summary('needs-qa', 'qa-skill', 'holdout'),
+  summary('needs-review', 'review-skill', 'holdout'),
+  summary('merge-conflict', 'resolve-conflict-skill'),
+  summary('retrospecting', 'retro-light-skill'),
+  summary('retrospecting', 'retro-deep-skill'),
+];
+
+const bugEntry: WorkflowCatalogEntry = {
+  kind: 'bug',
+  title: 'Bug workflow',
+  description:
+    'Bug work is triaged, repo-matched, investigated, optionally reproduced in-browser, then shipped through implementation, QA, review, and retro.',
+  nodes: [
+    ...triageNodes,
+    stateNode('investigating', 'Investigating', 'factory:investigating'),
+    stateNode('investigation-complete', 'Investigation complete', 'factory:investigation-complete'),
+    skillNode(
+      'investigate-skill',
+      'investigate',
+      'investigate',
+      'investigator',
+      'factory:investigating',
+    ),
+    skillNode(
+      'playwright-repro-skill',
+      'playwright-repro',
+      'playwright-repro',
+      'investigator',
+      'factory:investigating',
+      'Optional for browser/UI bugs.',
+    ),
+    ...deliveryNodes,
+  ],
+  edges: [
+    summary('triage-skill', 'repo-match-skill'),
+    primary('triaging', 'accepted'),
+    primary('accepted', 'investigating'),
+    primary('investigating', 'investigation-complete'),
+    primary('investigation-complete', 'dev-ready'),
+    optional('investigating', 'needs-human', 'Investigation blocked'),
+    summary('investigating', 'investigate-skill'),
+    summary('investigating', 'playwright-repro-skill', 'browser repro'),
+    ...deliveryEdges,
+  ],
+  normalPath: [
+    'triaging',
+    'accepted',
+    'investigating',
+    'investigation-complete',
+    'dev-ready',
+    'in-progress',
+    'needs-qa',
+    'needs-review',
+    'approved',
+    'retrospecting',
+    'done',
+  ],
+};
+
+const featureEntry: WorkflowCatalogEntry = {
+  kind: 'feature',
+  title: 'Feature workflow',
+  description:
+    'Fresh feature work enters discovery, turns into a PRD, decomposes into child issues, then each child ships through development, QA, review, and retro.',
+  nodes: [
+    ...triageNodes,
+    stateNode('grilling', 'Grilling', 'factory:grilling'),
+    stateNode('prd-drafting', 'PRD draft', 'factory:prd-drafting'),
+    stateNode('prd-review', 'PRD review', 'factory:prd-review'),
+    stateNode('decomposing', 'Decompose', 'factory:decomposing'),
+    stateNode('issues-created', 'Child issues', 'factory:issues-created'),
+    skillNode('grill-me-skill', 'grill-me', 'grill-me', 'griller', 'factory:grilling'),
+    skillNode('write-prd-skill', 'write-prd', 'write-prd', 'prd-writer', 'factory:prd-drafting'),
+    skillNode(
+      'advise-on-prd-skill',
+      'advise-on-prd',
+      'advise-on-prd',
+      'prd-writer',
+      'factory:prd-review',
+    ),
+    skillNode(
+      'decompose-issues-skill',
+      'decompose-issues',
+      'decompose-issues',
+      'decomposer',
+      'factory:decomposing',
+    ),
+    ...deliveryNodes,
+  ],
+  edges: [
+    summary('triage-skill', 'repo-match-skill'),
+    primary('triaging', 'accepted'),
+    primary('accepted', 'grilling'),
+    primary('grilling', 'prd-drafting'),
+    primary('prd-drafting', 'prd-review'),
+    primary('prd-review', 'decomposing'),
+    primary('decomposing', 'issues-created'),
+    primary('issues-created', 'dev-ready'),
+    optional('issues-created', 'done', 'Parent complete'),
+    summary('grilling', 'grill-me-skill'),
+    summary('prd-drafting', 'write-prd-skill'),
+    summary('prd-review', 'advise-on-prd-skill'),
+    summary('decomposing', 'decompose-issues-skill'),
+    ...deliveryEdges,
+  ],
+  normalPath: [
+    'triaging',
+    'accepted',
+    'grilling',
+    'prd-drafting',
+    'prd-review',
+    'decomposing',
+    'issues-created',
+    'dev-ready',
+    'in-progress',
+    'needs-qa',
+    'needs-review',
+    'approved',
+    'retrospecting',
+    'done',
+  ],
+};
+
+const choreEntry: WorkflowCatalogEntry = {
+  kind: 'chore',
+  title: 'Chore workflow',
+  description:
+    'Chores skip discovery and investigation after triage/repo-match, then move directly into implementation, QA, review, and retro.',
+  nodes: [...triageNodes, ...deliveryNodes],
+  edges: [
+    summary('triage-skill', 'repo-match-skill'),
+    primary('triaging', 'accepted'),
+    primary('accepted', 'dev-ready'),
+    ...deliveryEdges,
+  ],
+  normalPath: [
+    'triaging',
+    'accepted',
+    'dev-ready',
+    'in-progress',
+    'needs-qa',
+    'needs-review',
+    'approved',
+    'retrospecting',
+    'done',
+  ],
+};
+
+const researchEntry: WorkflowCatalogEntry = {
+  kind: 'research',
+  title: 'Research workflow',
+  description:
+    'Research items are triaged and repo-matched, move through research-pending/research-complete, then either become dev-ready follow-up work or require a human follow-up.',
+  nodes: [
+    ...triageNodes,
+    stateNode('research-pending', 'Research pending', 'factory:research-pending'),
+    stateNode('research-complete', 'Research complete', 'factory:research-complete'),
+    stateNode('dev-ready', 'Dev ready', 'factory:dev-ready'),
+    stateNode('needs-human', 'Needs human', 'factory:needs-human'),
+  ],
+  edges: [
+    summary('triage-skill', 'repo-match-skill'),
+    primary('triaging', 'accepted'),
+    primary('accepted', 'research-pending'),
+    primary('research-pending', 'research-complete'),
+    primary('research-complete', 'dev-ready'),
+    optional(
+      'research-complete',
+      'needs-human',
+      'Human follow-up',
+      'research is not directly actionable',
+      true,
+    ),
+  ],
+  normalPath: ['triaging', 'accepted', 'research-pending', 'research-complete', 'dev-ready'],
+};
+
+export const WORKFLOW_CATALOG = Object.freeze([
+  bugEntry,
+  featureEntry,
+  choreEntry,
+  researchEntry,
+] satisfies WorkflowCatalogEntry[]);
+
+export function getWorkflowCatalog(kind: WorkflowKind): WorkflowCatalogEntry {
+  const entry = WORKFLOW_CATALOG.find((candidate) => candidate.kind === kind);
+  if (entry == null) {
+    throw new Error(`Unknown workflow kind: ${kind}`);
+  }
+  return entry;
+}

--- a/slices/fix-issue/README.md
+++ b/slices/fix-issue/README.md
@@ -2,6 +2,10 @@
 
 The M7 supervised dev workflow. Picks up a `factory:dev-ready` issue, creates a worktree, optionally runs the advisor (high/critical priority), runs the implement skill (TDD), opens a PR, posts evidence, and transitions the issue to `factory:approved`.
 
+Current cross-workflow maps are catalog-backed in
+`core/workflows/workflow-catalog.ts` and rendered in Settings. The diagram below
+is a historical slice note for the legacy single-issue implementation path.
+
 ## State machine
 
 ```


### PR DESCRIPTION
Summary:
- Add a maintained core workflow catalog for bug, feature, chore, and research paths.
- Expose the catalog via GET /workflow-catalog and render a Workflow map tab in Settings.
- Add drift tests for triage routes, state names, legal transitions, and skill registration.

Verification:
- pnpm test core/workflows/workflow-catalog.test.ts apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx apps/web/src/components/settings/slice.test.ts apps/server/src/domains/workflows/state-flows.test.ts
- pnpm typecheck
- pnpm lint
- Playwright smoke check: Settings Workflow map renders, skill detail opens, no horizontal overflow.

No linked issue was provided for this direct request.