### PR TITLE
Group convergent review timeline runs

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -88,9 +88,11 @@ import {
 import { RetroCompletedEvent } from './timeline/RetroCompletedEvent';
 import { AgentRetryEscalatedEvent } from './timeline/RetryEvents';
 import { ReviewCompletedEvent } from './timeline/ReviewCompletedEvent';
+import { ReviewGroupWrapper } from './timeline/ReviewGroupWrapper';
 import {
   ReviewConvergedEvent,
   ReviewEscalatedEvent,
+  ReviewSlotCompletedEvent,
   ReviewWaveCompletedEvent,
   ReviewWaveFailedEvent,
 } from './timeline/ReviewWaveEvents';
@@ -161,6 +163,21 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       <InvestigationPhaseWrapper
         key={`investigation-phase-${item.investigationRunId}`}
         investigationRunId={item.investigationRunId}
+        items={item.items}
+        status={item.status}
+        startedAt={item.startedAt}
+        endedAt={item.endedAt}
+        lastEventAt={item.lastEventAt}
+        context={context}
+        renderItem={renderTimelineItem}
+      />
+    );
+  }
+  if (item.kind === 'review-group') {
+    return (
+      <ReviewGroupWrapper
+        key={`review-group-${item.reviewWorkflowRunId}`}
+        reviewWorkflowRunId={item.reviewWorkflowRunId}
         items={item.items}
         status={item.status}
         startedAt={item.startedAt}
@@ -259,6 +276,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <ReviewConvergedEvent key={event.id} event={event} />;
     case 'review.escalated':
       return <ReviewEscalatedEvent key={event.id} event={event} />;
+    case 'review.slot-completed':
+      return <ReviewSlotCompletedEvent key={event.id} event={event} />;
     case 'retrospective.completed':
       return <RetroCompletedEvent key={event.id} event={event} />;
     case 'pr.merged':

--- a/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
@@ -1,0 +1,49 @@
+import type { AgentEventDto } from '@/lib/types';
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { RenderItem } from '../../lib/timeline';
+import { ReviewGroupWrapper } from './ReviewGroupWrapper';
+
+afterEach(cleanup);
+
+function makeEvent(kind: string, payload: unknown = {}): AgentEventDto {
+  return {
+    id: 1,
+    kind,
+    payload,
+    createdAt: '2026-05-21T01:54:44Z',
+    workItemId: 'github:shaunnez/goose-hub#800',
+    projectId: 'goose-hub-self',
+  } as AgentEventDto;
+}
+
+describe('ReviewGroupWrapper', () => {
+  it('labels the parent as Review Run and shows terminal completion status', () => {
+    const item: RenderItem = {
+      kind: 'event',
+      event: makeEvent('review.completed', {
+        reviewWorkflowRunId: 'review-workflow-123',
+        verdict: 'approved',
+      }),
+    };
+
+    render(
+      <ul>
+        <ReviewGroupWrapper
+          reviewWorkflowRunId="review-workflow-123"
+          items={[item]}
+          status="completed"
+          startedAt="2026-05-21T01:54:44Z"
+          endedAt="2026-05-21T01:55:44Z"
+          lastEventAt="2026-05-21T01:55:44Z"
+          renderItem={(child, idx) => <li key={`${child.kind}-${idx}`}>review child</li>}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Review Run')).toBeTruthy();
+    expect(screen.getByText('Complete')).toBeTruthy();
+    expect(screen.queryByText('(Unknown) Run')).toBeNull();
+  });
+});

--- a/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.tsx
@@ -1,0 +1,128 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import type { RenderItem, TimelineContext } from '../../lib/timeline';
+import { formatDuration } from '../../lib/timeline';
+
+const STALL_MS = 15 * 60 * 1000;
+
+export function ReviewGroupWrapper({
+  reviewWorkflowRunId,
+  items,
+  status,
+  startedAt,
+  endedAt,
+  lastEventAt,
+  context,
+  renderItem,
+}: {
+  reviewWorkflowRunId: string;
+  items: RenderItem[];
+  status: 'live' | 'completed' | 'needs-human' | 'failed';
+  startedAt: string | null;
+  endedAt: string | null;
+  lastEventAt: string | null;
+  context?: TimelineContext;
+  renderItem: (item: RenderItem, idx: number, context?: TimelineContext) => React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const isActive = status === 'live';
+
+  useEffect(() => {
+    if (!isActive) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isActive]);
+
+  const expandTick = context?.expandSignal?.tick ?? 0;
+  const expandOpen = context?.expandSignal?.open ?? true;
+  useEffect(() => {
+    if (expandTick === 0) return;
+    setOpen(expandOpen);
+  }, [expandTick, expandOpen]);
+
+  const startMs = startedAt != null ? new Date(startedAt).getTime() : null;
+  const endMs = endedAt != null ? new Date(endedAt).getTime() : null;
+  const lastMs = lastEventAt != null ? new Date(lastEventAt).getTime() : null;
+  const isStalled = isActive && lastMs != null && now - lastMs > STALL_MS;
+  const activeDuration = startMs != null ? formatDuration(now - startMs) : null;
+  const completeDuration =
+    startMs != null && endMs != null ? formatDuration((lastMs ?? endMs) - startMs) : null;
+  const shortId =
+    reviewWorkflowRunId.length > 8 ? reviewWorkflowRunId.slice(0, 8) : reviewWorkflowRunId;
+
+  const statusBadge = isStalled ? (
+    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">
+      <span className="h-1.5 w-1.5 rounded-full bg-yellow-400" />
+      Stalled
+    </span>
+  ) : status === 'failed' ? (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-red-500/10 text-[color:var(--danger)] border border-red-500/20">
+      Failed
+    </span>
+  ) : status === 'needs-human' ? (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">
+      Needs human
+    </span>
+  ) : status === 'completed' ? (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-fg-5/10 text-fg-3 border border-line/50">
+      Complete
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-green-500/10 text-green-400 border border-green-500/20">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
+      Live
+    </span>
+  );
+
+  const metaLine = isStalled ? (
+    <span className="text-yellow-400/70 text-[10.5px]">
+      no activity for {lastMs != null ? formatDuration(now - lastMs) : '?'}
+    </span>
+  ) : isActive ? (
+    activeDuration != null ? (
+      <span className="text-fg-5 text-[10.5px]">running for {activeDuration}</span>
+    ) : null
+  ) : (
+    <span className="text-fg-5 text-[10.5px]">
+      {completeDuration != null && <>Ran for {completeDuration}</>}
+      {startedAt != null && <> &middot; Started {new Date(startedAt).toLocaleTimeString()}</>}
+      {endedAt != null && (
+        <> &middot; Ended {new Date(lastEventAt ?? endedAt).toLocaleTimeString()}</>
+      )}
+    </span>
+  );
+
+  return (
+    <li
+      data-review-workflow-run-id={reviewWorkflowRunId}
+      className="rounded-md border border-[color:var(--accent)]/20 bg-bg/30"
+    >
+      <details
+        open={open}
+        onToggle={(e) => {
+          e.stopPropagation();
+          setOpen((e.target as HTMLDetailsElement).open);
+        }}
+      >
+        <summary className="flex items-center gap-2 cursor-pointer list-none px-4 py-2 font-mono text-[11px] select-none">
+          <span className="shrink-0">
+            {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </span>
+          <span className="font-mono uppercase tracking-wider text-[color:var(--accent)] text-[10.5px]">
+            Review Run
+          </span>
+          <span aria-hidden className="h-[3px] w-[3px] shrink-0 rounded-full bg-fg-4" />
+          <span className="font-mono text-fg-5 text-[10.5px]">run {shortId}</span>
+          <span aria-hidden className="h-[3px] w-[3px] shrink-0 rounded-full bg-fg-4" />
+          <span className="w-[92px] shrink-0 flex justify-start">{statusBadge}</span>
+          <span className="flex-1 min-w-0 truncate">{metaLine}</span>
+          <span className="ml-auto shrink-0 text-fg-5">{items.length} items</span>
+        </summary>
+        <ol className="flex flex-col gap-2 px-3 pb-3">
+          {items.map((item, i) => renderItem(item, i, context))}
+        </ol>
+      </details>
+    </li>
+  );
+}

--- a/apps/web/src/components/detail/components/timeline/ReviewWaveEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewWaveEvents.test.tsx
@@ -108,6 +108,21 @@ describe('ReviewWaveEvents', () => {
       'Review escalated',
       'cap-with-new-critical',
     ],
+    [
+      'review.slot-completed',
+      {
+        round: 1,
+        slotIndex: 0,
+        slotModel: 'claude',
+        promptVariant: 'default',
+        verdict: 'approved',
+        confidence: 0.92,
+        findingsCount: 0,
+        criteriaChecks: [{ criterion: 'AC1', status: 'met' }],
+      },
+      'Review slot 1 completed',
+      '92%',
+    ],
   ])('routes %s through a custom timeline renderer', (kind, payload, title, detail) => {
     render(
       <ul>

--- a/apps/web/src/components/detail/components/timeline/ReviewWaveEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewWaveEvents.tsx
@@ -12,6 +12,13 @@ type ReviewWavePayload = {
   reason?: string;
   escalationReason?: string;
   unconvergedFindingsCount?: number;
+  slotIndex?: number;
+  slotModel?: string;
+  promptVariant?: string;
+  verdict?: string;
+  confidence?: number;
+  findingsCount?: number;
+  criteriaChecks?: unknown[];
 };
 
 function TimelineDot() {
@@ -195,6 +202,59 @@ export function ReviewEscalatedEvent({ event }: { event: AgentEventDto }) {
             Unconverged findings{' '}
             <span className="font-mono text-amber-300">{payload.unconvergedFindingsCount}</span>
           </div>
+        )}
+      </div>
+    </ReviewEventShell>
+  );
+}
+
+export function ReviewSlotCompletedEvent({ event }: { event: AgentEventDto }) {
+  const payload = event.payload as ReviewWavePayload | null;
+  const verdict = payload?.verdict ?? 'unknown';
+  const confidencePct =
+    typeof payload?.confidence === 'number' ? `${Math.round(payload.confidence * 100)}%` : null;
+  const checksCount = Array.isArray(payload?.criteriaChecks) ? payload.criteriaChecks.length : 0;
+  const findingsCount =
+    typeof payload?.findingsCount === 'number' ? payload.findingsCount : undefined;
+  const slotNumber = typeof payload?.slotIndex === 'number' ? payload.slotIndex + 1 : null;
+  const isApproved = verdict === 'approved';
+  const isNeedsHuman = verdict === 'needs-human';
+
+  return (
+    <ReviewEventShell
+      event={event}
+      icon={
+        isApproved ? (
+          <CheckCircle size={13} className="shrink-0 text-green-400" />
+        ) : (
+          <AlertTriangle
+            size={13}
+            className={`shrink-0 ${isNeedsHuman ? 'text-[color:var(--danger)]' : 'text-amber-400'}`}
+          />
+        )
+      }
+      title={slotNumber == null ? 'Review slot completed' : `Review slot ${slotNumber} completed`}
+      tone={isApproved ? 'success' : isNeedsHuman ? 'danger' : 'warning'}
+      round={payload?.round}
+    >
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[12px] text-fg-3">
+        <MetricRow
+          label="Verdict"
+          value={verdict}
+          tone={isNeedsHuman ? 'danger' : isApproved ? 'normal' : 'warning'}
+        />
+        {confidencePct != null && <MetricRow label="Confidence" value={confidencePct} />}
+        {findingsCount != null && (
+          <MetricRow
+            label="Findings"
+            value={findingsCount}
+            tone={findingsCount > 0 ? 'warning' : 'normal'}
+          />
+        )}
+        <MetricRow label="Criteria checks" value={checksCount} />
+        {payload?.slotModel != null && <MetricRow label="Model" value={payload.slotModel} />}
+        {payload?.promptVariant != null && (
+          <MetricRow label="Prompt" value={payload.promptVariant} />
         )}
       </div>
     </ReviewEventShell>

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -5,6 +5,7 @@ import {
   computeIsLive,
   computeIsWritePrdStuck,
   groupByDevPhase,
+  groupByReviewWorkflow,
   groupEvents,
 } from './timeline';
 
@@ -647,6 +648,138 @@ describe('groupByDevPhase', () => {
     expect(result.some((item) => item.kind === 'run-group' && item.runId === REPAIR_RUN)).toBe(
       true,
     );
+  });
+});
+
+describe('groupEvents — convergent review runs', () => {
+  it('groups reviewer child runs and review lifecycle events into one review-group', () => {
+    const REVIEW_RUN = 'review-workflow-123';
+    const SLOT_A = 'review-slot-a';
+    const SLOT_B = 'review-slot-b';
+    const events: AgentEventDto[] = [
+      makeEvent(1, 'agent.run-started', SLOT_A, {
+        payload: { skill: 'review', reviewWorkflowRunId: REVIEW_RUN, round: 1, slotIndex: 0 },
+      }),
+      makeEvent(2, 'review.slot-completed', SLOT_A, {
+        payload: {
+          reviewWorkflowRunId: REVIEW_RUN,
+          round: 1,
+          slotIndex: 0,
+          slotModel: 'claude',
+          promptVariant: 'default',
+          verdict: 'approved',
+          confidence: 0.9,
+          findingsCount: 0,
+          criteriaChecks: [],
+        },
+      }),
+      makeEvent(3, 'agent.run-started', SLOT_B, {
+        payload: { skill: 'review', reviewWorkflowRunId: REVIEW_RUN, round: 1, slotIndex: 1 },
+      }),
+      makeEvent(4, 'review.slot-completed', SLOT_B, {
+        payload: {
+          reviewWorkflowRunId: REVIEW_RUN,
+          round: 1,
+          slotIndex: 1,
+          slotModel: 'codex',
+          promptVariant: 'unconstrained',
+          verdict: 'approved',
+          confidence: 0.85,
+          findingsCount: 0,
+          criteriaChecks: [],
+        },
+      }),
+      makeEvent(5, 'review.wave-completed', null, {
+        payload: { reviewWorkflowRunId: REVIEW_RUN, round: 1, roundFindingsCount: 0 },
+      }),
+      makeEvent(6, 'review.converged', null, {
+        payload: { reviewWorkflowRunId: REVIEW_RUN, totalRounds: 1 },
+      }),
+      makeEvent(7, 'review.completed', null, {
+        payload: { reviewWorkflowRunId: REVIEW_RUN, verdict: 'approved', confidence: 0.88 },
+      }),
+      makeEvent(8, 'state.transitioned', null, {
+        payload: { reviewWorkflowRunId: REVIEW_RUN, to: 'factory:approved' },
+      }),
+    ];
+
+    const result = groupEvents(events);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('review-group');
+    if (result[0].kind !== 'review-group') return;
+
+    expect(result[0].reviewWorkflowRunId).toBe(REVIEW_RUN);
+    expect(result[0].status).toBe('completed');
+    expect(result[0].items.some((item) => item.kind === 'run-group' && item.runId === SLOT_A)).toBe(
+      true,
+    );
+    expect(result[0].items.some((item) => item.kind === 'run-group' && item.runId === SLOT_B)).toBe(
+      true,
+    );
+    const parentEventKinds = result[0].items
+      .filter((item) => item.kind === 'event')
+      .map((item) => (item as Extract<typeof item, { kind: 'event' }>).event.kind);
+    expect(parentEventKinds).toEqual(
+      expect.arrayContaining([
+        'review.wave-completed',
+        'review.converged',
+        'review.completed',
+        'state.transitioned',
+      ]),
+    );
+  });
+
+  it('marks review-group terminal on review.completed needs-human', () => {
+    const REVIEW_RUN = 'review-workflow-needs-human';
+    const result = groupByReviewWorkflow([
+      {
+        kind: 'event',
+        event: makeEvent(1, 'review.completed', null, {
+          payload: { reviewWorkflowRunId: REVIEW_RUN, verdict: 'needs-human' },
+        }),
+      },
+    ]);
+
+    expect(result[0].kind).toBe('review-group');
+    if (result[0].kind === 'review-group') {
+      expect(result[0].status).toBe('needs-human');
+      expect(result[0].endedAt).toBe(result[0].lastEventAt);
+    }
+  });
+
+  it('keeps child reviewer output inside the review parent group', () => {
+    const REVIEW_RUN = 'review-workflow-output';
+    const SLOT_RUN = 'review-slot-output';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', SLOT_RUN, {
+        payload: { skill: 'review', reviewWorkflowRunId: REVIEW_RUN },
+      }),
+      makeEvent(2, 'review.slot-completed', SLOT_RUN, {
+        payload: {
+          reviewWorkflowRunId: REVIEW_RUN,
+          round: 1,
+          slotIndex: 0,
+          verdict: 'needs-fix',
+          confidence: 0.7,
+          findingsCount: 1,
+          criteriaChecks: [{ criterion: 'AC1', status: 'unmet' }],
+        },
+      }),
+    ]);
+
+    expect(result[0].kind).toBe('review-group');
+    if (result[0].kind !== 'review-group') return;
+    const childRun = result[0].items.find(
+      (item) => item.kind === 'run-group' && item.runId === SLOT_RUN,
+    ) as Extract<(typeof result)[0], { kind: 'review-group' }>['items'][number] | undefined;
+    expect(childRun?.kind).toBe('run-group');
+    if (childRun?.kind === 'run-group') {
+      expect(
+        childRun.items.some(
+          (item) => item.kind === 'event' && item.event.kind === 'review.slot-completed',
+        ),
+      ).toBe(true);
+    }
   });
 });
 

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -747,6 +747,95 @@ describe('groupEvents — convergent review runs', () => {
     }
   });
 
