### PR TITLE
M7.XX: [improvement] Extract the sidebar brand wordmark i

### DIFF
--- a/apps/web/e2e/issue-889.spec.ts
+++ b/apps/web/e2e/issue-889.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar shows the shared Goose Hub wordmark when expanded', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.route('**/api/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    }),
+  );
+
+  await page.goto('/settings');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('Goose Hub')).toBeVisible();
+  await expect(page.getByTestId('settings-page')).toBeVisible();
+
+  await page.screenshot({ path: 'evidence/issue-889/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/cn';
+import { SIDEBAR_BRAND_WORDMARK } from '@/lib/constants';
 import {
   Building2,
   ChevronLeft,
@@ -127,7 +128,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              {SIDEBAR_BRAND_WORDMARK}
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { SIDEBAR_BRAND_WORDMARK } from '@/lib/constants';
 import { describe, expect, it } from 'vitest';
 
 // Chrome is mostly React components; the slice test ensures the public files
@@ -17,13 +18,14 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header renders the shared wordmark constant', () => {
+    expect(sidebarSource).toContain('SIDEBAR_BRAND_WORDMARK');
+    expect(sidebarSource).not.toContain('Goose Hub');
   });
 
   it('sidebar header does not read "Agentic OS"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0] ?? SIDEBAR_BRAND_WORDMARK).not.toContain('Agentic OS');
   });
 });
 

--- a/apps/web/src/lib/constants.test.ts
+++ b/apps/web/src/lib/constants.test.ts
@@ -5,6 +5,7 @@ import {
   PRIORITY_BG,
   PRIORITY_BORDER,
   PRIORITY_COLOR,
+  SIDEBAR_BRAND_WORDMARK,
   STATE_LABEL,
 } from './constants';
 
@@ -112,5 +113,11 @@ describe('GATE_STATES', () => {
     expect(GATE_STATES['factory:prd-review']).toBeTruthy();
     expect(GATE_STATES['factory:needs-human']).toBeTruthy();
     expect(GATE_STATES['factory:gate-pending']).toBeTruthy();
+  });
+});
+
+describe('SIDEBAR_BRAND_WORDMARK', () => {
+  it('matches the current sidebar product wordmark', () => {
+    expect(SIDEBAR_BRAND_WORDMARK).toBe('Goose Hub');
   });
 });

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,3 +1,5 @@
+export const SIDEBAR_BRAND_WORDMARK = 'Goose Hub';
+
 // Shared display constants for work-item state and priority.
 // Priority colour-coding per issue #32: critical=red, high=orange, medium=yellow, low=grey.
 // These replace local duplicates in TaskHeader.tsx, IssueCard.tsx, and gate-states.ts.


### PR DESCRIPTION
## Summary

[improvement] Extract the sidebar brand wordmark into a shared constant and have sidebar tests reference that constant to prevent futu

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change
- `apps/web/src/lib/constants.test.ts` — observed modified change
- `apps/web/src/lib/constants.ts` — observed modified change
- `apps/web/e2e/issue-889.spec.ts` — observed untracked change

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)
- `apps/web/src/lib/constants.test.ts` (1 cases)

Closes #889
