### PR TITLE
M20.15: conversation list — resume + delete in the chat panel

### DIFF
--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -1,6 +1,8 @@
 import {
   createConversation,
+  deleteConversation,
   fetchConversation,
+  listConversations,
   postMessage,
   resolveInvocation,
 } from '@/lib/api/chat';
@@ -11,7 +13,7 @@ import type {
   ChatRuntime,
   ChatToolInvocationDto,
 } from '@/lib/types';
-import { Bot, X } from 'lucide-react';
+import { Bot, List, MessageCircle, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { deriveThinkingFromEvents, mergeToolStatusFromEvents } from '../lib/liveState';
@@ -19,11 +21,16 @@ import { resolveScopeFromPath } from '../lib/scope';
 import { useChatEvents } from '../lib/useChatEvents';
 import { ChatInput } from './ChatInput';
 import { ChatThread } from './ChatThread';
+import { ConversationList } from './ConversationList';
+
+const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 
 interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
 }
+
+type View = 'thread' | 'list';
 
 export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const location = useLocation();
@@ -31,6 +38,8 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const resolved = useMemo(() => resolveScopeFromPath(location.pathname), [location.pathname]);
 
   const [conversation, setConversation] = useState<ChatConversationDto | null>(null);
+  const [conversations, setConversations] = useState<ChatConversationDto[]>([]);
+  const [view, setView] = useState<View>('list');
   const [messages, setMessages] = useState<ChatMessageDto[]>([]);
   const [invocations, setInvocations] = useState<ChatToolInvocationDto[]>([]);
   const [busy, setBusy] = useState(false);
@@ -38,45 +47,121 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [runtime, setRuntime] = useState<ChatRuntime>('claude');
 
