### PR TITLE
M19.XX: The items in the kanbna lanes order is wrong

### DIFF
--- a/apps/web/src/components/board/lib/all-projects.test.ts
+++ b/apps/web/src/components/board/lib/all-projects.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { LANES } from '@/lib/lanes.config';
+
+import { groupAllProjectsItems, type WorkItemWithProject } from './all-projects';
+
+function makeItem(overrides: Partial<WorkItemWithProject> = {}): WorkItemWithProject {
+  return {
+    id: 'github:org/repo#1',
+    externalId: '1',
+    repoRef: 'org/repo',
+    title: 'Test',
+    body: '',
+    type: 'bug',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:triaging',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date().toISOString(),
+    projectSlug: 'proj-a',
+    projectColor: '#f00',
+    ...overrides,
+  };
+}
+
+describe('groupAllProjectsItems', () => {
+  it('keeps same-priority lane items newest-first in /projects/all', () => {
+    const items: WorkItemWithProject[] = [
+      makeItem({ externalId: '10', priority: 'medium', state: 'factory:triaging' }),
+      makeItem({ externalId: '30', priority: 'medium', state: 'factory:triaging' }),
+      makeItem({ externalId: '20', priority: 'medium', state: 'factory:triaging' }),
+    ];
+
+    const map = groupAllProjectsItems(items, LANES);
+
+    expect(map.get('triage')?.map((item) => item.externalId)).toEqual(['30', '20', '10']);
+  });
+});

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,7 +23,7 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts by priority then newest issue number first', () => {
     const sorted = sortLaneItems([
       { externalId: '40', priority: 'medium' },
       { externalId: '12', priority: 'low' },
@@ -31,7 +31,7 @@ describe('lanes config', () => {
       { externalId: '99', priority: 'critical' },
       { externalId: '5', priority: 'high' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '5', '40', '12']);
   });
 
   it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
@@ -47,13 +47,13 @@ describe('lanes config', () => {
     expect(sorted[2].externalId).toBe('2');
   });
 
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
+  it('sortLaneItems stable-sorts items with the same priority by newest externalId first', () => {
     const sorted = sortLaneItems([
       { externalId: '30', priority: 'medium' },
       { externalId: '10', priority: 'medium' },
       { externalId: '20', priority: 'medium' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['30', '20', '10']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -124,13 +124,13 @@ interface SortableItem {
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Order matches the board contract: priority rank first, then newest issue
+ * number first within the same priority.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
     const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
     if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    return Number(b.externalId) - Number(a.externalId);
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanbna lanes order is wrong

## Work Packages

- ✓ **WP1**: Update `apps/web/src/lib/lanes.config.ts:121` and `apps/web/src/lib/lanes.config.ts:130` so the shared sorter keeps the 
- ✓ **WP2**: Update the existing sorter assertions in `apps/web/src/lib/lanes.config.test.ts:26` and `apps/web/src/lib/lanes.config.t

Closes #925
