### PR TITLE
M20.14: chat runs feed agent_run_costs + persona_stats

### DIFF
--- a/apps/web/src/components/costs/StageBar.tsx
+++ b/apps/web/src/components/costs/StageBar.tsx
@@ -9,6 +9,7 @@ const STAGE_LABEL: Record<CostStage, string> = {
   qa: 'QA',
   review: 'Review',
   retrospective: 'Retrospective',
+  chat: 'Chat',
   other: 'Other',
 };
 

--- a/apps/web/src/components/detail/components/CostsSection.tsx
+++ b/apps/web/src/components/detail/components/CostsSection.tsx
@@ -21,6 +21,7 @@ const STAGE_LABEL: Record<CostRowDto['stage'], string> = {
   qa: 'QA',
   review: 'Review',
   retrospective: 'Retrospective',
+  chat: 'Chat',
   other: 'Other',
 };
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -173,6 +173,7 @@ export type CostStage =
   | 'qa'
   | 'review'
   | 'retrospective'
+  | 'chat'
   | 'other';
 
 export interface CostRowDto {

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -57,6 +57,14 @@ export type InvokeSkillInput = {
     freshContextOverride?: boolean;
     /** Skip runtime-owned agent.run-started when caller already emitted the parent marker. */
     suppressRunStarted?: boolean;
+    /**
+     * Fired immediately after `selectPersona()` resolves a persona but before
+     * the spawn. Callers that need to record `persona_stats` on a throw can
+     * stash this and write `outcome: 'failure'` from their catch block — the
+     * augmented `InvokeSkillResult` only returns on successful resolve, so
+     * persona attribution would otherwise be lost on every error path.
+     */
+    onPersonaSelected?: (info: { personaId: string; role: string }) => void;
   };
 };
 
@@ -112,6 +120,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<InvokeSkillR
   // 4. Select persona (round-robin within projectId + role)
   const role = skillConfig.role ?? 'developer';
   const { personaId } = selectPersona(projectId, role);
+  overrides?.onPersonaSelected?.({ personaId, role });
 
   // 5. Resolve budgets — fall back for skills not yet in SKILL_BUDGETS
   const projectConfig =

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -61,6 +61,17 @@ export type InvokeSkillInput = {
 };
 
 /**
+ * Augmented result from `invokeSkill` that surfaces the resolved persona and
+ * role to callers — the orchestrator needs these to write `persona_stats`
+ * (M20.14) without re-running the round-robin selector. `AgentResult` fields
+ * (`output`, `decisionSummaries`, `events`) are preserved unchanged.
+ */
+export interface InvokeSkillResult extends AgentResult {
+  personaId: string;
+  role: string;
+}
+
+/**
  * Canonical entry point for skill-driven agent spawns. Handles the full
  * composer pipeline: config load → context validation → prompt load →
  * persona selection → budget resolution → model resolution → runtime
@@ -72,7 +83,7 @@ export type InvokeSkillInput = {
  *
  * See ADR 0038.
  */
-export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult> {
+export async function invokeSkill(input: InvokeSkillInput): Promise<InvokeSkillResult> {
   const { skillName, projectId, workItemId, runId, context, overrides } = input;
 
   // 1. Load skill config — absolute path import matches loader.ts pattern (tsx-safe)
@@ -180,5 +191,5 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<AgentResult>
     }
   }
 
-  return result;
+  return { ...result, personaId, role };
 }

--- a/core/cost/skill-stage.test.ts
+++ b/core/cost/skill-stage.test.ts
@@ -13,6 +13,10 @@ describe('stageForSkill', () => {
     expect(stageForSkill('retrospective-deep')).toBe('retrospective');
   });
 
