### PR TITLE
M20.11: bootstrap_project chat tool

### DIFF
--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -614,6 +614,36 @@ describe('chat-tools — bootstrap_project', () => {
     expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
   });
 
+  it('rejects a URL hosted somewhere other than github.com', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+        { repoUrl: 'https://evil.example/github.com/octo/widgets', rationale: 'attack' },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
+  });
+
+  it('rejects api.github.com URLs even though they share the company suffix', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+        { repoUrl: 'https://api.github.com/repos/octo/widgets', rationale: 'attack' },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
+  });
+
+  it('rejects HTTPS URLs that carry extra path segments', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+        { repoUrl: 'https://github.com/octo/widgets/issues/42', rationale: 'wrong path' },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
+  });
+
   it('rejects an invalid slug before calling the workflow', async () => {
     await expect(
       CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(

--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock all upstream dependencies before importing tools.ts so the module-time
 // imports resolve cleanly.
@@ -26,6 +26,33 @@ vi.mock('#shared/source.js', () => ({
 
 vi.mock('#shared/inbox-bridge.js', () => ({
   addInboxNote: vi.fn(async (_input: { title: string }) => ({ id: 42 })),
+}));
+
+interface BootstrapBridgeResult {
+  ok: boolean;
+  slug?: string;
+  status?: 'created' | 'idempotent-skip';
+  registrationPrUrl?: string | null;
+  stackSummary?: string;
+  auditAction?: string;
+  labelCounts?: { created: number; updated: number; skipped: number };
+  error?: string;
+  errorStatus?: number;
+}
+const mockRunBootstrapViaBridge: ReturnType<typeof vi.fn> = vi.fn(
+  async (): Promise<BootstrapBridgeResult> => ({
+    ok: true,
+    slug: 'widgets',
+    status: 'created',
+    registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/999',
+    stackSummary: 'Node + pnpm',
+    auditAction: 'ok',
+    labelCounts: { created: 10, updated: 0, skipped: 0 },
+  }),
+);
+vi.mock('#shared/bootstrap-bridge.js', () => ({
+  runBootstrapViaBridge: (repoRef: string, slug?: string) =>
+    mockRunBootstrapViaBridge(repoRef, slug),
 }));
 
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
@@ -517,5 +544,98 @@ describe('chat-tools — set_active_milestone', () => {
     )) as { ok: boolean; milestoneNumber: number | null; cleared: boolean };
     expect(result.milestoneNumber).toBeNull();
     expect(result.cleared).toBe(true);
+  });
+});
+
+describe('chat-tools — bootstrap_project', () => {
+  beforeEach(() => {
+    mockRunBootstrapViaBridge.mockReset();
+  });
+
+  it('runs the bootstrap workflow via the shared bridge and returns the registration PR url', async () => {
+    mockRunBootstrapViaBridge.mockResolvedValueOnce({
+      ok: true,
+      slug: 'widgets',
+      status: 'created',
+      registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/999',
+      stackSummary: 'Node + pnpm',
+      auditAction: 'create',
+      labelCounts: { created: 10, updated: 0, skipped: 0 },
+    });
+    const result = (await CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+      {
+        repoUrl: 'https://github.com/octo/widgets',
+        slug: 'widgets',
+        mode: 'supervised',
+        rationale: 'onboard widgets',
+      },
+      ctx,
+    )) as {
+      ok: boolean;
+      slug: string;
+      registrationPrUrl: string | null;
+      path: string;
+      requestedMode: string | null;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.slug).toBe('widgets');
+    expect(result.registrationPrUrl).toBe('https://github.com/shaunnez/goose-hub/pull/999');
+    expect(result.path).toBe('/projects/widgets');
+    expect(result.requestedMode).toBe('supervised');
+    expect(mockRunBootstrapViaBridge).toHaveBeenCalledWith('octo/widgets', 'widgets');
+  });
+
+  it('accepts an owner/repo shorthand and a git@ SSH URL', async () => {
+    mockRunBootstrapViaBridge.mockResolvedValue({
+      ok: true,
+      slug: 'a',
+      status: 'created',
+      registrationPrUrl: null,
+      stackSummary: 's',
+      auditAction: 'ok',
+    });
+    await CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+      { repoUrl: 'octo/alpha', rationale: 'a' },
+      ctx,
+    );
+    expect(mockRunBootstrapViaBridge).toHaveBeenLastCalledWith('octo/alpha', undefined);
+
+    await CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+      { repoUrl: 'git@github.com:octo/beta.git', rationale: 'b' },
+      ctx,
+    );
+    expect(mockRunBootstrapViaBridge).toHaveBeenLastCalledWith('octo/beta', undefined);
+  });
+
+  it('rejects an unparseable repoUrl with a 400 ToolExecutionError', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project({ repoUrl: 'not a url', rationale: 'x' }, ctx),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid slug before calling the workflow', async () => {
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project(
+        {
+          repoUrl: 'octo/widgets',
+          slug: 'Bad Slug!',
+          rationale: 'bad',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 400 });
+    expect(mockRunBootstrapViaBridge).not.toHaveBeenCalled();
+  });
+
+  it('surfaces bridge errors with their original status code', async () => {
+    mockRunBootstrapViaBridge.mockResolvedValueOnce({
+      ok: false,
+      error: 'server is missing GITHUB_TOKEN',
+      errorStatus: 500,
+    });
+    await expect(
+      CHAT_TOOL_IMPLEMENTATIONS.bootstrap_project({ repoUrl: 'octo/widgets', rationale: 'x' }, ctx),
+    ).rejects.toMatchObject({ name: 'ToolExecutionError', status: 500 });
   });
 });

