### PR TITLE
Tighten implement no-op guard

### DIFF
--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -60,16 +60,40 @@ When `<investigation>` has key files and no open questions, treat it as the impl
 - For `apps/web/` changes with evidence enabled, include the evidence spec path.
 - Emit `[decision] PLAN: <one-sentence implementation plan>`.
 
+#### No-op implementation guard
+
+Existing tests passing before any edit only proves the current baseline; it does
+not satisfy a bug fix.
+
+For `type:bug` or any work item with `<investigation>.keyFiles`, you must
+modify at least one implementation-surface file before returning success:
+either an investigated key file, or a different implementation file selected by
+a valid pivot under the investigation handoff rules above. When you pivot away
+from the investigated key files, emit the required `PLAN` decision summary with
+the contradictory evidence and name the new implementation surface you changed.
+
+Tests and evidence files support the implementation; they do not satisfy this
+guard by themselves for a bug fix. A true chore/no-code task may return without
+a behavioral code change only when the work item asks for that explicitly.
+
+If you believe no code change is needed, stop with `confidence: low`, emit a
+`BLOCKER` decision summary explaining why the issue appears already fixed or
+non-actionable, and return without pretending to ship.
+
+The `filesWritten` list must match actual writes made via
+`mcp__factory-tools__write_file` or `mcp__factory-tools__edit_file`; do not
+report files that were only read.
+
 ### 3. Red
 
-- Write failing targeted tests first unless this is a true chore with no behavioural surface.
+- Write or update targeted tests that fail with the current behavior before implementation unless this is a true chore with no behavioural surface. When existing tests encode stale behavior, update those tests so they fail against the current bug before changing implementation code.
 - Run the targeted test command via Factory test tools and record returned canonical paths.
 - Emit `[decision] RED: Wrote <N> failing tests for <surface>`.
 
 ### 4. Green
 
 - Implement the smallest slice that satisfies the tests and acceptance criteria.
-- Re-run targeted tests until green or blocked.
+- Re-run targeted tests only after a real write has occurred, then iterate until green or blocked.
 - For frontend changes with evidence enabled, create/update `apps/web/e2e/issue-<number>.spec.ts` or the provided `relatedSurface.evidenceSpecPath`. Use bounded discovery; if blocked, return `evidenceSpecPath: null` with `TOOL_FAILURE` or `UNCERTAINTY`.
 - If evidence is disabled, return `evidenceSpecPath: null` with a `SKIP_GATE` summary.
 - Emit `[decision] GREEN: Targeted tests pass`.

--- a/skills/implement/slice.test.ts
+++ b/skills/implement/slice.test.ts
@@ -428,6 +428,43 @@ describe('implement prompt', () => {
     expect(prompt).toContain('Do not continue broad discovery');
   });
 
+  it('guards against no-op bug-fix implementations', () => {
+    expect(prompt).toContain('No-op implementation guard');
+    expect(prompt).toContain(
+      'Existing tests passing before any edit only proves the current baseline',
+    );
+    expect(prompt).toMatch(/does\s+not satisfy a bug fix/);
+    expect(prompt).toContain('modify at least one implementation-surface file');
+    expect(prompt).toContain('either an investigated key file');
+    expect(prompt).toContain('different implementation file selected by');
+    expect(prompt).toContain('valid pivot under the investigation handoff rules');
+  });
+
+  it('does not allow test or evidence-only edits to satisfy a bug fix', () => {
+    expect(prompt).toContain('Tests and evidence files support the implementation');
+    expect(prompt).toMatch(/do not satisfy this\s+guard by themselves for a bug fix/);
+  });
+
+  it('requires low-confidence blocker output for no-change conclusions', () => {
+    expect(prompt).toContain('stop with `confidence: low`');
+    expect(prompt).toContain('`BLOCKER` decision summary');
+    expect(prompt).toMatch(/appears already fixed or\s+non-actionable/);
+    expect(prompt).toContain('return without pretending to ship');
+  });
+
+  it('forbids reporting filesWritten for files that were only read', () => {
+    expect(prompt).toContain('The `filesWritten` list must match actual writes');
+    expect(prompt).toContain('`mcp__factory-tools__write_file`');
+    expect(prompt).toContain('`mcp__factory-tools__edit_file`');
+    expect(prompt).toMatch(/do not\s+report files that were only read/);
+  });
+
+  it('requires red tests before implementation and green tests only after a write', () => {
+    expect(prompt).toContain('fail with the current behavior before');
+    expect(prompt).toContain('existing tests encode stale behavior');
+    expect(prompt).toMatch(/only after a\s+real write has occurred/);
+  });
+
   it('bounds frontend evidence discovery when e2e support is missing or unclear', () => {
     expect(prompt).toContain('Bounded frontend evidence rule');
     expect(prompt).toContain(


### PR DESCRIPTION
## Summary
- add a no-op implementation guard to the implement prompt for bug and investigation-backed runs
- require no-change conclusions to return low confidence with a BLOCKER summary
- extend implement prompt assertions for the new guard and Red/Green discipline

## Tests
- pnpm vitest run skills/implement/slice.test.ts
- pnpm exec biome check skills/implement/slice.test.ts skills/implement/prompt.md