### PR TITLE
M7.XX: Follow up issue #827 logo fix verification gap

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -27,12 +27,15 @@ The test skips gracefully when `GITHUB_TOKEN` is empty, per #36's acceptance cri
 
 The full state-transition round-trip (POST → GitHub label updated → SSE event arrives → Board card moves lane) is covered manually because the GitHub label flip side-effects a real issue. CI runs the popover-only path for safety.
 
-## Pipeline E2E (`e2e/pipeline/`)
+## Pipeline E2E (`e2e/pipeline/` + `issue-*.spec.ts`)
 
 `pnpm --filter @goose-hub/web test:e2e:pipeline` — runs against MOCK_AGENTS + MOCK_SOURCE + MOCK_OPEN_PR, no real GitHub token required.
 
-This is the canonical QA regression suite. The legacy UI smoke script is kept
-only for explicit manual checks against a real GitHub token.
+This is the canonical QA regression suite. It includes the durable pipeline
+fixtures under `e2e/pipeline/` plus issue-specific regression specs at
+`e2e/issue-*.spec.ts`, so evidence-post and QA stay aligned. The legacy UI
+smoke script is kept only for explicit manual checks against a real GitHub
+token.
 
 Specs:
 - `full-lifecycle.spec.ts` — chore: triaging → done (triage + fix + QA + review + approve)

--- a/apps/web/e2e/issue-861.spec.ts
+++ b/apps/web/e2e/issue-861.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar shows the Goose Hub brand label when expanded', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/projects/goose-hub-self');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('Goose Hub')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-861/step-1.png' });
+});

--- a/apps/web/playwright-e2e-pipeline.config.test.ts
+++ b/apps/web/playwright-e2e-pipeline.config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import pipelineConfig from './playwright-e2e-pipeline.config.js';
+
+describe('playwright-e2e-pipeline config', () => {
+  it('includes issue specs alongside the pipeline regression suite', () => {
+    expect(pipelineConfig.testDir).toBe('./e2e');
+    expect(pipelineConfig.testMatch).toEqual(['pipeline/**/*.spec.ts', 'issue-*.spec.ts']);
+  });
+
+  it('keeps the sandbox-safe pipeline exclusions', () => {
+    expect(pipelineConfig.testIgnore).toContain('**/state-flow.spec.ts');
+  });
+});

