### PR TITLE
Add symbol index CLI and freshness telemetry

### DIFF
--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -140,6 +140,8 @@ export type EventKind =
   // ImprovementCandidates, and the autonomous-mode escalation gate.
   | 'audit.completed'
   | 'audit.failed'
+  // Symbol index utility telemetry — lets us measure whether hints save work.
+  | 'symbol-index.lookup'
   | 'audit.autonomy-gate-fired';
 
 export interface AgentEvent {

--- a/core/symbol-index/README.md
+++ b/core/symbol-index/README.md
@@ -6,9 +6,23 @@ Local, regenerable SQLite index of every exported symbol and import statement ac
 
 ```sh
 pnpm symbol-index            # writes ~/.factory/symbol-index.db
+pnpm symbol refresh          # same rebuild through the query CLI
 ```
 
 Re-run any time the codebase changes. The build is sub-second and idempotent — files removed since the last run are dropped from the index automatically.
+
+## CLI
+
+```sh
+pnpm symbol find dispatchWave
+pnpm symbol callers dispatchWave
+pnpm symbol exports core/agent-runtime/swarm.ts
+pnpm symbol imports slices/investigate/workflow.ts
+pnpm symbol refresh
+```
+
+`find` prints exact symbol matches as `path:line kind name exported=<true|false>`.
+`callers` is deliberately labelled as importers: it reports files with static imports of the symbol name, not true runtime call sites. Query commands warn with `Run pnpm symbol-index` if the local DB is missing, stale, or unreadable.
 
 ## Files
 
@@ -16,6 +30,7 @@ Re-run any time the codebase changes. The build is sub-second and idempotent —
 |---|---|
 | `db.ts` | `openIndexDb(path?)` — opens (creates) the SQLite cache. `defaultDbPath()`. |
 | `builder.ts` | `buildIndex(opts)` — walks `apps/`, `core/`, `slices/`, `skills/` and indexes every `.ts`/`.tsx` file. `extractFromSource(absPath, content)` is the pure per-file extractor exposed for testing. |
+| `freshness.ts` | `assessSymbolIndexFreshness(opts)`, `ensureSymbolIndexFresh(opts)` — best-effort missing/stale/corrupt checks and optional rebuild. |
 | `query.ts` | `findSymbol(db, name)`, `findCallers(db, name)`, `listExportsOf(db, filePath)`, `listImports(db, filePath)`. |
 | `types.ts` | `SymbolRow`, `ImportRow`, `SymbolKind`. |
 | `index.ts` | Public surface. |
@@ -48,5 +63,5 @@ Indexes on `symbols.name`, `symbols.file_path`, `imports.source_module`, `import
 
 - Not vector / embedding search. Lexical-structural index over the TypeScript compiler AST. FACTORY_RULES rule 27 unchanged.
 - Not authoritative. The index is a cache; the filesystem is the source of truth. A stale index returns stale rows — callers regenerate as needed.
-- Not a runtime dependency. No workflow blocks on the index being fresh. Manual `pnpm symbol-index` for now; automatic refresh is future work.
+- Not a runtime dependency. No workflow blocks on the index being fresh. Investigation-heavy workflows do a best-effort rebuild if the DB is missing or older than indexed source files; failures only warn/telemetry and continue.
 - Not cross-repo. The index covers Goose Hub itself, not the target repos under `target-projects/<slug>/`.

--- a/core/symbol-index/builder.ts
+++ b/core/symbol-index/builder.ts
@@ -22,7 +22,7 @@ export interface BuildResult {
   importsIndexed: number;
 }
 
-const DEFAULT_INCLUDE_DIRS = ['apps', 'core', 'slices', 'skills'];
+export const DEFAULT_INCLUDE_DIRS = ['apps', 'core', 'slices', 'skills'];
 const SKIP_DIR_NAMES = new Set([
   'node_modules',
   'dist',
@@ -33,7 +33,7 @@ const SKIP_DIR_NAMES = new Set([
   '.claude',
 ]);
 
-function walkTsFiles(absRoot: string): string[] {
+export function walkTsFiles(absRoot: string): string[] {
   const out: string[] = [];
   const visit = (dir: string): void => {
     let entries: fs.Dirent[];

--- a/core/symbol-index/freshness.ts
+++ b/core/symbol-index/freshness.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { DEFAULT_INCLUDE_DIRS, buildIndex, walkTsFiles } from './builder.js';
+import { defaultDbPath, openIndexDb } from './db.js';
+
+export interface SymbolIndexFreshnessOptions {
+  repoRoot: string;
+  dbPath?: string;
+  includeDirs?: string[];
+}
+
+export interface SymbolIndexFreshness {
+  dbPath: string;
+  dbAgeMs: number;
+  stale: boolean;
+  missing: boolean;
+  corrupt: boolean;
+  newestSourceMtimeMs: number | null;
+  error?: string;
+}
+
+export interface EnsureSymbolIndexFreshResult extends SymbolIndexFreshness {
+  rebuilt: boolean;
+}
+
+function newestIndexedSourceMtimeMs(repoRoot: string, includeDirs: string[]): number | null {
+  let newest: number | null = null;
+  for (const dir of includeDirs) {
+    const absDir = path.join(repoRoot, dir);
+    if (!fs.existsSync(absDir)) continue;
+    for (const file of walkTsFiles(absDir)) {
+      let mtime: number;
+      try {
+        mtime = fs.statSync(file).mtimeMs;
+      } catch {
+        continue;
+      }
+      newest = newest == null ? mtime : Math.max(newest, mtime);
+    }
+  }
+  return newest;
+}
+
+function assertReadableIndex(dbPath: string): void {
+  const db = openIndexDb(dbPath);
+  try {
+    db.prepare('SELECT COUNT(*) AS count FROM files').get();
+  } finally {
+    db.close();
+  }
+}
+
+export function assessSymbolIndexFreshness(
+  options: SymbolIndexFreshnessOptions,
+): SymbolIndexFreshness {
+  const dbPath = options.dbPath ?? defaultDbPath();
+  const includeDirs = options.includeDirs ?? DEFAULT_INCLUDE_DIRS;
+  const newestSourceMtimeMs = newestIndexedSourceMtimeMs(options.repoRoot, includeDirs);
+
+  if (!fs.existsSync(dbPath)) {
+    return {
+      dbPath,
+      dbAgeMs: -1,
+      stale: true,
+      missing: true,
+      corrupt: false,
+      newestSourceMtimeMs,
+    };
+  }
+
+  try {
+    assertReadableIndex(dbPath);
+    const dbMtimeMs = fs.statSync(dbPath).mtimeMs;
+    const stale = newestSourceMtimeMs != null && dbMtimeMs < newestSourceMtimeMs;
+    return {
+      dbPath,
+      dbAgeMs: Math.max(0, Date.now() - dbMtimeMs),
+      stale,
+      missing: false,
+      corrupt: false,
+      newestSourceMtimeMs,
+    };
+  } catch (error) {
+    return {
+      dbPath,
+      dbAgeMs: -1,
+      stale: true,
+      missing: false,
+      corrupt: true,
+      newestSourceMtimeMs,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function ensureSymbolIndexFresh(
+  options: SymbolIndexFreshnessOptions,
+): EnsureSymbolIndexFreshResult {
+  const before = assessSymbolIndexFreshness(options);
+  if (!before.missing && !before.stale && !before.corrupt) return { ...before, rebuilt: false };
+
+  try {
+    if (before.corrupt && fs.existsSync(before.dbPath)) {
+      fs.rmSync(before.dbPath, { force: true });
+      fs.rmSync(`${before.dbPath}-wal`, { force: true });
+      fs.rmSync(`${before.dbPath}-shm`, { force: true });
+    }
+    buildIndex({
+      repoRoot: options.repoRoot,
+      dbPath: before.dbPath,
+      includeDirs: options.includeDirs,
+    });
+    const after = assessSymbolIndexFreshness(options);
+    return { ...after, rebuilt: true };
+  } catch (error) {
+    return {
+      ...before,
+      rebuilt: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/core/symbol-index/index.ts
+++ b/core/symbol-index/index.ts
@@ -1,7 +1,13 @@
 export type { ImportRow, SymbolKind, SymbolRow } from './types.js';
 export { defaultDbPath, openIndexDb } from './db.js';
-export { buildIndex, extractFromSource } from './builder.js';
+export { DEFAULT_INCLUDE_DIRS, buildIndex, extractFromSource, walkTsFiles } from './builder.js';
 export type { BuildOptions, BuildResult } from './builder.js';
+export { assessSymbolIndexFreshness, ensureSymbolIndexFresh } from './freshness.js';
+export type {
+  EnsureSymbolIndexFreshResult,
+  SymbolIndexFreshness,
+  SymbolIndexFreshnessOptions,
+} from './freshness.js';
 export { findCallers, findSymbol, listExportsOf, listImports } from './query.js';
 export { extractIdentifiers, lookupWorkItemSymbols } from './lookup.js';
 export type { LookupOptions, SymbolHint } from './lookup.js';

--- a/core/symbol-index/slice.test.ts
+++ b/core/symbol-index/slice.test.ts
@@ -5,6 +5,7 @@ import type Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildIndex } from './builder.js';
 import { openIndexDb } from './db.js';
+import { assessSymbolIndexFreshness, ensureSymbolIndexFresh } from './freshness.js';
 import { findCallers, findSymbol, listExportsOf, listImports } from './query.js';
 
 function writeFile(root: string, rel: string, content: string): void {
@@ -158,5 +159,51 @@ export const X = 1;`,
     expect(result.filesIndexed).toBe(2);
     expect(result.symbolsIndexed).toBeGreaterThanOrEqual(2);
     expect(result.importsIndexed).toBe(1);
+  });
+
+  it('reports a missing on-disk index as stale with rebuild instructions available to callers', () => {
+    writeFile(tmp, 'core/freshness/a.ts', 'export const FreshnessA = 1;');
+    const dbPath = path.join(tmp, 'missing.db');
+
+    const freshness = assessSymbolIndexFreshness({ repoRoot: tmp, dbPath, includeDirs: ['core'] });
+
+    expect(freshness.missing).toBe(true);
+    expect(freshness.stale).toBe(true);
+    expect(freshness.dbAgeMs).toBe(-1);
+  });
+
+  it('marks the index stale when an indexed source file is newer than the DB', () => {
+    writeFile(tmp, 'core/freshness/a.ts', 'export const FreshnessA = 1;');
+    const dbPath = path.join(tmp, 'freshness.db');
+    buildIndex({ repoRoot: tmp, dbPath, includeDirs: ['core'] });
+
+    const dbMtime = new Date(Date.now() - 10_000);
+    fs.utimesSync(dbPath, dbMtime, dbMtime);
+
+    const sourceMtime = new Date();
+    fs.utimesSync(path.join(tmp, 'core/freshness/a.ts'), sourceMtime, sourceMtime);
+
+    const freshness = assessSymbolIndexFreshness({ repoRoot: tmp, dbPath, includeDirs: ['core'] });
+
+    expect(freshness.missing).toBe(false);
+    expect(freshness.stale).toBe(true);
+  });
+
+  it('best-effort rebuilds a missing index', () => {
+    writeFile(tmp, 'core/freshness/a.ts', 'export const FreshnessA = 1;');
+    const dbPath = path.join(tmp, 'freshness.db');
+
+    const result = ensureSymbolIndexFresh({ repoRoot: tmp, dbPath, includeDirs: ['core'] });
+
+    expect(result.rebuilt).toBe(true);
+    expect(result.missing).toBe(false);
+    expect(result.stale).toBe(false);
+
+    const rebuilt = openIndexDb(dbPath);
+    try {
+      expect(findSymbol(rebuilt, 'FreshnessA')).toHaveLength(1);
+    } finally {
+      rebuilt.close();
+    }
   });
 });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "manifest": "tsx scripts/build-manifest.ts",
     "audit-docs": "tsx scripts/audit-docs.ts",
     "symbol-index": "tsx scripts/build-symbol-index.ts",