+  it('maps hub-chat to the chat stage so dashboards can group it separately', () => {
+    expect(stageForSkill('hub-chat')).toBe('chat');
+  });
+
   it('returns "other" for unknown skills', () => {
     expect(stageForSkill('something-new')).toBe('other');
     expect(stageForSkill('')).toBe('other');

--- a/core/cost/skill-stage.ts
+++ b/core/cost/skill-stage.ts
@@ -24,6 +24,10 @@ const SKILL_TO_STAGE: Record<string, Stage> = {
   review: 'review',
   'retrospective-light': 'retrospective',
   'retrospective-deep': 'retrospective',
+  // M20.14 — chat turns spawn the hub-chat skill via the chat orchestrator.
+  // Group them under their own stage so the costs dashboard separates them
+  // from the workflow pipeline.
+  'hub-chat': 'chat',
 };
 
 export function stageForSkill(skill: string): Stage {

--- a/core/cost/types.ts
+++ b/core/cost/types.ts
@@ -21,6 +21,7 @@ export type Stage =
   | 'qa'
   | 'review'
   | 'retrospective'
+  | 'chat'
   | 'other';
 
 export interface CostRecord {

--- a/slices/chat-orchestrator/slice.test.ts
+++ b/slices/chat-orchestrator/slice.test.ts
@@ -14,10 +14,24 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   },
 }));
 
+// Persona-stats writes touch SQLite; mock to a spy so we can assert against
+// the calls without needing a DB in this slice test.
+vi.mock('@goose-hub/core/persona/accumulate.js', () => ({
+  accumulatePersonaStats: vi.fn(),
+}));
+
 import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import type { Conversation } from '@goose-hub/core/conversations/types.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { runChatOrchestratorTurn } from './workflow.js';
