### PR TITLE
M20.07: live event interleave + thinking indicator in chat thread

### DIFF
--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -14,6 +14,7 @@ import type {
 import { Bot, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { deriveThinkingFromEvents, mergeToolStatusFromEvents } from '../lib/liveState';
 import { resolveScopeFromPath } from '../lib/scope';
 import { useChatEvents } from '../lib/useChatEvents';
 import { ChatInput } from './ChatInput';
@@ -65,28 +66,23 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     };
   }, [open, resolved.scope, resolved.projectSlug, resolved.workItemId, runtime]);
 
-  // Subscribe to chat.* events for this conversation. We use them to refresh
-  // the invocations list whenever a tool transitions state.
+  // Subscribe to chat.* events for this conversation. The events drive two
+  // render-only behaviours that don't need a network round-trip:
+  //   - the "thinking…" indicator between user message and agent reply
+  //   - live `running` → `completed`/`failed` status badge updates on tool
+  //     cards we already know about
+  //
+  // We deliberately do NOT refetch the conversation on every event tick.
+  // Authoritative reconciliation happens via `postMessage` (after a turn)
+  // and `resolveInvocation` (after an approve/reject). New invocations the
+  // base state hasn't seen yet are still rendered after the next refresh —
+  // tool events for unknown ids are ignored by the merge helper.
   const events = useChatEvents(conversation?.id ?? null);
