### PR TITLE
M7.XX: The items in the kanban lanes order is wrong 2

### DIFF
--- a/apps/web/e2e/issue-927.spec.ts
+++ b/apps/web/e2e/issue-927.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from '@playwright/test';
+
+test('Kanban board lanes show newest issues first', async ({ page }) => {
+  await page.route('**/api/projects/goose-hub-self/active-milestone', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ milestoneNumber: null, source: 'test' }),
+    }),
+  );
+
+  await page.route('**/api/projects/goose-hub-self/milestones', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ milestones: [] }),
+    }),
+  );
+
+  await page.route('**/api/projects/goose-hub-self/issues', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'github:goose-hub-self#101',
+            externalId: '101',
+            repoRef: 'goose-hub-self',
+            title: 'Oldest item',
+            body: 'Test body',
+            type: 'bug',
+            priority: 'medium',
+            mode: 'supervised',
+            state: 'factory:in-progress',
+            authorIsOwner: true,
+            schedule: 'current',
+            exec: 'serial',
+            dependsOn: [],
+            blocks: [],
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'github:goose-hub-self#103',
+            externalId: '103',
+            repoRef: 'goose-hub-self',
+            title: 'Middle item',
+            body: 'Test body',
+            type: 'bug',
+            priority: 'high',
+            mode: 'supervised',
+            state: 'factory:in-progress',
+            authorIsOwner: true,
+            schedule: 'current',
+            exec: 'serial',
+            dependsOn: [],
+            blocks: [],
+            createdAt: '2024-01-03T00:00:00.000Z',
+          },
+          {
+            id: 'github:goose-hub-self#102',
+            externalId: '102',
+            repoRef: 'goose-hub-self',
+            title: 'Newest item',
+            body: 'Test body',
+            type: 'bug',
+            priority: 'low',
+            mode: 'supervised',
+            state: 'factory:in-progress',
+            authorIsOwner: true,
+            schedule: 'current',
+            exec: 'serial',
+            dependsOn: [],
+            blocks: [],
+            createdAt: '2024-01-04T00:00:00.000Z',
+          },
+        ],
+      }),
+    }),
+  );
+
+  await page.route('**/api/projects/goose-hub-self/issues/*/costs', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        workItemId: 'github:goose-hub-self#101',
+        totalUsd: 0,
+        hasEstimated: false,
+        rows: [],
+      }),
+    }),
+  );
+
+  await page.route('**/api/projects/goose-hub-self/costs/summary', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        projectId: 'goose-hub-self',
+        dailyTokensUsed: 0,
+        dailyTokensLimit: 0,
+        dailyCostUsd: 0,
+        dailyBudgetExceeded: false,
+        resetsAtUtc: '2024-01-01T00:00:00.000Z',
+        lastExceededAt: null,
+        windows: {
+          week: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+          month: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+        },
+        byStage: [],
+        byProvider: {
+          claude: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+          codex: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+        },
+        symbolIndex: {
+          lookupCount: 0,
+          averageIdentifiersPerLookup: 0,
+          averageHintsPerLookup: 0,
+          staleRate: 0,
+          hintsUsedEventCount: 0,
+          usedHintCount: 0,
+          hintsByConsumerSkill: {},
+        },
+      }),
+    }),
+  );
+
+  await page.route('**/api/roster/names', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ names: [] }),
+    }),
+  );
+
+  await page.route('**/events*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: '',
+    }),
+  );
+
+  await page.goto('/projects/goose-hub-self');
+
+  const lane = page.locator('[data-testid="lane-dev"]');
+  await expect(lane).toBeVisible();
+
+  const cards = lane.locator('[data-testid="issue-card"]');
+  await expect(cards).toHaveCount(3);
+  await expect(cards.nth(0)).toHaveAttribute('data-issue-number', '102');
+  await expect(cards.nth(1)).toHaveAttribute('data-issue-number', '103');
+  await expect(cards.nth(2)).toHaveAttribute('data-issue-number', '101');
+
+  await page.screenshot({ path: 'evidence/issue-927/kanban-newest-first.png' });
+});

--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -8,15 +8,15 @@ import type { WorkItemWithProject } from './lib/all-projects';
 // Here we lock the sort/ordering rule and grouping logic.
 
 describe('issue card lane ordering', () => {
-  it('orders by priority desc, then issue number asc', () => {
+  it('orders newest items first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      { externalId: '40', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '12', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '7', createdAt: '2024-01-04T00:00:00.000Z' },
+      { externalId: '99', createdAt: '2024-01-05T00:00:00.000Z' },
+      { externalId: '5', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '12', '5', '40']);
   });
 });
 

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,37 +23,24 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts newest items first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      { externalId: '40', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '12', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '7', createdAt: '2024-01-04T00:00:00.000Z' },
+      { externalId: '99', createdAt: '2024-01-05T00:00:00.000Z' },
+      { externalId: '5', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '12', '5', '40']);
   });
 
-  it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
-    // Line 126: the ?? 9 fallback branch — items with unknown priority rank last
+  it('sortLaneItems uses descending issue number as the tie-break', () => {
     const sorted = sortLaneItems([
-      { externalId: '1', priority: 'high' },
-      { externalId: '2', priority: 'unknown-future-priority' },
-      { externalId: '3', priority: 'critical' },
+      { externalId: '30', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '10', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '20', createdAt: '2024-01-01T00:00:00.000Z' },
     ]);
-    // critical(0) < high(1) < unknown(9)
-    expect(sorted[0].externalId).toBe('3');
-    expect(sorted[1].externalId).toBe('1');
-    expect(sorted[2].externalId).toBe('2');
-  });
-
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
-    const sorted = sortLaneItems([
-      { externalId: '30', priority: 'medium' },
-      { externalId: '10', priority: 'medium' },
-      { externalId: '20', priority: 'medium' },
-    ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['30', '20', '10']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -111,26 +111,19 @@ export function laneForState(state: string): string | undefined {
   return STATE_TO_LANE.get(state);
 }
 
-const PRIORITY_RANK: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-};
-
 interface SortableItem {
   externalId: string;
-  priority: string;
+  createdAt: string;
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Order lanes newest-first so the most recently created item appears at the top.
+ * Ties fall back to descending issue number to keep the result deterministic.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
-    const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
-    if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    const createdDiff = Date.parse(b.createdAt) - Date.parse(a.createdAt);
+    if (createdDiff !== 0) return createdDiff;
+    return Number(b.externalId) - Number(a.externalId);
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanban lanes order is wrong 2

## Files
- `apps/web/src/components/board/slice.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.ts` — observed modified change
- `apps/web/e2e/issue-927.spec.ts` — observed untracked change

## Tests
- `apps/web/src/lib/lanes.config.test.ts` (2 cases)
- `apps/web/src/components/board/slice.test.ts` (1 cases)
- `apps/web/e2e/issue-927.spec.ts` (1 cases)

Closes #927