+  it('marks review-group terminal on review-linked needs-human state transition', () => {
+    const REVIEW_RUN = 'review-workflow-transition-needs-human';
+    const result = groupByReviewWorkflow([
+      {
+        kind: 'event',
+        event: makeEvent(1, 'state.transitioned', null, {
+          payload: { reviewWorkflowRunId: REVIEW_RUN, to: 'factory:needs-human' },
+        }),
+      },
+    ]);
+
+    expect(result[0].kind).toBe('review-group');
+    if (result[0].kind === 'review-group') {
+      expect(result[0].status).toBe('needs-human');
+      expect(result[0].endedAt).toBe(result[0].lastEventAt);
+    }
+  });
+
+  it('keeps review grouping separate from dev phase grouping when review events carry pipelineRunId', () => {
+    const PID = 'pipe-review-parent';
+    const REVIEW_RUN = 'review-workflow-pipeline';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', PID, { payload: { skill: 'spec-author' } }),
+      makeEvent(2, 'spec.completed', PID, { payload: { pipelineRunId: PID } }),
+      makeEvent(3, 'agent.run-completed', PID),
+      makeEvent(4, 'review.completed', null, {
+        payload: {
+          pipelineRunId: PID,
+          reviewWorkflowRunId: REVIEW_RUN,
+          verdict: 'approved',
+          confidence: 0.9,
+        },
+      }),
+      makeEvent(5, 'state.transitioned', null, {
+        payload: { pipelineRunId: PID, reviewWorkflowRunId: REVIEW_RUN, to: 'factory:approved' },
+      }),
+    ]);
+
+    const reviewGroup = result.find((item) => item.kind === 'review-group');
+    const phaseGroup = result.find((item) => item.kind === 'phase-group');
+
+    expect(reviewGroup).toBeDefined();
+    expect(phaseGroup).toBeDefined();
+    if (reviewGroup?.kind === 'review-group') {
+      const reviewEventKinds = reviewGroup.items.flatMap((item) =>
+        item.kind === 'event' ? [item.event.kind] : [],
+      );
+      expect(reviewEventKinds).toEqual(['state.transitioned', 'review.completed']);
+      expect(
+        reviewGroup.items.some((item) => item.kind === 'run-group' && item.runId === PID),
+      ).toBe(false);
+    }
+    if (phaseGroup?.kind === 'phase-group') {
+      expect(
+        phaseGroup.items.some(
+          (item) =>
+            item.kind === 'event' &&
+            (item.event.kind === 'review.completed' || item.event.kind === 'state.transitioned'),
+        ),
+      ).toBe(false);
+      expect(phaseGroup.items.some((item) => item.kind === 'run-group' && item.runId === PID)).toBe(
+        true,
+      );
+    }
+  });
+
+  it('keeps multiple reviewWorkflowRunIds on one pipeline as separate review groups', () => {
+    const PID = 'pipe-review-multi';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', PID, { payload: { skill: 'spec-author' } }),
+      makeEvent(2, 'spec.completed', PID, { payload: { pipelineRunId: PID } }),
+      makeEvent(3, 'agent.run-completed', PID),
+      makeEvent(4, 'review.completed', null, {
+        payload: { pipelineRunId: PID, reviewWorkflowRunId: 'review-one', verdict: 'needs-fix' },
+      }),
+      makeEvent(5, 'review.completed', null, {
+        payload: { pipelineRunId: PID, reviewWorkflowRunId: 'review-two', verdict: 'approved' },
+      }),
+    ]);
+
+    const reviewGroups = result.filter((item) => item.kind === 'review-group');
+    expect(reviewGroups).toHaveLength(2);
+    expect(
+      reviewGroups.map((item) =>
+        item.kind === 'review-group' ? item.reviewWorkflowRunId : 'not-review',
+      ),
+    ).toEqual(expect.arrayContaining(['review-one', 'review-two']));
+  });
+
   it('keeps child reviewer output inside the review parent group', () => {
     const REVIEW_RUN = 'review-workflow-output';
     const SLOT_RUN = 'review-slot-output';

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -421,10 +421,12 @@ export function groupEvents(
   const collapsed = collapseLogRuns(normalizedEvents);
   const grouped = groupByRunId(collapsed);
   const withInvestigationPhases = groupByInvestigationPhase([...grouped].sort(compareRenderItems));
-  const withDevPhases = groupByDevPhase([...withInvestigationPhases].sort(compareRenderItems));
-  const withReviewGroups = groupByReviewWorkflow([...withDevPhases].sort(compareRenderItems));
-  if (interventionDetails.length === 0) return withReviewGroups;
-  return [...withReviewGroups, ...interventionDetails.map(buildInterventionGroup)].sort(
+  const withReviewGroups = groupByReviewWorkflow(
+    [...withInvestigationPhases].sort(compareRenderItems),
+  );
+  const withDevPhases = groupByDevPhase([...withReviewGroups].sort(compareRenderItems));
+  if (interventionDetails.length === 0) return withDevPhases;
+  return [...withDevPhases, ...interventionDetails.map(buildInterventionGroup)].sort(
     compareRenderItems,
   );
 }
@@ -848,6 +850,17 @@ function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs
   if (events.some((event) => event.kind === 'review.wave-failed')) return 'failed';
   if (events.some((event) => event.kind === 'agent.run-failed')) return 'failed';
   if (events.some((event) => event.kind === 'review.escalated')) return 'needs-human';
+  if (
+    events.some((event) => {
+      const payload = event.payload as { to?: string; toState?: string } | null;
+      return (
+        event.kind === 'state.transitioned' &&
+        (payload?.to === 'factory:needs-human' || payload?.toState === 'factory:needs-human')
+      );
+    })
+  ) {
+    return 'needs-human';
+  }
 
   const completed = events
     .filter((event) => event.kind === 'review.completed')

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -70,6 +70,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'review.wave-failed': 'Review wave failed',
   'review.converged': 'Review converged',
   'review.escalated': 'Review escalated',
+  'review.slot-completed': 'Review slot completed',
   'evidence.no-spec-declared': 'Evidence — no spec declared',
   'evidence.playwright-repro-skipped': 'Playwright repro skipped',
   'evidence.playwright-ran': 'Playwright evidence ran',
@@ -248,6 +249,15 @@ export type RenderItem =
       startedAt: string | null;
       endedAt: string | null;
       lastEventAt: string | null;
+    }
+  | {
+      kind: 'review-group';
+      reviewWorkflowRunId: string;
+      items: RenderItem[];
+      status: 'live' | 'completed' | 'needs-human' | 'failed';
+      startedAt: string | null;
+      endedAt: string | null;
+      lastEventAt: string | null;
     };
 
 /**
@@ -267,6 +277,9 @@ function effectiveTimestamp(item: RenderItem): number {
   }
   if (item.kind === 'event') return new Date(item.event.createdAt).getTime();
   if (item.kind === 'phase-group') return new Date(item.startedAt ?? 0).getTime();
+  if (item.kind === 'review-group') {
+    return new Date(item.lastEventAt ?? item.startedAt ?? 0).getTime();
+  }
   return new Date(item.events[0]?.createdAt ?? 0).getTime();
 }
 
@@ -409,8 +422,9 @@ export function groupEvents(
   const grouped = groupByRunId(collapsed);
   const withInvestigationPhases = groupByInvestigationPhase([...grouped].sort(compareRenderItems));
   const withDevPhases = groupByDevPhase([...withInvestigationPhases].sort(compareRenderItems));
-  if (interventionDetails.length === 0) return withDevPhases;
-  return [...withDevPhases, ...interventionDetails.map(buildInterventionGroup)].sort(
+  const withReviewGroups = groupByReviewWorkflow([...withDevPhases].sort(compareRenderItems));
+  if (interventionDetails.length === 0) return withReviewGroups;
+  return [...withReviewGroups, ...interventionDetails.map(buildInterventionGroup)].sort(
     compareRenderItems,
   );
 }
@@ -632,6 +646,7 @@ function eventFromRenderItem(item: RenderItem): AgentEventDto[] {
   if (item.kind === 'run-group') return item.items.flatMap(eventFromRenderItem);
   if (item.kind === 'investigation-phase') return item.items.flatMap(eventFromRenderItem);
   if (item.kind === 'phase-group') return item.items.flatMap(eventFromRenderItem);
+  if (item.kind === 'review-group') return item.items.flatMap(eventFromRenderItem);
   if (item.kind === 'intervention-group') return [];
   return item.events;
 }
@@ -815,6 +830,73 @@ export function groupByInvestigationPhase(items: RenderItem[]): RenderItem[] {
   }
 
   return [...ungrouped, ...phases].sort(compareRenderItems);
+}
+
+function reviewWorkflowRunIdsForItem(item: RenderItem): string[] {
+  const ids = new Set<string>();
+  for (const event of eventFromRenderItem(item)) {
+    const payload = event.payload as { reviewWorkflowRunId?: unknown } | null;
+    if (typeof payload?.reviewWorkflowRunId === 'string' && payload.reviewWorkflowRunId !== '') {
+      ids.add(payload.reviewWorkflowRunId);
+    }
+  }
+  return [...ids];
+}
+
+function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs-human' | 'failed' {
+  const events = items.flatMap(eventFromRenderItem);
+  if (events.some((event) => event.kind === 'review.wave-failed')) return 'failed';
+  if (events.some((event) => event.kind === 'agent.run-failed')) return 'failed';
+  if (events.some((event) => event.kind === 'review.escalated')) return 'needs-human';
+
+  const completed = events
+    .filter((event) => event.kind === 'review.completed')
+    .sort((a, b) => a.id - b.id)
+    .at(-1);
+  const verdict = (completed?.payload as { verdict?: string } | null)?.verdict;
+  if (verdict === 'needs-human') return 'needs-human';
+  if (verdict === 'approved' || verdict === 'needs-fix') return 'completed';
+  return 'live';
+}
+
+export function groupByReviewWorkflow(items: RenderItem[]): RenderItem[] {
+  const reviewWorkflowRunIds = new Set<string>();
+  for (const item of items) {
+    for (const id of reviewWorkflowRunIdsForItem(item)) {
+      reviewWorkflowRunIds.add(id);
+    }
+  }
+  if (reviewWorkflowRunIds.size === 0) return items;
+
+  const reviewItems = new Map<string, RenderItem[]>();
+  for (const id of reviewWorkflowRunIds) reviewItems.set(id, []);
+
+  const ungrouped: RenderItem[] = [];
+  for (const item of items) {
+    const ids = reviewWorkflowRunIdsForItem(item).filter((id) => reviewWorkflowRunIds.has(id));
+    if (ids.length === 0) {
+      ungrouped.push(item);
+      continue;
+    }
+    reviewItems.get(ids[0])?.push(item);
+  }
+
+  const groups: RenderItem[] = [];
+  for (const [reviewWorkflowRunId, groupedItems] of reviewItems) {
+    if (groupedItems.length === 0) continue;
+    const times = extractPhaseTimes(groupedItems);
+    const status = resolveReviewStatus(groupedItems);
+    groups.push({
+      kind: 'review-group',
+      reviewWorkflowRunId,
+      items: groupedItems.sort(compareRenderItems),
+      status,
+      ...times,
+      endedAt: status === 'live' ? null : (times.endedAt ?? times.lastEventAt),
+    });
+  }
+
+  return [...ungrouped, ...groups].sort(compareRenderItems);
 }
 
 // ─── run-state detection ─────────────────────────────────────────────────────

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -127,6 +127,7 @@ export type EventKind =
   | 'review.wave-failed'
   | 'review.converged'
   | 'review.escalated'
+  | 'review.slot-completed'
   // M19.12 dev-review advisor — Codex pre-QA pass lifecycle events (#596)
   | 'dev-review.started'
   | 'dev-review.completed'

--- a/slices/review/convergent-review.ts
+++ b/slices/review/convergent-review.ts
@@ -3,6 +3,7 @@ import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { assembleSpawnContext } from '@goose-hub/core/agent-runtime/context-assembly.js';
 import type { AgentResult, AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
@@ -68,7 +69,16 @@ function getQaVerdict(
  * Divergent verdicts (approved + needs-fix) → verdictsDiverge: true.
  */
 export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<ReviewWaveResult> {
-  const { pr, qaResult, round, priorFindings, workItem, projectSlug, runtimeForSlot } = opts;
+  const {
+    pr,
+    qaResult,
+    round,
+    priorFindings,
+    workItem,
+    projectSlug,
+    reviewWorkflowRunId,
+    runtimeForSlot,
+  } = opts;
 
   const projectConfig = await getProjectBySlug(projectSlug);
   const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
@@ -97,7 +107,13 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
       reviewPrompt,
       reviewJsonSchema,
       resolvedBudgets,
-      extraEventPayload: { round, slotModel: slot.model, promptVariant: slot.prompt },
+      extraEventPayload: {
+        reviewWorkflowRunId,
+        round,
+        slotIndex: i,
+        slotModel: slot.model,
+        promptVariant: slot.prompt,
+      },
     });
   });
 
