### PR TITLE
Repair schema-validation retries

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -182,6 +182,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <WrongSurfaceGuardEvent key={event.id} event={event} />;
     case 'agent.path-normalized':
     case 'agent.output-repaired':
+    case 'agent.output-repair-failed':
     case 'agent.output-fact-mismatch':
     case 'agent.contract-gate-blocked':
       return <ContractDriftEvent key={event.id} event={event} />;

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -165,12 +165,23 @@ describe('Misc timeline events', () => {
       },
       13,
     );
+    const repairFailed = makeEvent(
+      'agent.output-repair-failed',
+      {
+        skill: 'implement',
+        reason: 'terminal-output-validation-failed-after-repair-retry',
+        message:
+          'Implementation/tool execution may have succeeded; the failure is terminal JSON output validation.',
+      },
+      14,
+    );
 
     render(
       <ul>
         {renderTimelineItem({ kind: 'event', event: normalized }, 0)}
         {renderTimelineItem({ kind: 'event', event: mismatch }, 1)}
         {renderTimelineItem({ kind: 'event', event: blocked }, 2)}
+        {renderTimelineItem({ kind: 'event', event: repairFailed }, 3)}
       </ul>,
     );
 
@@ -184,6 +195,8 @@ describe('Misc timeline events', () => {
     expect(rendered).toContain('Observed not declared');
     expect(rendered).toContain('Contract gate blocked');
     expect(rendered).toContain('ambiguous-files-owned');
+    expect(rendered).toContain('Output repair failed');
+    expect(rendered).toContain('terminal-output-validation-failed-after-repair-retry');
     expect(rendered).not.toContain('"observedChangedFiles"');
   });
 

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -475,11 +475,13 @@ export function ContractDriftEvent({ event }: { event: AgentEventDto }) {
   const title =
     event.kind === 'agent.output-repaired'
       ? 'Path normalized'
-      : event.kind === 'agent.output-fact-mismatch'
-        ? 'Operational fact mismatch'
-        : event.kind === 'agent.path-normalized'
-          ? 'Path normalized'
-          : 'Contract gate blocked';
+      : event.kind === 'agent.output-repair-failed'
+        ? 'Output repair failed'
+        : event.kind === 'agent.output-fact-mismatch'
+          ? 'Operational fact mismatch'
+          : event.kind === 'agent.path-normalized'
+            ? 'Path normalized'
+            : 'Contract gate blocked';
   const fields = p?.fields ?? [];
   return (
     <li

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -619,6 +619,7 @@ describe('EVENT_KIND_LABEL — QA and fix-feedback kinds', () => {
   const KINDS = [
     'agent.disclosure',
     'agent.fix-feedback-complete',
+    'agent.output-repair-failed',
     'agent.retry-escalated',
     'symbol-index.hints-used',
     'evidence.playwright-ran',

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -53,6 +53,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.discovery-budget-exceeded': 'Discovery budget exceeded',
   'agent.wrong-surface-guard': 'Wrong surface guard',
   'agent.output-repaired': 'Output repaired',
+  'agent.output-repair-failed': 'Output repair failed',
   'agent.output-fact-mismatch': 'Output fact mismatch',
   'agent.contract-gate-blocked': 'Contract gate blocked',
   'symbol-index.lookup': 'Symbol index lookup',

--- a/core/agent-runtime/with-escalation.test.ts
+++ b/core/agent-runtime/with-escalation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { ImplementSchema } from '../../skills/implement/schema.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { HoldoutFallbackForbiddenError } from './interface.js';
 import { runWithEscalation } from './with-escalation.js';
@@ -15,6 +16,34 @@ vi.mock('../event-stream/store.js', () => ({
 }));
 
 const Schema = z.object({ ok: z.literal(true) });
+
+const validImplementOutput = {
+  plan: '1. Add a regression test. 2. Fix the retry prompt. 3. Run focused tests.',
+  filesWritten: [{ path: 'core/agent-runtime/with-escalation.ts', reason: 'repair retry prompt' }],
+  testsWritten: [{ path: 'core/agent-runtime/with-escalation.test.ts', cases: 1 }],
+  testsRun: {
+    command: 'pnpm vitest',
+    paths: ['core/agent-runtime/with-escalation.test.ts'],
+  },
+  prUrl: 'https://github.com/owner/repo/issues/123',
+  evidenceSpecPath: null,
+  confidence: 'high',
+  decisionSummaries: [
+    { kind: 'PLAN', summary: 'Add a validation repair retry for terminal JSON shape failures' },
+  ],
+  selfQualityScore: {
+    openClosed: 18,
+    conceptCount: 12,
+    timeToCapability: 13,
+    complecting: 14,
+    loc: 8,
+    coupling: 9,
+    gallsLaw: 9,
+    cyclomaticComplexity: 4,
+  },
+  selfScoreBelowThreshold: false,
+  selfScoreWarnings: [],
+};
 
 function makeSpec(overrides: Partial<AgentSpec> = {}): AgentSpec {
   return {
@@ -139,8 +168,63 @@ describe('runWithEscalation — escalation', () => {
         projectId: 'p',
         workItemId: 'w',
       }),
-    ).rejects.toThrow(/validation failed after sonnet retry/i);
+    ).rejects.toThrow(/validation failed after sonnet-tier validation retry/i);
     expect(runFn).toHaveBeenCalledTimes(2);
+    expect(appendEvent).toHaveBeenCalledTimes(2);
+    const repairFailed = appendEvent.mock.calls[1][0] as Record<string, unknown>;
+    expect(repairFailed.kind).toBe('agent.output-repair-failed');
+    expect(repairFailed.payload).toMatchObject({
+      skill: 'implement',
+      reason: 'terminal-output-validation-failed-after-repair-retry',
+      message:
+        'Implementation/tool execution may have succeeded; the failure is terminal JSON output validation.',
+    });
+  });
+
+  it('repairs implement terminal JSON when self-quality fields exceed schema limits', async () => {
+    appendEvent.mockClear();
+    const invalidOutput = {
+      ...validImplementOutput,
+      selfQualityScore: {
+        openClosed: 21,
+        conceptCount: 16,
+        timeToCapability: 16,
+        complecting: 16,
+        loc: 11,
+        coupling: 11,
+        gallsLaw: 11,
+        cyclomaticComplexity: 6,
+      },
+      selfScoreBelowThreshold: false,
+    };
+    const correctedOutput = validImplementOutput;
+    const runFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeResult(invalidOutput))
+      .mockResolvedValueOnce(makeResult(correctedOutput));
+    const runtime = makeRuntime(runFn);
+
+    const out = await runWithEscalation({
+      runtime,
+      spec: makeSpec({ appendSystemPrompt: 'Base implement prompt.' }),
+      schema: ImplementSchema,
+      projectId: 'p',
+      workItemId: 'w',
+    });
+
+    expect(out.escalated).toBe(true);
+    expect(out.output.selfQualityScore).toEqual(validImplementOutput.selfQualityScore);
+    expect(runFn).toHaveBeenCalledTimes(2);
+
+    const retrySpec = runFn.mock.calls[1][0] as AgentSpec;
+    expect(retrySpec.appendSystemPrompt).toContain('Base implement prompt.');
+    expect(retrySpec.appendSystemPrompt).toContain('Terminal JSON Validation Repair');
+    expect(retrySpec.appendSystemPrompt).toContain('Do not redo implementation work');
+    expect(retrySpec.appendSystemPrompt).toContain('return corrected JSON only');
+    expect(retrySpec.appendSystemPrompt).toContain('selfQualityScore.openClosed');
+    expect(retrySpec.appendSystemPrompt).toContain('selfQualityScore.cyclomaticComplexity');
+    expect(retrySpec.appendSystemPrompt).toContain('"openClosed": 21');
+    expect(appendEvent).toHaveBeenCalledTimes(1);
   });
 
   it('retries at the same tier when escalation target equals current tier (opus→opus)', async () => {

--- a/core/agent-runtime/with-escalation.ts
+++ b/core/agent-runtime/with-escalation.ts
@@ -1,5 +1,6 @@
-import type { ZodType } from 'zod';
+import type { ZodIssue, ZodType } from 'zod';
 import { eventStore } from '../event-stream/store.js';
+import { redactSecrets } from '../tool-layer/secret-redaction.js';
 import type { ModelTier } from '../types.js';
 import type { SkillBudgetOverride } from './budgets.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
@@ -90,6 +91,11 @@ export async function runWithEscalation<T>(
     runId: retryRunId,
     budgets: escalated.budgets,
     modelOverride: escalatedModelOverride,
+    appendSystemPrompt: appendValidationRepairPrompt(
+      spec.appendSystemPrompt,
+      parsed.error.issues,
+      result.output,
+    ),
   };
 
   eventStore.appendEvent({
@@ -114,10 +120,76 @@ export async function runWithEscalation<T>(
   const retryResult = await runtime.run(retrySpec);
   const retryParsed = schema.safeParse(retryResult.output);
   if (!retryParsed.success) {
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItemId ?? null,
+      kind: 'agent.output-repair-failed',
+      payload: {
+        runId: spec.runId,
+        retryRunId,
+        skill: spec.skill,
+        reason: 'terminal-output-validation-failed-after-repair-retry',
+        message:
+          'Implementation/tool execution may have succeeded; the failure is terminal JSON output validation.',
+        originalValidationIssues: formatZodIssues(parsed.error.issues),
+        repairValidationIssues: formatZodIssues(retryParsed.error.issues),
+        originalRawOutputPreview: previewOutput(result.output),
+        repairRawOutputPreview: previewOutput(retryResult.output),
+      },
+      runId: retryRunId,
+    });
     throw makeValidationError(spec.skill, retryParsed.error.issues, retryResult.output, targetTier);
   }
 
   return { output: retryParsed.data, result: retryResult, escalated: true };
+}
+
+function appendValidationRepairPrompt(
+  appendSystemPrompt: string | undefined,
+  issues: ZodIssue[],
+  rawOutput: unknown,
+): string {
+  const basePrompt = appendSystemPrompt?.trimEnd() ?? '';
+  const repairPrompt = [
+    '## Terminal JSON Validation Repair',
+    '',
+    'Your previous run completed, but its terminal JSON output failed schema validation.',
+    'Do not redo implementation work, rerun commands, change files, or reopen the task.',
+    'Preserve every truthful field from the previous output and return corrected JSON only.',
+    'Repair only the terminal output shape and invalid values identified below.',
+    '',
+    'Validation issues:',
+    JSON.stringify(formatZodIssues(issues), null, 2),
+    '',
+    'Invalid output preview:',
+    previewOutput(rawOutput),
+  ].join('\n');
+
+  return basePrompt.length > 0 ? `${basePrompt}\n\n${repairPrompt}` : repairPrompt;
+}
+
+function formatZodIssues(
+  issues: ZodIssue[],
+): Array<{ path: string; message: string; code: string }> {
+  return issues.map((issue) => ({
+    path: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+    message: issue.message,
+    code: issue.code,
+  }));
+}
+
+function previewOutput(rawOutput: unknown): string {
+  const redacted = redactSecrets(rawOutput);
+  const rawPreview = typeof redacted === 'string' ? redacted : safeStringify(redacted);
+  return rawPreview.slice(0, 4000);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function makeValidationError(
@@ -126,12 +198,9 @@ function makeValidationError(
   rawOutput: unknown,
   retriedAtTier: ModelTier | null,
 ): Error {
-  const rawPreview =
-    typeof rawOutput === 'string'
-      ? rawOutput.slice(0, 800)
-      : JSON.stringify(rawOutput).slice(0, 800);
-  const suffix = retriedAtTier != null ? ` after ${retriedAtTier} retry` : '';
+  const rawPreview = previewOutput(rawOutput).slice(0, 800);
+  const suffix = retriedAtTier != null ? ` after ${retriedAtTier}-tier validation retry` : '';
   return new Error(
-    `${skill} output validation failed${suffix}: ${JSON.stringify(issues)}\nRaw output (first 800 chars): ${rawPreview}`,
+    `${skill} terminal output validation failed${suffix}; implementation/tool execution may have succeeded and only terminal JSON shape is invalid: ${JSON.stringify(issues)}\nRaw output (first 800 chars): ${rawPreview}`,
   );
 }

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -32,6 +32,7 @@ export type EventKind =
   | 'agent.wrong-surface-guard'
   | 'agent.path-normalized'
   | 'agent.output-repaired'
+  | 'agent.output-repair-failed'
   | 'agent.output-fact-mismatch'
   | 'agent.contract-gate-blocked'
   // Three-tier verification framework (M19.05, issue #562)

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -105,7 +105,7 @@ Do not inspect old e2e specs, Playwright config, or screenshot conventions befor
 ### 5. Refactor, Score, Verify
 
 - Refactor only if required for clarity or correctness, then re-run targeted tests.
-- If behavioural tests were written, score `selfQualityScore` against the schema categories and emit one `SELF_SCORE` summary with aggregate and lowest category. If below threshold, do one focused quality refactor, retest, and set `selfScoreBelowThreshold` if still below.
+- If behavioural tests were written, score `selfQualityScore` against the schema categories and emit one `SELF_SCORE` summary with aggregate and lowest category. Field ranges are `openClosed: 0-20`; `conceptCount`, `timeToCapability`, and `complecting: 0-15`; `loc`, `coupling`, and `gallsLaw: 0-10`; `cyclomaticComplexity: 0-5`. Individual fields are not percentages; only the aggregate is out of 100. If below threshold, do one focused quality refactor, retest, and set `selfScoreBelowThreshold` if still below.
 - Run lint/typecheck when commands are provided.
 - Emit `[decision] LINT: Lint/typecheck complete` or the relevant blocker summary.
 

--- a/skills/implement/slice.test.ts
+++ b/skills/implement/slice.test.ts
@@ -473,6 +473,15 @@ describe('implement prompt', () => {
     expect(prompt).toContain('ship the implementation plus targeted tests');
   });
 
+  it('documents per-field self-quality score ranges', () => {
+    expect(prompt).toContain('`openClosed: 0-20`');
+    expect(prompt).toContain('`conceptCount`, `timeToCapability`, and `complecting: 0-15`');
+    expect(prompt).toContain('`loc`, `coupling`, and `gallsLaw: 0-10`');
+    expect(prompt).toContain('`cyclomaticComplexity: 0-5`');
+    expect(prompt).toContain('Individual fields are not percentages');
+    expect(prompt).toContain('only the aggregate is out of 100');
+  });
+
   it('forbids memory and skill quick passes', () => {
     expect(prompt).toContain('No memory or skill quick pass');
     expect(prompt).toContain('Do not read local assistant memory');


### PR DESCRIPTION
## Summary
- Convert runWithEscalation schema-validation retries into output repair retries with Zod issue feedback and a redacted invalid-output preview.
- Emit agent.output-repair-failed when both the original and repair outputs fail validation, preserving evidence that implementation/tool execution may have succeeded.
- Clarify implement selfQualityScore field ranges and add regression coverage for bounded self-score repair.

## Verification
- pnpm vitest core/agent-runtime/with-escalation.test.ts
- pnpm vitest skills/implement/slice.test.ts
- pnpm vitest slices/fix-issue/slice.test.ts
- pnpm exec biome check core/agent-runtime/with-escalation.ts core/agent-runtime/with-escalation.test.ts core/event-stream/store.ts skills/implement/slice.test.ts
- Manual invalid ImplementSchema replay with temp DB_PATH repaired successfully after one retry.