### PR TITLE
M7.XX: Goose hub logo 999

### DIFF
--- a/apps/web/e2e/issue-827.spec.ts
+++ b/apps/web/e2e/issue-827.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar brand reads GOOSEHUB', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/projects/goose-hub-self');
+
+  const sidebar = page.getByTestId('sidebar');
+  await expect(sidebar).toBeVisible();
+  await expect(sidebar.getByText('GOOSEHUB')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-827/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GOOSEHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GOOSEHUB"', () => {
+    expect(sidebarSource).toContain('GOOSEHUB');
+  });
+
+  it('sidebar header no longer reads "Goose Hub"', () => {
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub logo 999

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — Changed the sidebar brand label from mixed-case text to the required `GOOSEHUB` copy.
- `apps/web/src/components/chrome/slice.test.ts` — Updated and expanded the colocated slice test to assert the new branding and guard against regressions.
- `apps/web/e2e/issue-827.spec.ts` — Added the Playwright evidence spec that expands the sidebar, verifies the visible brand text, and captures the required screenshot.

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/e2e/issue-827.spec.ts` (1 cases)

Closes #827
