### PR TITLE
M7.XX: Goose hub logo new

### DIFF
--- a/apps/web/e2e/issue-876.spec.ts
+++ b/apps/web/e2e/issue-876.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar shows the GOOSEHUB brand label when expanded', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('GOOSEHUB')).toBeVisible();
+  await page.screenshot({ path: 'evidence/issue-876/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => <div data-testid="project-switcher">Project switcher</div>,
+}));
+
+describe('Sidebar brand label', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows GOOSEHUB when the sidebar starts expanded', () => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Sidebar activeSlug="goose-hub-self" />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('GOOSEHUB');
+    expect(html).not.toContain('Goose Hub');
+  });
+
+  it('hides the wordmark when the sidebar starts collapsed', () => {
+    localStorage.setItem('sidebar-collapsed', 'true');
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Sidebar activeSlug="goose-hub-self" />
+      </MemoryRouter>,
+    );
+
+    expect(html).not.toContain('GOOSEHUB');
+    expect(html).not.toContain('Goose Hub');
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              GOOSEHUB
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Goose hub logo new

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/e2e/issue-876.spec.ts` — observed untracked change
- `apps/web/src/components/chrome/Sidebar.test.tsx` — observed untracked change

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)

Closes #876
