### PR TITLE
Finish operational truth roadmap

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -48,6 +48,7 @@ import {
   AgentBudgetExceededEvent,
   AgentDisclosureEvent,
   AgentModelSelectedEvent,
+  ContractDriftEvent,
   FallbackEvent,
   InvestigationContextInjectedEvent,
   ManualActionEvent,
@@ -159,6 +160,11 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <InvestigationContextInjectedEvent key={event.id} event={event} />;
     case 'agent.wrong-surface-guard':
       return <WrongSurfaceGuardEvent key={event.id} event={event} />;
+    case 'agent.path-normalized':
+    case 'agent.output-repaired':
+    case 'agent.output-fact-mismatch':
+    case 'agent.contract-gate-blocked':
+      return <ContractDriftEvent key={event.id} event={event} />;
     case 'symbol-index.hints-used':
       return <SymbolIndexHintsUsedEvent key={event.id} event={event} />;
     case 'agent.spawned':

--- a/apps/web/src/components/detail/components/timeline/AgentToolCallEvent.tsx
+++ b/apps/web/src/components/detail/components/timeline/AgentToolCallEvent.tsx
@@ -2,6 +2,12 @@ import type { AgentEventDto } from '@/lib/types';
 import { ChevronDown, ChevronRight, Wrench } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 
+type RepoRelativePathPayload = {
+  path?: string;
+  normalizedFrom?: string;
+  packageRoot?: string;
+};
+
 function normalizeToolInput(
   toolName: string,
   input: unknown,
@@ -23,8 +29,16 @@ function normalizeToolInput(
     const desc = typeof inp.description === 'string' ? inp.description : null;
     const timeoutMs = typeof inp.timeout === 'number' ? inp.timeout : null;
     const cmdPreview = inp.command.length > 60 ? `${inp.command.slice(0, 60)}…` : inp.command;
+    const commandLabel =
+      toolName === 'run_tests'
+        ? 'Test run'
+        : toolName === 'run_lint'
+          ? 'Lint run'
+          : toolName === 'run_typecheck'
+            ? 'Typecheck run'
+            : 'Command';
     return {
-      summary: desc != null ? `Bash: ${desc}` : `Bash: ${cmdPreview}`,
+      summary: desc != null ? `${commandLabel}: ${desc}` : `${commandLabel}: ${cmdPreview}`,
       body: (
         <div className="mt-1.5 flex flex-col gap-1">
           {desc != null && <span className="text-[11px] text-fg-3 italic">{desc}</span>}
@@ -165,9 +179,18 @@ function normalizeToolInput(
 
 export function AgentToolCallEvent({ event }: { event: AgentEventDto }) {
   const [open, setOpen] = useState(false);
-  const p = event.payload as { tool_name?: string; tool_input?: unknown } | null;
-  const toolName = p?.tool_name ?? 'unknown';
-  const { summary, body } = normalizeToolInput(toolName, p?.tool_input ?? null);
+  const p = event.payload as {
+    tool_name?: string;
+    tool?: string;
+    tool_input?: unknown;
+    input?: unknown;
+    raw_path?: string;
+    canonical_path?: RepoRelativePathPayload;
+  } | null;
+  const toolName = p?.tool_name ?? p?.tool ?? 'unknown';
+  const input = p?.tool_input ?? p?.input ?? null;
+  const { summary, body } = normalizeToolInput(toolName, input);
+  const canonicalPath = p?.canonical_path?.path;
   return (
     <li
       data-event-kind={event.kind}
@@ -186,6 +209,23 @@ export function AgentToolCallEvent({ event }: { event: AgentEventDto }) {
           <span>{summary}</span>
         </summary>
         {body}
+        {(p?.raw_path != null || canonicalPath != null) && (
+          <div className="mt-2 flex flex-col gap-1 text-[10.5px] text-fg-3">
+            {p.raw_path != null && (
+              <div>
+                raw path: <span className="font-mono text-fg-2">{p.raw_path}</span>
+              </div>
+            )}
+            {canonicalPath != null && (
+              <div>
+                canonical path: <span className="font-mono text-fg-2">{canonicalPath}</span>
+                {p.canonical_path?.normalizedFrom != null && (
+                  <span className="text-fg-4"> from {p.canonical_path.normalizedFrom}</span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </details>
     </li>
   );

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -6,9 +6,9 @@ import { renderTimelineItem } from '../TimelineEvents';
 
 afterEach(cleanup);
 
-function makeEvent(kind: string, payload: unknown): AgentEventDto {
+function makeEvent(kind: string, payload: unknown, id = 1): AgentEventDto {
   return {
-    id: 1,
+    id,
     kind,
     payload,
     runId: 'e3bb94b3-4bf6-4c93-9407-9a2dc30c760d',
@@ -83,6 +83,66 @@ describe('Misc timeline events', () => {
     expect(rendered).toContain('apps/server/src/domains/workflows/triage-batch.ts');
     expect(rendered).toContain('slices/parallel-implement/workflow.ts');
     expect(rendered).not.toContain('"expectedKeyFiles"');
+  });
+
+  it('renders path-normalized and contract drift events as compact operational facts', () => {
+    const normalized = makeEvent(
+      'agent.path-normalized',
+      {
+        skill: 'parallel-implement',
+        fields: [
+          {
+            field: 'workPackages[0].filesOwned[0]',
+            from: 'src/Button.tsx',
+            to: 'apps/web/src/Button.tsx',
+          },
+        ],
+      },
+      11,
+    );
+    const mismatch = makeEvent(
+      'agent.output-fact-mismatch',
+      {
+        skill: 'implement',
+        observedChangedFiles: { count: 1, paths: ['apps/web/src/Button.tsx'] },
+        observedWriteFiles: { count: 1, paths: ['apps/web/src/Button.tsx'] },
+        modelDeclaredFiles: { count: 1, paths: ['src/Button.tsx'] },
+        mismatches: {
+          observedNotDeclared: { count: 1, paths: ['apps/web/src/Button.tsx'] },
+          declaredNotObserved: { count: 1, paths: ['src/Button.tsx'] },
+        },
+      },
+      12,
+    );
+    const blocked = makeEvent(
+      'agent.contract-gate-blocked',
+      {
+        skill: 'implement-wp',
+        gate: 'implement-wp-ownership',
+        reason: 'ambiguous-files-owned',
+      },
+      13,
+    );
+
+    render(
+      <ul>
+        {renderTimelineItem({ kind: 'event', event: normalized }, 0)}
+        {renderTimelineItem({ kind: 'event', event: mismatch }, 1)}
+        {renderTimelineItem({ kind: 'event', event: blocked }, 2)}
+      </ul>,
+    );
+
+    const rendered = document.body.textContent ?? '';
+    expect(rendered).toContain('Path normalized');
+    expect(rendered).toContain('src/Button.tsx');
+    expect(rendered).toContain('apps/web/src/Button.tsx');
+    expect(rendered).toContain('Operational fact mismatch');
+    expect(rendered).toContain('Git observed changed');
+    expect(rendered).toContain('Tool observed writes');
+    expect(rendered).toContain('Observed not declared');
+    expect(rendered).toContain('Contract gate blocked');
+    expect(rendered).toContain('ambiguous-files-owned');
+    expect(rendered).not.toContain('"observedChangedFiles"');
   });
 
   it('renders agent.disclosure as summarized input metadata', () => {

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -32,6 +32,33 @@ type WrongSurfaceGuardPayload = {
   investigationRunId?: string | null;
 };
 
+type CompactPathList = {
+  count?: number;
+  paths?: string[];
+  truncated?: boolean;
+};
+
+type ContractDriftPayload = {
+  skill?: string;
+  gate?: string;
+  reason?: string;
+  fields?: Array<{
+    field?: string;
+    from?: string;
+    to?: string;
+    rawValue?: string;
+    normalizedValue?: string;
+    source?: string;
+  }>;
+  observedChangedFiles?: CompactPathList;
+  observedWriteFiles?: CompactPathList;
+  modelDeclaredFiles?: CompactPathList;
+  mismatches?: {
+    observedNotDeclared?: CompactPathList;
+    declaredNotObserved?: CompactPathList;
+  };
+};
+
 type DisclosurePayload = {
   kind?: string;
   skill?: string;
@@ -317,6 +344,83 @@ export function WrongSurfaceGuardEvent({ event }: { event: AgentEventDto }) {
           Touched: <span className="font-mono text-fg-2">{touched.slice(0, 3).join(', ')}</span>
         </div>
       )}
+    </li>
+  );
+}
+
+function PathList({ label, list }: { label: string; list?: CompactPathList }) {
+  const paths = list?.paths ?? [];
+  if (paths.length === 0 && list?.count == null) return null;
+  return (
+    <div className="mt-1 text-[11.5px] text-fg-3">
+      {label}: <span className="font-mono text-fg-2">{paths.slice(0, 3).join(', ')}</span>
+      {list?.count != null && list.count > paths.length && (
+        <span className="text-fg-4"> +{list.count - paths.length} more</span>
+      )}
+    </div>
+  );
+}
+
+export function ContractDriftEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as ContractDriftPayload | null;
+  const title =
+    event.kind === 'agent.output-repaired'
+      ? 'Path normalized'
+      : event.kind === 'agent.output-fact-mismatch'
+        ? 'Operational fact mismatch'
+        : event.kind === 'agent.path-normalized'
+          ? 'Path normalized'
+          : 'Contract gate blocked';
+  const fields = p?.fields ?? [];
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-warning bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-1 text-[11px] text-fg-3">
+        <AlertTriangle size={13} className="shrink-0 text-amber-400" />
+        <span className="font-mono uppercase tracking-wider">{title}</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="text-[12.5px] text-fg-2">
+        {p?.skill ?? 'agent'}
+        {p?.gate != null && (
+          <>
+            <span className="text-fg-4 mx-1">·</span>
+            {p.gate}
+          </>
+        )}
+        {p?.reason != null && (
+          <>
+            <span className="text-fg-4 mx-1">·</span>
+            {p.reason}
+          </>
+        )}
+      </div>
+      {fields.length > 0 && (
+        <div className="mt-2 flex flex-col gap-1 text-[11px] text-fg-3">
+          {fields.slice(0, 3).map((field, index) => (
+            <div key={`${field.field ?? 'field'}-${index}`}>
+              <span className="font-mono text-fg-2">{field.field}</span>
+              {(field.rawValue ?? field.from) != null &&
+                (field.normalizedValue ?? field.to) != null && (
+                  <>
+                    {' '}
+                    <span className="font-mono">{field.rawValue ?? field.from}</span>
+                    <span className="text-fg-4"> → </span>
+                    <span className="font-mono">{field.normalizedValue ?? field.to}</span>
+                  </>
+                )}
+            </div>
+          ))}
+        </div>
+      )}
+      <PathList label="Git observed changed" list={p?.observedChangedFiles} />
+      <PathList label="Tool observed writes" list={p?.observedWriteFiles} />
+      <PathList label="Model declared" list={p?.modelDeclaredFiles} />
+      <PathList label="Observed not declared" list={p?.mismatches?.observedNotDeclared} />
+      <PathList label="Declared not observed" list={p?.mismatches?.declaredNotObserved} />
     </li>
   );
 }

--- a/core/agent-runtime/operational-fact-owners.test.ts
+++ b/core/agent-runtime/operational-fact-owners.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OPERATIONAL_FACT_CONTRACTS,
+  operationalFactContractsByOwner,
+} from './operational-fact-owners.js';
+
+describe('operational-fact-owners', () => {
+  it('assigns each operational fact to an owner and limits model-authored facts', () => {
+    expect(OPERATIONAL_FACT_CONTRACTS.map((contract) => contract.fact)).toEqual([
+      'commands run',
+      'targeted test paths',
+      'changed files',
+      'evidence artifacts',
+      'PR metadata',
+      'state transitions',
+      'budget and cost',
+      'finding severity and rationale',
+    ]);
+
+    for (const contract of OPERATIONAL_FACT_CONTRACTS) {
+      expect(contract.owner).toMatch(/^(tool|workflow|collector|runtime|model)$/);
+      expect(contract.source.length).toBeGreaterThan(0);
+      if (contract.observed) {
+        expect(contract.modelMayDeclare).not.toBe('judgment');
+      }
+    }
+  });
+
+  it('groups contracts by owner for prompt and audit consumers', () => {
+    const grouped = operationalFactContractsByOwner();
+    expect(grouped.tool.map((contract) => contract.fact)).toContain('commands run');
+    expect(grouped.workflow.map((contract) => contract.fact)).toContain('changed files');
+    expect(grouped.collector.map((contract) => contract.fact)).toContain('evidence artifacts');
+    expect(grouped.runtime.map((contract) => contract.fact)).toContain('budget and cost');
+    expect(grouped.model.map((contract) => contract.fact)).toEqual([
+      'finding severity and rationale',
+    ]);
+  });
+});

--- a/core/agent-runtime/operational-fact-owners.ts
+++ b/core/agent-runtime/operational-fact-owners.ts
@@ -1,0 +1,85 @@
+export type OperationalFactOwner = 'tool' | 'workflow' | 'collector' | 'runtime' | 'model';
+
+export type OperationalFactContract = {
+  fact: string;
+  owner: OperationalFactOwner;
+  observed: boolean;
+  modelMayDeclare: 'never' | 'explanation-only' | 'judgment';
+  source: string;
+};
+
+export const OPERATIONAL_FACT_CONTRACTS: OperationalFactContract[] = [
+  {
+    fact: 'commands run',
+    owner: 'tool',
+    observed: true,
+    modelMayDeclare: 'explanation-only',
+    source: 'agent.tool-call payload.tool_input.command',
+  },
+  {
+    fact: 'targeted test paths',
+    owner: 'tool',
+    observed: true,
+    modelMayDeclare: 'explanation-only',
+    source: 'mcp__factory-tools__run_tests returned paths[].path',
+  },
+  {
+    fact: 'changed files',
+    owner: 'workflow',
+    observed: true,
+    modelMayDeclare: 'never',
+    source: 'git diff observed by workflow gates',
+  },
+  {
+    fact: 'evidence artifacts',
+    owner: 'collector',
+    observed: true,
+    modelMayDeclare: 'explanation-only',
+    source: 'evidence collector/publisher output',
+  },
+  {
+    fact: 'PR metadata',
+    owner: 'workflow',
+    observed: true,
+    modelMayDeclare: 'never',
+    source: 'pr.opened workflow event',
+  },
+  {
+    fact: 'state transitions',
+    owner: 'workflow',
+    observed: true,
+    modelMayDeclare: 'never',
+    source: 'state.transitioned event',
+  },
+  {
+    fact: 'budget and cost',
+    owner: 'runtime',
+    observed: true,
+    modelMayDeclare: 'never',
+    source: 'agent_run_costs and budget gate events',
+  },
+  {
+    fact: 'finding severity and rationale',
+    owner: 'model',
+    observed: false,
+    modelMayDeclare: 'judgment',
+    source: 'QA/review structured output',
+  },
+];
+
+export function operationalFactContractsByOwner(): Record<
+  OperationalFactOwner,
+  OperationalFactContract[]
+> {
+  const initial: Record<OperationalFactOwner, OperationalFactContract[]> = {
+    tool: [],
+    workflow: [],
+    collector: [],
+    runtime: [],
+    model: [],
+  };
+  return OPERATIONAL_FACT_CONTRACTS.reduce((acc, contract) => {
+    acc[contract.owner].push(contract);
+    return acc;
+  }, initial);
+}

--- a/core/agent-runtime/path-drift-report.test.ts
+++ b/core/agent-runtime/path-drift-report.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import type { AgentEvent } from '../event-stream/store.js';
 import { buildPathDriftReport, formatPathDriftReport } from './path-drift-report.js';
 
-function event(id: number, kind: AgentEvent['kind'], payload: unknown): AgentEvent {
+function event(
+  id: number,
+  kind: AgentEvent['kind'],
+  payload: unknown,
+  createdAt = '2026-05-20T00:00:00Z',
+): AgentEvent {
   return {
     id,
     projectId: 'goose-hub-self',
@@ -11,7 +16,7 @@ function event(id: number, kind: AgentEvent['kind'], payload: unknown): AgentEve
     payload,
     runId: 'run-1',
     personaId: null,
-    createdAt: '2026-05-20T00:00:00Z',
+    createdAt,
   };
 }
 
@@ -19,7 +24,7 @@ describe('path-drift-report', () => {
   it('groups repairs and mismatches by skill and field', () => {
     const report = buildPathDriftReport(
       [
-        event(1, 'agent.output-repaired', {
+        event(1, 'agent.path-normalized', {
           skill: 'implement',
           fields: [
             {
@@ -75,5 +80,19 @@ describe('path-drift-report', () => {
     expect(formatPathDriftReport(report)).toContain(
       'implement filesWritten[0].path: repaired=1 mismatches=0 blocked=0',
     );
+  });
+
+  it('computes trend from event time windows instead of list halves', () => {
+    const report = buildPathDriftReport([
+      event(1, 'agent.output-repaired', { skill: 'implement' }, '2026-05-20T00:00:00Z'),
+      event(2, 'agent.run-completed', {}, '2026-05-20T00:10:00Z'),
+      event(3, 'agent.output-fact-mismatch', { skill: 'implement' }, '2026-05-20T01:00:00Z'),
+      event(4, 'agent.contract-gate-blocked', { skill: 'implement' }, '2026-05-20T01:10:00Z'),
+    ]);
+
+    expect(report.trend.previousWindowDriftEvents).toBe(1);
+    expect(report.trend.currentWindowDriftEvents).toBe(2);
+    expect(report.trend.direction).toBe('increasing');
+    expect(formatPathDriftReport(report)).toContain('trend: increasing (1 -> 2)');
   });
 });

--- a/core/agent-runtime/path-drift-report.test.ts
+++ b/core/agent-runtime/path-drift-report.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentEvent } from '../event-stream/store.js';
+import { buildPathDriftReport, formatPathDriftReport } from './path-drift-report.js';
+
+function event(id: number, kind: AgentEvent['kind'], payload: unknown): AgentEvent {
+  return {
+    id,
+    projectId: 'goose-hub-self',
+    workItemId: 'github:shaunnez/goose-hub#1',
+    kind,
+    payload,
+    runId: 'run-1',
+    personaId: null,
+    createdAt: '2026-05-20T00:00:00Z',
+  };
+}
+
+describe('path-drift-report', () => {
+  it('groups repairs and mismatches by skill and field', () => {
+    const report = buildPathDriftReport(
+      [
+        event(1, 'agent.output-repaired', {
+          skill: 'implement',
+          fields: [
+            {
+              field: 'filesWritten[0].path',
+              rawValue: 'src/Foo.tsx',
+              normalizedValue: 'apps/web/src/Foo.tsx',
+            },
+          ],
+        }),
+        event(2, 'agent.output-fact-mismatch', {
+          skill: 'implement',
+          mismatches: {
+            observedNotDeclared: { count: 1, paths: ['apps/web/src/Foo.tsx'] },
+          },
+        }),
+        event(3, 'agent.contract-gate-blocked', {
+          skill: 'spec-author',
+          fields: [
+            {
+              field: 'workPackages[0].filesOwned[0]',
+              from: 'src/Foo.tsx',
+              to: 'apps/web/src/Foo.tsx',
+            },
+          ],
+        }),
+      ],
+      'goose-hub-self',
+    );
+
+    expect(report.projectId).toBe('goose-hub-self');
+    expect(report.driftEvents).toBe(3);
+    expect(report.buckets).toContainEqual({
+      skill: 'implement',
+      field: 'filesWritten[0].path',
+      repaired: 1,
+      mismatches: 0,
+      blocked: 0,
+    });
+    expect(report.buckets).toContainEqual({
+      skill: 'implement',
+      field: 'mismatches.observedNotDeclared',
+      repaired: 0,
+      mismatches: 1,
+      blocked: 0,
+    });
+    expect(report.buckets).toContainEqual({
+      skill: 'spec-author',
+      field: 'workPackages[0].filesOwned[0]',
+      repaired: 0,
+      mismatches: 0,
+      blocked: 1,
+    });
+    expect(formatPathDriftReport(report)).toContain(
+      'implement filesWritten[0].path: repaired=1 mismatches=0 blocked=0',
+    );
+  });
+});

--- a/core/agent-runtime/path-drift-report.ts
+++ b/core/agent-runtime/path-drift-report.ts
@@ -1,6 +1,7 @@
 import { type AgentEvent, eventStore } from '../event-stream/store.js';
 
 const DRIFT_EVENT_KINDS = new Set([
+  'agent.path-normalized',
   'agent.output-repaired',
   'agent.output-fact-mismatch',
   'agent.contract-gate-blocked',
@@ -44,8 +45,11 @@ export type PathDriftReport = {
   latestEventId?: number;
   buckets: PathDriftBucket[];
   trend: {
-    firstHalfDriftEvents: number;
-    secondHalfDriftEvents: number;
+    windowStartAt?: string;
+    midpointAt?: string;
+    windowEndAt?: string;
+    previousWindowDriftEvents: number;
+    currentWindowDriftEvents: number;
     direction: 'decreasing' | 'flat' | 'increasing';
   };
 };
@@ -82,6 +86,71 @@ function bucketKey(skill: string, field: string): string {
   return `${skill}\0${field}`;
 }
 
+function eventTime(event: AgentEvent): number | undefined {
+  const ms = Date.parse(event.createdAt);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function isoTime(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function buildTrend(events: AgentEvent[], driftEvents: AgentEvent[]): PathDriftReport['trend'] {
+  const eventTimes = events.flatMap((event) => {
+    const time = eventTime(event);
+    return time == null ? [] : [time];
+  });
+  if (eventTimes.length === 0 || driftEvents.length === 0) {
+    return {
+      previousWindowDriftEvents: 0,
+      currentWindowDriftEvents: 0,
+      direction: 'flat',
+    };
+  }
+
+  const windowStart = Math.min(...eventTimes);
+  const windowEnd = Math.max(...eventTimes);
+  if (windowStart === windowEnd) {
+    return {
+      windowStartAt: isoTime(windowStart),
+      midpointAt: isoTime(windowStart),
+      windowEndAt: isoTime(windowEnd),
+      previousWindowDriftEvents: driftEvents.length,
+      currentWindowDriftEvents: driftEvents.length,
+      direction: 'flat',
+    };
+  }
+
+  const midpoint = windowStart + (windowEnd - windowStart) / 2;
+  let previousWindowDriftEvents = 0;
+  let currentWindowDriftEvents = 0;
+  for (const event of driftEvents) {
+    const time = eventTime(event);
+    if (time == null) continue;
+    if (time <= midpoint) {
+      previousWindowDriftEvents += 1;
+    } else {
+      currentWindowDriftEvents += 1;
+    }
+  }
+
+  const direction =
+    currentWindowDriftEvents < previousWindowDriftEvents
+      ? 'decreasing'
+      : currentWindowDriftEvents > previousWindowDriftEvents
+        ? 'increasing'
+        : 'flat';
+
+  return {
+    windowStartAt: isoTime(windowStart),
+    midpointAt: isoTime(midpoint),
+    windowEndAt: isoTime(windowEnd),
+    previousWindowDriftEvents,
+    currentWindowDriftEvents,
+    direction,
+  };
+}
+
 export function buildPathDriftReport(events: AgentEvent[], projectId?: string): PathDriftReport {
   const driftEvents = events
     .filter((event) => DRIFT_EVENT_KINDS.has(event.kind))
@@ -102,22 +171,14 @@ export function buildPathDriftReport(events: AgentEvent[], projectId?: string): 
           mismatches: 0,
           blocked: 0,
         } satisfies PathDriftBucket);
-      if (event.kind === 'agent.output-repaired') bucket.repaired += 1;
+      if (event.kind === 'agent.path-normalized' || event.kind === 'agent.output-repaired') {
+        bucket.repaired += 1;
+      }
       if (event.kind === 'agent.output-fact-mismatch') bucket.mismatches += 1;
       if (event.kind === 'agent.contract-gate-blocked') bucket.blocked += 1;
       buckets.set(key, bucket);
     }
   }
-
-  const midpoint = Math.ceil(driftEvents.length / 2);
-  const firstHalfDriftEvents = driftEvents.slice(0, midpoint).length;
-  const secondHalfDriftEvents = driftEvents.slice(midpoint).length;
-  const direction =
-    secondHalfDriftEvents < firstHalfDriftEvents
-      ? 'decreasing'
-      : secondHalfDriftEvents > firstHalfDriftEvents
-        ? 'increasing'
-        : 'flat';
 
   return {
     ...(projectId != null ? { projectId } : {}),
@@ -130,11 +191,7 @@ export function buildPathDriftReport(events: AgentEvent[], projectId?: string): 
         a.skill.localeCompare(b.skill) ||
         a.field.localeCompare(b.field),
     ),
-    trend: {
-      firstHalfDriftEvents,
-      secondHalfDriftEvents,
-      direction,
-    },
+    trend: buildTrend(events, driftEvents),
   };
 }
 
@@ -155,8 +212,11 @@ export function formatPathDriftReport(report: PathDriftReport): string {
     `path drift report${report.projectId != null ? `: ${report.projectId}` : ''}`,
     `scannedEvents: ${report.scannedEvents}`,
     `driftEvents: ${report.driftEvents}`,
-    `trend: ${report.trend.direction} (${report.trend.firstHalfDriftEvents} -> ${report.trend.secondHalfDriftEvents})`,
+    `trend: ${report.trend.direction} (${report.trend.previousWindowDriftEvents} -> ${report.trend.currentWindowDriftEvents})`,
   ];
+  if (report.trend.windowStartAt != null && report.trend.windowEndAt != null) {
+    lines.push(`trendWindow: ${report.trend.windowStartAt}..${report.trend.windowEndAt}`);
+  }
 
   if (report.latestEventId != null) lines.push(`latestEventId: ${report.latestEventId}`);
   if (report.buckets.length === 0) {

--- a/core/agent-runtime/path-drift-report.ts
+++ b/core/agent-runtime/path-drift-report.ts
@@ -1,0 +1,174 @@
+import { type AgentEvent, eventStore } from '../event-stream/store.js';
+
+const DRIFT_EVENT_KINDS = new Set([
+  'agent.output-repaired',
+  'agent.output-fact-mismatch',
+  'agent.contract-gate-blocked',
+]);
+
+type CompactPathList = {
+  count?: number;
+  paths?: string[];
+};
+
+type DriftField = {
+  field?: string;
+  rawValue?: string;
+  normalizedValue?: string;
+  from?: string;
+  to?: string;
+};
+
+type DriftPayload = {
+  skill?: string;
+  gate?: string;
+  fields?: DriftField[];
+  mismatches?: {
+    observedNotDeclared?: CompactPathList;
+    declaredNotObserved?: CompactPathList;
+  };
+};
+
+export type PathDriftBucket = {
+  skill: string;
+  field: string;
+  repaired: number;
+  mismatches: number;
+  blocked: number;
+};
+
+export type PathDriftReport = {
+  projectId?: string;
+  scannedEvents: number;
+  driftEvents: number;
+  latestEventId?: number;
+  buckets: PathDriftBucket[];
+  trend: {
+    firstHalfDriftEvents: number;
+    secondHalfDriftEvents: number;
+    direction: 'decreasing' | 'flat' | 'increasing';
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function compactCount(list: CompactPathList | undefined): number {
+  if (typeof list?.count === 'number') return list.count;
+  return list?.paths?.length ?? 0;
+}
+
+function payload(event: AgentEvent): DriftPayload {
+  return isRecord(event.payload) ? (event.payload as DriftPayload) : {};
+}
+
+function fieldNames(payload: DriftPayload): string[] {
+  const fields =
+    payload.fields?.flatMap((field) => (field.field != null ? [field.field] : [])) ?? [];
+  const mismatchNames: string[] = [];
+  if (compactCount(payload.mismatches?.observedNotDeclared) > 0) {
+    mismatchNames.push('mismatches.observedNotDeclared');
+  }
+  if (compactCount(payload.mismatches?.declaredNotObserved) > 0) {
+    mismatchNames.push('mismatches.declaredNotObserved');
+  }
+  return fields.length > 0 || mismatchNames.length > 0
+    ? Array.from(new Set([...fields, ...mismatchNames])).sort()
+    : ['(unknown)'];
+}
+
+function bucketKey(skill: string, field: string): string {
+  return `${skill}\0${field}`;
+}
+
+export function buildPathDriftReport(events: AgentEvent[], projectId?: string): PathDriftReport {
+  const driftEvents = events
+    .filter((event) => DRIFT_EVENT_KINDS.has(event.kind))
+    .sort((a, b) => a.id - b.id);
+  const buckets = new Map<string, PathDriftBucket>();
+
+  for (const event of driftEvents) {
+    const p = payload(event);
+    const skill = p.skill ?? 'unknown';
+    for (const field of fieldNames(p)) {
+      const key = bucketKey(skill, field);
+      const bucket =
+        buckets.get(key) ??
+        ({
+          skill,
+          field,
+          repaired: 0,
+          mismatches: 0,
+          blocked: 0,
+        } satisfies PathDriftBucket);
+      if (event.kind === 'agent.output-repaired') bucket.repaired += 1;
+      if (event.kind === 'agent.output-fact-mismatch') bucket.mismatches += 1;
+      if (event.kind === 'agent.contract-gate-blocked') bucket.blocked += 1;
+      buckets.set(key, bucket);
+    }
+  }
+
+  const midpoint = Math.ceil(driftEvents.length / 2);
+  const firstHalfDriftEvents = driftEvents.slice(0, midpoint).length;
+  const secondHalfDriftEvents = driftEvents.slice(midpoint).length;
+  const direction =
+    secondHalfDriftEvents < firstHalfDriftEvents
+      ? 'decreasing'
+      : secondHalfDriftEvents > firstHalfDriftEvents
+        ? 'increasing'
+        : 'flat';
+
+  return {
+    ...(projectId != null ? { projectId } : {}),
+    scannedEvents: events.length,
+    driftEvents: driftEvents.length,
+    ...(driftEvents.at(-1)?.id != null ? { latestEventId: driftEvents.at(-1)?.id } : {}),
+    buckets: Array.from(buckets.values()).sort(
+      (a, b) =>
+        b.repaired + b.mismatches + b.blocked - (a.repaired + a.mismatches + a.blocked) ||
+        a.skill.localeCompare(b.skill) ||
+        a.field.localeCompare(b.field),
+    ),
+    trend: {
+      firstHalfDriftEvents,
+      secondHalfDriftEvents,
+      direction,
+    },
+  };
+}
+
+export function loadPathDriftReport(input: {
+  projectId?: string;
+  limit?: number;
+}): PathDriftReport {
+  const events = eventStore.replay({
+    ...(input.projectId != null ? { projectId: input.projectId } : {}),
+    order: 'desc',
+    limit: input.limit ?? 500,
+  });
+  return buildPathDriftReport(events.reverse(), input.projectId);
+}
+
+export function formatPathDriftReport(report: PathDriftReport): string {
+  const lines = [
+    `path drift report${report.projectId != null ? `: ${report.projectId}` : ''}`,
+    `scannedEvents: ${report.scannedEvents}`,
+    `driftEvents: ${report.driftEvents}`,
+    `trend: ${report.trend.direction} (${report.trend.firstHalfDriftEvents} -> ${report.trend.secondHalfDriftEvents})`,
+  ];
+
+  if (report.latestEventId != null) lines.push(`latestEventId: ${report.latestEventId}`);
+  if (report.buckets.length === 0) {
+    lines.push('buckets: (none)');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push('buckets:');
+  for (const bucket of report.buckets) {
+    lines.push(
+      `- ${bucket.skill} ${bucket.field}: repaired=${bucket.repaired} mismatches=${bucket.mismatches} blocked=${bucket.blocked}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/core/agent-runtime/skill-contract-audit.test.ts
+++ b/core/agent-runtime/skill-contract-audit.test.ts
@@ -14,6 +14,8 @@ describe('skill-contract-audit', () => {
     expect(output).toContain('allowlistTags:');
     expect(output).toContain('schemaFields:');
     expect(output).toContain('outputExample:');
+    expect(output).toContain('pathLanguageWorkspaceRelative:');
+    expect(output).toContain('pathLanguagePackageRelativeExamples:');
   });
 
   it('enforces deterministic context tag drift checks for every runtime skill', () => {
@@ -109,6 +111,24 @@ describe('skill-contract-audit', () => {
       expect(report?.extraPromptTags, `${skill} should only reference allowlisted tags`).toEqual(
         [],
       );
+    }
+  });
+
+  it('keeps implement-family path language canonical and advisory-audited', () => {
+    const audit = auditSkillContracts(process.cwd());
+    const implementFamily = ['implement', 'implement-wp', 'spec-author'];
+
+    for (const skill of implementFamily) {
+      const report = audit.skills.find((s: { skill: string }) => s.skill === skill);
+      expect(report, `${skill} should be audited`).toBeDefined();
+      expect(
+        report?.pathLanguage.vagueWorkspaceRelative,
+        `${skill} should avoid vague workspace-relative path language`,
+      ).toEqual([]);
+      expect(
+        report?.pathLanguage.packageRelativeExamples,
+        `${skill} should avoid package-relative src/... output examples`,
+      ).toEqual([]);
     }
   });
 

--- a/core/agent-runtime/skill-contract-audit.ts
+++ b/core/agent-runtime/skill-contract-audit.ts
@@ -10,6 +10,7 @@ export type SkillContractReport = {
   extraPromptTags: string[];
   schemaFields: string[];
   outputExample: OutputExampleReport;
+  pathLanguage: PathLanguageReport;
   consumerPaths: string[];
 };
 
@@ -27,6 +28,11 @@ export type OutputExampleReport = {
   parseableExamples: number;
   missingSchemaFields: string[];
   extraExampleFields: string[];
+};
+
+export type PathLanguageReport = {
+  vagueWorkspaceRelative: string[];
+  packageRelativeExamples: string[];
 };
 
 function extractTags(input: string): string[] {
@@ -174,6 +180,56 @@ function parseTopLevelObjectFields(source: string): string[] | null {
   }
 }
 
+function lineHits(source: string, predicate: (line: string) => boolean): string[] {
+  return source
+    .split('\n')
+    .map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
+    .filter(({ line }) => line.length > 0 && predicate(line))
+    .map(({ line, lineNumber }) => `${lineNumber}: ${line}`);
+}
+
+function collectJsonStrings(value: unknown, strings: string[] = []): string[] {
+  if (typeof value === 'string') {
+    strings.push(value);
+    return strings;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectJsonStrings(item, strings);
+    return strings;
+  }
+  if (value != null && typeof value === 'object') {
+    for (const item of Object.values(value)) collectJsonStrings(item, strings);
+  }
+  return strings;
+}
+
+function auditPathLanguage(prompt: string, schema: string): PathLanguageReport {
+  const combined = `${prompt}\n${schema}`;
+  const vagueWorkspaceRelative = lineHits(combined, (line) => {
+    const lower = line.toLowerCase();
+    if (!lower.includes('workspace-relative')) return false;
+    return !(
+      lower.includes('repo-root') ||
+      lower.includes('worktree-root') ||
+      lower.includes('canonical') ||
+      lower.includes('mcp__factory-tools__')
+    );
+  });
+
+  const packageRelativeExamples = extractJsonExamples(prompt).flatMap((example) => {
+    try {
+      return collectJsonStrings(JSON.parse(example)).filter((value) => /^src\/[^/]/.test(value));
+    } catch {
+      return [];
+    }
+  });
+
+  return {
+    vagueWorkspaceRelative,
+    packageRelativeExamples: Array.from(new Set(packageRelativeExamples)).sort(),
+  };
+}
+
 function auditOutputExample(prompt: string, schemaFields: string[]): OutputExampleReport {
   if (schemaFields.length === 0) {
     return {
@@ -316,6 +372,7 @@ export function auditSkillContracts(repoRoot: string): SkillContractAudit {
       extraPromptTags,
       schemaFields,
       outputExample: auditOutputExample(prompt, schemaFields),
+      pathLanguage: auditPathLanguage(prompt, schema),
       consumerPaths: existsSync(schemaPath)
         ? collectConsumers(repoRoot, schemaPath, schema, skill)
         : [],
@@ -340,6 +397,8 @@ export function formatSkillContractAudit(audit: SkillContractAudit): string {
         `outputExampleParseable: ${r.outputExample.parseableExamples}`,
         `outputExampleMissingFields: ${r.outputExample.missingSchemaFields.join(', ') || '(none)'}`,
         `outputExampleExtraFields: ${r.outputExample.extraExampleFields.join(', ') || '(none)'}`,
+        `pathLanguageWorkspaceRelative: ${r.pathLanguage.vagueWorkspaceRelative.length}`,
+        `pathLanguagePackageRelativeExamples: ${r.pathLanguage.packageRelativeExamples.join(', ') || '(none)'}`,
         `consumers: ${r.consumerPaths.length}`,
       ];
       for (const c of r.consumerPaths) lines.push(`- ${c}`);

--- a/core/tool-layer/README.md
+++ b/core/tool-layer/README.md
@@ -13,10 +13,9 @@ Tool management and security infrastructure for agent runtime.
 | `pre-tool-use-hook.ts` | `deployHooks`, `HOOK_PATH` | M4.08 |
 | `post-tool-use-hook.ts` | `deployPostHook`, `POST_HOOK_PATH` | M9.XX (#465) |
 | `path-contract.ts` | `RepoRelativePath`, `canonicalizeFactoryToolPath` | agent-operational-truth Slice 1 |
-| `tools/read.ts` | `readFile`, `searchFiles`, `SandboxViolationError` | M6.02 |
-| `tools/write.ts` | `writeFile` | M7.01 |
-| `tools/bash.ts` | `runBash`, `BashResult`, `DEFAULT_BASH_DENYLIST` | M7.01 |
-| `tools/test.ts` | `runTests`, `TestResult` | M7.01 |
+| `tool-call-audit.ts` | `normalizeToolCallAuditPayload`, `canonicalPathStringFromAuditPayload` | agent-operational-truth Slice 2 |
+| `mcp/` | `factory-tools` MCP server and tool implementations | ADR 0045 |
+| `tools/record-decision.ts` | `recordDecision`, `readRunDecisions` | M19.06 |
 
 ## Secret Redaction
 
@@ -30,19 +29,20 @@ Named bundles passed via `AgentSpec.toolBundles`. At spawn, `computeAllowlist(sp
 
 | Bundle | Tools | Used by |
 |--------|-------|---------|
-| `read-only` | `Read`, `Glob`, `Grep`, `Bash(cat *)`, `Bash(ls *)` | General read-only agents |
-| `read-write` | `Read`, `Write`, `Edit`, `Glob`, `Grep` | Developer agents |
-| `bash-restricted` | `Bash` | Shell agents |
-| `read` | `read`, `search`, `work-item-read` | Investigator agents (sandboxed) |
-| `dev-tools` | `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash` | Developer skills (`implement`, `implement-wp`, `resolve-conflict`) and dev workflows (`fix-issue`, `parallel-implement`, `fix-feedback`) |
-| `validate` | `Read`, `Write`, `Edit`, `Glob`, `Grep`, scoped `Bash(pnpm test:e2e*)`, evidence I/O, git push | Playwright skills (`evidence-post`, `playwright-repro`) |
+| `read` | `mcp__factory-tools__get_project_context`, read/search tools, git/diff tools | Investigator and read-only agents |
+| `dev-tools` | `mcp__factory-tools__*` context, read/search, write/edit, verify, git/diff tools | Developer skills (`implement`, `implement-wp`, `resolve-conflict`) and dev workflows (`fix-issue`, `parallel-implement`, `fix-feedback`) |
+| `qa-tools` | `mcp__factory-tools__*` context, read/search, git/diff, QA helpers | QA/review-style skills with no write tools |
+| `validate` | `mcp__factory-tools__*` context, read/search, evidence tools | Playwright/evidence validation skills |
+| `core` | no tools | Prompt-only skills |
+| `emergency-debug` | `Bash` | Explicit opt-in escape hatch |
 | `playwright-mcp` | `mcp__playwright-test__*` (browser/planner/generator) | `spec-author` skill (auto-merges `apps/web/.mcp.json`) |
+| `decision-record-only` | `record-decision` | Legacy A/B surface; blocked from holdouts |
 
-**Note on `dev-tools`:** the bundle currently uses Claude Code's built-in tools. The lowercase sandboxed variants in `tools/` (`runBash`, `writeFile`, `runTests`, `readFile`, `searchFiles`) are pre-built but not yet exposed via an MCP server, so agents reach the host shell through Claude Code's `Bash` rather than `runBash`. Workspace-level deny rules in `sandbox.ts` plus the PreToolUse hook are the active safety boundary. Wiring the MCP server (and thereby enforcing fields like `perBashCommandMaxSeconds`) is tracked in #635 — see ADR 0035 for the timeout-scope decision that depends on it.
+Every default agent-facing bundle is composed of `mcp__factory-tools__*` names only. Native `Read`, `Write`, `Edit`, `Glob`, `Grep`, and broad `Bash` are not in default bundles; native `Bash` is available only through `emergency-debug`.
 
 ## Canonical Path Contract
 
-`path-contract.ts` defines the reusable response shape for future `factory-tools` MCP path-bearing results:
+`path-contract.ts` defines the reusable response shape for `factory-tools` MCP path-bearing results:
 
 ```ts
 interface RepoRelativePath {
@@ -53,14 +53,20 @@ interface RepoRelativePath {
 }
 ```
 
-`canonicalizeFactoryToolPath({ rawPath, worktreePath })` reuses the shared repo-relative normalizer from `core/workspaces/path-normalization.ts`. It strips absolute worktree paths, resolves uniquely discoverable package-relative paths, and returns a structured `ambiguous-repo-relative-path` error with candidates when a package-relative path cannot be chosen safely.
+`canonicalizeFactoryToolPath({ rawPath, worktreePath })` reuses the shared repo-relative normalizer from `core/workspaces/path-normalization.ts`. It strips absolute worktree paths where workflow code passes them internally, resolves uniquely discoverable package-relative paths, and returns a structured `ambiguous-repo-relative-path` error with candidates when a package-relative path cannot be chosen safely.
 
-The current in-process helpers expose metadata-bearing variants for the future MCP server:
+The MCP path policy (`mcp/path-policy.ts`) is a denylist-first wrapper over this contract. Agent-supplied paths that are absolute, use `..` / `~`, touch assistant/Factory internals, or resolve outside the worktree are rejected before the tool runs. Every path-bearing tool response returns `RepoRelativePath` rather than a bare string.
 
-- `readFileWithMetadata` returns `{ path, content }`.
-- `searchFilesWithMetadata` returns `{ stdout, paths }` with canonicalized match prefixes.
-- `writeFileWithMetadata` returns `{ path, written: true }`.
-- `runTests` accepts optional `paths` and returns them as canonical `RepoRelativePath[]`.
+## factory-tools MCP Server
+
+`mcp/` contains the active tool layer for spawned agents. See `mcp/README.md` and ADR 0045 for the full surface.
+
+Core properties:
+
+- Agents express intent through `mcp__factory-tools__*` tools; Factory builds argv, validates paths, caps output, and emits audit events.
+- `mcp/audit.ts` emits `agent.tool-call` events through `normalizeToolCallAuditPayload()`, carrying sanitized `tool_input`, `raw_path`, and `canonical_path` where a path is present.
+- Workflow-owned operations such as staging, committing, PR mutation, issue comments, state transitions, and evidence publishing are not registered with the MCP server. Workflows import those helpers directly.
+- Legacy in-process helpers `core/tool-layer/tools/{read,write,bash,test}.ts` were deleted. `core/tool-layer/tools/record-decision.ts` remains because the decisions API and record-decision slice still import it.
 
 ## Workspace Sandbox
 
@@ -80,6 +86,8 @@ The PreToolUse script:
 2. Denies out-of-allowlist tools (exits with block decision)
 3. Audits every call to the event store as `agent.tool-call`
 
+For MCP calls, the MCP server itself emits the same event kind with the normalized audit payload. Hook-originated native-tool events use the historical `tool_name` / `tool_input` shape; MCP-originated events also provide `tool_name` / `tool_input` so downstream timeline and workflow consumers can use one contract.
+
 ## PostToolUse Hook
 
 The PostToolUse script (`post-tool-use-hook.ts`) fires after each tool call and scans the agent's `transcript_path` for new `[decision] …` marker lines since the last fire:
@@ -89,141 +97,3 @@ The PostToolUse script (`post-tool-use-hook.ts`) fires after each tool call and 
 3. Extracts markers via `/^\[decision\]\s+(.+)$/gm`
 4. POSTs each marker to `POST /events/decision-summary` as `agent.decision-summary-live`
 5. All failures are best-effort — a failing POST never blocks the agent's tool execution
-
-## Sandboxed Read and Search Tools
-
-`tools/read.ts` provides workspace-sandboxed file access for the investigator agent. Both functions enforce that all access stays within the workspace root.
-
-### `readFile({ workspaceRoot, path })`
-
-Reads a file at `path` inside `workspaceRoot`. Returns the file contents as a UTF-8 string.
-
-Security constraints:
-- `path` must be non-empty.
-- Absolute paths are allowed only when they resolve inside `workspaceRoot`; returned metadata strips the worktree prefix.
-- Package-relative paths are normalized when uniquely resolvable.
-- Ambiguous package-relative paths and `../` traversal are rejected.
-- Throws `SandboxViolationError` on any violation.
-
-```ts
-import { readFile, SandboxViolationError } from './tools/read.js';
-
-const content = await readFile({
-  workspaceRoot: '/home/user/.factory/workspaces/run-123/repo',
-  path: 'src/index.ts',
-});
-```
-
-### `searchFiles({ workspaceRoot, pattern, glob? })`
-
-Runs ripgrep (`rg`) within `workspaceRoot` to find lines matching `pattern`. Returns the ripgrep stdout (with filename and line number), or `""` when no matches are found.
-
-Security constraints:
-- `pattern` must be non-empty.
-- `pattern` must not contain `../` — the search path is always `workspaceRoot`, never user-supplied.
-- Throws `SandboxViolationError` on any violation.
-- Optionally accepts a `glob` parameter to restrict which file types are searched (e.g. `*.ts`).
-
-```ts
-import { searchFiles } from './tools/read.js';
-
-const results = await searchFiles({
-  workspaceRoot: '/home/user/.factory/workspaces/run-123/repo',
-  pattern: 'TODO',
-  glob: '*.ts',
-});
-```
-
-### `SandboxViolationError`
-
-Typed error class thrown when path traversal or invalid input is detected. Callers should catch this specifically to distinguish sandbox violations from filesystem errors.
-
-```ts
-import { SandboxViolationError } from './tools/read.js';
-
-try {
-  await readFile({ workspaceRoot, path: '../escape' });
-} catch (err) {
-  if (err instanceof SandboxViolationError) {
-    // path escape attempt
-  }
-}
-```
-
-## Sandboxed Write Tool
-
-`tools/write.ts` provides workspace-bound file writes for the developer agent. Same path-validation contract as `readFile`.
-
-### `writeFile({ workspaceRoot, path, content, createParents? })`
-
-Writes UTF-8 `content` to `path` inside `workspaceRoot`. Parent directories are created by default. Existing files are overwritten.
-
-```ts
-import { writeFile } from './tools/write.js';
-
-await writeFile({
-  workspaceRoot: '/home/user/.factory/workspaces/run-123/repo',
-  path: 'src/new-feature.ts',
-  content: 'export const x = 1;\n',
-});
-```
-
-Throws `SandboxViolationError` on paths outside the worktree, ambiguous package-relative paths, or `../` traversal.
-
-## Sandboxed Bash Tool
-
-`tools/bash.ts` provides shell-free command execution for the developer agent.
-
-### `runBash({ workspaceRoot, argv, denylist?, env?, timeoutMs? })`
-
-Spawns `argv[0]` with `argv.slice(1)` as positional arguments. Never invokes a shell (FACTORY_RULES rule 29 — `shell: false`). Cwd is `workspaceRoot`; env is minimal (`HOME`, `PATH`) plus any caller-supplied keys.
-
-Returns `BashResult`:
-
-```ts
-interface BashResult {
-  stdout: string;       // capped at 4 MB (FACTORY_RULES rule 31)
-  stderr: string;
-  exitCode: number;
-  truncated: boolean;   // true if stdout was capped
-  timedOut: boolean;    // true if killed by 30 s default timeout (FACTORY_RULES rule 32)
-}
-```
-
-The default denylist (`DEFAULT_BASH_DENYLIST`) rejects `sudo `, `rm -rf /`, `git push --force`, `mkfs`, fork-bomb, etc. — case-insensitive substring match against the joined argv. Override per-call with the `denylist` parameter.
-
-```ts
-import { runBash } from './tools/bash.js';
-
-const result = await runBash({
-  workspaceRoot: '/work/repo',
-  argv: ['pnpm', 'lint'],
-});
-if (result.exitCode !== 0) {
-  throw new Error(`lint failed: ${result.stderr}`);
-}
-```
-
-## Test Tool
-
-`tools/test.ts` is a thin wrapper around `runBash` that runs the project's `testCommand` (from `StackConfig`).
-
-### `runTests({ workspaceRoot, testCommand, timeoutMs? })`
-
-Tokenises `testCommand` on whitespace into argv, then delegates to `runBash`. Default timeout is **5 minutes** (test runs legitimately exceed the 30 s default).
-
-Returns `TestResult` (extends `BashResult` with a boolean `passed` field — `true` iff `exitCode === 0`).
-
-```ts
-import { runTests } from './tools/test.js';
-
-const result = await runTests({
-  workspaceRoot: '/work/repo',
-  testCommand: 'pnpm test',
-});
-if (!result.passed) {
-  // surface result.stderr to the agent
-}
-```
-
-Quoted arguments in `testCommand` are NOT supported; projects with complex test commands should wrap them in a `package.json` script and pass the script invocation here.

--- a/core/tool-layer/mcp/audit.ts
+++ b/core/tool-layer/mcp/audit.ts
@@ -31,10 +31,12 @@ export interface BlockedToolCallAudit extends ToolCallAudit {
  * tools, consistent with the rest of the system.
  */
 export function emitToolCall(ctx: FactoryContext, audit: ToolCallAudit): void {
+  const { input, ...rest } = audit;
   const raw: ToolCallAuditPayload = {
-    ...audit,
+    ...rest,
     blocked: false,
-    tool_input: audit.input,
+    tool_name: audit.tool,
+    tool_input: input,
     workspace_dir: ctx.workspaceRoot,
   };
   const normalized = normalizeToolCallAuditPayload(raw);
@@ -53,9 +55,11 @@ export function emitToolCall(ctx: FactoryContext, audit: ToolCallAudit): void {
  * can aggregate by failure class without parsing free text.
  */
 export function emitBlockedToolCall(ctx: FactoryContext, audit: BlockedToolCallAudit): void {
+  const { input, ...rest } = audit;
   const raw: ToolCallAuditPayload = {
-    ...audit,
-    tool_input: audit.input,
+    ...rest,
+    tool_name: audit.tool,
+    tool_input: input,
     workspace_dir: ctx.workspaceRoot,
   };
   const normalized = normalizeToolResultAuditPayload(raw);

--- a/core/tool-layer/mcp/tools/context.test.ts
+++ b/core/tool-layer/mcp/tools/context.test.ts
@@ -71,7 +71,9 @@ describe('recordDecisionTool', () => {
     expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
 
     const events = eventStore.replay({ runId: ctx.runId, kind: 'agent.tool-call' });
-    const audit = events.find((e) => (e.payload as { tool?: string }).tool === 'record_decision');
+    const audit = events.find(
+      (e) => (e.payload as { tool_name?: string }).tool_name === 'record_decision',
+    );
     expect(audit).toBeTruthy();
   });
 

--- a/core/tool-layer/mcp/tools/read.test.ts
+++ b/core/tool-layer/mcp/tools/read.test.ts
@@ -47,7 +47,9 @@ describe('readFileTool', () => {
     expect(result.truncated).toBe(false);
 
     const events = eventStore.replay({ runId: ctx.runId, kind: 'agent.tool-call' });
-    expect(events.find((e) => (e.payload as { tool: string }).tool === 'read_file')).toBeTruthy();
+    expect(
+      events.find((e) => (e.payload as { tool_name: string }).tool_name === 'read_file'),
+    ).toBeTruthy();
   });
 
   it('emits a blocked tool-call event when path is .codex', async () => {

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -1,21 +1,38 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FactoryContext } from '../context.js';
 import {
   PackageScriptNotAllowedError,
   runPackageScriptTool,
   runTargetedCommandTool,
+  runTestsTool,
   runTypecheckTool,
 } from './verify.js';
 
 const REAL_PROJECT_SLUG = 'goose-hub-self';
+const { mockRunCommand } = vi.hoisted(() => ({
+  mockRunCommand: vi.fn(),
+}));
+
+vi.mock('../command-policy.js', () => ({
+  minimalEnv: () => ({}),
+  runCommand: (...args: unknown[]) => mockRunCommand(...args),
+}));
 
 let workspace: string;
 let ctx: FactoryContext;
 
 beforeEach(() => {
+  mockRunCommand.mockResolvedValue({
+    status: 'ok',
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    durationMs: 12,
+    truncated: false,
+  });
   workspace = mkdtempSync(join(tmpdir(), 'factory-verify-'));
   ctx = {
     runId: `run-${Math.random().toString(36).slice(2, 12)}`,
@@ -62,6 +79,41 @@ describe('runTypecheckTool', () => {
     const isolatedCtx: FactoryContext = { ...ctx, projectId: 'no-such-project-xyz' };
     await expect(runTypecheckTool(isolatedCtx, {})).rejects.toMatchObject({
       kind: 'StackCommandMissingError',
+    });
+  });
+});
+
+describe('runTestsTool', () => {
+  it('returns raw and canonical test paths for a targeted test run', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+    mkdirSync(join(workspace, 'apps/web/src'), { recursive: true });
+    writeFileSync(join(workspace, 'apps/web/src/foo.test.ts'), 'test("x", () => {});\n');
+
+    const result = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+
+    expect(result.rawPaths).toEqual(['src/foo.test.ts']);
+    expect(result.paths).toEqual([
+      {
+        path: 'apps/web/src/foo.test.ts',
+        root: 'worktree',
+        packageRoot: 'apps/web',
+        normalizedFrom: 'src/foo.test.ts',
+      },
+    ]);
+    expect(result.command.at(-1)).toBe('apps/web/src/foo.test.ts');
+    const event = (await import('../../../event-stream/store.js')).eventStore
+      .replay({ runId: ctx.runId, kind: 'agent.tool-call' })
+      .find((entry) => (entry.payload as { tool_name?: string }).tool_name === 'run_tests');
+    expect(event?.payload).toMatchObject({
+      raw_path: 'src/foo.test.ts',
+      canonical_path: { path: 'apps/web/src/foo.test.ts', root: 'worktree' },
+      tool_input: {
+        command: 'pnpm test --reporter=json apps/web/src/foo.test.ts',
+        rawPaths: ['src/foo.test.ts'],
+        paths: ['apps/web/src/foo.test.ts'],
+      },
     });
   });
 });

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import type { z } from 'zod';
 import { getProjectBySlug } from '../../../projects/loader.js';
 import type { ProjectConfig, StackConfig } from '../../../types.js';
+import type { RepoRelativePath } from '../../path-contract.js';
 import { emitBlockedToolCall, emitToolCall } from '../audit.js';
 import { type CommandResult, minimalEnv, runCommand } from '../command-policy.js';
 import type { FactoryContext } from '../context.js';
@@ -50,6 +51,8 @@ export interface VerifyResult {
   durationMs: number;
   truncated: boolean;
   command: ReadonlyArray<string>;
+  rawPaths?: string[];
+  paths?: RepoRelativePath[];
 }
 
 function tokeniseCommand(command: string): string[] {
@@ -59,7 +62,11 @@ function tokeniseCommand(command: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-function toVerifyResult(argv: ReadonlyArray<string>, r: CommandResult): VerifyResult {
+function toVerifyResult(
+  argv: ReadonlyArray<string>,
+  r: CommandResult,
+  paths?: { rawPaths: string[]; paths: RepoRelativePath[] },
+): VerifyResult {
   return {
     status: r.status,
     exitCode: r.exitCode,
@@ -68,6 +75,8 @@ function toVerifyResult(argv: ReadonlyArray<string>, r: CommandResult): VerifyRe
     durationMs: r.durationMs,
     truncated: r.truncated,
     command: argv,
+    ...(paths != null && paths.rawPaths.length > 0 ? { rawPaths: paths.rawPaths } : {}),
+    ...(paths != null && paths.paths.length > 0 ? { paths: paths.paths } : {}),
   };
 }
 
@@ -117,15 +126,17 @@ export async function runTestsTool(
   }
 
   const argv = tokeniseCommand(stack.testCommand);
+  let pathMetadata: { rawPaths: string[]; paths: RepoRelativePath[] } | undefined;
   if (input.path != null) {
-    let relPath: string;
+    let canonical: RepoRelativePath;
     try {
-      relPath = resolveWorkspacePath(ctx.workspaceRoot, input.path).canonical.path;
+      canonical = resolveWorkspacePath(ctx.workspaceRoot, input.path).canonical;
     } catch (err) {
       if (err instanceof PathPolicyViolation) handleBlocked(ctx, 'run_tests', err, { ...input });
       throw err;
     }
-    argv.push(relPath);
+    argv.push(canonical.path);
+    pathMetadata = { rawPaths: [input.path], paths: [canonical] };
   }
 
   const result = await runCommand({
@@ -138,13 +149,18 @@ export async function runTestsTool(
 
   emitToolCall(ctx, {
     tool: 'run_tests',
-    input: { path: input.path ?? null },
+    input: {
+      path: input.path ?? null,
+      command: argv.join(' '),
+      rawPaths: pathMetadata?.rawPaths ?? [],
+      paths: pathMetadata?.paths.map((path) => path.path) ?? [],
+    },
     status: result.status,
     exitCode: result.exitCode,
     durationMs: result.durationMs,
     truncated: result.truncated,
   });
-  return toVerifyResult(argv, result);
+  return toVerifyResult(argv, result, pathMetadata);
 }
 
 export async function runLintTool(

--- a/core/tool-layer/mcp/tools/write.test.ts
+++ b/core/tool-layer/mcp/tools/write.test.ts
@@ -75,9 +75,14 @@ describe('canonical RepoRelativePath contract', () => {
   it('audit event carries canonical_path for a write_file call', async () => {
     await writeFileTool(ctx, { path: 'audit-test.ts', content: 'y' });
     const events = eventStore.replay({ runId: ctx.runId, kind: 'agent.tool-call' });
-    const writeEvent = events.find((e) => (e.payload as { tool: string }).tool === 'write_file');
+    const writeEvent = events.find(
+      (e) => (e.payload as { tool_name: string }).tool_name === 'write_file',
+    );
     const payload = writeEvent?.payload as Record<string, unknown>;
     expect(payload.canonical_path).toMatchObject({ path: 'audit-test.ts', root: 'worktree' });
+    expect(payload.raw_path).toBe('audit-test.ts');
+    expect(payload.tool_input).toEqual({ path: 'audit-test.ts', created: true });
+    expect(payload).not.toHaveProperty('input');
   });
 });
 

--- a/docs/adr/0035-bash-command-timeout-scope.md
+++ b/docs/adr/0035-bash-command-timeout-scope.md
@@ -1,6 +1,6 @@
 # ADR 0035 — Bash Command Timeout Scope and Field Naming
 
-**Status:** Accepted
+**Status:** Accepted; superseded for agent-facing tool execution by ADR 0045
 **Date:** 2026-05-08
 **Issue:** #630 (wire dead global budget fields from PR #628)
 
@@ -12,14 +12,13 @@ PR #628 added the `project_settings` table with three fields that are stored,
 exposed via API, and rendered in the UI but not yet read at runtime:
 `maxBashSeconds`, `perAgentMaxUsd`, and `maxIssuesPerDayFromNonOwners`.
 
-`maxBashSeconds` requires a scope decision before it can be wired. Two timeout
-locations already exist in the codebase:
+`maxBashSeconds` required a scope decision before it could be wired. At the
+time of this ADR, two timeout locations existed in the codebase:
 
-1. **Per-invocation** — `core/tool-layer/tools/bash.ts:27` defines
-   `BASH_TIMEOUT_MS = 30_000`. This caps any single `runBash()` call. The
-   function already accepts a `timeoutMs` override parameter. This is the
-   orchestrator's in-process bash, used for git operations, applying patches,
-   etc. (FACTORY_RULES rule 32.)
+1. **Per-invocation** — the pre-MCP in-process bash helper
+   (`core/tool-layer/tools/bash.ts`) capped any single `runBash()` call and
+   accepted a `timeoutMs` override parameter. That helper was later deleted
+   during the ADR 0045 `factory-tools` MCP migration.
 
 2. **Whole-agent-run** — `core/agent-runtime/claude-cli.ts:233` reads
    `spec.budgets.timeoutMs` to time-bound the entire Claude CLI subprocess.
@@ -31,15 +30,15 @@ by Claude CLI internals and cannot be capped per-command from the orchestrator.
 
 ## Decision
 
-`maxBashSeconds` caps **per-invocation orchestrator-side `runBash` calls only**.
-It overrides the default `BASH_TIMEOUT_MS = 30_000` for that project. It does
-**not** affect agent-run timeouts and does **not** affect bash commands the
-agent issues inside a Claude CLI run.
+`maxBashSeconds` caps **per-invocation orchestrator-side command/tool calls
+only**. It overrides the default per-command timeout for that project. It does
+**not** affect agent-run timeouts and does **not** affect native bash commands
+an agent issues inside a Claude CLI run.
 
-Precedence (in `runBash` callers):
+Precedence for command runners:
 
 ```
-effectiveTimeoutMs = explicitParam ?? (dbRow.perBashCommandMaxSeconds * 1000) ?? BASH_TIMEOUT_MS
+effectiveTimeoutMs = explicitParam ?? (dbRow.perBashCommandMaxSeconds * 1000) ?? toolDefaultTimeoutMs
 ```
 
 The DB value is in seconds (matching the field name and UI affordance); it is
@@ -78,22 +77,18 @@ internal bash calls would require either (a) replacing Claude CLI's bash tool
 with our own subprocess shim, or (b) post-hoc kill via PID inspection. Both
 are out of scope for #630 and would warrant a separate ADR.
 
-## Future consumption
+## Supersession
 
-`core/tool-layer/tools/bash.ts:runBash()` has no production callers at the time
-of this ADR — `core/tool-layer/bundles.ts` lines 13–14 note that the MCP
-sandboxed tool server is not yet wired up; agent bash runs through Claude CLI's
-built-in tools governed by workspace-level deny rules in `sandbox.ts`. When the
-MCP tool server lands, its bash adapter must read
-`resolveGlobalSettingsForProject(projectId).perBashCommandMaxSeconds`,
-multiply by 1000, and pass as the `timeoutMs` parameter to `runBash()` (only
-when the caller hasn't already supplied an explicit `timeoutMs`).
+ADR 0045 replaced the unused `runBash()` helper path with the `factory-tools`
+MCP server. Agent-facing bundles now use `mcp__factory-tools__*` tools instead
+of native broad `Bash` or the deleted `core/tool-layer/tools/bash.ts` helper.
+MCP command tools own argv construction, timeout selection, output caps, and
+audit events. Any future per-project `perBashCommandMaxSeconds` enforcement
+belongs in the MCP command-policy/verify-tool layer rather than in deleted
+`runBash()` callers.
 
-Until then, the field is structurally enforced: it is read from DB, exposed via
-the resolution layer, and ready for consumption. The "not yet enforced" UI
-badge is still removed, because the orchestrator's resolution layer *does*
-honour the value — it's the agent's bash subprocess that doesn't exist as a
-consumer yet.
+The original scope decision still stands: this setting is for individual
+command/tool invocations, not whole agent runs.
 
 ## Consequences
 
@@ -102,10 +97,9 @@ consumer yet.
 - `core/db/repositories/project-settings.ts`, `apps/server/src/domains/project-settings/router.ts`,
   `apps/web/src/lib/api.ts`, and `apps/web/src/components/settings/components/ProjectBudgetPanel.tsx`
   rename in lockstep.
-- `runBash()` callers in `core/` that have a `projectId` available need to read
-  the resolved value. A helper in `core/agent-runtime/resolve-for-project.ts`
-  (extending `EffectiveGlobalSettings`) is the natural place; callers without a
-  `projectId` continue to use the default.
+- MCP command tools with a `projectId` available need to read the resolved
+  value and apply it as a per-invocation timeout. Callers without a `projectId`
+  continue to use the tool default.
 - `maxIssuesPerDayFromNonOwners` is descoped (see #630 task 3) — Goose Hub is
   single-user (CLAUDE.md), there are no non-owners. Schema column dropped in
   the same migration.

--- a/docs/plans/agent-operational-truth-roadmap.md
+++ b/docs/plans/agent-operational-truth-roadmap.md
@@ -21,10 +21,10 @@ Do not start the plans below until workflow consumers can rely on canonical path
 
 ## Ordered Plans
 
-1. [Factory-tools canonical path integration](./factory-tools-canonical-paths.md)
-2. [Workflow-owned operational facts](./workflow-owned-operational-facts.md)
-3. [Workflow contract repair gates](./workflow-contract-repair-gates.md)
-4. [Telemetry and prompt hardening](./telemetry-and-prompt-hardening.md)
+1. [Factory-tools canonical path integration](./factory-tools-canonical-paths.md) - complete
+2. [Workflow-owned operational facts](./workflow-owned-operational-facts.md) - complete
+3. [Workflow contract repair gates](./workflow-contract-repair-gates.md) - complete
+4. [Telemetry and prompt hardening](./telemetry-and-prompt-hardening.md) - complete
 
 ## Resume Rule
 
@@ -36,6 +36,8 @@ When asked to continue this roadmap:
 4. Complete only the next unchecked slice in that plan.
 5. Update the plan document with status and notes.
 6. Stop and report the slice completed plus the next slice.
+
+Current status: all roadmap plan slices are complete; future work should start from new issues or follow-up plan docs rather than this roadmap's resume rule.
 
 ## Target End State
 
@@ -52,4 +54,3 @@ When asked to continue this roadmap:
 - Ambiguous normalization does not silently choose a candidate.
 - Workflow-owned evidence wins over model-declared facts.
 - Prompt rules are guidance only; enforcement lives in tools and workflows.
-

--- a/docs/plans/factory-tools-canonical-paths.md
+++ b/docs/plans/factory-tools-canonical-paths.md
@@ -72,7 +72,7 @@ Completed:
 - `workspace_dir` is passed transiently and stripped from persisted payloads.
 - Blocked tool-call events pass through the same normalizer.
 
-### [ ] Slice 3 - MCP test tool returns canonical test paths
+### [x] Slice 3 - MCP test tool returns canonical test paths
 
 Make the factory test tool report the canonical test files it ran.
 
@@ -82,7 +82,13 @@ Acceptance criteria:
 - `testsRun.paths` can be derived from tool output.
 - Package-relative test args such as `src/foo.test.ts` normalize to the package path when unique.
 
-### [ ] Slice 4 - Prompt simplification pass
+Completed:
+
+- `mcp__factory-tools__run_tests` now resolves targeted `path` input through the shared `RepoRelativePath` contract before building argv.
+- Test-tool results include `rawPaths` and canonical `paths` so workflow handoffs can derive `testsRun.paths` from observed tool output.
+- `agent.tool-call` audit payloads for `run_tests` include compact raw/canonical path metadata and never persist absolute worktree paths.
+
+### [x] Slice 4 - Prompt simplification pass
 
 Update implement-style skill prompts to tell agents to use `mcp__factory-tools__`-returned paths verbatim in terminal JSON.
 
@@ -91,6 +97,11 @@ Acceptance criteria:
 - Prompts no longer rely on agents inferring CWD or package root.
 - Prompts still state the canonical path contract.
 - Prompt wording does not replace workflow validation.
+
+Completed:
+
+- `skills/implement/prompt.md` and `skills/implement-wp/prompt.md` now instruct agents to use `mcp__factory-tools__*` returned `path` / `paths[].path` values verbatim.
+- Shell/CWD mechanics were reduced to high-signal rules while preserving tool/workflow validation as the enforcement boundary.
 
 ## Verification
 
@@ -102,9 +113,10 @@ Latest verification:
 
 - Prerequisite: `pnpm lint`
 - Prerequisite: `pnpm vitest run core/workspaces/path-normalization.test.ts slices/fix-issue/slice.test.ts slices/parallel-implement/slice.test.ts slices/spec-author/slice.test.ts`
-- Slice 1: `pnpm vitest run core/tool-layer/path-contract.test.ts core/tool-layer/tools/slice.test.ts core/tool-layer/tools/read.test.ts core/workspaces/path-normalization.test.ts`
+- Slice 1: `pnpm vitest run core/tool-layer/path-contract.test.ts core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/tools/read.test.ts core/tool-layer/mcp/tools/write.test.ts core/workspaces/path-normalization.test.ts`
 - Slice 2: `pnpm vitest run core/tool-layer/tool-call-audit.test.ts core/tool-layer/path-contract.test.ts core/tool-layer/pre-tool-use-hook.test.ts core/tool-layer/post-tool-use-hook.test.ts apps/server/src/domains/events/service.test.ts apps/server/src/domains/events/router.test.ts core/agent-runtime/codex-cli-runtime.test.ts`
 - Slice 2: `pnpm lint`
 - Final guard: `pnpm typecheck`
+- Slice 3/4: `pnpm test core/tool-layer/mcp/tools/verify.test.ts skills/implement/slice.test.ts skills/implement-wp/slice.test.ts`
 
-Next unchecked slice: Slice 3 - Test tool returns canonical test paths.
+Next unchecked slice: none.

--- a/docs/plans/telemetry-and-prompt-hardening.md
+++ b/docs/plans/telemetry-and-prompt-hardening.md
@@ -20,7 +20,7 @@ This is the cleanup layer after path normalization, factory-tools path output, o
 
 ## Slices
 
-### [ ] Slice 1 - Timeline labels for read/write/report/changed
+### [x] Slice 1 - Timeline labels for read/write/report/changed
 
 Update timeline/detail rendering so users can distinguish operational states:
 
@@ -37,7 +37,13 @@ Acceptance criteria:
 - Path-normalization events are visible but compact.
 - Existing older events still render sensibly.
 
-### [ ] Slice 2 - Path drift dashboard/report
+Completed:
+
+- Timeline rendering now labels `agent.tool-call` read/write/edit/test/lint/typecheck events from both legacy and MCP audit payload shapes.
+- `agent.path-normalized`, `agent.output-repaired`, `agent.output-fact-mismatch`, and `agent.contract-gate-blocked` render as compact operational-fact cards.
+- Cards distinguish normalized paths, git-observed changed files, tool-observed writes, model-declared files, and mismatch buckets without dumping raw payload JSON.
+
+### [x] Slice 2 - Path drift dashboard/report
 
 Add lightweight reporting for path repairs and mismatches.
 
@@ -47,7 +53,13 @@ Acceptance criteria:
 - Counts are grouped by skill and field.
 - The report identifies whether drift is decreasing after factory-tools adoption.
 
-### [ ] Slice 3 - Prompt contraction pass
+Completed:
+
+- Added `core/agent-runtime/path-drift-report.ts` to group repair, mismatch, and gate-block events by skill and field.
+- Added `pnpm path-drift:report [projectId] [limit]` for a lightweight developer report over recent event-stream data.
+- The report includes scanned event counts, drift event counts, latest event id, per-field buckets, and a simple first-half/second-half trend direction.
+
+### [x] Slice 3 - Prompt contraction pass
 
 Remove duplicated low-level mechanics once factory-tools owns them.
 
@@ -58,7 +70,13 @@ Acceptance criteria:
 - Path contract remains explicit.
 - Prompt examples use canonical paths only.
 
-### [ ] Slice 4 - Contract audit extension
+Completed:
+
+- `skills/implement/prompt.md` and `skills/implement-wp/prompt.md` now center `mcp__factory-tools__*` calls and returned canonical paths.
+- Prompt examples remain repo-root/worktree-root relative and avoid package-relative `src/...` output examples.
+- Low-level shell/CWD prose was contracted where Factory tools enforce the behavior directly.
+
+### [x] Slice 4 - Contract audit extension
 
 Extend existing skill-contract audit tooling to flag vague path language.
 
@@ -68,7 +86,12 @@ Acceptance criteria:
 - Output examples with `src/...` under package-owned surfaces are flagged.
 - The audit can run advisory first, then become enforced for implement-family skills.
 
-### [ ] Slice 5 - Generalize beyond paths
+Completed:
+
+- `core/agent-runtime/skill-contract-audit.ts` now reports vague `workspace-relative` path language and package-relative `src/...` JSON output examples.
+- `scripts/audit-skill-contracts.ts --strict` enforces the new path-language checks for `implement`, `implement-wp`, and `spec-author`; other skills remain advisory through the formatted report.
+
+### [x] Slice 5 - Generalize beyond paths
 
 Apply the same pattern to other model-declared operational facts.
 
@@ -87,6 +110,11 @@ Acceptance criteria:
 - Facts Factory can observe are no longer accepted only from model JSON.
 - Residual model-authored facts are documented as judgment or explanation fields.
 
+Completed:
+
+- Added `core/agent-runtime/operational-fact-owners.ts` as the current owner table for commands run, targeted test paths, changed files, evidence artifacts, PR metadata, state transitions, budget/cost facts, and residual model judgment.
+- The table marks observed facts as tool/workflow/collector/runtime owned and leaves only finding severity/rationale as model judgment.
+
 ## Verification
 
 - Timeline/component tests for new labels.
@@ -94,3 +122,9 @@ Acceptance criteria:
 - Snapshot or fixture tests for old and new events.
 - One end-to-end workflow fixture showing read, write, normalized path, observed changed file, and successful guard.
 
+Latest verification:
+
+- `pnpm test apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx core/agent-runtime/path-drift-report.test.ts core/agent-runtime/operational-fact-owners.test.ts core/agent-runtime/skill-contract-audit.test.ts`
+- `pnpm typecheck`
+
+Next unchecked slice: none.

--- a/docs/plans/telemetry-and-prompt-hardening.md
+++ b/docs/plans/telemetry-and-prompt-hardening.md
@@ -57,7 +57,7 @@ Completed:
 
 - Added `core/agent-runtime/path-drift-report.ts` to group repair, mismatch, and gate-block events by skill and field.
 - Added `pnpm path-drift:report [projectId] [limit]` for a lightweight developer report over recent event-stream data.
-- The report includes scanned event counts, drift event counts, latest event id, per-field buckets, and a simple first-half/second-half trend direction.
+- The report includes scanned event counts, drift event counts, latest event id, per-field buckets, and a time-window trend direction.
 
 ### [x] Slice 3 - Prompt contraction pass
 

--- a/docs/plans/workflow-contract-repair-gates.md
+++ b/docs/plans/workflow-contract-repair-gates.md
@@ -58,7 +58,7 @@ Verification:
 - `pnpm vitest run slices/fix-issue/slice.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/path-contract.test.ts` — passed, 48 tests.
 - `pnpm lint` — passed.
 
-Next unchecked slice: Slice 2 - Evidence requirement gate.
+Slice 1 status: complete.
 
 ### [x] Slice 2 - Evidence requirement gate
 
@@ -91,7 +91,7 @@ Verification:
 - `pnpm vitest run slices/fix-issue/slice.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/path-contract.test.ts` — passed, 50 tests.
 - `pnpm lint` — passed.
 
-Next unchecked slice: Slice 3 - Wrong-surface gate rewrite.
+Slice 2 status: complete.
 
 ### [x] Slice 3 - Wrong-surface gate rewrite
 
@@ -121,7 +121,7 @@ Verification:
 - `pnpm vitest run slices/fix-issue/slice.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/path-contract.test.ts` — passed, 52 tests.
 - `pnpm lint` — passed.
 
-Next unchecked slice: Slice 4 - Implement-wp ownership gate.
+Slice 3 status: complete.
 
 ### [x] Slice 4 - Implement-wp ownership gate
 
@@ -151,7 +151,7 @@ Verification:
 - `pnpm vitest run slices/parallel-implement/slice.test.ts core/workspaces/path-normalization.test.ts core/tool-layer/path-contract.test.ts` — passed, 42 tests.
 - `pnpm lint` — passed.
 
-Next unchecked slice: Slice 5 - Spec-author output gate.
+Slice 4 status: complete.
 
 ### [x] Slice 5 - Spec-author output gate
 
@@ -189,7 +189,7 @@ Completed in this run: Slices 1-5. Current code changes are concentrated in impl
 
 Final verification:
 
-- `pnpm vitest run slices/fix-issue/slice.test.ts slices/parallel-implement/slice.test.ts slices/spec-author/slice.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/path-contract.test.ts core/tool-layer/tools/slice.test.ts` — passed, 154 tests.
+- `pnpm vitest run slices/fix-issue/slice.test.ts slices/parallel-implement/slice.test.ts slices/spec-author/slice.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/path-contract.test.ts core/tool-layer/mcp/slice.test.ts` — passed, 154 tests.
 - `pnpm lint` — passed.
 - `pnpm typecheck` — passed.
 

--- a/docs/plans/workflow-owned-operational-facts.md
+++ b/docs/plans/workflow-owned-operational-facts.md
@@ -90,7 +90,7 @@ Notes:
 - Tool-audit reconciliation only uses write/edit-style tool calls that already carry canonical path metadata.
 - This slice does not derive canonical targeted test execution; `testsRun.paths` remains Slice 3.
 
-### [ ] Slice 3 - Derive targeted tests from tool/test audit
+### [x] Slice 3 - Derive targeted tests from tool/test audit
 
 Use factory-tools test output or existing test audit events to populate canonical `devTestsRun`.
 
@@ -100,7 +100,13 @@ Acceptance criteria:
 - Model `testsRun.paths` becomes advisory or a fallback.
 - Outside-targeted failure bucketing uses observed paths.
 
-### [ ] Slice 4 - Evidence facts come from collector output
+Completed:
+
+- QA now looks up the developer run's `agent.tool-call` events and derives `devTestsRun` from observed `run_tests` audit metadata when available.
+- Canonical test paths from audit events win over model-authored `agent.implement-complete.testsRun`; the model output remains a fallback for older runs.
+- Outside-targeted failure bucketing in QA receives canonical observed paths.
+
+### [x] Slice 4 - Evidence facts come from collector output
 
 Treat evidence artifacts, screenshots, GIFs, and comment URLs as collector/publisher facts, not model facts.
 
@@ -109,6 +115,12 @@ Acceptance criteria:
 - Evidence-post result reflects collector classification and publisher output.
 - Screenshot paths are discovered and normalized by workflow code.
 - Missing `commentUrl` is reported as publish failure, not guessed as Playwright failure.
+
+Completed:
+
+- Evidence-post success events now persist publisher/collector facts: `commentUrl`, `runId`, screenshot paths, GIF path, and commit SHA when available.
+- QA verification summaries carry those evidence artifact facts forward without relying on model-authored guesses.
+- Existing publish failure handling remains the source of truth for missing comment URLs.
 
 ## Verification
 
@@ -124,5 +136,6 @@ Latest verification:
 - Guard: `pnpm typecheck`
 - Slice 2: `pnpm vitest run slices/fix-issue/slice.test.ts core/workspaces/observed-changes.test.ts core/tool-layer/tool-call-audit.test.ts`
 - Slice 2: `pnpm lint`
+- Slice 3/4: `pnpm test slices/qa/slice.test.ts slices/fix-issue/slice.test.ts skills/qa/slice.test.ts`
 
-Next unchecked slice: Slice 3 - Derive targeted tests from tool/test audit.
+Next unchecked slice: none.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gen:office-assets": "tsx scripts/generate-office-assets.ts",
     "manifest": "tsx scripts/build-manifest.ts",
     "audit-docs": "tsx scripts/audit-docs.ts",
+    "path-drift:report": "tsx scripts/report-path-drift.ts",
     "symbol-index": "tsx scripts/build-symbol-index.ts",
     "symbol-index:report": "tsx scripts/report-symbol-index-lookups.ts",
     "symbol": "tsx scripts/query-symbol-index.ts",

--- a/scripts/audit-skill-contracts.ts
+++ b/scripts/audit-skill-contracts.ts
@@ -6,15 +6,19 @@ const audit = auditSkillContracts(process.cwd());
 console.log(formatSkillContractAudit(audit));
 
 if (strict) {
+  const enforcePathLanguageFor = new Set(['implement', 'implement-wp', 'spec-author']);
   const violations = audit.skills.filter(
     (s) =>
       s.snakeCaseTags.length > 0 ||
       s.missingFromPrompt.length > 0 ||
-      s.extraPromptTags.length > 0,
+      s.extraPromptTags.length > 0 ||
+      (enforcePathLanguageFor.has(s.skill) &&
+        (s.pathLanguage.vagueWorkspaceRelative.length > 0 ||
+          s.pathLanguage.packageRelativeExamples.length > 0)),
   );
   if (violations.length > 0) {
     console.error(
-      `\nstrict mode failed: ${violations.length} skill(s) contain deterministic tag drift`,
+      `\nstrict mode failed: ${violations.length} skill(s) contain deterministic contract drift`,
     );
     for (const violation of violations) {
       console.error(
@@ -23,6 +27,10 @@ if (strict) {
           `snakeCase=${violation.snakeCaseTags.join(',') || '(none)'}`,
           `missing=${violation.missingFromPrompt.join(',') || '(none)'}`,
           `extra=${violation.extraPromptTags.join(',') || '(none)'}`,
+          `pathLanguageWorkspaceRelative=${violation.pathLanguage.vagueWorkspaceRelative.length}`,
+          `pathLanguagePackageRelativeExamples=${
+            violation.pathLanguage.packageRelativeExamples.join(',') || '(none)'
+          }`,
         ].join(' '),
       );
     }

--- a/scripts/report-path-drift.ts
+++ b/scripts/report-path-drift.ts
@@ -1,0 +1,11 @@
+import { formatPathDriftReport, loadPathDriftReport } from '../core/agent-runtime/path-drift-report.js';
+
+const [, , projectIdArg, limitArg] = process.argv;
+const limit = limitArg != null ? Number.parseInt(limitArg, 10) : undefined;
+
+const report = loadPathDriftReport({
+  ...(projectIdArg != null && projectIdArg.length > 0 ? { projectId: projectIdArg } : {}),
+  ...(Number.isFinite(limit) ? { limit } : {}),
+});
+
+process.stdout.write(formatPathDriftReport(report));

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -45,7 +45,7 @@ The context contains a `<task>` block with:
 - `<worktreePath>` — absolute path to your scratch worktree (already checked out)
 - `<stack>` — JSON payload with `testCommand`, optional `lintCommand`, and optional `typecheckCommand`
 
-Path contract: all output paths must be repo-root/worktree-root relative POSIX paths. Do not use package-relative paths like `src/...` for files under `apps/web`; use `apps/web/src/...`.
+Path contract: all output paths must be repo-root/worktree-root relative POSIX paths. When a `mcp__factory-tools__*` response returns `{ path, root, packageRoot, normalizedFrom }`, copy the returned `path` value verbatim into your terminal JSON. Do not infer paths from CWD or package root.
 
 ## What you must do
 
@@ -57,7 +57,7 @@ Path contract: all output paths must be repo-root/worktree-root relative POSIX p
   investigation key files, stop and return `confidence: low` with a `BLOCKER`
   decision summary.
 - Read the files in `<wp>.filesOwned` to understand the current state.
-- Use `read` and `search` tools to load test files for the surfaces you will touch FIRST.
+- Use `mcp__factory-tools__read_file` and `mcp__factory-tools__search_text` to load test files for the surfaces you will touch FIRST.
 - Emit: `[decision] READ: Loaded WP <id> context and N relevant files`
 
 ### 2 — Plan
@@ -71,13 +71,13 @@ Path contract: all output paths must be repo-root/worktree-root relative POSIX p
 
 - Write test cases that fail with the current code. Cover the WP's acceptance criteria and
   at least one negative path.
-- Run the targeted test command via the `test` tool (pass only the new test file paths).
+- Run the targeted test command via `mcp__factory-tools__run_tests` (pass only the new test file paths).
 - Confirm the new tests fail and pre-existing tests still pass.
 - Emit: `[decision] RED: Wrote N failing tests for <surface>`
 
 ### 4 — Green — implementation
 
-- Write the implementation using the `write` tool. Repo-root/worktree-root relative POSIX paths only.
+- Write the implementation using `mcp__factory-tools__write_file` or `mcp__factory-tools__edit_file`. Use returned `path.path` values in `filesWritten` and `testsWritten`.
   Do NOT write files outside your `<wp>.filesOwned` list.
 - Re-run the targeted test command. Iterate until all targeted tests pass.
 - Emit: `[decision] GREEN: Implementation passes all targeted tests`
@@ -90,7 +90,7 @@ Only refactor if required to make the test pass cleanly.
 
 - If `stack.lintCommand` is provided, run it. Fix failures.
 - If `stack.typecheckCommand` is provided, run it. Fix errors.
-- Re-run targeted tests one final time to confirm still green. In `testsRun.paths`, return canonical repo-relative paths for the files you tested, even if the command accepted a shorter package-relative path.
+- Re-run targeted tests one final time to confirm still green. In `testsRun.paths`, return the canonical `paths[].path` values from `mcp__factory-tools__run_tests`.
 - Emit: `[decision] LINT: Lint and typecheck clean`
 
 ### 7 — Return (no commit — orchestrator commits)

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -10,15 +10,15 @@ You are a developer agent shipping a single slice. You follow the **Red → Gree
 
 These two rules are enforced before any other step. Violating them wastes budget and produces garbage output.
 
-**No shell syntax.** Never add `2>&1`, `>`, `&&`, `;`, or `|` to commands — `shell: false` passes them as literal arguments to the program, breaking the command silently. Use separate `bash` calls instead.
+**Use Factory tools, not shell syntax.** Prefer `mcp__factory-tools__read_file`, `search_text`, `write_file`, `edit_file`, `run_tests`, `run_lint`, and `run_typecheck`. Never add `2>&1`, `>`, `&&`, `;`, or `|` to commands; Factory tools construct argv and cap output for you.
 
 **No memory or skill quick pass.** Do not read local assistant memory, skill, config, or session files. Never inspect `~/.codex`, `~/.agents`, `~/.claude`, sibling repos, or parent directories. If prior context is needed, use only the context provided in this run.
 
-**No command retry.** CWD is always the worktree root and cannot change between bash calls. If a command returns output you have already seen, running it again (with any description or flag variation) produces identical output. Stop immediately: emit a diagnosis decision summary (`kind: BLOCKER`), set `confidence: low`, and return. Do not retry.
+**No command retry.** CWD is always the worktree root. If a command returns output you have already seen, running it again with a flag variation produces identical output. Stop immediately: emit a diagnosis decision summary (`kind: BLOCKER`), set `confidence: low`, and return. Do not retry.
 
 ## Role
 
-Developer (non-holdout). You see prior decision summaries (advisor feedback, prior runs), the issue body, and the worktree path. You write code with the sandboxed `dev-tools` bundle (`read`, `search`, `work-item-read`, `write`, `bash`, `test`) — all workspace-bound, no shell, bash-denylist enforced.
+Developer (non-holdout). You see prior decision summaries (advisor feedback, prior runs), the issue body, and the worktree path. You write code with the sandboxed `dev-tools` bundle, surfaced as `mcp__factory-tools__*` tools. Factory owns path normalization, argv construction, output caps, and audit events.
 
 ## Input
 
@@ -31,7 +31,7 @@ The context contains a `<task>` block with:
 - `<investigation>` (optional) — prior bug-investigation findings, key files, and open questions
 - `<revisionPass>` (optional) — `0` (default) or `1`
 
-Path contract: all output paths must be repo-root/worktree-root relative POSIX paths. Do not use package-relative paths like `src/...` for files under `apps/web`; use `apps/web/src/...`.
+Path contract: all output paths must be repo-root/worktree-root relative POSIX paths. When a `mcp__factory-tools__*` response returns `{ path, root, packageRoot, normalizedFrom }`, copy the returned `path` value verbatim into your terminal JSON. Do not infer paths from CWD or package root.
 
 ## What you must do
 
@@ -43,7 +43,7 @@ Path contract: all output paths must be repo-root/worktree-root relative POSIX p
   `keyFiles` before exploring adjacent surfaces. If you choose a different
   implementation surface, explain the pivot in a `PLAN` decision summary with
   concrete evidence.
-- Use the `read` and `search` tools to load the test files for the surfaces you'll touch FIRST. Existing tests are the strongest signal of intent.
+- Use `mcp__factory-tools__read_file` and `mcp__factory-tools__search_text` to load the test files for the surfaces you'll touch FIRST. Existing tests are the strongest signal of intent.
 
 #### Investigation handoff fast path
 
@@ -119,12 +119,12 @@ generation was blocked. Do not spend more discovery budget on e2e plumbing.
 ### 3 — Red — failing tests first
 
 - Write the test cases that will fail with the current implementation. Cover the acceptance criteria and at least one negative path.
-- Run the **targeted** test command via the `test` tool — pass the new test file path and any test files for surfaces you've modified, e.g. `stack.testCommand path/to/new.test.ts path/to/affected.test.ts`. Do not run the full suite. Confirm the new tests fail (and only the new ones — pre-existing tests must still pass or fail for known reasons).
+- Run the **targeted** test command via `mcp__factory-tools__run_tests` — pass the new test file path and any test files for surfaces you've modified. Use the `paths[].path` values returned by the tool in `testsRun.paths`. Do not run the full suite. Confirm the new tests fail (and only the new ones — pre-existing tests must still pass or fail for known reasons).
 - Emit: `[decision] RED: Wrote N failing tests for <surface>; targeted test command shows N new failures`
 
 ### 4 — Green — implementation
 
-- Write the implementation using the `write` tool. Repo-root/worktree-root relative POSIX paths only — no absolute paths, package-relative paths, backslashes, or `..` traversal.
+- Write the implementation using `mcp__factory-tools__write_file` or `mcp__factory-tools__edit_file`. Use returned `path.path` values in `filesWritten` and `testsWritten`.
 - Re-run the **targeted** test command (same file paths as in Red). Iterate until all targeted tests pass.
 - **Frontend changes (required when possible):** If any file written is under `apps/web/` and `<evidencePostEnabled>` is not `false`, write a Playwright spec at `apps/web/e2e/issue-<number>.spec.ts` now, before proceeding to step 5. The spec must navigate to the affected UI, assert the visible change, and call `page.screenshot({ path: 'evidence/issue-<number>/step-1.png' })`. Use plain `page.goto('/...')` — never `waitForLoadState('networkidle')` (the app's persistent SSE connection prevents it from firing; use `waitForSelector` or time-bounded assertions instead). This spec ships in the same commit as your implementation so the evidence-post skill can run it post-PR. If evidence is disabled by project setting, return `evidenceSpecPath: null` with a `SKIP_GATE` summary. If evidence spec generation is blocked after the bounded frontend evidence rule above, do not block the implementation; return `evidenceSpecPath: null` and include a `TOOL_FAILURE` or `UNCERTAINTY` decision summary that explicitly mentions the e2e/evidence/Playwright blockage.
 - Emit: `[decision] GREEN: Implementation passes all targeted tests including N new cases`
@@ -181,8 +181,8 @@ Score honestly. Identify your single lowest-scoring category and explain it in t
 
 ### 6 — Lint and typecheck
 
-- If `stack.lintCommand` is provided, run it via the `bash` tool. Fix any failures (auto-fix where possible).
-- If `stack.typecheckCommand` is provided, run it. Fix any errors.
+- If `stack.lintCommand` is provided, run `mcp__factory-tools__run_lint`. Fix any failures.
+- If `stack.typecheckCommand` is provided, run `mcp__factory-tools__run_typecheck`. Fix any errors.
 - Re-run the **targeted** test command one final time (same paths) to confirm nothing in your surface regressed.
 
 ### 7 — Do NOT commit (orchestrator commits on your behalf)
@@ -215,10 +215,10 @@ Return a JSON object conforming to `ImplementSchema`. The orchestrator opens the
 
 - **Single slice, single issue.** Do not absorb scope from related issues or improve unrelated code.
 - **TDD-first.** Write the test before the implementation. A test added after the fact does not count.
-- **Workspace-bound.** All paths via the `write` tool are relative to the worktree root. Absolute paths, package-relative paths, backslashes, and `..` traversal are rejected at the tool layer.
-- **No shell.** The `bash` tool spawns argv directly with `shell: false`. Do not chain commands with `&&`, `;`, or pipes — invoke them as separate `bash` calls.
+- **Workspace-bound.** All paths via Factory tools are resolved to canonical repo-relative paths. Absolute paths, package-relative ambiguity, backslashes, and `..` traversal are rejected at the tool layer.
+- **No shell.** Use Factory verification tools rather than shell strings. Do not chain commands with `&&`, `;`, or pipes.
 - **Targeted tests only.** QA runs the full suite — your job is to ship green for the surface you touched, not to verify the world. Re-running the entire suite on every Red→Green→Refactor pass burns budget and hides the "did dev break something elsewhere?" signal that QA should be the authority on. If you broke something far away, QA catches it.
-- **Record what you ran.** Populate `testsRun.command` with the test command you actually invoked and `testsRun.paths` with canonical repo-relative paths for the files you tested, even if the command accepted a shorter package-relative path. QA cross-references this against its own full-suite results — failures outside your `paths` are the high-signal regressions.
+- **Record what you ran.** Populate `testsRun.command` with the command returned by `mcp__factory-tools__run_tests` and `testsRun.paths` with the returned canonical `paths[].path` values. QA cross-references this against its own full-suite results — failures outside your `paths` are the high-signal regressions.
 - **`decisionSummaries` is required and must be ≥ 1 entry.** Single sentence per entry. No chain-of-thought, no secrets, no PII.
 - **Confidence honestly.** `low` is OK — surface uncertainty; the human reviewer would rather know.
 

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -139,6 +139,9 @@ export const VerificationSummarySchema = z.object({
   evidence: z.object({
     status: z.enum(['posted', 'skipped', 'failed', 'absent']),
     url: z.string().url().optional(),
+    screenshots: z.array(z.string()).optional(),
+    gifPath: z.string().nullable().optional(),
+    commitSha: z.string().optional(),
     error: z.string().optional(),
     reason: z.string().optional(),
   }),

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -177,7 +177,7 @@ function observedWritePathsFromToolAudit(runId: string): string[] {
   const paths: string[] = [];
   for (const event of events) {
     const payload = event.payload as Record<string, unknown> | null;
-    if (payload == null || !isWriteOrEditToolName(payload.tool_name)) continue;
+    if (payload == null || !isWriteOrEditToolName(payload.tool_name ?? payload.tool)) continue;
     const path = canonicalPathStringFromAuditPayload(payload);
     if (path != null) paths.push(path);
   }

--- a/slices/fix-issue/pr-helpers.ts
+++ b/slices/fix-issue/pr-helpers.ts
@@ -158,7 +158,13 @@ export async function runEvidencePost(input: RunEvidencePostInput): Promise<void
       projectId: input.projectId,
       workItemId: input.workItem.id,
       kind: 'evidence.posted',
-      payload: { commentUrl: parsed.data.commentUrl, runId: evidenceRunId },
+      payload: {
+        commentUrl: parsed.data.commentUrl,
+        runId: evidenceRunId,
+        screenshots: parsed.data.screenshots.map((screenshot) => screenshot.path),
+        gifPath: parsed.data.gifPath,
+        ...(parsed.data.commitSha != null ? { commitSha: parsed.data.commitSha } : {}),
+      },
       runId: evidenceRunId,
     });
   } catch (err) {

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -1505,7 +1505,7 @@ describe('runFixIssueWorkflow (#183)', () => {
             workItemId: item.id,
             kind: 'agent.tool-call',
             payload: {
-              tool_name: 'Write',
+              tool: 'write_file',
               canonical_path: { path: 'core/tool-observed.ts', root: 'worktree' },
             },
             runId: String(filter.runId),
@@ -1989,6 +1989,12 @@ describe('runFixIssueWorkflow — evidence-post branch coverage', () => {
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'evidence.posted');
     expect(evidencePosted).toBeDefined();
+    expect(evidencePosted?.[0].payload).toMatchObject({
+      commentUrl: 'https://github.com/owner/repo/issues/42#issuecomment-1',
+      screenshots: ['evidence/issue-42/step-1.png'],
+      gifPath: null,
+      commitSha: 'abc1234567890abcdef',
+    });
   });
 
   it('passes worktreePath as workspaceDir on the evidence-post run spec (so git commands work)', async () => {

--- a/slices/qa/qa-helpers.ts
+++ b/slices/qa/qa-helpers.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { canonicalPathStringFromAuditPayload } from '@goose-hub/core/tool-layer/tool-call-audit.js';
 
 export const QA_PR_DIFF_CHAR_LIMIT = 200_000;
 
@@ -177,7 +178,11 @@ export function findPrOpenedHints(workItemId: string): PrOpenedHints {
  */
 export function findDevTestsRun(
   workItemId: string,
+  devRunId?: string,
 ): { command: string; paths: string[] } | undefined {
+  const observed = devRunId == null ? undefined : findObservedDevTestsRun(devRunId);
+  if (observed != null) return observed;
+
   const events = eventStore.replay({ workItemId });
   const implementComplete = events
     .slice()
@@ -196,4 +201,33 @@ export function findDevTestsRun(
     return undefined;
   }
   return tr as { command: string; paths: string[] };
+}
+
+function findObservedDevTestsRun(runId: string): { command: string; paths: string[] } | undefined {
+  const events = eventStore.replay({ runId, kind: 'agent.tool-call' });
+  const testEvents = events.filter((event) => {
+    const payload = event.payload as Record<string, unknown> | null;
+    if (payload == null) return false;
+    const toolName = payload.tool_name ?? payload.tool;
+    return toolName === 'run_tests';
+  });
+  const latest = testEvents.at(-1);
+  if (latest == null) return undefined;
+
+  const payload = latest.payload as Record<string, unknown>;
+  const toolInput = payload.tool_input;
+  const command =
+    toolInput != null &&
+    typeof toolInput === 'object' &&
+    !Array.isArray(toolInput) &&
+    typeof (toolInput as { command?: unknown }).command === 'string'
+      ? (toolInput as { command: string }).command
+      : undefined;
+  const paths = testEvents.flatMap((event) => {
+    const path = canonicalPathStringFromAuditPayload(event.payload);
+    return path == null ? [] : [path];
+  });
+  const uniquePaths = [...new Set(paths)];
+  if (command == null || uniquePaths.length === 0) return undefined;
+  return { command, paths: uniquePaths };
 }

--- a/slices/qa/qa-helpers.ts
+++ b/slices/qa/qa-helpers.ts
@@ -205,29 +205,23 @@ export function findDevTestsRun(
 
 function findObservedDevTestsRun(runId: string): { command: string; paths: string[] } | undefined {
   const events = eventStore.replay({ runId, kind: 'agent.tool-call' });
-  const testEvents = events.filter((event) => {
+  const observedRuns = events.flatMap((event) => {
     const payload = event.payload as Record<string, unknown> | null;
-    if (payload == null) return false;
+    if (payload == null) return [];
     const toolName = payload.tool_name ?? payload.tool;
-    return toolName === 'run_tests';
-  });
-  const latest = testEvents.at(-1);
-  if (latest == null) return undefined;
-
-  const payload = latest.payload as Record<string, unknown>;
-  const toolInput = payload.tool_input;
-  const command =
-    toolInput != null &&
-    typeof toolInput === 'object' &&
-    !Array.isArray(toolInput) &&
-    typeof (toolInput as { command?: unknown }).command === 'string'
-      ? (toolInput as { command: string }).command
-      : undefined;
-  const paths = testEvents.flatMap((event) => {
+    if (toolName !== 'run_tests') return [];
+    const toolInput = payload.tool_input;
+    const command =
+      toolInput != null &&
+      typeof toolInput === 'object' &&
+      !Array.isArray(toolInput) &&
+      typeof (toolInput as { command?: unknown }).command === 'string'
+        ? (toolInput as { command: string }).command
+        : undefined;
     const path = canonicalPathStringFromAuditPayload(event.payload);
-    return path == null ? [] : [path];
+    return command == null || path == null ? [] : [{ command, paths: [path] }];
   });
-  const uniquePaths = [...new Set(paths)];
-  if (command == null || uniquePaths.length === 0) return undefined;
-  return { command, paths: uniquePaths };
+  const latest = observedRuns.at(-1);
+  if (latest == null) return undefined;
+  return { command: latest.command, paths: [...new Set(latest.paths)] };
 }

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -402,7 +402,12 @@ describe('verification summary harness', () => {
             projectId: 'test-project',
             workItemId: 'github:owner/repo#42',
             kind: 'evidence.posted',
-            payload: { commentUrl: 'https://github.com/owner/repo/issues/42#issuecomment-1' },
+            payload: {
+              commentUrl: 'https://github.com/owner/repo/issues/42#issuecomment-1',
+              screenshots: ['evidence/issue-42/step-1.png'],
+              gifPath: null,
+              commitSha: 'abc1234',
+            },
             createdAt: '',
           },
         ],
@@ -431,6 +436,11 @@ describe('verification summary harness', () => {
         status: 'passed',
       });
       expect(result.verificationSummary.evidence.status).toBe('posted');
+      expect(result.verificationSummary.evidence).toMatchObject({
+        screenshots: ['evidence/issue-42/step-1.png'],
+        gifPath: null,
+        commitSha: 'abc1234',
+      });
       expect(result.verificationSummary.devTestsRun?.paths).toEqual(['src/foo.test.ts']);
       expect(runCommand).toHaveBeenNthCalledWith(3, dir, 'pnpm test:e2e:pipeline', undefined);
     } finally {
@@ -1453,6 +1463,69 @@ describe('runQaWorkflow', () => {
   });
 
   describe('devTestsRun propagation (#467)', () => {
+    it('prefers observed factory-tools test audit paths over implement-complete payload', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockImplementation((filter = {}) => {
+        if ((filter as { runId?: string; kind?: string }).runId === 'dev-run-1') {
+          return [
+            {
+              id: 3,
+              kind: 'agent.tool-call',
+              payload: {
+                tool_name: 'run_tests',
+                tool_input: {
+                  command: 'pnpm test --reporter=json apps/web/src/foo.test.ts',
+                  path: 'src/foo.test.ts',
+                },
+                canonical_path: {
+                  path: 'apps/web/src/foo.test.ts',
+                  root: 'worktree',
+                  packageRoot: 'apps/web',
+                  normalizedFrom: 'src/foo.test.ts',
+                },
+              },
+              runId: 'dev-run-1',
+              createdAt: '',
+            },
+          ];
+        }
+        return [
+          {
+            id: 1,
+            kind: 'pr.opened',
+            payload: { worktreePath: '/wt/abc', devRunId: 'dev-run-1' },
+            createdAt: '',
+          },
+          {
+            id: 2,
+            kind: 'agent.implement-complete',
+            payload: {
+              testsRun: {
+                command: 'pnpm test ',
+                paths: ['src/foo.test.ts'],
+              },
+            },
+            createdAt: '',
+          },
+        ];
+      });
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const spec = mockRun.mock.calls[0][0] as {
+        context: Record<string, unknown>;
+        contextAllowlist: string[];
+      };
+      expect(spec.context.devTestsRun).toEqual({
+        command: 'pnpm test --reporter=json apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      });
+      expect(spec.contextAllowlist).toContain('devTestsRun');
+    });
+
     it('reads testsRun from agent.implement-complete and passes it as devTestsRun in context', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -1526,6 +1526,70 @@ describe('runQaWorkflow', () => {
       expect(spec.contextAllowlist).toContain('devTestsRun');
     });
 
+    it('keeps observed dev test command and paths from the same run_tests event', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockImplementation((filter = {}) => {
+        if ((filter as { runId?: string; kind?: string }).runId === 'dev-run-1') {
+          return [
+            {
+              id: 3,
+              kind: 'agent.tool-call',
+              payload: {
+                tool_name: 'run_tests',
+                tool_input: {
+                  command: 'pnpm test --reporter=json apps/web/src/foo.test.ts',
+                  path: 'src/foo.test.ts',
+                },
+                canonical_path: {
+                  path: 'apps/web/src/foo.test.ts',
+                  root: 'worktree',
+                  packageRoot: 'apps/web',
+                  normalizedFrom: 'src/foo.test.ts',
+                },
+              },
+              runId: 'dev-run-1',
+              createdAt: '',
+            },
+            {
+              id: 4,
+              kind: 'agent.tool-call',
+              payload: {
+                tool_name: 'run_tests',
+                tool_input: {
+                  command: 'pnpm test --reporter=json',
+                },
+              },
+              runId: 'dev-run-1',
+              createdAt: '',
+            },
+          ];
+        }
+        return [
+          {
+            id: 1,
+            kind: 'pr.opened',
+            payload: { worktreePath: '/wt/abc', devRunId: 'dev-run-1' },
+            createdAt: '',
+          },
+        ];
+      });
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const spec = mockRun.mock.calls[0][0] as {
+        context: Record<string, unknown>;
+        contextAllowlist: string[];
+      };
+      expect(spec.context.devTestsRun).toEqual({
+        command: 'pnpm test --reporter=json apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      });
+      expect(spec.contextAllowlist).toContain('devTestsRun');
+    });
+
     it('reads testsRun from agent.implement-complete and passes it as devTestsRun in context', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();

--- a/slices/qa/verification-summary.ts
+++ b/slices/qa/verification-summary.ts
@@ -324,9 +324,18 @@ function summarizeEvidence(events: AgentEvent[]): VerificationSummary['evidence'
 
   const payload = evidence.payload as Record<string, unknown>;
   if (evidence.kind === 'evidence.posted') {
-    return typeof payload.commentUrl === 'string'
-      ? { status: 'posted', url: payload.commentUrl }
-      : { status: 'posted' };
+    const screenshots = Array.isArray(payload.screenshots)
+      ? payload.screenshots.filter((path): path is string => typeof path === 'string')
+      : [];
+    return {
+      status: 'posted',
+      ...(typeof payload.commentUrl === 'string' ? { url: payload.commentUrl } : {}),
+      ...(screenshots.length > 0 ? { screenshots } : {}),
+      ...(typeof payload.gifPath === 'string' || payload.gifPath === null
+        ? { gifPath: payload.gifPath }
+        : {}),
+      ...(typeof payload.commitSha === 'string' ? { commitSha: payload.commitSha } : {}),
+    };
   }
   if (evidence.kind === 'evidence.post-failed') {
     return {

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -125,7 +125,7 @@ export async function runQaWorkflow(
   const evidenceCommentUrl = (evidencePosted?.payload as { commentUrl?: string } | undefined)
     ?.commentUrl;
 
-  const devTestsRun = findDevTestsRun(workItem.id);
+  const devTestsRun = findDevTestsRun(workItem.id, prHints.devRunId ?? prHints.pipelineRunId);
 
   try {
     // ─── Deterministic 3-tier verify (M19.19) ────────────────────────────────


### PR DESCRIPTION
## Summary
- finish factory-tools canonical test path output and implement prompt simplification
- derive QA devTestsRun and evidence facts from observed tool/workflow output
- add compact drift timeline rendering, path drift report, path-language audit checks, and operational fact ownership table
- mark the operational truth roadmap plans complete

## Verification
- pnpm test core/tool-layer/mcp/**/*.test.ts core/tool-layer/path-contract.test.ts core/tool-layer/tool-call-audit.test.ts core/workspaces/path-normalization.test.ts core/workspaces/observed-changes.test.ts slices/fix-issue/slice.test.ts slices/parallel-implement/slice.test.ts slices/spec-author/slice.test.ts slices/qa/slice.test.ts slices/qa/verification-summary.test.ts skills/implement/slice.test.ts skills/implement-wp/slice.test.ts skills/qa/slice.test.ts apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx core/agent-runtime/path-drift-report.test.ts core/agent-runtime/operational-fact-owners.test.ts core/agent-runtime/skill-contract-audit.test.ts
- pnpm test core/tool-layer/mcp/tools/verify.test.ts apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx core/agent-runtime/path-drift-report.test.ts core/agent-runtime/operational-fact-owners.test.ts core/agent-runtime/skill-contract-audit.test.ts
- pnpm lint
- pnpm typecheck
- pnpm tsx scripts/audit-skill-contracts.ts --strict
- pnpm path-drift:report goose-hub-self 10
- git diff --check