### PR TITLE
Fix partial investigation timeline grouping

### DIFF
--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -13,7 +13,7 @@ import { renderTimelineItem } from './TimelineEvents';
 
 export type { RenderItem } from '../lib/timeline';
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 200;
 
 interface TimelineSectionProps {
   projectSlug: string;

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -196,7 +196,7 @@ describe('groupEvents — investigation runs', () => {
     }
   });
 
-  it('leaves orphan scout runs flat when no parent investigation run exists', () => {
+  it('infers an investigation phase from scout child run ids', () => {
     const events: AgentEventDto[] = [
       makeEvent(1, 'agent.run-started', 'run-missing:scout:pattern:0', {
         payload: { skill: 'scout-pattern' },
@@ -206,8 +206,62 @@ describe('groupEvents — investigation runs', () => {
 
     const items = groupEvents(events);
 
-    expect(items.some((item) => item.kind === 'investigation-phase')).toBe(false);
-    expect(items[0]?.kind).toBe('run-group');
+    const phase = items[0];
+    expect(phase?.kind).toBe('investigation-phase');
+    if (phase?.kind === 'investigation-phase') {
+      expect(phase.investigationRunId).toBe('run-missing');
+      expect(
+        phase.items.some(
+          (item) => item.kind === 'run-group' && item.runId === 'run-missing:scout:pattern:0',
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('infers a live investigation phase from a partial swarm window', () => {
+    const parentRunId = 'run-investigate-partial';
+    const wave2RiskRunId = `${parentRunId}:scout:wave2-risk-analyst:1`;
+    const wave2UxRunId = `${parentRunId}:scout:wave2-ux-scout:2`;
+    const events: AgentEventDto[] = [
+      makeEvent(1, 'swarm.heartbeat', parentRunId, {
+        payload: { parentRunId, wave: 2, activeScouts: [wave2RiskRunId, wave2UxRunId] },
+      }),
+      makeEvent(2, 'swarm.wave-completed', parentRunId, {
+        payload: { parentRunId, wave: 1, completedScouts: ['scout-pattern'] },
+      }),
+      makeEvent(3, 'agent.run-started', wave2RiskRunId, {
+        payload: { skill: 'wave2-risk-analyst' },
+      }),
+      makeEvent(4, 'swarm.heartbeat', wave2RiskRunId, {
+        payload: { parentRunId, wave: 2, scoutName: 'wave2-risk-analyst' },
+      }),
+      makeEvent(5, 'agent.run-started', wave2UxRunId, {
+        payload: { skill: 'wave2-ux-scout' },
+      }),
+      makeEvent(6, 'swarm.heartbeat', wave2UxRunId, {
+        payload: { parentRunId, wave: 2, scoutName: 'wave2-ux-scout' },
+      }),
+    ];
+
+    const items = groupEvents(events);
+    const phases = items.filter((item) => item.kind === 'investigation-phase');
+
+    expect(phases).toHaveLength(1);
+    const phase = phases[0];
+    expect(phase.kind).toBe('investigation-phase');
+    if (phase.kind === 'investigation-phase') {
+      expect(phase.investigationRunId).toBe(parentRunId);
+      expect(phase.status).toBe('live');
+      const childRunIds = phase.items
+        .filter((item) => item.kind === 'run-group')
+        .map((item) => (item.kind === 'run-group' ? item.runId : null));
+      expect(childRunIds).toEqual(expect.arrayContaining([wave2RiskRunId, wave2UxRunId]));
+    }
+    expect(
+      items.some(
+        (item) => item.kind === 'run-group' && item.runId === parentRunId && item.skill == null,
+      ),
+    ).toBe(false);
   });
 
   it('marks an investigation phase as started before child runs appear', () => {

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -598,11 +598,33 @@ function getInvestigationChildParentRunId(item: RenderItem): string | null {
   return runId.slice(0, markerIndex);
 }
 
+function getInvestigationPayloadParentRunIds(item: RenderItem): string[] {
+  const parentRunIds = new Set<string>();
+  for (const event of eventFromRenderItem(item)) {
+    if (!event.kind.startsWith('swarm.')) continue;
+    const payload = event.payload as { parentRunId?: unknown } | null;
+    if (typeof payload?.parentRunId === 'string' && payload.parentRunId.trim() !== '') {
+      parentRunIds.add(payload.parentRunId);
+    }
+  }
+  return [...parentRunIds];
+}
+
 function isInvestigationParentItem(item: RenderItem): boolean {
   if (item.kind === 'run-group') return item.skill === 'investigate';
   if (item.kind !== 'event') return false;
   const payload = item.event.payload as { skill?: string } | null;
-  return item.event.kind === 'agent.run-started' && payload?.skill === 'investigate';
+  return (
+    (item.event.kind === 'agent.run-started' && payload?.skill === 'investigate') ||
+    item.event.kind === 'agent.investigation-complete'
+  );
+}
+
+function withInvestigationParentSkill(item: RenderItem, investigationRunId: string): RenderItem {
+  if (item.kind === 'run-group' && item.runId === investigationRunId && item.skill == null) {
+    return { ...item, skill: 'investigate' };
+  }
+  return item;
 }
 
 function eventFromRenderItem(item: RenderItem): AgentEventDto[] {
@@ -740,6 +762,13 @@ export function groupByInvestigationPhase(items: RenderItem[]): RenderItem[] {
     if (runId != null && isInvestigationParentItem(item)) {
       parentRunIds.add(runId);
     }
+    const childParentRunId = getInvestigationChildParentRunId(item);
+    if (childParentRunId != null) {
+      parentRunIds.add(childParentRunId);
+    }
+    for (const payloadParentRunId of getInvestigationPayloadParentRunIds(item)) {
+      parentRunIds.add(payloadParentRunId);
+    }
   }
   if (parentRunIds.size === 0) return items;
 
@@ -757,10 +786,16 @@ export function groupByInvestigationPhase(items: RenderItem[]): RenderItem[] {
       if (parentRunId != null && parentRunIds.has(parentRunId)) {
         phaseRunId = parentRunId;
       }
+      for (const payloadParentRunId of getInvestigationPayloadParentRunIds(item)) {
+        if (parentRunIds.has(payloadParentRunId)) {
+          phaseRunId = payloadParentRunId;
+          break;
+        }
+      }
     }
 
     if (phaseRunId != null) {
-      phaseItems.get(phaseRunId)?.push(item);
+      phaseItems.get(phaseRunId)?.push(withInvestigationParentSkill(item, phaseRunId));
     } else {
       ungrouped.push(item);
     }

--- a/apps/web/src/lib/api/issues.ts
+++ b/apps/web/src/lib/api/issues.ts
@@ -96,7 +96,7 @@ export async function fetchEventsPage(
   opts?: { limit?: number; before?: number },
   signal?: AbortSignal,
 ): Promise<{ events: AgentEventDto[]; hasMore: boolean }> {
-  const params = new URLSearchParams({ limit: String(opts?.limit ?? 100) });
+  const params = new URLSearchParams({ limit: String(opts?.limit ?? 200) });
   if (opts?.before != null) params.set('before', String(opts.before));
   return getJson<{ events: AgentEventDto[]; hasMore: boolean }>(
     `/projects/${slug}/issues/${id}/events?${params}`,


### PR DESCRIPTION
Summary:
- infer investigation phases from scout child run IDs and swarm parentRunId payloads when the parent run-started event is outside the loaded timeline window
- prevent inferred parent swarm groups from rendering as unknown top-level runs
- increase frontend timeline event pagination to 200

Verification:
- pnpm vitest run apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx