### PR TITLE
Add per-skill effort and runtime profiler

### DIFF
--- a/apps/server/src/domains/project-settings/router.test.ts
+++ b/apps/server/src/domains/project-settings/router.test.ts
@@ -18,6 +18,7 @@ const {
   mockWriteProjectReviewSettings,
   mockWriteProjectSettings,
   mockWriteProjectSkillSetting,
+  mockProfileRuntimeProject,
 } = vi.hoisted(() => ({
   mockDeleteProjectSkillSetting: vi.fn(),
   mockGetUseInvestigationSwarm: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockWriteProjectReviewSettings: vi.fn(),
   mockWriteProjectSettings: vi.fn(),
   mockWriteProjectSkillSetting: vi.fn(),
+  mockProfileRuntimeProject: vi.fn(),
 }));
 
 vi.mock('#shared/projects.js', () => ({
@@ -63,6 +65,10 @@ vi.mock('@goose-hub/core/db/repositories/project-review-settings.js', () => ({
   parseReviewerSlots: mockParseReviewerSlots,
   readProjectReviewSettings: mockReadProjectReviewSettings,
   writeProjectReviewSettings: mockWriteProjectReviewSettings,
+}));
+
+vi.mock('@goose-hub/core/runtime-profiler/profile-runs.js', () => ({
+  profileRuntimeProject: mockProfileRuntimeProject,
 }));
 
 import { projectSettingsRouter } from './router.js';
@@ -94,6 +100,15 @@ describe('project settings router', () => {
     mockParseReviewerSlots.mockReturnValue(null);
     mockGetUseMultiAgentPipeline.mockReturnValue(false);
     mockGetUseInvestigationSwarm.mockReturnValue(true);
+    mockProfileRuntimeProject.mockReturnValue({
+      projectId: 'goose-hub-self',
+      window: {
+        days: 14,
+        sinceIso: '2026-05-06T00:00:00.000Z',
+        untilIso: '2026-05-20T00:00:00.000Z',
+      },
+      skills: [],
+    });
   });
 
   it('does not expose the removed role-model settings route', async () => {
@@ -110,6 +125,22 @@ describe('project settings router', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
       loginCommand: 'codex login',
+    });
+  });
+
+  it('returns observed runtime profiler data for the project', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/runtime-profiler?days=7&skill=qa');
+
+    expect(res.status).toBe(200);
+    expect(mockProfileRuntimeProject).toHaveBeenCalledWith({
+      projectId: 'goose-hub-self',
+      days: 7,
+      skill: 'qa',
+    });
+    expect(await res.json()).toMatchObject({
+      projectId: 'goose-hub-self',
+      skills: [],
     });
   });
 
@@ -155,6 +186,23 @@ describe('project settings router', () => {
     );
   });
 
