### PR TITLE
Fix write-prd response schema optional fields

### DIFF
--- a/core/agent-runtime/schema-bridge.test.ts
+++ b/core/agent-runtime/schema-bridge.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ImplementSchema } from '../../skills/implement/schema.js';
 import { InterventionProposerOutputSchema } from '../../skills/intervention-proposer/schema.js';
 import { ReviewOutputSchema } from '../../skills/review/schema.js';
+import { PRDOutputSchema } from '../../skills/write-prd/schema.js';
 import { toJsonSchema } from './schema-bridge.js';
 
 describe('toJsonSchema', () => {
@@ -20,7 +21,7 @@ describe('toJsonSchema', () => {
     });
   });
 
-  it('removes optional properties from the runtime schema', () => {
+  it('preserves optional object properties without marking them required', () => {
     const schema = z.object({
       decisionSummaries: z.array(
         z.object({
@@ -36,7 +37,7 @@ describe('toJsonSchema', () => {
     const field = decisionSummaries.decisionSummaries as { items?: unknown };
     const item = field.items as { properties?: Record<string, unknown>; required?: string[] };
 
-    expect(item.properties).not.toHaveProperty('evidence');
+    expect(item.properties).toHaveProperty('evidence');
     expect(item.required).toEqual(['kind', 'summary']);
   });
 
@@ -76,6 +77,47 @@ describe('toJsonSchema', () => {
 
     expect(result).not.toContain('"format":"uri"');
     expect(result).not.toContain('"format": "uri"');
+  });
+
+  it('preserves optional PRD output fields needed by write-prd validation', () => {
+    const result = toJsonSchema(PRDOutputSchema);
+    const properties = result.properties as Record<string, unknown>;
+
+    const acceptanceCriteria = properties.acceptanceCriteria as { items?: unknown };
+    const acceptanceCriterion = acceptanceCriteria.items as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+      additionalProperties?: boolean;
+    };
+
+    expect(Object.keys(acceptanceCriterion.properties ?? {})).toEqual([
+      'id',
+      'statement',
+      'journeyId',
+      'stepIdx',
+      'crossCutting',
+      'verifyCommand',
+    ]);
+    expect(acceptanceCriterion.required).toEqual(['id', 'statement']);
+    expect(acceptanceCriterion.additionalProperties).toBe(false);
+
+    const implementationDecisions = properties.implementationDecisions as { items?: unknown };
+    const implementationDecision = implementationDecisions.items as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(implementationDecision.properties).toHaveProperty('rationale');
+    expect(implementationDecision.properties).toHaveProperty('moduleRef');
+    expect(implementationDecision.required).toEqual(['decision']);
+
+    const testingDecisions = properties.testingDecisions as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(testingDecisions.properties).toHaveProperty('priorArt');
+    expect(testingDecisions.required).toEqual(['approach', 'modulesToTest']);
   });
 
   it('keeps intervention proposer output schema acceptable for Codex response schemas', () => {

--- a/core/agent-runtime/schema-bridge.ts
+++ b/core/agent-runtime/schema-bridge.ts
@@ -111,14 +111,14 @@ function sanitizeSchemaNode(value: unknown): unknown {
     const required = new Set(
       Array.isArray(next.required) ? next.required.filter((key) => typeof key === 'string') : [],
     );
-    const strictProperties: Record<string, unknown> = {};
+    const requiredProperties: string[] = [];
 
-    for (const [key, child] of Object.entries(properties)) {
-      if (required.has(key)) strictProperties[key] = child;
+    for (const key of Object.keys(properties)) {
+      if (required.has(key)) requiredProperties.push(key);
     }
 
-    next.properties = strictProperties;
-    next.required = Object.keys(strictProperties);
+    next.properties = properties;
+    next.required = requiredProperties;
     next.additionalProperties = false;
   }
 

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -626,7 +626,14 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: prdRunId,
-      payload: { skill: 'write-prd', workflowRunId, error: prdDraftOutcome.error },
+      payload: {
+        skill: 'write-prd',
+        workflowRunId,
+        error: prdDraftOutcome.error,
+        ...(prdDraftOutcome.status === 'invalid' && prdDraftOutcome.issues != null
+          ? { issues: prdDraftOutcome.issues }
+          : {}),
+      },
     });
     return { phase: 'needs-human' };
   }

--- a/core/workflows/grill-and-prd/grill-and-prd.test.ts
+++ b/core/workflows/grill-and-prd/grill-and-prd.test.ts
@@ -459,6 +459,32 @@ describe('runPrdDraft', () => {
     expect(result.status).toBe('invalid');
   });
 
+  it('preserves formatted output validation issues', async () => {
+    mockInvokeSkill.mockRejectedValueOnce(
+      new OutputValidationError(
+        [
+          {
+            path: ['acceptanceCriteria', 0],
+            message:
+              'acceptanceCriteria[0] has no journeyId and is not marked crossCutting:true',
+          },
+        ],
+        'write-prd',
+        'run-prd-1',
+      ),
+    );
+
+    const result = await runPrdDraft(baseInput());
+
+    expect(result.status).toBe('invalid');
+    if (result.status === 'invalid') {
+      expect(result.error).toBe("invokeSkill: output validation failed for 'write-prd'");
+      expect(result.issues).toEqual([
+        'acceptanceCriteria.0: acceptanceCriteria[0] has no journeyId and is not marked crossCutting:true',
+      ]);
+    }
+  });
+
   it('returns failed on runtime error', async () => {
     mockInvokeSkill.mockRejectedValueOnce(new Error('timeout'));
 

--- a/core/workflows/grill-and-prd/prd-draft.ts
+++ b/core/workflows/grill-and-prd/prd-draft.ts
@@ -8,8 +8,20 @@ import type { ProjectContextBundle } from '../grill-and-prd.js';
 
 export type PrdDraftOutcome =
   | { status: 'ok'; prdOutput: PRDOutput }
-  | { status: 'invalid'; error: string }
+  | { status: 'invalid'; error: string; issues?: string[] }
   | { status: 'failed'; error: string };
+
+type OutputValidationIssue = {
+  path: Array<string | number>;
+  message: string;
+};
+
+function formatOutputValidationIssues(error: OutputValidationError): string[] {
+  return error.issues.flatMap((issue: OutputValidationIssue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    return `${path}: ${issue.message}`;
+  });
+}
 
 export interface RunPrdDraftInput {
   workItem: { id: string; title: string; body: string; externalId: string; priority: Priority };
@@ -68,7 +80,7 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
     });
   } catch (err) {
     if (err instanceof OutputValidationError) {
-      return { status: 'invalid', error: err.message };
+      return { status: 'invalid', error: err.message, issues: formatOutputValidationIssues(err) };
     }
     return { status: 'failed', error: String(err) };
   }

--- a/skills/write-prd/prompt.md
+++ b/skills/write-prd/prompt.md
@@ -102,6 +102,15 @@ Mid-run, also emit live `[decision] KIND: <one sentence>` markers.
 
 Return a single JSON object conforming to `PRDOutputSchema`. Free-text-only output fails the run. Your entire response must be valid JSON — no prose, no preamble, no explanation outside the object. Every required field must be present, `journeys[]` and `verticalSlices[]` must each have at least one entry, and every AC must satisfy the cross-reference rule above.
 
+Acceptance-criteria output contract:
+
+- Every non-cross-cutting AC must include `journeyId`.
+- `journeyId` must match one of the emitted `journeys[].id` values.
+- Cross-cutting ACs must include `crossCutting: true`.
+- Do not emit ACs with only `id` and `statement`.
+
+Invalid example in prose: an acceptance criterion shaped only like `{ id, statement }` fails because it has neither `journeyId` nor `crossCutting: true`.
+
 Exact field names (use these verbatim):
 
 <!-- output-example -->

--- a/skills/write-prd/slice.test.ts
+++ b/skills/write-prd/slice.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toJSONSchema } from 'zod';
+import { toJsonSchema } from '../../core/agent-runtime/schema-bridge.js';
 import { PRDOutputSchema } from './schema.js';
 import config, { WritePRDContextSchema } from './skill.config.js';
 
@@ -211,6 +212,30 @@ describe('PRD schema', () => {
     expect(typeof jsonSchema).toBe('object');
     expect(jsonSchema).not.toBeNull();
     expect(jsonSchema).toHaveProperty('properties');
+  });
+
+  it('generated Codex response schema allows AC cross-reference fields', () => {
+    if (config.outputSchema == null) throw new Error('write-prd outputSchema is required');
+
+    const jsonSchema = toJsonSchema(config.outputSchema);
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    const acceptanceCriteria = properties.acceptanceCriteria as { items?: unknown };
+    const acceptanceCriterion = acceptanceCriteria.items as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+      additionalProperties?: boolean;
+    };
+
+    expect(acceptanceCriterion.properties).toMatchObject({
+      id: expect.any(Object),
+      statement: expect.any(Object),
+      journeyId: expect.any(Object),
+      crossCutting: expect.any(Object),
+      stepIdx: expect.any(Object),
+      verifyCommand: expect.any(Object),
+    });
+    expect(acceptanceCriterion.required).toEqual(['id', 'statement']);
+    expect(acceptanceCriterion.additionalProperties).toBe(false);
   });
 });
 

--- a/slices/grill-and-prd/slice.test.ts
+++ b/slices/grill-and-prd/slice.test.ts
@@ -1325,6 +1325,81 @@ describe('skipGrill mode — retry write-prd directly', () => {
     expect(callArgs.skill).toBe('write-prd');
   });
 
+  it('includes output validation issues on write-prd run failure events', async () => {
+    const projectId = uniqueProjectId('skip-grill-invalid-prd');
+    const source = new InMemoryLabelsSource(projectId, REPO_REF);
+    const item = await source.seedIssue({
+      title: 'Retry PRD',
+      body: 'Some feature request.',
+      type: 'feature',
+      priority: 'medium',
+      state: 'factory:prd-drafting',
+    });
+    const workItem = await source.getItem(item.externalId);
+
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'grill.completed',
+      payload: { refinedIntent: 'Retry PRD with recovered intent', rounds: 2 },
+    });
+
+    const prdOutput = validPRD({
+      acceptanceCriteria: [
+        {
+          id: 'AC-1',
+          statement: 'This AC is missing its journey link.',
+        },
+      ] as unknown as ReturnType<typeof basePRD>['acceptanceCriteria'],
+    });
+    const runtime = makeQueuedRuntime([prdOutput]);
+
+    const result = await runGrillAndPrdWorkflow({
+      workItem,
+      stateSource: source,
+      projectId,
+      priorReplies: [],
+      skipGrill: true,
+      deps: {
+        runtime,
+        projectConfig: null,
+        totalSpendForSkill: () => 0,
+        buildContext: async () => ({
+          stackSummary: '',
+          contextMd: '',
+          adrSummaries: [],
+          claudeMd: '',
+        }),
+        createWorktreeImpl: () => {
+          throw new Error('should not create worktree in skipGrill mode');
+        },
+        cleanupWorktreeImpl: () => {
+          throw new Error('should not clean worktree in skipGrill mode');
+        },
+      },
+    });
+
+    expect(result.phase).toBe('needs-human');
+
+    const evs = eventStore.replay({ projectId, workItemId: workItem.id });
+    const failed = evs.find(
+      (e) =>
+        e.kind === 'agent.run-failed' &&
+        (e.payload as { skill?: string }).skill === 'write-prd',
+    );
+
+    expect(failed).toBeDefined();
+    expect(failed?.payload).toMatchObject({
+      skill: 'write-prd',
+      error: "invokeSkill: output validation failed for 'write-prd'",
+      issues: [
+        expect.stringContaining(
+          'acceptanceCriteria.0: acceptanceCriteria[0] (id="AC-1") has no journeyId',
+        ),
+      ],
+    });
+  });
+
   it('uses refinedIntent from grill.completed event when skipGrill:true', async () => {
     const projectId = uniqueProjectId('skip-grill-intent');
     const source = new InMemoryLabelsSource(projectId, REPO_REF);


### PR DESCRIPTION
## Summary
- Preserve optional object properties in Codex response schemas without marking them required
- Add PRD schema bridge and write-prd contract regressions for AC cross-reference fields
- Surface formatted write-prd output validation issues on agent.run-failed events
- Clarify the write-prd prompt acceptance-criteria output contract

## Verification
- pnpm test core/agent-runtime/schema-bridge.test.ts skills/write-prd/slice.test.ts core/workflows/grill-and-prd/grill-and-prd.test.ts slices/grill-and-prd/slice.test.ts
- pnpm skill-contract:audit
- git diff --check