### PR TITLE
M7.XX: Goose hub logo new 2

### DIFF
--- a/apps/web/e2e/issue-888.spec.ts
+++ b/apps/web/e2e/issue-888.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar branding shows The Goose', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/projects/goose-hub-self');
+
+  await expect(page.getByTestId('sidebar')).toContainText('The Goose');
+  await page.screenshot({ path: 'evidence/issue-888/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              The Goose
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,13 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "The Goose"', () => {
+    expect(sidebarSource).toContain('The Goose');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
+  it('sidebar header no longer reads "Goose Hub"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
   });
 });
 


### PR DESCRIPTION
## Summary

Goose hub logo new 2

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change
- `apps/web/e2e/issue-888.spec.ts` — observed untracked change

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)

Closes #888