+  it('writes effort patches to project_skill_settings', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings/skills/repo-match', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ effort: 'high' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteProjectSkillSetting).toHaveBeenCalledWith(
+      'goose-hub-self',
+      'repo-match',
+      { effort: 'high' },
+      'ui',
+    );
+  });
+
   it('resolves per-skill DB tier/provider above project config and skill defaults', async () => {
     mockGetProject.mockResolvedValue({
       ...project(),
@@ -173,6 +221,7 @@ describe('project settings router', () => {
             skillName: 'repo-match',
             modelTier: 'sonnet',
             modelProvider: 'codex',
+            effort: 'xhigh',
             updatedAt: '2026-05-18T00:00:00Z',
           },
         ],
@@ -188,6 +237,7 @@ describe('project settings router', () => {
           source: string;
           effectiveTier: string;
           effectiveProvider: string;
+          effectiveEffort: string | null;
           resolvedPrimary: { modelId: string };
         }
       >;
@@ -197,6 +247,7 @@ describe('project settings router', () => {
       source: 'db',
       effectiveTier: 'sonnet',
       effectiveProvider: 'codex',
+      effectiveEffort: 'xhigh',
       resolvedPrimary: { modelId: 'gpt-5.4' },
     });
   });

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -27,7 +27,8 @@ import {
   writeProjectSettings,
   writeProjectSkillSetting,
 } from '@goose-hub/core/db/repositories/project-settings.js';
-import type { ModelProvider, ModelTier, Role } from '@goose-hub/core/types.js';
+import { profileRuntimeProject } from '@goose-hub/core/runtime-profiler/profile-runs.js';
+import type { ModelProvider, ModelTier, Role, RuntimeEffort } from '@goose-hub/core/types.js';
 import { skillsRoot } from '@goose-hub/skills';
 import { Hono } from 'hono';
 import { z } from 'zod';
@@ -56,6 +57,7 @@ const SkillBudgetPatchSchema = z.object({
   timeoutMs: z.number().int().min(5_000).max(3_600_000).nullable().optional(),
   modelTier: z.enum(['haiku', 'sonnet', 'opus']).nullable().optional(),
   provider: z.enum(['claude', 'codex']).nullable().optional(),
+  effort: z.enum(['low', 'medium', 'high', 'xhigh']).nullable().optional(),
 });
 
 const DevReviewPatchSchema = z.object({
@@ -81,6 +83,11 @@ const ReviewPatchSchema = z.object({
 const PipelinePatchSchema = z.object({
   useMultiAgentPipeline: z.boolean().optional(),
   useInvestigationSwarm: z.boolean().optional(),
+});
+
+const RuntimeProfilerQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(90).optional(),
+  skill: z.string().min(1).optional(),
 });
 
 const SKILL_CALLERS: Record<string, string[]> = {
@@ -252,6 +259,7 @@ router.get('/:slug/settings', async (c) => {
       timeoutMs: number | null;
       modelTier: string | null;
       provider: string | null;
+      effort: RuntimeEffort | null;
       updatedAt: string | null;
     }
   > = {};
@@ -262,6 +270,13 @@ router.get('/:slug/settings', async (c) => {
       timeoutMs: row.timeoutMs ?? null,
       modelTier: row.modelTier ?? null,
       provider: row.modelProvider ?? null,
+      effort:
+        row.effort === 'low' ||
+        row.effort === 'medium' ||
+        row.effort === 'high' ||
+        row.effort === 'xhigh'
+          ? row.effort
+          : null,
       updatedAt: row.updatedAt,
     };
   }
@@ -277,6 +292,7 @@ router.get('/:slug/settings', async (c) => {
       timeoutMs: number;
       modelTier: string;
       modelProvider: string;
+      effort: RuntimeEffort | null;
     }
   > = {};
   const skillMetadata: Record<
@@ -295,6 +311,7 @@ router.get('/:slug/settings', async (c) => {
       timeoutMs: budget.timeoutMs,
       modelTier: budget.modelTier,
       modelProvider: hint?.provider ?? budget.provider ?? 'claude',
+      effort: budget.effort ?? null,
     };
     skillMetadata[skill] = {
       description: hint?.description ?? null,
@@ -309,6 +326,7 @@ router.get('/:slug/settings', async (c) => {
       source: string;
       effectiveTier: string;
       effectiveProvider: string;
+      effectiveEffort: RuntimeEffort | null;
       resolvedPrimary: unknown;
       resolvedFallback: unknown;
       resolvedAdvisor: unknown;
@@ -332,6 +350,7 @@ router.get('/:slug/settings', async (c) => {
       source: resolved.source,
       effectiveTier: resolved.tier,
       effectiveProvider: resolved.provider,
+      effectiveEffort: resolved.effort ?? null,
       resolvedPrimary: resolved.resolvedPrimary,
       resolvedFallback: resolved.resolvedFallback,
       resolvedAdvisor: resolved.resolvedAdvisor,
@@ -472,6 +491,29 @@ router.get('/:slug/settings/codex-auth', async (c) => {
     authPath,
     loginCommand: 'codex login',
   });
+});
+
+/** GET /projects/:slug/runtime-profiler — observed read-only runtime tuning data */
+router.get('/:slug/runtime-profiler', async (c) => {
+  const slug = c.req.param('slug');
+  const project = await getProject(slug);
+  if (project == null) return c.json({ error: 'project not found' }, 404);
+
+  const parsed = RuntimeProfilerQuerySchema.safeParse({
+    days: c.req.query('days'),
+    skill: c.req.query('skill'),
+  });
+  if (!parsed.success) {
+    return c.json({ error: 'invalid query', details: parsed.error.issues }, 422);
+  }
+
+  return c.json(
+    profileRuntimeProject({
+      projectId: project.id,
+      days: parsed.data.days,
+      skill: parsed.data.skill,
+    }),
+  );
 });
 
 /** GET /projects/:slug/settings/dev-review — merged view of config + DB override */

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
@@ -1,0 +1,117 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProjectBudgetPanel } from './ProjectBudgetPanel';
+
+vi.mock('@/lib/api', () => ({
+  deleteSkillBudgetSetting: vi.fn(),
+  fetchCodexAuthStatus: vi.fn().mockResolvedValue({
+    status: 'connected',
+    authPath: '/Users/test/.codex/auth.json',
+    loginCommand: 'codex login',
+  }),
+  fetchProjectSettings: vi.fn().mockResolvedValue({
+    projectId: 'goose-hub-self',
+    configBudgets: {},
+    dbGlobalOverrides: null,
+    dbPipelineFlags: null,
+    dbSkillOverrides: {
+      qa: {
+        maxTurns: null,
+        maxBudgetUsd: null,
+        timeoutMs: null,
+        modelTier: null,
+        provider: null,
+        effort: 'high',
+        updatedAt: '2026-05-20T00:00:00Z',
+      },
+    },
+    registeredSkills: ['qa'],
+    skillMetadata: {
+      qa: { description: 'Holdout QA check.', dependencies: ['prDiff'], callers: ['QA gate'] },
+    },
+    skillDefaults: {
+      qa: {
+        maxTurns: 100,
+        maxBudgetUsd: 3,
+        timeoutMs: 600000,
+        modelTier: 'sonnet',
+        modelProvider: 'claude',
+        effort: null,
+      },
+    },
+    resolvedSkillRuntimes: {
+      qa: {
+        source: 'db',
+        effectiveTier: 'sonnet',
+        effectiveProvider: 'claude',
+        effectiveEffort: 'high',
+        resolvedPrimary: { tier: 'sonnet', provider: 'claude', modelId: 'claude-sonnet' },
+        resolvedFallback: null,
+        resolvedAdvisor: null,
+      },
+    },
+  }),
+  fetchRuntimeProfiler: vi.fn().mockResolvedValue({
+    projectId: 'goose-hub-self',
+    window: {
+      days: 14,
+      sinceIso: '2026-05-06T00:00:00.000Z',
+      untilIso: '2026-05-20T00:00:00.000Z',
+    },
+    skills: [
+      {
+        skill: 'qa',
+        metrics: {
+          runCount: 6,
+          medianInputTokens: 1000,
+          p95InputTokens: 2000,
+          medianOutputTokens: 500,
+          p95OutputTokens: 700,
+          medianCostUsd: 0.1,
+          p95CostUsd: 0.3,
+          maxCostOutlier: { runId: 'r1', costUsd: 0.3 },
+          timeoutRate: 0,
+          budgetExceededRate: 0,
+          schemaValidationRetryRate: 0,
+          toolCallCount: 4,
+          topToolNames: [{ name: 'Read', count: 4 }],
+          repeatedBashCommands: [],
+          commonCommandSequences: [],
+        },
+        recommendations: [
+          {
+            kind: 'lower-runtime',
+            severity: 'info',
+            summary: 'This skill looks stable and inexpensive.',
+            evidence: 'p95 cost is $0.3000 across 6 runs.',
+          },
+        ],
+      },
+    ],
+  }),
+  patchGlobalBudgetSettings: vi.fn(),
+  patchSkillBudgetSetting: vi.fn(),
+  resetAllProjectBudgets: vi.fn(),
+}));
+
+afterEach(() => cleanup());
+
+describe('ProjectBudgetPanel', () => {
+  it('renders per-skill effort and observed runtime profile recommendations', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ProjectBudgetPanel slug="goose-hub-self" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Observed runtime profile')).toBeTruthy());
+    expect(screen.getByDisplayValue('high')).toBeTruthy();
+    expect(await screen.findByText('This skill looks stable and inexpensive.')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -2,15 +2,23 @@ import {
   deleteSkillBudgetSetting,
   fetchCodexAuthStatus,
   fetchProjectSettings,
+  fetchRuntimeProfiler,
   patchGlobalBudgetSettings,
   patchSkillBudgetSetting,
   resetAllProjectBudgets,
 } from '@/lib/api';
-import type { CodexAuthStatusDto, ModelProvider, ModelTier, ProjectSettingsDto } from '@/lib/types';
+import type {
+  CodexAuthStatusDto,
+  ModelProvider,
+  ModelTier,
+  ProjectSettingsDto,
+  RuntimeEffort,
+  RuntimeProfilerDto,
+} from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Copy, RotateCcw, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 interface Props {
   slug: string;
@@ -58,6 +66,7 @@ const GLOBAL_FIELDS: Array<{
 
 const TIERS: ModelTier[] = ['haiku', 'sonnet', 'opus'];
 const PROVIDERS: ModelProvider[] = ['claude', 'codex'];
+const EFFORTS: RuntimeEffort[] = ['low', 'medium', 'high', 'xhigh'];
 
 function NumericInput({
   value,
@@ -121,12 +130,14 @@ function RuntimeSelect({
   options,
   defaultValue,
   overridden,
+  subtitle,
   onCommit,
 }: {
   value: string | null;
   options: string[];
   defaultValue?: string;
   overridden: boolean;
+  subtitle?: string;
   onCommit: (val: string | null) => void;
 }) {
   return (
@@ -153,6 +164,9 @@ function RuntimeSelect({
       </div>
       {defaultValue != null && (
         <span className="text-[10px] text-fg-3 font-mono break-words">default: {defaultValue}</span>
+      )}
+      {subtitle != null && subtitle !== '' && (
+        <span className="text-[10px] text-fg-3 font-mono break-words">{subtitle}</span>
       )}
     </div>
   );
@@ -278,6 +292,103 @@ function CodexAuthSection({ slug }: { slug: string }) {
   );
 }
 
+function RuntimeProfilerSection({
+  slug,
+  settings,
+}: {
+  slug: string;
+  settings: ProjectSettingsDto;
+}) {
+  const { data, isLoading } = useQuery<RuntimeProfilerDto>({
+    queryKey: ['runtime-profiler', slug],
+    queryFn: ({ signal }) => fetchRuntimeProfiler(slug, signal),
+    staleTime: 60_000,
+  });
+
+  return (
+    <section>
+      <h3 className="text-[12px] font-semibold uppercase tracking-wider text-fg-2 mb-3">
+        Observed runtime profile
+      </h3>
+      <p className="text-[11px] text-fg-3 mb-4">
+        Read-only recommendations from recent run history. Suggested changes are context, not
+        auto-applied.
+      </p>
+      {isLoading ? (
+        <div className="border-y border-line px-3 py-4 text-[12px] text-fg-3">
+          Loading observed profile…
+        </div>
+      ) : data == null || data.skills.length === 0 ? (
+        <div className="border-y border-line px-3 py-4 text-[12px] text-fg-3">
+          No observed runs in the last 14 days.
+        </div>
+      ) : (
+        <div className="border-y border-line text-[12px]">
+          {data.skills.slice(0, 12).map((entry) => {
+            const current = settings.resolvedSkillRuntimes?.[entry.skill];
+            return (
+              <div key={entry.skill} className="border-b border-line/50 px-3 py-3 last:border-b-0">
+                <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <span className="block font-mono text-[12px] text-fg break-all leading-snug">
+                      {entry.skill}
+                    </span>
+                    <div className="mt-1 flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-[11px] text-fg-3">
+                      <span>{entry.metrics.runCount} runs</span>
+                      <span>p95 ${entry.metrics.p95CostUsd.toFixed(2)}</span>
+                      <span>p95 in {entry.metrics.p95InputTokens.toLocaleString()} tok</span>
+                      <span>p95 out {entry.metrics.p95OutputTokens.toLocaleString()} tok</span>
+                    </div>
+                  </div>
+                  <div className="min-w-0 text-right text-[11px] text-fg-3">
+                    <div>
+                      Current:{' '}
+                      <span className="font-mono text-fg">
+                        {current?.effectiveProvider ?? 'unknown'}:
+                        {current?.effectiveTier ?? 'unknown'}
+                      </span>
+                    </div>
+                    <div>
+                      Effort:{' '}
+                      <span className="font-mono text-fg">
+                        {current?.effectiveEffort ?? 'default'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-2 flex min-w-0 flex-wrap gap-2 text-[11px]">
+                  <ProfilerMetric label="timeout" value={entry.metrics.timeoutRate} />
+                  <ProfilerMetric label="budget" value={entry.metrics.budgetExceededRate} />
+                  <ProfilerMetric label="schema" value={entry.metrics.schemaValidationRetryRate} />
+                  <span className="text-fg-3">{entry.metrics.toolCallCount} tool calls</span>
+                </div>
+                {entry.recommendations.length > 0 && (
+                  <div className="mt-2 flex min-w-0 flex-col gap-1">
+                    {entry.recommendations.slice(0, 3).map((rec) => (
+                      <div key={`${rec.kind}-${rec.summary}`} className="min-w-0 text-[11px]">
+                        <span className="font-medium text-fg">{rec.summary}</span>{' '}
+                        <span className="text-fg-3">{rec.evidence}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ProfilerMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <span className={value > 0 ? 'text-warning' : 'text-fg-3'}>
+      {label} {Math.round(value * 100)}%
+    </span>
+  );
+}
+
 export function ProjectBudgetPanel({ slug }: Props) {
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery<ProjectSettingsDto>({
@@ -359,15 +470,11 @@ export function ProjectBudgetPanel({ slug }: Props) {
             const dbVal = dbGlobal?.[key] ?? null;
             const isOverridden = dbVal != null;
             return (
-              <>
-                <span
-                  key={`${key}-label`}
-                  className="text-[12px] text-fg-2 flex items-center gap-1.5 pt-1"
-                >
+              <Fragment key={key}>
+                <span className="text-[12px] text-fg-2 flex items-center gap-1.5 pt-1">
                   {label}
                 </span>
                 <NumericInput
-                  key={`${key}-input`}
                   value={dbVal}
                   placeholder={configVal != null ? String(configVal) : '—'}
                   isFloat={isFloat}
@@ -375,7 +482,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                   subtitle={configVal != null ? `default: ${configVal}` : null}
                   onCommit={(val) => patchGlobal.mutate({ [key]: val })}
                 />
-              </>
+              </Fragment>
             );
           })}
         </div>
@@ -403,7 +510,8 @@ export function ProjectBudgetPanel({ slug }: Props) {
                 row.maxBudgetUsd != null ||
                 row.timeoutMs != null ||
                 row.modelTier != null ||
-                row.provider != null);
+                row.provider != null ||
+                row.effort != null);
             return (
               <div
                 key={skill}
@@ -493,6 +601,25 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       }
                     />
                   </SkillRuntimeField>
+                  <SkillRuntimeField label="Effort">
+                    <RuntimeSelect
+                      value={row?.effort ?? null}
+                      options={EFFORTS}
+                      defaultValue={defaults?.effort ?? undefined}
+                      overridden={row?.effort != null}
+                      subtitle={
+                        (resolved?.effectiveProvider ?? defaults?.modelProvider) === 'claude'
+                          ? 'display only for Claude'
+                          : undefined
+                      }
+                      onCommit={(val) =>
+                        patchSkill.mutate({
+                          skill,
+                          patch: { effort: val as RuntimeEffort | null },
+                        })
+                      }
+                    />
+                  </SkillRuntimeField>
                   <SkillRuntimeField label="Primary" wide>
                     <RuntimeModelCell value={resolved?.resolvedPrimary} />
                   </SkillRuntimeField>
@@ -508,6 +635,8 @@ export function ProjectBudgetPanel({ slug }: Props) {
           })}
         </div>
       </section>
+
+      <RuntimeProfilerSection slug={slug} settings={data} />
     </div>
   );
 }

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -7,6 +7,8 @@ import type {
   ProjectSettingsDto,
   ReviewSettingsDto,
   ReviewerSlot,
+  RuntimeEffort,
+  RuntimeProfilerDto,
   WorkflowCatalogDto,
 } from '../types.js';
 import { deleteRequest, getJson, patchJson } from './client.js';
@@ -34,6 +36,7 @@ export async function patchSkillBudgetSetting(
     timeoutMs: number | null;
     modelTier: ModelTier | null;
     provider: ModelProvider | null;
+    effort: RuntimeEffort | null;
   }>,
 ): Promise<void> {
   await patchJson(`/projects/${slug}/settings/skills/${encodeURIComponent(skill)}`, patch);
@@ -53,6 +56,13 @@ export async function fetchCodexAuthStatus(
   signal?: AbortSignal,
 ): Promise<CodexAuthStatusDto> {
   return getJson<CodexAuthStatusDto>(`/projects/${slug}/settings/codex-auth`, signal);
+}
+
+export async function fetchRuntimeProfiler(
+  slug: string,
+  signal?: AbortSignal,
+): Promise<RuntimeProfilerDto> {
+  return getJson<RuntimeProfilerDto>(`/projects/${slug}/runtime-profiler?days=14`, signal);
 }
 
 export async function fetchDevReviewSettings(

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -391,6 +391,7 @@ export interface ProjectSettingsDto {
       timeoutMs: number | null;
       modelTier: ModelTier | null;
       provider: ModelProvider | null;
+      effort: RuntimeEffort | null;
       updatedAt: string;
     }
   >;
@@ -412,6 +413,7 @@ export interface ProjectSettingsDto {
       timeoutMs: number;
       modelTier: ModelTier;
       modelProvider: ModelProvider;
+      effort: RuntimeEffort | null;
     }
   >;
   resolvedSkillRuntimes?: Record<
@@ -420,11 +422,48 @@ export interface ProjectSettingsDto {
       source: string;
       effectiveTier: ModelTier;
       effectiveProvider: ModelProvider;
+      effectiveEffort: RuntimeEffort | null;
       resolvedPrimary: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedFallback: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedAdvisor: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
     }
   >;
+}
+
+export interface RuntimeProfilerDto {
+  projectId: string;
+  window: {
+    days: number;
+    sinceIso: string;
+    untilIso: string;
+  };
+  skills: Array<{
+    skill: string;
+    metrics: {
+      runCount: number;
+      medianInputTokens: number;
+      p95InputTokens: number;
+      medianOutputTokens: number;
+      p95OutputTokens: number;
+      medianCostUsd: number;
+      p95CostUsd: number;
+      maxCostOutlier: { runId: string; costUsd: number } | null;
+      timeoutRate: number;
+      budgetExceededRate: number;
+      schemaValidationRetryRate: number;
+      toolCallCount: number;
+      topToolNames: Array<{ name: string; count: number }>;
+      repeatedBashCommands: Array<{ command: string; count: number }>;
+      commonCommandSequences: Array<{ sequence: string[]; count: number }>;
+    };
+    recommendations: Array<{
+      kind: string;
+      severity: 'info' | 'warning' | 'critical';
+      summary: string;
+      evidence: string;
+      suggestedPatch?: Record<string, unknown>;
+    }>;
+  }>;
 }
 
 export type WorkflowKind = 'bug' | 'feature' | 'chore' | 'research';
@@ -533,6 +572,7 @@ export interface WorkflowCatalogDto {
 
 export type ModelTier = 'haiku' | 'sonnet' | 'opus';
 export type ModelProvider = 'claude' | 'codex';
+export type RuntimeEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface CodexAuthStatusDto {
   status: 'connected' | 'missing';

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -1,4 +1,4 @@
-import type { ModelProvider, ModelTier } from '../types.js';
+import type { ModelProvider, ModelTier, RuntimeEffort } from '../types.js';
 import type { AgentBudgets } from './interface.js';
 import { defaultModelForTierAndProvider } from './models.js';
 
@@ -7,6 +7,8 @@ export interface SkillBudget {
   maxBudgetUsd: number;
   timeoutMs: number;
   modelTier: ModelTier;
+  /** Runtime reasoning effort. Only enforced by runtimes that support it. */
+  effort?: RuntimeEffort | null;
   /** Default provider for this skill. Omit for Claude (the default). */
   provider?: ModelProvider;
   /**
@@ -239,6 +241,8 @@ export interface ResolvedBudget {
   budgets: AgentBudgets;
   /** Resolved model ID — maps directly to AgentSpec.modelOverride. */
   modelOverride: string;
+  /** Runtime reasoning effort when configured. Unsupported runtimes ignore it. */
+  effort?: RuntimeEffort;
 }
 
 /** DB-sourced per-skill override. Passed in by callers that have a projectId. */
@@ -248,6 +252,11 @@ export interface DbSkillOverride {
   timeoutMs?: number | null;
   modelTier?: ModelTier | string | null;
   modelProvider?: string | null;
+  effort?: RuntimeEffort | string | null;
+}
+
+function isRuntimeEffort(value: unknown): value is RuntimeEffort {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh';
 }
 
 /**
@@ -297,6 +306,7 @@ export function resolveBudgets(
     ...(dbOverride?.maxTurns != null ? { maxTurns: dbOverride.maxTurns } : {}),
     ...(dbOverride?.maxBudgetUsd != null ? { maxBudgetUsd: dbOverride.maxBudgetUsd } : {}),
     ...(dbOverride?.timeoutMs != null ? { timeoutMs: dbOverride.timeoutMs } : {}),
+    ...(isRuntimeEffort(dbOverride?.effort) ? { effort: dbOverride.effort } : {}),
   };
 
   const effectivePerWorkflowCap = dbPerWorkflowMaxUsd ?? projectBudgets?.perWorkflowMaxUsd;
@@ -310,9 +320,11 @@ export function resolveBudgets(
     maxBudgetUsd = effectivePerAgentCap;
   }
 
+  const effort = isRuntimeEffort(merged.effort) ? merged.effort : undefined;
   return {
     budgets: { maxTurns: merged.maxTurns, maxBudgetUsd, timeoutMs: merged.timeoutMs },
     modelOverride: defaultModelForTierAndProvider(merged.modelTier, 'claude'),
+    ...(effort != null ? { effort } : {}),
   };
 }
 
@@ -360,8 +372,10 @@ export function resolveEscalatedBudgets(
     maxBudgetUsd = effectivePerAgentCap;
   }
 
+  const effort = isRuntimeEffort(override?.effort) ? override.effort : undefined;
   return {
     budgets: { maxTurns, maxBudgetUsd, timeoutMs },
     modelOverride: defaultModelForTierAndProvider(escalation.modelTier, 'claude'),
+    ...(effort != null ? { effort } : {}),
   };
 }

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -139,6 +139,16 @@ describe('CodexCliRuntime timeout handling', () => {
     expect(call?.systemPrompt).toContain('skill prompt body');
   });
 
+  it('forwards AgentSpec effort into Codex argv construction', async () => {
+    await runSuccessfulCodexSpec({ effort: 'high' });
+
+    expect(buildCodexArgv).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effort: 'high',
+      }),
+    );
+  });
+
   it('does not use danger-full-access for QA even though QA includes validate', async () => {
     await runSuccessfulCodexSpec({
       skill: 'qa',

--- a/core/agent-runtime/codex-cli.test.ts
+++ b/core/agent-runtime/codex-cli.test.ts
@@ -39,6 +39,19 @@ describe('buildCodexArgv', () => {
       '<task></task>',
     ]);
   });
+
+  it('passes configured reasoning effort as a Codex config override', () => {
+    const argv = buildCodexArgv({
+      model: 'gpt-5.4',
+      workspaceDir: '/tmp/worktree',
+      prompt: '<task></task>',
+      effort: 'xhigh',
+    });
+
+    expect(argv).toContain('-c');
+    expect(argv).toContain('model_reasoning_effort="xhigh"');
+    expect(argv.at(-1)).toBe('<task></task>');
+  });
 });
 
 // ─── parseCodexEnvelope ───────────────────────────────────────────────────────

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -155,6 +155,7 @@ export class CodexCliRuntime implements AgentRuntime {
       workspaceDir,
       prompt: contextXml,
       systemPrompt: withFactoryRuntimeInstructions(spec.appendSystemPrompt),
+      effort: spec.effort,
       maxTurns: spec.budgets.maxTurns,
       commandSandbox: needsBrowserProcessAccess ? 'danger-full-access' : undefined,
       approvalPolicy: needsBrowserProcessAccess ? 'never' : undefined,

--- a/core/agent-runtime/codex-config.ts
+++ b/core/agent-runtime/codex-config.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import type { RuntimeEffort } from '../types.js';
 
 const CODEX_AUTH_PATH = join(homedir(), '.codex', 'auth.json');
 
@@ -123,6 +124,7 @@ export function buildCodexArgv(input: {
   workspaceDir: string;
   prompt: string;
   systemPrompt?: string;
+  effort?: RuntimeEffort;
   /** Reserved for future use; Codex `exec --json` does not currently accept turn caps. */
   maxTurns?: number;
   /** Optional Codex CLI sandbox mode for model-generated shell commands. */
@@ -156,6 +158,9 @@ export function buildCodexArgv(input: {
     // TOML multi-line basic string (triple-quoted) so prompts can carry raw
     // newlines without escaping; only `\` and any embedded `"""` need escape.
     argv.push('-c', `instructions="""${escapeForTomlMultilineBasic(input.systemPrompt)}"""`);
+  }
+  if (input.effort != null) {
+    argv.push('-c', `model_reasoning_effort=${tomlString(input.effort)}`);
   }
   if (input.inlineConfig != null && input.inlineConfig.length > 0) {
     argv.push(...input.inlineConfig);

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -1,6 +1,6 @@
 import type { ZodType } from 'zod';
 import type { AgentEvent } from '../event-stream/store.js';
-import type { ModelTier, Role } from '../types.js';
+import type { ModelTier, Role, RuntimeEffort } from '../types.js';
 import type { DecisionKind } from './decision-types.js';
 
 export interface DecisionSummary {
@@ -36,6 +36,8 @@ export type AgentSpec<R extends RoleSpec = RoleSpec> = {
   toolBundles: string[];
   toolExtras: string[];
   budgets: AgentBudgets;
+  /** Runtime reasoning effort when the selected backend supports it. Unsupported runtimes ignore it. */
+  effort?: RuntimeEffort;
   /** Persona identity for this run. Format: "<projectId>/<role>/<index>". Required. */
   personaId: string;
   /** Work-item driving this run. Promotes context.workItemId to first-class for runtime use. */

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -175,6 +175,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<InvokeSkillR
     toolBundles: skillConfig.toolBundles,
     toolExtras: [],
     budgets: resolved.budgets,
+    effort: resolved.effort,
     personaId,
     workItemId,
     modelOverride,

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -147,6 +147,7 @@ export async function runOneScout(
     toolBundles: ['read'],
     toolExtras: [],
     budgets,
+    effort: resolvedBudget.effort,
     personaId: ctx.personaId,
     modelOverride: resolvedBudget.modelOverride,
     appendSystemPrompt: skillAssets?.appendSystemPrompt,

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -44,6 +44,27 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.modelOverride).toBe('claude-opus-4-7');
   });
 
+  it('resolves effort with DB above project config and skill defaults', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      projectBudgets: { skillBudgetOverrides: { 'repo-match': { effort: 'medium' } } },
+      dbOverride: { effort: 'xhigh' },
+    });
+
+    expect(resolved.source).toBe('db');
+    expect(resolved.effort).toBe('xhigh');
+  });
+
+  it('keeps effort displayable when the effective provider is Claude', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { effort: 'high', modelProvider: 'claude' },
+    });
+
+    expect(resolved.provider).toBe('claude');
+    expect(resolved.effort).toBe('high');
+  });
+
   it('lets per-skill DB model/provider override skill defaults', () => {
     const resolved = resolveSkillRuntime({
       skill: 'investigate',

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -55,6 +55,18 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.effort).toBe('xhigh');
   });
 
+  it('keeps DB source attribution when DB tier wins but effort comes from config', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      projectBudgets: { skillBudgetOverrides: { 'repo-match': { effort: 'medium' } } },
+      dbOverride: { modelTier: 'opus' },
+    });
+
+    expect(resolved.source).toBe('db');
+    expect(resolved.tier).toBe('opus');
+    expect(resolved.effort).toBe('medium');
+  });
+
   it('keeps effort displayable when the effective provider is Claude', () => {
     const resolved = resolveSkillRuntime({
       skill: 'repo-match',

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -3,7 +3,7 @@ import {
   readProjectSettings,
   readProjectSkillSettings,
 } from '../db/repositories/project-settings.js';
-import type { BudgetConfig, ModelProvider, ModelTier, Role } from '../types.js';
+import type { BudgetConfig, ModelProvider, ModelTier, Role, RuntimeEffort } from '../types.js';
 import type { ResolvedBudget, SkillBudgetOverride } from './budgets.js';
 import { SKILL_BUDGETS, resolveBudgets } from './budgets.js';
 import { defaultModelForTierAndProvider, providerOf, tierOf } from './models.js';
@@ -17,6 +17,7 @@ export interface SkillRuntimeDbOverride {
   timeoutMs?: number | null;
   modelTier?: ModelTier | string | null;
   modelProvider?: ModelProvider | string | null;
+  effort?: RuntimeEffort | string | null;
 }
 
 export interface ResolvedDisplayModel {
@@ -32,6 +33,7 @@ export interface ResolvedSkillRuntime extends ResolvedBudget {
   resolvedPrimary: ResolvedDisplayModel;
   resolvedFallback: ResolvedDisplayModel | null;
   resolvedAdvisor: ResolvedDisplayModel | null;
+  effort?: RuntimeEffort;
 }
 
 const TIER_ORDER: ModelTier[] = ['haiku', 'sonnet', 'opus'];
@@ -42,6 +44,10 @@ function isModelTier(value: unknown): value is ModelTier {
 
 function isModelProvider(value: unknown): value is ModelProvider {
   return value === 'claude' || value === 'codex';
+}
+
+function isRuntimeEffort(value: unknown): value is RuntimeEffort {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh';
 }
 
 export function lowerTier(tier: ModelTier): ModelTier {
@@ -68,7 +74,12 @@ function sourceForSkill(
   skill: string,
   dbOverride?: SkillRuntimeDbOverride | null,
 ): SkillRuntimeSource {
-  if (isModelTier(dbOverride?.modelTier) || isModelProvider(dbOverride?.modelProvider)) return 'db';
+  if (
+    isModelTier(dbOverride?.modelTier) ||
+    isModelProvider(dbOverride?.modelProvider) ||
+    isRuntimeEffort(dbOverride?.effort)
+  )
+    return 'db';
   if (SKILL_BUDGETS[skill] != null) return 'skill-default';
   return 'fallback';
 }
@@ -106,6 +117,25 @@ function withoutConfigModelTier(
     skillBudgetOverrides[skill] = rest;
   }
   return { ...projectBudgets, skillBudgetOverrides };
+}
+
+function resolveEffort(input: {
+  skill: string;
+  projectBudgets?: Pick<BudgetConfig, 'skillBudgetOverrides'>;
+  dbOverride?: SkillRuntimeDbOverride | null;
+}): { effort?: RuntimeEffort; source: SkillRuntimeSource | null } {
+  if (isRuntimeEffort(input.dbOverride?.effort)) {
+    return { effort: input.dbOverride.effort, source: 'db' };
+  }
+  const configEffort = input.projectBudgets?.skillBudgetOverrides?.[input.skill]?.effort;
+  if (isRuntimeEffort(configEffort)) {
+    return { effort: configEffort, source: 'config' };
+  }
+  const skillEffort = SKILL_BUDGETS[input.skill]?.effort;
+  if (isRuntimeEffort(skillEffort)) {
+    return { effort: skillEffort, source: sourceForSkill(input.skill, input.dbOverride) };
+  }
+  return { source: null };
 }
 
 export function resolveSkillRuntime(input: {
@@ -159,6 +189,7 @@ export function resolveSkillRuntime(input: {
       resolvedPrimary: { tier, provider, modelId: input.callerModelOverride },
       resolvedFallback: null,
       resolvedAdvisor: null,
+      effort: resolvedBudget.effort,
     };
   }
 
@@ -180,7 +211,14 @@ export function resolveSkillRuntime(input: {
   const modelOverride = defaultModelForTierAndProvider(tier, provider);
   const supportsFallback = SKILL_BUDGETS[input.skill]?.escalation != null;
   const supportsAdvisor = input.skill === 'implement' || input.skill === 'write-prd';
-  const source = isModelProvider(dbOverride?.modelProvider) ? 'db' : tierResult.source;
+  const effortResult = resolveEffort({
+    skill: input.skill,
+    projectBudgets: input.projectBudgets,
+    dbOverride,
+  });
+  const source = isModelProvider(dbOverride?.modelProvider)
+    ? 'db'
+    : (effortResult.source ?? tierResult.source);
 
   return {
     ...resolvedBudget,
@@ -193,6 +231,7 @@ export function resolveSkillRuntime(input: {
       !isHoldout && supportsFallback ? displayModel(lowerTier(tier), provider) : null,
     resolvedAdvisor:
       !isHoldout && supportsAdvisor ? displayModel(higherTier(tier), provider) : null,
+    ...(effortResult.effort != null ? { effort: effortResult.effort } : {}),
   };
 }
 

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -216,9 +216,10 @@ export function resolveSkillRuntime(input: {
     projectBudgets: input.projectBudgets,
     dbOverride,
   });
-  const source = isModelProvider(dbOverride?.modelProvider)
-    ? 'db'
-    : (effortResult.source ?? tierResult.source);
+  const source =
+    isModelProvider(dbOverride?.modelProvider) || tierResult.source === 'db'
+      ? 'db'
+      : (effortResult.source ?? tierResult.source);
 
   return {
     ...resolvedBudget,

--- a/core/db/migrations/0033_project_skill_settings_effort.sql
+++ b/core/db/migrations/0033_project_skill_settings_effort.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `project_skill_settings` ADD `effort` text;

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1779200000001,
       "tag": "0032_chat_invocation_run_id",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1779286400000,
+      "tag": "0033_project_skill_settings_effort",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/repositories/project-settings.ts
+++ b/core/db/repositories/project-settings.ts
@@ -29,6 +29,7 @@ export type SkillBudgetPatch = {
   timeoutMs?: number | null;
   modelTier?: string | null;
   modelProvider?: string | null;
+  effort?: string | null;
 };
 
 export function readProjectSettings(projectId: string): ProjectSettingsRow | null {

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -295,6 +295,7 @@ export const projectSkillSettings = sqliteTable(
     timeoutMs: integer('timeout_ms'),
     modelTier: text('model_tier'),
     modelProvider: text('model_provider'),
+    effort: text('effort'),
     updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
     updatedBy: text('updated_by'),
   },

--- a/core/runtime-profiler/profile-runs.test.ts
+++ b/core/runtime-profiler/profile-runs.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { profileRuntimeRows } from './profile-runs.js';
+
+describe('profileRuntimeRows', () => {
+  it('aggregates token/cost percentiles and tool patterns by skill', () => {
+    const report = profileRuntimeRows({
+      projectId: 'p1',
+      days: 14,
+      untilIso: '2026-05-20T00:00:00.000Z',
+      runs: [
+        run('r1', 'qa', 100, 20, 0.1),
+        run('r2', 'qa', 300, 50, 0.4),
+        run('r3', 'qa', 200, 40, 0.2),
+      ],
+      events: [
+        tool('r1', 'Bash', 'pnpm test'),
+        tool('r1', 'Bash', 'pnpm test'),
+        tool('r2', 'Bash', 'pnpm test'),
+        tool('r2', 'Read'),
+        { runId: 'r2', kind: 'tool.timeout', payload: {}, createdAt: '2026-05-19T00:00:00Z' },
+      ],
+    });
+
+    const qa = report.skills[0];
+    expect(qa?.skill).toBe('qa');
+    expect(qa?.metrics.runCount).toBe(3);
+    expect(qa?.metrics.medianInputTokens).toBe(200);
+    expect(qa?.metrics.p95CostUsd).toBe(0.4);
+    expect(qa?.metrics.timeoutRate).toBeCloseTo(1 / 3);
+    expect(qa?.metrics.repeatedBashCommands[0]).toEqual({ command: 'pnpm test', count: 3 });
+    expect(qa?.recommendations.some((rec) => rec.kind === 'workflow-helper')).toBe(true);
+  });
+
+  it('filters to a requested skill before producing recommendations', () => {
+    const report = profileRuntimeRows({
+      projectId: 'p1',
+      days: 7,
+      untilIso: '2026-05-20T00:00:00.000Z',
+      skill: 'triage',
+      runs: [run('r1', 'qa', 100, 20, 0.1), run('r2', 'triage', 50, 10, 0.01)],
+      events: [tool('r1', 'Bash', 'pnpm test'), tool('r2', 'Read')],
+    });
+
+    expect(report.skills.map((entry) => entry.skill)).toEqual(['triage']);
+  });
+});
+
+function run(
+  runId: string,
+  skill: string,
+  inputTokens: number,
+  outputTokens: number,
+  costUsd: number,
+) {
+  return {
+    runId,
+    projectId: 'p1',
+    skill,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    createdAt: '2026-05-19T00:00:00Z',
+  };
+}
+
+function tool(runId: string, toolName: string, command?: string) {
+  return {
+    runId,
+    kind: 'agent.tool-call',
+    payload: { tool_name: toolName, command },
+    createdAt: '2026-05-19T00:00:00Z',
+  };
+}

--- a/core/runtime-profiler/profile-runs.test.ts
+++ b/core/runtime-profiler/profile-runs.test.ts
@@ -67,7 +67,7 @@ function tool(runId: string, toolName: string, command?: string) {
   return {
     runId,
     kind: 'agent.tool-call',
-    payload: { tool_name: toolName, command },
+    payload: { tool_name: toolName, tool_input: command == null ? {} : { command } },
     createdAt: '2026-05-19T00:00:00Z',
   };
 }

--- a/core/runtime-profiler/profile-runs.ts
+++ b/core/runtime-profiler/profile-runs.ts
@@ -141,9 +141,7 @@ function buildMetrics(
       sequence.push(toolName);
       sequencesByRun.set(event.runId, sequence);
       if (toolName === 'Bash') {
-        const command = normalizeCommand(
-          payload.command ?? payload.redacted_tool_input ?? payload.input,
-        );
+        const command = normalizeCommand(commandFromToolPayload(payload));
         if (command !== '') bashCommands.set(command, (bashCommands.get(command) ?? 0) + 1);
       }
     }
@@ -206,6 +204,17 @@ function commonSequences(
 function toolNameFromPayload(payload: Record<string, unknown>): string {
   const raw = payload.tool_name ?? payload.toolName ?? payload.name;
   return typeof raw === 'string' && raw !== '' ? raw : 'unknown';
+}
+
+function commandFromToolPayload(payload: Record<string, unknown>): unknown {
+  const toolInput = payloadRecord(payload.tool_input ?? payload.toolInput);
+  return (
+    toolInput.command ??
+    toolInput.cmd ??
+    payload.command ??
+    payload.redacted_tool_input ??
+    payload.input
+  );
 }
 
 function normalizeCommand(value: unknown): string {

--- a/core/runtime-profiler/profile-runs.ts
+++ b/core/runtime-profiler/profile-runs.ts
@@ -1,0 +1,233 @@
+import { and, eq, gte } from 'drizzle-orm';
+import { db } from '../db/db.js';
+import { events, agentRunCosts } from '../db/schema.js';
+import { recommendRuntimeProfile } from './recommendations.js';
+import type {
+  RuntimeProfilerEventRow,
+  RuntimeProfilerMetrics,
+  RuntimeProfilerReport,
+  RuntimeProfilerRunRow,
+  RuntimeSkillProfile,
+} from './types.js';
+
+export function profileRuntimeRows(input: {
+  projectId: string;
+  days: number;
+  untilIso: string;
+  runs: RuntimeProfilerRunRow[];
+  events: RuntimeProfilerEventRow[];
+  skill?: string;
+}): RuntimeProfilerReport {
+  const sinceIso = new Date(
+    Date.parse(input.untilIso) - input.days * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const runs =
+    input.skill == null ? input.runs : input.runs.filter((run) => run.skill === input.skill);
+  const bySkill = new Map<string, RuntimeProfilerRunRow[]>();
+  for (const run of runs) {
+    const group = bySkill.get(run.skill) ?? [];
+    group.push(run);
+    bySkill.set(run.skill, group);
+  }
+
+  const skills: RuntimeSkillProfile[] = [...bySkill.entries()]
+    .map(([skill, skillRuns]) => {
+      const runIds = new Set(skillRuns.map((run) => run.runId));
+      const skillEvents = input.events.filter(
+        (event) => event.runId != null && runIds.has(event.runId),
+      );
+      const metrics = buildMetrics(skillRuns, skillEvents);
+      return {
+        skill,
+        metrics,
+        recommendations: recommendRuntimeProfile({ skill, metrics }),
+      };
+    })
+    .sort((a, b) => b.metrics.p95CostUsd - a.metrics.p95CostUsd || a.skill.localeCompare(b.skill));
+
+  return {
+    projectId: input.projectId,
+    window: { days: input.days, sinceIso, untilIso: input.untilIso },
+    skills,
+  };
+}
+
+export function profileRuntimeProject(input: {
+  projectId: string;
+  days?: number;
+  skill?: string;
+}): RuntimeProfilerReport {
+  const days = clampDays(input.days);
+  const untilIso = new Date().toISOString();
+  const sinceIso = new Date(Date.parse(untilIso) - days * 24 * 60 * 60 * 1000).toISOString();
+  const runs = db
+    .select({
+      runId: agentRunCosts.runId,
+      projectId: agentRunCosts.projectId,
+      skill: agentRunCosts.skill,
+      inputTokens: agentRunCosts.inputTokens,
+      outputTokens: agentRunCosts.outputTokens,
+      costUsd: agentRunCosts.costUsd,
+      createdAt: agentRunCosts.createdAt,
+    })
+    .from(agentRunCosts)
+    .where(
+      and(eq(agentRunCosts.projectId, input.projectId), gte(agentRunCosts.createdAt, sinceIso)),
+    )
+    .all();
+  const eventRows = db
+    .select({
+      runId: events.runId,
+      kind: events.kind,
+      payload: events.payload,
+      createdAt: events.createdAt,
+    })
+    .from(events)
+    .where(and(eq(events.projectId, input.projectId), gte(events.createdAt, sinceIso)))
+    .all()
+    .map((event) => ({
+      ...event,
+      payload: parsePayload(event.payload),
+    }));
+
+  return profileRuntimeRows({
+    projectId: input.projectId,
+    days,
+    untilIso,
+    runs,
+    events: eventRows,
+    skill: input.skill,
+  });
+}
+
+function buildMetrics(
+  runs: RuntimeProfilerRunRow[],
+  eventsForRuns: RuntimeProfilerEventRow[],
+): RuntimeProfilerMetrics {
+  const runCount = runs.length;
+  const inputTokens = runs.map((run) => run.inputTokens);
+  const outputTokens = runs.map((run) => run.outputTokens);
+  const costs = runs.map((run) => run.costUsd);
+  const maxRun = [...runs].sort((a, b) => b.costUsd - a.costUsd)[0] ?? null;
+  const timeoutRuns = new Set<string>();
+  const budgetRuns = new Set<string>();
+  const schemaRuns = new Set<string>();
+  const toolCounts = new Map<string, number>();
+  const bashCommands = new Map<string, number>();
+  const sequencesByRun = new Map<string, string[]>();
+
+  for (const event of eventsForRuns) {
+    if (event.runId == null) continue;
+    const payload = payloadRecord(event.payload);
+    if (event.kind === 'tool.timeout' || String(payload.reason ?? '').includes('timeout')) {
+      timeoutRuns.add(event.runId);
+    }
+    if (event.kind === 'agent.budget-exceeded') {
+      budgetRuns.add(event.runId);
+    }
+    if (
+      event.kind === 'agent.retry-escalated' ||
+      event.kind === 'agent.output-repaired' ||
+      String(payload.reason ?? '')
+        .toLowerCase()
+        .includes('schema')
+    ) {
+      schemaRuns.add(event.runId);
+    }
+    if (event.kind === 'agent.tool-call') {
+      const toolName = toolNameFromPayload(payload);
+      toolCounts.set(toolName, (toolCounts.get(toolName) ?? 0) + 1);
+      const sequence = sequencesByRun.get(event.runId) ?? [];
+      sequence.push(toolName);
+      sequencesByRun.set(event.runId, sequence);
+      if (toolName === 'Bash') {
+        const command = normalizeCommand(
+          payload.command ?? payload.redacted_tool_input ?? payload.input,
+        );
+        if (command !== '') bashCommands.set(command, (bashCommands.get(command) ?? 0) + 1);
+      }
+    }
+  }
+
+  return {
+    runCount,
+    medianInputTokens: percentile(inputTokens, 0.5),
+    p95InputTokens: percentile(inputTokens, 0.95),
+    medianOutputTokens: percentile(outputTokens, 0.5),
+    p95OutputTokens: percentile(outputTokens, 0.95),
+    medianCostUsd: percentile(costs, 0.5),
+    p95CostUsd: percentile(costs, 0.95),
+    maxCostOutlier: maxRun == null ? null : { runId: maxRun.runId, costUsd: maxRun.costUsd },
+    timeoutRate: rate(timeoutRuns.size, runCount),
+    budgetExceededRate: rate(budgetRuns.size, runCount),
+    schemaValidationRetryRate: rate(schemaRuns.size, runCount),
+    toolCallCount: [...toolCounts.values()].reduce((sum, count) => sum + count, 0),
+    topToolNames: topEntries(toolCounts, 5).map(([name, count]) => ({ name, count })),
+    repeatedBashCommands: topEntries(bashCommands, 5)
+      .filter(([, count]) => count > 1)
+      .map(([command, count]) => ({ command, count })),
+    commonCommandSequences: commonSequences(sequencesByRun),
+  };
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(p * sorted.length) - 1);
+  return sorted[index] ?? 0;
+}
+
+function rate(count: number, total: number): number {
+  return total === 0 ? 0 : count / total;
+}
+
+function topEntries(map: Map<string, number>, limit: number): Array<[string, number]> {
+  return [...map.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, limit);
+}
+
+function commonSequences(
+  sequencesByRun: Map<string, string[]>,
+): Array<{ sequence: string[]; count: number }> {
+  const counts = new Map<string, { sequence: string[]; count: number }>();
+  for (const sequence of sequencesByRun.values()) {
+    if (sequence.length < 2) continue;
+    const compact = sequence.slice(0, 6);
+    const key = compact.join('\u001f');
+    const current = counts.get(key) ?? { sequence: compact, count: 0 };
+    current.count += 1;
+    counts.set(key, current);
+  }
+  return [...counts.values()]
+    .filter((entry) => entry.count > 1)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+}
+
+function toolNameFromPayload(payload: Record<string, unknown>): string {
+  const raw = payload.tool_name ?? payload.toolName ?? payload.name;
+  return typeof raw === 'string' && raw !== '' ? raw : 'unknown';
+}
+
+function normalizeCommand(value: unknown): string {
+  const raw = typeof value === 'string' ? value : value != null ? JSON.stringify(value) : '';
+  return raw.replace(/\s+/g, ' ').trim().slice(0, 240);
+}
+
+function payloadRecord(payload: unknown): Record<string, unknown> {
+  return payload != null && typeof payload === 'object' && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : {};
+}
+
+function parsePayload(payload: string): unknown {
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return {};
+  }
+}
+
+function clampDays(days: number | undefined): number {
+  if (days == null || !Number.isFinite(days)) return 14;
+  return Math.min(90, Math.max(1, Math.trunc(days)));
+}

--- a/core/runtime-profiler/recommendations.ts
+++ b/core/runtime-profiler/recommendations.ts
@@ -1,0 +1,100 @@
+import type { RuntimeProfilerMetrics, RuntimeProfilerRecommendation } from './types.js';
+
+export function recommendRuntimeProfile(input: {
+  skill: string;
+  metrics: RuntimeProfilerMetrics;
+}): RuntimeProfilerRecommendation[] {
+  const { skill, metrics } = input;
+  const recommendations: RuntimeProfilerRecommendation[] = [];
+
+  if (metrics.timeoutRate >= 0.2) {
+    recommendations.push({
+      kind: 'timeout',
+      severity: metrics.timeoutRate >= 0.4 ? 'critical' : 'warning',
+      summary: 'Timeout rate is high for this skill.',
+      evidence: `${percent(metrics.timeoutRate)} of observed runs timed out.`,
+      suggestedPatch: { timeoutMs: 'increase' },
+    });
+  }
+
+  if (metrics.budgetExceededRate >= 0.1) {
+    recommendations.push({
+      kind: 'budget',
+      severity: metrics.budgetExceededRate >= 0.25 ? 'critical' : 'warning',
+      summary: 'Budget pressure is visible in run history.',
+      evidence: `${percent(metrics.budgetExceededRate)} of observed runs hit a budget gate.`,
+      suggestedPatch: { effort: 'lower', modelTier: 'lower', maxBudgetUsd: 'review' },
+    });
+  }
+
+  if (metrics.schemaValidationRetryRate >= 0.15) {
+    recommendations.push({
+      kind: 'schema-validation',
+      severity: 'warning',
+      summary: 'Schema repair or retry events are common.',
+      evidence: `${percent(metrics.schemaValidationRetryRate)} of observed runs needed repair or retry.`,
+      suggestedPatch: { effort: 'higher' },
+    });
+  }
+
+  const bashCount = metrics.topToolNames.find((tool) => tool.name === 'Bash')?.count ?? 0;
+  if (metrics.runCount > 0 && bashCount / metrics.runCount >= 12) {
+    recommendations.push({
+      kind: 'tool-discipline',
+      severity: 'info',
+      summary: 'This skill leans heavily on shell exploration.',
+      evidence: `${bashCount} Bash calls across ${metrics.runCount} runs.`,
+    });
+  }
+
+  const repeated = metrics.repeatedBashCommands[0];
+  if (repeated != null && repeated.count >= 3) {
+    recommendations.push({
+      kind: 'workflow-helper',
+      severity: 'info',
+      summary: 'A repeated command pattern may deserve a deterministic helper.',
+      evidence: `${repeated.count} repeats of: ${repeated.command}`,
+    });
+  }
+
+  if (
+    metrics.runCount >= 5 &&
+    metrics.p95CostUsd <= 0.2 &&
+    metrics.timeoutRate === 0 &&
+    metrics.budgetExceededRate === 0 &&
+    metrics.schemaValidationRetryRate === 0
+  ) {
+    recommendations.push({
+      kind: 'lower-runtime',
+      severity: 'info',
+      summary: 'This skill looks stable and inexpensive.',
+      evidence: `p95 cost is $${metrics.p95CostUsd.toFixed(4)} across ${metrics.runCount} runs.`,
+      suggestedPatch: { effort: 'low', modelTier: 'lower' },
+    });
+  }
+
+  if (skill === 'qa' && hasE2eSequence(metrics)) {
+    recommendations.push({
+      kind: 'qa-e2e-boundary',
+      severity: 'warning',
+      summary: 'QA appears to be running browser/e2e commands.',
+      evidence: 'Observed command sequences include Playwright, browser, or e2e terms.',
+    });
+  }
+
+  return recommendations;
+}
+
+function hasE2eSequence(metrics: RuntimeProfilerMetrics): boolean {
+  const text = [
+    ...metrics.commonCommandSequences.map((entry) => entry.sequence.join(' ')),
+    ...metrics.repeatedBashCommands.map((entry) => entry.command),
+  ]
+    .join(' ')
+    .toLowerCase();
+  return text.includes('playwright') || text.includes('e2e') || text.includes('browser');
+}
+
+function percent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}

--- a/core/runtime-profiler/types.ts
+++ b/core/runtime-profiler/types.ts
@@ -1,0 +1,67 @@
+export interface RuntimeProfilerRunRow {
+  runId: string;
+  projectId: string;
+  skill: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  createdAt: string;
+}
+
+export interface RuntimeProfilerEventRow {
+  runId: string | null;
+  kind: string;
+  payload: unknown;
+  createdAt: string;
+}
+
+export interface RuntimeProfilerWindow {
+  days: number;
+  sinceIso: string;
+  untilIso: string;
+}
+
+export interface RuntimeProfilerMetrics {
+  runCount: number;
+  medianInputTokens: number;
+  p95InputTokens: number;
+  medianOutputTokens: number;
+  p95OutputTokens: number;
+  medianCostUsd: number;
+  p95CostUsd: number;
+  maxCostOutlier: { runId: string; costUsd: number } | null;
+  timeoutRate: number;
+  budgetExceededRate: number;
+  schemaValidationRetryRate: number;
+  toolCallCount: number;
+  topToolNames: Array<{ name: string; count: number }>;
+  repeatedBashCommands: Array<{ command: string; count: number }>;
+  commonCommandSequences: Array<{ sequence: string[]; count: number }>;
+}
+
+export interface RuntimeProfilerRecommendation {
+  kind:
+    | 'timeout'
+    | 'budget'
+    | 'schema-validation'
+    | 'tool-discipline'
+    | 'lower-runtime'
+    | 'workflow-helper'
+    | 'qa-e2e-boundary';
+  severity: 'info' | 'warning' | 'critical';
+  summary: string;
+  evidence: string;
+  suggestedPatch?: Record<string, unknown>;
+}
+
+export interface RuntimeSkillProfile {
+  skill: string;
+  metrics: RuntimeProfilerMetrics;
+  recommendations: RuntimeProfilerRecommendation[];
+}
+
+export interface RuntimeProfilerReport {
+  projectId: string;
+  window: RuntimeProfilerWindow;
+  skills: RuntimeSkillProfile[];
+}

--- a/core/types.ts
+++ b/core/types.ts
@@ -22,6 +22,7 @@ export interface StackConfig {
 }
 
 export type ModelTier = 'haiku' | 'sonnet' | 'opus';
+export type RuntimeEffort = 'low' | 'medium' | 'high' | 'xhigh';
 export type FallbackPolicy = 'same-tier-only' | 'allow-down-tier';
 export type Role =
   | 'triager'
@@ -141,7 +142,13 @@ export interface BudgetConfig {
   /** Per-project overrides for specific skill budgets. Merged over SKILL_BUDGETS defaults. */
   skillBudgetOverrides?: Record<
     string,
-    { maxTurns?: number; maxBudgetUsd?: number; timeoutMs?: number; modelTier?: ModelTier }
+    {
+      maxTurns?: number;
+      maxBudgetUsd?: number;
+      timeoutMs?: number;
+      modelTier?: ModelTier;
+      effort?: RuntimeEffort | null;
+    }
   >;
 }
 


### PR DESCRIPTION
## Summary
- add per-skill runtime effort through schema, settings API/UI, resolver, AgentSpec, and Codex CLI argv config
- add a read-only runtime profiler endpoint backed by observed run costs/events with rule-based recommendations
- render observed runtime profile recommendations near Skill runtime settings

## Verification
- pnpm vitest run core/agent-runtime/skill-runtime-resolver.test.ts core/agent-runtime/codex-cli.test.ts core/agent-runtime/codex-cli-runtime.test.ts core/runtime-profiler/profile-runs.test.ts apps/server/src/domains/project-settings/router.test.ts apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
- pnpm typecheck
- pnpm lint
- DB_PATH=/private/tmp/goose-hub-effort-migrate3.db pnpm db:migrate