### PR TITLE
Add schema-backed skill contract audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Audit docs (drift check)
         run: pnpm audit-docs
 
+      - name: Audit skill contracts
+        run: pnpm skill-contract:audit
+
       - name: Manifest freshness check
         run: pnpm manifest --check
 

--- a/core/agent-runtime/skill-contract-audit.test.ts
+++ b/core/agent-runtime/skill-contract-audit.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { auditSkillContracts, formatSkillContractAudit } from './skill-contract-audit.js';
 
 describe('skill-contract-audit', () => {
-  it('produces a readable per-skill report without enforcing cleanliness', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('produces a readable per-skill report without enforcing cleanliness', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     expect(audit.skills.length).toBeGreaterThan(0);
 
     const implement = audit.skills.find((s: { skill: string }) => s.skill === 'implement');
@@ -19,8 +19,8 @@ describe('skill-contract-audit', () => {
     expect(output).toContain('pathLanguagePackageRelativeExamples:');
   });
 
-  it('enforces deterministic context tag drift checks for every runtime skill', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('enforces deterministic context tag drift checks for every runtime skill', async () => {
+    const audit = await auditSkillContracts(process.cwd());
 
     for (const report of audit.skills) {
       expect(report.snakeCaseTags, `${report.skill} should not reference snake_case tags`).toEqual(
@@ -37,8 +37,8 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('requires every runtime skill to declare its output schema in skill.config.ts', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('requires every runtime skill to declare its output schema in skill.config.ts', async () => {
+    const audit = await auditSkillContracts(process.cwd());
 
     for (const report of audit.skills) {
       expect(
@@ -48,8 +48,19 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('marks the grill/prd/decompose/advisor family clean', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('requires every runtime skill output example to be marked and schema-valid', async () => {
+    const audit = await auditSkillContracts(process.cwd());
+
+    for (const report of audit.skills) {
+      expect(
+        report.outputExample.status,
+        `${report.skill} should have a marked output example that passes outputSchema.safeParse`,
+      ).toBe('valid-output-example');
+    }
+  });
+
+  it('marks the grill/prd/decompose/advisor family clean', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     const cleanSkills = [
       'grill-me',
       'write-prd',
@@ -71,8 +82,8 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('marks the investigate/scout/wave/spec-author family clean', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('marks the investigate/scout/wave/spec-author family clean', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     const cleanSkills = [
       'investigate',
       'scout-code-path',
@@ -99,8 +110,8 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('marks the implement/QA/review/evidence family clean', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('marks the implement/QA/review/evidence family clean', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     const cleanSkills = [
       'implement',
       'implement-wp',
@@ -126,8 +137,8 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('keeps implement-family path language canonical and advisory-audited', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('keeps implement-family path language canonical and advisory-audited', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     const implementFamily = ['implement', 'implement-wp', 'spec-author'];
 
     for (const skill of implementFamily) {
@@ -144,8 +155,8 @@ describe('skill-contract-audit', () => {
     }
   });
 
-  it('keeps worktreePath out of skill prompts and context allowlists', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('keeps worktreePath out of skill prompts and context allowlists', async () => {
+    const audit = await auditSkillContracts(process.cwd());
 
     for (const report of audit.skills) {
       expect(
@@ -159,8 +170,8 @@ describe('skill-contract-audit', () => {
     }
   }, 10_000);
 
-  it('marks the retrospective/audit/coach/sprint family clean', () => {
-    const audit = auditSkillContracts(process.cwd());
+  it('marks the retrospective/audit/coach/sprint family clean', async () => {
+    const audit = await auditSkillContracts(process.cwd());
     const cleanSkills = [
       'retrospective-light',
       'retrospective-deep',

--- a/core/agent-runtime/skill-contract-audit.ts
+++ b/core/agent-runtime/skill-contract-audit.ts
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { SkillConfig } from './interface.js';
 
 export type SkillContractReport = {
   skill: string;
@@ -22,14 +24,16 @@ export type SkillContractAudit = {
 
 export type OutputExampleReport = {
   status:
-    | 'matches-schema-fields'
-    | 'field-drift'
-    | 'no-schema-fields'
-    | 'no-json-example'
-    | 'no-parseable-json-example';
+    | 'valid-output-example'
+    | 'missing-output-example'
+    | 'invalid-output-example'
+    | 'no-marked-output-example'
+    | 'example-not-required';
+  markedExamples: number;
   parseableExamples: number;
   missingSchemaFields: string[];
   extraExampleFields: string[];
+  issues: string[];
 };
 
 export type OutputSchemaReport = {
@@ -64,112 +68,6 @@ function extractConfiguredOutputSchema(configSource: string): string | null {
   return configSource.match(/outputSchema\s*:\s*([A-Za-z][A-Za-z0-9_]*)/)?.[1] ?? null;
 }
 
-function findMatchingBrace(source: string, openIndex: number): number {
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
-
-  for (let i = openIndex; i < source.length; i += 1) {
-    const char = source[i];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char;
-    } else if (char === '{') {
-      depth += 1;
-    } else if (char === '}') {
-      depth -= 1;
-      if (depth === 0) return i;
-    }
-  }
-
-  return -1;
-}
-
-function topLevelObjectFields(objectBody: string): string[] {
-  const fields = new Set<string>();
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
-  let tokenStart = 0;
-
-  for (let i = 0; i < objectBody.length; i += 1) {
-    const char = objectBody[i];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char;
-      continue;
-    }
-
-    if (char === '{' || char === '[' || char === '(') depth += 1;
-    if (char === '}' || char === ']' || char === ')') depth -= 1;
-
-    if ((char === '\n' || char === ',') && depth === 0) {
-      const token = objectBody.slice(tokenStart, i).trim();
-      const field = token.match(/^([a-zA-Z][a-zA-Z0-9_]*)\s*:/)?.[1];
-      if (field) fields.add(field);
-      tokenStart = i + 1;
-    }
-  }
-
-  const finalToken = objectBody.slice(tokenStart).trim();
-  const finalField = finalToken.match(/^([a-zA-Z][a-zA-Z0-9_]*)\s*:/)?.[1];
-  if (finalField) fields.add(finalField);
-
-  return Array.from(fields);
-}
-
-function extractFieldsFromFirstObjectExpression(source: string, startIndex: number): string[] {
-  const objectCallIndex = source.indexOf('z.object', startIndex);
-  if (objectCallIndex === -1) return [];
-
-  const openBraceIndex = source.indexOf('{', objectCallIndex);
-  if (openBraceIndex === -1) return [];
-
-  const closeBraceIndex = findMatchingBrace(source, openBraceIndex);
-  if (closeBraceIndex === -1) return [];
-
-  return topLevelObjectFields(source.slice(openBraceIndex + 1, closeBraceIndex)).sort();
-}
-
-function extractSchemaFields(schemaSource: string, configSource: string): string[] {
-  const configuredSchema = extractConfiguredOutputSchema(configSource);
-  const exportedSchemas = Array.from(
-    schemaSource.matchAll(/export const ([A-Za-z][A-Za-z0-9_]*Schema)\s*=/g),
-    (m) => ({ name: m[1], index: m.index ?? 0 }),
-  );
-
-  const preferred =
-    exportedSchemas.find((schema) => schema.name === configuredSchema) ??
-    exportedSchemas.find((schema) => schema.name.endsWith('OutputSchema')) ??
-    exportedSchemas.at(-1);
-
-  if (!preferred) return [];
-
-  return extractFieldsFromFirstObjectExpression(schemaSource, preferred.index);
-}
-
 function isSnakeCase(tag: string): boolean {
   return /_/.test(tag) && /^[a-z0-9_]+$/.test(tag);
 }
@@ -187,11 +85,20 @@ function extractJsonExamples(prompt: string): string[] {
   return Array.from(prompt.matchAll(/```json\s*([\s\S]*?)```/g), (m) => m[1].trim());
 }
 
-function parseTopLevelObjectFields(source: string): string[] | null {
+function extractMarkedJsonExamples(prompt: string): string[] {
+  return Array.from(
+    prompt.matchAll(/<!--\s*output-example\s*-->\s*```json\s*([\s\S]*?)```/g),
+    (m) => m[1].trim(),
+  );
+}
+
+function parseJsonObject(
+  source: string,
+): { value: Record<string, unknown>; fields: string[] } | null {
   try {
     const parsed = JSON.parse(source);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-    return Object.keys(parsed).sort();
+    return { value: parsed as Record<string, unknown>, fields: Object.keys(parsed).sort() };
   } catch {
     return null;
   }
@@ -261,58 +168,127 @@ function auditWorktreePathExposure(prompt: string, config: string): WorktreePath
   };
 }
 
-function auditOutputExample(prompt: string, schemaFields: string[]): OutputExampleReport {
-  if (schemaFields.length === 0) {
+function shapeKeysFromSchema(schema: unknown): string[] {
+  const def = getSchemaDef(schema);
+  if (!def) return [];
+
+  if (def.type === 'object') {
+    const shape = typeof def.shape === 'function' ? def.shape() : def.shape;
+    return shape && typeof shape === 'object' ? Object.keys(shape).sort() : [];
+  }
+
+  if (def.type === 'union') {
+    const options = Array.isArray(def.options) ? def.options : [];
+    return Array.from(new Set(options.flatMap(shapeKeysFromSchema))).sort();
+  }
+
+  if (def.type === 'intersection') {
+    return Array.from(
+      new Set([
+        ...(shapeKeysFromSchema(def.left) ?? []),
+        ...(shapeKeysFromSchema(def.right) ?? []),
+      ]),
+    ).sort();
+  }
+
+  return [];
+}
+
+function getSchemaDef(schema: unknown): Record<string, unknown> | null {
+  if (!schema || typeof schema !== 'object') return null;
+  const maybeSchema = schema as { def?: unknown; _def?: unknown };
+  const def = maybeSchema.def ?? maybeSchema._def;
+  return def && typeof def === 'object' ? (def as Record<string, unknown>) : null;
+}
+
+function summarizeValidationError(error: unknown): string {
+  if (!error || typeof error !== 'object') return 'schema validation failed';
+  const issues = (error as { issues?: unknown }).issues;
+  if (!Array.isArray(issues) || issues.length === 0) return 'schema validation failed';
+
+  return issues
+    .slice(0, 5)
+    .map((issue) => {
+      if (!issue || typeof issue !== 'object') return 'schema validation failed';
+      const path = Array.isArray((issue as { path?: unknown }).path)
+        ? ((issue as { path: unknown[] }).path.join('.') ?? '')
+        : '';
+      const message =
+        typeof (issue as { message?: unknown }).message === 'string'
+          ? (issue as { message: string }).message
+          : 'schema validation failed';
+      return path ? `${path}: ${message}` : message;
+    })
+    .join('; ');
+}
+
+function auditOutputExample(
+  prompt: string,
+  outputSchema: SkillConfig['outputSchema'],
+  schemaFields: string[],
+): OutputExampleReport {
+  if (outputSchema == null) {
     return {
-      status: 'no-schema-fields',
+      status: 'example-not-required',
+      markedExamples: 0,
       parseableExamples: 0,
       missingSchemaFields: [],
       extraExampleFields: [],
+      issues: [],
     };
   }
 
-  const examples = extractJsonExamples(prompt);
-  if (examples.length === 0) {
+  const allJsonExamples = extractJsonExamples(prompt);
+  const markedExamples = extractMarkedJsonExamples(prompt);
+  if (markedExamples.length === 0) {
     return {
-      status: 'no-json-example',
+      status: allJsonExamples.length === 0 ? 'missing-output-example' : 'no-marked-output-example',
+      markedExamples: 0,
       parseableExamples: 0,
       missingSchemaFields: schemaFields,
       extraExampleFields: [],
-    };
-  }
-
-  const parseable = examples
-    .map(parseTopLevelObjectFields)
-    .filter((fields): fields is string[] => fields !== null);
-
-  if (parseable.length === 0) {
-    return {
-      status: 'no-parseable-json-example',
-      parseableExamples: 0,
-      missingSchemaFields: schemaFields,
-      extraExampleFields: [],
+      issues:
+        allJsonExamples.length === 0
+          ? ['prompt contains no JSON code block marked as output']
+          : ['prompt contains JSON blocks, but none are preceded by <!-- output-example -->'],
     };
   }
 
   const schemaFieldSet = new Set(schemaFields);
-  const candidates = parseable
-    .map((fields) => ({
-      fields,
-      missing: schemaFields.filter((field) => !fields.includes(field)),
-      extra: fields.filter((field) => !schemaFieldSet.has(field)),
-    }))
-    .sort((a, b) => a.missing.length + a.extra.length - (b.missing.length + b.extra.length));
+  const issues: string[] = [];
+  let parseableExamples = 0;
+  const missingFields = new Set<string>();
+  const extraFields = new Set<string>();
 
-  const best = candidates[0];
+  for (const [index, example] of markedExamples.entries()) {
+    const parsed = parseJsonObject(example);
+    if (!parsed) {
+      issues.push(`marked output example ${index + 1}: invalid top-level JSON object`);
+      for (const field of schemaFields) missingFields.add(field);
+      continue;
+    }
+
+    parseableExamples += 1;
+    for (const field of schemaFields.filter((field) => !parsed.fields.includes(field))) {
+      missingFields.add(field);
+    }
+    for (const field of parsed.fields.filter((field) => !schemaFieldSet.has(field))) {
+      extraFields.add(field);
+    }
+
+    const result = outputSchema.safeParse(parsed.value);
+    if (!result.success) {
+      issues.push(`marked output example ${index + 1}: ${summarizeValidationError(result.error)}`);
+    }
+  }
 
   return {
-    status:
-      best.missing.length === 0 && best.extra.length === 0
-        ? 'matches-schema-fields'
-        : 'field-drift',
-    parseableExamples: parseable.length,
-    missingSchemaFields: best.missing,
-    extraExampleFields: best.extra,
+    status: issues.length === 0 ? 'valid-output-example' : 'invalid-output-example',
+    markedExamples: markedExamples.length,
+    parseableExamples,
+    missingSchemaFields: Array.from(missingFields).sort(),
+    extraExampleFields: Array.from(extraFields).sort(),
+    issues,
   };
 }
 
@@ -369,14 +345,22 @@ function collectConsumers(
   return Array.from(consumers).sort();
 }
 
-export function auditSkillContracts(repoRoot: string): SkillContractAudit {
+async function loadSkillConfig(configPath: string): Promise<SkillConfig | null> {
+  if (!existsSync(configPath)) return null;
+  const module = (await import(pathToFileURL(configPath).href)) as { default?: SkillConfig };
+  return module.default ?? null;
+}
+
+export async function auditSkillContracts(repoRoot: string): Promise<SkillContractAudit> {
   const skillsDir = join(repoRoot, 'skills');
   const skills = readdirSync(skillsDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name)
     .sort();
 
-  const reports: SkillContractReport[] = skills.map((skill) => {
+  const reports: SkillContractReport[] = [];
+
+  for (const skill of skills) {
     const skillDir = join(skillsDir, skill);
     const promptPath = join(skillDir, 'prompt.md');
     const configPath = join(skillDir, 'skill.config.ts');
@@ -392,10 +376,11 @@ export function auditSkillContracts(repoRoot: string): SkillContractAudit {
     const missingFromPrompt = allowlistTags.filter((t) => !promptTags.includes(t));
     const extraPromptTags = promptTags.filter((t) => t !== 'task' && !allowlistTags.includes(t));
 
-    const schemaFields = extractSchemaFields(schema, config);
+    const skillConfig = await loadSkillConfig(configPath);
+    const schemaFields = shapeKeysFromSchema(skillConfig?.outputSchema);
     const configuredOutputSchema = extractConfiguredOutputSchema(config);
 
-    return {
+    reports.push({
       skill,
       allowlistTags,
       promptTags,
@@ -404,17 +389,17 @@ export function auditSkillContracts(repoRoot: string): SkillContractAudit {
       extraPromptTags,
       schemaFields,
       outputSchema: {
-        configured: configuredOutputSchema != null,
+        configured: skillConfig?.outputSchema != null,
         configuredSchema: configuredOutputSchema,
       },
-      outputExample: auditOutputExample(prompt, schemaFields),
+      outputExample: auditOutputExample(prompt, skillConfig?.outputSchema, schemaFields),
       pathLanguage: auditPathLanguage(prompt, schema),
       worktreePathExposure: auditWorktreePathExposure(prompt, config),
       consumerPaths: existsSync(schemaPath)
         ? collectConsumers(repoRoot, schemaPath, schema, skill)
         : [],
-    };
-  });
+    });
+  }
 
   return { skills: reports };
 }
@@ -436,9 +421,11 @@ export function formatSkillContractAudit(audit: SkillContractAudit): string {
             : '(missing)'
         }`,
         `outputExample: ${r.outputExample.status}`,
+        `outputExampleMarked: ${r.outputExample.markedExamples}`,
         `outputExampleParseable: ${r.outputExample.parseableExamples}`,
         `outputExampleMissingFields: ${r.outputExample.missingSchemaFields.join(', ') || '(none)'}`,
         `outputExampleExtraFields: ${r.outputExample.extraExampleFields.join(', ') || '(none)'}`,
+        `outputExampleIssues: ${r.outputExample.issues.join(' | ') || '(none)'}`,
         `pathLanguageWorkspaceRelative: ${r.pathLanguage.vagueWorkspaceRelative.length}`,
         `pathLanguagePackageRelativeExamples: ${r.pathLanguage.packageRelativeExamples.join(', ') || '(none)'}`,
         `worktreePathExposure: allowlist=${r.worktreePathExposure.allowlist} prompt=${r.worktreePathExposure.promptLines.length} config=${r.worktreePathExposure.configLines.length}`,

--- a/scripts/audit-skill-contracts.ts
+++ b/scripts/audit-skill-contracts.ts
@@ -1,7 +1,7 @@
 import { auditSkillContracts, formatSkillContractAudit } from '../core/agent-runtime/skill-contract-audit.js';
 
 const strict = process.argv.includes('--strict');
-const audit = auditSkillContracts(process.cwd());
+const audit = await auditSkillContracts(process.cwd());
 
 console.log(formatSkillContractAudit(audit));
 
@@ -15,6 +15,9 @@ if (strict) {
       !s.outputSchema.configured ||
       s.worktreePathExposure.allowlist ||
       s.worktreePathExposure.promptLines.length > 0 ||
+      ['missing-output-example', 'invalid-output-example', 'no-marked-output-example'].includes(
+        s.outputExample.status,
+      ) ||
       (enforcePathLanguageFor.has(s.skill) &&
         (s.pathLanguage.vagueWorkspaceRelative.length > 0 ||
           s.pathLanguage.packageRelativeExamples.length > 0)),
@@ -35,6 +38,8 @@ if (strict) {
               ? (violation.outputSchema.configuredSchema ?? '(configured)')
               : '(missing)'
           }`,
+          `outputExample=${violation.outputExample.status}`,
+          `outputExampleIssues=${violation.outputExample.issues.join('|') || '(none)'}`,
           `worktreePathExposure=${violation.worktreePathExposure.allowlist ? 'allowlist' : ''}:${
             violation.worktreePathExposure.promptLines.length
           }`,

--- a/skills/advise-on-plan/prompt.md
+++ b/skills/advise-on-plan/prompt.md
@@ -47,6 +47,7 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
 
 ### proceed
 
+<!-- output-example -->
 ```json
 {
   "verdict": "proceed",
@@ -59,6 +60,7 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
 
 ### revise
 
+<!-- output-example -->
 ```json
 {
   "verdict": "revise",
@@ -72,6 +74,7 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
 
 ### abort
 
+<!-- output-example -->
 ```json
 {
   "verdict": "abort",

--- a/skills/advise-on-prd/prompt.md
+++ b/skills/advise-on-prd/prompt.md
@@ -45,6 +45,7 @@ Return a JSON object conforming to `AdvisePRDOutputSchema`. JSON only — no pro
 
 ### approve (clean)
 
+<!-- output-example -->
 ```json
 {
   "verdict": "approve",
@@ -58,6 +59,7 @@ Return a JSON object conforming to `AdvisePRDOutputSchema`. JSON only — no pro
 
 ### approve with notes
 
+<!-- output-example -->
 ```json
 {
   "verdict": "approve",
@@ -71,6 +73,7 @@ Return a JSON object conforming to `AdvisePRDOutputSchema`. JSON only — no pro
 
 ### revise
 
+<!-- output-example -->
 ```json
 {
   "verdict": "revise",
@@ -90,6 +93,7 @@ Return a JSON object conforming to `AdvisePRDOutputSchema`. JSON only — no pro
 
 ### revise with no section patches
 
+<!-- output-example -->
 ```json
 {
   "verdict": "revise",

--- a/skills/bug-enhance/prompt.md
+++ b/skills/bug-enhance/prompt.md
@@ -30,6 +30,7 @@ A bug is **NOT** a UI/web bug if it describes:
 
 Then return:
 
+<!-- output-example -->
 ```json
 {
   "enhancedContent": "",
@@ -69,6 +70,7 @@ Emit: `[decision] VERDICT: Classified bug as UI/web or not, then enhanced only i
 
 Then return **only** the JSON object below — no prose, no markdown, no preamble. Begin with `{` and end with `}`. Nothing else.
 
+<!-- output-example -->
 ```json
 {
   "enhancedContent": "<markdown string — only the new sections>",

--- a/skills/code-quality-audit/prompt.md
+++ b/skills/code-quality-audit/prompt.md
@@ -207,6 +207,30 @@ Your output MUST be valid JSON conforming to the `CodeQualityAuditOutputSchema`.
 - `projectedScoreAfterTop3`: realistic score after the top-3 P0/P1 recommendations are applied (must be ≥ total)
 - `decisionSummaries`: at least one summary per major scoring decision (use `SELF_SCORE` kind)
 
+<!-- output-example -->
+```json
+{
+  "scorecard": [
+    { "category": 1, "name": "Open/Closed", "score": 10, "max": 20, "evidence": [{ "file": "core/workflows/example.ts", "note": "Adding a case requires editing a central switch." }] },
+    { "category": 2, "name": "Concept count", "score": 8, "max": 15, "evidence": [{ "file": "core/workflows/example.ts", "note": "Three concepts are interleaved in one function." }] },
+    { "category": 3, "name": "Time to capability", "score": 9, "max": 15, "evidence": [{ "file": "core/workflows/example.ts", "note": "Entrypoint is discoverable but setup requires two call sites." }] },
+    { "category": 4, "name": "Complecting", "score": 7, "max": 15, "evidence": [{ "file": "core/workflows/example.ts", "note": "Validation and persistence are coupled." }] },
+    { "category": 5, "name": "LOC discipline", "score": 6, "max": 10, "evidence": [{ "file": "core/workflows/example.ts", "note": "Primary file is over the preferred size." }] },
+    { "category": 6, "name": "Coupling", "score": 5, "max": 10, "evidence": [{ "file": "core/workflows/example.ts", "note": "Imports span unrelated modules." }] },
+    { "category": 7, "name": "Gall's Law", "score": 6, "max": 10, "evidence": [{ "file": "core/workflows/example.ts", "note": "Change can be staged without a rewrite." }] },
+    { "category": 8, "name": "Cyclomatic complexity", "score": 4, "max": 5, "evidence": [{ "file": "core/workflows/example.ts", "note": "Branching is modest." }] }
+  ],
+  "rating": "NeedsWork",
+  "strengths": ["Workflow entrypoint is easy to find."],
+  "recommendations": [
+    { "priority": "P1", "principle": "Open/Closed", "file": "core/workflows/example.ts", "line": 42, "fix": "Move case-specific behavior behind a registry.", "effort": "Medium", "impactPoints": 12 }
+  ],
+  "mcIlroyQuestion": "The current components expose objects rather than pipe-friendly stages.",
+  "projectedScoreAfterTop3": 70,
+  "decisionSummaries": [{ "kind": "SELF_SCORE", "summary": "Scored the workflow as NeedsWork based on 55 total points." }]
+}
+```
+
 ---
 
 ## Decision summary discipline

--- a/skills/decompose-issues/prompt.md
+++ b/skills/decompose-issues/prompt.md
@@ -75,6 +75,7 @@ Emit at least one `decisionSummary` per major decision point:
 
 Return a JSON object conforming to `DecomposeOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "issues": [

--- a/skills/dev-review-response/prompt.md
+++ b/skills/dev-review-response/prompt.md
@@ -24,6 +24,27 @@ Your terminal JSON must include:
   - `reason`: required for `"dismissed"`, optional for `"addressed"` (explain briefly what you changed).
 - `decisionSummaries`: at minimum one entry per finding with kind `DEV_REVIEW_ADDRESSED` or `DEV_REVIEW_DISMISSED` and a one-sentence summary. Include `evidence` = `findingRef`.
 
+<!-- output-example -->
+```json
+{
+  "findingDispositions": [
+    {
+      "findingRef": "core/example.ts:42",
+      "severity": "P1",
+      "disposition": "addressed",
+      "reason": "Added the missing null guard and verified the affected test."
+    }
+  ],
+  "decisionSummaries": [
+    {
+      "kind": "DEV_REVIEW_ADDRESSED",
+      "summary": "Addressed the P1 review finding by adding the missing null guard.",
+      "evidence": "core/example.ts:42"
+    }
+  ]
+}
+```
+
 ## Constraints
 
 - **One pass only** — you will not get a second Codex review after this turn.

--- a/skills/dev-review/prompt.md
+++ b/skills/dev-review/prompt.md
@@ -130,22 +130,23 @@ Emit:
 
 Return JSON conforming to `DevReviewOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
-  "verdict": "no-blockers" | "blockers-found" | "inconclusive",
+  "verdict": "blockers-found",
   "findings": [
     {
-      "severity": "P0" | "P1" | "P2" | "P3",
-      "category": "correctness" | "security" | "edge-case" | "design" | "other",
+      "severity": "P1",
+      "category": "correctness",
       "file": "core/agent-runtime/codex-cli.ts",
       "line": 142,
-      "summary": "<one sentence — what is wrong>",
-      "suggestion": "<one sentence — what to do about it>"
+      "summary": "The runtime ignores output-schema validation failures.",
+      "suggestion": "Return blockers-found and require the developer to validate the failing path."
     }
   ],
   "decisionSummaries": [
-    { "kind": "READ", "summary": "..." },
-    { "kind": "VERDICT", "summary": "..." }
+    { "kind": "READ", "summary": "Read the changed runtime validation path.", "evidence": "core/agent-runtime/codex-cli.ts:142" },
+    { "kind": "VERDICT", "summary": "Found one P1 blocker in runtime validation." }
   ]
 }
 ```

--- a/skills/echo-test-holdout/prompt.md
+++ b/skills/echo-test-holdout/prompt.md
@@ -9,6 +9,19 @@ You are a QA test agent. Your only job is to echo back the allowed input message
    - `echo`: the exact value of the message field
    - `decisionSummaries`: one entry — step `"echo"`, summary `"Echoed input message (holdout)"`
 
+<!-- output-example -->
+```json
+{
+  "echo": "hello",
+  "decisionSummaries": [
+    {
+      "kind": "VERDICT",
+      "summary": "Echoed input message (holdout)."
+    }
+  ]
+}
+```
+
 Note: This is a holdout skill. No implementation reasoning, decision context, or persona history is visible to you.
 
 [decision] VERDICT: Echoed input message (holdout)

--- a/skills/echo-test/prompt.md
+++ b/skills/echo-test/prompt.md
@@ -11,6 +11,7 @@ You are a test agent. Your only job is to echo back the input message and produc
 
 ## Output schema
 
+<!-- output-example -->
 ```json
 {
   "echo": "<the message value>",

--- a/skills/evidence-post/prompt.md
+++ b/skills/evidence-post/prompt.md
@@ -44,6 +44,7 @@ If the spec path is missing or clearly not an AFTER-state validation, still retu
 
 Return only JSON conforming to the evidence plan schema:
 
+<!-- output-example -->
 ```json
 {
   "specPath": "apps/web/e2e/issue-233.spec.ts",

--- a/skills/grill-me/prompt.md
+++ b/skills/grill-me/prompt.md
@@ -64,6 +64,7 @@ When `readyForPRD: false` you **must** include exactly one question in `question
 
 Return a single JSON object conforming to this exact structure. Free-text-only output fails the run. Your entire response must be valid JSON — no prose, no preamble, no explanation outside the object.
 
+<!-- output-example -->
 ```json
 {
   "questions": [

--- a/skills/hub-chat/prompt.md
+++ b/skills/hub-chat/prompt.md
@@ -71,6 +71,7 @@ Emit live progress with `[decision] KIND: <one sentence>` markers in your text t
 
 Return a single JSON object conforming exactly to the output schema. Free-text-only output fails the run. Your entire response must be valid JSON — no prose, no preamble, no explanation outside the object.
 
+<!-- output-example -->
 ```json
 {
   "say": "<the user-facing reply>",

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -102,6 +102,7 @@ Return the structured output now. The `wpId` field must match the `<id>` from yo
 
 ## Output format
 
+<!-- output-example -->
 ```json
 {
   "wpId": "WP1",

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -113,6 +113,7 @@ Do not inspect old e2e specs, Playwright config, or screenshot conventions befor
 
 Return JSON conforming to `ImplementSchema`. `prUrl` must be a valid placeholder URL; the orchestrator overwrites it.
 
+<!-- output-example -->
 ```json
 {
   "plan": "1. Add tests for X in Y. 2. Implement X. 3. Lint passes.",

--- a/skills/intervention-proposer/prompt.md
+++ b/skills/intervention-proposer/prompt.md
@@ -35,6 +35,28 @@ Allowed `actionType` values:
 - `resolve_conflict` - payload may include `{ "reason": "..." }`.
 - `no_action` - payload must include `{ "reason": "..." }`.
 
+<!-- output-example -->
+```json
+{
+  "summary": "The workflow is blocked on a gate that requires human approval.",
+  "options": [
+    {
+      "actionType": "approve_gate",
+      "label": "Approve gate",
+      "description": "Resume the workflow from the pending gate after human approval.",
+      "payload": { "reason": "Human approved the pending gate." },
+      "risk": "low"
+    }
+  ],
+  "decisionSummaries": [
+    {
+      "kind": "VERDICT",
+      "summary": "Recommended approving the pending gate because the legal target is available."
+    }
+  ]
+}
+```
+
 Prefer the least surprising option. If evidence is insufficient, include
 `no_action` with a concrete reason instead of inventing a transition.
 

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -113,23 +113,21 @@ Emit: `[decision] INSIGHT: Recorded <N> open questions`
 
 Return a JSON object with this exact structure:
 
+<!-- output-example -->
 ```json
 {
-  "findings": "<root cause hypothesis and full analysis, 2–5 paragraphs>",
+  "findings": "The root cause is that the audit is checking inferred top-level fields rather than the configured runtime schema. This misses nested validation failures and treats incidental JSON snippets as output examples.",
   "keyFiles": [
-    { "path": "<repo-relative POSIX file path>", "reason": "<why this file is relevant>" }
+    { "path": "core/agent-runtime/skill-contract-audit.ts", "reason": "Contains the audit logic that reads prompt examples and validates contracts." }
   ],
-  "confidence": "<low|medium|high>",
+  "confidence": "high",
   "openQuestions": [
-    "<question 1>",
-    "<question 2>"
+    "Should strict mode require examples for every runtime skill?"
   ],
   "requiresBrowserRepro": false,
   "decisionSummaries": [
-    { "kind": "READ", "summary": "<one sentence>", "evidence": "<quote or signal>" },
-    { "kind": "READ", "summary": "<one sentence>", "evidence": "<file names or search terms>" },
-    { "kind": "READ", "summary": "<one sentence>", "evidence": "<function or module name>" },
-    { "kind": "INSIGHT", "summary": "<one sentence>", "evidence": "<file:line or code snippet>" }
+    { "kind": "READ", "summary": "Read the skill contract audit implementation.", "evidence": "core/agent-runtime/skill-contract-audit.ts" },
+    { "kind": "INSIGHT", "summary": "The audit must validate marked examples with the configured output schema.", "evidence": "outputSchema.safeParse" }
   ]
 }
 ```

--- a/skills/playwright-repro/prompt.md
+++ b/skills/playwright-repro/prompt.md
@@ -57,6 +57,7 @@ If the runtime still asks you to run Playwright directly, run it at most once, t
 
 Return only JSON conforming to the spec-plan schema:
 
+<!-- output-example -->
 ```json
 {
   "specPath": "apps/web/e2e/repro-login-error.spec.ts",

--- a/skills/qa/prompt.md
+++ b/skills/qa/prompt.md
@@ -327,6 +327,7 @@ Bad summaries:
 
 Return a JSON object conforming exactly to this structure:
 
+<!-- output-example -->
 ```json
 {
   "verdict": "fail",

--- a/skills/repo-match/prompt.md
+++ b/skills/repo-match/prompt.md
@@ -24,21 +24,22 @@ The context contains:
 
 Return a JSON object:
 
+<!-- output-example -->
 ```json
 {
   "candidates": [
     {
-      "repo": "<owner/slug>",
-      "confidence": <0-100>,
-      "evidence": "<one sentence>",
+      "repo": "shaunnez/goose-hub",
+      "confidence": 92,
+      "evidence": "The work item mentions Factory workflows and skill prompts, which match Goose Hub.",
       "tier": 3
     }
   ],
   "decisionSummaries": [
     {
       "kind": "PLAN",
-      "summary": "<one sentence describing the match decision>",
-      "evidence": "<key signal from work item or repo description>"
+      "summary": "Selected shaunnez/goose-hub as the best repository match.",
+      "evidence": "Factory workflows and skill prompts"
     }
   ]
 }

--- a/skills/resolve-conflict/prompt.md
+++ b/skills/resolve-conflict/prompt.md
@@ -41,6 +41,7 @@ Then output **only** the JSON object below — no prose, no markdown, no preambl
 
 If `unresolvable` is non-empty OR `confidence` is `low`, the slice will escalate to `factory:needs-human` without attempting the merge.
 
+<!-- output-example -->
 ```json
 {
   "resolved": ["src/foo.ts", "src/bar.ts"],

--- a/skills/retrospective-cross-run/prompt.md
+++ b/skills/retrospective-cross-run/prompt.md
@@ -101,4 +101,61 @@ Return JSON conforming to `CrossRunRetroOutputSchema`. No free-text outside the 
 - `aggregatedLearnings[]`, `topPatterns[]`, `gateThresholds[]`, `costBaselines[]`, `improvementCandidates[]` — arrays (any may be empty)
 - `decisionSummaries[]` — at least one VERDICT
 
+<!-- output-example -->
+```json
+{
+  "outcome": "success",
+  "workItemNumber": 0,
+  "summary": {
+    "wentWell": "Repeated QA failures were grouped into one stable pattern.",
+    "didNotGoWell": "Several archived runs lacked enough evidence for cost baselines.",
+    "architecturalTakeaway": "Cross-run learning is strongest when patterns retain source run ids."
+  },
+  "improvementCandidates": [
+    {
+      "kind": "skill-prompt",
+      "targetPath": "skills/qa/prompt.md",
+      "suggestionText": "Ask QA to cite verificationSummary fields before judging browser evidence.",
+      "evidence": "pattern:qa-evidence-citation",
+      "confidence": "high"
+    }
+  ],
+  "decisionSummaries": [
+    {
+      "kind": "VERDICT",
+      "summary": "Cross-run review found one converged QA evidence pattern."
+    }
+  ],
+  "windowStartAt": "2026-05-01T00:00:00.000Z",
+  "windowEndAt": "2026-05-07T00:00:00.000Z",
+  "lifecycleCount": 12,
+  "aggregatedLearnings": [
+    {
+      "observation": "QA evidence comments are more reliable when verificationSummary is cited directly.",
+      "rationale": "The same pattern appeared in three successful QA runs.",
+      "improvementKind": "skill-prompt",
+      "targetPath": "skills/qa/prompt.md",
+      "confidence": "high"
+    }
+  ],
+  "topPatterns": [
+    {
+      "patternId": "qa-evidence-citation",
+      "pattern": "QA output cites workflow-owned verification facts before judging browser evidence.",
+      "occurrenceCount": 3,
+      "consistencyScore": 0.9,
+      "role": "qa",
+      "kind": "skill-prompt",
+      "exampleWorkItemIds": ["#701", "#702"]
+    }
+  ],
+  "gateThresholds": [
+    { "gate": "qa", "mean": 72, "min": 60, "max": 90, "stdDev": 8, "sampleCount": 6 }
+  ],
+  "costBaselines": [
+    { "role": "qa", "skill": "qa", "mean": 0.42, "p50": 0.4, "p95": 0.7, "sampleCount": 6 }
+  ]
+}
+```
+
 [decision] VERDICT: Cross-run playbook complete: <one sentence on the headline finding>

--- a/skills/retrospective-deep/prompt.md
+++ b/skills/retrospective-deep/prompt.md
@@ -121,6 +121,7 @@ Return JSON conforming to `DeepRetroSchema`. No free-text outside the schema fie
 
 ### Example output
 
+<!-- output-example -->
 ```json
 {
   "outcome": "success",

--- a/skills/retrospective-light/prompt.md
+++ b/skills/retrospective-light/prompt.md
@@ -82,6 +82,7 @@ Return JSON conforming to `LightRetroSchema`. No free-text outside the schema fi
 
 ### Example output
 
+<!-- output-example -->
 ```json
 {
   "outcome": "success",

--- a/skills/review/prompt.md
+++ b/skills/review/prompt.md
@@ -251,6 +251,7 @@ Return a JSON object conforming exactly to this structure.
 
 For `approved` or `needs-fix`:
 
+<!-- output-example -->
 ```json
 {
   "verdict": "approved",
@@ -274,6 +275,7 @@ For `approved` or `needs-fix`:
 
 For `needs-human` (escalationReason is REQUIRED):
 
+<!-- output-example -->
 ```json
 {
   "verdict": "needs-human",

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -42,6 +42,7 @@ You have **read and search access only**.
 
 Return JSON conforming to `ScoutOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -36,6 +36,7 @@ You have **read and search access only**.
 
 Return JSON conforming to `ScoutOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -43,6 +43,7 @@ You have **read and search access only**.
 
 Return JSON conforming to `ScoutOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -62,6 +62,7 @@ Bad behaviour example:
 
 Return a JSON object with this exact shape (validated by `ScoutOutputSchema`):
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -36,6 +36,7 @@ You have **read and search access only**.
 
 Return JSON conforming to `ScoutOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -34,6 +34,7 @@ You have **read and search access only**.
 
 Return JSON conforming to `ScoutOutputSchema`:
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/skill-coach/prompt.md
+++ b/skills/skill-coach/prompt.md
@@ -58,4 +58,22 @@ Return JSON conforming to `SkillCoachOutputSchema`. Required fields:
 - `confidence` — `low | medium | high`
 - `decisionSummaries` — at least one VERDICT
 
+<!-- output-example -->
+```json
+{
+  "skillName": "qa",
+  "diagnosis": "The QA prompt under-specifies how to cite workflow-owned verification facts.",
+  "proposedPatch": "diff --git a/skills/qa/prompt.md b/skills/qa/prompt.md\n--- a/skills/qa/prompt.md\n+++ b/skills/qa/prompt.md\n@@\n-Check evidence.\n+Check verificationSummary before judging evidence.\n",
+  "rationale": "Pattern qa-evidence-citation shows that successful QA runs cite structured verification facts before judging browser evidence, so the prompt should make that ordering explicit.",
+  "evidencePatternIds": ["qa-evidence-citation"],
+  "confidence": "high",
+  "decisionSummaries": [
+    {
+      "kind": "VERDICT",
+      "summary": "Coached qa to cite verificationSummary before browser evidence."
+    }
+  ]
+}
+```
+
 [decision] VERDICT: Skill coach complete: <one sentence on the headline finding>

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -190,6 +190,75 @@ Live markers are short progress/rationale markers, not raw thinking. Emit them b
 
 Live marker format: `[decision] KIND: <one sentence>`. Example: `[decision] PLAN: Defining falsifiable ACs around the checkout journey and verifyCommand coverage`.
 
+<!-- output-example -->
+```json
+{
+  "objective": "Add schema-backed audit validation for marked skill output examples.",
+  "userJourneys": [
+    {
+      "id": "J1",
+      "actor": "developer",
+      "steps": [
+        { "idx": 1, "description": "Run the skill contract audit." },
+        { "idx": 2, "description": "See which marked output examples fail schema validation." }
+      ]
+    }
+  ],
+  "functionalRequirements": [
+    { "id": "FR1", "statement": "The audit must validate marked output examples with outputSchema.safeParse." }
+  ],
+  "architecture": {
+    "current": "The audit compares source-inferred field names.",
+    "new": "The audit loads each skill config and validates marked prompt examples against the configured output schema.",
+    "decisionRationale": "Runtime schema validation is the source of truth for terminal skill output."
+  },
+  "schemaChanges": { "ddl": [], "migrations": [] },
+  "interfaceContracts": [
+    {
+      "name": "auditSkillContracts",
+      "signature": "export async function auditSkillContracts(repoRoot: string): Promise<SkillContractAudit>",
+      "file": "core/agent-runtime/skill-contract-audit.ts",
+      "lineRange": "1-220"
+    }
+  ],
+  "workPackages": [
+    {
+      "id": "WP1",
+      "filesOwned": ["core/agent-runtime/skill-contract-audit.ts", "scripts/audit-skill-contracts.ts"],
+      "changes": "Load skill.config.ts and validate marked output examples through outputSchema.safeParse.",
+      "dependsOn": [],
+      "builderTier": "sonnet"
+    }
+  ],
+  "executionOrder": [{ "batch": 0, "wpIds": ["WP1"] }],
+  "verificationTooling": [
+    { "name": "skill-contract audit", "scriptPath": "scripts/audit-skill-contracts.ts", "expectedExitCodes": [0] }
+  ],
+  "acceptanceCriteria": [
+    {
+      "id": "AC1",
+      "statement": "Marked output examples fail the audit when they do not satisfy the configured output schema.",
+      "journeyRef": "J1",
+      "stepIdx": 2,
+      "verifyCommand": "pnpm skill-contract:audit",
+      "source": "user-journey"
+    }
+  ],
+  "constraints": [
+    { "kind": "output-format", "name": "marked-output-example", "source": "core/agent-runtime/skill-contract-audit.ts:auditOutputExample" }
+  ],
+  "riskRegister": [
+    { "risk": "Incidental JSON snippets could be treated as terminal output.", "mitigation": "Only validate JSON blocks preceded by the output-example marker.", "severity": "medium" }
+  ],
+  "decisionSummaries": [
+    {
+      "kind": "PLAN",
+      "summary": "Specified schema-backed validation for marked skill output examples."
+    }
+  ]
+}
+```
+
 ## Failure modes (the validator will catch)
 
 - Same path in two WPs' `filesOwned` → `file-ownership-collision`

--- a/skills/sprint-review/prompt.md
+++ b/skills/sprint-review/prompt.md
@@ -51,6 +51,7 @@ Emit one `VERDICT` decision summary summarising the milestone outcome.
 
 Return a JSON object conforming to `SprintReviewOutputSchema`. No free text outside the JSON.
 
+<!-- output-example -->
 ```json
 {
   "milestoneTitle": "M13: Subagents",

--- a/skills/triage/prompt.md
+++ b/skills/triage/prompt.md
@@ -56,15 +56,16 @@ Emit one `[decision] VERDICT: <one sentence>` line before the JSON as a progress
 
 The JSON must have this exact structure:
 
+<!-- output-example -->
 ```json
 {
-  "type": "<feature|bug|chore|research>",
-  "priority": "<p0|p1|p2|p3>",
-  "labels": ["<label>", ...],
-  "reasoning": "<one to three sentences>",
+  "type": "bug",
+  "priority": "p1",
+  "labels": ["type:bug", "priority:high", "schedule:current"],
+  "reasoning": "The report describes broken existing behavior in a core workflow path.",
   "decisionSummaries": [
-    { "kind": "PLAN", "summary": "<one sentence>", "evidence": "<quote or signal>" },
-    { "kind": "ESCALATE", "summary": "<one sentence>", "evidence": "<quote or signal>" }
+    { "kind": "PLAN", "summary": "Classified the work item as a bug because it reports existing behavior drift.", "evidence": "broken existing behavior" },
+    { "kind": "VERDICT", "summary": "Assigned p1 priority because the workflow can produce invalid output." }
   ]
 }
 ```

--- a/skills/wave2-interface-designer/prompt.md
+++ b/skills/wave2-interface-designer/prompt.md
@@ -45,6 +45,7 @@ Encode open questions as findings:
 
 Return JSON conforming to `ScoutOutputSchema` (same shape as Wave-1 scouts):
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/wave2-risk-analyst/prompt.md
+++ b/skills/wave2-risk-analyst/prompt.md
@@ -48,6 +48,7 @@ Encode open questions as findings:
 
 Return JSON conforming to `ScoutOutputSchema` (same shape as Wave-1 scouts):
 
+<!-- output-example -->
 ```json
 {
   "findings": [

--- a/skills/write-prd/prompt.md
+++ b/skills/write-prd/prompt.md
@@ -104,6 +104,7 @@ Return a single JSON object conforming to `PRDOutputSchema`. Free-text-only outp
 
 Exact field names (use these verbatim):
 
+<!-- output-example -->
 ```json
 {
   "title": "<string>",
@@ -131,9 +132,9 @@ Exact field names (use these verbatim):
     "dataConstraints": [{ "type": "<string>", "validation": "<string>" }]
   },
   "verticalSlices": [
-    { "title": "<string>", "goal": "<string>", "estimatedSize": "S|M|L", "journeyRefs": ["<journeyId>"] }
+    { "title": "Schema-backed audit", "goal": "Validate marked output examples against skill schemas", "estimatedSize": "M", "journeyRefs": ["<journeyId>"] }
   ],
-  "estimatedComplexity": "low|medium|high",
+  "estimatedComplexity": "medium",
   "implementationDecisions": [
     { "decision": "<string>", "rationale": "<optional — cite ADR or CONTEXT.md>", "moduleRef": "<optional — primary file affected>" }
   ],


### PR DESCRIPTION
## Summary
- load each runtime skill config and validate marked output examples with the configured outputSchema.safeParse
- add the <!-- output-example --> prompt convention and fix/add marked examples across runtime skills
- ratchet strict mode for missing/unmarked/invalid output examples and wire pnpm skill-contract:audit into CI

## Verification
- pnpm skill-contract:audit
- pnpm vitest run core/agent-runtime/skill-contract-audit.test.ts
- pnpm typecheck
- pnpm lint