### PR TITLE
Harden scout tool discipline

### DIFF
--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -405,6 +405,86 @@ describe('CodexCliRuntime timeout handling', () => {
     );
   });
 
+  it('rejects a successful Codex process when stderr shows a forbidden runtime surface', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec({ skill: 'scout-code-path' }));
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '{"ok":true}' },
+        })}\n`,
+      ),
+    );
+    child.stderr.emit('data', Buffer.from('resources/read failed: file://memory\n'));
+    child.emit('close', 0);
+
+    await expect(run).rejects.toThrow('forbidden-runtime-surface');
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.tool-call',
+        payload: expect.objectContaining({
+          tool_name: 'resources/read',
+          blocked: true,
+          block_reason: 'forbidden-runtime-surface: resources/read failed',
+          status: 'failed',
+        }),
+        personaId: 'test-project/developer/0',
+      }),
+    );
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.run-failed',
+        payload: expect.objectContaining({
+          skill: 'scout-code-path',
+          reason: 'forbidden-runtime-surface',
+        }),
+      }),
+    );
+    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.run-completed' }),
+    );
+  });
+
+  it('logs normal Codex stderr without failing the run', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '{"ok":true}' },
+        })}\n`,
+      ),
+    );
+    child.stderr.emit('data', Buffer.from('Reading additional input from stdin...\n'));
+    child.emit('close', 0);
+
+    await expect(run).resolves.toMatchObject({ output: { ok: true } });
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.log',
+        payload: expect.objectContaining({
+          stream: 'stderr',
+          text: 'Reading additional input from stdin...',
+        }),
+      }),
+    );
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.run-completed' }),
+    );
+  });
+
   it('emits one live decision event from a streamed agent_message marker', async () => {
     const child = makeHangingChild();
     mockSpawn.mockReturnValue(child);

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -422,7 +422,6 @@ describe('CodexCliRuntime timeout handling', () => {
       ),
     );
     child.stderr.emit('data', Buffer.from('resources/read failed: file://memory\n'));
-    child.emit('close', 0);
 
     await expect(run).rejects.toThrow('forbidden-runtime-surface');
     expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
@@ -447,6 +446,40 @@ describe('CodexCliRuntime timeout handling', () => {
       }),
     );
     expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.run-completed' }),
+    );
+  });
+
+  it('does not fail on the startup resources/list probe', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '{"ok":true}' },
+        })}\n`,
+      ),
+    );
+    child.stderr.emit('data', Buffer.from('resources/list failed: startup probe\n'));
+    child.emit('close', 0);
+
+    await expect(run).resolves.toMatchObject({ output: { ok: true } });
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.log',
+        payload: expect.objectContaining({
+          stream: 'stderr',
+          text: 'resources/list failed: startup probe',
+        }),
+      }),
+    );
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );
   });

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -61,6 +61,20 @@ const BROWSER_PROCESS_ACCESS_SKILLS = new Set(['playwright-repro', 'evidence-pos
 const ABSOLUTE_USER_PATH_RE = /\/Users\/[^\s'"`]+/g;
 const NATIVE_PATCH_REJECTION_RE =
   /patch rejected:\s*writing is blocked by read-only sandbox|writing is blocked by read-only sandbox/i;