@@ -115,6 +131,48 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
   const parsed = rawResults.map((r) =>
     r instanceof Error ? null : ReviewOutputSchema.safeParse((r as AgentResult).output),
   );
+
+  const successfulReviewerOutputs = parsed.flatMap((p, i) => {
+    if (p == null || !p.success) return [];
+    const slot = slots[i];
+    return [
+      {
+        parsed: p.data,
+        runId: runIds[i],
+        round,
+        slotIndex: i,
+        slotModel: slot.model,
+        promptVariant: slot.prompt,
+      },
+    ];
+  });
+
+  for (const output of successfulReviewerOutputs) {
+    eventStore.appendEvent({
+      projectId: projectSlug,
+      workItemId: workItem.id,
+      kind: 'review.slot-completed',
+      payload: {
+        reviewWorkflowRunId,
+        round: output.round,
+        slotIndex: output.slotIndex,
+        slotModel: output.slotModel,
+        promptVariant: output.promptVariant,
+        verdict: output.parsed.verdict,
+        confidence: output.parsed.confidence,
+        findingsCount: output.parsed.findings.length,
+        criteriaChecks: output.parsed.criteriaChecks,
+      },
+      runId: output.runId,
+    });
+    reconcileDecisionSummaries(
+      output.runId,
+      projectSlug,
+      workItem.id,
+      'review',
+      output.parsed.decisionSummaries,
+    );
+  }
 
   if (parsed.some((p) => p == null || !p.success)) {
     const errors = rawResults
@@ -158,7 +216,7 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
   return {
     roundFindings,
     newCriticalFindings,
-    reviewerOutputs: parsedData.map((d, i) => ({ parsed: d, runId: runIds[i] })),
+    reviewerOutputs: successfulReviewerOutputs,
     parseFailure: false,
     anyNeedsHuman,
     anyNeedsFix,
@@ -179,6 +237,8 @@ export async function runConvergentReviewWorkflow(
   _targetRepo: string,
   deps: { runtime?: AgentRuntime } = {},
 ): Promise<void> {
+  const reviewWorkflowRunId = crypto.randomUUID();
+  const reviewWorkflowPayload = { reviewWorkflowRunId };
   const injectedRuntime = deps.runtime;
   const runtimeForSlot = injectedRuntime
     ? () => injectedRuntime
@@ -220,6 +280,7 @@ export async function runConvergentReviewWorkflow(
         priorFindings: previousRoundFindings,
         workItem,
         projectSlug,
+        reviewWorkflowRunId,
         runtimeForSlot,
       });
 
@@ -228,7 +289,7 @@ export async function runConvergentReviewWorkflow(
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.wave-failed',
-          payload: { round, error: waveResult.parseFailureError },
+          payload: { ...reviewWorkflowPayload, round, error: waveResult.parseFailureError },
           runId: crypto.randomUUID(),
         });
         await stateSource.comment(
@@ -251,6 +312,7 @@ export async function runConvergentReviewWorkflow(
           from: 'factory:needs-review',
           to: 'factory:needs-human',
           by: 'convergent-review',
+          extraPayload: reviewWorkflowPayload,
         });
         return;
       }
