### PR TITLE
M7.XX: Goose hub logo

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+function createLocalStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+  } as Storage;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createLocalStorage({ 'sidebar-collapsed': 'true' }));
+});
+
+function renderSidebar() {
+  render(
+    <MemoryRouter>
+      <Sidebar activeSlug="goose-hub-self" />
+    </MemoryRouter>,
+  );
+}
+
+describe('Sidebar', () => {
+  it('shows the GOOSEHUB brand when expanded', () => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+
+    renderSidebar();
+
+    expect(screen.getByText('GOOSEHUB')).toBeTruthy();
+  });
+
+  it('hides the brand text when collapsed by default', () => {
+    renderSidebar();
+
+    expect(screen.queryByText('GOOSEHUB')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,8 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GOOSEHUB"', () => {
+    expect(sidebarSource).toContain('GOOSEHUB');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub logo

## Files
- `apps/web/src/components/chrome/Sidebar.test.tsx` — Added a regression test for the sidebar brand text in expanded and collapsed states.
- `apps/web/src/components/chrome/slice.test.ts` — Updated the chrome slice contract to expect the new GOOSEHUB sidebar label.

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/src/components/chrome/slice.test.ts` (6 cases)

Closes #823
