### PR TITLE
Strict Grill thread comment contract

### DIFF
--- a/apps/web/src/components/detail/components/GrillSection.test.tsx
+++ b/apps/web/src/components/detail/components/GrillSection.test.tsx
@@ -1,14 +1,13 @@
 /** @vitest-environment jsdom */
-import { addComment, fetchComments, transitionState } from '@/lib/api';
+import { addComment, fetchComments, proceedToPrd, transitionState } from '@/lib/api';
 import type { IssueCommentDto } from '@/lib/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GRILL_QUESTION_MARKER, GRILL_REPLY_MARKER } from '../lib/grill-comments';
 import { GrillSection } from './GrillSection';
 
 afterEach(cleanup);
-
-import { proceedToPrd } from '@/lib/api';
 
 vi.mock('@/lib/api', () => ({
   fetchComments: vi.fn(),
@@ -19,7 +18,6 @@ vi.mock('@/lib/api', () => ({
 
 // Reset call history between tests so call-count assertions in one test
 // aren't polluted by other tests in the same file.
-import { beforeEach } from 'vitest';
 beforeEach(() => {
   vi.mocked(fetchComments).mockClear();
   vi.mocked(addComment).mockClear();
@@ -52,8 +50,8 @@ describe('GrillSection', () => {
 
   it('distinguishes agent question (with marker) from user reply', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\n**Round 1** — What does better mean?'),
-      comment(2, 'Better means fewer drop-offs.'),
+      comment(1, `${GRILL_QUESTION_MARKER}\n**Round 1** — What does better mean?`),
+      comment(2, `${GRILL_REPLY_MARKER}\nBetter means fewer drop-offs.`),
     ]);
     render_(
       <GrillSection projectSlug="proj" externalId="42" id="42" state="factory:gate-pending" />,
@@ -64,20 +62,75 @@ describe('GrillSection', () => {
     });
   });
 
-  it('filters out PRD marker comments from the chat thread', async () => {
+  it('renders marked grill question', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
-      comment(2, '<!-- factory:prd -->\n# PRD'),
+      comment(1, `${GRILL_QUESTION_MARKER}\nWhat does better mean?`, 'factory-agent'),
     ]);
-    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:prd-review" />);
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('grill-msg-agent').textContent).toContain('griller');
+    });
+    expect(screen.getByTestId('grill-msg-agent').textContent).toContain('What does better mean?');
+    expect(screen.getByTestId('grill-msg-agent').textContent).not.toContain(
+      'factory:grill-question',
+    );
+  });
+
+  it('renders marked grill reply as the comment author', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([
+      comment(1, `${GRILL_REPLY_MARKER}\nBetter means fewer drop-offs.`, 'shaun'),
+    ]);
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('grill-msg-user').textContent).toContain('shaun');
+    });
+    expect(screen.getByTestId('grill-msg-user').textContent).toContain(
+      'Better means fewer drop-offs.',
+    );
+    expect(screen.getByTestId('grill-msg-user').textContent).not.toContain('factory:grill-reply');
+  });
+
+  it('preserves legacy unmarked human replies after a grill question', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?`),
+      comment(2, 'Legacy answer before reply markers existed.'),
+    ]);
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+    await waitFor(() => {
+      expect(screen.getAllByTestId('grill-msg-agent')).toHaveLength(1);
+    });
+    expect(screen.getByTestId('grill-msg-user').textContent).toContain(
+      'Legacy answer before reply markers existed.',
+    );
+  });
+
+  it('hides unmarked human comments before the grill thread starts', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([
+      comment(1, 'Plain GitHub comment.'),
+      comment(2, `${GRILL_QUESTION_MARKER}\nQ?`),
+    ]);
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+    await waitFor(() => {
+      expect(screen.getAllByTestId('grill-msg-agent')).toHaveLength(1);
+    });
+    expect(screen.queryByText('Plain GitHub comment.')).toBeNull();
+  });
+
+  it('hides [Investigate] Escalated comments from the grill thread', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?`),
+      comment(2, '[Investigate] Escalated\nNeeds additional research.'),
+    ]);
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
     await waitFor(() => {
       expect(screen.getAllByTestId('grill-msg-agent')).toHaveLength(1);
     });
     expect(screen.queryByTestId('grill-msg-user')).toBeNull();
