### PR TITLE
M7.XX: goose hub sidbear logo wrong

### DIFF
--- a/apps/web/e2e/issue-901.spec.ts
+++ b/apps/web/e2e/issue-901.spec.ts
@@ -1,0 +1,20 @@
+import { mkdirSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+
+test('sidebar branding says Agentic OS', async ({ page }) => {
+  await page.route('**/api/projects/configs', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configs: [] }),
+    });
+  });
+
+  await page.goto('/settings');
+
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+  await expect(page.getByText('Agentic OS')).toBeVisible();
+
+  mkdirSync('evidence/issue-901', { recursive: true });
+  await page.screenshot({ path: 'evidence/issue-901/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Sidebar', () => {
+  const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
+
+  it('includes the Agentic OS brand label in the expanded header branch', () => {
+    expect(sidebarSource).toContain('Agentic OS');
+  });
+
+  it('does not keep the old Goose Hub brand label in the expanded header branch', () => {
+    const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,13 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "Agentic OS"', () => {
+    expect(sidebarSource).toContain('Agentic OS');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
+  it('sidebar header does not read "Goose Hub"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
   });
 });
 


### PR DESCRIPTION
## Summary

goose hub sidbear logo wrong

## Files
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change
- `apps/web/e2e/issue-901.spec.ts` — observed untracked change
- `apps/web/src/components/chrome/Sidebar.test.tsx` — observed untracked change

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/src/components/chrome/slice.test.ts` (6 cases)
- `apps/web/e2e/issue-901.spec.ts` (1 cases)

Closes #901
