### PR TITLE
M20.09: invoke_skill spawns through agent-runtime

### DIFF
--- a/apps/server/src/domains/chat/repository.ts
+++ b/apps/server/src/domains/chat/repository.ts
@@ -13,6 +13,7 @@ export {
   listMessages,
   listToolInvocations,
   recordToolInvocation,
+  setToolInvocationRunId,
   touchConversation,
   transitionToolInvocationStatus,
   updateToolInvocation,

--- a/apps/server/src/domains/chat/service.ts
+++ b/apps/server/src/domains/chat/service.ts
@@ -313,6 +313,7 @@ export async function executeInvocation(
     conversationId: conversation.id,
     projectId: conversation.projectId,
     workItemId: conversation.workItemId,
+    invocationId,
   };
 
   try {

--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -120,6 +120,32 @@ vi.mock('#shared/projects.js', () => ({
   getProject: (slug: string) => mockGetProject(slug),
 }));
 
+const invokeSkillHoisted = vi.hoisted(() => {
+  class ContextValidationErrorMock extends Error {
+    issues: Array<{ path: Array<string | number>; message: string }>;
+    constructor(issues: Array<{ path: Array<string | number>; message: string }>) {
+      super('ContextValidationError');
+      this.name = 'ContextValidationError';
+      this.issues = issues;
+    }
+  }
+  return {
+    mockInvokeSkill: vi.fn(),
+    ContextValidationErrorMock,
+  };
+});
+const { mockInvokeSkill, ContextValidationErrorMock } = invokeSkillHoisted;
+
+vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
+  invokeSkill: (...args: unknown[]) => invokeSkillHoisted.mockInvokeSkill(...args),
+  ContextValidationError: invokeSkillHoisted.ContextValidationErrorMock,
+}));
+
+const mockSetToolInvocationRunId = vi.hoisted(() => vi.fn());
+vi.mock('@goose-hub/core/conversations/repository.js', () => ({
+  setToolInvocationRunId: (...args: unknown[]) => mockSetToolInvocationRunId(...args),
+}));
+
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { CHAT_TOOL_IMPLEMENTATIONS, ToolExecutionError } from './tools.js';
 
@@ -710,5 +736,105 @@ describe('chat-tools — bootstrap_project', () => {
     await expect(
       CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project({ repoUrl: 'octo/widgets', rationale: 'x' }, ctx),
     ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 500 });
+  });
+});
+
+describe('chat-tools — invoke_skill', () => {
+  beforeEach(() => {
+    mockInvokeSkill.mockReset();
+    mockSetToolInvocationRunId.mockReset();
+  });
+
+  it('spawns the requested skill via invokeSkill and surfaces the runId', async () => {
+    mockInvokeSkill.mockResolvedValueOnce({
+      output: { ok: true, note: 'fake skill result' },
+    });
+
+    const result = (await CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+      {
+        skillName: 'list-skills',
+        projectSlug: 'goose-hub-self',
+        workItemId: 'github:shaunnez/goose-hub#1',
+        rationale: 'manual run',
+      },
+      { ...ctx, conversationId: 'conv_invoke', invocationId: 'tool_inv_1' },
+    )) as { ok: boolean; runId: string; skillName: string };
+
+    expect(result.ok).toBe(true);
+    expect(result.skillName).toBe('list-skills');
+    expect(result.runId).toMatch(/^chat_skill_/);
+
+    expect(mockInvokeSkill).toHaveBeenCalledTimes(1);
+    const args = mockInvokeSkill.mock.calls[0][0];
+    expect(args.skillName).toBe('list-skills');
+    expect(args.projectId).toBe('goose-hub-self');
+    expect(args.workItemId).toBe('github:shaunnez/goose-hub#1');
+    expect(args.runId).toBe(result.runId);
+
+    expect(mockSetToolInvocationRunId).toHaveBeenCalledWith('tool_inv_1', result.runId);
+  });
+
+  it('rejects with a 404 ToolExecutionError when the project is unknown', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'list-skills',
+          projectSlug: 'unknown',
+          rationale: 'x',
+        },
+        ctx,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockInvokeSkill).not.toHaveBeenCalled();
+  });
+
+  it('translates unknown-skill failures into a 404 ToolExecutionError', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new Error("invokeSkill: skill 'never-was' config has no valid default export"),
+    );
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'never-was',
+          projectSlug: 'goose-hub-self',
+          rationale: 'x',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 404 });
+  });
+
+  it('translates a context validation error into a 400 ToolExecutionError with field info', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new ContextValidationErrorMock([{ path: ['workItem', 'id'], message: 'Required' }]),
+    );
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'triage',
+          projectSlug: 'goose-hub-self',
+          rationale: 'try it',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({
+      name: 'ToolExecutionError',
+      status: 400,
+      message: expect.stringContaining('workItem.id'),
+    });
+  });
+
+  it('refuses to spawn holdout / post-implementation skills from chat', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'qa',
+          projectSlug: 'goose-hub-self',
+          rationale: 'try qa',
+        },
+        ctx,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockInvokeSkill).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -770,6 +770,11 @@ describe('chat-tools — invoke_skill', () => {
     expect(args.projectId).toBe('goose-hub-self');
     expect(args.workItemId).toBe('github:shaunnez/goose-hub#1');
     expect(args.runId).toBe(result.runId);
+    expect(args.context).toMatchObject({
+      projectId: 'goose-hub-self',
+      projectSlug: 'goose-hub-self',
+      workItemId: 'github:shaunnez/goose-hub#1',
+    });
 
     expect(mockSetToolInvocationRunId).toHaveBeenCalledWith('tool_inv_1', result.runId);
   });