-
-  useEffect(() => {
-    if (events.length === 0 || conversation == null) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const full = await fetchConversation(conversation.id);
-        if (!cancelled) {
-          setMessages(full.messages);
-          setInvocations(full.invocations);
-        }
-      } catch {
-        // best-effort refresh; ignore
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [events.length, conversation]);
+  const isThinking = useMemo(() => deriveThinkingFromEvents(events), [events]);
+  const liveInvocations = useMemo(
+    () => mergeToolStatusFromEvents(invocations, events),
+    [invocations, events],
+  );
 
   const sendMessage = useCallback(
     async (content: string) => {
@@ -216,8 +212,9 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
 
       <ChatThread
         messages={messages}
-        invocations={invocations}
+        invocations={liveInvocations}
         pendingDecision={pendingDecision}
+        thinking={isThinking}
         onApprove={handleApprove}
         onReject={handleReject}
         onNavigate={handleNavigate}

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -89,18 +89,36 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       if (conversation == null) return;
       setBusy(true);
       setError(null);
+      // Optimistic user bubble. `postUserMessage` on the server runs the
+      // whole orchestrator turn before responding, which can be several
+      // seconds; without this the user's message would not render until
+      // the agent reply lands. The authoritative refetch below replaces
+      // the optimistic row with the persisted one.
+      const optimisticId = -Date.now();
+      const optimistic: ChatMessageDto = {
+        id: optimisticId,
+        conversationId: conversation.id,
+        role: 'user',
+        content,
+        runId: null,
+        meta: null,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, optimistic]);
       try {
         await postMessage(conversation.id, content);
         // Authoritative reconciliation — refetch once after the POST settles.
-        // The SSE handler may also refresh during the turn, but both paths
-        // converge through fetchConversation, which is the single source of
-        // truth. Appending the POST response inline would double messages
-        // if the SSE refresh fired first (Codex P2 finding).
+        // The fetchConversation result is the single source of truth and
+        // already includes the persisted user message, so this replaces the
+        // optimistic row cleanly.
         const full = await fetchConversation(conversation.id);
         setMessages(full.messages);
         setInvocations(full.invocations);
       } catch (err) {
         setError(`Send failed: ${String(err)}`);
+        // Roll back the optimistic row on failure so we don't leave a
+        // phantom bubble the server doesn't know about.
+        setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
       } finally {
         setBusy(false);
       }

--- a/apps/web/src/components/chat/components/ChatThread.test.tsx
+++ b/apps/web/src/components/chat/components/ChatThread.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+import type { ChatMessageDto, ChatToolInvocationDto } from '@/lib/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { ChatThread } from './ChatThread';
+
+beforeAll(() => {
+  // jsdom does not implement Element.scrollTo; the thread auto-scrolls.
+  if (typeof Element.prototype.scrollTo !== 'function') {
+    Element.prototype.scrollTo = () => {};
+  }
+});
+
+afterEach(cleanup);
+
+const noop = () => {};
+
+const baseMessage: ChatMessageDto = {
+  id: 1,
+  conversationId: 'conv_x',
+  role: 'user',
+  content: 'hi',
+  runId: null,
+  meta: null,
+  createdAt: '2026-05-18T00:00:00Z',
+};
+
+const completedInvocation: ChatToolInvocationDto = {
+  id: 'tool_a',
+  conversationId: 'conv_x',
+  messageId: 1,
+  toolName: 'list_projects',
+  input: {},
+  mutating: false,
+  status: 'completed',
+  result: null,
+  errorMessage: null,
+  createdAt: '2026-05-18T00:00:00Z',
+  updatedAt: '2026-05-18T00:00:00Z',
+};
+
+describe('ChatThread', () => {
+  it('renders a thinking indicator when thinking is true', () => {
+    render(
+      <ChatThread
+        messages={[baseMessage]}
+        invocations={[]}
+        pendingDecision={null}
+        thinking
+        onApprove={noop}
+        onReject={noop}
+      />,
+    );
+    expect(screen.getByTestId('chat-thinking-indicator')).toBeTruthy();
+  });
+
+  it('hides the thinking indicator when thinking is false', () => {
+    render(
+      <ChatThread
+        messages={[baseMessage]}
+        invocations={[]}
+        pendingDecision={null}
+        thinking={false}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    );
+    expect(screen.queryByTestId('chat-thinking-indicator')).toBeNull();
+  });
+
+  it('reflects the invocation status passed in via props (no internal fetch)', () => {
+    render(
+      <ChatThread
+        messages={[baseMessage]}
+        invocations={[completedInvocation]}
+        pendingDecision={null}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    );
+    // ToolProposalCard renders the status badge text — completed flows
+    // through verbatim from the prop, proving the thread does not fetch on
+    // its own.
+    expect(screen.getByText(/completed/i)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chat/components/ChatThread.tsx
+++ b/apps/web/src/components/chat/components/ChatThread.tsx
@@ -1,4 +1,5 @@
 import type { ChatMessageDto, ChatToolInvocationDto } from '@/lib/types';
+import { Loader2 } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { MessageBubble } from './MessageBubble';
 import { ToolProposalCard } from './ToolProposalCard';
@@ -7,6 +8,7 @@ interface ChatThreadProps {
   messages: ChatMessageDto[];
   invocations: ChatToolInvocationDto[];
   pendingDecision: string | null;
+  thinking?: boolean;
   onApprove: (id: string) => void;
   onReject: (id: string) => void;
   onNavigate?: (path: string) => void;
@@ -22,6 +24,7 @@ export function ChatThread({
   messages,
   invocations,
   pendingDecision,
+  thinking = false,
   onApprove,
   onReject,
   onNavigate,
@@ -31,7 +34,7 @@ export function ChatThread({
   // biome-ignore lint/correctness/useExhaustiveDependencies: only scroll on length change
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
-  }, [messages.length, invocations.length]);
+  }, [messages.length, invocations.length, thinking]);
 
   return (
     <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
@@ -72,6 +75,16 @@ export function ChatThread({
             onNavigate={onNavigate}
           />
         ))}
+      {thinking && (
+        <output
+          data-testid="chat-thinking-indicator"
+          className="my-2 inline-flex items-center gap-1.5 text-[11.5px] text-fg-2"
+          aria-live="polite"
+        >
+          <Loader2 size={12} className="animate-spin" />
+          <span>thinking…</span>
+        </output>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/chat/lib/liveState.test.ts
+++ b/apps/web/src/components/chat/lib/liveState.test.ts
@@ -118,4 +118,46 @@ describe('mergeToolStatusFromEvents', () => {
     ]);
     expect(merged[0].status).toBe('completed');
   });
+
+  it('does not flip completed to failed when a stale chat.tool-failed arrives', () => {
+    const base = [invocation('tool_a', 'completed')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-failed', { invocationId: 'tool_a', error: 'stale' }),
+    ]);
+    expect(merged[0].status).toBe('completed');
+    expect(merged[0].errorMessage).toBeNull();
+  });
+
+  it('does not flip failed to completed when a stale chat.tool-completed arrives', () => {
+    const base = [invocation('tool_a', 'failed')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-completed', { invocationId: 'tool_a', result: { stale: true } }),
+    ]);
+    expect(merged[0].status).toBe('failed');
+    expect(merged[0].result).toBeNull();
+  });
+
+  it('flips a proposed invocation to approved on chat.tool-approved', () => {
+    const base = [invocation('tool_a', 'proposed')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-approved', { invocationId: 'tool_a' }),
+    ]);
+    expect(merged[0].status).toBe('approved');
+  });
+
+  it('flips a proposed invocation to rejected on chat.tool-rejected', () => {
+    const base = [invocation('tool_a', 'proposed')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-rejected', { invocationId: 'tool_a' }),
+    ]);
+    expect(merged[0].status).toBe('rejected');
+  });
+
+  it('ignores chat.tool-approved when the invocation is no longer proposed', () => {
+    const base = [invocation('tool_a', 'running')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-approved', { invocationId: 'tool_a' }),
+    ]);
+    expect(merged[0].status).toBe('running');
+  });
 });

--- a/apps/web/src/components/chat/lib/liveState.test.ts
+++ b/apps/web/src/components/chat/lib/liveState.test.ts
@@ -1,0 +1,121 @@
+import type { ChatToolInvocationDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import { deriveThinkingFromEvents, mergeToolStatusFromEvents } from './liveState';
+import type { ChatLiveEvent } from './useChatEvents';
+
+function event(id: number, kind: string, payload: Record<string, unknown> = {}): ChatLiveEvent {
+  return { id, kind, payload, createdAt: '2026-05-18T00:00:00Z' };
+}
+
+function invocation(id: string, status: ChatToolInvocationDto['status']): ChatToolInvocationDto {
+  return {
+    id,
+    conversationId: 'conv_x',
+    messageId: 1,
+    toolName: 'list_projects',
+    input: {},
+    mutating: false,
+    status,
+    result: null,
+    errorMessage: null,
+    createdAt: '2026-05-18T00:00:00Z',
+    updatedAt: '2026-05-18T00:00:00Z',
+  };
+}
+
+describe('deriveThinkingFromEvents', () => {
+  it('is false on an empty stream', () => {
+    expect(deriveThinkingFromEvents([])).toBe(false);
+  });
+
+  it('is true once a thinking event has arrived with no later agent-message', () => {
+    expect(
+      deriveThinkingFromEvents([
+        event(1, 'chat.user-message'),
+        event(2, 'chat.agent-thinking', { checkpoint: 'skill-invoked' }),
+      ]),
+    ).toBe(true);
+  });
+
+  it('clears the moment chat.agent-message arrives', () => {
+    expect(
+      deriveThinkingFromEvents([
+        event(1, 'chat.agent-thinking', { checkpoint: 'skill-invoked' }),
+        event(2, 'chat.agent-thinking', { checkpoint: 'structured-output-received' }),
+        event(3, 'chat.agent-message'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('clears when the run fails', () => {
+    expect(
+      deriveThinkingFromEvents([
+        event(1, 'chat.agent-thinking', { checkpoint: 'skill-invoked' }),
+        event(2, 'chat.run-failed'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('reactivates if a new turn starts after a previous reply', () => {
+    expect(
+      deriveThinkingFromEvents([
+        event(1, 'chat.agent-thinking'),
+        event(2, 'chat.agent-message'),
+        event(3, 'chat.user-message'),
+        event(4, 'chat.agent-thinking'),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('mergeToolStatusFromEvents', () => {
+  it('returns the base unchanged when there are no events', () => {
+    const base = [invocation('tool_a', 'proposed')];
+    expect(mergeToolStatusFromEvents(base, [])).toBe(base);
+  });
+
+  it('flips a known invocation to running on chat.tool-running', () => {
+    const base = [invocation('tool_a', 'approved')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-running', { invocationId: 'tool_a' }),
+    ]);
+    expect(merged[0].status).toBe('running');
+  });
+
+  it('flips a known invocation to completed and merges the result', () => {
+    const base = [invocation('tool_a', 'running')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-completed', { invocationId: 'tool_a', result: { ok: true } }),
+    ]);
+    expect(merged[0].status).toBe('completed');
+    expect(merged[0].result).toEqual({ ok: true });
+  });
+
+  it('flips a known invocation to failed and stores the error message', () => {
+    const base = [invocation('tool_a', 'running')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-failed', { invocationId: 'tool_a', error: 'kaboom' }),
+    ]);
+    expect(merged[0].status).toBe('failed');
+    expect(merged[0].errorMessage).toBe('kaboom');
+  });
+
+  it('ignores tool events whose invocationId is not in the base list', () => {
+    const base = [invocation('tool_a', 'completed')];
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-running', { invocationId: 'tool_unknown' }),
+    ]);
+    expect(merged).toBe(base);
+  });
+
+  it('does not regress a terminal status back to running', () => {
+    const base = [invocation('tool_a', 'completed')];
+    // A late chat.tool-running for an already-completed invocation must not
+    // flip the badge back; the SSE stream is best-effort and may arrive out
+    // of order.
+    const merged = mergeToolStatusFromEvents(base, [
+      event(1, 'chat.tool-running', { invocationId: 'tool_a' }),
+    ]);
+    expect(merged[0].status).toBe('completed');
+  });
+});

--- a/apps/web/src/components/chat/lib/liveState.ts
+++ b/apps/web/src/components/chat/lib/liveState.ts
@@ -24,7 +24,17 @@ export function deriveThinkingFromEvents(events: ChatLiveEvent[]): boolean {
  * ids are ignored — they belong to a sibling conversation, or to a new
  * proposal the base fetch hasn't seen yet (the next refresh will pick them
  * up).
+ *
+ * Terminal states are sticky: once an invocation reaches `completed` or
+ * `failed`, no later event in either direction overwrites it. The SSE
+ * stream is best-effort and can deliver out of order; we never want a
+ * stale completion to clobber a real failure or vice versa.
  */
+const TERMINAL_STATUSES: ReadonlySet<ChatToolInvocationDto['status']> = new Set([
+  'completed',
+  'failed',
+]);
+
 export function mergeToolStatusFromEvents(
   base: ChatToolInvocationDto[],
   events: ChatLiveEvent[],
@@ -37,12 +47,10 @@ export function mergeToolStatusFromEvents(
     if (id == null) continue;
     const existing = byId.get(id);
     if (existing == null) continue;
+    // Sticky terminal: nothing overwrites `completed`/`failed`.
+    if (TERMINAL_STATUSES.has(existing.status)) continue;
     let next: ChatToolInvocationDto | null = null;
-    if (
-      ev.kind === 'chat.tool-running' &&
-      existing.status !== 'completed' &&
-      existing.status !== 'failed'
-    ) {
+    if (ev.kind === 'chat.tool-running') {
       next = { ...existing, status: 'running' };
     } else if (ev.kind === 'chat.tool-completed') {
       next = {
@@ -57,6 +65,12 @@ export function mergeToolStatusFromEvents(
         status: 'failed',
         errorMessage: typeof error === 'string' ? error : existing.errorMessage,
       };
+    } else if (ev.kind === 'chat.tool-approved' && existing.status === 'proposed') {
+      // Multi-tab: another client resolved the proposal. Flip locally so the
+      // Approve/Reject buttons disappear instead of waiting for refresh.
+      next = { ...existing, status: 'approved' };
+    } else if (ev.kind === 'chat.tool-rejected' && existing.status === 'proposed') {
+      next = { ...existing, status: 'rejected' };
     }
     if (next != null) {
       byId.set(id, next);

--- a/apps/web/src/components/chat/lib/liveState.ts
+++ b/apps/web/src/components/chat/lib/liveState.ts
@@ -1,0 +1,67 @@
+import type { ChatToolInvocationDto } from '@/lib/types';
+import type { ChatLiveEvent } from './useChatEvents';
+
+/**
+ * The orchestrator emits `chat.agent-thinking` at meaningful checkpoints
+ * (at least `skill-invoked` and `structured-output-received`). The indicator
+ * stays visible while an agent turn is in flight and clears the moment the
+ * structured reply lands as `chat.agent-message`. We treat `chat.run-failed`
+ * as a clear too — otherwise a stuck indicator would outlive a crashed run.
+ */
+export function deriveThinkingFromEvents(events: ChatLiveEvent[]): boolean {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const kind = events[i].kind;
+    if (kind === 'chat.agent-message' || kind === 'chat.run-failed') return false;
+    if (kind === 'chat.agent-thinking') return true;
+  }
+  return false;
+}
+
+/**
+ * Apply live tool-call status updates from the SSE stream onto a base set
+ * of invocations. Returns a new array with `status`, `result`, `errorMessage`
+ * patched for every invocation referenced by the events. Unknown invocation
+ * ids are ignored — they belong to a sibling conversation, or to a new
+ * proposal the base fetch hasn't seen yet (the next refresh will pick them
+ * up).
+ */
+export function mergeToolStatusFromEvents(
+  base: ChatToolInvocationDto[],
+  events: ChatLiveEvent[],
+): ChatToolInvocationDto[] {
+  if (events.length === 0) return base;
+  const byId = new Map(base.map((i) => [i.id, i]));
+  let changed = false;
+  for (const ev of events) {
+    const id = (ev.payload as { invocationId?: string }).invocationId;
+    if (id == null) continue;
+    const existing = byId.get(id);
+    if (existing == null) continue;
+    let next: ChatToolInvocationDto | null = null;
+    if (
+      ev.kind === 'chat.tool-running' &&
+      existing.status !== 'completed' &&
+      existing.status !== 'failed'
+    ) {
+      next = { ...existing, status: 'running' };
+    } else if (ev.kind === 'chat.tool-completed') {
+      next = {
+        ...existing,
+        status: 'completed',
+        result: (ev.payload as { result?: unknown }).result ?? existing.result,
+      };
+    } else if (ev.kind === 'chat.tool-failed') {
+      const error = (ev.payload as { error?: string }).error;
+      next = {
+        ...existing,
+        status: 'failed',
+        errorMessage: typeof error === 'string' ? error : existing.errorMessage,
+      };
+    }
+    if (next != null) {
+      byId.set(id, next);
+      changed = true;
+    }
+  }
+  return changed ? base.map((i) => byId.get(i.id) ?? i) : base;
+}

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -14,7 +14,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `server` | yes | API + SSE host for the Goose Hub web UI. Stands up the server process the UI talks to. Closes M2.01 (#26). |
 | `web` | yes | Vite + React 19 + Tailwind 4 + React Router v6. Closes M2.02 (#27). |
 
-## core/ (28 entries, 1 missing README)
+## core/ (30 entries, 1 missing README)
 
 | Name | README | Summary |
 |---|---|---|

--- a/slices/chat-orchestrator/slice.test.ts
+++ b/slices/chat-orchestrator/slice.test.ts
@@ -16,6 +16,7 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 
 import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import type { Conversation } from '@goose-hub/core/conversations/types.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { runChatOrchestratorTurn } from './workflow.js';
 
 const stubConversation: Conversation = {
@@ -104,5 +105,55 @@ describe('chat-orchestrator slice', () => {
       runId: 'chat_test_run_4',
     });
     expect(result.reply).toBeNull();
+  });
+
+  it('emits chat.agent-thinking checkpoints around the skill invocation', async () => {
+    vi.mocked(eventStore.appendEvent).mockClear();
+    vi.mocked(invokeSkill).mockResolvedValueOnce({
+      output: {
+        say: 'sure.',
+        proposals: [],
+        done: false,
+        decisionSummaries: [{ kind: 'PLAN', summary: 'ok.' }],
+      },
+      decisionSummaries: [],
+      events: [],
+    });
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_thinking',
+    });
+    const thinkingCalls = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.map((c) => c[0])
+      .filter((e) => e.kind === 'chat.agent-thinking');
+    expect(thinkingCalls).toHaveLength(2);
+    const checkpoints = thinkingCalls.map((e) => (e.payload as { checkpoint?: string }).checkpoint);
+    expect(checkpoints).toEqual(['skill-invoked', 'structured-output-received']);
+    for (const e of thinkingCalls) {
+      const payload = e.payload as { conversationId?: string; runId?: string };
+      expect(payload.conversationId).toBe('conv_test');
+      expect(payload.runId).toBe('chat_test_thinking');
+      expect(e.runId).toBe('chat_test_thinking');
+    }
+  });
+
+  it('emits the skill-invoked thinking event even when the run later throws', async () => {
+    vi.mocked(eventStore.appendEvent).mockClear();
+    vi.mocked(invokeSkill).mockRejectedValueOnce(new Error('boom'));
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_thinking_err',
+    });
+    const thinkingCalls = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.map((c) => c[0])
+      .filter((e) => e.kind === 'chat.agent-thinking');
+    // Only the pre-spawn checkpoint should fire on a thrown run.
+    expect(thinkingCalls.map((e) => (e.payload as { checkpoint?: string }).checkpoint)).toEqual([
+      'skill-invoked',
+    ]);
   });
 });

--- a/slices/chat-orchestrator/slice.test.ts
+++ b/slices/chat-orchestrator/slice.test.ts
@@ -156,4 +156,27 @@ describe('chat-orchestrator slice', () => {
       'skill-invoked',
     ]);
   });
+
+  it('emits chat.run-failed when the skill throws so the thinking indicator clears', async () => {
+    vi.mocked(eventStore.appendEvent).mockClear();
+    vi.mocked(invokeSkill).mockRejectedValueOnce(new Error('subprocess died'));
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_run_failed_event',
+    });
+    const failedCalls = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.map((c) => c[0])
+      .filter((e) => e.kind === 'chat.run-failed');
+    expect(failedCalls).toHaveLength(1);
+    const payload = failedCalls[0].payload as {
+      conversationId?: string;
+      runId?: string;
+      error?: string;
+    };
+    expect(payload.conversationId).toBe('conv_test');
+    expect(payload.runId).toBe('chat_test_run_failed_event');
+    expect(payload.error).toMatch(/subprocess died/);
+  });
 });

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -224,6 +224,17 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
     };
   } catch (err) {
     logger.error('chat orchestrator invokeSkill threw', { runId, err: String(err) });
+    // Clear the thinking indicator the UI is now showing. The dispatch
+    // wrapper only emits `chat.run-failed` from its own try/catch — we
+    // swallow the throw and return `{reply: null}`, so without this emit
+    // the in-flight indicator would never go away for this conversation.
+    eventStore.appendEvent({
+      projectId: conversation.projectId ?? 'goose-hub-self',
+      workItemId: conversation.workItemId,
+      kind: 'chat.run-failed',
+      payload: { conversationId: conversation.id, runId, error: String(err) },
+      runId,
+    });
     return { reply: null };
   }
 }

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -178,6 +178,8 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
   const provider = conversation.runtime === 'codex' ? 'codex' : 'claude';
   const modelOverride = defaultModelForTierAndProvider('sonnet', provider);
 
+  emitThinking(conversation, runId, 'skill-invoked');
+
   try {
     const result = await invokeSkill({
       skillName: 'hub-chat',
@@ -187,6 +189,7 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
       context,
       overrides: { modelOverride },
     });
+    emitThinking(conversation, runId, 'structured-output-received');
     const parsed = HubChatOutputSchema.safeParse(result.output);
     if (!parsed.success) {
       logger.warn('hub-chat: output validation failed', {
@@ -227,4 +230,16 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
 
 function manifestHas(name: string): boolean {
   return listToolManifests().some((t) => t.name === name);
+}
+
+type ThinkingCheckpoint = 'skill-invoked' | 'structured-output-received';
+
+function emitThinking(conversation: Conversation, runId: string, checkpoint: ThinkingCheckpoint) {
+  eventStore.appendEvent({
+    projectId: conversation.projectId ?? 'goose-hub-self',
+    workItemId: conversation.workItemId,
+    kind: 'chat.agent-thinking',
+    payload: { conversationId: conversation.id, runId, checkpoint },
+    runId,
+  });
 }


### PR DESCRIPTION
## Summary

- The chat orchestrator now emits `chat.agent-thinking` events at two checkpoints inside a single turn — when the skill is invoked and when its structured output lands. The pre-spawn checkpoint also fires when the run later throws, so the thinking indicator clears via the matching `chat.run-failed` event instead of getting stuck.
- The chat panel folds the existing `chat.*` SSE stream into render-only state via two pure helpers in `apps/web/src/components/chat/lib/liveState.ts`. The heavyweight per-event `fetchConversation` refresh is gone; authoritative reconciliation still happens after `postMessage` and `resolveInvocation`.
- `ChatThread` now renders a thinking indicator when `thinking` is true; tool cards reflect `chat.tool-running` / `-completed` / `-failed` live, with the merge helper deliberately ignoring late events for terminal invocations and unknown ids.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — new + touched tests pass; only the pre-existing `slices/qa/slice.test.ts` git-signing fixtures and `apps/web/src/lib/constants.test.ts` GATE_STATES failures remain (unrelated to M20).
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean
- [x] Boot the app (`pnpm dev`) — open the chat panel, send a question, confirm the thinking indicator appears immediately and disappears the moment the agent reply lands.
- [x] Approve a read-only proposal — tool card flips `proposed` → `running` → `completed` live without a network refetch (verify in DevTools Network panel).
- [x] Reject / fail a proposal — `failed` badge surfaces the error message live.

Closes #838

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqtjymJ4gBvDofnYjcpTa2)_