### PR TITLE
M7.XX: The items in the kanban lanes order is wrong

### DIFF
--- a/apps/web/e2e/issue-919.spec.ts
+++ b/apps/web/e2e/issue-919.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+
+const slug = 'goose-hub-self';
+
+const project = {
+  id: 'project-goose-hub-self',
+  name: 'Goose Hub',
+  slug,
+  color: '#7c3aed',
+  source: { kind: 'github', repo: 'shaunnez/goose-hub' },
+};
+
+const issue = (overrides: Record<string, unknown>) => ({
+  id: 'github:shaunnez/goose-hub#1',
+  externalId: '1',
+  repoRef: 'shaunnez/goose-hub',
+  title: 'Placeholder',
+  body: '',
+  type: 'bug',
+  priority: 'medium',
+  mode: 'supervised',
+  state: 'factory:triaging',
+  authorIsOwner: true,
+  schedule: 'current',
+  exec: 'serial',
+  dependsOn: [],
+  blocks: [],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const newest = issue({
+  id: 'github:shaunnez/goose-hub#300',
+  externalId: '300',
+  title: 'Newest item',
+  createdAt: '2024-01-03T12:00:00.000Z',
+});
+
+const middle = issue({
+  id: 'github:shaunnez/goose-hub#200',
+  externalId: '200',
+  title: 'Middle item',
+  createdAt: '2024-01-02T12:00:00.000Z',
+});
+
+const oldest = issue({
+  id: 'github:shaunnez/goose-hub#100',
+  externalId: '100',
+  title: 'Oldest item',
+  createdAt: '2024-01-01T12:00:00.000Z',
+});
+
+test('kanban lane cards render newest first', async ({ page }) => {
+  await page.route('**/projects', (route) => route.fulfill({ json: { projects: [project] } }));
+  await page.route('**/projects/configs', (route) =>
+    route.fulfill({
+      json: {
+        configs: [
+          {
+            slug,
+            name: 'Goose Hub',
+            colorStripe: '#7c3aed',
+            activeMilestone: null,
+            budgets: { perWorkflowMaxUsd: 10, dailyTokens: 5_000_000, perAdvisorMaxUsd: 2 },
+            mode: 'supervised',
+            source: { kind: 'github', repo: 'shaunnez/goose-hub' },
+          },
+        ],
+      },
+    }),
+  );
+  await page.route(`**/projects/${slug}/active-milestone`, (route) =>
+    route.fulfill({ json: { milestoneNumber: null, source: 'github-default' } }),
+  );
+  await page.route(`**/projects/${slug}/milestones`, (route) =>
+    route.fulfill({ json: { milestones: [] } }),
+  );
+  await page.route('**/roster/names', (route) => route.fulfill({ json: { names: [] } }));
+  await page.route(`**/projects/${slug}/issues`, (route) =>
+    route.fulfill({ json: { items: [oldest, newest, middle] } }),
+  );
+  await page.route(`**/projects/${slug}/issues/*/costs`, (route) =>
+    route.fulfill({ json: { workItemId: 'wi-1', totalUsd: 0, hasEstimated: false, rows: [] } }),
+  );
+  await page.route('**/events*', (route) =>
+    route.fulfill({ contentType: 'text/event-stream', body: '' }),
+  );
+
+  await page.goto(`/projects/${slug}`);
+  await expect(page.getByTestId('board')).toBeVisible();
+
+  const lane = page.getByTestId('lane-triage');
+  await expect(lane).toBeVisible();
+
+  const cards = lane.getByTestId('issue-card');
+  await expect(cards).toHaveCount(3);
+  await expect(cards.nth(0)).toHaveAttribute('data-issue-number', '300');
+  await expect(cards.nth(1)).toHaveAttribute('data-issue-number', '200');
+  await expect(cards.nth(2)).toHaveAttribute('data-issue-number', '100');
+});

--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -8,15 +8,13 @@ import type { WorkItemWithProject } from './lib/all-projects';
 // Here we lock the sort/ordering rule and grouping logic.
 
 describe('issue card lane ordering', () => {
-  it('orders by priority desc, then issue number asc', () => {
+  it('orders newest cards first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      { externalId: '100', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '300', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '200', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['300', '200', '100']);
   });
 });
 

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,37 +23,31 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts newest first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      { externalId: '100', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '300', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '200', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['300', '200', '100']);
   });
 
-  it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
-    // Line 126: the ?? 9 fallback branch — items with unknown priority rank last
+  it('sortLaneItems falls back to issue number descending for equal timestamps', () => {
     const sorted = sortLaneItems([
-      { externalId: '1', priority: 'high' },
-      { externalId: '2', priority: 'unknown-future-priority' },
-      { externalId: '3', priority: 'critical' },
+      { externalId: '10', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '40', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '20', createdAt: '2024-01-01T00:00:00.000Z' },
     ]);
-    // critical(0) < high(1) < unknown(9)
-    expect(sorted[0].externalId).toBe('3');
-    expect(sorted[1].externalId).toBe('1');
-    expect(sorted[2].externalId).toBe('2');
+    expect(sorted.map((s) => s.externalId)).toEqual(['40', '20', '10']);
   });
 
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
+  it('sortLaneItems treats invalid timestamps as oldest', () => {
     const sorted = sortLaneItems([
-      { externalId: '30', priority: 'medium' },
-      { externalId: '10', priority: 'medium' },
-      { externalId: '20', priority: 'medium' },
+      { externalId: '1', createdAt: 'not-a-date' },
+      { externalId: '3', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '2', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['3', '2', '1']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -111,26 +111,41 @@ export function laneForState(state: string): string | undefined {
   return STATE_TO_LANE.get(state);
 }
 
-const PRIORITY_RANK: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-};
-
 interface SortableItem {
   externalId: string;
-  priority: string;
+  createdAt: string;
+  repoRef?: string;
+}
+
+function timestampOf(createdAt: string): number {
+  const ts = Date.parse(createdAt);
+  return Number.isFinite(ts) ? ts : Number.NEGATIVE_INFINITY;
+}
+
+function compareExternalIdDesc(a: string, b: string): number {
+  const aNum = Number(a);
+  const bNum = Number(b);
+  if (Number.isFinite(aNum) && Number.isFinite(bNum) && aNum !== bNum) {
+    return bNum - aNum;
+  }
+  return b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' });
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Newest cards appear first in each lane, with deterministic fallbacks for
+ * equal or missing timestamps.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
-    const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
-    if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    const timeDiff = timestampOf(b.createdAt) - timestampOf(a.createdAt);
+    if (timeDiff !== 0) return timeDiff;
+
+    const externalDiff = compareExternalIdDesc(a.externalId, b.externalId);
+    if (externalDiff !== 0) return externalDiff;
+
+    return (a.repoRef ?? '').localeCompare(b.repoRef ?? '', undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanban lanes order is wrong

## Files
- `apps/web/src/components/board/slice.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.ts` — observed modified change
- `apps/web/e2e/issue-919.spec.ts` — observed untracked change

## Tests
- `apps/web/src/lib/lanes.config.test.ts` (3 cases)
- `apps/web/src/components/board/slice.test.ts` (1 cases)
- `apps/web/e2e/issue-919.spec.ts` (1 cases)

Closes #919