+const FORBIDDEN_RUNTIME_SURFACE_PATTERNS: Array<{
+  surface: string;
+  toolName: string;
+  re: RegExp;
+}> = [
+  { surface: 'resources/read failed', toolName: 'resources/read', re: /resources\/read\s+failed/i },
+  { surface: 'resources/list failed', toolName: 'resources/list', re: /resources\/list\s+failed/i },
+  { surface: 'collab spawn failed', toolName: 'collab.spawn', re: /collab\s+spawn\s+failed/i },
+  {
+    surface: 'full-history fork/spawn failed',
+    toolName: 'full-history-fork-spawn',
+    re: /(?:full[- ]history.*(?:fork|spawn)|(?:fork|spawn).*full[- ]history).*(?:failed|error)/i,
+  },
+];
 
 function isPathUnderRoot(path: string, root: string): boolean {
   const normalizedRoot = join(root, '.');
@@ -119,6 +133,23 @@ function contextSizeTelemetry(input: { contextXml: string; systemPrompt: string 
 
 function stderrIncludesNativePatchRejection(stderr: string): boolean {
   return NATIVE_PATCH_REJECTION_RE.test(stderr);
+}
+
+function detectForbiddenRuntimeSurface(stderr: string): {
+  surface: string;
+  toolName: string;
+  blockReason: string;
+} | null {
+  for (const pattern of FORBIDDEN_RUNTIME_SURFACE_PATTERNS) {
+    if (pattern.re.test(stderr)) {
+      return {
+        surface: pattern.surface,
+        toolName: pattern.toolName,
+        blockReason: `forbidden-runtime-surface: ${pattern.surface}`,
+      };
+    }
+  }
+  return null;
 }
 
 export class CodexCliRuntime implements AgentRuntime {
@@ -298,6 +329,30 @@ export class CodexCliRuntime implements AgentRuntime {
             workspace_dir: workspaceDir,
             blocked: true,
             block_reason: 'native-write-blocked',
+            status: 'failed',
+          }),
+          runId,
+          personaId,
+        });
+      };
+
+      const emitForbiddenRuntimeSurfaceBlocked = (violation: {
+        surface: string;
+        toolName: string;
+        blockReason: string;
+      }) => {
+        eventStore.appendEvent({
+          projectId,
+          workItemId,
+          kind: 'agent.tool-call',
+          payload: normalizeToolCallAuditPayload({
+            tool_name: violation.toolName,
+            run_id: runId,
+            tool_input: { source: 'codex-stderr', surface: violation.surface },
+            skill: spec.skill,
+            workspace_dir: workspaceDir,
+            blocked: true,
+            block_reason: violation.blockReason,
             status: 'failed',
           }),
           runId,
@@ -540,6 +595,26 @@ export class CodexCliRuntime implements AgentRuntime {
         stdoutLineBuffer = '';
 
         const envelope = parseCodexEnvelope(stdout);
+        const forbiddenRuntimeSurface = detectForbiddenRuntimeSurface(stderr);
+
+        if (forbiddenRuntimeSurface != null) {
+          emitForbiddenRuntimeSurfaceBlocked(forbiddenRuntimeSurface);
+          eventStore.appendEvent({
+            projectId,
+            workItemId,
+            kind: 'agent.run-failed',
+            payload: {
+              runId,
+              skill: spec.skill,
+              reason: 'forbidden-runtime-surface',
+              error: forbiddenRuntimeSurface.blockReason,
+            },
+            runId,
+            personaId,
+          });
+          reject(new Error(forbiddenRuntimeSurface.blockReason));
+          return;
+        }
 
         if (code !== 0 && envelope == null) {
           if (stderrIncludesNativePatchRejection(stderr)) emitNativePatchBlocked();

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -67,7 +67,6 @@ const FORBIDDEN_RUNTIME_SURFACE_PATTERNS: Array<{
   re: RegExp;
 }> = [
   { surface: 'resources/read failed', toolName: 'resources/read', re: /resources\/read\s+failed/i },
-  { surface: 'resources/list failed', toolName: 'resources/list', re: /resources\/list\s+failed/i },
   { surface: 'collab spawn failed', toolName: 'collab.spawn', re: /collab\s+spawn\s+failed/i },
   {
     surface: 'full-history fork/spawn failed',
@@ -150,6 +149,14 @@ function detectForbiddenRuntimeSurface(stderr: string): {
     }
   }
   return null;
+}
+
+function handleForbiddenRuntimeSurface(line: string): {
+  surface: string;
+  toolName: string;
+  blockReason: string;
+} | null {
+  return detectForbiddenRuntimeSurface(line);
 }
 
 export class CodexCliRuntime implements AgentRuntime {
@@ -308,6 +315,7 @@ export class CodexCliRuntime implements AgentRuntime {
       let stdout = '';
       let stderr = '';
       let stdoutLineBuffer = '';
+      let stderrLineBuffer = '';
       let truncated = false;
       let settled = false;
       let toolCallCount = 0;
@@ -358,6 +366,32 @@ export class CodexCliRuntime implements AgentRuntime {
           runId,
           personaId,
         });
+      };
+
+      const failForbiddenRuntimeSurface = (violation: {
+        surface: string;
+        toolName: string;
+        blockReason: string;
+      }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        emitForbiddenRuntimeSurfaceBlocked(violation);
+        eventStore.appendEvent({
+          projectId,
+          workItemId,
+          kind: 'agent.run-failed',
+          payload: {
+            runId,
+            skill: spec.skill,
+            reason: 'forbidden-runtime-surface',
+            error: violation.blockReason,
+          },
+          runId,
+          personaId,
+        });
+        killProcessGroupOrChild(child);
+        reject(new Error(violation.blockReason));
       };
 
       const handleStdoutLine = (line: string) => {
@@ -527,7 +561,18 @@ export class CodexCliRuntime implements AgentRuntime {
       };
 
       child.stderr?.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
+        const text = chunk.toString();
+        stderr += text;
+        stderrLineBuffer += text;
+        const lines = stderrLineBuffer.split(/\r?\n/);
+        stderrLineBuffer = lines.pop() ?? '';
+        for (const line of lines) {
+          const violation = handleForbiddenRuntimeSurface(line);
+          if (violation != null) {
+            failForbiddenRuntimeSurface(violation);
+            return;
+          }
+        }
       });
 
       child.stdout.on('data', (chunk: Buffer) => {
@@ -593,28 +638,29 @@ export class CodexCliRuntime implements AgentRuntime {
         clearTimeout(timeout);
         handleStdoutLine(stdoutLineBuffer);
         stdoutLineBuffer = '';
+        if (stderrLineBuffer.length > 0) {
+          const violation = handleForbiddenRuntimeSurface(stderrLineBuffer);
+          if (violation != null) {
+            emitForbiddenRuntimeSurfaceBlocked(violation);
+            eventStore.appendEvent({
+              projectId,
+              workItemId,
+              kind: 'agent.run-failed',
+              payload: {
+                runId,
+                skill: spec.skill,
+                reason: 'forbidden-runtime-surface',
+                error: violation.blockReason,
+              },
+              runId,
+              personaId,
+            });
+            reject(new Error(violation.blockReason));
+            return;
+          }
+        }
 
         const envelope = parseCodexEnvelope(stdout);
-        const forbiddenRuntimeSurface = detectForbiddenRuntimeSurface(stderr);
-
-        if (forbiddenRuntimeSurface != null) {
-          emitForbiddenRuntimeSurfaceBlocked(forbiddenRuntimeSurface);
-          eventStore.appendEvent({
-            projectId,
-            workItemId,
-            kind: 'agent.run-failed',
-            payload: {
-              runId,
-              skill: spec.skill,
-              reason: 'forbidden-runtime-surface',
-              error: forbiddenRuntimeSurface.blockReason,
-            },
-            runId,
-            personaId,
-          });
-          reject(new Error(forbiddenRuntimeSurface.blockReason));
-          return;
-        }
 
         if (code !== 0 && envelope == null) {
           if (stderrIncludesNativePatchRejection(stderr)) emitNativePatchBlocked();

--- a/core/agent-runtime/runtime-instructions.test.ts
+++ b/core/agent-runtime/runtime-instructions.test.ts
@@ -60,6 +60,18 @@ describe('FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS', () => {
   it('states that paths must be workspace-relative', () => {
     expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toMatch(/workspace-relative/i);
   });
+
+  it('forbids MCP resources and spawning while naming Claude factory read tools', () => {
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('resources/read');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('resources/list');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('file://');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toMatch(/spawn/i);
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toMatch(/delegation/i);
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('mcp__factory-tools__read_file');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('mcp__factory-tools__list_dir');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('mcp__factory-tools__list_files');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS).toContain('mcp__factory-tools__search_text');
+  });
 });
 
 describe('FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX', () => {
@@ -79,6 +91,18 @@ describe('FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX', () => {
 
   it('does not advertise Claude-style prefixed names to Codex', () => {
     expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).not.toContain('mcp__factory-tools__');
+  });
+
+  it('forbids MCP resources and spawning while naming bare Codex factory read tools', () => {
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('resources/read');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('resources/list');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('file://');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toMatch(/spawn/i);
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toMatch(/delegation/i);
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('`read_file`');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('`list_dir`');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('`list_files`');
+    expect(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX).toContain('`search_text`');
   });
 });
 

--- a/core/agent-runtime/runtime-instructions.ts
+++ b/core/agent-runtime/runtime-instructions.ts
@@ -26,6 +26,8 @@ Prefer the \`mcp__factory-tools__*\` tools over native Read / Write / Edit / Glo
 
 All paths are workspace-relative. Absolute paths and \`..\` traversal are rejected. Commands run with \`shell: false\`; no shell strings. Output is byte-capped and timeouts are per-tool. Every call emits a structured \`agent.tool-call\` audit event.
 
+Do not use MCP resource surfaces or delegation surfaces unless this run explicitly allows them. Forbidden surfaces include \`resources/list\`, \`resources/read\`, \`file://...\` resource handles, collab tools, fork/full-history fork, spawn, and subagent delegation. File access must go through the exposed Factory tools such as \`mcp__factory-tools__read_file\`, \`mcp__factory-tools__list_dir\`, \`mcp__factory-tools__list_files\`, and \`mcp__factory-tools__search_text\`.
+
 Workflow-owned operations (commit, open PR, transition state, publish evidence) are not in your toolset — the orchestrator drives them.`;
 
 /**
@@ -47,6 +49,8 @@ Use the Factory MCP tools exposed by the \`factory-tools\` MCP server. Do not us
 - Project context: \`get_project_context\`, \`get_stack_commands\`
 
 All paths are workspace-relative. Absolute paths and \`..\` traversal are rejected. Commands run with \`shell: false\`; no shell strings. Output is byte-capped and timeouts are per-tool. Every call emits a structured \`agent.tool-call\` audit event.
+
+Do not use MCP resource surfaces or delegation surfaces unless this run explicitly allows them. Forbidden surfaces include \`resources/list\`, \`resources/read\`, \`file://...\` resource handles, collab tools, fork/full-history fork, spawn, and subagent delegation. File access must go through the exposed Factory tools such as \`read_file\`, \`list_dir\`, \`list_files\`, and \`search_text\`.
 
 Workflow-owned operations (commit, open PR, transition state, publish evidence) are not in your toolset — the orchestrator drives them.`;
 

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Trace the execution path of one symbol or function relev
 
 You have **read and search access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Map the direct + first-tier transitive imports of the mo
 
 You have **read and search access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Find existing usages of a code pattern or idiom relevant
 
 You have **read and search access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Your sole job is to gather **facts** about schema-shaped
 
 You have **read and search access only**. Any write attempt will be rejected.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Catalog the existing tests that cover the area named in 
 
 You have **read and search access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/scout-tool-boundary.test.ts
+++ b/skills/scout-tool-boundary.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const PROMPT_PATHS = [
+  'scout-code-path/prompt.md',
+  'scout-dependency/prompt.md',
+  'scout-pattern/prompt.md',
+  'scout-schema/prompt.md',
+  'scout-test-inventory/prompt.md',
+  'scout-user-journey/prompt.md',
+  'wave2-interface-designer/prompt.md',
+  'wave2-risk-analyst/prompt.md',
+];
+
+function readPrompt(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+function expectToolBoundary(prompt: string): void {
+  expect(prompt).toContain('## Tool Boundary');
+  expect(prompt).toContain('read_file');
+  expect(prompt).toContain('search_text');
+  expect(prompt).toContain('resources/read');
+  expect(prompt).toMatch(/spawning/i);
+  expect(prompt).toMatch(/delegation/i);
+}
+
+describe('scout and Wave 2 prompt tool boundaries', () => {
+  it.each(PROMPT_PATHS)('%s uses factory tools and forbids resource/delegation drift', (path) => {
+    expectToolBoundary(readPrompt(path));
+  });
+});

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-1 scout. Walk the user-facing flow (UI route, API surface, or CLI
 
 You have **read and search access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/wave2-interface-designer/prompt.md
+++ b/skills/wave2-interface-designer/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-2 deep agent. You consume the cross-validated Wave-1 scout report
 
 You have **read access only**. You never write files. The implementer (M19.03) does that.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`

--- a/skills/wave2-risk-analyst/prompt.md
+++ b/skills/wave2-risk-analyst/prompt.md
@@ -4,6 +4,11 @@ You are a Wave-2 deep agent. You read the cross-validated Wave-1 scout reports (
 
 You have **read access only**.
 
+## Tool Boundary
+
+- Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
+- Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`


### PR DESCRIPTION
## Summary
- tighten shared runtime instructions so Codex and Claude agents use factory-tools for file access and avoid MCP resources, file:// handles, spawn/fork/collab, and delegation surfaces
- add Tool Boundary sections to Wave 1 scout and Wave 2 prompts
- fail Codex runs when forbidden resource/spawn stderr surfaces appear, emitting blocked agent.tool-call plus agent.run-failed reason forbidden-runtime-surface

## Verification
- ../../node_modules/.bin/vitest run core/agent-runtime/runtime-instructions.test.ts core/agent-runtime/codex-cli-runtime.test.ts skills/scout-tool-boundary.test.ts skills/scout-code-path/slice.test.ts skills/scout-dependency/slice.test.ts skills/scout-pattern/slice.test.ts skills/scout-schema/slice.test.ts skills/scout-test-inventory/slice.test.ts skills/scout-user-journey/slice.test.ts skills/wave2-interface-designer/slice.test.ts skills/wave2-risk-analyst/slice.test.ts
- ../../node_modules/.bin/biome check core/agent-runtime/runtime-instructions.ts core/agent-runtime/runtime-instructions.test.ts core/agent-runtime/codex-cli.ts core/agent-runtime/codex-cli-runtime.test.ts skills/scout-tool-boundary.test.ts skills/scout-code-path/prompt.md skills/scout-dependency/prompt.md skills/scout-pattern/prompt.md skills/scout-schema/prompt.md skills/scout-test-inventory/prompt.md skills/scout-user-journey/prompt.md skills/wave2-interface-designer/prompt.md skills/wave2-risk-analyst/prompt.md