### PR TITLE
M7.XX: Goose Hub sidebar logo wrong

### DIFF
--- a/apps/web/e2e/issue-896.spec.ts
+++ b/apps/web/e2e/issue-896.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar branding shows Agentic OS when expanded', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/projects/goose-hub-self');
+
+  await expect(page.getByTestId('sidebar').getByText('Agentic OS')).toBeVisible();
+  await page.screenshot({ path: 'evidence/issue-896/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,13 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "Agentic OS"', () => {
+    expect(sidebarSource).toContain('Agentic OS');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
+  it('sidebar header does not read "Goose Hub"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
   });
 });
 


### PR DESCRIPTION
## Summary

Goose Hub sidebar logo wrong

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change
- `apps/web/e2e/issue-896.spec.ts` — observed untracked change

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (6 cases)
- `apps/web/e2e/issue-896.spec.ts` (1 cases)

Closes #896
