### PR TITLE
M19.XX: Capture Idea Promotion Bug

### DIFF
--- a/apps/server/src/domains/inbox/enhance.ts
+++ b/apps/server/src/domains/inbox/enhance.ts
@@ -6,8 +6,110 @@ import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/ski
 import { logger } from '@goose-hub/core/logger.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { BugEnhanceOutputSchema } from '@goose-hub/skills/bug-enhance/schema.js';
+import { IssueEnhanceOutputSchema } from '@goose-hub/skills/issue-enhance/schema.js';
 
-const jsonSchema = toJsonSchema(BugEnhanceOutputSchema);
+const bugEnhanceJsonSchema = toJsonSchema(BugEnhanceOutputSchema);
+const issueEnhanceJsonSchema = toJsonSchema(IssueEnhanceOutputSchema);
+
+type EnhancableInboxItemType = 'feature' | 'bug' | 'chore' | 'research';
+type GenericEnhanceType = Exclude<EnhancableInboxItemType, 'bug'>;
+type EnhanceSkillName = 'bug-enhance' | 'issue-enhance';
+
+type EnhanceOutput = {
+  enhancedContent: string;
+  decisionSummaries: unknown[];
+};
+
+type EnhanceOptions = {
+  skill: EnhanceSkillName;
+  projectId: string;
+  inboxItemId: number;
+  title: string;
+  body: string;
+  type?: GenericEnhanceType;
+  outputJsonSchema: object;
+  parseOutput: (
+    output: unknown,
+  ) => { success: true; data: EnhanceOutput } | { success: false; error: { issues: unknown } };
+};
+
+async function runEnhance({
+  skill,
+  projectId,
+  inboxItemId,
+  title,
+  body,
+  type,
+  outputJsonSchema,
+  parseOutput,
+}: EnhanceOptions): Promise<string | null> {
+  const projectConfig = await getProjectBySlug(projectId);
+  const skillRuntime = resolveSkillRuntimeForProject({
+    skill,
+    projectBudgets: projectConfig?.budgets,
+    projectId,
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    role: 'triager',
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+  });
+  const runtime = selectRuntime({
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    model: skillRuntime.modelOverride,
+    skillProvider: skillRuntime.provider,
+  });
+  const runId = crypto.randomUUID();
+  const { personaId } = selectPersona(projectId, 'triager');
+  const workItemId = `inbox:${inboxItemId}`;
+
+  let prompt: string;
+  try {
+    prompt = readPromptWithContext(skill, projectId);
+  } catch (err) {
+    logger.error(`${skill}: failed to read prompt`, { err: String(err) });
+    return null;
+  }
+
+  const workItem = type == null ? { title, body } : { type, title, body };
+
+  try {
+    const result = await runtime.run({
+      runId,
+      role: 'triager',
+      skill,
+      context: { projectId, workItemId, workItem },
+      contextAllowlist: ['workItem'],
+      freshContext: false,
+      toolBundles: [],
+      toolExtras: [],
+      budgets: skillRuntime.budgets,
+      modelOverride: skillRuntime.modelOverride,
+      personaId,
+      outputJsonSchema,
+      appendSystemPrompt: prompt,
+    });
+
+    const parsed = parseOutput(result.output);
+    if (!parsed.success) {
+      logger.warn(`${skill}: output validation failed`, {
+        errors: parsed.error.issues,
+        raw: JSON.stringify(result.output),
+      });
+      return null;
+    }
+
+    const content = parsed.data.enhancedContent.trim();
+    if (content.length === 0) {
+      logger.warn(`${skill}: enhancedContent empty after trim`, {
+        runId,
+        decisions: parsed.data.decisionSummaries,
+      });
+    }
+    return content.length > 0 ? content : null;
+  } catch (err) {
+    logger.error(`${skill}: agent run failed`, { err: String(err) });
+    return null;
+  }
+}
 
 /**
  * Runs the bug-enhance agent on a UI/web bug report.
@@ -22,68 +124,46 @@ export async function runBugEnhance(
   title: string,
   body: string,
 ): Promise<string | null> {
-  const projectConfig = await getProjectBySlug(projectId);
-  const bugEnhanceRuntime = resolveSkillRuntimeForProject({
+  return runEnhance({
     skill: 'bug-enhance',
-    projectBudgets: projectConfig?.budgets,
     projectId,
-    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-    role: 'triager',
-    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+    inboxItemId,
+    title,
+    body,
+    outputJsonSchema: bugEnhanceJsonSchema,
+    parseOutput: (output) => BugEnhanceOutputSchema.safeParse(output),
   });
-  const runtime = selectRuntime({
-    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-    model: bugEnhanceRuntime.modelOverride,
-    skillProvider: bugEnhanceRuntime.provider,
-  });
-  const runId = crypto.randomUUID();
-  const { personaId } = selectPersona(projectId, 'triager');
-  const workItemId = `inbox:${inboxItemId}`;
+}
 
-  let prompt: string;
-  try {
-    prompt = readPromptWithContext('bug-enhance', projectId);
-  } catch (err) {
-    logger.error('bug-enhance: failed to read prompt', { err: String(err) });
-    return null;
+export async function runIssueEnhance(
+  projectId: string,
+  inboxItemId: number,
+  type: GenericEnhanceType,
+  title: string,
+  body: string,
+): Promise<string | null> {
+  return runEnhance({
+    skill: 'issue-enhance',
+    projectId,
+    inboxItemId,
+    type,
+    title,
+    body,
+    outputJsonSchema: issueEnhanceJsonSchema,
+    parseOutput: (output) => IssueEnhanceOutputSchema.safeParse(output),
+  });
+}
+
+export async function runInboxEnhance(
+  projectId: string,
+  inboxItemId: number,
+  type: EnhancableInboxItemType,
+  title: string,
+  body: string,
+): Promise<string | null> {
+  if (type === 'bug') {
+    return runBugEnhance(projectId, inboxItemId, title, body);
   }
 
-  try {
-    const result = await runtime.run({
-      runId,
-      role: 'triager',
-      skill: 'bug-enhance',
-      context: { projectId, workItemId, workItem: { title, body } },
-      contextAllowlist: ['workItem'],
-      freshContext: false,
-      toolBundles: [],
-      toolExtras: [],
-      budgets: bugEnhanceRuntime.budgets,
-      modelOverride: bugEnhanceRuntime.modelOverride,
-      personaId,
-      outputJsonSchema: jsonSchema,
-      appendSystemPrompt: prompt,
-    });
-
-    const parsed = BugEnhanceOutputSchema.safeParse(result.output);
-    if (!parsed.success) {
-      logger.warn('bug-enhance: output validation failed', {
-        errors: parsed.error.issues,
-        raw: JSON.stringify(result.output),
-      });
-      return null;
-    }
-
-    const content = parsed.data.enhancedContent.trim();
-    if (content.length === 0) {
-      logger.warn('bug-enhance: enhancedContent empty after trim', {
-        runId,
-        decisions: parsed.data.decisionSummaries,
-      });
-    }
-    return content.length > 0 ? content : null;
-  } catch (err) {
-    logger.error('bug-enhance: agent run failed', { err: String(err) });
-    return null;
-  }
+  return runIssueEnhance(projectId, inboxItemId, type, title, body);
 }

--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -15,6 +15,10 @@ vi.mock('./repository.js', () => ({
   deleteInboxItem: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./enhance.js', () => ({
+  runBugEnhance: vi.fn(),
+}));
+
 vi.mock('@goose-hub/core/db/db.js', () => ({
   db: {
     select: () => ({ from: () => ({ where: () => ({ all: () => [] }) }) }),
@@ -23,6 +27,7 @@ vi.mock('@goose-hub/core/db/db.js', () => ({
 
 import { dispatchTriageBatch } from '#shared/dispatch.js';
 import { getSourceForSlug } from '#shared/source.js';
+import { runBugEnhance } from './enhance.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
 import {
   createInboxItem,
@@ -36,7 +41,9 @@ const mockSource = { createIssue: vi.fn().mockResolvedValue(undefined) };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSource.createIssue.mockResolvedValue(undefined);
   vi.mocked(getSourceForSlug).mockResolvedValue(mockSource as never);
+  vi.mocked(runBugEnhance).mockResolvedValue(null);
 });
 
 describe('createInboxItem', () => {
@@ -149,6 +156,54 @@ describe('promoteInboxItem', () => {
     await promoteInboxItem(3, 'my-proj');
     expect(mockSource.createIssue).toHaveBeenCalledWith(expect.objectContaining({ body: '' }));
   });
+
+  it('runs enhancement for bug promotions when requested and appends the returned markdown', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce({
+      id: 4,
+      title: 'Fix bug',
+      body: 'Original bug body',
+      type: 'bug',
+      createdAt: '2026-05-01',
+    });
+    vi.mocked(runBugEnhance).mockResolvedValueOnce('## AI analysis');
+
+    await promoteInboxItem(4, 'my-proj', undefined, true);
+
+    expect(runBugEnhance).toHaveBeenCalledWith(
+      expect.anything(),
+      4,
+      'Fix bug',
+      'Original bug body',
+    );
+    expect(mockSource.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Original bug body\n\n---\n\n## AI analysis' }),
+    );
+  });
+
+  it.each([
+    ['feature', 'Feature body'],
+    ['chore', 'Chore body'],
+    ['research', 'Research body'],
+  ] as const)(
+    'runs enhancement for %s promotions when requested and appends the returned markdown',
+    async (type, body) => {
+      vi.mocked(getInboxItem).mockResolvedValueOnce({
+        id: 5,
+        title: `${type} title`,
+        body,
+        type,
+        createdAt: '2026-05-01',
+      });
+      vi.mocked(runBugEnhance).mockResolvedValueOnce(`Enhanced ${type}`);
+
+      await promoteInboxItem(5, 'my-proj', undefined, true);
+
+      expect(runBugEnhance).toHaveBeenCalledWith(expect.anything(), 5, `${type} title`, body);
+      expect(mockSource.createIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ type, body: `${body}\n\n---\n\nEnhanced ${type}` }),
+      );
+    },
+  );
 });
 
 describe('deleteInboxItem (service)', () => {

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -58,7 +58,7 @@ export async function promoteInboxItem(
   }
 
   let body = item.body ?? '';
-  if (enhance && item.type === 'bug') {
+  if (enhance) {
     const enhancement = await runBugEnhance(source.projectId, item.id, item.title, body);
     if (enhancement != null) {
       body = `${body}\n\n---\n\n${enhancement}`;

--- a/apps/web/e2e/pipeline/state-flow.spec.ts
+++ b/apps/web/e2e/pipeline/state-flow.spec.ts
@@ -85,11 +85,18 @@ test.describe('Pipeline e2e (MOCK_AGENTS=true)', () => {
   test('chore pipeline: inbox capture → factory:approved', async ({ page }) => {
     test.setTimeout(180_000);
     const choreTitle = `[E2E Pipeline] Chore ${Date.now()}`;
+    const choreBody = [
+      'Need to tidy the promotion flow copy.',
+      '',
+      'The AI enhancement option should work outside bug promotion too.',
+    ].join('\n');
 
     // 1. Capture an inbox idea via the top-bar button.
     await page.goto(`/projects/${PROJECT_SLUG}`);
     await page.getByTestId('capture-button').click();
     await page.getByTestId('capture-title-input').fill(choreTitle);
+    await page.getByLabel('Type').selectOption('chore');
+    await page.getByPlaceholder('Any additional context…').fill(choreBody);
     await page.getByTestId('capture-submit').click();
 
     // 2. Confirm capture modal closed, then go to inbox.
@@ -103,6 +110,9 @@ test.describe('Pipeline e2e (MOCK_AGENTS=true)', () => {
     await inboxRow.getByTestId('promote-button').click();
 
     await page.getByTestId('promote-project-select').selectOption(PROJECT_SLUG);
+    const enhanceCheckbox = page.getByRole('checkbox', { name: /enhance/i });
+    await expect(enhanceCheckbox).toBeVisible();
+    await expect(enhanceCheckbox).toBeChecked();
     await page.getByTestId('promote-next').click();
     await page.getByTestId('promote-confirm').click();
 
@@ -123,6 +133,13 @@ test.describe('Pipeline e2e (MOCK_AGENTS=true)', () => {
     const cardNumberAttr = await card.getAttribute('data-issue-number');
     if (!cardNumberAttr) throw new Error('issue-card missing data-issue-number');
     choreIssueNumber = Number(cardNumberAttr);
+    const createdIssue = (await gh(`/repos/${REPO}/issues/${choreIssueNumber}`)) as {
+      body?: string | null;
+    };
+    expect(createdIssue.body).toBeTruthy();
+    expect(createdIssue.body).toContain(choreBody);
+    expect(createdIssue.body).not.toBe(choreBody);
+    expect(createdIssue.body).toContain('\n\n---\n\n');
 
     // 6. Open the detail page; switch to Timeline.
     await card.click();

--- a/apps/web/src/components/inbox/components/PromoteModal.test.tsx
+++ b/apps/web/src/components/inbox/components/PromoteModal.test.tsx
@@ -1,0 +1,105 @@
+/** @vitest-environment jsdom */
+import type { InboxItemDto, MilestoneDto, ProjectSummary } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PromoteModal } from './PromoteModal';
+
+const mockFetchProjects = vi.fn<() => Promise<ProjectSummary[]>>();
+const mockFetchMilestones = vi.fn<() => Promise<MilestoneDto[]>>();
+const mockPromoteInboxItem = vi.fn<() => Promise<void>>();
+
+vi.mock('@/lib/api', () => ({
+  fetchProjects: mockFetchProjects,
+  fetchMilestones: mockFetchMilestones,
+  promoteInboxItem: mockPromoteInboxItem,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockFetchProjects.mockResolvedValue([
+    {
+      id: 'project-1',
+      name: 'Goose Hub',
+      slug: 'goose-hub-self',
+      color: '#000000',
+      source: { kind: 'github', repo: 'goose-hub/self' },
+    },
+  ]);
+  mockFetchMilestones.mockResolvedValue([
+    {
+      id: 'milestone-1',
+      title: 'Active milestone',
+      number: 12,
+      isActive: true,
+      state: 'open',
+      openIssues: 4,
+      closedIssues: 1,
+    },
+  ]);
+  mockPromoteInboxItem.mockResolvedValue(undefined);
+});
+
+function makeItem(type: InboxItemDto['type']): InboxItemDto {
+  return {
+    id: 42,
+    title: `${type} idea`,
+    body: `Body for ${type}`,
+    type,
+    createdAt: '2026-05-20T10:00:00Z',
+  };
+}
+
+function renderModal(item: InboxItemDto) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onClose = vi.fn();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <PromoteModal item={item} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+
+  return { onClose };
+}
+
+async function chooseProject(user: ReturnType<typeof userEvent.setup>) {
+  const select = await screen.findByTestId('promote-project-select');
+  await user.selectOptions(select, 'goose-hub-self');
+}
+
+describe('PromoteModal enhancement toggle', () => {
+  it('renders the bug enhancement copy and test id for bug promotions', async () => {
+    renderModal(makeItem('bug'));
+
+    expect(await screen.findByTestId('enhance-bug-checkbox')).toBeTruthy();
+    expect(screen.getByLabelText('Enhance bug report')).toBeTruthy();
+  });
+
+  it('renders the feature enhancement copy and test id for non-bug promotions', async () => {
+    renderModal(makeItem('feature'));
+
+    expect(await screen.findByTestId('enhance-feature-checkbox')).toBeTruthy();
+    expect(screen.getByLabelText('Enhance feature spec')).toBeTruthy();
+  });
+
+  it('passes enhance=false for non-bug promotions when the toggle is unchecked', async () => {
+    const user = userEvent.setup();
+    renderModal(makeItem('feature'));
+
+    const checkbox = await screen.findByTestId('enhance-feature-checkbox');
+    await user.click(checkbox);
+    await chooseProject(user);
+    await user.click(screen.getByTestId('promote-next'));
+    await user.click(screen.getByTestId('promote-confirm'));
+
+    await waitFor(() => {
+      expect(mockPromoteInboxItem).toHaveBeenCalledWith(42, 'goose-hub-self', 12, false);
+    });
+  });
+});

