### PR TITLE
Clean up timeline transport noise

### DIFF
--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -101,6 +101,16 @@ function makePlainEvent(id: number, createdAt: string): AgentEventDto {
   };
 }
 
+function makeCodexTransportWarning(id: number, runId: string): AgentEventDto {
+  return makeRunEvent(id, runId, 'agent.log', {
+    stream: 'stderr',
+    text: JSON.stringify({
+      source: 'responses_websocket',
+      message: 'failed to connect to websocket: 503 Service Unavailable',
+    }),
+  });
+}
+
 function makeIntervention(overrides: Partial<InterventionDto> = {}): InterventionDto {
   return {
     id: 'intervention-123456789',
@@ -269,6 +279,34 @@ describe('TimelineSection — expand/collapse all', () => {
     expect(await screen.findByText('gpt-5.4-mini')).toBeTruthy();
     expect(screen.getByText('codex-cli')).toBeTruthy();
     expect(screen.getByText(/Started .* Running for/)).toBeTruthy();
+  });
+
+  it('renders recovered Codex websocket 503 stderr as a warning without changing completed status', async () => {
+    const { fetchEventsPage } = await import('@/lib/api');
+    const rawWarning = JSON.stringify({
+      source: 'responses_websocket',
+      message: 'failed to connect to websocket: 503 Service Unavailable',
+    });
+    vi.mocked(fetchEventsPage).mockResolvedValue({
+      events: [
+        makeRunEvent(1, 'run-codex', 'agent.run-started', { skill: 'implement' }),
+        makeCodexTransportWarning(2, 'run-codex'),
+        makeRunEvent(3, 'run-codex', 'agent.run-completed', { skill: 'implement' }),
+      ],
+      hasMore: false,
+    });
+
+    const { TimelineSection } = await import('./TimelineSection');
+    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
+
+    await screen.findByTestId('timeline-expand-all');
+    fireEvent.click(screen.getByTestId('timeline-expand-all'));
+
+    expect(await screen.findByText('Complete')).toBeTruthy();
+    expect(
+      await screen.findByText('Codex transport warning: websocket 503; run recovered'),
+    ).toBeTruthy();
+    expect(screen.queryByText(rawWarning)).toBeNull();
   });
 
   it('invalidates issue costs when a run terminal event arrives over SSE', async () => {

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -46,6 +46,24 @@ function makePromptContextTelemetryLog(id: number): AgentEventDto {
   };
 }
 
+function makeCodexTransportWarningLog(id: number): AgentEventDto {
+  return {
+    id,
+    projectId: 'proj',
+    workItemId: 'wi-1',
+    kind: 'agent.log',
+    payload: {
+      stream: 'stderr',
+      text: JSON.stringify({
+        source: 'responses_websocket',
+        message: 'failed to connect to websocket: 503 Service Unavailable',
+      }),
+    },
+    runId: 'run-codex',
+    createdAt: new Date().toISOString(),
+  };
+}
+
 function makeEvent(id: number, kind: string): AgentEventDto {
   return {
     id,
@@ -146,6 +164,34 @@ describe('groupEvents — agent.log collapsing', () => {
     }
   });
 
+  it('strips the Codex stdin stderr banner from multiline logs before grouping', () => {
+    const stderrLog: AgentEventDto = {
+      ...makeCodexStdinNoiseLog(2),
+      payload: {
+        stream: 'stderr',
+        text: 'Reading additional input from stdin...\nreal warning\nsecond line',
+      },
+    };
+
+    const result = groupEvents([
+      makeRunEvent(1, 'run-codex', 'agent.run-started', 'implement'),
+      stderrLog,
+      makeRunEvent(3, 'run-codex', 'agent.run-completed', 'implement'),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('run-group');
+    if (result[0].kind === 'run-group') {
+      const log = result[0].items.find(
+        (item) => item.kind === 'event' && item.event.kind === 'agent.log',
+      );
+      expect(log?.kind).toBe('event');
+      if (log?.kind === 'event') {
+        expect((log.event.payload as { text?: string }).text).toBe('real warning\nsecond line');
+      }
+    }
+  });
+
   it('filters prompt context telemetry before grouping', () => {
     const result = groupEvents([
       makeRunEvent(1, 'run-codex', 'agent.run-started', 'implement'),
@@ -180,6 +226,31 @@ describe('groupEvents — agent.log collapsing', () => {
     expect(result[0].kind).toBe('event');
     if (result[0].kind === 'event') {
       expect(result[0].event).toBe(stderrLog);
+    }
+  });
+
+  it('keeps Codex websocket transport warnings inside the run group instead of a log group', () => {
+    const result = groupEvents([
+      makeRunEvent(1, 'run-codex', 'agent.run-started', 'implement'),
+      { ...makeLogEvent(2), runId: 'run-codex' },
+      makeCodexTransportWarningLog(3),
+      { ...makeLogEvent(4), runId: 'run-codex' },
+      { ...makeLogEvent(5), runId: 'run-codex' },
+      { ...makeLogEvent(6), runId: 'run-codex' },
+      makeRunEvent(7, 'run-codex', 'agent.run-completed', 'implement'),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('run-group');
+    if (result[0].kind === 'run-group') {
+      expect(
+        result[0].items.some(
+          (item) =>
+            item.kind === 'event' &&
+            item.event.kind === 'agent.log' &&
+            (item.event.payload as { text?: string }).text?.includes('responses_websocket'),
+        ),
+      ).toBe(true);
     }
   });
 });

--- a/apps/web/src/components/detail/components/timeline/LogEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/LogEvents.tsx
@@ -1,17 +1,17 @@
 import type { AgentEventDto } from '@/lib/types';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
-import { getPayloadStr } from '../../lib/timeline';
+import { getAgentLogDisplayText, normalizeAgentLogEvent } from '../../lib/timeline';
 
 export function AgentLogEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as {
-    line?: string;
     metric?: string;
     stream?: string;
-    text?: string;
   } | null;
   if (p?.stream === 'telemetry' && p.metric === 'prompt_context_size') return null;
-  const line = p?.line ?? p?.text ?? getPayloadStr(event.payload);
+  const normalized = normalizeAgentLogEvent(event);
+  if (normalized == null) return null;
+  const line = getAgentLogDisplayText(normalized);
   return (
     <li
       data-event-kind={event.kind}
@@ -40,13 +40,13 @@ export function AgentLogGroupEvent({ events }: { events: AgentEventDto[] }) {
         <div className="mt-1 flex flex-col gap-0.5">
           {events.map((ev) => {
             const p = ev.payload as {
-              line?: string;
               metric?: string;
               stream?: string;
-              text?: string;
             } | null;
             if (p?.stream === 'telemetry' && p.metric === 'prompt_context_size') return null;
-            const line = p?.line ?? p?.text ?? getPayloadStr(ev.payload);
+            const normalized = normalizeAgentLogEvent(ev);
+            if (normalized == null) return null;
+            const line = getAgentLogDisplayText(normalized);
             return (
               <div key={ev.id} className="font-mono text-[11.5px] text-fg-2">
                 {line}

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
@@ -1,6 +1,6 @@
 import { resumeIssue } from '@/lib/api';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
-import { ChevronDown, ChevronRight, Loader2, RefreshCw } from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, Loader2, RefreshCw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import {
   type RenderItem,
@@ -8,6 +8,8 @@ import {
   computeIsWritePrdStuck,
   formatDuration,
   formatSkillName,
+  getAgentLogDisplayText,
+  isCodexTransportWarningLog,
 } from '../../lib/timeline';
 import { CostBadge } from '../CostBadge';
 
@@ -61,16 +63,33 @@ export function RunGroupWrapper({
     setOpen(expandOpen);
   }, [expandTick, expandOpen]);
 
-  const displayItems = items.map((item) => {
-    if (
-      item.kind === 'event' &&
-      (item.event.kind === 'agent.run-completed' || item.event.kind === 'agent.run-failed') &&
-      lastEventAt != null
-    ) {
-      return { ...item, event: { ...item.event, createdAt: lastEventAt } };
-    }
-    return item;
-  });
+  const groupEventList = items
+    .filter((item): item is Extract<RenderItem, { kind: 'event' }> => item.kind === 'event')
+    .map((item) => item.event);
+  const hasCompleted = groupEventList.some((event) => event.kind === 'agent.run-completed');
+  const isFailed = groupEventList.some((event) => event.kind === 'agent.run-failed');
+  const codexTransportWarnings = groupEventList.filter(isCodexTransportWarningLog);
+  const codexTransportWarning = codexTransportWarnings[0] ?? null;
+  const warningRecovered = codexTransportWarning != null && hasCompleted;
+
+  const displayItems = items
+    .filter(
+      (item) =>
+        !(
+          item.kind === 'event' &&
+          codexTransportWarnings.some((event) => event.id === item.event.id)
+        ),
+    )
+    .map((item) => {
+      if (
+        item.kind === 'event' &&
+        (item.event.kind === 'agent.run-completed' || item.event.kind === 'agent.run-failed') &&
+        lastEventAt != null
+      ) {
+        return { ...item, event: { ...item.event, createdAt: lastEventAt } };
+      }
+      return item;
+    });
   const getItemTs = (item: RenderItem): number => {
     if (item.kind === 'event') {
       const base = new Date(item.event.createdAt).getTime();
@@ -92,10 +111,6 @@ export function RunGroupWrapper({
   const liveDuration = startMs != null ? formatDuration(now - startMs) : null;
   const completeDuration =
     startMs != null && endMs != null ? formatDuration((lastMs ?? endMs) - startMs) : null;
-  const isFailed = items.some(
-    (item) => item.kind === 'event' && item.event.kind === 'agent.run-failed',
-  );
-
   const isOrphaned = items.some(
     (item) =>
       item.kind === 'event' &&
@@ -103,9 +118,6 @@ export function RunGroupWrapper({
       (item.event.payload as { orphaned?: boolean } | null)?.orphaned === true,
   );
 
-  const groupEventList = items
-    .filter((item): item is Extract<RenderItem, { kind: 'event' }> => item.kind === 'event')
-    .map((item) => item.event);
   const isWritePrdStuck = computeIsWritePrdStuck(groupEventList);
   const isLatestRun = context?.latestRunId === runId;
   const canResume =
@@ -246,6 +258,25 @@ export function RunGroupWrapper({
             <li className="rounded-md border border-dashed border-[color:var(--accent)]/30 bg-[color:var(--accent)]/5 px-3 py-2 flex items-center gap-2 text-[10.5px] text-[color:var(--accent)]">
               <Loader2 size={12} className="shrink-0 animate-spin" />
               <span className="font-mono uppercase tracking-wider">Agent running…</span>
+            </li>
+          )}
+          {codexTransportWarning != null && (
+            <li
+              className={
+                isFailed && !warningRecovered
+                  ? 'rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 flex items-center gap-2 text-[10.5px] text-[color:var(--danger)]'
+                  : 'rounded-md border border-yellow-500/20 bg-yellow-500/5 px-3 py-2 flex items-center gap-2 text-[10.5px] text-yellow-400'
+              }
+              title={getAgentLogDisplayText(codexTransportWarning)}
+            >
+              <AlertTriangle size={12} className="shrink-0" />
+              <span className="font-mono uppercase tracking-wider">
+                {warningRecovered
+                  ? 'Codex transport warning: websocket 503; run recovered'
+                  : isFailed
+                    ? 'Codex transport warning: websocket 503; run failed after warning'
+                    : 'Codex transport warning: websocket 503; run still active'}
+              </span>
             </li>
           )}
           {sorted.map((item, i) => renderItem(item, idx * 1000 + i, context))}

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -136,6 +136,69 @@ export function getPayloadStr(payload: unknown): string {
   return text.length <= 80 ? text : `${text.slice(0, 79)}…`;
 }
 
+const CODEX_STDIN_BANNER = 'Reading additional input from stdin...';
+
+type AgentLogPayload = {
+  line?: string;
+  metric?: string;
+  stream?: string;
+  text?: string;
+};
+
+function stripCodexStdinBanner(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .filter((line) => line !== CODEX_STDIN_BANNER)
+    .join('\n')
+    .trim();
+}
+
+export function normalizeAgentLogEvent(event: AgentEventDto): AgentEventDto | null {
+  if (event.kind !== 'agent.log') return event;
+
+  const payload = event.payload as AgentLogPayload | null;
+  if (payload?.stream === 'telemetry' && payload.metric === 'prompt_context_size') return null;
+  if (payload?.stream !== 'stderr') return event;
+
+  const nextPayload = { ...payload };
+  let changed = false;
+
+  if (typeof payload.text === 'string') {
+    nextPayload.text = stripCodexStdinBanner(payload.text);
+    changed = changed || nextPayload.text !== payload.text;
+  }
+  if (typeof payload.line === 'string') {
+    nextPayload.line = stripCodexStdinBanner(payload.line);
+    changed = changed || nextPayload.line !== payload.line;
+  }
+
+  if (nextPayload.text === '' && nextPayload.line === '') return null;
+  if (nextPayload.text === '' && nextPayload.line == null) return null;
+  if (nextPayload.line === '' && nextPayload.text == null) return null;
+
+  return changed ? { ...event, payload: nextPayload } : event;
+}
+
+export function getAgentLogDisplayText(event: AgentEventDto): string {
+  const normalized = normalizeAgentLogEvent(event) ?? event;
+  const payload = normalized.payload as AgentLogPayload | null;
+  return payload?.line ?? payload?.text ?? getPayloadStr(normalized.payload);
+}
+
+export function isCodexTransportWarningLog(event: AgentEventDto): boolean {
+  if (event.kind !== 'agent.log') return false;
+  const payload = event.payload as AgentLogPayload | null;
+  if (payload?.stream !== 'stderr') return false;
+
+  const detail = JSON.stringify(event.payload ?? {});
+  const lowerDetail = detail.toLowerCase();
+  return (
+    lowerDetail.includes('responses_websocket') &&
+    lowerDetail.includes('failed to connect to websocket') &&
+    lowerDetail.includes('503 service unavailable')
+  );
+}
+
 // ─── grouping ────────────────────────────────────────────────────────────────
 
 export type RenderItem =
@@ -332,7 +395,11 @@ export function groupEvents(
   events: AgentEventDto[],
   interventionDetails: InterventionTimelineDetail[] = [],
 ): RenderItem[] {
-  const collapsed = collapseLogRuns(events.filter((event) => !isHiddenAgentLog(event)));
+  const normalizedEvents = events.flatMap((event) => {
+    const normalized = normalizeAgentLogEvent(event);
+    return normalized == null ? [] : [normalized];
+  });
+  const collapsed = collapseLogRuns(normalizedEvents);
   const grouped = groupByRunId(collapsed);
   const withInvestigationPhases = groupByInvestigationPhase([...grouped].sort(compareRenderItems));
   const withDevPhases = groupByDevPhase([...withInvestigationPhases].sort(compareRenderItems));
@@ -342,32 +409,33 @@ export function groupEvents(
   );
 }
 
-function isHiddenAgentLog(event: AgentEventDto): boolean {
-  if (event.kind !== 'agent.log') return false;
-  const payload = event.payload as { metric?: string; stream?: string; text?: string } | null;
-  return (
-    (payload?.stream === 'stderr' && payload.text === 'Reading additional input from stdin...') ||
-    (payload?.stream === 'telemetry' && payload.metric === 'prompt_context_size')
-  );
-}
-
 function collapseLogRuns(events: AgentEventDto[]): RenderItem[] {
   const items: RenderItem[] = [];
+  const flushLogGroup = (group: AgentEventDto[]) => {
+    if (group.length >= 4) {
+      items.push({ kind: 'log-group', events: group });
+    } else {
+      for (const ev of group) {
+        items.push({ kind: 'event', event: ev });
+      }
+    }
+  };
   let i = 0;
   while (i < events.length) {
     if (events[i].kind === 'agent.log') {
       const group: AgentEventDto[] = [];
       while (i < events.length && events[i].kind === 'agent.log') {
+        if (isCodexTransportWarningLog(events[i])) {
+          flushLogGroup(group);
+          group.length = 0;
+          items.push({ kind: 'event', event: events[i] });
+          i++;
+          continue;
+        }
         group.push(events[i]);
         i++;
       }
-      if (group.length >= 4) {
-        items.push({ kind: 'log-group', events: group });
-      } else {
-        for (const ev of group) {
-          items.push({ kind: 'event', event: ev });
-        }
-      }
+      flushLogGroup(group);
     } else {
       items.push({ kind: 'event', event: events[i] });
       i++;


### PR DESCRIPTION
## Summary
- Strip the Codex stdin banner from stderr logs, including multiline stderr payloads, while keeping remaining stderr visible.
- Detect Codex websocket 503 transport stderr and render it as a compact run-group warning instead of raw JSON.
- Mark completed runs with that warning as recovered without changing the run status.

## Verification
- pnpm exec biome check apps/web/src/components/detail/lib/timeline.ts apps/web/src/components/detail/components/timeline/LogEvents.tsx apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx apps/web/src/components/detail/components/TimelineSection.test.ts apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
- pnpm --filter @goose-hub/web exec vitest run src/components/detail/components/TimelineSection.test.ts src/components/detail/components/TimelineExpandCollapse.test.tsx

## Known unrelated blocker
- pnpm --filter @goose-hub/web build currently fails in src/components/interventions/OperatorQueuePage.test.tsx because ProjectConfigDto mocks are missing targetRepo, stack, storage, and isolation.