### PR TITLE
Add Factory workspace-only runtime instruction

### DIFF
--- a/core/agent-runtime/claude-cli.test.ts
+++ b/core/agent-runtime/claude-cli.test.ts
@@ -120,6 +120,27 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
     expect(child.stdin.end).toHaveBeenCalledWith('<task></task>');
   });
 
+  it('includes the Factory workspace-only instruction in Claude system prompt', async () => {
+    const envelope = JSON.stringify({ is_error: false, result: '{"ok":true}' });
+    mockSpawn.mockReturnValue(makeChild(0, envelope));
+
+    const runtime = new ClaudeCliRuntime();
+    await runtime.run(makeSpec({ appendSystemPrompt: 'skill prompt body' }));
+
+    const argv = mockSpawn.mock.calls[0][1] as string[];
+    const promptIndex = argv.indexOf('--system-prompt');
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    const systemPrompt = argv[promptIndex + 1];
+    expect(systemPrompt).toContain('Factory agents must not read ~/.codex');
+    expect(systemPrompt).toContain(
+      'All repo exploration must stay under workspaceDir / <worktreePath>.',
+    );
+    expect(systemPrompt).toContain(
+      'If prior context is needed, use only context provided by Factory.',
+    );
+    expect(systemPrompt).toContain('skill prompt body');
+  });
+
   it('inserts a success row when CLI exits with valid envelope', async () => {
     const valuesRun = vi.fn();
     const values = vi.fn().mockReturnValue({ run: valuesRun });

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -19,6 +19,7 @@ import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { resolveMockOutput } from './mock-outputs.js';
 import { defaultModelForTier } from './models.js';
 import { killProcessGroupOrChild } from './process-kill.js';
+import { withFactoryRuntimeInstructions } from './runtime-instructions.js';
 import type { JsonSchema } from './schema-bridge.js';
 
 const STDOUT_CAP = 4 * 1024 * 1024; // 4 MB
@@ -181,10 +182,9 @@ export class ClaudeCliRuntime implements AgentRuntime {
     ];
 
     // --system-prompt replaces the default IDE system prompt so the agent follows
-    // the skill's instructions rather than responding as a general coding assistant.
-    if (spec.appendSystemPrompt != null) {
-      argv.push('--system-prompt', spec.appendSystemPrompt);
-    }
+    // Factory runtime invariants and the skill's instructions rather than responding
+    // as a general coding assistant.
+    argv.push('--system-prompt', withFactoryRuntimeInstructions(spec.appendSystemPrompt));
 
     // Pass --allowedTools whenever bundles were explicitly declared, even if they
     // resolve to an empty list. An empty list means "no tools" (e.g. grill-me uses

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -118,6 +118,24 @@ describe('CodexCliRuntime timeout handling', () => {
     );
   });
 
+  it('includes the Factory workspace-only instruction in Codex system instructions', async () => {
+    await runSuccessfulCodexSpec({ appendSystemPrompt: 'skill prompt body' });
+
+    const call = vi.mocked(buildCodexArgv).mock.calls[0]?.[0];
+    expect(call).toEqual(
+      expect.objectContaining({
+        systemPrompt: expect.stringContaining('Factory agents must not read ~/.codex'),
+      }),
+    );
+    expect(call?.systemPrompt).toContain(
+      'All repo exploration must stay under workspaceDir / <worktreePath>.',
+    );
+    expect(call?.systemPrompt).toContain(
+      'If prior context is needed, use only context provided by Factory.',
+    );
+    expect(call?.systemPrompt).toContain('skill prompt body');
+  });
+
   it('does not use danger-full-access for QA even though QA includes validate', async () => {
     await runSuccessfulCodexSpec({
       skill: 'qa',

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -33,6 +33,7 @@ import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { resolveMockOutput } from './mock-outputs.js';
 import { defaultModelForTierAndProvider, estimateCostUsd } from './models.js';
 import { killProcessGroupOrChild } from './process-kill.js';
+import { withFactoryRuntimeInstructions } from './runtime-instructions.js';
 
 export { CodexBinaryNotFoundError, CodexNotAuthenticatedError } from './codex-config.js';
 export {
@@ -139,7 +140,7 @@ export class CodexCliRuntime implements AgentRuntime {
       model,
       workspaceDir,
       prompt: contextXml,
-      systemPrompt: spec.appendSystemPrompt,
+      systemPrompt: withFactoryRuntimeInstructions(spec.appendSystemPrompt),
       maxTurns: spec.budgets.maxTurns,
       commandSandbox: needsBrowserProcessAccess ? 'danger-full-access' : undefined,
       approvalPolicy: needsBrowserProcessAccess ? 'never' : undefined,

--- a/core/agent-runtime/runtime-instructions.ts
+++ b/core/agent-runtime/runtime-instructions.ts
@@ -1,0 +1,12 @@
+export const FACTORY_WORKSPACE_ONLY_INSTRUCTIONS = `## Factory workspace boundary
+
+Factory agents must not read ~/.codex, ~/.agents, ~/.claude, user home memory files, or sibling repos.
+All repo exploration must stay under workspaceDir / <worktreePath>.
+If prior context is needed, use only context provided by Factory.`;
+
+export function withFactoryRuntimeInstructions(systemPrompt: string | undefined): string {
+  if (systemPrompt == null || systemPrompt.trim().length === 0) {
+    return FACTORY_WORKSPACE_ONLY_INSTRUCTIONS;
+  }
+  return `${FACTORY_WORKSPACE_ONLY_INSTRUCTIONS}\n\n${systemPrompt}`;
+}

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -40,7 +40,9 @@ When wired, dispatch the 4–6 scouts that are actually relevant. Do **not** dis
 
 ### Discipline — applied throughout (single-agent and wave-aware modes)
 
-- **Orient first.** Before searching for anything, list the top-level directory structure to understand the codebase layout. Know where `core/`, `apps/`, and `slices/` live before diving in.
+- **Orient inside `<worktreePath>` first.** Before searching for anything, list the top-level directory structure under `<worktreePath>` only to understand the codebase layout. Know where `core/`, `apps/`, and `slices/` live before diving in.
+- **Stay under `<worktreePath>`.** All list, read, and search operations must stay inside the provided `<worktreePath>`. Do not inspect sibling repos, parent directories, user home directories, or local assistant memory/config folders such as `~/.codex`, `~/.agents`, or `~/.claude`.
+- **No memory quick pass.** Do not perform memory quick passes or read local assistant memory files. If prior context is needed, use only the context Factory provided in this run.
 - **Read before hypothesising.** Read actual source files before forming hypotheses. File names and directory names are not evidence. Code is evidence.
 - **Search before assuming location.** Grep for symbol definitions before assuming a file path. A module named `Sidebar` may not be in `sidebar.ts` — search for the export.
 - **Widen before speculating.** If two search attempts return no relevant results, widen the search term or try a synonym. Do not speculate about root cause from empty search results.

--- a/skills/investigate/slice.test.ts
+++ b/skills/investigate/slice.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { toJSONSchema } from 'zod';
 import { InvestigateSchema } from './schema.js';
 import config, { InvestigateContextSchema } from './skill.config.js';
+
+const PROMPT = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
 
 describe('investigate schema', () => {
   it('accepts valid output with all required fields', () => {
@@ -215,5 +218,19 @@ describe('investigate skill config', () => {
       worktreePath: '/tmp/worktrees/1',
     });
     expect(invalid.success).toBe(false);
+  });
+});
+
+describe('investigate prompt workspace boundary', () => {
+  it('forbids memory quick passes and requires exploration under worktreePath', () => {
+    expect(PROMPT).toContain('No memory quick pass');
+    expect(PROMPT).toContain('Do not perform memory quick passes');
+    expect(PROMPT).toContain(
+      'All list, read, and search operations must stay inside the provided `<worktreePath>`',
+    );
+    expect(PROMPT).toContain('Do not inspect sibling repos');
+    expect(PROMPT).toContain('~/.codex');
+    expect(PROMPT).toContain('~/.agents');
+    expect(PROMPT).toContain('~/.claude');
   });
 });

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -324,6 +324,26 @@ describe('runInvestigateWorkflow', () => {
       expect(mockDispatchWave).toHaveBeenCalledTimes(2);
     });
 
+    it('mock investigate run keeps workflow prompts and context away from assistant memory paths', async () => {
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const invokeSpec = mockInvokeSkill.mock.calls[0]?.[0] as {
+        context: { worktreePath?: string };
+      };
+      expect(invokeSpec.context.worktreePath).toBe('/tmp/test-worktree');
+
+      const renderedRunInputs = JSON.stringify({
+        wave1: mockDispatchWave.mock.calls[0]?.[0],
+        wave2: mockDispatchWave.mock.calls[1]?.[0],
+        synth: invokeSpec,
+      });
+      expect(renderedRunInputs).not.toContain('/.codex/memories');
+      expect(renderedRunInputs).not.toContain('/.agents');
+      expect(renderedRunInputs).not.toContain('/.claude');
+      expect(renderedRunInputs).not.toContain('sibling repos');
+    });
+
     it('skips Wave 1 and Wave 2 when investigation swarm is disabled', async () => {
       mockGetUseInvestigationSwarm.mockReturnValue(false);
 


### PR DESCRIPTION
## Summary
- add a shared Factory workspace-only runtime invariant for Codex and Claude spawned agents
- tighten the investigate prompt to prohibit memory quick passes and assistant memory/config reads
- add regression coverage for Codex/Claude prompt assembly, investigate prompt text, and mock investigate workflow inputs

## Verification
- pnpm vitest run core/agent-runtime/codex-cli-runtime.test.ts core/agent-runtime/claude-cli.test.ts skills/investigate/slice.test.ts slices/investigate/slice.test.ts
- pnpm typecheck
- pnpm lint