### PR TITLE
M7.XX: Goose hub logo new

### DIFF
--- a/apps/web/e2e/issue-865.spec.ts
+++ b/apps/web/e2e/issue-865.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar brand label shows GOOSEHUB', async ({ page }) => {
+  await page.route('**/api/projects', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        projects: [
+          {
+            id: 'goose-hub-self',
+            name: 'Goose Hub (self)',
+            slug: 'goose-hub-self',
+            color: '#7c3aed',
+            source: { kind: 'local', repo: 'goose-hub' },
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/projects/configs', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configs: [] }),
+    });
+  });
+
+  await page.goto('/settings');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('GOOSEHUB')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-865/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GOOSEHUB
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,8 +17,12 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "GOOSEHUB"', () => {
+    expect(sidebarSource).toContain('GOOSEHUB');
+  });
+
+  it('sidebar header does not read "Goose Hub"', () => {
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {


### PR DESCRIPTION
## Summary

Goose hub logo new

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — changed the visible sidebar brand label to the required GOOSEHUB copy
- `apps/web/src/components/chrome/slice.test.ts` — updated the chrome slice guard to catch the stale Goose Hub branding
- `apps/web/e2e/issue-865.spec.ts` — added Playwright evidence coverage for the visible sidebar brand label

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (3 cases)
- `apps/web/e2e/issue-865.spec.ts` (1 cases)

Closes #865
