### PR TITLE
Add symbol index hints-used telemetry

### DIFF
--- a/apps/server/src/domains/costs/service.test.ts
+++ b/apps/server/src/domains/costs/service.test.ts
@@ -96,6 +96,44 @@ describe('getCostSummary', () => {
       totalRuns: 1,
       hasEstimated: false,
     });
+    expect(r.data.symbolIndex).toMatchObject({
+      lookupCount: 0,
+      averageIdentifiersPerLookup: 0,
+    });
+  });
+
+  it('includes symbol-index lookup and usage metrics', async () => {
+    mockTotalsForProject
+      .mockReturnValueOnce({ totalUsd: 0, totalRuns: 0, hasEstimated: false })
+      .mockReturnValueOnce({ totalUsd: 0, totalRuns: 0, hasEstimated: false });
+    mockTotalsByStage.mockReturnValue([]);
+    mockListCostsForProjectSince.mockReturnValue([]);
+    mockEventReplay.mockImplementation((filter = {}) => {
+      if (filter.kind === 'project.budget-exceeded') return [];
+      return [
+        {
+          kind: 'symbol-index.lookup',
+          payload: {
+            identifierCount: 4,
+            hintCount: 2,
+            consumerHintCounts: { 'scout-code-path': 2 },
+          },
+        },
+        {
+          kind: 'symbol-index.hints-used',
+          payload: { usedHintCount: 1 },
+        },
+      ];
+    });
+
+    const r = await getCostSummary('goose-hub-self');
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.data.symbolIndex.lookupCount).toBe(1);
+    expect(r.data.symbolIndex.averageIdentifiersPerLookup).toBe(4);
+    expect(r.data.symbolIndex.hintsUsedEventCount).toBe(1);
+    expect(r.data.symbolIndex.usedHintCount).toBe(1);
   });
 
   it('returns daily budget status for the current UTC day', async () => {

--- a/apps/server/src/domains/costs/service.ts
+++ b/apps/server/src/domains/costs/service.ts
@@ -1,6 +1,10 @@
 import { tryProviderOf } from '@goose-hub/core/agent-runtime/models.js';
 import type { CostLabel, Stage } from '@goose-hub/core/cost/types.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import {
+  type SymbolIndexLookupReport,
+  buildSymbolIndexLookupReport,
+} from '@goose-hub/core/symbol-index/report.js';
 import type { Result } from '#shared/middleware.js';
 import {
   type CostRow,
@@ -32,6 +36,7 @@ export interface CostSummaryDto {
     claude: { totalUsd: number; totalRuns: number; hasEstimated: boolean };
     codex: { totalUsd: number; totalRuns: number; hasEstimated: boolean };
   };
+  symbolIndex: SymbolIndexLookupReport;
 }
 
 export interface CostRowDto {
@@ -111,6 +116,7 @@ export async function getCostSummary(
   })[0];
   const claudeRows = monthRows.filter((r) => tryProviderOf(r.modelId) === 'claude');
   const codexRows = monthRows.filter((r) => tryProviderOf(r.modelId) === 'codex');
+  const symbolIndex = buildSymbolIndexLookupReport(eventStore.replay({ projectId }));
 
   return {
     ok: true,
@@ -128,6 +134,7 @@ export async function getCostSummary(
         claude: toProviderTotals(claudeRows),
         codex: toProviderTotals(codexRows),
       },
+      symbolIndex,
     },
   };
 }

--- a/apps/web/src/components/costs/CostsPage.tsx
+++ b/apps/web/src/components/costs/CostsPage.tsx
@@ -27,6 +27,10 @@ function StatTile({
   );
 }
 