--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -11,6 +11,7 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
 import { skillsRoot } from '@goose-hub/skills';
+import { runBootstrapViaBridge } from '#shared/bootstrap-bridge.js';
 import { addInboxNote } from '#shared/inbox-bridge.js';
 import { setActiveMilestoneViaBridge } from '#shared/milestone-bridge.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
@@ -560,6 +561,61 @@ async function setActiveMilestoneTool(input: {
   };
 }
 
+/**
+ * Accept GitHub repo URL or owner/repo ref. Returns canonical 'owner/repo'.
+ * Throws ToolExecutionError on shapes we cannot parse.
+ */
+function parseRepoUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) throw new ToolExecutionError('repoUrl is required', 400);
+
+  // owner/repo direct form
+  if (!trimmed.includes('://') && !trimmed.startsWith('git@')) {
+    const parts = trimmed.replace(/\.git$/, '').split('/');
+    if (parts.length === 2 && parts[0] && parts[1]) return `${parts[0]}/${parts[1]}`;
+    throw new ToolExecutionError(`could not parse repoUrl: '${raw}'`, 400);
+  }
+
+  // https://github.com/owner/repo[.git]
+  const httpsMatch = /github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/|$)/i.exec(trimmed);
+  if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
+
+  // git@github.com:owner/repo[.git]
+  const sshMatch = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i.exec(trimmed);
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
+
+  throw new ToolExecutionError(`unsupported repoUrl shape: '${raw}'`, 400);
+}
+
+async function bootstrapProjectTool(input: {
+  repoUrl: string;
+  slug?: string;
+  mode?: 'interactive' | 'supervised' | 'autonomous';
+  rationale: string;
+}): Promise<unknown> {
+  const repoRef = parseRepoUrl(input.repoUrl);
+  if (input.slug != null && !isValidSlug(input.slug)) {
+    throw new ToolExecutionError(`invalid slug '${input.slug}' — must match /^[a-z0-9-]+$/`, 400);
+  }
+  const result = await runBootstrapViaBridge(repoRef, input.slug);
+  if (!result.ok) {
+    const status = result.errorStatus ?? 500;
+    throw new ToolExecutionError(result.error ?? 'bootstrap failed', status);
+  }
+  return {
+    ok: true,
+    repoRef,
+    slug: result.slug,
+    status: result.status,
+    registrationPrUrl: result.registrationPrUrl,
+    stackSummary: result.stackSummary,
+    auditAction: result.auditAction,
+    labelCounts: result.labelCounts,
+    requestedMode: input.mode ?? null,
+    path: result.slug ? `/projects/${result.slug}` : null,
+  };
+}
+
 type ToolFn = (input: unknown, ctx: ToolContext) => Promise<unknown>;
 
 export const CHAT_TOOL_IMPLEMENTATIONS: Record<string, ToolFn> = {
@@ -586,4 +642,6 @@ export const CHAT_TOOL_IMPLEMENTATIONS: Record<string, ToolFn> = {
   update_settings: (input) => updateSettings(input as Parameters<typeof updateSettings>[0]),
   set_active_milestone: (input) =>
     setActiveMilestoneTool(input as Parameters<typeof setActiveMilestoneTool>[0]),
+  bootstrap_project: (input) =>
+    bootstrapProjectTool(input as Parameters<typeof bootstrapProjectTool>[0]),
 };

--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -561,30 +561,73 @@ async function setActiveMilestoneTool(input: {
   };
 }
 
+// Owner and repo segments may contain alphanumerics, dashes, dots, and
+// underscores; the test is conservative on purpose so a hostile URL with extra
+// path segments cannot smuggle in a different repo.
+const OWNER_REPO_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
 /**
- * Accept GitHub repo URL or owner/repo ref. Returns canonical 'owner/repo'.
- * Throws ToolExecutionError on shapes we cannot parse.
+ * Accept a GitHub repo URL or `owner/repo` shorthand. Returns canonical
+ * `owner/repo`. Throws ToolExecutionError on anything that doesn't anchor
+ * exactly to the github.com host (or the equivalent ssh form).
+ *
+ * Defence against tricks like `https://evil.example/github.com/octo/widgets`
+ * or `https://api.github.com/repos/octo/widgets` parsing as `octo/widgets` —
+ * the bootstrap workflow would create labels and PRs against an unintended
+ * target. We parse https URLs through `URL` so the host check is exact.
  */
 function parseRepoUrl(raw: string): string {
   const trimmed = raw.trim();
   if (trimmed.length === 0) throw new ToolExecutionError('repoUrl is required', 400);
 
-  // owner/repo direct form
+  // owner/repo direct form (no scheme, no SSH).
   if (!trimmed.includes('://') && !trimmed.startsWith('git@')) {
-    const parts = trimmed.replace(/\.git$/, '').split('/');
-    if (parts.length === 2 && parts[0] && parts[1]) return `${parts[0]}/${parts[1]}`;
+    const cleaned = trimmed.replace(/\.git$/, '');
+    const parts = cleaned.split('/');
+    if (
+      parts.length === 2 &&
+      OWNER_REPO_SEGMENT.test(parts[0]) &&
+      OWNER_REPO_SEGMENT.test(parts[1])
+    ) {
+      return `${parts[0]}/${parts[1]}`;
+    }
     throw new ToolExecutionError(`could not parse repoUrl: '${raw}'`, 400);
   }
 
-  // https://github.com/owner/repo[.git]
-  const httpsMatch = /github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/|$)/i.exec(trimmed);
-  if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
+  // git@github.com:owner/repo[.git] — anchored to the exact host.
+  if (trimmed.startsWith('git@')) {
+    const sshMatch = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/.exec(trimmed);
+    if (sshMatch && OWNER_REPO_SEGMENT.test(sshMatch[1]) && OWNER_REPO_SEGMENT.test(sshMatch[2])) {
+      return `${sshMatch[1]}/${sshMatch[2]}`;
+    }
+    throw new ToolExecutionError(`unsupported repoUrl shape: '${raw}'`, 400);
+  }
 
-  // git@github.com:owner/repo[.git]
-  const sshMatch = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i.exec(trimmed);
-  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
-
-  throw new ToolExecutionError(`unsupported repoUrl shape: '${raw}'`, 400);
+  // HTTPS — parse through URL so the host check is exact and path segments
+  // are validated. Anything other than `github.com` host with exactly
+  // `/owner/repo[.git]` is rejected.
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new ToolExecutionError(`could not parse repoUrl: '${raw}'`, 400);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new ToolExecutionError(`unsupported repoUrl protocol: '${url.protocol}'`, 400);
+  }
+  if (url.host.toLowerCase() !== 'github.com') {
+    throw new ToolExecutionError(`repoUrl host must be github.com, got '${url.host}'`, 400);
+  }
+  const segments = url.pathname.replace(/^\/+/, '').replace(/\/+$/, '').split('/');
+  if (segments.length !== 2) {
+    throw new ToolExecutionError(`repoUrl path must be /owner/repo, got '${url.pathname}'`, 400);
+  }
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/, '');
+  if (!OWNER_REPO_SEGMENT.test(owner) || !OWNER_REPO_SEGMENT.test(repo)) {
+    throw new ToolExecutionError(`invalid owner/repo characters in '${raw}'`, 400);
+  }
+  return `${owner}/${repo}`;
 }
 
 async function bootstrapProjectTool(input: {

--- a/apps/server/src/shared/bootstrap-bridge.ts
+++ b/apps/server/src/shared/bootstrap-bridge.ts
@@ -1,0 +1,38 @@
+/**
+ * Cross-domain bridge for running the project-bootstrap workflow. Per
+ * `apps/server/STANDARDS.md`, domains never import from other domains; this
+ * shared helper is the gateway the chat domain uses to drive bootstrap from
+ * its `bootstrap_project` tool.
+ */
+import { runBootstrapService } from '../domains/bootstrap/service.js';
+
+export interface BootstrapRunBridgeResult {
+  ok: boolean;
+  slug?: string;
+  status?: 'created' | 'idempotent-skip';
+  registrationPrUrl?: string | null;
+  stackSummary?: string;
+  auditAction?: string;
+  labelCounts?: { created: number; updated: number; skipped: number } | undefined;
+  error?: string;
+  errorStatus?: number;
+}
+
+export async function runBootstrapViaBridge(
+  repoRef: string,
+  slugOverride?: string,
+): Promise<BootstrapRunBridgeResult> {
+  const result = await runBootstrapService(repoRef, slugOverride);
+  if (!result.ok) {
+    return { ok: false, error: result.error, errorStatus: result.status };
+  }
+  return {
+    ok: true,
+    slug: result.data.slug,
+    status: result.data.status,
+    registrationPrUrl: result.data.registrationPrUrl ?? null,
+    stackSummary: result.data.stackSummary,
+    auditAction: result.data.auditAction,
+    labelCounts: result.data.labelCounts,
+  };
+}

--- a/core/chat-tools/registry.test.ts
+++ b/core/chat-tools/registry.test.ts
@@ -39,6 +39,10 @@ describe('chat-tools registry', () => {
     expect(getToolManifest('set_active_milestone')?.mutating).toBe(true);
   });
 
+  it('registers bootstrap_project as a mutating tool', () => {
+    expect(getToolManifest('bootstrap_project')?.mutating).toBe(true);
+  });
+
   it('every entry has a non-empty description', () => {
     for (const entry of CHAT_TOOL_REGISTRY) {
       expect(entry.description.length, `empty description for ${entry.name}`).toBeGreaterThan(10);

--- a/core/chat-tools/registry.ts
+++ b/core/chat-tools/registry.ts
@@ -135,6 +135,27 @@ const SetActiveMilestoneInput = z.object({
   rationale: z.string().min(1),
 });
 
+const BootstrapProjectInput = z.object({
+  repoUrl: z
+    .string()
+    .min(1)
+    .describe(
+      'GitHub repo URL or owner/repo ref (e.g. https://github.com/octo/widgets, git@github.com:octo/widgets.git, octo/widgets).',
+    ),
+  slug: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Optional slug override; defaults to a sanitised repo name.'),
+  mode: z
+    .enum(['interactive', 'supervised', 'autonomous'])
+    .optional()
+    .describe(
+      "Requested initial mode for the project. Recorded in the result and surfaced to reviewers; the bootstrap workflow does not yet flip the rendered config's mode automatically.",
+    ),
+  rationale: z.string().min(1),
+});
+
 export const CHAT_TOOL_REGISTRY: ChatToolManifestEntry[] = [
   // ── Read-only ────────────────────────────────────────────────────────────
   {
@@ -264,6 +285,13 @@ export const CHAT_TOOL_REGISTRY: ChatToolManifestEntry[] = [
       "Flip the active milestone for a project. Pass null to clear the project_state override and fall back to the project config's milestone.",
     mutating: true,
     inputSchema: SetActiveMilestoneInput,
+  },
+  {
+    name: 'bootstrap_project',
+    description:
+      'Bootstrap a new target project by running the M12 onboarding workflow (detect stack, audit CLAUDE.md, install factory labels, open a registration PR against shaunnez/goose-hub). Opus-tier expensive; approval is critical.',
+    mutating: true,
+    inputSchema: BootstrapProjectInput,
   },
 ];
 


### PR DESCRIPTION
Closes #842

## Summary

`bootstrap_project` chat tool drives the existing `runBootstrapService` (which wraps `bootstrapProject` from `core/workflows/`) so the user can onboard a new target project from chat.

## What landed

- `core/chat-tools/registry.ts` — `bootstrap_project` manifest, `mutating: true`. Accepts `repoUrl`, optional `slug`, optional `mode`, `rationale`.
- `apps/server/src/shared/bootstrap-bridge.ts` — new shared bridge so the chat domain can call the bootstrap service without violating the no-cross-domain-imports rule.
- `apps/server/src/domains/chat/tools.ts` — implementation parses `repoUrl` (HTTPS / `git@` SSH / owner/repo shorthand → canonical `owner/repo`), validates the optional slug override against `isValidSlug`, invokes the bridge, and surfaces the registration PR URL + audit action + label counts.

## Result shape

```
{
  ok: true,
  repoRef: "octo/widgets",
  slug: "widgets",
  status: "created" | "idempotent-skip",
  registrationPrUrl: "https://github.com/shaunnez/goose-hub/pull/N" | null,
  stackSummary: string,
  auditAction: "create" | "update" | "ok",
  labelCounts: { created, updated, skipped },
  requestedMode: "interactive" | "supervised" | "autonomous" | null,
  path: "/projects/<slug>"
}
```

`mode` is captured on the result for review traceability; the underlying bootstrap workflow does not yet flip the rendered config's mode automatically and the registry description documents this.

## Tests

- 5 new `bootstrap_project` cases: HTTPS happy path, SSH + owner/repo shorthand parsing, 400 on unparseable URL, 400 on invalid slug, bridge error status passthrough.
- Registry test extended for the new tool's mutating flag.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 4060 passed, 3 skipped, 279 test files
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_