@@ -260,6 +322,7 @@ export async function runConvergentReviewWorkflow(
         workItemId: workItem.id,
         kind: 'review.wave-completed',
         payload: {
+          ...reviewWorkflowPayload,
           round,
           roundFindingsCount: waveResult.roundFindings.length,
           newCriticalCount: waveResult.newCriticalFindings.length,
@@ -283,7 +346,12 @@ export async function runConvergentReviewWorkflow(
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.escalated',
-          payload: { reason: 'reviewer-needs-human', round, escalationReason },
+          payload: {
+            ...reviewWorkflowPayload,
+            reason: 'reviewer-needs-human',
+            round,
+            escalationReason,
+          },
           runId,
         });
         eventStore.appendEvent({
@@ -291,6 +359,7 @@ export async function runConvergentReviewWorkflow(
           workItemId: workItem.id,
           kind: 'review.completed',
           payload: {
+            ...reviewWorkflowPayload,
             verdict: 'needs-human',
             confidence: humanReviewer?.parsed.confidence ?? 0,
             criteriaChecks: humanReviewer?.parsed.criteriaChecks ?? [],
@@ -321,6 +390,7 @@ export async function runConvergentReviewWorkflow(
           to: 'factory:needs-human',
           by: 'convergent-review',
           runId,
+          extraPayload: reviewWorkflowPayload,
         });
         return;
       }
@@ -332,7 +402,7 @@ export async function runConvergentReviewWorkflow(
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.escalated',
-          payload: { reason: 'divergent-verdicts', round },
+          payload: { ...reviewWorkflowPayload, reason: 'divergent-verdicts', round },
           runId,
         });
         eventStore.appendEvent({
@@ -340,6 +410,7 @@ export async function runConvergentReviewWorkflow(
           workItemId: workItem.id,
           kind: 'review.completed',
           payload: {
+            ...reviewWorkflowPayload,
             verdict: 'needs-human',
             confidence: 0,
             criteriaChecks: [],
@@ -370,6 +441,7 @@ export async function runConvergentReviewWorkflow(
           to: 'factory:needs-human',
           by: 'convergent-review',
           runId,
+          extraPayload: reviewWorkflowPayload,
         });
         return;
       }
@@ -397,7 +469,7 @@ export async function runConvergentReviewWorkflow(
           projectId: projectSlug,
           workItemId: workItem.id,
           kind: 'review.converged',
-          payload: { totalRounds: round },
+          payload: { ...reviewWorkflowPayload, totalRounds: round },
           runId,
         });
 
@@ -422,6 +494,7 @@ export async function runConvergentReviewWorkflow(
           workItemId: workItem.id,
           kind: 'review.completed',
           payload: {
+            ...reviewWorkflowPayload,
             verdict: finalVerdict,
             confidence: avgConfidence,
             criteriaChecks: [],
@@ -451,6 +524,7 @@ export async function runConvergentReviewWorkflow(
             to: 'factory:needs-human',
             by: 'convergent-review',
             runId,
+            extraPayload: reviewWorkflowPayload,
           });
           return;
         }
@@ -476,6 +550,7 @@ export async function runConvergentReviewWorkflow(
           to: 'factory:approved',
           by: 'convergent-review',
           runId,
+          extraPayload: reviewWorkflowPayload,
         });
         return;
       }
@@ -488,6 +563,7 @@ export async function runConvergentReviewWorkflow(
           workItemId: workItem.id,
           kind: 'review.escalated',
           payload: {
+            ...reviewWorkflowPayload,
             reason: 'cap-with-new-critical',
             round,
             unconvergedFindingsCount: waveResult.newCriticalFindings.length,
@@ -501,6 +577,7 @@ export async function runConvergentReviewWorkflow(
           workItemId: workItem.id,
           kind: 'review.completed',
           payload: {
+            ...reviewWorkflowPayload,
             verdict: 'needs-human',
             confidence: 0,
             criteriaChecks: [],
@@ -534,6 +611,7 @@ export async function runConvergentReviewWorkflow(
           to: 'factory:needs-human',
           by: 'convergent-review',
           runId,
+          extraPayload: reviewWorkflowPayload,
         });
         return;
       }
@@ -551,6 +629,7 @@ export async function runConvergentReviewWorkflow(
       from: 'factory:needs-review',
       to: 'factory:needs-human',
       by: 'convergent-review',
+      extraPayload: reviewWorkflowPayload,
     });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -559,7 +638,7 @@ export async function runConvergentReviewWorkflow(
       projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
-      payload: { error: error.message, skill: 'review' },
+      payload: { ...reviewWorkflowPayload, error: error.message, skill: 'review' },
       runId: catchRunId,
     });
     await stateSource.comment(
@@ -583,6 +662,7 @@ export async function runConvergentReviewWorkflow(
       to: 'factory:needs-human',
       by: 'convergent-review',
       runId: catchRunId,
+      extraPayload: reviewWorkflowPayload,
     });
   }
 }