+    expect(screen.queryByText('[Investigate] Escalated')).toBeNull();
   });
 
   it('Send button posts a comment and (when gate-pending) transitions back to grilling', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([comment(1, '<!-- factory:grill-question -->\nQ?')]);
+    vi.mocked(fetchComments).mockResolvedValue([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     vi.mocked(addComment).mockResolvedValueOnce(undefined);
     vi.mocked(transitionState).mockResolvedValueOnce({
       status: 200,
@@ -98,7 +151,11 @@ describe('GrillSection', () => {
     fireEvent.click(screen.getByTestId('grill-send-btn'));
 
     await waitFor(() => {
-      expect(addComment).toHaveBeenCalledWith('proj', '42', 'Better means fewer drop-offs.');
+      expect(addComment).toHaveBeenCalledWith(
+        'proj',
+        '42',
+        `${GRILL_REPLY_MARKER}\nBetter means fewer drop-offs.`,
+      );
     });
     await waitFor(() => {
       expect(transitionState).toHaveBeenCalledWith(
@@ -120,7 +177,7 @@ describe('GrillSection', () => {
   });
 
   it('shows the optimistic reply in the thread before round-trip resolves', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([comment(1, '<!-- factory:grill-question -->\nQ?')]);
+    vi.mocked(fetchComments).mockResolvedValue([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     const pending = new Promise<void>((resolve) => {
       // Stash the resolver on the ref so the test can drain the mutation
       // after assertions complete.
@@ -140,6 +197,7 @@ describe('GrillSection', () => {
     await waitFor(() => {
       const userMsgs = screen.getAllByTestId('grill-msg-user');
       expect(userMsgs.some((el) => el.getAttribute('data-optimistic') === 'true')).toBe(true);
+      expect(userMsgs.some((el) => el.textContent?.includes('factory:grill-reply'))).toBe(false);
     });
 
     // Drain the pending mutation so React Query doesn't keep the promise open.
@@ -148,7 +206,7 @@ describe('GrillSection', () => {
 
   it('filters out <!-- factory:system --> comments from the grill thread', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?`),
       comment(2, '<!-- factory:system -->\nUser rejected the PRD; returning to grill.'),
     ]);
     render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
@@ -160,7 +218,7 @@ describe('GrillSection', () => {
 
   it('filters out ## Child issues comments from the grill thread', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?`),
       comment(2, '## Child issues\n- #101 Slice 1\n- #102 Slice 2'),
     ]);
     render_(
@@ -173,9 +231,7 @@ describe('GrillSection', () => {
   });
 
   it('renders the "Grilling complete" footer when state has progressed past grilling', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
-    ]);
+    vi.mocked(fetchComments).mockResolvedValueOnce([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('grill-complete-footer')).toBeTruthy();
@@ -187,7 +243,7 @@ describe('GrillSection', () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
       comment(
         1,
-        '<!-- factory:grill-question -->\nWhat does "better" mean?\n<!-- factory:recommended-answer -->\nFewer user drop-offs on the checkout screen.',
+        `${GRILL_QUESTION_MARKER}\nWhat does "better" mean?\n<!-- factory:recommended-answer -->\nFewer user drop-offs on the checkout screen.`,
       ),
     ]);
     render_(
@@ -208,7 +264,7 @@ describe('GrillSection', () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
       comment(
         1,
-        '<!-- factory:grill-question -->\nQ?\n<!-- factory:recommended-answer -->\nSuggested text here.',
+        `${GRILL_QUESTION_MARKER}\nQ?\n<!-- factory:recommended-answer -->\nSuggested text here.`,
       ),
     ]);
     render_(
@@ -223,20 +279,43 @@ describe('GrillSection', () => {
 
   it('does not show recommended answer pill when state is not gate-pending', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(
-        1,
-        '<!-- factory:grill-question -->\nQ?\n<!-- factory:recommended-answer -->\nAnswer.',
-      ),
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?\n<!-- factory:recommended-answer -->\nAnswer.`),
     ]);
     render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:prd-review" />);
     await waitFor(() => expect(screen.getByTestId('grill-msg-agent')).toBeTruthy());
     expect(screen.queryByTestId('grill-recommended-answer')).toBeNull();
   });
 
-  it('shows "Proceed to PRD" button in gate-pending state', async () => {
+  it('does not show recommended answer from an earlier grill question', async () => {
     vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
+      comment(
+        1,
+        `${GRILL_QUESTION_MARKER}\nFirst question?\n<!-- factory:recommended-answer -->\nOld answer.`,
+      ),
+      comment(2, `${GRILL_REPLY_MARKER}\nFirst reply.`),
+      comment(3, `${GRILL_QUESTION_MARKER}\nLatest question?`),
     ]);
+    render_(
+      <GrillSection projectSlug="proj" externalId="42" id="42" state="factory:gate-pending" />,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('grill-msg-agent')).toHaveLength(2));
+    expect(screen.queryByTestId('grill-recommended-answer')).toBeNull();
+  });
+
+  it('keeps recommended-answer parsing on questions only', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([
+      comment(1, `${GRILL_QUESTION_MARKER}\nQ?`),
+      comment(2, `${GRILL_REPLY_MARKER}\nA.\n<!-- factory:recommended-answer -->\nIgnore me.`),
+    ]);
+    render_(
+      <GrillSection projectSlug="proj" externalId="42" id="42" state="factory:gate-pending" />,
+    );
+    await waitFor(() => expect(screen.getByTestId('grill-msg-agent')).toBeTruthy());
+    expect(screen.queryByTestId('grill-recommended-answer')).toBeNull();
+  });
+
+  it('shows "Proceed to PRD" button in gate-pending state', async () => {
+    vi.mocked(fetchComments).mockResolvedValueOnce([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     render_(
       <GrillSection projectSlug="proj" externalId="42" id="42" state="factory:gate-pending" />,
     );
@@ -244,9 +323,7 @@ describe('GrillSection', () => {
   });
 
   it('calls proceedToPrd when "Proceed to PRD" is clicked', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([
-      comment(1, '<!-- factory:grill-question -->\nQ?'),
-    ]);
+    vi.mocked(fetchComments).mockResolvedValueOnce([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     vi.mocked(proceedToPrd).mockResolvedValueOnce({ ok: true });
 
     render_(

--- a/apps/web/src/components/detail/components/GrillSection.tsx
+++ b/apps/web/src/components/detail/components/GrillSection.tsx
@@ -5,6 +5,14 @@ import { timeAgo } from '@/lib/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckCircle2, MessageCircleQuestion } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import {
+  GRILL_REPLY_MARKER,
+  isGrillQuestion,
+  parseRecommendedAnswer,
+  selectGrillThreadComments,
+  stripGrillMarker,
+  stripRecommendedAnswer,
+} from '../lib/grill-comments';
 import { SectionEmptyState } from './SectionEmptyState';
 
 interface GrillSectionProps {
@@ -12,35 +20,6 @@ interface GrillSectionProps {
   externalId: string;
   id: string;
   state: string | undefined;
-}
-
-const GRILL_QUESTION_MARKER = '<!-- factory:grill-question -->';
-const RECOMMENDED_ANSWER_MARKER = '<!-- factory:recommended-answer -->';
-const PRD_MARKER = '<!-- factory:prd -->';
-const SYSTEM_MARKER = '<!-- factory:system -->';
-const CHILD_ISSUES_MARKER = '## Child issues';
-
-function isAgentQuestion(body: string): boolean {
-  return body.startsWith(GRILL_QUESTION_MARKER);
-}
-
-function stripMarker(body: string): string {
-  if (body.startsWith(GRILL_QUESTION_MARKER)) {
-    return body.slice(GRILL_QUESTION_MARKER.length).trimStart();
-  }
-  return body;
-}
-
-function parseRecommendedAnswer(body: string): string | null {
-  const idx = body.indexOf(RECOMMENDED_ANSWER_MARKER);
-  if (idx === -1) return null;
-  return body.slice(idx + RECOMMENDED_ANSWER_MARKER.length).trimStart() || null;
-}
-
-function stripRecommendedAnswer(body: string): string {
-  const idx = body.indexOf(RECOMMENDED_ANSWER_MARKER);
-  if (idx === -1) return body;
-  return body.slice(0, idx).trimEnd();
 }
 
 interface OptimisticReply extends IssueCommentDto {
@@ -101,18 +80,11 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
     },
   });
 
-  // Filter out system/metadata comments — PRD drafts, system notices, child
-  // issues posts — they are not part of the grill conversation.
-  const grillComments = comments.filter(
-    (c) =>
-      !c.body.startsWith(PRD_MARKER) &&
-      !c.body.startsWith(SYSTEM_MARKER) &&
-      !c.body.startsWith(CHILD_ISSUES_MARKER),
-  );
+  const grillComments = selectGrillThreadComments(comments);
   const merged: Array<IssueCommentDto | OptimisticReply> = [...grillComments, ...optimisticReplies];
 
   // The last agent question in the thread (used for recommended-answer pill).
-  const lastAgentQuestionId = [...merged].reverse().find((c) => isAgentQuestion(c.body))?.id;
+  const lastAgentQuestionId = [...merged].reverse().find((c) => isGrillQuestion(c.body))?.id;
 
   const grillingComplete =
     state === 'factory:prd-drafting' ||
@@ -129,17 +101,18 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
     e.preventDefault();
     const trimmed = text.trim();
     if (trimmed.length === 0 || send.isPending) return;
+    const replyBody = `${GRILL_REPLY_MARKER}\n${trimmed}`;
     setErrorMsg(null);
     // Optimistic insert.
     const reply: OptimisticReply = {
       id: -Date.now(),
-      body: trimmed,
+      body: replyBody,
       authorLogin: 'you',
       createdAt: new Date().toISOString(),
       __optimistic: true,
     };
     setOptimisticReplies((prev) => [...prev, reply]);
-    send.mutate(trimmed);
+    send.mutate(replyBody);
   };
 
   if (isLoading) {
@@ -183,8 +156,8 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
       ) : (
         <ol className="flex flex-col gap-3" data-testid="grill-thread">
           {merged.map((c) => {
-            const agent = isAgentQuestion(c.body);
-            const rawStripped = stripMarker(c.body);
+            const agent = isGrillQuestion(c.body);
+            const rawStripped = stripGrillMarker(c.body);
             const display = agent ? stripRecommendedAnswer(rawStripped) : rawStripped;
             const isOptimistic = '__optimistic' in c && c.__optimistic === true;
             const recommendedAnswer =

--- a/apps/web/src/components/detail/lib/grill-comments.test.ts
+++ b/apps/web/src/components/detail/lib/grill-comments.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRILL_QUESTION_MARKER,
+  GRILL_REPLY_MARKER,
+  isGrillQuestion,
+  isGrillReply,
+  isGrillThreadComment,
+  parseRecommendedAnswer,
+  selectGrillThreadComments,
+  stripGrillMarker,
+  stripRecommendedAnswer,
+} from './grill-comments';
+
+describe('grill-comments', () => {
+  it('classifies only strict grill thread markers', () => {
+    expect(isGrillThreadComment(`${GRILL_QUESTION_MARKER}\nQ?`)).toBe(true);
+    expect(isGrillThreadComment(`${GRILL_REPLY_MARKER}\nA.`)).toBe(true);
+    expect(isGrillThreadComment('<!-- factory:system -->\nState changed.')).toBe(false);
+    expect(isGrillThreadComment('<!-- factory:prd -->\n# PRD')).toBe(false);
+    expect(isGrillThreadComment('[Investigate] Escalated')).toBe(false);
+    expect(isGrillThreadComment(`text before ${GRILL_QUESTION_MARKER}`)).toBe(false);
+  });
+
+  it('classifies question and reply markers separately', () => {
+    expect(isGrillQuestion(`${GRILL_QUESTION_MARKER}\nQ?`)).toBe(true);
+    expect(isGrillQuestion(`${GRILL_REPLY_MARKER}\nA.`)).toBe(false);
+    expect(isGrillReply(`${GRILL_REPLY_MARKER}\nA.`)).toBe(true);
+    expect(isGrillReply(`${GRILL_QUESTION_MARKER}\nQ?`)).toBe(false);
+  });
+
+  it('strips grill markers for display', () => {
+    expect(stripGrillMarker(`${GRILL_QUESTION_MARKER}\nQ?`)).toBe('Q?');
+    expect(stripGrillMarker(`${GRILL_REPLY_MARKER}\nA.`)).toBe('A.');
+    expect(stripGrillMarker('plain comment')).toBe('plain comment');
+  });
+
+  it('parses and strips recommended answers', () => {
+    const body = `${GRILL_QUESTION_MARKER}\nQ?\n<!-- factory:recommended-answer -->\nSuggested.`;
+
+    expect(parseRecommendedAnswer(body)).toBe('Suggested.');
+    expect(stripRecommendedAnswer(stripGrillMarker(body))).toBe('Q?');
+    expect(parseRecommendedAnswer(`${GRILL_QUESTION_MARKER}\nQ?`)).toBeNull();
+  });
+
+  it('selects legacy unmarked replies only after a marked grill question', () => {
+    const selected = selectGrillThreadComments([
+      { body: 'Plain comment before grill.' },
+      { body: `${GRILL_QUESTION_MARKER}\nQ?` },
+      { body: 'Legacy plain reply.' },
+      { body: '<!-- factory:system -->\nSystem note.' },
+      { body: '[Investigate] Escalated\nNeeds research.' },
+      { body: `${GRILL_REPLY_MARKER}\nMarked reply.` },
+    ]);
+
+    expect(selected.map((comment) => comment.body)).toEqual([
+      `${GRILL_QUESTION_MARKER}\nQ?`,
+      'Legacy plain reply.',
+      `${GRILL_REPLY_MARKER}\nMarked reply.`,
+    ]);
+  });
+});

--- a/apps/web/src/components/detail/lib/grill-comments.ts
+++ b/apps/web/src/components/detail/lib/grill-comments.ts
@@ -1,0 +1,65 @@
+export const GRILL_QUESTION_MARKER = '<!-- factory:grill-question -->';
+export const GRILL_REPLY_MARKER = '<!-- factory:grill-reply -->';
+
+const RECOMMENDED_ANSWER_MARKER = '<!-- factory:recommended-answer -->';
+const NON_GRILL_THREAD_PREFIXES = [
+  '<!-- factory:prd -->',
+  '<!-- factory:system -->',
+  '## Child issues',
+  '[Investigate] Escalated',
+] as const;
+
+export function isGrillQuestion(body: string): boolean {
+  return body.startsWith(GRILL_QUESTION_MARKER);
+}
+
+export function isGrillReply(body: string): boolean {
+  return body.startsWith(GRILL_REPLY_MARKER);
+}
+
+export function isGrillThreadComment(body: string): boolean {
+  return isGrillQuestion(body) || isGrillReply(body);
+}
+
+function isKnownNonGrillThreadComment(body: string): boolean {
+  return NON_GRILL_THREAD_PREFIXES.some((prefix) => body.startsWith(prefix));
+}
+
+export function selectGrillThreadComments<T extends { body: string }>(comments: readonly T[]): T[] {
+  let hasSeenGrillQuestion = false;
+
+  return comments.filter((comment) => {
+    if (isGrillQuestion(comment.body)) {
+      hasSeenGrillQuestion = true;
+      return true;
+    }
+
+    if (isGrillReply(comment.body)) {
+      return true;
+    }
+
+    return hasSeenGrillQuestion && !isKnownNonGrillThreadComment(comment.body);
+  });
+}
+
+export function stripGrillMarker(body: string): string {
+  if (isGrillQuestion(body)) {
+    return body.slice(GRILL_QUESTION_MARKER.length).trimStart();
+  }
+  if (isGrillReply(body)) {
+    return body.slice(GRILL_REPLY_MARKER.length).trimStart();
+  }
+  return body;
+}
+
+export function parseRecommendedAnswer(body: string): string | null {
+  const idx = body.indexOf(RECOMMENDED_ANSWER_MARKER);
+  if (idx === -1) return null;
+  return body.slice(idx + RECOMMENDED_ANSWER_MARKER.length).trimStart() || null;
+}
+
+export function stripRecommendedAnswer(body: string): string {
+  const idx = body.indexOf(RECOMMENDED_ANSWER_MARKER);
+  if (idx === -1) return body;
+  return body.slice(0, idx).trimEnd();
+}


### PR DESCRIPTION
## Summary
- Add a strict Grill comment marker contract for questions and replies.
- Render only marked Grill thread comments in the Grill section and strip markers from display.
- Post user replies with the factory:grill-reply marker and keep suggested-answer UI scoped to the latest marked question.

## Testing
- pnpm test apps/web/src/components/detail/lib/grill-comments.test.ts apps/web/src/components/detail/components/GrillSection.test.tsx
- pnpm exec biome check apps/web/src/components/detail/lib/grill-comments.ts apps/web/src/components/detail/lib/grill-comments.test.ts apps/web/src/components/detail/components/GrillSection.tsx apps/web/src/components/detail/components/GrillSection.test.tsx
- Manual check: /projects/goose-hub-self/items/912/grill rendered marked Grill questions only; [Investigate] Escalated and raw Grill markers were not visible.