@@ -788,6 +793,20 @@ describe('chat-tools — invoke_skill', () => {
     expect(mockInvokeSkill).not.toHaveBeenCalled();
   });
 
+  it('rejects a skillName with path traversal characters', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: '../triage',
+          projectSlug: 'goose-hub-self',
+          rationale: 'should not be allowed',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockInvokeSkill).not.toHaveBeenCalled();
+  });
+
   it('translates unknown-skill failures into a 404 ToolExecutionError', async () => {
     mockInvokeSkill.mockRejectedValueOnce(
       new Error("invokeSkill: skill 'never-was' config has no valid default export"),
@@ -802,6 +821,22 @@ describe('chat-tools — invoke_skill', () => {
         ctx,
       ),
     ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 404 });
+  });
+
+  it('does not misclassify generic ENOENT failures as unknown-skill', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new Error("ENOENT: no such file or directory, open '/tmp/missing-fixture.json'"),
+    );
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'triage',
+          projectSlug: 'goose-hub-self',
+          rationale: 'real error',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 500 });
   });
 
   it('translates a context validation error into a 400 ToolExecutionError with field info', async () => {
@@ -822,6 +857,26 @@ describe('chat-tools — invoke_skill', () => {
       status: 400,
       message: expect.stringContaining('workItem.id'),
     });
+  });
+
+  it('does not stamp the invocation row when the run never reached the spawn phase', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new ContextValidationErrorMock([{ path: ['workItem'], message: 'Required' }]),
+    );
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.invoke_skill(
+        {
+          skillName: 'triage',
+          projectSlug: 'goose-hub-self',
+          rationale: 'context check',
+        },
+        { ...ctx, invocationId: 'tool_pre_spawn' },
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockSetToolInvocationRunId).not.toHaveBeenCalledWith(
+      'tool_pre_spawn',
+      expect.any(String),
+    );
   });
 
   it('refuses to spawn holdout / post-implementation skills from chat', async () => {

--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -391,6 +391,11 @@ async function tickProject(input: {
   return { ok: true };
 }
 
+// Tight skill-name validator. Same shape as project slugs (lowercase, digits,
+// dashes) so a crafted name like '../triage' cannot escape skillsRoot when
+// invokeSkill builds its import path from `skillsRoot + skillName`.
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
 /**
  * Spawn a Factory skill through the agent-runtime. Returns the runId so the
  * UI can link the chat invocation row to the live run. The runtime layer
@@ -403,6 +408,9 @@ async function invokeSkillTool(
   ctx: ToolContext,
 ): Promise<unknown> {
   assertValidSlug(input.projectSlug);
+  if (!SKILL_NAME_PATTERN.test(input.skillName)) {
+    throw new ToolExecutionError(`invalid skill name: '${input.skillName}'`, 400);
+  }
   if (SKILLS_BLOCKED_FROM_CHAT.has(input.skillName)) {
     throw new ToolExecutionError(
       `skill '${input.skillName}' must be invoked from a workflow, not chat (holdout / post-implementation role).`,
@@ -417,12 +425,15 @@ async function invokeSkillTool(
   }
 
   const runId = `chat_skill_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-  if (ctx.invocationId) {
-    // Stamp the row before spawn so the UI live-links the run as soon as
-    // `agent.run-started` arrives — without this, the run is anonymous until
-    // the spawn returns.
-    setToolInvocationRunId(ctx.invocationId, runId);
-  }
+
+  // Pass project + work-item identifiers up-front so skills whose contextSchema
+  // declares them as required fields can validate. Skills that need additional
+  // fields will surface a clear ContextValidationError below.
+  const skillContext: Record<string, unknown> = {
+    projectId: source.projectId,
+    projectSlug: input.projectSlug,
+    ...(input.workItemId != null && { workItemId: input.workItemId }),
+  };
 
   try {
     const result = await invokeSkill({
@@ -430,8 +441,15 @@ async function invokeSkillTool(
       projectId: source.projectId,
       workItemId: input.workItemId,
       runId,
-      context: {},
+      context: skillContext,
     });
+    // Stamp the row only after invokeSkill has at least entered the spawn
+    // phase. ContextValidationError throws before any subprocess starts; we
+    // skip the stamp in that case so the runId does not point at a run the
+    // runtime never tried to spawn.
+    if (ctx.invocationId) {
+      setToolInvocationRunId(ctx.invocationId, runId);
+    }
     return {
       ok: true,
       runId,
@@ -449,8 +467,21 @@ async function invokeSkillTool(
       );
     }
     const message = err instanceof Error ? err.message : String(err);
-    if (/no valid default export|Cannot find module|ENOENT/.test(message)) {
+    // "Unknown skill" only when the failure is specifically about the skill's
+    // own config import. Generic ENOENTs from runtime filesystem dependencies
+    // (prompt overlays, workspace setup) must surface as 500s so the operator
+    // can diagnose them, not be misclassified as "skill doesn't exist".
+    if (
+      /invokeSkill: skill '.+?' config has no valid default export/.test(message) ||
+      /Cannot find module .*?skill\.config/.test(message) ||
+      /ENOENT.*?skill\.config/.test(message)
+    ) {
       throw new ToolExecutionError(`unknown skill: '${input.skillName}'`, 404);
+    }
+    // Past the validation gate — stamp so the chat invocation links to the
+    // real (failed) run that the runtime attempted.
+    if (ctx.invocationId) {
+      setToolInvocationRunId(ctx.invocationId, runId);
     }
     logger.warn('chat-tools.invoke_skill failed', { err: message, runId, input });
     throw new ToolExecutionError(`invoke_skill failed: ${message}`, 500);

--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -1,6 +1,8 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { ContextValidationError, invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import { UPDATE_SETTINGS_KEYS } from '@goose-hub/core/chat-tools/registry.js';
+import { setToolInvocationRunId } from '@goose-hub/core/conversations/repository.js';
 import {
   getUseInvestigationSwarm,
   getUseMultiAgentPipeline,
@@ -19,10 +21,19 @@ import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug, isValidSlug } from '#shared/source.js';
 import { getWatchRegistry } from './watch-singleton.js';
 
+// Skills that must be invoked from a workflow context, not chat. Chat-driven
+// runs of these would either fail context validation immediately (holdouts
+// require fresh context fed by the workflow) or run without the inputs they
+// need (post-implementation reviewers). Reject them up-front with a clear
+// message instead of letting the validator throw a noisy error.
+const SKILLS_BLOCKED_FROM_CHAT = new Set(['qa', 'review', 'retro', 'retro-deep']);
+
 export interface ToolContext {
   conversationId: string;
   projectId?: string | null;
   workItemId?: string | null;
+  /** Set when the dispatcher is executing a recorded invocation row. */
+  invocationId?: string;
 }
 
 export class ToolExecutionError extends Error {
@@ -380,21 +391,70 @@ async function tickProject(input: {
   return { ok: true };
 }
 
-async function invokeSkillTool(input: {
-  skillName: string;
-  projectSlug: string;
-  workItemId?: string;
-  rationale: string;
-}): Promise<unknown> {
-  // Defensive: we accept invoke_skill proposals but do not actually run skills
-  // from chat in v1 — chat-driven skill runs need a dedicated workflow that
-  // routes through invokeSkill() with budgets + persona selection. Marking the
-  // tool as a no-op with a clear message keeps the contract honest.
-  return {
-    ok: false,
-    note: 'invoke_skill via chat is not yet wired to the agent-runtime; this proposal is approved but not executed. File an issue if you need this capability.',
-    skillName: input.skillName,
-  };
+/**
+ * Spawn a Factory skill through the agent-runtime. Returns the runId so the
+ * UI can link the chat invocation row to the live run. The runtime layer
+ * emits `agent.run-started` / `agent.run-completed` / `agent.run-failed` and
+ * records cost into `agent_run_costs` automatically; this function only
+ * orchestrates the spawn and surfaces the terminal output back to chat.
+ */
+async function invokeSkillTool(
+  input: { skillName: string; projectSlug: string; workItemId?: string; rationale: string },
+  ctx: ToolContext,
+): Promise<unknown> {
+  assertValidSlug(input.projectSlug);
+  if (SKILLS_BLOCKED_FROM_CHAT.has(input.skillName)) {
+    throw new ToolExecutionError(
+      `skill '${input.skillName}' must be invoked from a workflow, not chat (holdout / post-implementation role).`,
+      400,
+    );
+  }
+
+  // Resolve project so projectId is the canonical ProjectConfig.id, not the slug.
+  const source = await getSourceForSlug(input.projectSlug);
+  if (source == null) {
+    throw new ToolExecutionError(`project not found: ${input.projectSlug}`, 404);
+  }
+
+  const runId = `chat_skill_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  if (ctx.invocationId) {
+    // Stamp the row before spawn so the UI live-links the run as soon as
+    // `agent.run-started` arrives — without this, the run is anonymous until
+    // the spawn returns.
+    setToolInvocationRunId(ctx.invocationId, runId);
+  }
+
+  try {
+    const result = await invokeSkill({
+      skillName: input.skillName,
+      projectId: source.projectId,
+      workItemId: input.workItemId,
+      runId,
+      context: {},
+    });
+    return {
+      ok: true,
+      runId,
+      skillName: input.skillName,
+      output: result.output,
+    };
+  } catch (err) {
+    if (err instanceof ContextValidationError) {
+      const issues = err.issues
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; ');
+      throw new ToolExecutionError(
+        `skill '${input.skillName}' rejected context — chat does not currently supply the fields it needs: ${issues}`,
+        400,
+      );
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    if (/no valid default export|Cannot find module|ENOENT/.test(message)) {
+      throw new ToolExecutionError(`unknown skill: '${input.skillName}'`, 404);
+    }
+    logger.warn('chat-tools.invoke_skill failed', { err: message, runId, input });
+    throw new ToolExecutionError(`invoke_skill failed: ${message}`, 500);
+  }
 }
 
 async function openUrl(input: { path: string; rationale: string }): Promise<unknown> {
@@ -702,7 +762,8 @@ export const CHAT_TOOL_IMPLEMENTATIONS: Record<string, ToolFn> = {
   comment_on_issue: (input) => commentOnIssue(input as Parameters<typeof commentOnIssue>[0]),
   create_inbox_note: (input) => createInboxNote(input as Parameters<typeof createInboxNote>[0]),
   tick_project: (input) => tickProject(input as Parameters<typeof tickProject>[0]),
-  invoke_skill: (input) => invokeSkillTool(input as Parameters<typeof invokeSkillTool>[0]),
+  invoke_skill: (input, ctx) =>
+    invokeSkillTool(input as Parameters<typeof invokeSkillTool>[0], ctx),
   open_url: (input) => openUrl(input as Parameters<typeof openUrl>[0]),
   subscribe_to_run: (input, ctx) =>
     subscribeToRun(input as Parameters<typeof subscribeToRun>[0], ctx),

--- a/apps/web/src/components/chat/components/ChatThread.test.tsx
+++ b/apps/web/src/components/chat/components/ChatThread.test.tsx
@@ -35,6 +35,7 @@ const completedInvocation: ChatToolInvocationDto = {
   status: 'completed',
   result: null,
   errorMessage: null,
+  runId: null,
   createdAt: '2026-05-18T00:00:00Z',
   updatedAt: '2026-05-18T00:00:00Z',
 };

--- a/apps/web/src/components/chat/lib/liveState.test.ts
+++ b/apps/web/src/components/chat/lib/liveState.test.ts
@@ -18,6 +18,7 @@ function invocation(id: string, status: ChatToolInvocationDto['status']): ChatTo
     status,
     result: null,
     errorMessage: null,
+    runId: null,
     createdAt: '2026-05-18T00:00:00Z',
     updatedAt: '2026-05-18T00:00:00Z',
   };

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -662,6 +662,8 @@ export interface ChatToolInvocationDto {
   status: ChatToolStatus;
   result: unknown;
   errorMessage: string | null;
+  /** Set when the tool spawned an agent-runtime run (M20.09). */
+  runId: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/core/conversations/repository.test.ts
+++ b/core/conversations/repository.test.ts
@@ -7,6 +7,7 @@ import {
   listMessages,
   listToolInvocations,
   recordToolInvocation,
+  setToolInvocationRunId,
   updateToolInvocation,
 } from './repository.js';
 
@@ -69,6 +70,24 @@ describe('conversations repository', () => {
     const invocations = listToolInvocations(id);
     expect(invocations.length).toBe(1);
     expect(invocations[0].status).toBe('completed');
+  });
+
+  it('setToolInvocationRunId stamps the runId on the invocation row', () => {
+    const id = newId();
+    createConversation({ id, scope: 'global' });
+    const toolId = `tool_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+    recordToolInvocation({
+      id: toolId,
+      conversationId: id,
+      toolName: 'invoke_skill',
+      input: {},
+      mutating: true,
+      status: 'running',
+    });
+
+    const stamped = setToolInvocationRunId(toolId, 'run_abc123');
+    expect(stamped?.runId).toBe('run_abc123');
+    expect(listToolInvocations(id)[0].runId).toBe('run_abc123');
   });
 
   it('lists conversations filtered by scope', () => {

--- a/core/conversations/repository.ts
+++ b/core/conversations/repository.ts
@@ -51,6 +51,7 @@ function rowToInvocation(r: typeof chatToolInvocations.$inferSelect): ChatToolIn
     status: r.status as ChatToolStatus,
     result: r.resultJson ? JSON.parse(r.resultJson) : null,
     errorMessage: r.errorMessage,
+    runId: r.runId,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   };
@@ -182,6 +183,7 @@ export interface UpdateToolInvocationInput {
   status: ChatToolStatus;
   result?: unknown;
   errorMessage?: string | null;
+  runId?: string | null;
 }
 
 export function updateToolInvocation(input: UpdateToolInvocationInput): ChatToolInvocation | null {
@@ -191,11 +193,27 @@ export function updateToolInvocation(input: UpdateToolInvocationInput): ChatTool
   };
   if (input.result !== undefined) update.resultJson = JSON.stringify(input.result);
   if (input.errorMessage !== undefined) update.errorMessage = input.errorMessage;
+  if (input.runId !== undefined) update.runId = input.runId;
 
   const [row] = db
     .update(chatToolInvocations)
     .set(update)
     .where(eq(chatToolInvocations.id, input.id))
+    .returning()
+    .all();
+  return row ? rowToInvocation(row) : null;
+}
+
+/**
+ * Stamp a chat tool invocation with the runId of the agent-runtime run it
+ * spawned (M20.09). Used by `invoke_skill` to link the row back to the run
+ * before the run completes so the UI can render the live indicator.
+ */
+export function setToolInvocationRunId(id: string, runId: string): ChatToolInvocation | null {
+  const [row] = db
+    .update(chatToolInvocations)
+    .set({ runId, updatedAt: nowIso() })
+    .where(eq(chatToolInvocations.id, id))
     .returning()
     .all();
   return row ? rowToInvocation(row) : null;

--- a/core/conversations/types.ts
+++ b/core/conversations/types.ts
@@ -40,6 +40,8 @@ export interface ChatToolInvocation {
   status: ChatToolStatus;
   result: unknown;
   errorMessage: string | null;
+  /** Set when the tool spawned an agent-runtime run (M20.09). */
+  runId: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/core/db/migrations/0032_chat_invocation_run_id.sql
+++ b/core/db/migrations/0032_chat_invocation_run_id.sql
@@ -1,0 +1,3 @@
+-- Adds run_id to chat_tool_invocations so chat-driven invoke_skill runs
+-- can be linked back to the spawned agent run.
+ALTER TABLE `chat_tool_invocations` ADD COLUMN `run_id` text;

--- a/core/db/migrations/meta/0032_snapshot.json
+++ b/core/db/migrations/meta/0032_snapshot.json
@@ -1,0 +1,2158 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "61cd8510-a1c9-4954-a783-f397545696a9",
+  "prevId": "511ab15f-50e0-449f-920b-47225e332dbb",
+  "tables": {
+    "agent_artifacts": {
+      "name": "agent_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_artifacts_artifact_key_uniq": {
+          "name": "agent_artifacts_artifact_key_uniq",
+          "columns": [
+            "artifact_key"
+          ],
+          "isUnique": true
+        },
+        "agent_artifacts_project_work_item_idx": {
+          "name": "agent_artifacts_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "agent_artifacts_run_id_idx": {
+          "name": "agent_artifacts_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "agent_artifacts_project_work_item_run_kind_idx": {
+          "name": "agent_artifacts_project_work_item_run_kind_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "run_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_decisions": {
+      "name": "agent_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what": {
+          "name": "what",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_decisions_run_kind_what_uniq": {
+          "name": "agent_decisions_run_kind_what_uniq",
+          "columns": [
+            "run_id",
+            "kind",
+            "what"
+          ],
+          "isUnique": true
+        },
+        "agent_decisions_run_idx": {
+          "name": "agent_decisions_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_runs": {
+      "name": "agent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_runs_run_id_uniq": {
+          "name": "agent_runs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_runs_persona_idx": {
+          "name": "agent_runs_persona_idx",
+          "columns": [
+            "persona_id"
+          ],
+          "isUnique": false
+        },
+        "agent_runs_project_idx": {
+          "name": "agent_runs_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "archived_lifecycles": {
+      "name": "archived_lifecycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_summaries": {
+          "name": "decision_summaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "learning_entries": {
+          "name": "learning_entries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "quality_scores": {
+          "name": "quality_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "costs_usd": {
+          "name": "costs_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "run_ids": {
+          "name": "run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "archived_lifecycles_project_work_item_idx": {
+          "name": "archived_lifecycles_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "archived_lifecycles_project_closed_idx": {
+          "name": "archived_lifecycles_project_closed_idx",
+          "columns": [
+            "project_id",
+            "closed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_conversations": {
+      "name": "chat_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_conversations_scope_idx": {
+          "name": "chat_conversations_scope_idx",
+          "columns": [
+            "scope",
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "chat_conversations_updated_idx": {
+          "name": "chat_conversations_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_messages_conversation_idx": {
+          "name": "chat_messages_conversation_idx",
+          "columns": [
+            "conversation_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_tool_invocations": {
+      "name": "chat_tool_invocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_json": {
+          "name": "input_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mutating": {
+          "name": "mutating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_tool_invocations_conversation_idx": {
+          "name": "chat_tool_invocations_conversation_idx",
+          "columns": [
+            "conversation_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "chat_tool_invocations_status_idx": {
+          "name": "chat_tool_invocations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_patterns": {
+      "name": "decision_patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_summary": {
+          "name": "action_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_summary": {
+          "name": "reason_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consistency_score": {
+          "name": "consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "example_work_item_ids": {
+          "name": "example_work_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "decision_patterns_project_kind_role_uniq": {
+          "name": "decision_patterns_project_kind_role_uniq",
+          "columns": [
+            "project_id",
+            "kind",
+            "role"
+          ],
+          "isUnique": true
+        },
+        "decision_patterns_project_idx": {
+          "name": "decision_patterns_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engineering_specs": {
+      "name": "engineering_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "engineering_specs_project_work_item_uniq": {
+          "name": "engineering_specs_project_work_item_uniq",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": true
+        },
+        "engineering_specs_project_work_item_idx": {
+          "name": "engineering_specs_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_work_item_idx": {
+          "name": "events_work_item_idx",
+          "columns": [
+            "work_item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_diff": {
+          "name": "proposed_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_playbook_id": {
+          "name": "source_playbook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playbooks": {
+      "name": "playbooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_count": {
+          "name": "lifecycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "playbooks_project_created_idx": {
+          "name": "playbooks_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "playbooks_project_window_idx": {
+          "name": "playbooks_project_window_idx",
+          "columns": [
+            "project_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_dev_review_settings": {
+      "name": "project_dev_review_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_on": {
+          "name": "trigger_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_revision_turns": {
+          "name": "max_revision_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_cycle_max_usd": {
+          "name": "per_cycle_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_review_settings": {
+      "name": "project_review_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_slots": {
+          "name": "reviewer_slots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "per_workflow_max_usd": {
+          "name": "per_workflow_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_agent_max_usd": {
+          "name": "per_agent_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_advisor_max_usd": {
+          "name": "per_advisor_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_tokens": {
+          "name": "daily_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_parallel_agents": {
+          "name": "max_parallel_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_scout_agents": {
+          "name": "max_scout_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_bash_command_max_seconds": {
+          "name": "per_bash_command_max_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_multi_agent_pipeline": {
+          "name": "use_multi_agent_pipeline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_investigation_swarm": {
+          "name": "use_investigation_swarm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qa_e2e_mode": {
+          "name": "qa_e2e_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playwright_repro_enabled": {
+          "name": "playwright_repro_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "evidence_post_enabled": {
+          "name": "evidence_post_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "record_decision_tool": {
+          "name": "record_decision_tool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_skill_settings": {
+      "name": "project_skill_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_budget_usd": {
+          "name": "max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_tier": {
+          "name": "model_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_skill_settings_project_id_skill_name_pk": {
+          "columns": [
+            "project_id",
+            "skill_name"
+          ],
+          "name": "project_skill_settings_project_id_skill_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_quality_scores": {
+      "name": "run_quality_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "components_json": {
+          "name": "components_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_score": {
+          "name": "audit_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "run_quality_scores_run_iteration_uniq": {
+          "name": "run_quality_scores_run_iteration_uniq",
+          "columns": [
+            "run_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "run_quality_scores_project_ts_idx": {
+          "name": "run_quality_scores_project_ts_idx",
+          "columns": [
+            "project_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "run_quality_scores_pipeline_run_idx": {
+          "name": "run_quality_scores_pipeline_run_idx",
+          "columns": [
+            "pipeline_run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scout_reports": {
+      "name": "scout_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "investigation_run_id": {
+          "name": "investigation_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scout_skill": {
+          "name": "scout_skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report": {
+          "name": "report",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "scout_reports_project_work_item_run_skill_uniq": {
+          "name": "scout_reports_project_work_item_run_skill_uniq",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id",
+            "scout_skill"
+          ],
+          "isUnique": true
+        },
+        "scout_reports_project_work_item_run_idx": {
+          "name": "scout_reports_project_work_item_run_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wp_iterations": {
+      "name": "wp_iterations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wp_id": {
+          "name": "wp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "wp_iterations_run_wp_iteration_uniq": {
+          "name": "wp_iterations_run_wp_iteration_uniq",
+          "columns": [
+            "run_id",
+            "wp_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "wp_iterations_run_wp_idx": {
+          "name": "wp_iterations_run_wp_idx",
+          "columns": [
+            "run_id",
+            "wp_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1779200000000,
       "tag": "0031_hub_chat",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1779200000001,
+      "tag": "0032_chat_invocation_run_id",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -513,6 +513,8 @@ export const chatToolInvocations = sqliteTable(
     status: text('status').notNull(), // 'proposed' | 'approved' | 'rejected' | 'running' | 'completed' | 'failed'
     resultJson: text('result_json'),
     errorMessage: text('error_message'),
+    /** Run id when the tool spawned an agent-runtime run (M20.09). */
+    runId: text('run_id'),
     createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
     updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },


### PR DESCRIPTION
Closes #840

## Summary

`invoke_skill` now spawns a real run through `invokeSkill()` instead of returning a stub. The runtime layer (Claude or Codex CLI) handles persona selection, budget resolution, event emission, and `agent_run_costs` recording as on any other Factory run.

## What landed

| Layer | What |
|---|---|
| Migration 0032 | `chat_tool_invocations` gains a nullable `run_id` column. |
| `core/conversations/` | `ChatToolInvocation.runId` field; new `setToolInvocationRunId()` helper; `updateToolInvocation()` accepts an explicit `runId`. |
| `apps/server/src/domains/chat/tools.ts` | `invokeSkillTool` validates slug, resolves the project, generates a `chat_skill_*` runId, stamps it on the invocation row, then calls `invokeSkill`. Translates `ContextValidationError` into a 400, "skill not found" into a 404, and everything else into a 500. |
| `ToolContext` | New optional `invocationId` so tool implementations can stamp the row they're running for. |
| `apps/web/src/lib/types.ts` | `ChatToolInvocationDto.runId` and the matching test-fixture updates. |
| Holdout guard | A small in-file deny-set (`qa`, `review`, `retro`, `retro-deep`) rejects chat-driven invocations of holdout / post-implementation skills with a clear message instead of letting context validation throw. |

## Cost integration

`invokeSkill` returns through the runtime's normal post-spawn path — `core/agent-runtime/claude-cli.ts` and `codex-cli.ts` call `recordCost()` after a successful run, so the per-run row in `agent_run_costs` lands automatically. No new write path in this PR.

## Tests

- `core/conversations/repository.test.ts` — new test asserting `setToolInvocationRunId` stamps the row.
- `apps/server/src/domains/chat/tools.test.ts` — 5 new `invoke_skill` cases: happy path (asserts `invokeSkill` args + `setToolInvocationRunId` call), unknown project → 404, unknown-skill → 404, context-validation failure → 400 with field info, holdout-skill blocked → 400.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 4060 passed, 3 skipped, 279 test files
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_