+function formatMetric(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
 export function CostsPage() {
   const { slug = 'goose-hub-self' } = useParams<{ slug: string }>();
 
@@ -107,6 +111,67 @@ export function CostsPage() {
                 sub={`${data.byProvider.codex.totalRuns} run${data.byProvider.codex.totalRuns === 1 ? '' : 's'}`}
               />
             </div>
+          </section>
+
+          <section
+            data-testid="symbol-index-measurement"
+            className="border border-line rounded-lg p-5 mb-6"
+          >
+            <h2 className="text-[11px] uppercase tracking-wider text-fg-2 mb-4">
+              Symbol index · all time
+            </h2>
+            <div className="flex gap-3 mb-4">
+              <StatTile
+                testId="symbol-index-lookups"
+                label="Lookups"
+                value={data.symbolIndex.lookupCount.toLocaleString()}
+                sub={`${data.symbolIndex.hintsUsedEventCount.toLocaleString()} hints-used event${data.symbolIndex.hintsUsedEventCount === 1 ? '' : 's'}`}
+              />
+              <StatTile
+                testId="symbol-index-identifiers"
+                label="Avg identifiers"
+                value={formatMetric(data.symbolIndex.averageIdentifiersPerLookup)}
+                sub={`${formatMetric(data.symbolIndex.averageHintsPerLookup)} hints per lookup`}
+              />
+              <StatTile
+                testId="symbol-index-used"
+                label="Used hints"
+                value={data.symbolIndex.usedHintCount.toLocaleString()}
+                sub={`${Math.round(data.symbolIndex.staleRate * 100)}% stale lookups`}
+              />
+            </div>
+            {Object.keys(data.symbolIndex.hintsByConsumerSkill).length > 0 && (
+              <div className="overflow-hidden rounded-md border border-line/70">
+                <table className="w-full text-left text-[11.5px]">
+                  <thead className="bg-bg/60 text-fg-3">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Consumer</th>
+                      <th className="px-3 py-2 font-medium text-right">Lookups</th>
+                      <th className="px-3 py-2 font-medium text-right">Avg hints</th>
+                      <th className="px-3 py-2 font-medium text-right">Total hints</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(data.symbolIndex.hintsByConsumerSkill).map(
+                      ([consumerSkill, row]) => (
+                        <tr key={consumerSkill} className="border-t border-line/60">
+                          <td className="px-3 py-2 font-mono text-fg-2">{consumerSkill}</td>
+                          <td className="px-3 py-2 text-right tnum">
+                            {row.lookupCount.toLocaleString()}
+                          </td>
+                          <td className="px-3 py-2 text-right tnum">
+                            {formatMetric(row.averageHints)}
+                          </td>
+                          <td className="px-3 py-2 text-right tnum">
+                            {row.totalHints.toLocaleString()}
+                          </td>
+                        </tr>
+                      ),
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </section>
 
           <section data-testid="stage-breakdown" className="border border-line rounded-lg p-5">

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -87,6 +87,7 @@ import {
   SwarmScoutTimeoutEvent,
   SwarmWaveEvent,
 } from './timeline/SwarmEvents';
+import { SymbolIndexHintsUsedEvent } from './timeline/SymbolIndexEvents';
 import { AgentVerifyCommandEvent, ToolWarningEvent } from './timeline/VerifyToolEvents';
 
 export function renderTimelineItem(item: RenderItem, idx: number, context?: TimelineContext) {
@@ -153,6 +154,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <InvestigationContextInjectedEvent key={event.id} event={event} />;
     case 'agent.wrong-surface-guard':
       return <WrongSurfaceGuardEvent key={event.id} event={event} />;
+    case 'symbol-index.hints-used':
+      return <SymbolIndexHintsUsedEvent key={event.id} event={event} />;
     case 'agent.spawned':
       return <AgentSpawnedEvent key={event.id} event={event} />;
     case 'agent.decision-summary':

--- a/apps/web/src/components/detail/components/timeline/SymbolIndexEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/SymbolIndexEvents.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import type { AgentEventDto } from '@/lib/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderTimelineItem } from '../TimelineEvents';
+
+afterEach(cleanup);
+
+function makeEvent(payload: unknown): AgentEventDto {
+  return {
+    id: 1,
+    kind: 'symbol-index.hints-used',
+    payload,
+    runId: 'run-1',
+    createdAt: '2026-05-14T02:41:57Z',
+    workItemId: 'github:shaunnez/goose-hub#782',
+    projectId: 'goose-hub-self',
+  };
+}
+
+describe('SymbolIndexHintsUsedEvent', () => {
+  it('renders symbol-index.hints-used as a card instead of raw JSON', () => {
+    const event = makeEvent({
+      consumerSkill: 'scout-schema',
+      runId: 'run-1',
+      offeredHintCount: 4,
+      usedHintCount: 2,
+      detectionMethod: 'tool-call-path-match',
+      usedHints: [
+        { name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' },
+        { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'importer' },
+      ],
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Symbol hints used')).toBeTruthy();
+    expect(screen.getByText('scout-schema used 2 of 4 offered hints')).toBeTruthy();
+    expect(screen.getByText('AuthPayload')).toBeTruthy();
+    expect(screen.getByText('skills/auth/schema.ts')).toBeTruthy();
+    expect(screen.getByText('· definition')).toBeTruthy();
+    expect(screen.getByText('dispatchWave')).toBeTruthy();
+    expect(screen.getByText('slices/investigate/workflow.ts')).toBeTruthy();
+    expect(screen.getByText('· importer')).toBeTruthy();
+    expect(document.body.textContent).not.toContain('"usedHints"');
+  });
+});

--- a/apps/web/src/components/detail/components/timeline/SymbolIndexEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/SymbolIndexEvents.tsx
@@ -1,0 +1,59 @@
+import type { AgentEventDto } from '@/lib/types';
+import { Lightbulb } from 'lucide-react';
+
+type SymbolIndexHintSource =
+  | 'definition'
+  | 'importer'
+  | 'nearby-test'
+  | 'key-file'
+  | 'symbol-impact';
+
+type SymbolIndexHintsUsedPayload = {
+  consumerSkill?: string;
+  offeredHintCount?: number;
+  usedHintCount?: number;
+  usedHints?: Array<{
+    name?: string;
+    path?: string;
+    source?: SymbolIndexHintSource;
+  }>;
+};
+
+export function SymbolIndexHintsUsedEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as SymbolIndexHintsUsedPayload | null;
+  const consumerSkill = p?.consumerSkill ?? 'agent';
+  const usedHintCount = p?.usedHintCount ?? p?.usedHints?.length ?? 0;
+  const offeredHintCount = p?.offeredHintCount ?? usedHintCount;
+  const usedHints = p?.usedHints ?? [];
+
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-line bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="flex items-center gap-2 mb-1 text-[11px] text-fg-3">
+        <Lightbulb size={13} className="shrink-0 text-[color:var(--accent)]" />
+        <span className="font-mono uppercase tracking-wider">Symbol hints used</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="text-[12.5px] text-fg-2">
+        {consumerSkill} used {usedHintCount} of {offeredHintCount} offered hints
+      </div>
+      {usedHints.length > 0 && (
+        <div className="mt-2 flex flex-col gap-1.5">
+          {usedHints.map((hint, idx) => (
+            <div
+              key={`${hint.name ?? 'hint'}-${hint.path ?? idx}-${idx}`}
+              className="flex min-w-0 items-baseline gap-2 text-[11.5px]"
+            >
+              <span className="shrink-0 font-medium text-fg-2">{hint.name ?? 'Symbol'}</span>
+              <span className="min-w-0 truncate font-mono text-fg-3">{hint.path ?? 'unknown'}</span>
+              <span className="shrink-0 text-fg-4">· {hint.source ?? 'definition'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -517,6 +517,7 @@ describe('EVENT_KIND_LABEL — QA and fix-feedback kinds', () => {
     'agent.disclosure',
     'agent.fix-feedback-complete',
     'agent.retry-escalated',
+    'symbol-index.hints-used',
     'evidence.playwright-ran',
     'qa.structural-passed',
     'qa.functional-passed',

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -45,6 +45,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.investigation-complete': 'Investigation complete',
   'agent.investigation-context-injected': 'Investigation context injected',
   'agent.wrong-surface-guard': 'Wrong surface guard',
+  'symbol-index.hints-used': 'Symbol hints used',
   'agent.implement-complete': 'Implement complete',
   'agent.fix-feedback-complete': 'Fix feedback complete',
   'agent.retry-escalated': 'Retry escalated',

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -200,6 +200,19 @@ export interface CostStageTotal extends CostWindowTotals {
   stage: CostStage;
 }
 
+export interface SymbolIndexLookupReportDto {
+  lookupCount: number;
+  averageIdentifiersPerLookup: number;
+  averageHintsPerLookup: number;
+  staleRate: number;
+  hintsUsedEventCount: number;
+  usedHintCount: number;
+  hintsByConsumerSkill: Record<
+    string,
+    { lookupCount: number; averageHints: number; totalHints: number }
+  >;
+}
+
 export interface CostSummaryDto {
   projectId: string;
   dailyTokensUsed: number;
@@ -214,6 +227,7 @@ export interface CostSummaryDto {
     claude: CostWindowTotals;
     codex: CostWindowTotals;
   };
+  symbolIndex: SymbolIndexLookupReportDto;
 }
 
 export interface WorkItemCostsDto {

--- a/core/agent-runtime/dev-review-advisor.ts
+++ b/core/agent-runtime/dev-review-advisor.ts
@@ -17,6 +17,10 @@ import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
 import { eventStore } from '../event-stream/store.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { WorkItem } from '../state-source/interface.js';
+import {
+  emitSymbolIndexHintsUsedEvent,
+  offeredHintsFromSymbolImpact,
+} from '../symbol-index/hints-used.js';
 import { lookupChangedExportImpact } from '../symbol-index/lookup.js';
 import type { AgentConfig } from '../types.js';
 import { GIT_ENV } from '../workspaces/git-env.js';
@@ -294,6 +298,18 @@ export async function runDevReview(input: RunDevReviewInput): Promise<DevReviewO
     personaId,
     outputJsonSchema,
     appendSystemPrompt: prompt,
+  });
+  emitSymbolIndexHintsUsedEvent({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    consumerSkill: 'dev-review',
+    runId: devReviewRunId,
+    parentRunId: input.runId,
+    personaId,
+    offeredHints: offeredHintsFromSymbolImpact(symbolImpact),
+    toolEvents: eventStore.replay({ runId: devReviewRunId, kind: 'agent.tool-call' }),
+    worktreePath: input.worktreePath,
+    appendEvent: input.appendEvent,
   });
 
   const parsed = DevReviewOutputSchema.safeParse(result.output);

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -142,6 +142,7 @@ export type EventKind =
   | 'audit.failed'
   // Symbol index utility telemetry — lets us measure whether hints save work.
   | 'symbol-index.lookup'
+  | 'symbol-index.hints-used'
   | 'audit.autonomy-gate-fired';
 
 export interface AgentEvent {

--- a/core/symbol-index/hints-used.test.ts
+++ b/core/symbol-index/hints-used.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  detectSymbolIndexHintsUsed,
+  emitSymbolIndexHintsUsedEvent,
+  offeredHintsFromScoutSymbolIndexHints,
+  offeredHintsFromSymbolImpact,
+  offeredHintsFromSymbolKeyFiles,
+} from './hints-used.js';
+
+describe('symbol-index hints-used detection', () => {
+  it('returns null when no offered hint path appears in tool-call payloads', () => {
+    const payload = detectSymbolIndexHintsUsed({
+      consumerSkill: 'scout-code-path',
+      runId: 'run-1',
+      offeredHints: [{ name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' }],
+      toolEvents: [
+        {
+          payload: {
+            tool_name: 'Read',
+            tool_input: { file_path: 'skills/payments/schema.ts' },
+          },
+        },
+      ],
+    });
+
+    expect(payload).toBeNull();
+  });
+
+  it('detects exact file reads and shell searches of hinted paths', () => {
+    const payload = detectSymbolIndexHintsUsed({
+      consumerSkill: 'scout-schema',
+      runId: 'run-2',
+      parentRunId: 'parent-1',
+      offeredHints: [
+        { name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' },
+        { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'importer' },
+      ],
+      toolEvents: [
+        {
+          payload: {
+            tool_name: 'Read',
+            tool_input: { file_path: '/repo/skills/auth/schema.ts' },
+          },
+        },
+        {
+          payload: {
+            tool_name: 'Bash',
+            tool_input: { command: 'rg dispatchWave slices/investigate/workflow.ts' },
+          },
+        },
+      ],
+      worktreePath: '/repo',
+    });
+
+    expect(payload).toEqual({
+      consumerSkill: 'scout-schema',
+      runId: 'run-2',
+      parentRunId: 'parent-1',
+      offeredHintCount: 2,
+      usedHintCount: 2,
+      detectionMethod: 'tool-call-path-match',
+      usedHints: [
+        { name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' },
+        { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'importer' },
+      ],
+    });
+  });
+
+  it('caps emitted usedHints while preserving the full usedHintCount', () => {
+    const offeredHints = Array.from({ length: 10 }, (_, idx) => ({
+      name: `Hint${idx}`,
+      path: `src/hint-${idx}.ts`,
+      source: 'definition' as const,
+    }));
+    const payload = detectSymbolIndexHintsUsed({
+      consumerSkill: 'scout-code-path',
+      runId: 'run-3',
+      offeredHints,
+      toolEvents: offeredHints.map((hint) => ({
+        payload: { tool_name: 'Read', tool_input: { file_path: hint.path } },
+      })),
+      maxUsedHints: 8,
+    });
+
+    expect(payload?.usedHintCount).toBe(10);
+    expect(payload?.usedHints).toHaveLength(8);
+  });
+
+  it('emits symbol-index.hints-used only when detection finds usage', () => {
+    const appendEvent = vi.fn();
+
+    const payload = emitSymbolIndexHintsUsedEvent({
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+      consumerSkill: 'implement',
+      runId: 'run-4',
+      offeredHints: [
+        { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'key-file' },
+      ],
+      toolEvents: [
+        {
+          payload: {
+            tool_name: 'Grep',
+            tool_input: { path: 'slices/investigate/workflow.ts', pattern: 'dispatchWave' },
+          },
+        },
+      ],
+      appendEvent,
+    });
+
+    expect(payload?.usedHintCount).toBe(1);
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'symbol-index.hints-used',
+        payload: expect.objectContaining({
+          consumerSkill: 'implement',
+          usedHintCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it('shapes scout, key-file, and symbol-impact offers with source labels', () => {
+    expect(
+      offeredHintsFromScoutSymbolIndexHints([
+        {
+          name: 'AuthPayload',
+          definedIn: 'skills/auth/schema.ts',
+          importers: ['skills/auth/prompt.ts'],
+          nearbyTests: ['skills/auth/slice.test.ts'],
+        },
+      ]),
+    ).toEqual([
+      { name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' },
+      { name: 'AuthPayload', path: 'skills/auth/prompt.ts', source: 'importer' },
+      { name: 'AuthPayload', path: 'skills/auth/slice.test.ts', source: 'nearby-test' },
+    ]);
+
+    expect(
+      offeredHintsFromSymbolKeyFiles([
+        { path: 'slices/investigate/workflow.ts', reason: 'Symbol index: imports dispatchWave' },
+      ]),
+    ).toEqual([
+      { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'key-file' },
+    ]);
+
+    expect(
+      offeredHintsFromSymbolImpact([
+        {
+          changedExport: 'dispatchWave',
+          definedIn: 'core/agent-runtime/swarm.ts',
+          importers: ['slices/investigate/workflow.ts'],
+        },
+      ]),
+    ).toEqual([
+      { name: 'dispatchWave', path: 'core/agent-runtime/swarm.ts', source: 'symbol-impact' },
+      { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'symbol-impact' },
+    ]);
+  });
+});

--- a/core/symbol-index/hints-used.ts
+++ b/core/symbol-index/hints-used.ts
@@ -1,0 +1,230 @@
+import path from 'node:path';
+import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
+import type { ShapedSymbolHint, SymbolImpact, SymbolKeyFileHint } from './lookup.js';
+
+export type SymbolIndexHintsUsedConsumerSkill =
+  | 'scout-code-path'
+  | 'scout-dependency'
+  | 'scout-schema'
+  | 'scout-test-inventory'
+  | 'implement'
+  | 'dev-review';
+
+export type SymbolIndexHintSource =
+  | 'definition'
+  | 'importer'
+  | 'nearby-test'
+  | 'key-file'
+  | 'symbol-impact';
+
+export interface OfferedSymbolIndexHint {
+  name: string;
+  path: string;
+  source: SymbolIndexHintSource;
+}
+
+export interface SymbolIndexHintsUsedPayload {
+  consumerSkill: SymbolIndexHintsUsedConsumerSkill;
+  runId: string;
+  parentRunId?: string;
+  offeredHintCount: number;
+  usedHintCount: number;
+  detectionMethod: 'tool-call-path-match';
+  usedHints: OfferedSymbolIndexHint[];
+}
+
+const DEFAULT_MAX_USED_HINTS = 8;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function normalizeRepoPath(value: string, worktreePath?: string): string {
+  let normalized = value.trim().replaceAll('\\', '/');
+  normalized = normalized.replace(/^['"]|['"]$/g, '');
+  if (worktreePath != null) {
+    const root = worktreePath.replaceAll('\\', '/').replace(/\/$/, '');
+    if (normalized === root) return '';
+    if (normalized.startsWith(`${root}/`)) normalized = normalized.slice(root.length + 1);
+  }
+  normalized = normalized.replace(/^\.\//, '');
+  return normalized.replace(/\/+$/, '');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function commandMentionsPath(command: string, hintPath: string, worktreePath?: string): boolean {
+  const normalizedCommand = command.replaceAll('\\', '/');
+  const normalizedHint = normalizeRepoPath(hintPath);
+  const variants = [`./${normalizedHint}`, normalizedHint];
+  if (worktreePath != null) {
+    variants.push(`${worktreePath.replaceAll('\\', '/').replace(/\/$/, '')}/${normalizedHint}`);
+  }
+
+  return variants.some((variant) => {
+    const pattern = new RegExp(
+      `(^|[^A-Za-z0-9_./-])${escapeRegExp(variant)}(?=$|[^A-Za-z0-9_./-])`,
+    );
+    return pattern.test(normalizedCommand);
+  });
+}
+
+function pathFieldMatches(value: string, hintPath: string, worktreePath?: string): boolean {
+  return normalizeRepoPath(value, worktreePath) === normalizeRepoPath(hintPath);
+}
+
+function toolCallMatchesHintPath(
+  event: Pick<AgentEvent, 'payload'>,
+  hintPath: string,
+  worktreePath?: string,
+): boolean {
+  const payload = asRecord(event.payload);
+  const input = asRecord(
+    payload.tool_input ?? payload.toolInput ?? payload.redacted_tool_input ?? payload.input,
+  );
+
+  for (const key of ['file_path', 'path']) {
+    const value = input[key];
+    if (typeof value === 'string' && pathFieldMatches(value, hintPath, worktreePath)) {
+      return true;
+    }
+  }
+
+  for (const key of ['command', 'cmd']) {
+    const value = input[key];
+    if (typeof value === 'string' && commandMentionsPath(value, hintPath, worktreePath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function dedupeOfferedHints(hints: OfferedSymbolIndexHint[]): OfferedSymbolIndexHint[] {
+  const out: OfferedSymbolIndexHint[] = [];
+  const seen = new Set<string>();
+  for (const hint of hints) {
+    const normalizedPath = normalizeRepoPath(hint.path);
+    if (hint.name.trim().length === 0 || normalizedPath.length === 0) continue;
+    const key = `${hint.name}\0${normalizedPath}\0${hint.source}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ ...hint, path: normalizedPath });
+  }
+  return out;
+}
+
+export function detectSymbolIndexHintsUsed(input: {
+  consumerSkill: SymbolIndexHintsUsedConsumerSkill;
+  runId: string;
+  parentRunId?: string;
+  offeredHints: OfferedSymbolIndexHint[];
+  toolEvents: Array<Pick<AgentEvent, 'payload'>>;
+  worktreePath?: string;
+  maxUsedHints?: number;
+}): SymbolIndexHintsUsedPayload | null {
+  const offeredHints = dedupeOfferedHints(input.offeredHints);
+  if (offeredHints.length === 0) return null;
+
+  const usedHints = offeredHints.filter((hint) =>
+    input.toolEvents.some((event) => toolCallMatchesHintPath(event, hint.path, input.worktreePath)),
+  );
+  if (usedHints.length === 0) return null;
+
+  return {
+    consumerSkill: input.consumerSkill,
+    runId: input.runId,
+    ...(input.parentRunId != null ? { parentRunId: input.parentRunId } : {}),
+    offeredHintCount: offeredHints.length,
+    usedHintCount: usedHints.length,
+    detectionMethod: 'tool-call-path-match',
+    usedHints: usedHints.slice(0, input.maxUsedHints ?? DEFAULT_MAX_USED_HINTS),
+  };
+}
+
+export function emitSymbolIndexHintsUsedEvent(input: {
+  projectId: string;
+  workItemId?: string | null;
+  consumerSkill: SymbolIndexHintsUsedConsumerSkill;
+  runId: string;
+  parentRunId?: string;
+  personaId?: string | null;
+  offeredHints: OfferedSymbolIndexHint[];
+  toolEvents: Array<Pick<AgentEvent, 'payload'>>;
+  worktreePath?: string;
+  appendEvent: (event: AppendEventInput) => unknown;
+}): SymbolIndexHintsUsedPayload | null {
+  const payload = detectSymbolIndexHintsUsed(input);
+  if (payload == null) return null;
+
+  input.appendEvent({
+    projectId: input.projectId,
+    workItemId: input.workItemId ?? null,
+    kind: 'symbol-index.hints-used',
+    payload,
+    runId: input.runId,
+    personaId: input.personaId ?? null,
+  });
+
+  return payload;
+}
+
+export function offeredHintsFromScoutSymbolIndexHints(hints: unknown): OfferedSymbolIndexHint[] {
+  if (!Array.isArray(hints)) return [];
+
+  const offered: OfferedSymbolIndexHint[] = [];
+  for (const rawHint of hints) {
+    const hint = rawHint as Partial<ShapedSymbolHint>;
+    if (typeof hint.name !== 'string') continue;
+
+    if (typeof hint.definedIn === 'string') {
+      offered.push({ name: hint.name, path: hint.definedIn, source: 'definition' });
+    }
+    for (const importer of asStringArray(hint.importers ?? hint.callers)) {
+      offered.push({ name: hint.name, path: importer, source: 'importer' });
+    }
+    for (const nearbyTest of asStringArray(hint.nearbyTests)) {
+      offered.push({ name: hint.name, path: nearbyTest, source: 'nearby-test' });
+    }
+  }
+  return offered;
+}
+
+function symbolNameFromKeyFileReason(reason: string, filePath: string): string {
+  const exported = reason.match(/^Symbol index: (.+?) is exported here$/);
+  if (exported?.[1] != null) return exported[1];
+  const imported = reason.match(/^Symbol index: imports (.+)$/);
+  if (imported?.[1] != null) return imported[1];
+  return path.posix.basename(filePath).replace(/\.[^.]+$/, '');
+}
+
+export function offeredHintsFromSymbolKeyFiles(
+  keyFiles: SymbolKeyFileHint[],
+): OfferedSymbolIndexHint[] {
+  return keyFiles.map((keyFile) => ({
+    name: symbolNameFromKeyFileReason(keyFile.reason, keyFile.path),
+    path: keyFile.path,
+    source: 'key-file',
+  }));
+}
+
+export function offeredHintsFromSymbolImpact(impacts: SymbolImpact[]): OfferedSymbolIndexHint[] {
+  return impacts.flatMap((impact) => [
+    { name: impact.changedExport, path: impact.definedIn, source: 'symbol-impact' as const },
+    ...impact.importers.map((importer) => ({
+      name: impact.changedExport,
+      path: importer,
+      source: 'symbol-impact' as const,
+    })),
+  ]);
+}

--- a/core/symbol-index/report.test.ts
+++ b/core/symbol-index/report.test.ts
@@ -32,12 +32,18 @@ describe('buildSymbolIndexLookupReport', () => {
         kind: 'agent.run-started',
         payload: {},
       },
+      {
+        kind: 'symbol-index.hints-used',
+        payload: { usedHintCount: 2 },
+      },
     ]);
 
     expect(report.lookupCount).toBe(2);
     expect(report.averageIdentifiersPerLookup).toBe(3);
     expect(report.averageHintsPerLookup).toBe(2);
     expect(report.staleRate).toBe(0.5);
+    expect(report.hintsUsedEventCount).toBe(1);
+    expect(report.usedHintCount).toBe(2);
     expect(report.hintsByConsumerSkill).toEqual({
       'scout-code-path': { lookupCount: 2, averageHints: 2, totalHints: 4 },
       'scout-dependency': { lookupCount: 2, averageHints: 1, totalHints: 2 },

--- a/core/symbol-index/report.ts
+++ b/core/symbol-index/report.ts
@@ -5,6 +5,8 @@ export interface SymbolIndexLookupReport {
   averageIdentifiersPerLookup: number;
   averageHintsPerLookup: number;
   staleRate: number;
+  hintsUsedEventCount: number;
+  usedHintCount: number;
   hintsByConsumerSkill: Record<
     string,
     { lookupCount: number; averageHints: number; totalHints: number }
@@ -25,10 +27,12 @@ export function buildSymbolIndexLookupReport(
   events: Array<Pick<AgentEvent, 'kind' | 'payload'>>,
 ): SymbolIndexLookupReport {
   const lookups = events.filter((event) => event.kind === 'symbol-index.lookup');
+  const hintsUsedEvents = events.filter((event) => event.kind === 'symbol-index.hints-used');
   const consumerTotals = new Map<string, { lookupCount: number; totalHints: number }>();
   let identifierTotal = 0;
   let hintTotal = 0;
   let staleCount = 0;
+  let usedHintCount = 0;
 
   for (const event of lookups) {
     const payload = asRecord(event.payload);
@@ -57,6 +61,11 @@ export function buildSymbolIndexLookupReport(
     consumerTotals.set(consumerSkill, current);
   }
 
+  for (const event of hintsUsedEvents) {
+    const payload = asRecord(event.payload);
+    usedHintCount += asNumber(payload.usedHintCount);
+  }
+
   const lookupCount = lookups.length;
   const hintsByConsumerSkill = Object.fromEntries(
     [...consumerTotals.entries()].map(([consumerSkill, totals]) => [
@@ -74,6 +83,8 @@ export function buildSymbolIndexLookupReport(
     averageIdentifiersPerLookup: lookupCount === 0 ? 0 : identifierTotal / lookupCount,
     averageHintsPerLookup: lookupCount === 0 ? 0 : hintTotal / lookupCount,
     staleRate: lookupCount === 0 ? 0 : staleCount / lookupCount,
+    hintsUsedEventCount: hintsUsedEvents.length,
+    usedHintCount,
     hintsByConsumerSkill,
   };
 }

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -16,6 +16,11 @@ import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-tra
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import {
+  emitSymbolIndexHintsUsedEvent,
+  offeredHintsFromSymbolKeyFiles,
+} from '@goose-hub/core/symbol-index/hints-used.js';
+import type { SymbolKeyFileHint } from '@goose-hub/core/symbol-index/lookup.js';
 import type { orchestratorCommitAll } from '@goose-hub/core/workspaces/orchestrator-git.js';
 import { ImplementSchema } from '@goose-hub/skills/implement/schema.js';
 import { buildPrBody, runEvidencePost } from './pr-helpers.js';
@@ -36,6 +41,7 @@ export interface RunImplementInput {
   advisorFeedback?: string;
   investigation?: InvestigationContext;
   surfaceGuardInvestigation?: InvestigationContext;
+  symbolIndexKeyFiles?: SymbolKeyFileHint[];
   revisionPass?: 0 | 1;
 }
 
@@ -242,6 +248,17 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
       outputJsonSchema: input.outputJsonSchema,
       appendSystemPrompt: input.appendSystemPrompt,
     },
+  });
+  emitSymbolIndexHintsUsedEvent({
+    projectId: input.projectId,
+    workItemId: input.workItem.id,
+    consumerSkill: 'implement',
+    runId: input.runId,
+    personaId: input.personaId,
+    offeredHints: offeredHintsFromSymbolKeyFiles(input.symbolIndexKeyFiles ?? []),
+    toolEvents: eventStore.replay({ runId: input.runId, kind: 'agent.tool-call' }),
+    worktreePath: input.worktreePath,
+    appendEvent: (event) => eventStore.appendEvent(event),
   });
   const touchedPaths = [
     ...output.filesWritten.map((f) => f.path),

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -661,6 +661,100 @@ describe('runFixIssueWorkflow (#183)', () => {
     expect(JSON.stringify(implementSpec.context)).not.toContain('"callers"');
   });
 
+  it('emits symbol-index.hints-used when implement tool calls touch curated symbol key files', async () => {
+    const item = makeWorkItem({ priority: 'medium', type: 'bug', title: 'Fix dispatchWave' });
+    const source = makeStateSource();
+    vi.mocked(eventStore.replay).mockImplementation((filter = {}) => {
+      if (filter.kind === 'agent.investigation-complete') return [makeInvestigationEvent(item)];
+      if (filter.runId != null && filter.kind === 'agent.tool-call') {
+        return [
+          {
+            id: 101,
+            projectId: 'proj',
+            workItemId: item.id,
+            kind: 'agent.tool-call',
+            payload: {
+              tool_name: 'Read',
+              tool_input: { file_path: '/work/wt/slices/investigate/workflow.ts' },
+            },
+            runId: String(filter.runId),
+            createdAt: new Date().toISOString(),
+          },
+        ] as never;
+      }
+      return [];
+    });
+    mockLookupWorkItemSymbols.mockReturnValue([
+      {
+        name: 'dispatchWave',
+        definedIn: 'core/agent-runtime/swarm.ts',
+        line: 10,
+        kind: 'function',
+        callers: ['slices/investigate/workflow.ts'],
+      },
+    ]);
+    mockSymbolHintsToKeyFiles.mockReturnValue([
+      {
+        path: 'slices/investigate/workflow.ts',
+        reason: 'Symbol index: imports dispatchWave',
+      },
+    ]);
+
+    const runtime: AgentRuntime = {
+      run: vi.fn().mockResolvedValueOnce({
+        output: makeImplementOutput({
+          filesWritten: [
+            {
+              path: 'apps/server/src/domains/workflows/triage-batch.ts',
+              reason: 'fix investigated surface',
+            },
+          ],
+          testsWritten: [
+            {
+              path: 'apps/server/src/domains/workflows/triage-batch.test.ts',
+              cases: 1,
+            },
+          ],
+          testsRun: {
+            command: 'pnpm test --reporter=json',
+            paths: ['apps/server/src/domains/workflows/triage-batch.test.ts'],
+          },
+        }),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult),
+    };
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', {
+      runtime,
+      openPRImpl: vi.fn().mockResolvedValue({
+        prNumber: 100,
+        prUrl: 'https://github.com/owner/repo/pull/100',
+        branch: 'factory/abc',
+        base: 'main',
+      }),
+      adviseOnPlanImpl: vi.fn(),
+      createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
+      cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
+    });
+
+    const hintsUsed = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([event]) => event.kind === 'symbol-index.hints-used');
+    expect(hintsUsed?.[0].payload).toMatchObject({
+      consumerSkill: 'implement',
+      offeredHintCount: 1,
+      usedHintCount: 1,
+      usedHints: [
+        { name: 'dispatchWave', path: 'slices/investigate/workflow.ts', source: 'key-file' },
+      ],
+    });
+  });
+
   it('keeps wrong-surface guard anchored to investigation key files, not symbol key files', async () => {
     const item = makeWorkItem({ priority: 'medium', type: 'bug', title: 'Fix dispatchWave' });
     const source = makeStateSource();

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -176,6 +176,7 @@ export async function runFixIssueWorkflow(
         personaId: implementPersonaId,
         investigation: implementInvestigation,
         surfaceGuardInvestigation: investigation,
+        symbolIndexKeyFiles: symbolKeyFiles,
         revisionPass: 0,
       });
 
@@ -264,6 +265,7 @@ export async function runFixIssueWorkflow(
       personaId: implementPersonaId,
       investigation: implementInvestigation,
       surfaceGuardInvestigation: investigation,
+      symbolIndexKeyFiles: symbolKeyFiles,
       advisorFeedback,
       revisionPass,
     });

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -100,6 +100,7 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
     appendEvent: vi
       .fn()
       .mockReturnValue({ id: 1, kind: 'agent.investigation-complete', payload: {}, createdAt: '' }),
+    replay: vi.fn().mockReturnValue([]),
   },
 }));
 
@@ -1259,6 +1260,53 @@ describe('runInvestigateWorkflow', () => {
             }),
             dbAgeMs: 123,
             stale: true,
+          }),
+        }),
+      );
+    });
+
+    it('emits symbol-index.hints-used when scout tool calls touch offered hint paths', async () => {
+      const hints = [
+        {
+          name: 'AuthPayload',
+          definedIn: 'skills/auth/schema.ts',
+          line: 10,
+          kind: 'type',
+          callers: [],
+        },
+      ];
+      mockLookupWorkItemSymbols.mockReturnValue(hints);
+
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      vi.mocked(eventStore.replay).mockImplementation((filter = {}) => {
+        if (filter.runId === 'run:scout:scout-code-path:0') {
+          return [
+            {
+              kind: 'agent.tool-call',
+              payload: {
+                tool_name: 'Read',
+                tool_input: { file_path: '/tmp/test-worktree/skills/auth/schema.ts' },
+              },
+            },
+          ] as never;
+        }
+        return [];
+      });
+
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(eventStore.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'symbol-index.hints-used',
+          payload: expect.objectContaining({
+            consumerSkill: 'scout-code-path',
+            offeredHintCount: 1,
+            usedHintCount: 1,
+            detectionMethod: 'tool-call-path-match',
+            usedHints: [
+              { name: 'AuthPayload', path: 'skills/auth/schema.ts', source: 'definition' },
+            ],
           }),
         }),
       );

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -29,6 +29,11 @@ import { persistScoutReport } from '@goose-hub/core/scout-reports/repository.js'
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { ensureSymbolIndexFresh } from '@goose-hub/core/symbol-index/freshness.js';
 import {
+  type SymbolIndexHintsUsedConsumerSkill,
+  emitSymbolIndexHintsUsedEvent,
+  offeredHintsFromScoutSymbolIndexHints,
+} from '@goose-hub/core/symbol-index/hints-used.js';
+import {
   extractIdentifiers,
   lookupWorkItemSymbols,
   shapeSymbolIndexHintsForScout,
@@ -52,6 +57,37 @@ import { runPlaywrightReproPlan, shouldSkipBeforeEvidence } from './playwright-r
 import { WAVE_1_SCOUTS, selectWave2Scouts } from './wave2-selection.js';
 
 type InvestigateOutput = z.infer<typeof InvestigateSchema>;
+
+function emitScoutSymbolHintUsage(input: {
+  parentRunId: string;
+  projectId: string;
+  workItemId: string;
+  worktreePath: string;
+  personaId: string;
+  scoutSpecs: Array<{ scoutName: string; extraContext?: Record<string, unknown> }>;
+  reports: Array<{ scoutName: string; runId: string }>;
+}): void {
+  for (const report of input.reports) {
+    const spec = input.scoutSpecs.find((candidate) => candidate.scoutName === report.scoutName);
+    const offeredHints = offeredHintsFromScoutSymbolIndexHints(
+      spec?.extraContext?.symbolIndexHints,
+    );
+    if (offeredHints.length === 0) continue;
+
+    emitSymbolIndexHintsUsedEvent({
+      projectId: input.projectId,
+      workItemId: input.workItemId,
+      consumerSkill: report.scoutName as SymbolIndexHintsUsedConsumerSkill,
+      runId: report.runId,
+      parentRunId: input.parentRunId,
+      personaId: input.personaId,
+      offeredHints,
+      toolEvents: eventStore.replay({ runId: report.runId, kind: 'agent.tool-call' }),
+      worktreePath: input.worktreePath,
+      appendEvent: (event) => eventStore.appendEvent(event),
+    });
+  }
+}
 
 export function chooseScoutModelOverride(input: {
   resolvedBudget: ResolvedBudget;
@@ -351,6 +387,15 @@ export async function runInvestigateWorkflow(
         resolveScoutBudget: resolveInvestigateScoutBudget,
         loadSkillAssets,
       });
+      emitScoutSymbolHintUsage({
+        parentRunId: runId,
+        projectId,
+        workItemId: workItem.id,
+        worktreePath,
+        personaId,
+        scoutSpecs: wave1Scouts,
+        reports: wave1Result.reports,
+      });
 
       const wave1HandoffReports: unknown[] = [];
       for (const report of wave1Result.reports) {
@@ -431,6 +476,15 @@ export async function runInvestigateWorkflow(
         minSuccessfulScouts: wave2Scouts.length,
         resolveScoutBudget: resolveInvestigateScoutBudget,
         loadSkillAssets,
+      });
+      emitScoutSymbolHintUsage({
+        parentRunId: runId,
+        projectId,
+        workItemId: workItem.id,
+        worktreePath,
+        personaId,
+        scoutSpecs: wave2Scouts,
+        reports: wave2Result.reports,
       });
 
       const wave2HandoffReports: unknown[] = [];


### PR DESCRIPTION
## Summary
- add symbol-index.hints-used detection from real agent.tool-call path matches
- emit hints-used telemetry from scouts, implement, and dev-review
- render a timeline card and add symbol-index metrics to the costs dashboard

## Verification
- pnpm test core/symbol-index/hints-used.test.ts core/symbol-index/report.test.ts apps/server/src/domains/costs/service.test.ts apps/web/src/components/detail/components/timeline/SymbolIndexEvents.test.tsx apps/web/src/components/detail/lib/timeline.test.ts slices/investigate/slice.test.ts slices/fix-issue/slice.test.ts
- pnpm run typecheck
- pnpm run lint
- local costs-page smoke check on alternate ports: symbol panel rendered, no horizontal overflow