### PR TITLE
M20.08: subscribe_to_run / subscribe_to_issue chat tools

### DIFF
--- a/apps/server/src/domains/chat/service.test.ts
+++ b/apps/server/src/domains/chat/service.test.ts
@@ -5,11 +5,13 @@ vi.mock('#shared/chat-dispatch.js', () => ({
 }));
 
 import {
+  deleteConversationService,
   fetchConversation,
   listConversationsService,
   postUserMessage,
   startConversation,
 } from './service.js';
+import { __resetWatchRegistryForTests, getWatchRegistry } from './watch-singleton.js';
 
 describe('chat service', () => {
   it('rejects scope=project without a projectSlug', async () => {
@@ -57,6 +59,27 @@ describe('chat service', () => {
       expect(after.data.messages.length).toBe(1);
       expect(after.data.messages[0].content).toBe('hello goose hub');
     }
+  });
+
+  it('deletes a conversation and clears its pending watches', async () => {
+    __resetWatchRegistryForTests();
+    const start = await startConversation({ scope: 'global' });
+    if (!start.ok) throw new Error('expected ok');
+    const id = start.data.conversation.id;
+
+    getWatchRegistry().addRunWatch(id, 'run_owned');
+    getWatchRegistry().addRunWatch('other_conversation', 'run_other');
+
+    const result = await deleteConversationService(id);
+    expect(result.ok).toBe(true);
+
+    expect(getWatchRegistry().listForConversation(id)).toHaveLength(0);
+    expect(getWatchRegistry().listForConversation('other_conversation')).toHaveLength(1);
+
+    const fetched = await fetchConversation(id);
+    expect(fetched.ok).toBe(false);
+
+    __resetWatchRegistryForTests();
   });
 
   it('lists conversations filtered by scope', async () => {

--- a/apps/server/src/domains/chat/service.ts
+++ b/apps/server/src/domains/chat/service.ts
@@ -25,6 +25,7 @@ import {
   updateToolInvocation,
 } from './repository.js';
 import { CHAT_TOOL_IMPLEMENTATIONS, type ToolContext, ToolExecutionError } from './tools.js';
+import { getWatchRegistry } from './watch-singleton.js';
 
 function newConversationId(): string {
   const ts = Date.now().toString(36);
@@ -97,6 +98,7 @@ export async function listConversationsService(
 
 export async function deleteConversationService(id: string): Promise<Result<{ ok: true }>> {
   if (getConversation(id) == null) return { ok: false, error: 'not found', status: 404 };
+  getWatchRegistry().removeByConversation(id);
   deleteConversation(id);
   return { ok: true, data: { ok: true } };
 }

--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -14,6 +14,7 @@ vi.mock('#shared/source.js', () => ({
     if (slug === 'unknown') return null;
     return {
       projectId: slug,
+      repoRef: `shaunnez/${slug}`,
       listOpenWork: mockListOpenWork,
       getItem: mockGetItem,
       listMilestones: mockListMilestones,
@@ -31,6 +32,7 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     replay: vi.fn(() => []),
     appendEvent: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
   },
 }));
 
@@ -188,5 +190,51 @@ describe('chat-tools — open_url', () => {
       ctx,
     )) as { ok: boolean; path: string };
     expect(result).toEqual({ ok: true, path: '/projects/goose-hub-self' });
+  });
+});
+
+describe('chat-tools — subscribe_to_run', () => {
+  it('registers a watch in the shared registry for the given runId', async () => {
+    const { getWatchRegistry, __resetWatchRegistryForTests } = await import('./watch-singleton.js');
+    __resetWatchRegistryForTests();
+    const result = (await CHAT_TOOL_IMPLEMENTATIONS.subscribe_to_run(
+      { runId: 'run_test_alpha', rationale: 'long investigation' },
+      { ...ctx, conversationId: 'conv_subscribe' },
+    )) as { ok: boolean; watchId: string; runId: string; expiresAt: string };
+
+    expect(result.ok).toBe(true);
+    expect(result.runId).toBe('run_test_alpha');
+    expect(getWatchRegistry().listForConversation('conv_subscribe')).toHaveLength(1);
+    __resetWatchRegistryForTests();
+  });
+});
+
+describe('chat-tools — subscribe_to_issue', () => {
+  it('resolves project + workItemId then registers a watch', async () => {
+    const { getWatchRegistry, __resetWatchRegistryForTests } = await import('./watch-singleton.js');
+    __resetWatchRegistryForTests();
+    const result = (await CHAT_TOOL_IMPLEMENTATIONS.subscribe_to_issue(
+      { projectSlug: 'goose-hub-self', issueNumber: 42, rationale: 'awaiting QA' },
+      { ...ctx, conversationId: 'conv_subscribe_issue' },
+    )) as {
+      ok: boolean;
+      workItemId: string;
+      projectId: string;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.workItemId).toBe('github:shaunnez/goose-hub-self#42');
+    expect(result.projectId).toBe('goose-hub-self');
+    expect(getWatchRegistry().listForConversation('conv_subscribe_issue')).toHaveLength(1);
+    __resetWatchRegistryForTests();
+  });
+
+  it('returns a 404 ToolExecutionError when the project is unknown', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.subscribe_to_issue(
+        { projectSlug: 'unknown', issueNumber: 1, rationale: 'x' },
+        ctx,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
   });
 });

--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -6,6 +6,7 @@ import { loadProjects } from '@goose-hub/core/projects/loader.js';
 import { skillsRoot } from '@goose-hub/skills';
 import { addInboxNote } from '#shared/inbox-bridge.js';
 import { getSourceForSlug, isValidSlug } from '#shared/source.js';
+import { getWatchRegistry } from './watch-singleton.js';
 
 export interface ToolContext {
   conversationId: string;
@@ -365,6 +366,39 @@ async function openUrl(input: { path: string; rationale: string }): Promise<unkn
   return { ok: true, path: input.path };
 }
 
+async function subscribeToRun(
+  input: { runId: string; rationale: string },
+  ctx: ToolContext,
+): Promise<unknown> {
+  const watch = getWatchRegistry().addRunWatch(ctx.conversationId, input.runId);
+  return {
+    ok: true,
+    watchId: watch.id,
+    watchKind: watch.kind,
+    runId: input.runId,
+    expiresAt: new Date(watch.expiresAt).toISOString(),
+  };
+}
+
+async function subscribeToIssue(
+  input: { projectSlug: string; issueNumber: number | string; rationale: string },
+  ctx: ToolContext,
+): Promise<unknown> {
+  assertValidSlug(input.projectSlug);
+  const source = await getSourceForSlug(input.projectSlug);
+  if (source == null) throw new ToolExecutionError(`project not found: ${input.projectSlug}`, 404);
+  const workItemId = `github:${source.repoRef}#${String(input.issueNumber)}`;
+  const watch = getWatchRegistry().addIssueWatch(ctx.conversationId, source.projectId, workItemId);
+  return {
+    ok: true,
+    watchId: watch.id,
+    watchKind: watch.kind,
+    projectId: source.projectId,
+    workItemId,
+    expiresAt: new Date(watch.expiresAt).toISOString(),
+  };
+}
+
 type ToolFn = (input: unknown, ctx: ToolContext) => Promise<unknown>;
 
 export const CHAT_TOOL_IMPLEMENTATIONS: Record<string, ToolFn> = {
@@ -383,4 +417,8 @@ export const CHAT_TOOL_IMPLEMENTATIONS: Record<string, ToolFn> = {
   tick_project: (input) => tickProject(input as Parameters<typeof tickProject>[0]),
   invoke_skill: (input) => invokeSkillTool(input as Parameters<typeof invokeSkillTool>[0]),
   open_url: (input) => openUrl(input as Parameters<typeof openUrl>[0]),
+  subscribe_to_run: (input, ctx) =>
+    subscribeToRun(input as Parameters<typeof subscribeToRun>[0], ctx),
+  subscribe_to_issue: (input, ctx) =>
+    subscribeToIssue(input as Parameters<typeof subscribeToIssue>[0], ctx),
 };

--- a/apps/server/src/domains/chat/watch-singleton.ts
+++ b/apps/server/src/domains/chat/watch-singleton.ts
@@ -1,0 +1,95 @@
+import { appendMessage, getConversation } from '@goose-hub/core/conversations/repository.js';
+import type { ChatMessage } from '@goose-hub/core/conversations/types.js';
+import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
+import { logger } from '@goose-hub/core/logger.js';
+import { type Watch, WatchRegistry } from './watches.js';
+
+function buildSummary(watch: Watch, event: AgentEvent): string {
+  if (watch.kind === 'run') {
+    const { runId } = watch.params as { runId: string };
+    const payload = (event.payload as Record<string, unknown>) ?? {};
+    if (event.kind === 'agent.run-failed') {
+      const error = typeof payload.error === 'string' ? payload.error : 'unknown error';
+      return `Watched run \`${runId}\` failed: ${error}`;
+    }
+    const cost = typeof payload.costUsd === 'number' ? payload.costUsd : null;
+    const decisions = Array.isArray(payload.decisionSummaries)
+      ? payload.decisionSummaries.length
+      : 0;
+    const parts: string[] = [`Watched run \`${runId}\` completed.`];
+    if (cost != null) parts.push(`Cost: $${cost.toFixed(4)}`);
+    parts.push(`${decisions} decision${decisions === 1 ? '' : 's'} emitted.`);
+    return parts.join(' ');
+  }
+  const { workItemId } = watch.params as { workItemId: string };
+  const payload = (event.payload as Record<string, unknown>) ?? {};
+  const from = typeof payload.from === 'string' ? payload.from : null;
+  const to = typeof payload.to === 'string' ? payload.to : null;
+  const itemLabel = workItemId.includes('#') ? `#${workItemId.split('#').pop()}` : workItemId;
+  if (from != null && to != null) {
+    return `Watched issue ${itemLabel} moved from \`${from}\` to \`${to}\`.`;
+  }
+  return `Watched issue ${itemLabel} transitioned.`;
+}
+
+function fireSubscriptionFollowUp({ watch, event }: { watch: Watch; event: AgentEvent }): void {
+  const conversation = getConversation(watch.conversationId);
+  if (conversation == null) return;
+
+  const summary = buildSummary(watch, event);
+  let message: ChatMessage;
+  try {
+    message = appendMessage({
+      conversationId: conversation.id,
+      role: 'agent',
+      content: summary,
+      meta: {
+        kind: 'subscription-fired',
+        watchId: watch.id,
+        watchKind: watch.kind,
+        watchParams: watch.params,
+        sourceEvent: { id: event.id, kind: event.kind, createdAt: event.createdAt },
+      },
+    });
+  } catch (err) {
+    logger.warn('chat-watches.appendMessage failed', { err: String(err), watchId: watch.id });
+    return;
+  }
+
+  eventStore.appendEvent({
+    projectId: conversation.projectId ?? 'goose-hub-self',
+    workItemId: conversation.workItemId,
+    kind: 'chat.agent-message',
+    payload: {
+      conversationId: conversation.id,
+      messageId: message.id,
+      runId: null,
+      content: summary,
+      subscriptionFired: {
+        watchId: watch.id,
+        watchKind: watch.kind,
+        sourceEventId: event.id,
+      },
+    },
+  });
+}
+
+let singleton: WatchRegistry | null = null;
+
+/**
+ * Lazily-constructed shared registry. First reference subscribes to the event
+ * store; subsequent references reuse the same instance.
+ */
+export function getWatchRegistry(): WatchRegistry {
+  if (singleton == null) {
+    singleton = new WatchRegistry(fireSubscriptionFollowUp);
+    singleton.start();
+  }
+  return singleton;
+}
+
+/** Test-only: reset the lazy singleton so tests can swap behaviour. */
+export function __resetWatchRegistryForTests(replacement: WatchRegistry | null = null): void {
+  if (singleton != null) singleton.stop();
+  singleton = replacement;
+}

--- a/apps/server/src/domains/chat/watches.test.ts
+++ b/apps/server/src/domains/chat/watches.test.ts
@@ -1,0 +1,183 @@
+import type { AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
+import { describe, expect, it, vi } from 'vitest';
+import { WatchRegistry } from './watches.js';
+
+type SubscribeFn = typeof eventStore.subscribe;
+
+function event(overrides: Partial<AgentEvent>): AgentEvent {
+  return {
+    id: 1,
+    projectId: 'goose-hub-self',
+    workItemId: null,
+    kind: 'state.transitioned',
+    payload: {},
+    runId: null,
+    personaId: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('WatchRegistry — run subscriptions', () => {
+  it('fires once when a matching agent.run-completed arrives', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    const watch = reg.addRunWatch('conv_1', 'run_alpha');
+    expect(reg.size()).toBe(1);
+
+    reg.handle(event({ kind: 'agent.run-completed', runId: 'run_alpha' }));
+
+    expect(onFire).toHaveBeenCalledTimes(1);
+    expect(onFire.mock.calls[0][0].watch.id).toBe(watch.id);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('fires on agent.run-failed for the watched runId', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addRunWatch('conv_1', 'run_alpha');
+
+    reg.handle(event({ kind: 'agent.run-failed', runId: 'run_alpha' }));
+
+    expect(onFire).toHaveBeenCalledTimes(1);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('ignores events for unrelated runs', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addRunWatch('conv_1', 'run_alpha');
+
+    reg.handle(event({ kind: 'agent.run-completed', runId: 'run_beta' }));
+    reg.handle(event({ kind: 'agent.run-started', runId: 'run_alpha' }));
+
+    expect(onFire).not.toHaveBeenCalled();
+    expect(reg.size()).toBe(1);
+  });
+});
+
+describe('WatchRegistry — issue subscriptions', () => {
+  it('fires when state.transitioned matches projectId + workItemId', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addIssueWatch('conv_1', 'goose-hub-self', 'github:shaunnez/goose-hub#42');
+
+    reg.handle(
+      event({
+        kind: 'state.transitioned',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:shaunnez/goose-hub#42',
+        payload: { from: 'factory:in-progress', to: 'factory:needs-qa' },
+      }),
+    );
+
+    expect(onFire).toHaveBeenCalledTimes(1);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('ignores transitions for other work items', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addIssueWatch('conv_1', 'goose-hub-self', 'github:shaunnez/goose-hub#42');
+
+    reg.handle(
+      event({
+        kind: 'state.transitioned',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:shaunnez/goose-hub#7',
+      }),
+    );
+
+    expect(onFire).not.toHaveBeenCalled();
+    expect(reg.size()).toBe(1);
+  });
+
+  it('ignores non-transition events for the same workItemId', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addIssueWatch('conv_1', 'goose-hub-self', 'github:shaunnez/goose-hub#42');
+
+    reg.handle(
+      event({
+        kind: 'agent.log',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:shaunnez/goose-hub#42',
+      }),
+    );
+
+    expect(onFire).not.toHaveBeenCalled();
+  });
+});
+
+describe('WatchRegistry — TTL expiry', () => {
+  it('drops watches once their expiresAt has passed', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire, { ttlMs: 1_000 });
+    const baseNow = 1_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(baseNow);
+    reg.addRunWatch('conv_1', 'run_alpha');
+    expect(reg.size()).toBe(1);
+
+    // Advance past TTL — the next event handle prunes the expired watch.
+    vi.spyOn(Date, 'now').mockReturnValue(baseNow + 2_000);
+    reg.handle(event({ kind: 'agent.run-completed', runId: 'run_alpha' }));
+
+    expect(onFire).not.toHaveBeenCalled();
+    expect(reg.size()).toBe(0);
+  });
+
+  it('pruneExpired removes watches without firing them', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire, { ttlMs: 500 });
+    const baseNow = 2_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(baseNow);
+    reg.addRunWatch('conv_1', 'run_alpha');
+
+    vi.spyOn(Date, 'now').mockReturnValue(baseNow + 600);
+    const pruned = reg.pruneExpired();
+
+    expect(pruned).toBe(1);
+    expect(reg.size()).toBe(0);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+});
+
+describe('WatchRegistry — conversation-scoped cleanup', () => {
+  it('removeByConversation drops every watch owned by that conversation', () => {
+    const onFire = vi.fn();
+    const reg = new WatchRegistry(onFire);
+    reg.addRunWatch('conv_a', 'run_1');
+    reg.addRunWatch('conv_a', 'run_2');
+    reg.addRunWatch('conv_b', 'run_3');
+
+    const removed = reg.removeByConversation('conv_a');
+
+    expect(removed).toBe(2);
+    expect(reg.size()).toBe(1);
+    expect(reg.listForConversation('conv_a')).toHaveLength(0);
+    expect(reg.listForConversation('conv_b')).toHaveLength(1);
+  });
+
+  it('returns 0 when no watches match the conversation', () => {
+    const reg = new WatchRegistry(vi.fn());
+    expect(reg.removeByConversation('nope')).toBe(0);
+  });
+});
+
+describe('WatchRegistry — event-stream wiring', () => {
+  it('start subscribes once and stop unsubscribes', () => {
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(() => unsubscribe);
+    const reg = new WatchRegistry(vi.fn(), {
+      subscribe: subscribe as unknown as SubscribeFn,
+    });
+
+    reg.start();
+    reg.start();
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+
+    reg.stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/domains/chat/watches.ts
+++ b/apps/server/src/domains/chat/watches.ts
@@ -1,0 +1,149 @@
+import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
+
+export type WatchKind = 'run' | 'issue';
+
+export interface RunWatchParams {
+  runId: string;
+}
+export interface IssueWatchParams {
+  projectId: string;
+  workItemId: string;
+}
+
+export type WatchParams = RunWatchParams | IssueWatchParams;
+
+export interface Watch {
+  id: string;
+  conversationId: string;
+  kind: WatchKind;
+  params: WatchParams;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface WatchFireInput {
+  watch: Watch;
+  event: AgentEvent;
+}
+export type WatchFireCallback = (input: WatchFireInput) => void;
+
+export interface WatchRegistryOptions {
+  /** Time-to-live in milliseconds before an unmet watch expires. Default 30 min. */
+  ttlMs?: number;
+  /** Override the event-store subscribe function. Test-only injection point. */
+  subscribe?: typeof eventStore.subscribe;
+}
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Tracks transient watches that fire follow-up chat messages when a matching
+ * event lands. Two kinds today: by `runId` (agent.run-completed / -failed) and
+ * by work-item (state.transitioned). Watches are one-shot — the first matching
+ * event removes them — and self-expire after `ttlMs`.
+ */
+export class WatchRegistry {
+  private watches = new Map<string, Watch>();
+  private readonly ttlMs: number;
+  private readonly onFire: WatchFireCallback;
+  private readonly subscribeFn: typeof eventStore.subscribe;
+  private unsubscribeFromEvents: (() => void) | null = null;
+  private idCounter = 0;
+
+  constructor(onFire: WatchFireCallback, options: WatchRegistryOptions = {}) {
+    this.onFire = onFire;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.subscribeFn = options.subscribe ?? eventStore.subscribe.bind(eventStore);
+  }
+
+  start(): void {
+    if (this.unsubscribeFromEvents != null) return;
+    this.unsubscribeFromEvents = this.subscribeFn((event) => this.handle(event));
+  }
+
+  stop(): void {
+    this.unsubscribeFromEvents?.();
+    this.unsubscribeFromEvents = null;
+  }
+
+  addRunWatch(conversationId: string, runId: string): Watch {
+    return this.add({ conversationId, kind: 'run', params: { runId } });
+  }
+
+  addIssueWatch(conversationId: string, projectId: string, workItemId: string): Watch {
+    return this.add({ conversationId, kind: 'issue', params: { projectId, workItemId } });
+  }
+
+  removeByConversation(conversationId: string): number {
+    let count = 0;
+    for (const [id, watch] of this.watches) {
+      if (watch.conversationId === conversationId) {
+        this.watches.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  pruneExpired(): number {
+    const now = Date.now();
+    let count = 0;
+    for (const [id, watch] of this.watches) {
+      if (watch.expiresAt <= now) {
+        this.watches.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  listForConversation(conversationId: string): Watch[] {
+    return [...this.watches.values()].filter((w) => w.conversationId === conversationId);
+  }
+
+  /** Visible to tests; production callers route through `start()` + eventStore. */
+  handle(event: AgentEvent): void {
+    this.pruneExpired();
+    if (this.watches.size === 0) return;
+    for (const [id, watch] of [...this.watches]) {
+      if (!matches(watch, event)) continue;
+      this.watches.delete(id);
+      this.onFire({ watch, event });
+    }
+  }
+
+  /** Test-only: total pending watches. */
+  size(): number {
+    return this.watches.size;
+  }
+
+  private add(input: { conversationId: string; kind: WatchKind; params: WatchParams }): Watch {
+    const now = Date.now();
+    this.idCounter += 1;
+    const id = `watch_${this.idCounter.toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    const watch: Watch = {
+      id,
+      conversationId: input.conversationId,
+      kind: input.kind,
+      params: input.params,
+      createdAt: now,
+      expiresAt: now + this.ttlMs,
+    };
+    this.watches.set(id, watch);
+    return watch;
+  }
+}
+
+function matches(watch: Watch, event: AgentEvent): boolean {
+  if (watch.kind === 'run') {
+    const { runId } = watch.params as RunWatchParams;
+    if (event.runId !== runId) return false;
+    return event.kind === 'agent.run-completed' || event.kind === 'agent.run-failed';
+  }
+  const { projectId, workItemId } = watch.params as IssueWatchParams;
+  return (
+    event.kind === 'state.transitioned' &&
+    event.projectId === projectId &&
+    event.workItemId === workItemId
+  );
+}

--- a/core/chat-tools/registry.test.ts
+++ b/core/chat-tools/registry.test.ts
@@ -28,6 +28,11 @@ describe('chat-tools registry', () => {
     expect(getToolManifest('open_url')?.mutating).toBe(true);
   });
 
+  it('registers the subscribe_to_run / subscribe_to_issue tools as mutating', () => {
+    expect(getToolManifest('subscribe_to_run')?.mutating).toBe(true);
+    expect(getToolManifest('subscribe_to_issue')?.mutating).toBe(true);
+  });
+
   it('every entry has a non-empty description', () => {
     for (const entry of CHAT_TOOL_REGISTRY) {
       expect(entry.description.length, `empty description for ${entry.name}`).toBeGreaterThan(10);

--- a/core/chat-tools/registry.ts
+++ b/core/chat-tools/registry.ts
@@ -87,6 +87,20 @@ const OpenUrlInput = z.object({
   rationale: z.string().min(1),
 });
 
+const SubscribeToRunInput = z.object({
+  runId: z.string().min(1).describe('Run identifier emitted on agent.run-started events.'),
+  rationale: z
+    .string()
+    .min(1)
+    .describe('Why this run is worth waiting on — shown to the human approver.'),
+});
+
+const SubscribeToIssueInput = z.object({
+  projectSlug: z.string().min(1),
+  issueNumber: z.union([z.number().int().positive(), z.string()]),
+  rationale: z.string().min(1),
+});
+
 export const CHAT_TOOL_REGISTRY: ChatToolManifestEntry[] = [
   // ── Read-only ────────────────────────────────────────────────────────────
   {
@@ -181,6 +195,20 @@ export const CHAT_TOOL_REGISTRY: ChatToolManifestEntry[] = [
       'Navigate the active web UI to an internal path (e.g. open the kanban, an issue detail page, settings). Side-effect only: no return value.',
     mutating: true,
     inputSchema: OpenUrlInput,
+  },
+  {
+    name: 'subscribe_to_run',
+    description:
+      'Watch an in-flight agent run by runId and post a follow-up chat message when it completes or fails. Auto-expires after 30 minutes.',
+    mutating: true,
+    inputSchema: SubscribeToRunInput,
+  },
+  {
+    name: 'subscribe_to_issue',
+    description:
+      'Watch a work item for its next state.transitioned event and post a follow-up chat message when it lands. Auto-expires after 30 minutes.',
+    mutating: true,
+    inputSchema: SubscribeToIssueInput,
   },
 ];
 

--- a/skills/hub-chat/prompt.md
+++ b/skills/hub-chat/prompt.md
@@ -47,6 +47,8 @@ If you don't know a term, say so. Don't guess.
 - Use `invoke_skill` only when the user explicitly wants a one-off skill run; default to `tick_project` for normal workflow advancement.
 - Use `open_url` to navigate the user's UI after answering a question that has a natural "show me" follow-up (e.g. opening the kanban after a status summary). Always pair it with a `say` reply — never just navigate.
 - Use `create_inbox_note` to capture follow-ups the user mentions in passing ("oh, also we should…"). The note title is the actionable summary; the body is the context.
+- Use `subscribe_to_run` when the user asks you to wait for a specific `runId` to finish and report back. The chat panel will receive a follow-up agent message when the run completes or fails; auto-expires after 30 minutes.
+- Use `subscribe_to_issue` when the user asks you to wait for the next state change on a work item. Requires `projectSlug` and `issueNumber`; auto-expires after 30 minutes.
 
 ## Quality bar
 


### PR DESCRIPTION
Closes #839

## Summary

Adds two new chat tools so the Hub Chat assistant can watch in-flight work and post a synthesised follow-up turn when the watched thing finishes.

- `subscribe_to_run` — watches a `runId` for `agent.run-completed` / `agent.run-failed`.
- `subscribe_to_issue` — watches a work item for its next `state.transitioned`.

Both are mutating (require Approve/Reject) because they add a follow-up turn without a fresh user prompt.

## What landed

| Layer | What |
|---|---|
| `core/chat-tools/registry.ts` | Two new mutating entries with Zod input schemas. |
| `apps/server/src/domains/chat/watches.ts` | `WatchRegistry` class — keeps a `Map<watchId, Watch>`, dispatches event-store events to interested watches, drops them on first match or TTL. |
| `apps/server/src/domains/chat/watch-singleton.ts` | Lazy module-scoped singleton that wires the registry to `eventStore.subscribe()` and writes the follow-up `chat_messages` row + `chat.agent-message` event. |
| `apps/server/src/domains/chat/tools.ts` | `subscribe_to_run` / `subscribe_to_issue` implementations resolve `projectId` + `workItemId`, register a watch, and return the resulting `watchId` + `expiresAt`. |
| `apps/server/src/domains/chat/service.ts` | `deleteConversationService` clears all watches owned by the conversation before deleting it. |
| `skills/hub-chat/prompt.md` | Two new lines in the tool-call rules block. |

## Behaviour

- Follow-up message has `role: 'agent'` and `meta.kind: 'subscription-fired'`, plus `watchId`, `watchKind`, `watchParams`, and a `sourceEvent` pointer.
- Default TTL is 30 minutes; expired watches are pruned lazily on the next event arrival or `pruneExpired()` call.
- Watch matching is one-shot — the first matching event removes the watch from the registry before invoking the fire callback.

## Tests

- 11 new `WatchRegistry` tests covering registration, firing, TTL expiry, and conversation-scoped cleanup.
- 3 new tool tests: `subscribe_to_run` happy path, `subscribe_to_issue` happy path, `subscribe_to_issue` unknown-project 404.
- 1 new service test: `deleteConversationService` removes only the deleted conversation's watches.
- Registry test extended to assert both new tools are registered as mutating.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 4070 passed, 3 skipped, 280 test files
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_