### PR TITLE
Add runtime resolution attribution

### DIFF
--- a/apps/server/src/domains/project-settings/router.test.ts
+++ b/apps/server/src/domains/project-settings/router.test.ts
@@ -239,6 +239,11 @@ describe('project settings router', () => {
           effectiveProvider: string;
           effectiveEffort: string | null;
           resolvedPrimary: { modelId: string };
+          resolutionTrace: {
+            tier: { value: string; source: string };
+            provider: { value: string; source: string };
+            effort?: { value: string; source: string };
+          };
         }
       >;
     };
@@ -249,6 +254,11 @@ describe('project settings router', () => {
       effectiveProvider: 'codex',
       effectiveEffort: 'xhigh',
       resolvedPrimary: { modelId: 'gpt-5.4' },
+      resolutionTrace: {
+        tier: { value: 'sonnet', source: 'db' },
+        provider: { value: 'codex', source: 'db' },
+        effort: { value: 'xhigh', source: 'db' },
+      },
     });
   });
 
@@ -280,12 +290,25 @@ describe('project settings router', () => {
     const body = (await res.json()) as {
       resolvedSkillRuntimes: Record<
         string,
-        { effectiveProvider: string; resolvedPrimary: { modelId: string } }
+        {
+          source: string;
+          effectiveProvider: string;
+          resolvedPrimary: { modelId: string };
+          resolutionTrace: { provider: { value: string; source: string; reason: string } };
+        }
       >;
     };
 
+    expect(body.resolvedSkillRuntimes['repo-match'].source).toBe('db');
     expect(body.resolvedSkillRuntimes['repo-match'].effectiveProvider).toBe('codex');
     expect(body.resolvedSkillRuntimes['repo-match'].resolvedPrimary.modelId).toBe('gpt-5.4');
+    expect(body.resolvedSkillRuntimes['repo-match'].resolutionTrace.provider).toMatchObject({
+      value: 'codex',
+      source: 'config',
+    });
+    expect(body.resolvedSkillRuntimes['repo-match'].resolutionTrace.provider.reason).toContain(
+      'codex-cli forces provider codex',
+    );
   });
 
   it('does not expose fallback or advisor models for holdout skills', async () => {
@@ -314,6 +337,10 @@ describe('project settings router', () => {
           effectiveProvider: string;
           resolvedFallback: unknown;
           resolvedAdvisor: unknown;
+          resolutionTrace: {
+            tier: { value: string; source: string; reason: string };
+            provider: { value: string; source: string; reason: string };
+          };
         }
       >;
     };
@@ -322,5 +349,11 @@ describe('project settings router', () => {
     expect(body.resolvedSkillRuntimes.qa.effectiveProvider).toBe('claude');
     expect(body.resolvedSkillRuntimes.qa.resolvedFallback).toBeNull();
     expect(body.resolvedSkillRuntimes.qa.resolvedAdvisor).toBeNull();
+    expect(body.resolvedSkillRuntimes.qa.resolutionTrace.tier.reason).toContain(
+      'holdout skill ignores',
+    );
+    expect(body.resolvedSkillRuntimes.qa.resolutionTrace.provider.reason).toContain(
+      'holdout skill ignores',
+    );
   });
 });

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -330,6 +330,8 @@ router.get('/:slug/settings', async (c) => {
       resolvedPrimary: unknown;
       resolvedFallback: unknown;
       resolvedAdvisor: unknown;
+      selectionReason: string;
+      resolutionTrace: unknown;
     }
   > = {};
   for (const skill of Object.keys(SKILL_BUDGETS)) {
@@ -354,6 +356,8 @@ router.get('/:slug/settings', async (c) => {
       resolvedPrimary: resolved.resolvedPrimary,
       resolvedFallback: resolved.resolvedFallback,
       resolvedAdvisor: resolved.resolvedAdvisor,
+      selectionReason: resolved.selectionReason,
+      resolutionTrace: resolved.runtimeTrace,
     };
   }
 

--- a/apps/web/src/components/settings/README.md
+++ b/apps/web/src/components/settings/README.md
@@ -29,6 +29,12 @@ settings/
 
 Fields shown per project: slug, source, activeMilestone, mode, colorStripe, budget limits.
 
+The Skill runtime settings tab reads `GET /projects/:slug/settings` and shows
+editable per-skill overrides for budget, tier, provider, and effort. The same
+response includes resolved runtime attribution, so each row can explain where
+the effective tier/provider/effort came from while keeping primary, fallback,
+and advisor models read-only.
+
 The Workflow map tab also reads:
 
 - `GET /workflow-catalog`
@@ -39,4 +45,5 @@ The Workflow map tab also reads:
 
 It renders the effective vertical path for the selected project: active variants are highlighted,
 inactive alternatives are muted, conditional/retry branches stay secondary, and selected skill
-details open in a modal.
+details open in a modal. Skill nodes stay lightweight; the modal reuses
+`resolvedSkillRuntimes` to show resolved primary runtime plus tier/provider/effort attribution.

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
@@ -50,6 +50,21 @@ vi.mock('@/lib/api', () => ({
         resolvedPrimary: { tier: 'sonnet', provider: 'claude', modelId: 'claude-sonnet' },
         resolvedFallback: null,
         resolvedAdvisor: null,
+        selectionReason: 'tier skill-default, provider fallback, effort db',
+        resolutionTrace: {
+          tier: {
+            value: 'sonnet',
+            source: 'skill-default',
+            reason: 'holdout skill ignores DB/config tier overrides; using SKILL_BUDGETS default',
+          },
+          provider: {
+            value: 'claude',
+            source: 'fallback',
+            reason:
+              'holdout skill ignores DB/config provider overrides; using resolver fallback provider',
+          },
+          effort: { value: 'high', source: 'db', reason: 'project_skill_settings.effort override' },
+        },
       },
     },
   }),
@@ -112,6 +127,9 @@ describe('ProjectBudgetPanel', () => {
 
     await waitFor(() => expect(screen.getByText('Observed runtime profile')).toBeTruthy());
     expect(screen.getByDisplayValue('high')).toBeTruthy();
+    expect(screen.getByText(/from skill-default: holdout skill ignores/)).toBeTruthy();
+    expect(screen.getByText(/from fallback: holdout skill ignores/)).toBeTruthy();
+    expect(screen.getByText(/from db: project_skill_settings\.effort override/)).toBeTruthy();
     expect(await screen.findByText('This skill looks stable and inexpensive.')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -68,6 +68,18 @@ const TIERS: ModelTier[] = ['haiku', 'sonnet', 'opus'];
 const PROVIDERS: ModelProvider[] = ['claude', 'codex'];
 const EFFORTS: RuntimeEffort[] = ['low', 'medium', 'high', 'xhigh'];
 
+type ResolvedSkillRuntimeDto = NonNullable<ProjectSettingsDto['resolvedSkillRuntimes']>[string];
+type RuntimeAxis = keyof NonNullable<ResolvedSkillRuntimeDto['resolutionTrace']>;
+
+function provenanceSubtitle(
+  resolved: ResolvedSkillRuntimeDto | undefined,
+  axis: RuntimeAxis,
+): string | undefined {
+  const decision = resolved?.resolutionTrace?.[axis];
+  if (decision == null) return undefined;
+  return `from ${decision.source}: ${decision.reason}`;
+}
+
 function NumericInput({
   value,
   placeholder,
@@ -582,6 +594,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       options={TIERS}
                       defaultValue={defaults?.modelTier}
                       overridden={row?.modelTier != null}
+                      subtitle={provenanceSubtitle(resolved, 'tier')}
                       onCommit={(val) =>
                         patchSkill.mutate({ skill, patch: { modelTier: val as ModelTier | null } })
                       }
@@ -593,6 +606,7 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       options={PROVIDERS}
                       defaultValue={defaults?.modelProvider}
                       overridden={row?.provider != null}
+                      subtitle={provenanceSubtitle(resolved, 'provider')}
                       onCommit={(val) =>
                         patchSkill.mutate({
                           skill,
@@ -608,9 +622,14 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       defaultValue={defaults?.effort ?? undefined}
                       overridden={row?.effort != null}
                       subtitle={
-                        (resolved?.effectiveProvider ?? defaults?.modelProvider) === 'claude'
-                          ? 'display only for Claude'
-                          : undefined
+                        [
+                          provenanceSubtitle(resolved, 'effort'),
+                          (resolved?.effectiveProvider ?? defaults?.modelProvider) === 'claude'
+                            ? 'display only for Claude'
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(' | ') || undefined
                       }
                       onCommit={(val) =>
                         patchSkill.mutate({

--- a/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
@@ -57,6 +57,7 @@ vi.mock('@/lib/api', () => ({
         timeoutMs: 120000,
         modelTier: 'haiku',
         modelProvider: 'claude',
+        effort: null,
       },
       qa: {
         maxTurns: 100,
@@ -64,6 +65,7 @@ vi.mock('@/lib/api', () => ({
         timeoutMs: 600000,
         modelTier: 'sonnet',
         modelProvider: 'claude',
+        effort: null,
       },
       'dev-review': {
         maxTurns: 20,
@@ -71,32 +73,55 @@ vi.mock('@/lib/api', () => ({
         timeoutMs: 180000,
         modelTier: 'sonnet',
         modelProvider: 'codex',
+        effort: null,
       },
     },
     resolvedSkillRuntimes: {
       triage: {
-        source: 'default',
+        source: 'skill-default',
         effectiveTier: 'haiku',
         effectiveProvider: 'claude',
+        effectiveEffort: null,
         resolvedPrimary: { tier: 'haiku', provider: 'claude', modelId: 'claude-haiku' },
         resolvedFallback: null,
         resolvedAdvisor: null,
+        selectionReason: 'tier skill-default, provider fallback',
+        resolutionTrace: {
+          tier: { value: 'haiku', source: 'skill-default', reason: 'SKILL_BUDGETS default tier' },
+          provider: { value: 'claude', source: 'fallback', reason: 'resolver fallback provider' },
+        },
       },
       qa: {
-        source: 'default',
+        source: 'skill-default',
         effectiveTier: 'sonnet',
         effectiveProvider: 'claude',
+        effectiveEffort: null,
         resolvedPrimary: { tier: 'sonnet', provider: 'claude', modelId: 'claude-sonnet' },
         resolvedFallback: null,
         resolvedAdvisor: null,
+        selectionReason: 'tier skill-default, provider fallback',
+        resolutionTrace: {
+          tier: { value: 'sonnet', source: 'skill-default', reason: 'SKILL_BUDGETS default tier' },
+          provider: { value: 'claude', source: 'fallback', reason: 'resolver fallback provider' },
+        },
       },
       'dev-review': {
-        source: 'default',
+        source: 'skill-default',
         effectiveTier: 'sonnet',
         effectiveProvider: 'codex',
+        effectiveEffort: null,
         resolvedPrimary: { tier: 'sonnet', provider: 'codex', modelId: 'gpt-5.4' },
         resolvedFallback: null,
         resolvedAdvisor: null,
+        selectionReason: 'tier skill-default, provider skill-default',
+        resolutionTrace: {
+          tier: { value: 'sonnet', source: 'skill-default', reason: 'SKILL_BUDGETS default tier' },
+          provider: {
+            value: 'codex',
+            source: 'skill-default',
+            reason: 'skill runtime provider hint',
+          },
+        },
       },
     },
   }),
@@ -334,6 +359,9 @@ describe('WorkflowMapPanel', () => {
     expect(modal).toBeTruthy();
     expect(screen.getByRole('dialog', { name: 'triage details' })).toBeTruthy();
     expect(detail.textContent).toContain('Classifies incoming work.');
+    expect(detail.textContent).toContain('Tier from skill-default');
+    expect(detail.textContent).toContain('Provider from fallback');
+    expect(screen.getAllByTestId('workflow-skill-node')[0]?.textContent).not.toContain('Tier from');
 
     fireEvent.click(screen.getByRole('button', { name: 'Close skill detail' }));
     expect(screen.queryByTestId('skill-detail-modal')).toBeNull();

--- a/apps/web/src/components/settings/components/WorkflowSkillDetailModal.tsx
+++ b/apps/web/src/components/settings/components/WorkflowSkillDetailModal.tsx
@@ -113,6 +113,30 @@ function SkillDetail({
               : 'Inherits default',
           ]}
         />
+        {runtime?.resolutionTrace?.tier != null && (
+          <DetailBlock
+            label={`Tier from ${runtime.resolutionTrace.tier.source}`}
+            values={[
+              `${runtime.resolutionTrace.tier.value}: ${runtime.resolutionTrace.tier.reason}`,
+            ]}
+          />
+        )}
+        {runtime?.resolutionTrace?.provider != null && (
+          <DetailBlock
+            label={`Provider from ${runtime.resolutionTrace.provider.source}`}
+            values={[
+              `${runtime.resolutionTrace.provider.value}: ${runtime.resolutionTrace.provider.reason}`,
+            ]}
+          />
+        )}
+        {runtime?.resolutionTrace?.effort != null && (
+          <DetailBlock
+            label={`Effort from ${runtime.resolutionTrace.effort.source}`}
+            values={[
+              `${runtime.resolutionTrace.effort.value}: ${runtime.resolutionTrace.effort.reason}`,
+            ]}
+          />
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -419,6 +419,7 @@ export interface ProjectSettingsDto {
   resolvedSkillRuntimes?: Record<
     string,
     {
+      /** Compact compatibility summary for older settings consumers. */
       source: string;
       effectiveTier: ModelTier;
       effectiveProvider: ModelProvider;
@@ -426,8 +427,28 @@ export interface ProjectSettingsDto {
       resolvedPrimary: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedFallback: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedAdvisor: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
+      /** Human-readable summary of the per-axis runtime resolution. */
+      selectionReason?: string;
+      /**
+       * Per-axis runtime provenance. Each decision records the selected value,
+       * source layer, and reason so the UI can explain mixed inheritance such
+       * as DB tier + config effort or forced runtime provider coercion.
+       */
+      resolutionTrace?: RuntimeResolutionTraceDto;
     }
   >;
+}
+
+export interface RuntimeTraceDecisionDto<T> {
+  value: T;
+  source: string;
+  reason: string;
+}
+
+export interface RuntimeResolutionTraceDto {
+  tier: RuntimeTraceDecisionDto<ModelTier>;
+  provider: RuntimeTraceDecisionDto<ModelProvider>;
+  effort?: RuntimeTraceDecisionDto<RuntimeEffort>;
 }
 
 export interface RuntimeProfilerDto {

--- a/core/agent-runtime/index.ts
+++ b/core/agent-runtime/index.ts
@@ -11,4 +11,9 @@ export {
   resolveSkillRuntime,
   resolveSkillRuntimeForProject,
 } from './skill-runtime-resolver.js';
-export type { ResolvedSkillRuntime, SkillRuntimeSource } from './skill-runtime-resolver.js';
+export type {
+  ResolvedSkillRuntime,
+  RuntimeResolutionTrace,
+  RuntimeTraceDecision,
+  SkillRuntimeSource,
+} from './skill-runtime-resolver.js';

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -12,6 +12,8 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.tier).toBe('sonnet');
     expect(resolved.provider).toBe('codex');
     expect(resolved.modelOverride).toBe('gpt-5.4');
+    expect(resolved.runtimeTrace.tier).toMatchObject({ value: 'sonnet', source: 'db' });
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'codex', source: 'db' });
   });
 
   it('resolves playwright-repro to Codex haiku from a per-skill DB override', () => {
@@ -65,6 +67,8 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.source).toBe('db');
     expect(resolved.tier).toBe('opus');
     expect(resolved.effort).toBe('medium');
+    expect(resolved.runtimeTrace.tier).toMatchObject({ value: 'opus', source: 'db' });
+    expect(resolved.runtimeTrace.effort).toMatchObject({ value: 'medium', source: 'config' });
   });
 
   it('keeps effort displayable when the effective provider is Claude', () => {
@@ -101,6 +105,10 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.tier).toBe('sonnet');
     expect(resolved.provider).toBe('codex');
     expect(resolved.modelOverride).toBe('gpt-5.4');
+    expect(resolved.runtimeTrace.provider).toMatchObject({
+      value: 'codex',
+      source: 'skill-default',
+    });
   });
 
   it('coerces provider when the project runtime is forced', () => {
@@ -112,6 +120,9 @@ describe('resolveSkillRuntime', () => {
 
     expect(resolved.provider).toBe('codex');
     expect(resolved.modelOverride).toBe('gpt-5.4');
+    expect(resolved.source).toBe('db');
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'codex', source: 'config' });
+    expect(resolved.runtimeTrace.provider.reason).toContain('codex-cli forces provider codex');
   });
 
   it('keeps a caller concrete model override above forced runtime provider', () => {
@@ -124,6 +135,8 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.source).toBe('caller');
     expect(resolved.provider).toBe('claude');
     expect(resolved.modelOverride).toBe('claude-opus-4-7');
+    expect(resolved.runtimeTrace.tier).toMatchObject({ value: 'opus', source: 'caller' });
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'claude', source: 'caller' });
   });
 
   it('does not derive fallback/advisor models for holdouts', () => {
@@ -145,6 +158,13 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.tier).toBe('sonnet');
     expect(resolved.provider).toBe('claude');
     expect(resolved.modelOverride).toBe('claude-sonnet-4-6');
+    expect(resolved.runtimeTrace.tier).toMatchObject({
+      value: 'sonnet',
+      source: 'skill-default',
+    });
+    expect(resolved.runtimeTrace.tier.reason).toContain('holdout skill ignores');
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'claude', source: 'fallback' });
+    expect(resolved.runtimeTrace.provider.reason).toContain('holdout skill ignores');
   });
 
   it('can ignore provider overrides for injected runtimes while keeping the tier', () => {
@@ -158,6 +178,9 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.tier).toBe('sonnet');
     expect(resolved.provider).toBe('claude');
     expect(resolved.modelOverride).toBe('claude-sonnet-4-6');
+    expect(resolved.runtimeTrace.tier).toMatchObject({ value: 'sonnet', source: 'db' });
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'claude', source: 'fallback' });
+    expect(resolved.runtimeTrace.provider.reason).toContain('provider override ignored');
   });
 });
 

--- a/core/agent-runtime/skill-runtime-resolver.test.ts
+++ b/core/agent-runtime/skill-runtime-resolver.test.ts
@@ -125,6 +125,23 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.runtimeTrace.provider.reason).toContain('codex-cli forces provider codex');
   });
 
+  it('preserves DB source when forced runtime coerces a DB provider-only override', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { modelProvider: 'claude' },
+      configRuntime: 'codex-cli',
+    });
+
+    expect(resolved.source).toBe('db');
+    expect(resolved.tier).toBe('haiku');
+    expect(resolved.provider).toBe('codex');
+    expect(resolved.runtimeTrace.tier).toMatchObject({
+      value: 'haiku',
+      source: 'skill-default',
+    });
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'codex', source: 'config' });
+  });
+
   it('keeps a caller concrete model override above forced runtime provider', () => {
     const resolved = resolveSkillRuntime({
       skill: 'repo-match',
@@ -179,6 +196,25 @@ describe('resolveSkillRuntime', () => {
     expect(resolved.provider).toBe('claude');
     expect(resolved.modelOverride).toBe('claude-sonnet-4-6');
     expect(resolved.runtimeTrace.tier).toMatchObject({ value: 'sonnet', source: 'db' });
+    expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'claude', source: 'fallback' });
+    expect(resolved.runtimeTrace.provider.reason).toContain('provider override ignored');
+  });
+
+  it('preserves DB source when injected runtimes ignore a DB provider-only override', () => {
+    const resolved = resolveSkillRuntime({
+      skill: 'repo-match',
+      dbOverride: { modelProvider: 'codex' },
+      configRuntime: 'codex-cli',
+      ignoreProviderOverride: true,
+    });
+
+    expect(resolved.source).toBe('db');
+    expect(resolved.tier).toBe('haiku');
+    expect(resolved.provider).toBe('claude');
+    expect(resolved.runtimeTrace.tier).toMatchObject({
+      value: 'haiku',
+      source: 'skill-default',
+    });
     expect(resolved.runtimeTrace.provider).toMatchObject({ value: 'claude', source: 'fallback' });
     expect(resolved.runtimeTrace.provider.reason).toContain('provider override ignored');
   });

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -26,10 +26,24 @@ export interface ResolvedDisplayModel {
   modelId: string;
 }
 
+export interface RuntimeTraceDecision<T> {
+  value: T;
+  source: SkillRuntimeSource;
+  reason: string;
+}
+
+export interface RuntimeResolutionTrace {
+  tier: RuntimeTraceDecision<ModelTier>;
+  provider: RuntimeTraceDecision<ModelProvider>;
+  effort?: RuntimeTraceDecision<RuntimeEffort>;
+}
+
 export interface ResolvedSkillRuntime extends ResolvedBudget {
   tier: ModelTier;
   provider: ModelProvider;
   source: SkillRuntimeSource;
+  selectionReason: string;
+  runtimeTrace: RuntimeResolutionTrace;
   resolvedPrimary: ResolvedDisplayModel;
   resolvedFallback: ResolvedDisplayModel | null;
   resolvedAdvisor: ResolvedDisplayModel | null;
@@ -70,41 +84,47 @@ function displayModel(tier: ModelTier, provider: ModelProvider): ResolvedDisplay
   return { tier, provider, modelId: defaultModelForTierAndProvider(tier, provider) };
 }
 
-function sourceForSkill(
-  skill: string,
-  dbOverride?: SkillRuntimeDbOverride | null,
-): SkillRuntimeSource {
-  if (
-    isModelTier(dbOverride?.modelTier) ||
-    isModelProvider(dbOverride?.modelProvider) ||
-    isRuntimeEffort(dbOverride?.effort)
-  )
-    return 'db';
-  if (SKILL_BUDGETS[skill] != null) return 'skill-default';
-  return 'fallback';
-}
-
-function resolveTier(input: {
+function resolveTierDecision(input: {
   skill: string;
   projectBudgets?: Pick<BudgetConfig, 'skillBudgetOverrides'>;
   dbOverride?: SkillRuntimeDbOverride | null;
   fallbackTier?: ModelTier;
-}): { tier: ModelTier; source: SkillRuntimeSource } {
+  suppressedModelOverride?: boolean;
+}): RuntimeTraceDecision<ModelTier> {
   if (isModelTier(input.dbOverride?.modelTier)) {
-    return { tier: input.dbOverride.modelTier, source: 'db' };
+    return {
+      value: input.dbOverride.modelTier,
+      source: 'db',
+      reason: 'project_skill_settings.model_tier override',
+    };
   }
 
   const configTier = input.projectBudgets?.skillBudgetOverrides?.[input.skill]?.modelTier;
   if (isModelTier(configTier)) {
-    return { tier: configTier, source: 'config' };
+    return {
+      value: configTier,
+      source: 'config',
+      reason: `project config budgets.skillBudgetOverrides.${input.skill}.modelTier`,
+    };
   }
 
   const skillTier = SKILL_BUDGETS[input.skill]?.modelTier;
   if (skillTier != null) {
-    return { tier: skillTier, source: sourceForSkill(input.skill, input.dbOverride) };
+    return {
+      value: skillTier,
+      source: 'skill-default',
+      reason:
+        input.suppressedModelOverride === true
+          ? 'holdout skill ignores DB/config tier overrides; using SKILL_BUDGETS default'
+          : 'SKILL_BUDGETS default tier',
+    };
   }
 
-  return { tier: input.fallbackTier ?? 'sonnet', source: 'fallback' };
+  return {
+    value: input.fallbackTier ?? 'sonnet',
+    source: 'fallback',
+    reason: input.fallbackTier != null ? 'caller fallbackTier' : 'resolver fallback tier',
+  };
 }
 
 function withoutConfigModelTier(
@@ -119,23 +139,116 @@ function withoutConfigModelTier(
   return { ...projectBudgets, skillBudgetOverrides };
 }
 
-function resolveEffort(input: {
+function resolveProviderDecision(input: {
+  skill: string;
+  dbOverride?: SkillRuntimeDbOverride | null;
+  providerConfigRuntime: ConfigRuntime;
+  skillProvider?: ModelProvider;
+  fallbackProvider?: ModelProvider;
+  ignoreProviderOverride?: boolean;
+  suppressedModelOverride?: boolean;
+}): RuntimeTraceDecision<ModelProvider> {
+  const forcedProvider = forcedProviderFromRuntime(input.providerConfigRuntime);
+  if (forcedProvider != null) {
+    return {
+      value: forcedProvider,
+      source: 'config',
+      reason: `${input.providerConfigRuntime} forces provider ${forcedProvider}`,
+    };
+  }
+
+  if (!input.ignoreProviderOverride && isModelProvider(input.dbOverride?.modelProvider)) {
+    return {
+      value: input.dbOverride.modelProvider,
+      source: 'db',
+      reason: 'project_skill_settings.model_provider override',
+    };
+  }
+
+  if (input.skillProvider != null) {
+    return {
+      value: input.skillProvider,
+      source: 'skill-default',
+      reason:
+        input.ignoreProviderOverride === true
+          ? 'provider override ignored for injected runtime; using skill provider hint'
+          : 'skill runtime provider hint',
+    };
+  }
+
+  const skillProvider = SKILL_BUDGETS[input.skill]?.provider;
+  if (skillProvider != null) {
+    return {
+      value: skillProvider,
+      source: 'skill-default',
+      reason:
+        input.ignoreProviderOverride === true
+          ? 'provider override ignored for injected runtime; using SKILL_BUDGETS provider'
+          : 'SKILL_BUDGETS provider',
+    };
+  }
+
+  if (input.fallbackProvider != null) {
+    return {
+      value: input.fallbackProvider,
+      source: 'fallback',
+      reason: 'caller fallbackProvider',
+    };
+  }
+
+  return {
+    value: 'claude',
+    source: 'fallback',
+    reason:
+      input.ignoreProviderOverride === true
+        ? 'provider override ignored for injected runtime; using resolver fallback provider'
+        : input.suppressedModelOverride === true
+          ? 'holdout skill ignores DB/config provider overrides; using resolver fallback provider'
+          : 'resolver fallback provider',
+  };
+}
+
+function resolveEffortDecision(input: {
   skill: string;
   projectBudgets?: Pick<BudgetConfig, 'skillBudgetOverrides'>;
   dbOverride?: SkillRuntimeDbOverride | null;
-}): { effort?: RuntimeEffort; source: SkillRuntimeSource | null } {
+}): RuntimeTraceDecision<RuntimeEffort> | null {
   if (isRuntimeEffort(input.dbOverride?.effort)) {
-    return { effort: input.dbOverride.effort, source: 'db' };
+    return {
+      value: input.dbOverride.effort,
+      source: 'db',
+      reason: 'project_skill_settings.effort override',
+    };
   }
   const configEffort = input.projectBudgets?.skillBudgetOverrides?.[input.skill]?.effort;
   if (isRuntimeEffort(configEffort)) {
-    return { effort: configEffort, source: 'config' };
+    return {
+      value: configEffort,
+      source: 'config',
+      reason: `project config budgets.skillBudgetOverrides.${input.skill}.effort`,
+    };
   }
   const skillEffort = SKILL_BUDGETS[input.skill]?.effort;
   if (isRuntimeEffort(skillEffort)) {
-    return { effort: skillEffort, source: sourceForSkill(input.skill, input.dbOverride) };
+    return {
+      value: skillEffort,
+      source: 'skill-default',
+      reason: 'SKILL_BUDGETS default effort',
+    };
   }
-  return { source: null };
+  return null;
+}
+
+function legacySourceFromTrace(trace: RuntimeResolutionTrace): SkillRuntimeSource {
+  if (trace.tier.source === 'caller' || trace.provider.source === 'caller') return 'caller';
+  if (trace.tier.source === 'db' || trace.provider.source === 'db') return 'db';
+  if (trace.effort?.source === 'db') return 'db';
+  return trace.effort?.source ?? trace.tier.source;
+}
+
+function selectionReasonFromTrace(trace: RuntimeResolutionTrace): string {
+  const effort = trace.effort != null ? `, effort ${trace.effort.source}` : '';
+  return `tier ${trace.tier.source}, provider ${trace.provider.source}${effort}`;
 }
 
 export function resolveSkillRuntime(input: {
@@ -160,6 +273,11 @@ export function resolveSkillRuntime(input: {
   const configRuntime = input.configRuntime ?? 'auto';
   const isHoldout = input.role === 'qa' || input.role === 'reviewer';
   const honourModelOverrides = !isHoldout || input.allowHoldoutOverride === true;
+  const suppressedModelOverride =
+    !honourModelOverrides &&
+    (isModelTier(input.dbOverride?.modelTier) ||
+      isModelProvider(input.dbOverride?.modelProvider) ||
+      input.projectBudgets?.skillBudgetOverrides?.[input.skill]?.modelTier != null);
   const dbOverride = honourModelOverrides
     ? input.dbOverride
     : input.dbOverride == null
@@ -180,12 +298,32 @@ export function resolveSkillRuntime(input: {
   if (input.callerModelOverride != null) {
     const tier = tierOf(input.callerModelOverride);
     const provider = providerOf(input.callerModelOverride);
+    const effortResult = resolveEffortDecision({
+      skill: input.skill,
+      projectBudgets: input.projectBudgets,
+      dbOverride,
+    });
+    const runtimeTrace: RuntimeResolutionTrace = {
+      tier: {
+        value: tier,
+        source: 'caller',
+        reason: 'caller supplied concrete modelOverride',
+      },
+      provider: {
+        value: provider,
+        source: 'caller',
+        reason: 'caller supplied concrete modelOverride',
+      },
+      ...(effortResult != null ? { effort: effortResult } : {}),
+    };
     return {
       ...resolvedBudget,
       modelOverride: input.callerModelOverride,
       tier,
       provider,
       source: 'caller',
+      selectionReason: selectionReasonFromTrace(runtimeTrace),
+      runtimeTrace,
       resolvedPrimary: { tier, provider, modelId: input.callerModelOverride },
       resolvedFallback: null,
       resolvedAdvisor: null,
@@ -193,33 +331,38 @@ export function resolveSkillRuntime(input: {
     };
   }
 
-  const tierResult = resolveTier({
+  const tierResult = resolveTierDecision({
     skill: input.skill,
     projectBudgets: modelProjectBudgets,
     dbOverride,
     fallbackTier: input.fallbackTier,
+    suppressedModelOverride,
   });
-  const tier = tierResult.tier;
-  const provider =
-    forcedProviderFromRuntime(providerConfigRuntime) ??
-    (!input.ignoreProviderOverride && isModelProvider(dbOverride?.modelProvider)
-      ? dbOverride.modelProvider
-      : (input.skillProvider ??
-        SKILL_BUDGETS[input.skill]?.provider ??
-        input.fallbackProvider ??
-        'claude'));
+  const providerResult = resolveProviderDecision({
+    skill: input.skill,
+    dbOverride,
+    providerConfigRuntime,
+    skillProvider: input.skillProvider,
+    fallbackProvider: input.fallbackProvider,
+    ignoreProviderOverride: input.ignoreProviderOverride,
+    suppressedModelOverride,
+  });
+  const tier = tierResult.value;
+  const provider = providerResult.value;
   const modelOverride = defaultModelForTierAndProvider(tier, provider);
   const supportsFallback = SKILL_BUDGETS[input.skill]?.escalation != null;
   const supportsAdvisor = input.skill === 'implement' || input.skill === 'write-prd';
-  const effortResult = resolveEffort({
+  const effortResult = resolveEffortDecision({
     skill: input.skill,
     projectBudgets: input.projectBudgets,
     dbOverride,
   });
-  const source =
-    isModelProvider(dbOverride?.modelProvider) || tierResult.source === 'db'
-      ? 'db'
-      : (effortResult.source ?? tierResult.source);
+  const runtimeTrace: RuntimeResolutionTrace = {
+    tier: tierResult,
+    provider: providerResult,
+    ...(effortResult != null ? { effort: effortResult } : {}),
+  };
+  const source = legacySourceFromTrace(runtimeTrace);
 
   return {
     ...resolvedBudget,
@@ -227,12 +370,14 @@ export function resolveSkillRuntime(input: {
     tier,
     provider,
     source,
+    selectionReason: selectionReasonFromTrace(runtimeTrace),
+    runtimeTrace,
     resolvedPrimary: displayModel(tier, provider),
     resolvedFallback:
       !isHoldout && supportsFallback ? displayModel(lowerTier(tier), provider) : null,
     resolvedAdvisor:
       !isHoldout && supportsAdvisor ? displayModel(higherTier(tier), provider) : null,
-    ...(effortResult.effort != null ? { effort: effortResult.effort } : {}),
+    ...(effortResult?.value != null ? { effort: effortResult.value } : {}),
   };
 }
 

--- a/core/agent-runtime/skill-runtime-resolver.ts
+++ b/core/agent-runtime/skill-runtime-resolver.ts
@@ -239,8 +239,12 @@ function resolveEffortDecision(input: {
   return null;
 }
 
-function legacySourceFromTrace(trace: RuntimeResolutionTrace): SkillRuntimeSource {
+function legacySourceFromTrace(
+  trace: RuntimeResolutionTrace,
+  dbOverride?: SkillRuntimeDbOverride | null,
+): SkillRuntimeSource {
   if (trace.tier.source === 'caller' || trace.provider.source === 'caller') return 'caller';
+  if (isModelProvider(dbOverride?.modelProvider)) return 'db';
   if (trace.tier.source === 'db' || trace.provider.source === 'db') return 'db';
   if (trace.effort?.source === 'db') return 'db';
   return trace.effort?.source ?? trace.tier.source;
@@ -362,7 +366,7 @@ export function resolveSkillRuntime(input: {
     provider: providerResult,
     ...(effortResult != null ? { effort: effortResult } : {}),
   };
-  const source = legacySourceFromTrace(runtimeTrace);
+  const source = legacySourceFromTrace(runtimeTrace, dbOverride);
 
   return {
     ...resolvedBudget,

--- a/docs/adr/0042-per-skill-runtime-settings.md
+++ b/docs/adr/0042-per-skill-runtime-settings.md
@@ -16,22 +16,44 @@ Users configure skills, not internal roles. Role rows also create holdout risks:
 
 Per-skill runtime settings are the only normal user-facing model, tier, provider, budget, and timeout surface.
 
-Normal skill dispatch uses this precedence:
+Normal skill dispatch resolves runtime per axis, then reports a compact legacy
+`source` plus richer per-axis attribution for settings/debugging.
+
+Tier precedence:
+
+1. Caller explicit concrete `modelOverride`.
+2. DB per-skill `model_tier` from `project_skill_settings`.
+3. Project config `budgets.skillBudgetOverrides[skill].modelTier`.
+4. Built-in `SKILL_BUDGETS[skill].modelTier`.
+5. Resolver fallback.
+
+Provider precedence:
 
 1. Caller explicit concrete `modelOverride`.
 2. Forced project runtime provider from `codex-cli` or `claude-cli`.
-3. DB per-skill `model_tier` / `model_provider` from `project_skill_settings`.
-4. Project config `budgets.skillBudgetOverrides[skill]`.
-5. Built-in `SKILL_BUDGETS[skill]`.
+3. DB per-skill `model_provider` from `project_skill_settings`.
+4. Skill runtime provider hint or built-in `SKILL_BUDGETS[skill].provider`.
+5. Resolver fallback.
+
+Effort precedence:
+
+1. DB per-skill `effort` from `project_skill_settings`.
+2. Project config `budgets.skillBudgetOverrides[skill].effort`.
+3. Built-in `SKILL_BUDGETS[skill].effort`.
+
+Forced runtime provider behavior is intentionally separate from tier/effort:
+`codex-cli` forces provider `codex`, and `claude-cli` forces provider `claude`,
+but neither changes the selected tier or effort. Injected runtimes may also
+ignore provider override coercion while preserving the selected tier.
 
 The role UI, role settings API, role repository, and `project_model_settings` table are removed. Historical migrations that created or altered the table remain in the migration history; a later migration drops the table from current databases.
 
 Holdout rules:
 
 - `qa` and `reviewer` run in fresh contexts defined by skill config.
-- Per-skill model overrides for holdouts are ignored unless `agentConfig.allowHoldoutOverride` is explicitly true.
+- DB/config tier and provider overrides for holdouts are ignored unless `agentConfig.allowHoldoutOverride` is explicitly true.
 - Holdout runtime rows do not expose fallback or advisor models.
-- Per-skill budget settings must not change context isolation or tool policy.
+- Per-skill budget and effort settings must not change context isolation or tool policy.
 
 Unknown skills fail fast unless they have an intentional, complete compatibility path. A stray DB row in `project_skill_settings` is not a fallback skill registration mechanism.
 
@@ -43,3 +65,4 @@ Unknown skills fail fast unless they have an intentional, complete compatibility
 - `invokeSkill()` receives budgets from `resolveSkillRuntimeForProject()` and does not reintroduce role budget overrides.
 - Codex CLI auth status is displayed in Skill runtime because provider selection is per skill.
 - `agentConfig.rolesModels` remains parsed for historical config compatibility, but normal dispatch does not read it.
+- `GET /projects/:slug/settings` exposes additive `resolutionTrace` data so the Skill runtime settings table and Workflow map detail modal can explain tier/provider/effort provenance without duplicating project config UI.


### PR DESCRIPTION
## Summary
- add per-axis runtimeTrace/selectionReason to skill runtime resolution while preserving legacy source
- expose resolutionTrace in project settings and render provenance in Skill runtime settings plus Workflow skill detail modal
- document per-axis precedence, forced provider behavior, and holdout suppression

## Tests
- pnpm -s vitest core/agent-runtime/skill-runtime-resolver.test.ts apps/server/src/domains/project-settings/router.test.ts apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
- pnpm exec biome check core/agent-runtime/skill-runtime-resolver.ts core/agent-runtime/skill-runtime-resolver.test.ts core/agent-runtime/index.ts apps/server/src/domains/project-settings/router.ts apps/server/src/domains/project-settings/router.test.ts apps/web/src/lib/types.ts apps/web/src/components/settings/components/ProjectBudgetPanel.tsx apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx apps/web/src/components/settings/components/WorkflowSkillDetailModal.tsx
- pnpm -s typecheck