--- a/apps/web/playwright-e2e-pipeline.config.ts
+++ b/apps/web/playwright-e2e-pipeline.config.ts
@@ -11,7 +11,8 @@ const MOCK_SERVER_PORT = Number(process.env.MOCK_SERVER_PORT ?? process.env.API_
 process.env.SERVER_URL = `http://localhost:${MOCK_SERVER_PORT}`;
 
 export default defineConfig({
-  testDir: './e2e/pipeline',
+  testDir: './e2e',
+  testMatch: ['pipeline/**/*.spec.ts', 'issue-*.spec.ts'],
   testIgnore: ['**/state-flow.spec.ts'],
   timeout: 120_000,
   expect: { timeout: 30_000 },

--- a/slices/fix-issue/evidence-post-workflow.test.ts
+++ b/slices/fix-issue/evidence-post-workflow.test.ts
@@ -14,6 +14,7 @@ afterEach(() => {
   fs.rmSync(helperWorktree, { recursive: true, force: true });
   fs.rmSync('/tmp/evidence-staging-813', { recursive: true, force: true });
   fs.rmSync('/tmp/evidence-issue-813', { recursive: true, force: true });
+  fs.rmSync('/tmp/evidence-post-outside.spec.ts', { force: true });
 });
 
 function plan() {
@@ -208,5 +209,29 @@ describe('evidence-post workflow helper', () => {
     expect(spawnSync).not.toHaveBeenCalled();
     expect(output.commentUrl).toBeUndefined();
     expect(output.decisionSummaries[0]?.summary).toContain('no AFTER-state assertions');
+  });
+
+  it('rejects evidence specs outside apps/web/e2e before spawning Playwright', () => {
+    const outsideSpecPath = '/tmp/evidence-post-outside.spec.ts';
+    fs.writeFileSync(outsideSpecPath, 'spec');
+
+    const spawnSync = vi.fn(() => ({ status: 0 }));
+
+    const output = runEvidencePostPlan({
+      plan: {
+        ...plan(),
+        specPath: outsideSpecPath,
+      },
+      workspaceDir,
+      issueNumber,
+      repo: 'owner/repo',
+      prNumber: 10,
+      prHeadSha: 'def5678',
+      publisher: { spawnSync: spawnSync as never },
+    });
+
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(output.commentUrl).toBeUndefined();
+    expect(output.decisionSummaries[0]?.summary).toContain('Invalid evidence specPath');
   });
 });

--- a/slices/fix-issue/evidence-post-workflow.ts
+++ b/slices/fix-issue/evidence-post-workflow.ts
@@ -30,6 +30,20 @@ function webSpecPath(specPath: string): string {
   return specPath.startsWith('apps/web/') ? specPath.slice('apps/web/'.length) : specPath;
 }
 
+function materializeEvidenceSpec(workspaceDir: string, specPath: string): string {
+  const webRelativePath = webSpecPath(specPath);
+  const normalizedWebPath = path.normalize(webRelativePath);
+  if (
+    path.isAbsolute(specPath) ||
+    normalizedWebPath.startsWith('..') ||
+    !normalizedWebPath.startsWith(`e2e${path.sep}`)
+  ) {
+    throw new Error(`Invalid evidence specPath: ${specPath}`);
+  }
+
+  return path.join(workspaceDir, 'apps', 'web', normalizedWebPath);
+}
+
 function evidencePath(issueNumber: number, filePath: string): string {
   return `evidence/issue-${issueNumber}/${path.basename(filePath)}`;
 }
@@ -271,7 +285,16 @@ export function runEvidencePostPlan(input: RunEvidencePostPlanInput): EvidencePo
   const stagingDir = `/tmp/evidence-staging-${input.issueNumber}`;
   const resultsPath = path.join(stagingDir, 'pw-results.json');
   const stderrPath = path.join(stagingDir, 'pw-stderr.txt');
-  const absoluteSpecPath = path.join(input.workspaceDir, input.plan.specPath);
+  let absoluteSpecPath: string;
+  let webRelativeSpecPath: string;
+
+  try {
+    absoluteSpecPath = materializeEvidenceSpec(input.workspaceDir, input.plan.specPath);
+    webRelativeSpecPath = webSpecPath(input.plan.specPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failedEvidencePlan(input.plan, message);
+  }
 
   if (input.plan.expectedAssertions.length === 0) {
     return failedEvidencePlan(input.plan, 'Evidence plan declared no AFTER-state assertions');
@@ -293,7 +316,7 @@ export function runEvidencePostPlan(input: RunEvidencePostPlanInput): EvidencePo
         'exec',
         'playwright',
         'test',
-        webSpecPath(input.plan.specPath),
+        webRelativeSpecPath,
         '--config',
         'playwright-evidence.config.ts',
         '--reporter=json',


### PR DESCRIPTION
## Summary

Follow up issue #827 logo fix verification gap

## Files
- `apps/web/playwright-e2e-pipeline.config.ts` — include issue regression specs in the pipeline suite
- `apps/web/playwright-e2e-pipeline.config.test.ts` — lock the pipeline glob contract with regression tests
- `apps/web/e2e/issue-861.spec.ts` — exercise the sidebar/logo surface for the follow-up regression
- `apps/web/e2e/README.md` — document that issue specs now run in the pipeline suite
- `slices/fix-issue/evidence-post-workflow.ts` — reject unsafe evidence spec paths before spawning Playwright
- `slices/fix-issue/evidence-post-workflow.test.ts` — cover the new evidence-path safety guard

## Tests
- `apps/web/playwright-e2e-pipeline.config.test.ts` (2 cases)
- `slices/fix-issue/evidence-post-workflow.test.ts` (1 cases)
- `apps/web/e2e/issue-861.spec.ts` (1 cases)

Closes #861
