### PR TITLE
Add PRD read model resolver

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -12,6 +12,7 @@ API + SSE host for the Goose Hub web UI. Stands up the server process the UI tal
 | GET | `/workflow-catalog` | returns the maintained workflow map catalog used by Settings |
 | GET | `/projects/:slug/issues` | proxies `StateSource.listOpenWork()` |
 | GET | `/projects/:slug/issues/:id` | proxies `StateSource.getItem()` |
+| GET | `/projects/:slug/issues/:id/prd` | returns latest PRD read model, preferring local structured events with legacy comment fallback |
 | GET | `/projects/:slug/milestones` | proxies `StateSource.listMilestones()` |
 | GET | `/projects/:slug/active-milestone` | reads `project_state.activeMilestoneNumber` (falls back to GitHub default) |
 | POST | `/projects/:slug/active-milestone` | writes `project_state.activeMilestoneNumber`; emits `milestone.activated` |

--- a/apps/server/src/domains/issues/prd-actions.test.ts
+++ b/apps/server/src/domains/issues/prd-actions.test.ts
@@ -196,6 +196,13 @@ describe('revisePRD', () => {
       state: 'factory:prd-review',
     });
     vi.mocked(getSourceForSlug).mockResolvedValue(source);
+    const priorPrd = { title: 'Stored PRD' };
+    eventStore.appendEvent({
+      projectId,
+      workItemId: item.id,
+      kind: 'prd.drafted',
+      payload: { prd: priorPrd, advisorConcerns: null },
+    });
 
     const concerns = ['Journey J-1 step 2 is unclear', 'Missing error state for network timeout'];
     const result = await revisePRD(projectId, item.externalId, concerns);
