### PR TITLE
Fix timeline transport warning regressions

### DIFF
--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -309,6 +309,32 @@ describe('TimelineSection — expand/collapse all', () => {
     expect(screen.queryByText(rawWarning)).toBeNull();
   });
 
+  it('renders non-lifecycle terminal runs with transport warnings as recovered', async () => {
+    const { fetchEventsPage } = await import('@/lib/api');
+    vi.mocked(fetchEventsPage).mockResolvedValue({
+      events: [
+        makeRunEvent(1, 'run-prd', 'agent.run-started', { skill: 'write-prd' }),
+        makeCodexTransportWarning(2, 'run-prd'),
+        makeRunEvent(3, 'run-prd', 'prd.approved', { skill: 'write-prd' }),
+      ],
+      hasMore: false,
+    });
+
+    const { TimelineSection } = await import('./TimelineSection');
+    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
+
+    await screen.findByTestId('timeline-expand-all');
+    fireEvent.click(screen.getByTestId('timeline-expand-all'));
+
+    expect(await screen.findByText('Complete')).toBeTruthy();
+    expect(
+      await screen.findByText('Codex transport warning: websocket 503; run recovered'),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText('Codex transport warning: websocket 503; run still active'),
+    ).toBeNull();
+  });
+
   it('invalidates issue costs when a run terminal event arrives over SSE', async () => {
     const { fetchEventsPage } = await import('@/lib/api');
     vi.mocked(fetchEventsPage).mockResolvedValue({

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -1,6 +1,6 @@
 import type { AgentEventDto } from '@/lib/types';
 import { describe, expect, it } from 'vitest';
-import { groupEvents } from '../lib/timeline';
+import { getAgentLogDisplayText, groupEvents } from '../lib/timeline';
 
 function makeLogEvent(id: number): AgentEventDto {
   return {
@@ -251,6 +251,40 @@ describe('groupEvents — agent.log collapsing', () => {
             (item.event.payload as { text?: string }).text?.includes('responses_websocket'),
         ),
       ).toBe(true);
+    }
+  });
+
+  it('uses non-empty stderr text when the normalized line field becomes empty', () => {
+    const result = groupEvents([
+      {
+        ...makeCodexStdinNoiseLog(1),
+        payload: {
+          stream: 'stderr',
+          line: 'Reading additional input from stdin...',
+          text: 'real warning',
+        },
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('event');
+    if (result[0].kind === 'event') {
+      expect(getAgentLogDisplayText(result[0].event)).toBe('real warning');
+    }
+  });
+
+  it('preserves intentionally empty log lines when no text fallback exists', () => {
+    const result = groupEvents([
+      {
+        ...makeLogEvent(1),
+        payload: { stream: 'stdout', line: '' },
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('event');
+    if (result[0].kind === 'event') {
+      expect(getAgentLogDisplayText(result[0].event)).toBe('');
     }
   });
 });

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
@@ -66,11 +66,10 @@ export function RunGroupWrapper({
   const groupEventList = items
     .filter((item): item is Extract<RenderItem, { kind: 'event' }> => item.kind === 'event')
     .map((item) => item.event);
-  const hasCompleted = groupEventList.some((event) => event.kind === 'agent.run-completed');
   const isFailed = groupEventList.some((event) => event.kind === 'agent.run-failed');
   const codexTransportWarnings = groupEventList.filter(isCodexTransportWarningLog);
   const codexTransportWarning = codexTransportWarnings[0] ?? null;
-  const warningRecovered = codexTransportWarning != null && hasCompleted;
+  const warningRecovered = codexTransportWarning != null && endedAt != null && !isFailed;
 
   const displayItems = items
     .filter(

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -182,7 +182,9 @@ export function normalizeAgentLogEvent(event: AgentEventDto): AgentEventDto | nu
 export function getAgentLogDisplayText(event: AgentEventDto): string {
   const normalized = normalizeAgentLogEvent(event) ?? event;
   const payload = normalized.payload as AgentLogPayload | null;
-  return payload?.line ?? payload?.text ?? getPayloadStr(normalized.payload);
+  if (payload?.line != null && (payload.line !== '' || payload.text == null)) return payload.line;
+  if (payload?.text != null) return payload.text;
+  return getPayloadStr(normalized.payload);
 }
 
 export function isCodexTransportWarningLog(event: AgentEventDto): boolean {


### PR DESCRIPTION
## Summary
- Treat ended non-failed runs as recovered for Codex transport warning copy.
- Prefer non-empty normalized stderr text when a stripped line field becomes empty.
- Add regressions for non-lifecycle terminal recovery and mixed line/text stderr payloads.

## Verification
- pnpm exec biome check apps/web/src/components/detail/lib/timeline.ts apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx apps/web/src/components/detail/components/TimelineSection.test.ts apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
- pnpm --filter @goose-hub/web exec vitest run src/components/detail/components/TimelineSection.test.ts src/components/detail/components/TimelineExpandCollapse.test.tsx

## Known unrelated blocker
- pnpm --filter @goose-hub/web build still fails in src/components/interventions/OperatorQueuePage.test.tsx because ProjectConfigDto mocks are missing targetRepo, stack, storage, and isolation.