### PR TITLE
Fix project config target repo defaults

### DIFF
--- a/apps/server/src/domains/projects/service.test.ts
+++ b/apps/server/src/domains/projects/service.test.ts
@@ -97,6 +97,36 @@ describe('listProjectConfigsService (#280)', () => {
     expect(result.configs[0].activeMilestone).toBeNull();
   });
 
+  it('falls back to "main" when targetRepo.defaultBranch is absent', async () => {
+    vi.mocked(listProjectConfigs).mockResolvedValueOnce([
+      {
+        ...mockProject,
+        targetRepo: {
+          cloneUrl: 'git@github.com:owner/my-proj.git',
+          localPath: '~/code/my-proj',
+        },
+      },
+    ] as never);
+    const result = await listProjectConfigsService();
+    expect(result.configs[0].targetRepo).toEqual({
+      cloneUrl: 'git@github.com:owner/my-proj.git',
+      defaultBranch: 'main',
+      localPath: '~/code/my-proj',
+    });
+  });
+
+  it('fills empty target repo fields when targetRepo is absent', async () => {
+    vi.mocked(listProjectConfigs).mockResolvedValueOnce([
+      { ...mockProject, targetRepo: undefined },
+    ] as never);
+    const result = await listProjectConfigsService();
+    expect(result.configs[0].targetRepo).toEqual({
+      cloneUrl: '',
+      defaultBranch: 'main',
+      localPath: '',
+    });
+  });
+
   it('returns empty configs when no projects are registered', async () => {
     vi.mocked(listProjectConfigs).mockResolvedValueOnce([] as never);
     const result = await listProjectConfigsService();

--- a/apps/server/src/domains/projects/service.ts
+++ b/apps/server/src/domains/projects/service.ts
@@ -33,9 +33,9 @@ export async function listProjectConfigsService(): Promise<{ configs: ProjectCon
     name: p.name,
     source: p.source,
     targetRepo: {
-      cloneUrl: p.targetRepo.cloneUrl,
-      defaultBranch: p.targetRepo.defaultBranch,
-      localPath: p.targetRepo.localPath,
+      cloneUrl: p.targetRepo?.cloneUrl ?? '',
+      defaultBranch: p.targetRepo?.defaultBranch ?? 'main',
+      localPath: p.targetRepo?.localPath ?? '',
     },
     stack: {
       runtime: p.stack.runtime,


### PR DESCRIPTION
Addresses the Codex review feedback from #878.\n\nSummary:\n- Normalize missing targetRepo fields in /projects/configs instead of throwing.\n- Preserve the existing defaultBranch fallback to main.\n- Add service coverage for missing targetRepo and missing targetRepo.defaultBranch.\n\nTests:\n- pnpm vitest run apps/server/src/domains/projects/service.test.ts apps/server/src/shared/projects.test.ts