@@ -214,9 +221,36 @@ describe('revisePRD', () => {
     expect(dispatchRevisePrdMock).toHaveBeenCalledWith(
       projectId,
       Number(item.externalId),
-      undefined,
+      priorPrd,
       concerns,
     );
+  });
+
+  it('returns 409 and moves to needs-human when no PRD draft can be resolved', async () => {
+    const projectId = uniqueProjectId('revise-no-prd');
+    const source = new InMemoryLabelsSource(projectId, REPO_REF);
+    const item = await source.seedIssue({
+      title: 'Build feature with missing PRD',
+      body: 'desc',
+      type: 'feature',
+      priority: 'medium',
+      state: 'factory:prd-review',
+    });
+    vi.mocked(getSourceForSlug).mockResolvedValue(source);
+
+    const result = await revisePRD(projectId, item.externalId, ['Missing detail']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+      expect(result.error).toContain('no PRD draft found');
+    }
+    await expect(source.getItem(item.externalId)).resolves.toMatchObject({
+      state: 'factory:needs-human',
+    });
+    const comments = await source.listComments(item.externalId);
+    expect(comments.at(-1)?.body).toContain('revise-prd: no PRD draft found');
+    expect(dispatchRevisePrdMock).not.toHaveBeenCalled();
   });
 
   it('returns 409 when the issue is not in factory:prd-review', async () => {

--- a/apps/server/src/domains/issues/prd-actions.ts
+++ b/apps/server/src/domains/issues/prd-actions.ts
@@ -11,22 +11,13 @@
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
+import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { PRDOutput } from '@goose-hub/skills/write-prd/schema.js';
 import { dispatchDecomposePrd, dispatchGrillAndPrd, dispatchRevisePrd } from '#shared/dispatch.js';
 import type { Result } from '#shared/middleware.js';
 import { getSourceForSlug } from '#shared/source.js';
 import { getRepoRef } from './internal.js';
-
-function parsePrdFromCommentBody(body: string): PRDOutput | null {
-  const fenceMatch = body.match(/```json\s*\n([\s\S]*?)\n```/);
-  if (fenceMatch == null) return null;
-  try {
-    return JSON.parse(fenceMatch[1]) as PRDOutput;
-  } catch {
-    return null;
-  }
-}
 
 async function moveOrForce(
   source: import('@goose-hub/core/state-source/interface.js').StateSource,
@@ -105,10 +96,20 @@ export async function revisePRD(
     };
   }
 
-  // Fetch the latest PRD comment and parse its JSON blob.
-  const comments = await source.listComments(id);
-  const prdComment = [...comments].reverse().find((c) => c.body.startsWith('<!-- factory:prd -->'));
-  const priorPrd = prdComment != null ? parsePrdFromCommentBody(prdComment.body) : null;
+  const latestPrd = await resolveLatestPrd({
+    projectId: slug,
+    workItemId,
+    loadLegacyComments: () => source.listComments(id),
+  });
+  const priorPrd = latestPrd?.prd != null ? (latestPrd.prd as PRDOutput) : undefined;
+  if (priorPrd == null) {
+    await source.comment(
+      id,
+      'revise-prd: no PRD draft found for this issue. Returning to needs-human.',
+    );
+    await source.forceState(id, 'factory:needs-human');
+    return { ok: false, error: 'no PRD draft found for revision', status: 409 };
+  }
 
   eventStore.appendEvent({
     projectId: slug,
@@ -118,7 +119,7 @@ export async function revisePRD(
   });
 
   // Re-dispatch write-prd with concerns; state stays prd-review.
-  dispatchRevisePrd(slug, Number(id), priorPrd ?? undefined, concerns).catch((err: unknown) => {
+  dispatchRevisePrd(slug, Number(id), priorPrd, concerns).catch((err: unknown) => {
     logger.error('dispatchRevisePrd after revisePRD failed', {
       slug,
       id,

--- a/apps/server/src/domains/issues/router.test.ts
+++ b/apps/server/src/domains/issues/router.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetIssueEvents,
   mockGetIssueArtifact,
   mockGetIssueComments,
+  mockGetIssuePrd,
   mockGetIssueTriage,
   mockGetIssueWorktreeDiff,
   mockTransitionIssue,
@@ -33,6 +34,7 @@ const {
   mockGetIssueEvents: vi.fn(),
   mockGetIssueArtifact: vi.fn(),
   mockGetIssueComments: vi.fn(),
+  mockGetIssuePrd: vi.fn(),
   mockGetIssueTriage: vi.fn(),
   mockGetIssueWorktreeDiff: vi.fn(),
   mockTransitionIssue: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('./service.js', () => ({
   getIssueEvents: mockGetIssueEvents,
   getIssueArtifact: mockGetIssueArtifact,
   getIssueComments: mockGetIssueComments,
+  getIssuePrd: mockGetIssuePrd,
   getIssueTriage: mockGetIssueTriage,
   getIssueWorktreeDiff: mockGetIssueWorktreeDiff,
   transitionIssue: mockTransitionIssue,
@@ -203,6 +206,38 @@ describe('GET /projects/:slug/issues/:id/comments', () => {
 
     const app = makeApp();
     const res = await app.request('/projects/unknown/issues/1/comments', { method: 'GET' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /projects/:slug/issues/:id/prd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with the latest PRD read model on success', async () => {
+    const prd = {
+      prd: { title: 'Stored PRD' },
+      advisorConcerns: null,
+      source: 'event',
+      createdAt: '2026-05-21T00:00:00.000Z',
+      runId: 'run-1',
+    };
+    mockGetIssuePrd.mockResolvedValue({ ok: true, data: { prd } });
+
+    const app = makeApp();
+    const res = await app.request('/projects/my-project/issues/42/prd', { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prd: unknown };
+    expect(body.prd).toEqual(prd);
+    expect(mockGetIssuePrd).toHaveBeenCalledWith('my-project', '42');
+  });
+
+  it('returns 404 when project not found', async () => {
+    mockGetIssuePrd.mockResolvedValue({ ok: false, error: 'project not found', status: 404 });
+
+    const app = makeApp();
+    const res = await app.request('/projects/unknown/issues/1/prd', { method: 'GET' });
     expect(res.status).toBe(404);
   });
 });

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -12,6 +12,7 @@ import {
   getIssueComments,
   getIssueEvents,
   getIssueLegalTargets,
+  getIssuePrd,
   getIssueSpec,
   getIssueTriage,
   getIssueWorktreeDiff,
@@ -71,6 +72,11 @@ router.get('/:slug/issues/:id/triage', async (c) => {
 
 router.get('/:slug/issues/:id/spec', async (c) => {
   const result = await getIssueSpec(c.req.param('slug'), c.req.param('id'));
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
+});
+
+router.get('/:slug/issues/:id/prd', async (c) => {
+  const result = await getIssuePrd(c.req.param('slug'), c.req.param('id'));
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
 });
 

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -1,6 +1,7 @@
 import { getArtifact } from '@goose-hub/core/agent-artifacts/repository.js';
 import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
+import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import { STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { legalTargets } from '@goose-hub/core/state-machine/transitions.js';
@@ -149,6 +150,32 @@ export async function getIssueSpec(
       },
     },
   };
+}
+
+export async function getIssuePrd(
+  slug: string,
+  id: string,
+): Promise<
+  Result<{
+    prd: {
+      prd: unknown | null;
+      advisorConcerns: string | null;
+      source: 'event' | 'legacy-comment';
+      createdAt: string;
+      runId: string | null;
+    } | null;
+  }>
+> {
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+  const repoRef = await getRepoRef(slug);
+  const workItemId = `github:${repoRef}#${id}`;
+  const prd = await resolveLatestPrd({
+    projectId: slug,
+    workItemId,
+    loadLegacyComments: () => source.listComments(id),
+  });
+  return { ok: true, data: { prd } };
 }
 
 export async function getIssueArtifact(

--- a/apps/server/src/shared/dispatch-discover.ts
+++ b/apps/server/src/shared/dispatch-discover.ts
@@ -1,4 +1,5 @@
 import { logger } from '@goose-hub/core/logger.js';
+import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import { parallelLock } from '@goose-hub/core/projects/parallel-lock.js';
 import { runDecomposePrdWorkflow } from '@goose-hub/core/workflows/decompose-prd.js';
 import { runGrillAndPrdWorkflow } from '@goose-hub/core/workflows/grill-and-prd.js';
@@ -11,29 +12,6 @@ const PRD_MARKER = '<!-- factory:prd -->';
 const GRILL_QUESTION_MARKER = '<!-- factory:grill-question -->';
 const SYSTEM_MARKER = '<!-- factory:system -->';
 const CHILD_ISSUES_MARKER = '## Child issues';
-const PRD_JSON_FENCE_RE = /```json\s*\n([\s\S]*?)\n```/;
-
-/**
- * Extract the PRDOutput JSON from the latest `<!-- factory:prd -->` marker
- * comment. Returns `null` if no marker comment exists or the JSON fence
- * fails to parse. The decompose-prd workflow validates the parsed shape
- * against `DecomposeOutputSchema`'s upstream `PRDOutputSchema` itself.
- */
-function extractPrdFromComments(
-  comments: ReadonlyArray<{ body: string; createdAt: string }>,
-): unknown {
-  const matches = comments.filter((c) => c.body.startsWith(PRD_MARKER));
-  if (matches.length === 0) return null;
-  const sorted = [...matches].sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
-  const fence = sorted[sorted.length - 1].body.match(PRD_JSON_FENCE_RE);
-  if (fence == null) return null;
-  try {
-    return JSON.parse(fence[1]);
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Build the `priorReplies` array for grill-and-prd from issue comments.
  * Agent messages: grill questions (<!-- factory:grill-question -->) and PRD
@@ -217,20 +195,36 @@ export async function dispatchDecomposePrd(slug: string, issueNumber: number): P
         });
         return;
       }
-      const comments = await source.listComments(issueNumber.toString());
-      const prdOutput = extractPrdFromComments(comments);
+      const prdOutput = await resolveLatestPrd({
+        projectId: slug,
+        workItemId: item.id,
+        loadLegacyComments: () => source.listComments(issueNumber.toString()),
+      });
       if (prdOutput == null) {
-        logger.error('dispatchDecomposePrd: no PRD marker comment found', { slug, issueNumber });
+        logger.error('dispatchDecomposePrd: no PRD draft found', { slug, issueNumber });
         await source.comment(
           issueNumber.toString(),
-          'decompose-prd: no PRD comment found on this issue. Returning to needs-human.',
+          'decompose-prd: no PRD draft found on this issue. Returning to needs-human.',
+        );
+        await source.forceState(issueNumber.toString(), 'factory:needs-human');
+        return;
+      }
+      if (prdOutput.prd == null) {
+        logger.error('dispatchDecomposePrd: PRD draft could not be parsed', {
+          slug,
+          issueNumber,
+          source: prdOutput.source,
+        });
+        await source.comment(
+          issueNumber.toString(),
+          'decompose-prd: PRD draft could not be parsed. Returning to needs-human.',
         );
         await source.forceState(issueNumber.toString(), 'factory:needs-human');
         return;
       }
       await runDecomposePrdWorkflow({
         workItem: item,
-        prdOutput,
+        prdOutput: prdOutput.prd,
         stateSource: source,
         projectId: slug,
       });

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -20,6 +20,7 @@ const mockRunRetroForItem = vi.fn();
 const mockFilterEligibleByDependencies = vi.fn();
 const mockCreateProjectAwareTargetSource = vi.fn();
 const mockRunGrillAndPrdWorkflow = vi.fn();
+const mockRunDecomposePrdWorkflow = vi.fn();
 const mockGetUseMultiAgentPipeline = vi.fn();
 const mockGetEngineeringSpec = vi.fn();
 const mockRunParallelImplementWorkflow = vi.fn();
@@ -85,6 +86,10 @@ vi.mock('@goose-hub/core/workflows/grill-and-prd.js', () => ({
   runGrillAndPrdWorkflow: mockRunGrillAndPrdWorkflow,
 }));
 
+vi.mock('@goose-hub/core/workflows/decompose-prd.js', () => ({
+  runDecomposePrdWorkflow: mockRunDecomposePrdWorkflow,
+}));
+
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
   eventStore: {
     replay: mockEventStoreReplay,
@@ -109,6 +114,7 @@ beforeEach(() => {
   mockRunInvestigateWorkflow.mockResolvedValue(undefined);
   mockRunRetroForItem.mockResolvedValue(undefined);
   mockRunGrillAndPrdWorkflow.mockResolvedValue(undefined);
+  mockRunDecomposePrdWorkflow.mockResolvedValue(undefined);
   mockRunParallelImplementWorkflow.mockResolvedValue({ status: 'success' });
   mockGetSourceForSlug.mockResolvedValue(null);
   // Default: single-workflow-per-project (backward-compat) for tests that don't override.
@@ -1328,9 +1334,45 @@ describe('dispatchGrillAndPrd: buildPriorReplies filtering', () => {
 // ─── dispatchDecomposePrd — no-PRD escape ────────────────────────────────
 
 describe('dispatchDecomposePrd: no-PRD escape', () => {
-  it('posts a comment and forces needs-human when no PRD comment is found', async () => {
+  it('runs decompose from a local prd.drafted event without reading a marker comment', async () => {
+    const item = { id: 'github:owner/repo#54', state: 'factory:decomposing' };
+    const prd = { title: 'Local PRD' };
     const source = {
-      getItem: vi.fn().mockResolvedValue({ state: 'factory:decomposing' }),
+      getItem: vi.fn().mockResolvedValue(item),
+      listComments: vi.fn().mockResolvedValue([]),
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockEventStoreReplay.mockReturnValue([
+      {
+        id: 100,
+        projectId: 'slug',
+        workItemId: item.id,
+        kind: 'prd.drafted',
+        payload: { prd, advisorConcerns: null },
+        runId: 'run-1',
+        personaId: null,
+        createdAt: '2026-05-21T00:00:00.000Z',
+      },
+    ]);
+
+    const { dispatchDecomposePrd } = await import('./dispatch.js');
+    await dispatchDecomposePrd('slug', 54);
+
+    expect(source.listComments).not.toHaveBeenCalled();
+    expect(mockRunDecomposePrdWorkflow).toHaveBeenCalledWith({
+      workItem: item,
+      prdOutput: prd,
+      stateSource: source,
+      projectId: 'slug',
+    });
+  });
+
+  it('posts a comment and forces needs-human when no PRD draft is found', async () => {
+    const source = {
+      getItem: vi.fn().mockResolvedValue({
+        id: 'github:owner/repo#55',
+        state: 'factory:decomposing',
+      }),
       listComments: vi.fn().mockResolvedValue([]),
       comment: vi.fn().mockResolvedValue(undefined),
       forceState: vi.fn().mockResolvedValue(undefined),
@@ -1341,12 +1383,12 @@ describe('dispatchDecomposePrd: no-PRD escape', () => {
     await dispatchDecomposePrd('slug', 55);
 
     expect(mockLoggerError).toHaveBeenCalledWith(
-      'dispatchDecomposePrd: no PRD marker comment found',
+      'dispatchDecomposePrd: no PRD draft found',
       expect.objectContaining({ slug: 'slug', issueNumber: 55 }),
     );
     expect(source.comment).toHaveBeenCalledWith(
       '55',
-      expect.stringContaining('no PRD comment found'),
+      expect.stringContaining('no PRD draft found'),
     );
     expect(source.forceState).toHaveBeenCalledWith('55', 'factory:needs-human');
   });

--- a/apps/web/src/components/detail/components/PRDSection.test.tsx
+++ b/apps/web/src/components/detail/components/PRDSection.test.tsx
@@ -1,15 +1,16 @@
 /** @vitest-environment jsdom */
-import { approvePRD, declinePRD, fetchComments, revisePRD } from '@/lib/api';
-import type { IssueCommentDto } from '@/lib/types';
+import { approvePRD, declinePRD, fetchEvents, fetchPRD, revisePRD } from '@/lib/api';
+import type { PrdReadModelDto } from '@/lib/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PRDSection } from './PRDSection';
 
 afterEach(cleanup);
 
 vi.mock('@/lib/api', () => ({
-  fetchComments: vi.fn(),
+  fetchPRD: vi.fn(),
+  fetchEvents: vi.fn(),
   approvePRD: vi.fn(),
   revisePRD: vi.fn(),
   declinePRD: vi.fn(),
@@ -76,10 +77,14 @@ const PRD_FIXTURE = {
   },
 };
 
-function makePRDComment(advisor?: string): IssueCommentDto {
-  let body = `<!-- factory:prd -->\n# PRD\n\n\`\`\`json\n${JSON.stringify(PRD_FIXTURE, null, 2)}\n\`\`\``;
-  if (advisor != null) body += `\n\n## Advisor concerns\n${advisor}`;
-  return { id: 1, body, authorLogin: 'factory-bot', createdAt: '2026-05-07T10:00:00Z' };
+function makePRDReadModel(advisor?: string): PrdReadModelDto {
+  return {
+    prd: PRD_FIXTURE,
+    advisorConcerns: advisor ?? null,
+    source: 'event',
+    createdAt: '2026-05-07T10:00:00Z',
+    runId: 'run-1',
+  };
 }
 
 function render_(jsx: React.ReactNode) {
@@ -88,8 +93,12 @@ function render_(jsx: React.ReactNode) {
 }
 
 describe('PRDSection', () => {
+  beforeEach(() => {
+    vi.mocked(fetchEvents).mockResolvedValue([]);
+  });
+
   it('renders the empty state when no PRD comment is present', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(null);
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-empty-state')).toBeTruthy();
@@ -97,7 +106,7 @@ describe('PRDSection', () => {
   });
 
   it('renders Drafting state when state is factory:prd-drafting and no PRD yet', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(null);
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-drafting" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-drafting')).toBeTruthy();
@@ -105,7 +114,7 @@ describe('PRDSection', () => {
   });
 
   it('renders title, problem, vertical slices, and complexity badge from PRD comment', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(makePRDReadModel());
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-title').textContent).toBe('Inline validation in onboarding');
@@ -120,9 +129,7 @@ describe('PRDSection', () => {
   });
 
   it('renders Advisor notes panel when advisor concerns are present', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([
-      makePRDComment('- Quantify the success metric.'),
-    ]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(makePRDReadModel('- Quantify the success metric.'));
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-advisor-panel').textContent).toContain('Quantify');
@@ -130,7 +137,7 @@ describe('PRDSection', () => {
   });
 
   it('shows Approve, Request Changes, and Decline buttons only when state is factory:prd-review', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
     const { unmount } = render_(
       <PRDSection projectSlug="proj" id="42" state="factory:prd-review" />,
     );
@@ -150,7 +157,7 @@ describe('PRDSection', () => {
   });
 
   it('Approve PRD button calls approvePRD API', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
     vi.mocked(approvePRD).mockResolvedValueOnce({ ok: true });
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
@@ -163,7 +170,7 @@ describe('PRDSection', () => {
   });
 
   it('Request Changes opens the concern form and submits revisePRD', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
     vi.mocked(revisePRD).mockResolvedValueOnce({ ok: true });
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => expect(screen.getByTestId('prd-request-changes-btn')).toBeTruthy());
@@ -181,7 +188,7 @@ describe('PRDSection', () => {
   });
 
   it('Decline Feature shows confirmation and calls declinePRD on confirm', async () => {
-    vi.mocked(fetchComments).mockResolvedValue([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
     vi.mocked(declinePRD).mockResolvedValueOnce({ ok: true });
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => expect(screen.getByTestId('prd-decline-btn')).toBeTruthy());
@@ -196,14 +203,13 @@ describe('PRDSection', () => {
   });
 
   it('renders parse-error state when JSON block is malformed', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([
-      {
-        id: 1,
-        body: '<!-- factory:prd -->\n# PRD\n\n```json\nnot-json\n```',
-        authorLogin: 'factory-bot',
-        createdAt: '2026-05-07T10:00:00Z',
-      },
-    ]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce({
+      prd: null,
+      advisorConcerns: null,
+      source: 'legacy-comment',
+      createdAt: '2026-05-07T10:00:00Z',
+      runId: null,
+    });
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-parse-error')).toBeTruthy();
@@ -211,7 +217,7 @@ describe('PRDSection', () => {
   });
 
   it('renders Implementation Decisions section when present', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(makePRDReadModel());
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-implementation-decisions')).toBeTruthy();
@@ -223,7 +229,7 @@ describe('PRDSection', () => {
   });
 
   it('renders Testing Approach section when present', async () => {
-    vi.mocked(fetchComments).mockResolvedValueOnce([makePRDComment()]);
+    vi.mocked(fetchPRD).mockResolvedValueOnce(makePRDReadModel());
     render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-testing-decisions')).toBeTruthy();

--- a/apps/web/src/components/detail/components/PRDSection.tsx
+++ b/apps/web/src/components/detail/components/PRDSection.tsx
@@ -1,15 +1,11 @@
-import { approvePRD, declinePRD, fetchComments, fetchEvents, revisePRD } from '@/lib/api';
+import { approvePRD, declinePRD, fetchEvents, fetchPRD, revisePRD } from '@/lib/api';
 import { renderMarkdownToHtml } from '@/lib/markdown';
-import type { AgentEventDto, IssueCommentDto } from '@/lib/types';
+import type { AgentEventDto, PrdReadModelDto } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckCircle2, ChevronDown, ChevronRight, FileText, Loader2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  type ParsedPRDView,
-  findLatestPRDCommentBody,
-  parsePRDComment,
-} from '../lib/parse-prd-comment';
+import type { ParsedPRDView } from '../lib/parse-prd-comment';
 import { SectionEmptyState } from './SectionEmptyState';
 
 interface PRDSectionProps {
@@ -33,11 +29,11 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
   const [concernsText, setConcernsText] = useState('');
   const [showDeclineConfirm, setShowDeclineConfirm] = useState(false);
   const [submittedConcerns, setSubmittedConcerns] = useState<string[] | null>(null);
-  const baselinePrdBodyRef = useRef<string | null>(null);
+  const baselinePrdKeyRef = useRef<string | null>(null);
 
-  const { data: comments = [], isLoading } = useQuery<IssueCommentDto[]>({
-    queryKey: ['comments', projectSlug, id],
-    queryFn: () => fetchComments(projectSlug, id),
+  const { data: prdResult = null, isLoading } = useQuery<PrdReadModelDto | null>({
+    queryKey: ['prd', projectSlug, id],
+    queryFn: () => fetchPRD(projectSlug, id),
     refetchInterval: submittedConcerns !== null ? 3000 : false,
   });
 
@@ -56,7 +52,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, id] });
     void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
-    void queryClient.invalidateQueries({ queryKey: ['comments', projectSlug, id] });
+    void queryClient.invalidateQueries({ queryKey: ['prd', projectSlug, id] });
     void queryClient.invalidateQueries({ queryKey: ['events', projectSlug, id] });
   };
 
@@ -86,13 +82,16 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
     onError: (err: unknown) => setErrorMsg(err instanceof Error ? err.message : String(err)),
   });
 
-  const currentBody = findLatestPRDCommentBody(comments);
+  const currentPrdKey =
+    prdResult != null
+      ? `${prdResult.source}:${prdResult.createdAt}:${prdResult.runId ?? ''}`
+      : null;
 
   useEffect(() => {
-    if (submittedConcerns !== null && currentBody !== baselinePrdBodyRef.current) {
+    if (submittedConcerns !== null && currentPrdKey !== baselinePrdKeyRef.current) {
       setSubmittedConcerns(null);
     }
-  }, [currentBody, submittedConcerns]);
+  }, [currentPrdKey, submittedConcerns]);
 
   if (isLoading) {
     return (
@@ -105,7 +104,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
   // Drafting state — show a friendly waiting message even before any PRD has
   // been posted.
   if (state === 'factory:prd-drafting') {
-    if (currentBody == null) {
+    if (prdResult == null) {
       return (
         <div className="px-8 py-6">
           <div className="mb-5">
@@ -125,7 +124,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
     }
   }
 
-  if (currentBody == null) {
+  if (prdResult == null) {
     return (
       <div className="px-8 py-6">
         <div className="mb-5">
@@ -144,7 +143,8 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
     );
   }
 
-  const { prd, advisorConcerns } = parsePRDComment(currentBody);
+  const prd = prdResult.prd as ParsedPRDView | null;
+  const advisorConcerns = prdResult.advisorConcerns;
 
   if (prd == null) {
     return (
@@ -176,7 +176,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
       .split(/\n|;/)
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
-    baselinePrdBodyRef.current = currentBody;
+    baselinePrdKeyRef.current = currentPrdKey;
     requestChanges.mutate(concerns);
   };
 

--- a/apps/web/src/lib/api/issues.ts
+++ b/apps/web/src/lib/api/issues.ts
@@ -3,6 +3,7 @@ import type {
   EngineeringSpecDto,
   IssueCommentDto,
   IssueDiffDto,
+  PrdReadModelDto,
   TransitionResult,
   TriageResultDto,
   WorkItemCostsDto,
@@ -29,6 +30,13 @@ export async function fetchEngineeringSpec(
     `/projects/${slug}/issues/${id}/spec`,
   );
   return spec;
+}
+
+export async function fetchPRD(slug: string, id: string): Promise<PrdReadModelDto | null> {
+  const { prd } = await getJson<{ prd: PrdReadModelDto | null }>(
+    `/projects/${slug}/issues/${id}/prd`,
+  );
+  return prd;
 }
 
 export async function fetchClosedIssues(

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -51,6 +51,14 @@ export interface IssueCommentDto {
   createdAt: string;
 }
 
+export interface PrdReadModelDto {
+  prd: unknown | null;
+  advisorConcerns: string | null;
+  source: 'event' | 'legacy-comment';
+  createdAt: string;
+  runId: string | null;
+}
+
 export interface ChangelogEntryDto {
   number: number;
   title: string;

--- a/core/prd/read-model.test.ts
+++ b/core/prd/read-model.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { eventStore } from '../event-stream/store.js';
+import { parseLegacyPrdComment, resolveLatestPrd } from './read-model.js';
+
+function workItemId(issueNumber: number): string {
+  return `github:owner/repo#${issueNumber}`;
+}
+
+function projectId(label: string): string {
+  return `prd-read-model-${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+describe('resolveLatestPrd', () => {
+  it('prefers the latest local prd.drafted event over a legacy comment', async () => {
+    const project = projectId('event-first');
+    const item = workItemId(1);
+    eventStore.appendEvent({
+      projectId: project,
+      workItemId: item,
+      kind: 'prd.drafted',
+      runId: 'run-old',
+      payload: { prd: { title: 'Old local PRD' }, advisorConcerns: ['needs tighter ACs'] },
+    });
+    eventStore.appendEvent({
+      projectId: project,
+      workItemId: item,
+      kind: 'prd.drafted',
+      runId: 'run-new',
+      payload: { prd: { title: 'New local PRD' }, advisorConcerns: [] },
+    });
+
+    const result = await resolveLatestPrd({
+      projectId: project,
+      workItemId: item,
+      loadLegacyComments: async () => [
+        {
+          body: '<!-- factory:prd -->\n# PRD\n\n```json\n{"title":"Comment PRD"}\n```',
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      prd: { title: 'New local PRD' },
+      advisorConcerns: null,
+      source: 'event',
+      runId: 'run-new',
+    });
+  });
+
+  it('falls back to the latest legacy marker comment', async () => {
+    const result = await resolveLatestPrd({
+      projectId: projectId('comment-fallback'),
+      workItemId: workItemId(2),
+      loadLegacyComments: async () => [
+        {
+          body: '<!-- factory:prd -->\n# PRD\n\n```json\n{"title":"Old comment PRD"}\n```',
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+        {
+          body: '<!-- factory:prd -->\n# PRD\n\n```json\n{"title":"New comment PRD"}\n```\n\n## Advisor concerns\n- quantify success',
+          createdAt: '2026-05-02T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      prd: { title: 'New comment PRD' },
+      advisorConcerns: '- quantify success',
+      source: 'legacy-comment',
+      runId: null,
+    });
+  });
+
+  it('returns a malformed legacy marker as a parse-error result', async () => {
+    const result = await resolveLatestPrd({
+      projectId: projectId('malformed-comment'),
+      workItemId: workItemId(3),
+      loadLegacyComments: async () => [
+        {
+          body: '<!-- factory:prd -->\n# PRD\n\n```json\nnot-json\n```',
+          createdAt: '2026-05-03T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      prd: null,
+      advisorConcerns: null,
+      source: 'legacy-comment',
+    });
+  });
+});
+
+describe('parseLegacyPrdComment', () => {
+  it('ignores non-marker comments', () => {
+    expect(parseLegacyPrdComment('hello')).toEqual({ prd: null, advisorConcerns: null });
+  });
+});

--- a/core/prd/read-model.ts
+++ b/core/prd/read-model.ts
@@ -1,0 +1,108 @@
+import { eventStore } from '../event-stream/store.js';
+
+const PRD_MARKER = '<!-- factory:prd -->';
+const JSON_FENCE = /```json\s*\n([\s\S]*?)\n```/;
+const ADVISOR_HEADING = /\n##\s+Advisor concerns\s*\n/;
+
+export type LatestPrdSource = 'event' | 'legacy-comment';
+
+export interface LegacyPrdComment {
+  body: string;
+  createdAt: string;
+}
+
+export interface LatestPrdResult {
+  prd: unknown | null;
+  advisorConcerns: string | null;
+  source: LatestPrdSource;
+  createdAt: string;
+  runId: string | null;
+}
+
+export interface ResolveLatestPrdInput {
+  projectId: string;
+  workItemId: string;
+  loadLegacyComments?: () => Promise<ReadonlyArray<LegacyPrdComment>>;
+}
+
+interface PrdDraftedPayload {
+  prd?: unknown;
+  advisorConcerns?: unknown;
+}
+
+function normalizeAdvisorConcerns(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (Array.isArray(value)) {
+    const concerns = value.filter((item): item is string => typeof item === 'string');
+    return concerns.length > 0 ? concerns.map((item) => `- ${item}`).join('\n') : null;
+  }
+  return null;
+}
+
+export function isLegacyPrdMarkerComment(body: string): boolean {
+  return body.startsWith(PRD_MARKER);
+}
+
+export function parseLegacyPrdComment(
+  body: string,
+): Pick<LatestPrdResult, 'prd' | 'advisorConcerns'> {
+  if (!isLegacyPrdMarkerComment(body)) return { prd: null, advisorConcerns: null };
+
+  const fenceMatch = body.match(JSON_FENCE);
+  let prd: unknown | null = null;
+  if (fenceMatch != null) {
+    try {
+      prd = JSON.parse(fenceMatch[1]);
+    } catch {
+      prd = null;
+    }
+  }
+
+  const advisorIdx = body.search(ADVISOR_HEADING);
+  const advisorConcerns =
+    advisorIdx >= 0 ? body.slice(advisorIdx).replace(ADVISOR_HEADING, '').trimEnd() : null;
+
+  return { prd, advisorConcerns };
+}
+
+export async function resolveLatestPrd(
+  input: ResolveLatestPrdInput,
+): Promise<LatestPrdResult | null> {
+  const draftedEvents = eventStore.replay({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    kind: 'prd.drafted',
+  });
+  const latestDrafted = draftedEvents.at(-1);
+  if (latestDrafted != null) {
+    const payload = latestDrafted.payload as PrdDraftedPayload;
+    if (payload.prd != null) {
+      return {
+        prd: payload.prd,
+        advisorConcerns: normalizeAdvisorConcerns(payload.advisorConcerns),
+        source: 'event',
+        createdAt: latestDrafted.createdAt,
+        runId: latestDrafted.runId ?? null,
+      };
+    }
+  }
+
+  if (input.loadLegacyComments == null) return null;
+
+  const comments = await input.loadLegacyComments();
+  const matches = comments.filter((comment) => isLegacyPrdMarkerComment(comment.body));
+  if (matches.length === 0) return null;
+
+  const sorted = [...matches].sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+  const latest = sorted[sorted.length - 1];
+  const parsed = parseLegacyPrdComment(latest.body);
+  return {
+    ...parsed,
+    source: 'legacy-comment',
+    createdAt: latest.createdAt,
+    runId: null,
+  };
+}

--- a/docs/runbooks/prd-storage-read-model-plan.md
+++ b/docs/runbooks/prd-storage-read-model-plan.md
@@ -1,0 +1,232 @@
+# PRD Storage Read Model Plan
+
+## Goal
+
+Stop using the GitHub PRD marker comment as Factory's primary PRD storage.
+The PRD should be a structured Factory artifact/read model, with GitHub comments
+kept only for human visibility and backwards compatibility.
+
+## Current State
+
+`runGrillAndPrdWorkflow` currently writes the complete PRD JSON into a GitHub
+issue comment with the marker `<!-- factory:prd -->`.
+
+That comment is not just a notification:
+
+- The PRD tab fetches issue comments, finds the latest marker comment, and
+  parses the fenced JSON.
+- PRD revision fetches the latest marker comment to recover `priorPrd`.
+- `decompose-prd` fetches the latest marker comment to recover the approved PRD.
+- `prd.drafted` also stores the structured PRD in the local event stream, but
+  most consumers still ignore it as the source of truth.
+
+This makes the system brittle. A malformed, deleted, edited, paginated, or
+out-of-order GitHub comment can break internal workflow behavior even though the
+structured PRD was already produced by Factory.
+
+## Desired Model
+
+Factory should treat the latest structured PRD as local operational state.
+GitHub should remain the lifecycle source of truth for labels and a human-facing
+audit surface, not the database for generated artifacts.
+
+Recommended target:
+
+- Persist PRD drafts in a first-class local table or artifact record.
+- Expose a server endpoint that returns the latest PRD for a work item.
+- Move the PRD tab, revision flow, and decompose flow to that endpoint/read
+  function.
+- Continue posting a GitHub comment, but reduce it to a summary plus a link or
+  compact markdown rendering.
+- Keep marker-comment parsing as a fallback for older work items.
+
+## Slice 1: Centralize Latest-PRD Lookup
+
+Status: completed in `codex/prd-storage-read-model`.
+
+Create one server/core function for resolving the latest PRD for a work item.
+Initial implementation may read from existing sources in this order:
+
+1. Latest local structured `prd.drafted` event payload.
+2. Latest legacy `<!-- factory:prd -->` marker comment.
+
+This slice should not change behavior. It only removes duplicated parsing from
+`PRDSection`, `revisePRD`, and `dispatchDecomposePrd`.
+
+Acceptance criteria:
+
+- One shared latest-PRD resolver exists.
+- It returns `{ prd, advisorConcerns, source, createdAt/runId }`.
+- It prefers structured local event data over comment data.
+- Existing marker-comment PRDs still parse.
+- Unit tests cover event-first, comment fallback, and malformed-comment cases.
+
+## Slice 2: Add A PRD API Read Surface
+
+Status: completed in `codex/prd-storage-read-model`.
+
+Add an issue-scoped endpoint such as:
+
+```text
+GET /projects/:slug/issues/:id/prd
+```
+
+The endpoint should use the centralized resolver and return the parsed PRD
+view model directly. The browser should not fetch all comments just to discover
+the PRD.
+
+Acceptance criteria:
+
+- PRD tab fetches the PRD endpoint instead of comments for PRD content.
+- PRD tab still fetches events only for child issue links and timeline-adjacent
+  details it actually needs.
+- Empty, drafting, parse-error, advisor-notes, approval, request-changes, and
+  declined states still render correctly.
+- Existing PRD comment parser tests are kept for the fallback resolver, not as
+  the primary UI contract.
+
+## Slice 3: Move Revision And Decompose To Structured Lookup
+
+Status: completed in `codex/prd-storage-read-model`.
+
+Update backend workflow actions to use the centralized latest-PRD resolver:
+
+- `revisePRD` should get `priorPrd` from the resolver.
+- `dispatchDecomposePrd` should get the approved PRD from the resolver.
+
+Comment parsing remains as a fallback inside the resolver only.
+
+Acceptance criteria:
+
+- A missing GitHub marker comment no longer blocks decompose when a local
+  `prd.drafted` event exists.
+- Revision works from structured local PRD data.
+- If neither structured data nor a legacy comment exists, behavior still moves
+  to `factory:needs-human` with a clear diagnostic.
+- Tests prove comment deletion does not break revise/decompose when local PRD
+  data exists.
+
+## Slice 4: Persist PRDs As First-Class Artifacts
+
+Status: not started.
+
+Events are append-only telemetry, but PRDs are durable generated artifacts. Add
+a dedicated persistence record so the latest PRD can be queried without
+replaying events.
+
+Two acceptable implementations:
+
+1. A `prd_drafts` table keyed by project/work item/version.
+2. The existing agent artifact mechanism, if it supports durable issue-scoped
+   structured payloads without expiry.
+
+Preferred shape:
+
+- `projectId`
+- `workItemId`
+- `runId`
+- `version`
+- `prd`
+- `advisorConcerns`
+- `sourceCommentUrl` nullable
+- `createdAt`
+
+Acceptance criteria:
+
+- `runGrillAndPrdWorkflow` persists the PRD before moving to
+  `factory:prd-review`.
+- `prd.drafted` remains as timeline telemetry.
+- Latest-PRD resolver reads artifact/table first, then event, then legacy
+  comment.
+- A failed GitHub comment post does not lose the PRD draft if local persistence
+  succeeded.
+
+## Slice 5: Demote The GitHub Comment
+
+Status: not started.
+
+Once the app and workflows read local structured state, change the GitHub
+comment from "full JSON database" to "human-facing publication".
+
+Recommended comment shape:
+
+```md
+<!-- factory:prd-summary -->
+# PRD drafted
+
+Factory drafted a PRD for this issue.
+
+- Title: ...
+- Complexity: ...
+- Acceptance criteria: N
+- Vertical slices: N
+
+Review in Goose Hub: ...
+```
+
+Keep posting the legacy full JSON marker only behind a temporary compatibility
+flag if needed for existing workflows.
+
+Acceptance criteria:
+
+- New PRDs no longer need a full JSON fence in GitHub comments.
+- Existing legacy PRD marker comments still render through fallback.
+- Timeline/comment surfaces do not become noisy with giant generated payloads.
+- There is a clear operator diagnostic when comment publication fails but local
+  PRD persistence succeeds.
+
+## Slice 6: Cleanup And Guardrails
+
+Status: not started.
+
+Remove direct PRD marker-comment parsing from UI and workflow code after all
+callers use the resolver.
+
+Acceptance criteria:
+
+- `<!-- factory:prd -->` parsing is isolated to a legacy fallback module.
+- Tests fail if a new primary caller reads PRD JSON directly from issue
+  comments.
+- Documentation for PRD review and revision states the source of truth is the
+  local PRD artifact/read model.
+- ADR 0033 is amended or superseded if the persistence model changes the PRD
+  revision contract materially.
+
+## Verification Plan
+
+Run focused unit and integration coverage:
+
+```sh
+pnpm vitest apps/web/src/components/detail/components/PRDSection.test.tsx
+pnpm vitest apps/web/src/components/detail/lib/parse-prd-comment.test.ts
+pnpm vitest apps/server/src/domains/issues/prd-actions.test.ts
+pnpm vitest slices/grill-and-prd/slice.test.ts
+pnpm vitest slices/decompose-prd/slice.test.ts
+```
+
+Add one end-to-end recovery case:
+
+- Draft PRD.
+- Delete or hide the GitHub marker comment in the test source.
+- Confirm PRD tab still renders.
+- Approve PRD.
+- Confirm decompose runs from local structured PRD data.
+
+## Non-Goals
+
+- Do not change the PRD schema.
+- Do not add direct manual PRD editing.
+- Do not move issue lifecycle authority out of GitHub labels.
+- Do not remove legacy comment fallback until existing work items have either
+  been migrated or are known safe to abandon.
+
+## Recommended Order
+
+Implement slices 1-3 first. That gives the practical robustness win without a
+schema migration.
+
+Then implement slice 4 if replaying events proves awkward or if PRDs need
+version history, search, export, or audit metadata beyond timeline display.
+
+Only demote the GitHub comment after every internal consumer has moved off the
+comment parser.


### PR DESCRIPTION
## Summary
- add a centralized latest-PRD resolver that prefers local prd.drafted events and falls back to legacy PRD marker comments
- add GET /projects/:slug/issues/:id/prd and update the PRD tab to use it instead of fetching comments
- move PRD revision and decompose dispatch to the shared resolver

## Verification
- pnpm install --offline
- pnpm exec biome check core/prd/read-model.ts core/prd/read-model.test.ts apps/server/README.md apps/server/src/domains/issues/service.ts apps/server/src/domains/issues/router.ts apps/server/src/domains/issues/router.test.ts apps/server/src/domains/issues/prd-actions.ts apps/server/src/domains/issues/prd-actions.test.ts apps/server/src/shared/dispatch-discover.ts apps/server/src/shared/dispatch.test.ts apps/web/src/lib/types.ts apps/web/src/lib/api/issues.ts apps/web/src/components/detail/components/PRDSection.tsx apps/web/src/components/detail/components/PRDSection.test.tsx docs/runbooks/prd-storage-read-model-plan.md
- pnpm exec vitest run core/prd/read-model.test.ts apps/web/src/components/detail/components/PRDSection.test.tsx apps/web/src/components/detail/lib/parse-prd-comment.test.ts apps/server/src/domains/issues/prd-actions.test.ts apps/server/src/domains/issues/router.test.ts apps/server/src/shared/dispatch.test.ts slices/grill-and-prd/slice.test.ts slices/decompose-prd/slice.test.ts