+
+const baseInvokeResult = {
+  personaId: 'auditor-1',
+  role: 'auditor',
+  decisionSummaries: [],
+  events: [],
+};
 
 const stubConversation: Conversation = {
   id: 'conv_test',
@@ -33,14 +47,13 @@ const stubConversation: Conversation = {
 describe('chat-orchestrator slice', () => {
   it('returns a parsed reply when the skill output validates', async () => {
     vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
       output: {
         say: 'Hello there.',
         proposals: [],
         done: false,
         decisionSummaries: [{ kind: 'PLAN', summary: 'Replied to greeting.' }],
       },
-      decisionSummaries: [],
-      events: [],
     });
     const result = await runChatOrchestratorTurn({
       conversation: stubConversation,
@@ -63,6 +76,7 @@ describe('chat-orchestrator slice', () => {
 
   it('drops proposals for unknown tool names', async () => {
     vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
       output: {
         say: 'Doing things.',
         proposals: [
@@ -72,8 +86,6 @@ describe('chat-orchestrator slice', () => {
         done: false,
         decisionSummaries: [{ kind: 'PLAN', summary: 'Proposing two tools.' }],
       },
-      decisionSummaries: [],
-      events: [],
     });
     const result = await runChatOrchestratorTurn({
       conversation: stubConversation,
@@ -85,9 +97,8 @@ describe('chat-orchestrator slice', () => {
 
   it('returns a graceful error message on schema validation failure', async () => {
     vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
       output: { not: 'the right shape' },
-      decisionSummaries: [],
-      events: [],
     });
     const result = await runChatOrchestratorTurn({
       conversation: stubConversation,
@@ -110,14 +121,13 @@ describe('chat-orchestrator slice', () => {
   it('emits chat.agent-thinking checkpoints around the skill invocation', async () => {
     vi.mocked(eventStore.appendEvent).mockClear();
     vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
       output: {
         say: 'sure.',
         proposals: [],
         done: false,
         decisionSummaries: [{ kind: 'PLAN', summary: 'ok.' }],
       },
-      decisionSummaries: [],
-      events: [],
     });
     await runChatOrchestratorTurn({
       conversation: stubConversation,
@@ -155,6 +165,52 @@ describe('chat-orchestrator slice', () => {
     expect(thinkingCalls.map((e) => (e.payload as { checkpoint?: string }).checkpoint)).toEqual([
       'skill-invoked',
     ]);
+  });
+
+  it('writes a success persona-stats row when the run lands a parseable reply', async () => {
+    vi.mocked(accumulatePersonaStats).mockClear();
+    vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
+      personaId: 'auditor-2',
+      role: 'auditor',
+      output: {
+        say: 'Sure.',
+        proposals: [],
+        done: false,
+        decisionSummaries: [{ kind: 'PLAN', summary: 'replied.' }],
+      },
+    });
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_persona_success',
+    });
+    expect(accumulatePersonaStats).toHaveBeenCalledTimes(1);
+    expect(accumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'auditor-2',
+      role: 'auditor',
+      outcome: 'success',
+    });
+  });
+
+  it('writes a failure persona-stats row when the skill output fails validation', async () => {
+    vi.mocked(accumulatePersonaStats).mockClear();
+    vi.mocked(invokeSkill).mockResolvedValueOnce({
+      ...baseInvokeResult,
+      personaId: 'auditor-3',
+      role: 'auditor',
+      output: { not: 'the right shape' },
+    });
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_persona_failure',
+    });
+    expect(accumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'auditor-3',
+      role: 'auditor',
+      outcome: 'failure',
+    });
   });
 
   it('emits chat.run-failed when the skill throws so the thinking indicator clears', async () => {

--- a/slices/chat-orchestrator/slice.test.ts
+++ b/slices/chat-orchestrator/slice.test.ts
@@ -33,6 +33,25 @@ const baseInvokeResult = {
   events: [],
 };
 
+type InvokeArgs = Parameters<typeof invokeSkill>[0];
+
+/**
+ * Mirror the real invokeSkill contract: fire `onPersonaSelected` before the
+ * promise settles so the orchestrator can capture persona attribution and
+ * write `persona_stats` even on a throw. The returned value/throw is chosen
+ * by the caller.
+ */
+function mockInvokeOnce(
+  outcome: { resolve: typeof baseInvokeResult & { output: unknown } } | { reject: Error },
+  selected: { personaId: string; role: string } = baseInvokeResult,
+) {
+  vi.mocked(invokeSkill).mockImplementationOnce(async (input: InvokeArgs) => {
+    input.overrides?.onPersonaSelected?.(selected);
+    if ('reject' in outcome) throw outcome.reject;
+    return outcome.resolve;
+  });
+}
+
 const stubConversation: Conversation = {
   id: 'conv_test',
   scope: 'global',
@@ -46,13 +65,15 @@ const stubConversation: Conversation = {
 
 describe('chat-orchestrator slice', () => {
   it('returns a parsed reply when the skill output validates', async () => {
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      output: {
-        say: 'Hello there.',
-        proposals: [],
-        done: false,
-        decisionSummaries: [{ kind: 'PLAN', summary: 'Replied to greeting.' }],
+    mockInvokeOnce({
+      resolve: {
+        ...baseInvokeResult,
+        output: {
+          say: 'Hello there.',
+          proposals: [],
+          done: false,
+          decisionSummaries: [{ kind: 'PLAN', summary: 'Replied to greeting.' }],
+        },
       },
     });
     const result = await runChatOrchestratorTurn({
@@ -75,16 +96,18 @@ describe('chat-orchestrator slice', () => {
   });
 
   it('drops proposals for unknown tool names', async () => {
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      output: {
-        say: 'Doing things.',
-        proposals: [
-          { toolName: 'list_projects', input: {}, rationale: 'see all projects' },
-          { toolName: 'i_made_this_up', input: {}, rationale: 'nope' },
-        ],
-        done: false,
-        decisionSummaries: [{ kind: 'PLAN', summary: 'Proposing two tools.' }],
+    mockInvokeOnce({
+      resolve: {
+        ...baseInvokeResult,
+        output: {
+          say: 'Doing things.',
+          proposals: [
+            { toolName: 'list_projects', input: {}, rationale: 'see all projects' },
+            { toolName: 'i_made_this_up', input: {}, rationale: 'nope' },
+          ],
+          done: false,
+          decisionSummaries: [{ kind: 'PLAN', summary: 'Proposing two tools.' }],
+        },
       },
     });
     const result = await runChatOrchestratorTurn({
@@ -96,9 +119,11 @@ describe('chat-orchestrator slice', () => {
   });
 
   it('returns a graceful error message on schema validation failure', async () => {
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      output: { not: 'the right shape' },
+    mockInvokeOnce({
+      resolve: {
+        ...baseInvokeResult,
+        output: { not: 'the right shape' },
+      },
     });
     const result = await runChatOrchestratorTurn({
       conversation: stubConversation,
@@ -109,7 +134,7 @@ describe('chat-orchestrator slice', () => {
   });
 
   it('returns reply: null when the runtime throws', async () => {
-    vi.mocked(invokeSkill).mockRejectedValueOnce(new Error('subprocess died'));
+    mockInvokeOnce({ reject: new Error('subprocess died') });
     const result = await runChatOrchestratorTurn({
       conversation: stubConversation,
       history: [],
@@ -120,13 +145,15 @@ describe('chat-orchestrator slice', () => {
 
   it('emits chat.agent-thinking checkpoints around the skill invocation', async () => {
     vi.mocked(eventStore.appendEvent).mockClear();
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      output: {
-        say: 'sure.',
-        proposals: [],
-        done: false,
-        decisionSummaries: [{ kind: 'PLAN', summary: 'ok.' }],
+    mockInvokeOnce({
+      resolve: {
+        ...baseInvokeResult,
+        output: {
+          say: 'sure.',
+          proposals: [],
+          done: false,
+          decisionSummaries: [{ kind: 'PLAN', summary: 'ok.' }],
+        },
       },
     });
     await runChatOrchestratorTurn({
@@ -151,7 +178,7 @@ describe('chat-orchestrator slice', () => {
 
   it('emits the skill-invoked thinking event even when the run later throws', async () => {
     vi.mocked(eventStore.appendEvent).mockClear();
-    vi.mocked(invokeSkill).mockRejectedValueOnce(new Error('boom'));
+    mockInvokeOnce({ reject: new Error('boom') });
     await runChatOrchestratorTurn({
       conversation: stubConversation,
       history: [],
@@ -169,17 +196,22 @@ describe('chat-orchestrator slice', () => {
 
   it('writes a success persona-stats row when the run lands a parseable reply', async () => {
     vi.mocked(accumulatePersonaStats).mockClear();
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      personaId: 'auditor-2',
-      role: 'auditor',
-      output: {
-        say: 'Sure.',
-        proposals: [],
-        done: false,
-        decisionSummaries: [{ kind: 'PLAN', summary: 'replied.' }],
+    mockInvokeOnce(
+      {
+        resolve: {
+          ...baseInvokeResult,
+          personaId: 'auditor-2',
+          role: 'auditor',
+          output: {
+            say: 'Sure.',
+            proposals: [],
+            done: false,
+            decisionSummaries: [{ kind: 'PLAN', summary: 'replied.' }],
+          },
+        },
       },
-    });
+      { personaId: 'auditor-2', role: 'auditor' },
+    );
     await runChatOrchestratorTurn({
       conversation: stubConversation,
       history: [],
@@ -195,12 +227,17 @@ describe('chat-orchestrator slice', () => {
 
   it('writes a failure persona-stats row when the skill output fails validation', async () => {
     vi.mocked(accumulatePersonaStats).mockClear();
-    vi.mocked(invokeSkill).mockResolvedValueOnce({
-      ...baseInvokeResult,
-      personaId: 'auditor-3',
-      role: 'auditor',
-      output: { not: 'the right shape' },
-    });
+    mockInvokeOnce(
+      {
+        resolve: {
+          ...baseInvokeResult,
+          personaId: 'auditor-3',
+          role: 'auditor',
+          output: { not: 'the right shape' },
+        },
+      },
+      { personaId: 'auditor-3', role: 'auditor' },
+    );
     await runChatOrchestratorTurn({
       conversation: stubConversation,
       history: [],
@@ -213,9 +250,50 @@ describe('chat-orchestrator slice', () => {
     });
   });
 
+  it('writes a failure persona-stats row when invokeSkill rejects after persona selection', async () => {
+    vi.mocked(accumulatePersonaStats).mockClear();
+    mockInvokeOnce(
+      { reject: new Error('OutputValidationError: bad shape') },
+      { personaId: 'auditor-4', role: 'auditor' },
+    );
+    await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_persona_reject',
+    });
+    expect(accumulatePersonaStats).toHaveBeenCalledWith({
+      personaName: 'auditor-4',
+      role: 'auditor',
+      outcome: 'failure',
+    });
+  });
+
+  it('still returns a parseable reply when persona-stats telemetry throws', async () => {
+    vi.mocked(accumulatePersonaStats).mockImplementationOnce(() => {
+      throw new Error('sqlite locked');
+    });
+    mockInvokeOnce({
+      resolve: {
+        ...baseInvokeResult,
+        output: {
+          say: 'Replied OK.',
+          proposals: [],
+          done: false,
+          decisionSummaries: [{ kind: 'PLAN', summary: 'replied.' }],
+        },
+      },
+    });
+    const result = await runChatOrchestratorTurn({
+      conversation: stubConversation,
+      history: [],
+      runId: 'chat_test_telemetry_throws',
+    });
+    expect(result.reply?.say).toBe('Replied OK.');
+  });
+
   it('emits chat.run-failed when the skill throws so the thinking indicator clears', async () => {
     vi.mocked(eventStore.appendEvent).mockClear();
-    vi.mocked(invokeSkill).mockRejectedValueOnce(new Error('subprocess died'));
+    mockInvokeOnce({ reject: new Error('subprocess died') });
     await runChatOrchestratorTurn({
       conversation: stubConversation,
       history: [],

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -19,6 +19,7 @@ import type {
 } from '@goose-hub/core/conversations/types.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
+import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import {
   type HubChatOutput,
   HubChatOutputSchema,
@@ -180,8 +181,9 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
 
   emitThinking(conversation, runId, 'skill-invoked');
 
+  let invokeResult: Awaited<ReturnType<typeof invokeSkill>> | null = null;
   try {
-    const result = await invokeSkill({
+    invokeResult = await invokeSkill({
       skillName: 'hub-chat',
       projectId: conversation.projectId ?? 'goose-hub-self',
       workItemId: conversation.workItemId ?? undefined,
@@ -190,11 +192,19 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
       overrides: { modelOverride },
     });
     emitThinking(conversation, runId, 'structured-output-received');
-    const parsed = HubChatOutputSchema.safeParse(result.output);
+    const parsed = HubChatOutputSchema.safeParse(invokeResult.output);
     if (!parsed.success) {
       logger.warn('hub-chat: output validation failed', {
         runId,
         issues: parsed.error.issues,
+      });
+      // M20.14: count this turn as a failure for the picked persona so the
+      // round-robin router can deprioritise personas that keep emitting
+      // unparseable output.
+      accumulatePersonaStats({
+        personaName: invokeResult.personaId,
+        role: invokeResult.role,
+        outcome: 'failure',
       });
       return {
         reply: {
@@ -216,6 +226,11 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
     const validProposals = parsed.data.proposals.filter((p: HubChatProposal) =>
       manifestHas(p.toolName),
     );
+    accumulatePersonaStats({
+      personaName: invokeResult.personaId,
+      role: invokeResult.role,
+      outcome: 'success',
+    });
     return {
       reply: {
         ...parsed.data,
@@ -235,6 +250,16 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
       payload: { conversationId: conversation.id, runId, error: String(err) },
       runId,
     });
+    // Persona-stats failure path only when invokeSkill made it past
+    // selectPersona — pre-spawn ContextValidationError throws before any
+    // persona is picked, so `invokeResult` will still be null and we skip.
+    if (invokeResult != null) {
+      accumulatePersonaStats({
+        personaName: invokeResult.personaId,
+        role: invokeResult.role,
+        outcome: 'failure',
+      });
+    }
     return { reply: null };
   }
 }

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -181,18 +181,45 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
 
   emitThinking(conversation, runId, 'skill-invoked');
 
-  let invokeResult: Awaited<ReturnType<typeof invokeSkill>> | null = null;
+  // Captured the moment `selectPersona()` resolves inside `invokeSkill`, so we
+  // can still attribute persona stats on a post-spawn throw (the resolved
+  // result is never returned in that path).
+  let selectedPersona: { personaId: string; role: string } | null = null;
+
+  // Telemetry write — never let a SQLite hiccup turn a successful chat reply
+  // into a user-visible failure. Persona attribution is best-effort.
+  const tryAccumulate = (outcome: 'success' | 'failure') => {
+    if (selectedPersona == null) return;
+    try {
+      accumulatePersonaStats({
+        personaName: selectedPersona.personaId,
+        role: selectedPersona.role,
+        outcome,
+      });
+    } catch (statsErr) {
+      logger.warn('chat orchestrator: persona stats write failed', {
+        runId,
+        err: String(statsErr),
+      });
+    }
+  };
+
   try {
-    invokeResult = await invokeSkill({
+    const result = await invokeSkill({
       skillName: 'hub-chat',
       projectId: conversation.projectId ?? 'goose-hub-self',
       workItemId: conversation.workItemId ?? undefined,
       runId,
       context,
-      overrides: { modelOverride },
+      overrides: {
+        modelOverride,
+        onPersonaSelected: (info) => {
+          selectedPersona = info;
+        },
+      },
     });
     emitThinking(conversation, runId, 'structured-output-received');
-    const parsed = HubChatOutputSchema.safeParse(invokeResult.output);
+    const parsed = HubChatOutputSchema.safeParse(result.output);
     if (!parsed.success) {
       logger.warn('hub-chat: output validation failed', {
         runId,
@@ -201,11 +228,7 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
       // M20.14: count this turn as a failure for the picked persona so the
       // round-robin router can deprioritise personas that keep emitting
       // unparseable output.
-      accumulatePersonaStats({
-        personaName: invokeResult.personaId,
-        role: invokeResult.role,
-        outcome: 'failure',
-      });
+      tryAccumulate('failure');
       return {
         reply: {
           say: 'I tried to reply but the structured output failed validation. Please try again.',
@@ -226,11 +249,7 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
     const validProposals = parsed.data.proposals.filter((p: HubChatProposal) =>
       manifestHas(p.toolName),
     );
-    accumulatePersonaStats({
-      personaName: invokeResult.personaId,
-      role: invokeResult.role,
-      outcome: 'success',
-    });
+    tryAccumulate('success');
     return {
       reply: {
         ...parsed.data,
@@ -250,16 +269,11 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
       payload: { conversationId: conversation.id, runId, error: String(err) },
       runId,
     });
-    // Persona-stats failure path only when invokeSkill made it past
-    // selectPersona — pre-spawn ContextValidationError throws before any
-    // persona is picked, so `invokeResult` will still be null and we skip.
-    if (invokeResult != null) {
-      accumulatePersonaStats({
-        personaName: invokeResult.personaId,
-        role: invokeResult.role,
-        outcome: 'failure',
-      });
-    }
+    // `selectedPersona` is non-null when the throw happened after
+    // `selectPersona()` ran (OutputValidationError or any runtime throw).
+    // Pre-spawn ContextValidationError throws before the callback fires,
+    // so we skip in that case — there's no persona to penalise.
+    tryAccumulate('failure');
     return { reply: null };
   }
 }


### PR DESCRIPTION
Closes #845

## Summary

Wire chat runs into the cost dashboard and persona-routing tables.

`agent_run_costs` already received a row per hub-chat turn (the Claude/Codex runtime layers call `recordCost()` automatically), but the rows landed under `stage: 'other'` because `hub-chat` wasn't in `SKILL_TO_STAGE`. Add a `chat` stage and map `hub-chat` → `chat` so the costs dashboard can group chat spend separately.

`persona_stats` was missing entirely for chat. `invokeSkill` now returns the resolved `personaId` + `role` alongside its `AgentResult`, and the chat-orchestrator slice calls `accumulatePersonaStats` at each terminal state.

## What landed

| File | Change |
|---|---|
| `core/cost/types.ts` | Add `'chat'` to the `Stage` union. |
| `core/cost/skill-stage.ts` | Map `hub-chat` → `chat`. |
| `core/cost/skill-stage.test.ts` | Regression case for the new mapping. |
| `core/agent-runtime/invoke-skill.ts` | New `InvokeSkillResult` extends `AgentResult` with `personaId` + `role`. Existing callers ignore the extra fields. |
| `slices/chat-orchestrator/workflow.ts` | Capture `invokeResult`, call `accumulatePersonaStats` with `outcome: 'success'` after a parseable reply, `outcome: 'failure'` on schema failure, and on a thrown run only when the persona was actually picked. |
| `slices/chat-orchestrator/slice.test.ts` | Mock `accumulatePersonaStats`; baseInvokeResult fixture; new success + failure persona-stats cases. |
| `apps/web/src/lib/types.ts` + `apps/web/src/components/costs/StageBar.tsx` | UI knows about the new stage and labels it "Chat" in the breakdown bar. |

## Cost wiring

`recordCost()` already runs inside the runtime (`core/agent-runtime/claude-cli.ts:401` and `codex-cli.ts:434`) after every successful spawn. With the new `stageForSkill('hub-chat') === 'chat'`, the row written for a chat turn now carries the correct stage, and the dashboard's per-stage bar groups it separately. `costLabel` is propagated unchanged from the runtime's reported metadata.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 4057 passed, 3 skipped, 279 test files
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_