### PR TITLE
Refine settings summary and milestones tabs

### DIFF
--- a/apps/server/src/domains/projects/service.test.ts
+++ b/apps/server/src/domains/projects/service.test.ts
@@ -27,6 +27,19 @@ describe('listProjectConfigsService (#280)', () => {
     slug: 'my-proj',
     name: 'My Project',
     source: { kind: 'github', repo: 'owner/my-proj' },
+    targetRepo: {
+      cloneUrl: 'git@github.com:owner/my-proj.git',
+      defaultBranch: 'main',
+      localPath: '~/code/my-proj',
+    },
+    stack: {
+      runtime: 'node',
+      packageManager: 'pnpm',
+      testCommand: 'pnpm test',
+      lintCommand: 'pnpm lint',
+      typecheckCommand: 'pnpm typecheck',
+      e2eCommand: 'pnpm test:e2e',
+    },
     activeMilestone: 'M10: Orchestration',
     colorStripe: '#7c3aed',
     budgets: {
@@ -39,6 +52,8 @@ describe('listProjectConfigsService (#280)', () => {
       perAgentMaxUsd: 1,
     },
     mode: 'supervised',
+    storage: { kind: 'local', path: '~/.factory/data/my-proj' },
+    isolation: { mode: 'native' },
   };
 
   it('maps full ProjectConfig to ProjectConfigDto shape', async () => {
@@ -50,10 +65,25 @@ describe('listProjectConfigsService (#280)', () => {
           slug: 'my-proj',
           name: 'My Project',
           source: { kind: 'github', repo: 'owner/my-proj' },
+          targetRepo: {
+            cloneUrl: 'git@github.com:owner/my-proj.git',
+            defaultBranch: 'main',
+            localPath: '~/code/my-proj',
+          },
+          stack: {
+            runtime: 'node',
+            packageManager: 'pnpm',
+            testCommand: 'pnpm test',
+            lintCommand: 'pnpm lint',
+            typecheckCommand: 'pnpm typecheck',
+            e2eCommand: 'pnpm test:e2e',
+          },
           activeMilestone: 'M10: Orchestration',
           colorStripe: '#7c3aed',
           budgets: { perWorkflowMaxUsd: 2, dailyTokens: 500000, perAdvisorMaxUsd: 0.5 },
           mode: 'supervised',
+          storage: { path: '~/.factory/data/my-proj' },
+          isolation: { mode: 'native' },
         },
       ],
     });

--- a/apps/server/src/domains/projects/service.ts
+++ b/apps/server/src/domains/projects/service.ts
@@ -9,10 +9,21 @@ export interface ProjectConfigDto {
   slug: string;
   name: string;
   source: { kind: string; repo: string };
+  targetRepo: { cloneUrl: string; defaultBranch: string; localPath: string };
+  stack: {
+    runtime: string;
+    packageManager: string;
+    testCommand: string;
+    lintCommand?: string;
+    typecheckCommand?: string;
+    e2eCommand?: string;
+  };
   activeMilestone: string | null;
   colorStripe: string;
   budgets: { perWorkflowMaxUsd: number; dailyTokens: number; perAdvisorMaxUsd: number };
   mode: string;
+  storage: { path: string };
+  isolation: { mode: string };
 }
 
 export async function listProjectConfigsService(): Promise<{ configs: ProjectConfigDto[] }> {
@@ -21,6 +32,19 @@ export async function listProjectConfigsService(): Promise<{ configs: ProjectCon
     slug: p.slug,
     name: p.name,
     source: p.source,
+    targetRepo: {
+      cloneUrl: p.targetRepo.cloneUrl,
+      defaultBranch: p.targetRepo.defaultBranch,
+      localPath: p.targetRepo.localPath,
+    },
+    stack: {
+      runtime: p.stack.runtime,
+      packageManager: p.stack.packageManager,
+      testCommand: p.stack.testCommand,
+      lintCommand: p.stack.lintCommand,
+      typecheckCommand: p.stack.typecheckCommand,
+      e2eCommand: p.stack.e2eCommand,
+    },
     activeMilestone: p.activeMilestone ?? null,
     colorStripe: p.colorStripe,
     budgets: {
@@ -29,6 +53,8 @@ export async function listProjectConfigsService(): Promise<{ configs: ProjectCon
       perAdvisorMaxUsd: p.budgets.perAdvisorMaxUsd,
     },
     mode: p.mode,
+    storage: { path: p.storage.path },
+    isolation: { mode: p.isolation.mode },
   }));
   return { configs };
 }

--- a/apps/web/src/components/settings/components/ProjectConfigPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectConfigPanel.test.tsx
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ProjectConfigPanel } from './ProjectConfigPanel';
+
+const CONFIG = {
+  slug: 'my-proj',
+  name: 'My Project',
+  source: { kind: 'github', repo: 'owner/my-proj' },
+  targetRepo: {
+    cloneUrl: 'git@github.com:owner/my-proj.git',
+    defaultBranch: 'main',
+    localPath: '~/code/my-proj',
+  },
+  stack: {
+    runtime: 'node',
+    packageManager: 'pnpm',
+    testCommand: 'pnpm test',
+    lintCommand: 'pnpm lint',
+    typecheckCommand: 'pnpm typecheck',
+    e2eCommand: 'pnpm test:e2e',
+  },
+  activeMilestone: 'M10: Orchestration',
+  colorStripe: '#7c3aed',
+  budgets: { perWorkflowMaxUsd: 2, dailyTokens: 500000, perAdvisorMaxUsd: 0.5 },
+  mode: 'supervised',
+  storage: { path: '~/.factory/data/my-proj' },
+  isolation: { mode: 'native' },
+};
+
+afterEach(() => cleanup());
+
+describe('ProjectConfigPanel', () => {
+  it('renders project summary fields without budget or milestone management sections', () => {
+    render(<ProjectConfigPanel config={CONFIG} />);
+
+    expect(screen.getByText('My Project')).toBeTruthy();
+    expect(screen.getByText('github:owner/my-proj')).toBeTruthy();
+    expect(screen.getByText('main')).toBeTruthy();
+    expect(screen.getByText('~/code/my-proj')).toBeTruthy();
+    expect(screen.getByText('pnpm test')).toBeTruthy();
+    expect(screen.getByText('~/.factory/data/my-proj')).toBeTruthy();
+
+    expect(screen.queryByText('Per-workflow $')).toBeNull();
+    expect(screen.queryByText('Daily tokens')).toBeNull();
+    expect(screen.queryByText('Per-advisor $')).toBeNull();
+    expect(screen.queryByText('Milestones')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/components/ProjectConfigPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectConfigPanel.tsx
@@ -1,5 +1,4 @@
 import type { ProjectConfigDto } from '@/lib/types';
-import { MilestonesPanel } from './MilestonesPanel';
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
@@ -12,45 +11,75 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
+function OptionalRow({ label, value }: { label: string; value?: React.ReactNode }) {
+  if (value == null || value === '') return null;
+  return <Row label={label} value={value} />;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="border-t border-line pt-5 first:border-t-0 first:pt-0">
+      <h3 className="text-[11px] uppercase tracking-wider text-fg-2 mb-1.5">{title}</h3>
+      <div>{children}</div>
+    </section>
+  );
+}
+
 interface Props {
   config: ProjectConfigDto;
 }
 
 export function ProjectConfigPanel({ config }: Props) {
   return (
-    <div data-testid="project-config-panel" className="flex flex-col gap-0">
-      <Row label="Slug" value={config.slug} />
-      <Row label="Source" value={`${config.source.kind}:${config.source.repo}`} />
-      <Row
-        label="Active Milestone"
-        value={
-          config.activeMilestone != null ? (
-            config.activeMilestone
-          ) : (
-            <span className="text-fg-2 italic">github default</span>
-          )
-        }
-      />
-      <Row label="Mode" value={config.mode} />
-      <Row
-        label="Color"
-        value={
-          <span className="flex items-center gap-2">
-            <span
-              className="inline-block w-3 h-3 rounded-sm"
-              style={{ background: config.colorStripe }}
-            />
-            {config.colorStripe}
-          </span>
-        }
-      />
-      <Row label="Per-workflow $" value={`$${config.budgets.perWorkflowMaxUsd}`} />
-      <Row label="Daily tokens" value={config.budgets.dailyTokens.toLocaleString()} />
-      <Row label="Per-advisor $" value={`$${config.budgets.perAdvisorMaxUsd}`} />
+    <div data-testid="project-config-panel" className="flex flex-col gap-6">
+      <Section title="Project">
+        <Row label="Name" value={config.name} />
+        <Row label="Slug" value={config.slug} />
+        <Row label="Source" value={`${config.source.kind}:${config.source.repo}`} />
+        <Row
+          label="Active milestone"
+          value={
+            config.activeMilestone != null ? (
+              config.activeMilestone
+            ) : (
+              <span className="text-fg-2 italic">github default</span>
+            )
+          }
+        />
+        <Row label="Mode" value={config.mode} />
+        <Row
+          label="Color"
+          value={
+            <span className="flex items-center gap-2">
+              <span
+                className="inline-block w-3 h-3 rounded-sm"
+                style={{ background: config.colorStripe }}
+              />
+              {config.colorStripe}
+            </span>
+          }
+        />
+      </Section>
 
-      <div className="mt-6 border-t border-line pt-6">
-        <MilestonesPanel slug={config.slug} />
-      </div>
+      <Section title="Target repo">
+        <Row label="Default branch" value={config.targetRepo.defaultBranch} />
+        <Row label="Local path" value={config.targetRepo.localPath} />
+        <Row label="Clone URL" value={config.targetRepo.cloneUrl} />
+      </Section>
+
+      <Section title="Stack">
+        <Row label="Runtime" value={config.stack.runtime} />
+        <Row label="Package manager" value={config.stack.packageManager} />
+        <OptionalRow label="Test command" value={config.stack.testCommand} />
+        <OptionalRow label="Lint command" value={config.stack.lintCommand} />
+        <OptionalRow label="Typecheck command" value={config.stack.typecheckCommand} />
+        <OptionalRow label="E2E command" value={config.stack.e2eCommand} />
+      </Section>
+
+      <Section title="Runtime context">
+        <Row label="Storage path" value={config.storage.path} />
+        <Row label="Isolation" value={config.isolation.mode} />
+      </Section>
     </div>
   );
 }

--- a/apps/web/src/components/settings/components/SettingsPage.test.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SettingsPage } from './SettingsPage';
+
+vi.mock('@/components/bootstrap/components/BootstrapWizard', () => ({
+  BootstrapWizard: () => null,
+}));
+
+vi.mock('@/lib/api', () => ({
+  fetchProjectConfigs: vi.fn().mockResolvedValue([
+    {
+      slug: 'my-proj',
+      name: 'My Project',
+      source: { kind: 'github', repo: 'owner/my-proj' },
+      targetRepo: {
+        cloneUrl: 'git@github.com:owner/my-proj.git',
+        defaultBranch: 'main',
+        localPath: '~/code/my-proj',
+      },
+      stack: {
+        runtime: 'node',
+        packageManager: 'pnpm',
+        testCommand: 'pnpm test',
+      },
+      activeMilestone: 'M10: Orchestration',
+      colorStripe: '#7c3aed',
+      budgets: { perWorkflowMaxUsd: 2, dailyTokens: 500000, perAdvisorMaxUsd: 0.5 },
+      mode: 'supervised',
+      storage: { path: '~/.factory/data/my-proj' },
+      isolation: { mode: 'native' },
+    },
+  ]),
+}));
+
+vi.mock('./DevReviewPanel', () => ({
+  DevReviewPanel: () => <div data-testid="dev-review-panel" />,
+}));
+vi.mock('./MilestonesPanel', () => ({
+  MilestonesPanel: ({ slug }: { slug: string }) => (
+    <div data-testid="milestones-panel">Milestones for {slug}</div>
+  ),
+}));
+vi.mock('./PipelinePanel', () => ({
+  PipelinePanel: () => <div data-testid="pipeline-panel" />,
+}));
+vi.mock('./ProjectBudgetPanel', () => ({
+  ProjectBudgetPanel: () => <div data-testid="project-budget-panel" />,
+}));
+vi.mock('./ReviewPanel', () => ({
+  ReviewPanel: () => <div data-testid="review-panel" />,
+}));
+vi.mock('./WorkflowMapPanel', () => ({
+  WorkflowMapPanel: () => <div data-testid="workflow-map-panel" />,
+}));
+
+afterEach(() => cleanup());
+
+function renderSettingsPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={client}>
+      <SettingsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe('SettingsPage', () => {
+  it('uses Summary as the default tab and moves milestones into their own tab', async () => {
+    renderSettingsPage();
+
+    await waitFor(() => expect(screen.getByTestId('project-config-panel')).toBeTruthy());
+
+    expect(screen.getByRole('button', { name: 'Summary' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Config' })).toBeNull();
+    expect(screen.queryByTestId('milestones-panel')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Milestones' }));
+
+    expect(screen.getByTestId('milestones-panel').textContent).toContain('my-proj');
+  });
+});

--- a/apps/web/src/components/settings/components/SettingsPage.tsx
+++ b/apps/web/src/components/settings/components/SettingsPage.tsx
@@ -5,17 +5,26 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { DevReviewPanel } from './DevReviewPanel';
+import { MilestonesPanel } from './MilestonesPanel';
 import { PipelinePanel } from './PipelinePanel';
 import { ProjectBudgetPanel } from './ProjectBudgetPanel';
 import { ProjectConfigPanel } from './ProjectConfigPanel';
 import { ReviewPanel } from './ReviewPanel';
 import { WorkflowMapPanel } from './WorkflowMapPanel';
 
-type Tab = 'config' | 'runtime' | 'workflow-map' | 'pipeline' | 'review' | 'dev-review';
+type Tab =
+  | 'summary'
+  | 'runtime'
+  | 'milestones'
+  | 'workflow-map'
+  | 'pipeline'
+  | 'review'
+  | 'dev-review';
 
 const TAB_LABELS: Record<Tab, string> = {
-  config: 'Config',
+  summary: 'Summary',
   runtime: 'Skill runtime',
+  milestones: 'Milestones',
   'workflow-map': 'Workflow map',
   pipeline: 'Pipeline',
   review: 'Review',
@@ -25,7 +34,7 @@ const TAB_LABELS: Record<Tab, string> = {
 export function SettingsPage() {
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>('config');
+  const [tab, setTab] = useState<Tab>('summary');
   const [wizardOpen, setWizardOpen] = useState(false);
 
   const {
@@ -95,36 +104,47 @@ export function SettingsPage() {
         ))}
       </div>
 
-      {/* Right: config detail */}
+      {/* Right: project detail */}
       <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-8 py-6">
         <h1 className="text-[15px] font-semibold mb-1">Settings</h1>
 
         {/* Tab bar */}
         <div className="flex flex-wrap gap-1 mb-6 border-b border-line">
-          {(['config', 'runtime', 'workflow-map', 'pipeline', 'review', 'dev-review'] as Tab[]).map(
-            (t) => (
-              <button
-                key={t}
-                type="button"
-                onClick={() => setTab(t)}
-                className={[
-                  'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
-                  tab === t
-                    ? 'border-accent text-fg font-medium'
-                    : 'border-transparent text-fg-2 hover:text-fg',
-                ].join(' ')}
-              >
-                {TAB_LABELS[t]}
-              </button>
-            ),
-          )}
+          {(
+            [
+              'summary',
+              'runtime',
+              'milestones',
+              'workflow-map',
+              'pipeline',
+              'review',
+              'dev-review',
+            ] as Tab[]
+          ).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={[
+                'px-3 py-1.5 text-[12px] capitalize -mb-px border-b-2 transition-colors',
+                tab === t
+                  ? 'border-accent text-fg font-medium'
+                  : 'border-transparent text-fg-2 hover:text-fg',
+              ].join(' ')}
+            >
+              {TAB_LABELS[t]}
+            </button>
+          ))}
         </div>
 
-        {tab === 'config' && selectedConfig != null && (
+        {tab === 'summary' && selectedConfig != null && (
           <ProjectConfigPanel config={selectedConfig} />
         )}
         {tab === 'runtime' && selectedConfig != null && (
           <ProjectBudgetPanel slug={selectedConfig.slug} />
+        )}
+        {tab === 'milestones' && selectedConfig != null && (
+          <MilestonesPanel slug={selectedConfig.slug} />
         )}
         {tab === 'workflow-map' && selectedConfig != null && (
           <WorkflowMapPanel slug={selectedConfig.slug} />

--- a/apps/web/src/components/settings/slice.test.ts
+++ b/apps/web/src/components/settings/slice.test.ts
@@ -25,6 +25,11 @@ describe('settings slice', () => {
     expect(typeof mod.ProjectBudgetPanel).toBe('function');
   });
 
+  it('exports MilestonesPanel', async () => {
+    const mod = await import('./components/MilestonesPanel');
+    expect(typeof mod.MilestonesPanel).toBe('function');
+  });
+
   it('exports DevReviewPanel', async () => {
     const mod = await import('./components/DevReviewPanel');
     expect(typeof mod.DevReviewPanel).toBe('function');

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -242,10 +242,21 @@ export interface ProjectConfigDto {
   slug: string;
   name: string;
   source: { kind: string; repo: string };
+  targetRepo: { cloneUrl: string; defaultBranch: string; localPath: string };
+  stack: {
+    runtime: string;
+    packageManager: string;
+    testCommand: string;
+    lintCommand?: string;
+    typecheckCommand?: string;
+    e2eCommand?: string;
+  };
   activeMilestone: string | null;
   colorStripe: string;
   budgets: { perWorkflowMaxUsd: number; dailyTokens: number; perAdvisorMaxUsd: number };
   mode: string;
+  storage: { path: string };
+  isolation: { mode: string };
 }
 
 export interface ImprovementCandidateDto {


### PR DESCRIPTION
## Summary
- Rename the settings Config tab to Summary and make it the default
- Move milestone management into a dedicated Milestones tab
- Replace summary budget rows with project identity, target repo, stack, storage, and isolation fields
- Expand the project config DTO and add focused settings tests

## Verification
- pnpm test apps/web/src/components/settings/components/ProjectConfigPanel.test.tsx apps/web/src/components/settings/components/SettingsPage.test.tsx apps/web/src/components/settings/slice.test.ts apps/server/src/domains/projects/service.test.ts
- pnpm typecheck
- pnpm lint
- Local Playwright smoke on /settings: Config absent, budget rows absent, target repo visible, Milestones tab renders, no horizontal overflow