### PR TITLE
M7.XX: Goose hub sidebar logo wrong 2

### DIFF
--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -33,6 +33,28 @@ vi.mock('@goose-hub/core/db/schema.js', async (importOriginal) => {
   return { ...actual };
 });
 
+function workItem(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'github:owner/repo#5',
+    externalId: '5',
+    repoRef: 'owner/repo',
+    title: 'Done item',
+    body: '',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:done',
+    authorIsOwner: true,
+    milestoneId: '3',
+    schedule: 'current',
+    exec: 'parallel',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date('2024-01-01'),
+    ...overrides,
+  };
+}
+
 vi.mock('./shared/source.js', () => ({
   getSourceForSlug: vi.fn().mockResolvedValue({
     repoRef: 'owner/repo',
@@ -42,67 +64,19 @@ vi.mock('./shared/source.js', () => ({
     setLabelInGroup: vi.fn().mockResolvedValue(undefined),
     transitionState: vi.fn().mockResolvedValue(undefined),
     listOpenWork: vi.fn().mockResolvedValue([]),
-    listClosedWorkByMilestone: vi.fn().mockResolvedValue([
-      {
-        id: 'github:owner/repo#5',
-        externalId: '5',
-        repoRef: 'owner/repo',
-        title: 'Done item',
-        body: '',
-        type: 'feature',
-        priority: 'medium',
-        mode: 'supervised',
-        state: 'factory:done',
-        authorIsOwner: true,
-        milestoneId: '3',
-        schedule: 'current',
-        exec: 'parallel',
-        dependsOn: [],
-        blocks: [],
-        createdAt: new Date('2024-01-01'),
-      },
-    ]),
+    listClosedWorkByMilestone: vi.fn().mockResolvedValue([workItem()]),
     listWorkByMilestone: vi.fn().mockResolvedValue([
-      {
-        id: 'github:owner/repo#5',
-        externalId: '5',
-        repoRef: 'owner/repo',
-        title: 'Done item',
-        body: '',
-        type: 'feature',
-        priority: 'medium',
-        mode: 'supervised',
-        state: 'factory:done',
-        authorIsOwner: true,
-        milestoneId: '3',
-        schedule: 'current',
-        exec: 'parallel',
-        dependsOn: [],
-        blocks: [],
-        createdAt: new Date('2024-01-01'),
-      },
-      {
+      workItem(),
+      workItem({
         id: 'github:owner/repo#6',
         externalId: '6',
-        repoRef: 'owner/repo',
         title: 'Open item',
-        body: '',
-        type: 'feature',
-        priority: 'medium',
-        mode: 'supervised',
         state: 'factory:in-progress',
-        authorIsOwner: true,
-        milestoneId: '3',
-        schedule: 'current',
-        exec: 'parallel',
-        dependsOn: [],
-        blocks: [],
         createdAt: new Date('2024-01-02'),
-      },
+      }),
     ]),
   }),
 }));
-
 
 describe('GET /projects/:slug/milestones/:milestone/closed-issues', () => {
   it('returns closed work items for the milestone', async () => {

--- a/apps/web/e2e/issue-903.spec.ts
+++ b/apps/web/e2e/issue-903.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar branding shows Agentic OS', async ({ page }) => {
+  await page.route('**/api/projects', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        projects: [
+          {
+            id: 'goose-hub-self',
+            name: 'Goose Hub (self)',
+            slug: 'goose-hub-self',
+            color: '#7c3aed',
+            source: { kind: 'github', repo: 'shaunnez/goose-hub' },
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.addInitScript(() => {
+    localStorage.setItem('sidebar-collapsed', 'false');
+  });
+
+  await page.goto('/');
+
+  const sidebar = page.getByTestId('sidebar');
+  const header = sidebar.locator('div').first();
+  await expect(header).toContainText('Agentic OS');
+  await expect(header).not.toContainText('Goose Hub');
+  await page.screenshot({ path: 'evidence/issue-903/step-1.png' });
+});

--- a/apps/web/src/components/chrome/Sidebar.test.tsx
+++ b/apps/web/src/components/chrome/Sidebar.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => null,
+}));
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  localStorage.setItem('sidebar-collapsed', 'false');
+});
+
+function renderSidebar() {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe('Sidebar', () => {
+  it('renders Agentic OS branding when expanded', () => {
+    const html = renderSidebar();
+    expect(html).toContain('Agentic OS');
+    expect(html).not.toContain('Goose Hub');
+  });
+
+  it('hides the brand text when collapsed', () => {
+    localStorage.setItem('sidebar-collapsed', 'true');
+
+    const html = renderSidebar();
+    expect(html).not.toContain('Agentic OS');
+  });
+});

--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({ activeSlug }: SidebarProps) {
               style={{ background: '#7c3aed' }}
             />
             <span className="text-[14px] font-semibold tracking-tight whitespace-nowrap">
-              Goose Hub
+              Agentic OS
             </span>
           </div>
         )}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -17,13 +17,13 @@ const DEFERRED_SURFACES = [
 describe('chrome slice — sidebar brand label', () => {
   const sidebarSource = readFileSync(join(import.meta.dirname, 'Sidebar.tsx'), 'utf-8');
 
-  it('sidebar header reads "Goose Hub"', () => {
-    expect(sidebarSource).toContain('Goose Hub');
+  it('sidebar header reads "Agentic OS"', () => {
+    expect(sidebarSource).toContain('Agentic OS');
   });
 
-  it('sidebar header does not read "Agentic OS"', () => {
+  it('sidebar header no longer reads "Goose Hub"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
-    expect(labelMatch?.[0]).not.toContain('Agentic OS');
+    expect(labelMatch?.[0]).not.toContain('Goose Hub');
   });
 });
 


### PR DESCRIPTION
## Summary

Goose hub sidebar logo wrong 2

## Files
- `apps/server/src/index.test.ts` — observed modified change
- `apps/web/src/components/chrome/Sidebar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change
- `apps/web/e2e/issue-903.spec.ts` — observed untracked change
- `apps/web/src/components/chrome/Sidebar.test.tsx` — observed untracked change

## Tests
- `apps/web/src/components/chrome/Sidebar.test.tsx` (2 cases)
- `apps/web/src/components/chrome/slice.test.ts` (6 cases)
- `apps/web/e2e/issue-903.spec.ts` (1 cases)

Closes #903