-  // Whenever the panel opens or the scope changes, start (or resume) a
-  // conversation matching the current scope. v1 starts a fresh conversation
-  // each time; conversation listing is a follow-up UI feature.
+  const readActiveId = useCallback((): string | null => {
+    try {
+      return localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const writeActiveId = useCallback((id: string | null) => {
+    try {
+      if (id == null) localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+      else localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, id);
+    } catch {
+      // localStorage unavailable — accept the loss; selection is best-effort.
+    }
+  }, []);
+
+  const loadConversation = useCallback(
+    async (id: string) => {
+      try {
+        const full = await fetchConversation(id);
+        setConversation(full.conversation);
+        setMessages(full.messages);
+        setInvocations(full.invocations);
+        writeActiveId(full.conversation.id);
+        setView('thread');
+      } catch (err) {
+        setError(`Could not load conversation: ${String(err)}`);
+      }
+    },
+    [writeActiveId],
+  );
+
+  // Refresh the conversation roster whenever the panel opens. Don't auto-
+  // create on mount any more; the user picks one or clicks New explicitly
+  // (M20.15 AC).
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     setError(null);
     (async () => {
       try {
-        const conv = await createConversation({
-          scope: resolved.scope,
-          projectSlug: resolved.projectSlug,
-          workItemId: resolved.workItemId,
-          runtime,
-        });
+        const list = await listConversations({});
         if (cancelled) return;
-        setConversation(conv);
-        setMessages([]);
-        setInvocations([]);
+        setConversations(list);
+        const previousId = readActiveId();
+        const previous = list.find((c) => c.id === previousId);
+        if (previous != null) {
+          await loadConversation(previous.id);
+          setView('thread');
+        } else {
+          setConversation(null);
+          setMessages([]);
+          setInvocations([]);
+          setView('list');
+        }
       } catch (err) {
-        if (!cancelled) setError(`Could not start a conversation: ${String(err)}`);
+        if (!cancelled) setError(`Could not load conversations: ${String(err)}`);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [open, resolved.scope, resolved.projectSlug, resolved.workItemId, runtime]);
+  }, [open, readActiveId, loadConversation]);
+
+  const handleNewConversation = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const conv = await createConversation({
+        scope: resolved.scope,
+        projectSlug: resolved.projectSlug,
+        workItemId: resolved.workItemId,
+        runtime,
+      });
+      setConversation(conv);
+      setMessages([]);
+      setInvocations([]);
+      setConversations((prev) => [conv, ...prev.filter((c) => c.id !== conv.id)]);
+      writeActiveId(conv.id);
+      setView('thread');
+    } catch (err) {
+      setError(`Could not start a conversation: ${String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [resolved.scope, resolved.projectSlug, resolved.workItemId, runtime, writeActiveId]);
+
+  const handleDeleteConversation = useCallback(
+    async (id: string) => {
+      setBusy(true);
+      try {
+        await deleteConversation(id);
+        setConversations((prev) => prev.filter((c) => c.id !== id));
+        if (conversation?.id === id) {
+          setConversation(null);
+          setMessages([]);
+          setInvocations([]);
+          writeActiveId(null);
+          setView('list');
+        }
+      } catch (err) {
+        setError(`Delete failed: ${String(err)}`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [conversation, writeActiveId],
+  );
 
   // Subscribe to chat.* events for this conversation. The events drive two
   // render-only behaviours that don't need a network round-trip:
   //   - the "thinking…" indicator between user message and agent reply
   //   - live `running` → `completed`/`failed` status badge updates on tool
   //     cards we already know about
-  //
-  // We deliberately do NOT refetch the conversation on every event tick.
-  // Authoritative reconciliation happens via `postMessage` (after a turn)
-  // and `resolveInvocation` (after an approve/reject). New invocations the
-  // base state hasn't seen yet are still rendered after the next refresh —
-  // tool events for unknown ids are ignored by the merge helper.
   const events = useChatEvents(conversation?.id ?? null);
   const isThinking = useMemo(() => deriveThinkingFromEvents(events), [events]);
   const liveInvocations = useMemo(
@@ -107,17 +192,17 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       setMessages((prev) => [...prev, optimistic]);
       try {
         await postMessage(conversation.id, content);
-        // Authoritative reconciliation — refetch once after the POST settles.
-        // The fetchConversation result is the single source of truth and
-        // already includes the persisted user message, so this replaces the
-        // optimistic row cleanly.
         const full = await fetchConversation(conversation.id);
         setMessages(full.messages);
         setInvocations(full.invocations);
+        setConversation(full.conversation);
+        // Keep the roster fresh (title may have been derived from the first
+        // user message).
+        setConversations((prev) =>
+          prev.map((c) => (c.id === full.conversation.id ? full.conversation : c)),
+        );
       } catch (err) {
         setError(`Send failed: ${String(err)}`);
-        // Roll back the optimistic row on failure so we don't leave a
-        // phantom bubble the server doesn't know about.
         setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
       } finally {
         setBusy(false);
@@ -135,9 +220,6 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         setInvocations((prev) =>
           prev.map((i) => (i.id === res.invocation.id ? res.invocation : i)),
         );
-        // Auto-navigate when the approved tool is open_url. The agent
-        // proposed a navigation intent; approving it should actually navigate
-        // rather than render a second click target.
         if (
           res.invocation.toolName === 'open_url' &&
           res.invocation.status === 'completed' &&
@@ -184,6 +266,10 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     [navigate, onClose],
   );
 
+  const toggleView = useCallback(() => {
+    setView((v) => (v === 'thread' ? 'list' : conversation != null ? 'thread' : 'list'));
+  }, [conversation]);
+
   return (
     <aside
       data-testid="chat-panel"
@@ -198,15 +284,29 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         <Bot size={14} className="text-accent" />
         <h2 className="text-[13px] font-semibold tracking-tight">Hub Chat</h2>
         <span
+          data-testid="chat-scope-chip"
           className="text-[10.5px] uppercase tracking-wider text-fg-2"
           title="Current conversation scope (derived from page)"
         >
           {resolved.label}
         </span>
+        <button
+          type="button"
+          onClick={toggleView}
+          aria-label={view === 'thread' ? 'Show conversations' : 'Show current thread'}
+          data-testid="chat-toggle-view"
+          className={cn(
+            'ml-auto p-1 rounded text-fg-2 hover:text-fg',
+            view === 'list' && 'bg-bg text-fg',
+          )}
+          title={view === 'thread' ? 'Show conversations' : 'Back to thread'}
+        >
+          {view === 'thread' ? <List size={14} /> : <MessageCircle size={14} />}
+        </button>
         <select
           value={runtime}
           onChange={(e) => setRuntime(e.target.value as ChatRuntime)}
-          className="ml-auto bg-bg border border-line rounded text-[11px] px-1 py-0.5"
+          className="bg-bg border border-line rounded text-[11px] px-1 py-0.5"
           title="Runtime"
         >
           <option value="claude">claude</option>
@@ -228,17 +328,30 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         </div>
       )}
 
-      <ChatThread
-        messages={messages}
-        invocations={liveInvocations}
-        pendingDecision={pendingDecision}
-        thinking={isThinking}
-        onApprove={handleApprove}
-        onReject={handleReject}
-        onNavigate={handleNavigate}
-      />
+      {view === 'list' ? (
+        <ConversationList
+          conversations={conversations}
+          activeConversationId={conversation?.id ?? null}
+          busy={busy}
+          onSelect={(id) => loadConversation(id)}
+          onDelete={handleDeleteConversation}
+          onNew={handleNewConversation}
+        />
+      ) : (
+        <ChatThread
+          messages={messages}
+          invocations={liveInvocations}
+          pendingDecision={pendingDecision}
+          thinking={isThinking}
+          onApprove={handleApprove}
+          onReject={handleReject}
+          onNavigate={handleNavigate}
+        />
+      )}
 
-      <ChatInput disabled={busy || conversation == null} onSubmit={sendMessage} />
+      {view === 'thread' && (
+        <ChatInput disabled={busy || conversation == null} onSubmit={sendMessage} />
+      )}
     </aside>
   );
 }

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -14,7 +14,7 @@ import type {
   ChatToolInvocationDto,
 } from '@/lib/types';
 import { Bot, List, MessageCircle, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { deriveThinkingFromEvents, mergeToolStatusFromEvents } from '../lib/liveState';
 import { resolveScopeFromPath } from '../lib/scope';
@@ -46,6 +46,13 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const [pendingDecision, setPendingDecision] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [runtime, setRuntime] = useState<ChatRuntime>('claude');
+  // Monotonic counter the load handlers bump on every new request. Only the
+  // response whose token still matches `loadTokenRef.current` is allowed to
+  // apply state — protects against:
+  //  * rapid A → B clicks where A's response arrives after B's,
+  //  * the open-panel roster effect clobbering a thread the user just clicked
+  //    "New" to create while the list was still in flight.
+  const loadTokenRef = useRef(0);
 
   const readActiveId = useCallback((): string | null => {
     try {
@@ -64,17 +71,29 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     }
   }, []);
 
+  /**
+   * Load a conversation by id. Returns the loaded conversation on success or
+   * `null` on either failure or a stale response (because a newer load
+   * request started in the meantime). Callers use the return value to decide
+   * whether to flip the view to 'thread' — a failed load should NOT force
+   * thread view onto an empty panel.
+   */
   const loadConversation = useCallback(
-    async (id: string) => {
+    async (id: string): Promise<ChatConversationDto | null> => {
+      const token = ++loadTokenRef.current;
       try {
         const full = await fetchConversation(id);
+        if (loadTokenRef.current !== token) return null;
         setConversation(full.conversation);
         setMessages(full.messages);
         setInvocations(full.invocations);
         writeActiveId(full.conversation.id);
         setView('thread');
+        return full.conversation;
       } catch (err) {
+        if (loadTokenRef.current !== token) return null;
         setError(`Could not load conversation: ${String(err)}`);
+        return null;
       }
     },
     [writeActiveId],
@@ -87,17 +106,27 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     if (!open) return;
     let cancelled = false;
     setError(null);
+    // Token snapshot for this open. If `loadTokenRef` advances before we
+    // settle (e.g. user clicked New / picked a row mid-flight), drop our
+    // state writes — the newer interaction is the source of truth now.
+    const openToken = ++loadTokenRef.current;
     (async () => {
       try {
         const list = await listConversations({});
-        if (cancelled) return;
+        if (cancelled || loadTokenRef.current !== openToken) return;
         setConversations(list);
         const previousId = readActiveId();
         const previous = list.find((c) => c.id === previousId);
         if (previous != null) {
-          await loadConversation(previous.id);
-          setView('thread');
+          // loadConversation flips the view + state on its own; we don't
+          // force 'thread' here so a failed restore lands cleanly on 'list'.
+          const restored = await loadConversation(previous.id);
+          if (cancelled) return;
+          if (restored == null) {
+            setView('list');
+          }
         } else {
+          if (cancelled) return;
           setConversation(null);
           setMessages([]);
           setInvocations([]);
@@ -115,6 +144,10 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const handleNewConversation = useCallback(async () => {
     setBusy(true);
     setError(null);
+    // Bumping the token here invalidates any in-flight roster/load response —
+    // they'd otherwise reset the panel back to 'list' after the new
+    // conversation lands.
+    const token = ++loadTokenRef.current;
     try {
       const conv = await createConversation({
         scope: resolved.scope,
@@ -122,6 +155,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         workItemId: resolved.workItemId,
         runtime,
       });
+      if (loadTokenRef.current !== token) return;
       setConversation(conv);
       setMessages([]);
       setInvocations([]);
@@ -129,6 +163,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       writeActiveId(conv.id);
       setView('thread');
     } catch (err) {
+      if (loadTokenRef.current !== token) return;
       setError(`Could not start a conversation: ${String(err)}`);
     } finally {
       setBusy(false);

--- a/apps/web/src/components/chat/components/ConversationList.test.tsx
+++ b/apps/web/src/components/chat/components/ConversationList.test.tsx
@@ -1,0 +1,117 @@
+/** @vitest-environment jsdom */
+import type { ChatConversationDto } from '@/lib/types';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConversationList } from './ConversationList';
+
+afterEach(cleanup);
+
+const noop = () => {};
+
+function conv(overrides: Partial<ChatConversationDto>): ChatConversationDto {
+  return {
+    id: `conv_${Math.random().toString(36).slice(2, 8)}`,
+    scope: 'project',
+    projectId: 'goose-hub-self',
+    workItemId: null,
+    title: '',
+    runtime: 'claude',
+    createdAt: '2026-05-18T00:00:00Z',
+    updatedAt: '2026-05-18T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ConversationList', () => {
+  it('renders the empty state when there are no conversations', () => {
+    render(
+      <ConversationList
+        conversations={[]}
+        activeConversationId={null}
+        busy={false}
+        onSelect={noop}
+        onDelete={noop}
+        onNew={noop}
+      />,
+    );
+    expect(screen.getByText(/No conversations yet/)).toBeTruthy();
+    expect(screen.getByTestId('chat-new-conversation')).toBeTruthy();
+  });
+
+  it('renders rows grouped by scope (item → project → global)', () => {
+    render(
+      <ConversationList
+        conversations={[
+          conv({ id: 'g1', scope: 'global', projectId: null, title: 'Global chat' }),
+          conv({
+            id: 'i1',
+            scope: 'item',
+            projectId: 'goose-hub-self',
+            workItemId: 'github:owner/repo#42',
+            title: 'Item chat',
+          }),
+          conv({ id: 'p1', scope: 'project', title: 'Project chat' }),
+        ]}
+        activeConversationId={null}
+        busy={false}
+        onSelect={noop}
+        onDelete={noop}
+        onNew={noop}
+      />,
+    );
+    const groupLabels = screen.getAllByText(/^(Work item|Project|Global)$/);
+    expect(groupLabels.map((el) => el.textContent)).toEqual(['Work item', 'Project', 'Global']);
+  });
+
+  it('invokes onSelect when a row is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ConversationList
+        conversations={[conv({ id: 'p1', scope: 'project', title: 'Hello' })]}
+        activeConversationId={null}
+        busy={false}
+        onSelect={onSelect}
+        onDelete={noop}
+        onNew={noop}
+      />,
+    );
+    const selectButton = screen.getByTestId('chat-conversation-select');
+    fireEvent.click(selectButton);
+    expect(onSelect).toHaveBeenCalledWith('p1');
+  });
+
+  it('confirms before deleting and calls onDelete only after the confirm click', () => {
+    const onDelete = vi.fn();
+    render(
+      <ConversationList
+        conversations={[conv({ id: 'p1', title: 'doomed' })]}
+        activeConversationId={null}
+        busy={false}
+        onSelect={noop}
+        onDelete={onDelete}
+        onNew={noop}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('chat-conversation-delete'));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-conversation-delete-confirm')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('chat-conversation-delete-confirm'));
+    expect(onDelete).toHaveBeenCalledWith('p1');
+  });
+
+  it('highlights the active conversation row', () => {
+    render(
+      <ConversationList
+        conversations={[conv({ id: 'p1', title: 'one' }), conv({ id: 'p2', title: 'two' })]}
+        activeConversationId="p2"
+        busy={false}
+        onSelect={noop}
+        onDelete={noop}
+        onNew={noop}
+      />,
+    );
+    const rows = screen.getAllByTestId('chat-conversation-row');
+    const p2 = rows.find((r) => r.getAttribute('data-conversation-id') === 'p2');
+    expect(p2?.className).toMatch(/border-accent/);
+  });
+});

--- a/apps/web/src/components/chat/components/ConversationList.tsx
+++ b/apps/web/src/components/chat/components/ConversationList.tsx
@@ -1,0 +1,177 @@
+import { cn } from '@/lib/cn';
+import type { ChatConversationDto } from '@/lib/types';
+import { Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface ConversationListProps {
+  conversations: ChatConversationDto[];
+  activeConversationId: string | null;
+  busy: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onNew: () => void;
+}
+
+/**
+ * Renders the conversation history inline with the panel body. The agent
+ * thread only renders when an active conversation is selected; this is the
+ * "between conversations" view shown otherwise.
+ */
+export function ConversationList({
+  conversations,
+  activeConversationId,
+  busy,
+  onSelect,
+  onDelete,
+  onNew,
+}: ConversationListProps) {
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  // Group by scope so the user can scan project conversations together.
+  const grouped = groupByScope(conversations);
+
+  return (
+    <div data-testid="chat-conversation-list" className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-line bg-bg-elev">
+        <span className="text-[11px] uppercase tracking-wider text-fg-2">
+          Conversations · {conversations.length}
+        </span>
+        <button
+          type="button"
+          onClick={onNew}
+          disabled={busy}
+          data-testid="chat-new-conversation"
+          className={cn(
+            'ml-auto inline-flex items-center gap-1 px-2 py-1 rounded text-[11.5px]',
+            'bg-accent text-bg hover:bg-accent/90 disabled:opacity-50',
+          )}
+        >
+          <Plus size={12} /> New
+        </button>
+      </div>
+      {conversations.length === 0 && (
+        <div className="text-center text-fg-2 text-[12px] py-8">
+          <p className="mb-1">No conversations yet.</p>
+          <p>Click "New" to start one.</p>
+        </div>
+      )}
+      {grouped.map((group) => (
+        <div key={group.label} className="py-2">
+          <div className="px-3 text-[10.5px] uppercase tracking-wider text-fg-3">{group.label}</div>
+          <ul>
+            {group.items.map((c) => (
+              <li
+                key={c.id}
+                data-testid="chat-conversation-row"
+                data-conversation-id={c.id}
+                className={cn(
+                  'mx-2 my-1 rounded-md border border-line bg-bg flex items-stretch',
+                  'hover:bg-bg-hover transition-colors',
+                  activeConversationId === c.id && 'border-accent',
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => onSelect(c.id)}
+                  className="flex-1 min-w-0 text-left px-2.5 py-1.5"
+                  data-testid="chat-conversation-select"
+                  disabled={busy}
+                >
+                  <div className="truncate text-[12.5px] text-fg">
+                    {c.title || '(empty conversation)'}
+                  </div>
+                  <div className="text-[10.5px] text-fg-2 mt-0.5">
+                    {formatScopeRef(c)} · {formatRelative(c.updatedAt)}
+                  </div>
+                </button>
+                {pendingDelete === c.id ? (
+                  <div className="flex items-center gap-1 px-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onDelete(c.id);
+                        setPendingDelete(null);
+                      }}
+                      data-testid="chat-conversation-delete-confirm"
+                      className="text-red-300 text-[11px] hover:text-red-200 px-1.5 py-0.5 rounded bg-red-900/30"
+                    >
+                      Delete?
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDelete(null)}
+                      className="text-fg-2 text-[11px] hover:text-fg px-1.5 py-0.5 rounded"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    aria-label="Delete conversation"
+                    onClick={() => setPendingDelete(c.id)}
+                    data-testid="chat-conversation-delete"
+                    className="px-2 text-fg-2 hover:text-red-300"
+                    disabled={busy}
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ScopeGroup {
+  label: string;
+  items: ChatConversationDto[];
+}
+
+function groupByScope(conversations: ChatConversationDto[]): ScopeGroup[] {
+  const groups = new Map<string, ChatConversationDto[]>();
+  for (const c of conversations) {
+    const key = c.scope;
+    const list = groups.get(key) ?? [];
+    list.push(c);
+    groups.set(key, list);
+  }
+  // Stable order: item → project → global so per-issue threads sit on top.
+  const order: Array<{ key: string; label: string }> = [
+    { key: 'item', label: 'Work item' },
+    { key: 'project', label: 'Project' },
+    { key: 'global', label: 'Global' },
+  ];
+  return order
+    .filter((o) => groups.has(o.key))
+    .map((o) => ({ label: o.label, items: groups.get(o.key) ?? [] }));
+}
+
+function formatScopeRef(c: ChatConversationDto): string {
+  if (c.scope === 'item' && c.projectId && c.workItemId) {
+    return `${c.projectId} ${c.workItemId.split('#').pop() ?? c.workItemId}`;
+  }
+  if (c.scope === 'project' && c.projectId) return c.projectId;
+  return 'global';
+}
+
+function formatRelative(iso: string): string {
+  try {
+    const then = new Date(iso).getTime();
+    const now = Date.now();
+    const delta = Math.max(0, now - then);
+    const minutes = Math.floor(delta / 60_000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d ago`;
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
Closes #846

## Summary

ChatPanel no longer auto-creates a conversation on mount. The panel gains a list/thread toggle plus a sidebar-style conversation list with resume + delete affordances. The active conversation id is persisted in localStorage so closing/reopening the panel resumes the previous thread.

## What landed

- `apps/web/src/components/chat/components/ConversationList.tsx` — new component. Lists conversations grouped by scope (item → project → global), each row shows title (or "(empty conversation)"), scope ref, relative timestamp. Per-row delete confirms inline ("Delete?" → click again to commit). Header carries a "New" button.
- `apps/web/src/components/chat/components/ChatPanel.tsx` — refactored:
  - Removed the auto-create-on-open useEffect.
  - On panel open, calls `listConversations` and reads the persisted active id; resumes that thread when it still exists, otherwise lands on the list view.
  - New `loadConversation`, `handleNewConversation`, `handleDeleteConversation` handlers.
  - Header has a list/thread toggle button (`chat-toggle-view`).
  - Chat input only renders in thread view; the panel reuses the list space when no conversation is active.
- `apps/web/src/components/chat/components/ConversationList.test.tsx` — 5 cases: empty state, scope grouping order, select callback, two-click delete confirm, active-row highlight.

## localStorage key

`hub-chat-active-conversation-id` stores the last selected conversation. The roster fetch on panel-open is the source of truth — if the id no longer exists (e.g. deleted from another tab), the panel falls back to the list view.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 4059 passed, 3 skipped, 280 test files
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_