--- a/slices/review/review-spec.ts
+++ b/slices/review/review-spec.ts
@@ -18,7 +18,14 @@ export interface FindingKey {
 export interface ReviewWaveResult {
   roundFindings: FindingKey[];
   newCriticalFindings: FindingKey[];
-  reviewerOutputs: Array<{ parsed: ReviewOutput; runId: string }>;
+  reviewerOutputs: Array<{
+    parsed: ReviewOutput;
+    runId: string;
+    round: number;
+    slotIndex: number;
+    slotModel: ReviewerSlot['model'];
+    promptVariant: ReviewerSlot['prompt'];
+  }>;
   parseFailure: boolean;
   parseFailureError?: string;
   /** True if any reviewer returned verdict: 'needs-human' — must escalate immediately. */
@@ -37,6 +44,7 @@ export interface DispatchReviewWaveOpts {
   priorFindings: FindingKey[];
   workItem: WorkItem;
   projectSlug: string;
+  reviewWorkflowRunId: string;
   /** Returns the runtime to use for a given slot model. */
   runtimeForSlot: (model: ReviewerSlot['model']) => AgentRuntime;
 }

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -883,6 +883,136 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
     expect(completedEvents[0]?.[0].payload).toMatchObject({ verdict: 'approved' });
   });
 