+    "symbol": "tsx scripts/query-symbol-index.ts",
     "db:generate": "drizzle-kit generate --config=drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config=drizzle.config.ts",
     "cleanup-worktrees": "bash scripts/cleanup-worktrees.sh",

--- a/scripts/query-symbol-index.ts
+++ b/scripts/query-symbol-index.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env tsx
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  assessSymbolIndexFreshness,
+  buildIndex,
+  defaultDbPath,
+  findCallers,
+  findSymbol,
+  listExportsOf,
+  listImports,
+  openIndexDb,
+} from '../core/symbol-index/index.js';
+
+type Command = 'find' | 'callers' | 'exports' | 'imports' | 'refresh';
+
+function repoRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function usage(exitCode = 2): never {
+  console.error(`Usage:
+  pnpm symbol find <identifier>
+  pnpm symbol callers <identifier>
+  pnpm symbol exports <file>
+  pnpm symbol imports <file>
+  pnpm symbol refresh`);
+  process.exit(exitCode);
+}
+
+function parseDbFlag(argv: string[]): { dbPath: string; rest: string[] } {
+  const idx = argv.indexOf('--db');
+  if (idx === -1) return { dbPath: defaultDbPath(), rest: argv };
+  const value = argv[idx + 1];
+  if (!value) {
+    console.error('--db requires a path argument');
+    process.exit(2);
+  }
+  return { dbPath: value, rest: argv.filter((_, i) => i !== idx && i !== idx + 1) };
+}
+
+function assertUsableDb(dbPath: string): void {
+  const freshness = assessSymbolIndexFreshness({ repoRoot: repoRoot(), dbPath });
+  if (freshness.missing) {
+    console.error(`symbol-index: DB missing at ${dbPath}. Run pnpm symbol-index.`);
+    process.exit(1);
+  }
+  if (freshness.corrupt) {
+    console.error(`symbol-index: DB unreadable at ${dbPath}. Run pnpm symbol-index.`);
+    process.exit(1);
+  }
+  if (freshness.stale) {
+    console.error(`symbol-index: DB may be stale at ${dbPath}. Run pnpm symbol-index.`);
+  }
+}
+
+function refresh(dbPath: string): void {
+  const started = Date.now();
+  const result = buildIndex({ repoRoot: repoRoot(), dbPath });
+  const ms = Date.now() - started;
+  console.log(
+    `symbol-index: indexed ${result.filesIndexed} files, ${result.symbolsIndexed} symbols, ${result.importsIndexed} imports in ${ms}ms`,
+  );
+  console.log(`db: ${dbPath}`);
+}
+
+function main(): void {
+  const { dbPath, rest } = parseDbFlag(process.argv.slice(2));
+  const [rawCommand, arg] = rest;
+  const command = rawCommand as Command | undefined;
+
+  if (command === 'refresh') {
+    refresh(dbPath);
+    return;
+  }
+
+  if (!command || !['find', 'callers', 'exports', 'imports'].includes(command) || !arg) usage();
+  assertUsableDb(dbPath);
+
+  const db = openIndexDb(dbPath);
+  try {
+    if (command === 'find') {
+      const rows = findSymbol(db, arg);
+      if (rows.length === 0) {
+        console.log(`no symbol found: ${arg}`);
+        return;
+      }
+      for (const row of rows) {
+        console.log(`${row.filePath}:${row.line} ${row.kind} ${row.name} exported=${row.exported}`);
+      }
+      return;
+    }
+
+    if (command === 'callers') {
+      const importers = findCallers(db, arg);
+      console.log(`importers for ${arg} (static imports, not runtime callers):`);
+      if (importers.length === 0) {
+        console.log('(none)');
+        return;
+      }
+      for (const importer of importers) console.log(importer);
+      return;
+    }
+
+    if (command === 'exports') {
+      const rows = listExportsOf(db, arg);
+      if (rows.length === 0) {
+        console.log(`no exports found: ${arg}`);
+        return;
+      }
+      for (const row of rows) {
+        console.log(`${row.filePath}:${row.line} ${row.kind} ${row.name} exported=true`);
+      }
+      return;
+    }
+
+    if (command === 'imports') {
+      const rows = listImports(db, arg);
+      if (rows.length === 0) {
+        console.log(`no imports found: ${arg}`);
+        return;
+      }
+      for (const row of rows) {
+        console.log(`${row.filePath} imports ${row.importedName} from ${row.sourceModule}`);
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+main();

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -17,6 +17,7 @@ const mockInvokeSkill = vi.fn();
 const mockPersistScoutReport = vi.fn();
 const mockLookupWorkItemSymbols = vi.fn();
 const mockExtractIdentifiers = vi.fn();
+const mockEnsureSymbolIndexFresh = vi.fn();
 const mockGetUseInvestigationSwarm = vi.fn();
 const mockReadProjectSettings = vi.fn();
 const mockReadProjectSkillSettings = vi.fn();
@@ -29,6 +30,10 @@ vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
 vi.mock('@goose-hub/core/symbol-index/lookup.js', () => ({
   lookupWorkItemSymbols: (...args: unknown[]) => mockLookupWorkItemSymbols(...args),
   extractIdentifiers: (...args: unknown[]) => mockExtractIdentifiers(...args),
+}));
+
+vi.mock('@goose-hub/core/symbol-index/freshness.js', () => ({
+  ensureSymbolIndexFresh: (...args: unknown[]) => mockEnsureSymbolIndexFresh(...args),
 }));
 
 vi.mock('@goose-hub/core/agent-runtime/cross-validate.js', () => ({
@@ -219,6 +224,7 @@ beforeEach(() => {
   mockCrossValidate.mockReset();
   mockInvokeSkill.mockReset();
   mockPersistScoutReport.mockReset();
+  mockEnsureSymbolIndexFresh.mockReset();
   mockGetUseInvestigationSwarm.mockReset();
   mockReadProjectSettings.mockReset();
   mockReadProjectSkillSettings.mockReset();
@@ -228,6 +234,15 @@ beforeEach(() => {
   mockAccumulatePersonaStats.mockClear();
   mockLookupWorkItemSymbols.mockReturnValue([]);
   mockExtractIdentifiers.mockReturnValue([]);
+  mockEnsureSymbolIndexFresh.mockReturnValue({
+    dbPath: '/tmp/symbol-index.db',
+    dbAgeMs: 10,
+    stale: false,
+    missing: false,
+    corrupt: false,
+    newestSourceMtimeMs: Date.now(),
+    rebuilt: false,
+  });
   mockGetUseInvestigationSwarm.mockReturnValue(true);
   mockReadProjectSettings.mockReturnValue(null);
   mockReadProjectSkillSettings.mockReturnValue(new Map());
@@ -1153,6 +1168,61 @@ describe('runInvestigateWorkflow', () => {
         'Fix AuthService',
         'Crashes on login',
         expect.objectContaining({ worktreePath: '/tmp/test-worktree' }),
+      );
+    });
+
+    it('ensures symbol index freshness before lookup without blocking investigation', async () => {
+      mockEnsureSymbolIndexFresh.mockReturnValue({
+        dbPath: '/tmp/symbol-index.db',
+        dbAgeMs: -1,
+        stale: true,
+        missing: true,
+        corrupt: false,
+        newestSourceMtimeMs: null,
+        rebuilt: false,
+        error: 'build failed',
+      });
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockEnsureSymbolIndexFresh).toHaveBeenCalledWith(
+        expect.objectContaining({ repoRoot: expect.any(String) }),
+      );
+      expect(mockDispatchWave).toHaveBeenCalled();
+    });
+
+    it('emits symbol-index.lookup telemetry with counts and freshness', async () => {
+      const hints = [
+        { name: 'AuthService', definedIn: 'core/auth.ts', line: 10, kind: 'function', callers: [] },
+      ];
+      mockLookupWorkItemSymbols.mockReturnValue(hints);
+      mockExtractIdentifiers.mockReturnValue(['AuthService', 'SessionStore']);
+      mockEnsureSymbolIndexFresh.mockReturnValue({
+        dbPath: '/tmp/symbol-index.db',
+        dbAgeMs: 123,
+        stale: true,
+        missing: false,
+        corrupt: false,
+        newestSourceMtimeMs: Date.now(),
+        rebuilt: true,
+      });
+
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(eventStore.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'symbol-index.lookup',
+          payload: {
+            consumerSkill: 'scout-code-path',
+            identifierCount: 2,
+            hintCount: 1,
+            dbAgeMs: 123,
+            stale: true,
+          },
+        }),
       );
     });
   });

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -26,6 +26,7 @@ import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { persistScoutReport } from '@goose-hub/core/scout-reports/repository.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { ensureSymbolIndexFresh } from '@goose-hub/core/symbol-index/freshness.js';
 import { extractIdentifiers, lookupWorkItemSymbols } from '@goose-hub/core/symbol-index/lookup.js';
 import {
   cleanupWorktree,
@@ -238,14 +239,48 @@ export async function runInvestigateWorkflow(
     let allScoutReports: string | undefined;
 
     if (investigationSwarmEnabled) {
-      // Pre-fetch symbol index hints for scout-code-path (best-effort; empty if index absent).
+      // Pre-fetch symbol index hints for scout-code-path. Freshness and lookup are best-effort:
+      // a missing, stale, or corrupt index must never block investigation.
+      const symbolIndexFreshness = ensureSymbolIndexFresh({ repoRoot: process.cwd() });
+      const symbolIdentifiers = extractIdentifiers(`${workItem.title} ${workItem.body}`);
+
+      if (symbolIndexFreshness.error != null) {
+        eventStore.appendEvent({
+          projectId,
+          workItemId: workItem.id,
+          kind: 'agent.log',
+          payload: {
+            level: 'warn',
+            message: 'symbol-index: freshness check failed; continuing without blocking',
+            error: symbolIndexFreshness.error,
+          },
+          runId,
+          personaId,
+        });
+      }
+
       // Pass worktreePath so hints are filtered to files that actually exist in the target repo,
       // preventing Goose Hub-internal paths from leaking into non-goose-hub investigations.
       const symbolIndexHints = lookupWorkItemSymbols(workItem.title, workItem.body, {
         worktreePath,
       });
 
-      const patternTokens = extractIdentifiers(`${workItem.title} ${workItem.body}`).slice(0, 4);
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'symbol-index.lookup',
+        payload: {
+          consumerSkill: 'scout-code-path',
+          identifierCount: symbolIdentifiers.length,
+          hintCount: symbolIndexHints.length,
+          dbAgeMs: symbolIndexFreshness.dbAgeMs,
+          stale: symbolIndexFreshness.stale,
+        },
+        runId,
+        personaId,
+      });
+
+      const patternTokens = symbolIdentifiers.slice(0, 4);
       const patternFocus =
         patternTokens.length > 0
           ? `Find existing usages of: ${patternTokens.join(', ')} — patterns this fix must follow`


### PR DESCRIPTION
Summary:
- add pnpm symbol CLI for find/callers/exports/imports/refresh
- add best-effort symbol index freshness checks before investigate scout hints
- emit symbol-index.lookup telemetry for hint usage measurement

Verification:
- pnpm typecheck
- pnpm lint
- pnpm vitest core/symbol-index
- pnpm vitest slices/investigate/slice.test.ts
- pnpm vitest core/agent-runtime/swarm.test.ts
- pnpm symbol-index
- pnpm symbol refresh
- pnpm symbol find dispatchWave
- pnpm symbol callers dispatchWave
- pnpm symbol exports core/agent-runtime/swarm.ts
- pnpm symbol imports slices/investigate/workflow.ts
- pnpm symbol --db /private/tmp/goose-hub-missing-symbol-index.db find dispatchWave

Note:
- core/agent-runtime/scout-runner.test.ts does not exist in this checkout; core/agent-runtime/swarm.test.ts covers the related dispatch surface.
- No linked GitHub issue was supplied for this request.