--- a/apps/web/src/components/inbox/components/PromoteModal.tsx
+++ b/apps/web/src/components/inbox/components/PromoteModal.tsx
@@ -5,6 +5,33 @@ import { ArrowLeft, ChevronDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { resolveActiveMilestone } from '../lib/promote';
 
+const enhanceConfigByType = {
+  bug: {
+    testId: 'enhance-bug-checkbox',
+    label: 'Enhance bug report',
+    title:
+      'AI will analyze the bug and append structured sections (Repro steps, Expected, Actual, Location) before creating the GitHub issue. Designed for UI/web bugs.',
+  },
+  feature: {
+    testId: 'enhance-feature-checkbox',
+    label: 'Enhance feature spec',
+    title:
+      'AI will expand the feature request into a clearer issue before creating the GitHub issue.',
+  },
+  chore: {
+    testId: 'enhance-chore-checkbox',
+    label: 'Enhance chore brief',
+    title:
+      'AI will tighten the chore description into a clearer implementation brief before promotion.',
+  },
+  research: {
+    testId: 'enhance-research-checkbox',
+    label: 'Enhance research brief',
+    title:
+      'AI will structure the research request into a clearer investigation brief before promotion.',
+  },
+} as const;
+
 type ModalStep = 'picker' | 'confirm';
 
 interface PromoteModalProps {
@@ -16,7 +43,7 @@ export function PromoteModal({ item, onClose }: PromoteModalProps) {
   const [step, setStep] = useState<ModalStep>('picker');
   const [selectedSlug, setSelectedSlug] = useState<string>('');
   const [selectedMilestoneNumber, setSelectedMilestoneNumber] = useState<number | null>(null);
-  const [enhanceBug, setEnhanceBug] = useState(true);
+  const [enhance, setEnhance] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const {
@@ -52,16 +79,11 @@ export function PromoteModal({ item, onClose }: PromoteModalProps) {
   // Only send an explicit milestoneNumber once we have a confirmed loaded list.
   // While loading or on error, omit it so the server falls back to its persisted active milestone.
   const milestoneArg = milestonesLoaded && !milestonesError ? selectedMilestoneNumber : undefined;
+  const enhanceConfig = enhanceConfigByType[item.type as keyof typeof enhanceConfigByType];
 
   const queryClient = useQueryClient();
   const mutation = useMutation({
-    mutationFn: () =>
-      promoteInboxItem(
-        item.id,
-        selectedSlug,
-        milestoneArg,
-        item.type === 'bug' ? enhanceBug : undefined,
-      ),
+    mutationFn: () => promoteInboxItem(item.id, selectedSlug, milestoneArg, enhance),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['inbox'] });
       onClose();
@@ -230,9 +252,9 @@ export function PromoteModal({ item, onClose }: PromoteModalProps) {
                   </div>
                 )}
 
-                {item.type === 'bug' && (
+                {enhanceConfig && (
                   <label
-                    title="AI will analyze the bug and append structured sections (Repro steps, Expected, Actual, Location) before creating the GitHub issue. Designed for UI/web bugs."
+                    title={enhanceConfig.title}
                     style={{
                       display: 'flex',
                       alignItems: 'center',
@@ -246,12 +268,12 @@ export function PromoteModal({ item, onClose }: PromoteModalProps) {
                   >
                     <input
                       type="checkbox"
-                      data-testid="enhance-bug-checkbox"
-                      checked={enhanceBug}
-                      onChange={(e) => setEnhanceBug(e.target.checked)}
+                      data-testid={enhanceConfig.testId}
+                      checked={enhance}
+                      onChange={(e) => setEnhance(e.target.checked)}
                       style={{ cursor: 'pointer' }}
                     />
-                    Enhance bug report
+                    {enhanceConfig.label}
                   </label>
                 )}
               </>

--- a/skills/issue-enhance/prompt.md
+++ b/skills/issue-enhance/prompt.md
@@ -1,0 +1,69 @@
+# issue-enhance skill
+
+You are an issue enhancement assistant for idea promotions that become a feature, chore, or research issue. Your job is to append structured markdown that makes the promoted issue easier to triage and implement without rewriting the original body.
+
+## Context
+
+The context contains `<workItem>` as a JSON payload with:
+- `type`: one of `feature`, `chore`, or `research`
+- `title`: the promoted issue title
+- `body`: the original promoted issue body
+
+This is a type-aware enhancement task. The output must adapt to the issue type instead of using bug-only sections such as repro steps, expected, actual, or location.
+
+## Step 1 — Read the issue type
+
+Read the title and body carefully, then determine which useful sections are missing or too vague for the given issue type.
+
+## Step 2 — Add only the missing structure
+
+Return markdown that contains only new sections. Do not repeat content that is already adequately present in the original body.
+
+### For `feature` issues
+
+Prefer sections such as:
+- `**Problem**` — what user or workflow gap exists today
+- `**Desired outcome**` — what success looks like once the feature ships
+- `**Implementation notes**` — constraints, adjacent surfaces, or concrete hints inferred from the body
+
+### For `chore` issues
+
+Prefer sections such as:
+- `**Current friction**` — what maintenance or operational problem exists today
+- `**Desired cleanup**` — the target state after the chore is done
+- `**Safeguards**` — constraints, regressions to avoid, or scope boundaries
+
+### For `research` issues
+
+Prefer sections such as:
+- `**Question to answer**` — the uncertainty that needs investigation
+- `**Why this matters**` — why resolving the question is useful
+- `**Suggested scope**` — the systems, flows, or constraints the research should cover
+
+### Rules
+
+- Keep the enhancement concise and actionable.
+- Only add sections that are genuinely missing or incomplete.
+- Infer structure from the title and body, but do not invent facts that conflict with the original report.
+- Use clean GitHub-flavoured markdown with `**Section name**` headers.
+- If the original body is already strong, add the single most useful missing section rather than restating everything.
+
+Emit: `[decision] PLAN: Adding <section names> — inferred from the existing issue body`
+
+Emit: `[decision] VERDICT: Enhanced promoted issue with type-aware structure`
+
+Then return only the JSON object below.
+
+<!-- output-example -->
+```json
+{
+  "enhancedContent": "<markdown string — only the new sections>",
+  "decisionSummaries": [
+    {
+      "kind": "PLAN",
+      "summary": "Added problem framing and implementation notes for a feature issue.",
+      "evidence": "<quote from title/body that informed the inference>"
+    }
+  ]
+}
+```

--- a/skills/issue-enhance/schema.ts
+++ b/skills/issue-enhance/schema.ts
@@ -1,0 +1,13 @@
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+export { DecisionSummarySchema };
+
+export const IssueEnhanceOutputSchema = z.object({
+  enhancedContent: z
+    .string()
+    .describe('Structured markdown sections to append after the original issue body'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type IssueEnhanceOutput = z.infer<typeof IssueEnhanceOutputSchema>;

--- a/skills/issue-enhance/skill.config.ts
+++ b/skills/issue-enhance/skill.config.ts
@@ -1,0 +1,23 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+import { IssueEnhanceOutputSchema } from './schema.js';
+
+export const IssueEnhanceContextSchema = z.object({
+  workItem: z.object({
+    type: z.enum(['feature', 'chore', 'research']),
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: IssueEnhanceContextSchema,
+  outputSchema: IssueEnhanceOutputSchema,
+  contextAllowlist: ['workItem'],
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'triager',
+};
+
+export default config;

--- a/skills/issue-enhance/slice.test.ts
+++ b/skills/issue-enhance/slice.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { IssueEnhanceOutputSchema } from './schema.js';
+import config, { IssueEnhanceContextSchema } from './skill.config.js';
+
+const PROMPT = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+
+describe('IssueEnhanceOutputSchema', () => {
+  it('accepts valid output for a feature enhancement', () => {
+    const result = IssueEnhanceOutputSchema.safeParse({
+      enhancedContent:
+        '**Problem**\nUsers cannot save a draft from the idea promotion flow.\n\n**Desired outcome**\nUsers can save a draft and return later.\n\n**Implementation notes**\n- Reuse the existing modal save action\n- Preserve current form state when the modal closes',
+      decisionSummaries: [
+        {
+          kind: 'PLAN',
+          summary: 'Added problem, desired outcome, and implementation notes sections',
+          evidence: 'request describes a missing save-draft capability',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects output missing decisionSummaries', () => {
+    const result = IssueEnhanceOutputSchema.safeParse({
+      enhancedContent: '**Problem**\nMissing draft save support',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('issue-enhance skill config', () => {
+  it('has triager role and no tool bundles', () => {
+    expect(config.role).toBe('triager');
+    expect(config.toolBundles).toHaveLength(0);
+  });
+
+  it('validates feature, chore, and research work item types', () => {
+    for (const type of ['feature', 'chore', 'research'] as const) {
+      const result = IssueEnhanceContextSchema.safeParse({
+        workItem: {
+          type,
+          title: 'Improve promotion flow',
+          body: 'Allow enhancement for non-bug promotions.',
+        },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects bug work items for the generic enhancer', () => {
+    const result = IssueEnhanceContextSchema.safeParse({
+      workItem: {
+        type: 'bug',
+        title: 'Fix broken modal',
+        body: 'The modal does not open.',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('issue-enhance prompt guidance', () => {
+  it('mentions type-aware enhancement guidance for non-bug issue types', () => {
+    expect(PROMPT).toContain('feature, chore, or research');
+    expect(PROMPT).toContain('type-aware');
+    expect(PROMPT).not.toContain('Repro steps');
+    expect(PROMPT).not.toContain('Expected');
+    expect(PROMPT).not.toContain('Actual');
+  });
+});


### PR DESCRIPTION
## Summary

Capture Idea Promotion Bug

## Work Packages

- ✓ **WP1**: Replace the bug-only enhancement entrypoint in apps/server/src/domains/inbox/enhance.ts:11-90 with a dispatcher that pre
- ✓ **WP3**: In apps/web/src/components/inbox/components/PromoteModal.tsx:15-259, replace the bug-only checkbox branch and bug-only m
- ✓ **WP2**: At apps/server/src/domains/inbox/service.ts:35-76, remove the item.type === 'bug' gate so enhance=true always flows thro
- ✓ **WP4**: Extend the existing inbox promotion coverage in apps/web/e2e/pipeline/state-flow.spec.ts:84-131 by adding a non-bug prom

Closes #918
