### PR TITLE
M20.12: per-project agent-context overlay for hub-chat

### DIFF
--- a/target-projects/goose-hub-self/agent-context/README.md
+++ b/target-projects/goose-hub-self/agent-context/README.md
@@ -1,0 +1,55 @@
+# agent-context overlays
+
+Per-skill prompt overlays for the `goose-hub-self` target project. Each
+`<skillName>.md` file in this directory is appended to the corresponding
+skill's base prompt (`skills/<skillName>/prompt.md`) at spawn time via
+`readPromptWithContext(skillName, 'goose-hub-self')` in
+`core/agent-runtime/read-prompt.ts`.
+
+## When to add an overlay
+
+When a skill needs project-specific guidance that doesn't belong in the
+universal `skills/<name>/prompt.md`:
+
+- Project quirks the agent should know about (hot files, naming
+  conventions, anti-patterns).
+- Vocabulary specific to this project (e.g. "the milestone" means the
+  active milestone in `project.config.ts`).
+- Pointers to the right governance / docs (CONTEXT.md, FACTORY_RULES.md).
+
+Keep overlays tight and resolved — they ride alongside the prompt on every
+spawn. Long histories of decisions belong in `docs/adr/`, not here.
+
+## Files
+
+| File | Skill | Purpose |
+|---|---|---|
+| `advise-on-plan.md` | `advise-on-plan` | Advisor pattern reminders |
+| `evidence-post.md` | `evidence-post` | Where evidence goes on this project |
+| `hub-chat.md` | `hub-chat` | Hub Chat assistant project-specific quirks |
+| `implement.md` | `implement` | Dev conventions for this repo |
+| `investigate.md` | `investigate` | Investigation pointers (CONTEXT.md, etc.) |
+| `playwright-repro.md` | `playwright-repro` | Repro spec conventions |
+| `qa.md` | `qa` | Test commands, known noise, slice structure |
+| `spec-author.md` | `spec-author` | Spec authoring conventions |
+
+## How loading works
+
+```ts
+// In core/agent-runtime/read-prompt.ts
+const base = readPrompt(skillName);                      // skills/<name>/prompt.md
+const overlayPath = `target-projects/${projectSlug}/agent-context/${skillName}.md`;
+const overlay = fs.existsSync(overlayPath) ? read(overlayPath) : '';
+return [base, overlay].filter(Boolean).join('\n\n');
+```
+
+Missing overlay files are silently skipped — adding an overlay is opt-in
+per (project, skill).
+
+## Governance status
+
+`target-projects/<slug>/agent-context/*.md` files are **not** in the
+FACTORY_RULES rule-12 governance perimeter. They can be edited by any
+Factory PR. Governance-locked content (`project.config.ts`,
+`MISSION.md`, `FACTORY_RULES.md`, `personas/`) lives elsewhere in this
+directory tree.

--- a/target-projects/goose-hub-self/agent-context/hub-chat.md
+++ b/target-projects/goose-hub-self/agent-context/hub-chat.md
@@ -1,0 +1,43 @@
+## Project quirks for the Hub Chat assistant
+
+The user (Shaun) runs **Goose Hub** — the local-first command centre — and
+operates on a single registered project, `goose-hub-self`, which is also the
+repo you're embedded in. Most chat questions resolve against this project.
+
+## Where things live
+
+| Question | Source of truth |
+|---|---|
+| "Why is X wired this way?" | `CONTEXT.md` (resolved decisions) → `docs/adr/` (long-form ADRs) |
+| "What's the rule about Y?" | `FACTORY_RULES.md` (numbered, currently 1–33) |
+| "What's the active milestone?" | `target-projects/goose-hub-self/project.config.ts` → `activeMilestone` field |
+| "Where's the workflow for state Z?" | `slices/<name>/workflow.ts` first; `core/workflows/` only when 2+ callers |
+| "What skills exist?" | `skills/<name>/` — each has `prompt.md`, `schema.ts`, `skill.config.ts` |
+
+## Naming conventions
+
+- Work item ids: `github:shaunnez/goose-hub#<N>` — always the full form on events; chat shorthand `#N` should be resolved against `goose-hub-self` by default.
+- State labels live on **issues**, never PRs. Labels are `factory:<state>`.
+- PR titles follow `M<milestone>.<task>: <one-line>`, e.g. `M20.16: richer find_pr via GitHub PR search`.
+- Branch convention: `claude/m<milestone>-<task>-<slug>` for milestone work.
+
+## When the user says…
+
+- **"the milestone"** — they mean the value of `activeMilestone` in `goose-hub-self/project.config.ts`. Don't list milestones unless asked.
+- **"what's stuck"** — surface `factory:needs-human`, `factory:gate-pending`, and recent `agent.run-failed` events. `what_needs_human_help` covers this.
+- **"the chat backlog"** — M20 follow-ups under `area:web` / `area:agent-runtime` with `schedule:current`.
+- **"the kanban"** — `/projects/goose-hub-self`. The default landing route.
+
+## Anti-patterns — don't propose these
+
+- **No tools that modify governance files** (`MISSION.md`, `FACTORY_RULES.md`, `CLAUDE.md`, `target-projects/<slug>/project.config.ts`, `target-projects/<slug>/personas/`). Factory PRs can't touch them per FACTORY_RULES rule 12. If the user asks for a change there, reply with a one-liner explaining the rule-12 carve-out and offer to draft the edit as text for them to apply.
+- **No `invoke_skill` for holdouts** — `qa`, `review`, `retro`, `retro-deep` must run from a workflow. The tool rejects these already; don't propose them.
+- **No `tick_project` mid-conversation** without asking — it dispatches whatever the orchestrator picks next, which is rarely what the user meant.
+
+## Hot directories the user refers to often
+
+- `apps/server/src/domains/<name>/` — server routes (router → service → repository layering enforced by `apps/server/STANDARDS.md`).
+- `apps/web/src/components/<name>/` — UI features as vertical slices.
+- `slices/<name>/` — workflow slices, one per orchestrator phase.
+- `skills/<name>/` — versioned agent prompts.
+- `target-projects/<slug>/agent-context/<skillName>.md` — per-project overlays loaded by `readPromptWithContext()`.


### PR DESCRIPTION
Closes #843

## Summary

Adds the per-project hub-chat overlay file the issue asks for, plus a README documenting the overlay mechanism.

`target-projects/goose-hub-self/agent-context/hub-chat.md` is appended to the base hub-chat prompt at spawn time via `readPromptWithContext('hub-chat', 'goose-hub-self')` in `core/agent-runtime/read-prompt.ts`. No code changes required — the hooks were already wired.

## Owner authorization

The user explicitly authorized this content under the FACTORY_RULES rule-12 carve-out. The `agent-context/` tree itself is **not** in the governance perimeter (`isGovernancePath` only flags `project.config.ts`, `personas/**`, `MISSION.md`, `FACTORY_RULES.md`), so this PR doesn't actually need the bootstrap label — the governance CI check should pass.

## What landed

- `target-projects/goose-hub-self/agent-context/hub-chat.md` — project quirks: where to find decisions/rules/milestones, naming conventions, "when the user says X" shorthand resolution, anti-patterns (no governance edits, no holdout invocations, no surprise `tick_project`), hot directories.
- `target-projects/goose-hub-self/agent-context/README.md` — explains the overlay mechanism, when to add one, governance status of the tree.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm audit-docs` clean
- [x] `pnpm manifest --check` clean
- [x] Manual: run hub-chat on goose-hub-self, confirm the overlay content is visible in the loaded prompt (see decision-summary trace).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvp5KHXocr6WaNVrchzPe)_