+  it('shares one reviewWorkflowRunId across review lifecycle, state transition, and child output events', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    const events = vi.mocked(eventStore.appendEvent).mock.calls.map(([event]) => event);
+    const correlatedEvents = events.filter((event) =>
+      [
+        'review.wave-completed',
+        'review.slot-completed',
+        'review.converged',
+        'review.completed',
+        'state.transitioned',
+      ].includes(event.kind),
+    );
+    const workflowIds = new Set(
+      correlatedEvents.map(
+        (event) => (event.payload as { reviewWorkflowRunId?: string }).reviewWorkflowRunId,
+      ),
+    );
+
+    expect(correlatedEvents.length).toBeGreaterThan(0);
+    expect(workflowIds.size).toBe(1);
+    expect([...workflowIds][0]).toEqual(expect.any(String));
+
+    const firstSpec = mockRun.mock.calls[0][0] as AgentSpec;
+    expect(firstSpec.extraEventPayload).toMatchObject({
+      reviewWorkflowRunId: [...workflowIds][0],
+      round: 1,
+      slotIndex: 0,
+      slotModel: 'claude',
+      promptVariant: 'default',
+    });
+  });
+
+  it('emits review.slot-completed for every reviewer with slot, round, and verdict metadata', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    const slotEvents = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([event]) => event.kind === 'review.slot-completed');
+
+    expect(slotEvents).toHaveLength(mockRun.mock.calls.length);
+    expect(slotEvents[0]?.[0]).toMatchObject({
+      runId: expect.any(String),
+      payload: {
+        round: 1,
+        slotIndex: 0,
+        slotModel: 'claude',
+        promptVariant: 'default',
+        verdict: 'approved',
+        confidence: 0.95,
+        findingsCount: 0,
+        criteriaChecks: [],
+        reviewWorkflowRunId: expect.any(String),
+      },
+    });
+    expect(slotEvents[1]?.[0].payload).toMatchObject({
+      round: 1,
+      slotIndex: 1,
+      promptVariant: 'unconstrained',
+    });
+  });
+
+  it('reconciles each reviewer decision summary under the child reviewer runId', async () => {
+    const item = makeWorkItem();
+    const source = makeMockSource({
+      getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+    });
+
+    mockRun.mockResolvedValueOnce({
+      output: {
+        verdict: 'needs-human',
+        confidence: 0.2,
+        criteriaChecks: [],
+        findings: [],
+        decisionSummaries: [{ kind: 'VERDICT', summary: 'slot A needs human' }],
+        escalationReason: 'Spec is ambiguous',
+      },
+      decisionSummaries: [],
+      events: [],
+    } satisfies AgentResult);
+    mockRun.mockResolvedValueOnce({
+      output: {
+        verdict: 'approved',
+        confidence: 0.9,
+        criteriaChecks: [],
+        findings: [],
+        decisionSummaries: [{ kind: 'VERDICT', summary: 'slot B approves' }],
+      },
+      decisionSummaries: [],
+      events: [],
+    } satisfies AgentResult);
+
+    const { runConvergentReviewWorkflow } = await import('./workflow.js');
+    const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+    await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+    const slotRunIds = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([event]) => event.kind === 'review.slot-completed')
+      .map(([event]) => event.runId);
+    const decisionEvents = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.filter(([event]) => event.kind === 'agent.decision-summary');
+
+    expect(slotRunIds).toHaveLength(2);
+    expect(decisionEvents).toHaveLength(2);
+    expect(decisionEvents.map(([event]) => event.runId).sort()).toEqual([...slotRunIds].sort());
+    expect(
+      decisionEvents.map(([event]) => (event.payload as { summary?: string }).summary),
+    ).toEqual(['slot A needs human', 'slot B approves']);
+  });
+
   // M19.20: configurable reviewer slots — divergent verdicts escalate immediately
   describe('configurable reviewer slots (M19.20)', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary
- add a stable reviewWorkflowRunId across convergent review lifecycle, state transitions, and child reviewer run metadata
- emit review.slot-completed for each parsed reviewer output and reconcile reviewer decision summaries under each child runId
- group convergent review timeline items under a Review Run parent with child reviewer output rendered inside it

## Verification
- pnpm typecheck
- pnpm test slices/review/slice.test.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/timeline/ReviewWaveEvents.test.tsx apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
- pnpm exec biome check core/event-stream/store.ts slices/review/convergent-review.ts slices/review/review-spec.ts slices/review/slice.test.ts apps/web/src/components/detail/lib/timeline.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineEvents.tsx apps/web/src/components/detail/components/timeline/ReviewWaveEvents.tsx apps/web/src/components/detail/components/timeline/ReviewWaveEvents.test.tsx apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.tsx apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx