### PR TITLE
Fix dev-phase verification routing

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -83,6 +83,7 @@ import {
   QaCompletedEvent,
   QaFailedEvent,
   QaPassedEvent,
+  QaVerificationBlockedEvent,
   QaVerificationSummaryBuiltEvent,
 } from './timeline/QaEvents';
 import { RetroCompletedEvent } from './timeline/RetroCompletedEvent';
@@ -233,6 +234,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <ToolWarningEvent key={event.id} event={event} />;
     case 'qa.completed':
       return <QaCompletedEvent key={event.id} event={event} />;
+    case 'qa.verification-blocked':
+      return <QaVerificationBlockedEvent key={event.id} event={event} />;
     case 'qa.verification-summary-built':
       return <QaVerificationSummaryBuiltEvent key={event.id} event={event} />;
     case 'qa.structural-passed':

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -574,6 +574,60 @@ describe('groupEvents — run-group metadata', () => {
     }
   });
 
+  it('infers parent parallel implement run label and completion from PR opened', () => {
+    const events: AgentEventDto[] = [
+      makeRunEvent(1, 'pipeline-1', 'parallel-implement.iteration-started'),
+      makeRunEvent(2, 'pipeline-1', 'parallel-implement.wp-committed'),
+      makeRunEvent(3, 'pipeline-1', 'pr.opened'),
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    if (result[0].kind === 'run-group') {
+      expect(result[0].skill).toBe('parallel-implement');
+      expect(result[0].startedAt).toBe(events[0].createdAt);
+      expect(result[0].endedAt).toBe(events[2].createdAt);
+    }
+  });
+
+  it('infers deterministic QA run label and completion from qa.completed', () => {
+    const events: AgentEventDto[] = [
+      makeRunEvent(1, 'qa-run-1', 'qa.functional-failed'),
+      {
+        ...makeRunEvent(2, 'qa-run-1', 'qa.completed'),
+        payload: { verdict: 'fail', deterministic: true, agentSkipped: true },
+      },
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    if (result[0].kind === 'run-group') {
+      expect(result[0].skill).toBe('qa');
+      expect(result[0].startedAt).toBe(events[0].createdAt);
+      expect(result[0].endedAt).toBe(events[1].createdAt);
+    }
+  });
+
+  it('treats verification-blocked deterministic QA as terminal instead of live', () => {
+    const events: AgentEventDto[] = [
+      makeRunEvent(1, 'qa-run-1', 'qa.functional-failed'),
+      {
+        ...makeRunEvent(2, 'qa-run-1', 'qa.verification-blocked'),
+        payload: { failedTier: 2, reason: 'malformed-verification-command', agentSkipped: true },
+      },
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    if (result[0].kind === 'run-group') {
+      expect(result[0].skill).toBe('qa');
+      expect(result[0].endedAt).toBe(events[1].createdAt);
+    }
+  });
+
   it('resolves skill from any event payload, not just lifecycle events', () => {
     const events: AgentEventDto[] = [
       { ...makeRunEvent(1, 'run-abc', 'agent.tool-call'), payload: { skill: 'implement' } },

--- a/apps/web/src/components/detail/components/timeline/QaEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/cn';
 import type { AgentEventDto } from '@/lib/types';
-import { CheckCircle, Circle, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, Circle, XCircle } from 'lucide-react';
 
 type TierResult = {
   passed: boolean;
@@ -223,6 +223,8 @@ export function QaVerificationSummaryBuiltEvent({ event }: { event: AgentEventDt
 
 export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as {
+    agentSkipped?: boolean;
+    deterministic?: boolean;
     verdict?: string;
     overallScore?: number;
     threshold?: number;
@@ -271,6 +273,11 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
         >
           {verdict.toUpperCase()}
         </span>
+        {p?.agentSkipped === true && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold border border-fg-5/20 bg-fg-5/10 text-fg-3">
+            Agent skipped
+          </span>
+        )}
         {score != null && (
           <span className="text-[11.5px] text-fg-3 font-mono">
             <span className={score >= threshold ? 'text-green-400' : 'text-[color:var(--danger)]'}>
@@ -304,6 +311,55 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
             );
           })}
         </div>
+      )}
+    </li>
+  );
+}
+
+export function QaVerificationBlockedEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as {
+    failedTier?: number;
+    findings?: string[];
+    reason?: string;
+    agentSkipped?: boolean;
+  } | null;
+  const findings = p?.findings ?? [];
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-yellow-500/20 bg-yellow-500/5 px-4 py-3"
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-2 text-[11px] text-fg-3">
+        <AlertTriangle size={13} className="shrink-0 text-yellow-400" />
+        <span className="font-mono uppercase tracking-wider">QA verification blocked</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="mb-2 flex flex-wrap gap-2">
+        {p?.failedTier != null && (
+          <span className="rounded border border-yellow-500/20 bg-yellow-500/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-yellow-400">
+            Tier {p.failedTier}
+          </span>
+        )}
+        {p?.reason != null && (
+          <span className="rounded border border-line bg-bg/40 px-1.5 py-0.5 font-mono text-[10px] text-fg-3">
+            {p.reason}
+          </span>
+        )}
+        {p?.agentSkipped === true && (
+          <span className="rounded border border-fg-5/20 bg-fg-5/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-fg-3">
+            Agent skipped
+          </span>
+        )}
+      </div>
+      {findings.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {findings.slice(0, 3).map((finding) => (
+            <li key={finding} className="text-[11.5px] leading-relaxed text-fg-2">
+              {finding}
+            </li>
+          ))}
+        </ul>
       )}
     </li>
   );

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
@@ -66,7 +66,16 @@ export function RunGroupWrapper({
   const groupEventList = items
     .filter((item): item is Extract<RenderItem, { kind: 'event' }> => item.kind === 'event')
     .map((item) => item.event);
-  const isFailed = groupEventList.some((event) => event.kind === 'agent.run-failed');
+  const isFailed = groupEventList.some(
+    (event) =>
+      event.kind === 'agent.run-failed' ||
+      event.kind === 'qa.verification-blocked' ||
+      event.kind === 'parallel-implement.exhausted' ||
+      event.kind === 'parallel-implement.wp-failed' ||
+      event.kind === 'parallel-implement.wp-timeout' ||
+      event.kind === 'parallel-implement.wp-commit-failed' ||
+      /^qa\..*-failed$/.test(event.kind),
+  );
   const codexTransportWarnings = groupEventList.filter(isCodexTransportWarningLog);
   const codexTransportWarning = codexTransportWarnings[0] ?? null;
   const warningRecovered = codexTransportWarning != null && endedAt != null && !isFailed;

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -85,6 +85,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'qa.regression-passed': 'QA regression passed',
   'qa.regression-failed': 'QA regression failed',
   'qa.verification-summary-built': 'QA verification summary built',
+  'qa.verification-blocked': 'QA verification blocked',
   'retrospective.completed': 'Retrospective completed',
   'grill.question-posted': 'Grill question posted',
   'grill.completed': 'Grill completed',
@@ -123,6 +124,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
 
 export function formatSkillName(skill: string | null): string {
   if (skill == null) return '(Unknown)';
+  if (skill === 'qa') return 'QA';
   return skill
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
@@ -533,6 +535,32 @@ function extractRunMeta(items: RenderItem[]): {
       if (endedAt == null) endedAt = ev.createdAt;
     } else if (ev.kind === 'decompose.completed') {
       if (endedAt == null) endedAt = ev.createdAt;
+    } else if (ev.kind === 'parallel-implement.iteration-started') {
+      if (startedAt == null) startedAt = ev.createdAt;
+      if (displaySkill == null) displaySkill = 'parallel-implement';
+    } else if (
+      ev.kind.startsWith('parallel-implement.') ||
+      ev.kind === 'pr.opened' ||
+      (ev.kind === 'state.transitioned' &&
+        ((ev.payload as { to?: string; toState?: string } | null)?.to === 'factory:needs-qa' ||
+          (ev.payload as { to?: string; toState?: string } | null)?.toState === 'factory:needs-qa'))
+    ) {
+      if (displaySkill == null) displaySkill = 'parallel-implement';
+      if (
+        ev.kind === 'pr.opened' ||
+        ev.kind === 'parallel-implement.exhausted' ||
+        (ev.kind === 'state.transitioned' &&
+          ((ev.payload as { to?: string; toState?: string } | null)?.to === 'factory:needs-qa' ||
+            (ev.payload as { to?: string; toState?: string } | null)?.toState ===
+              'factory:needs-qa'))
+      ) {
+        if (endedAt == null || ms > new Date(endedAt).getTime()) endedAt = ev.createdAt;
+      }
+    } else if (ev.kind.startsWith('qa.')) {
+      if (displaySkill == null) displaySkill = 'qa';
+      if (ev.kind === 'qa.completed' || ev.kind === 'qa.verification-blocked') {
+        if (endedAt == null || ms > new Date(endedAt).getTime()) endedAt = ev.createdAt;
+      }
     }
   }
 
@@ -827,6 +855,10 @@ const TERMINAL_EVENTS = new Set([
   'decompose.completed',
   'retrospective.completed',
   'prd.drafted',
+  'pr.opened',
+  'parallel-implement.exhausted',
+  'qa.completed',
+  'qa.verification-blocked',
 ]);
 
 export function computeIsLive(events: AgentEventDto[]): boolean {

--- a/core/event-stream/store.ts
+++ b/core/event-stream/store.ts
@@ -43,6 +43,7 @@ export type EventKind =
   | 'qa.regression-passed'
   | 'qa.regression-failed'
   | 'qa.verification-summary-built'
+  | 'qa.verification-blocked'
   // M7 fix-issue workflow lifecycle (#183) + evidence-post wiring (#234)
   | 'agent.implement-complete'
   | 'pr.opened'

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -182,6 +182,69 @@ describe('Tier 2 (Functional) — golden test', () => {
     expect(result.findings[0]?.code).toBe('malformed-verification-command');
   });
 
+  it('classifies missing command on malformed persisted specs as verification infrastructure', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'old persisted verifier',
+          scriptPath: 'apps/web/src/foo.test.ts',
+          expectedExitCodes: [0],
+        } as unknown as EngineeringSpec['verificationTooling'][number],
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp');
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('verification-infrastructure');
+    expect(result.findings[0]?.code).toBe('malformed-verification-command');
+  });
+
+  it('does not classify product ENOENT output as verification infrastructure', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'focused test',
+          command: 'pnpm vitest run src/foo.test.ts',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp', {
+      runVerificationCommandImpl: async () => ({
+        passed: false,
+        output: "Error: ENOENT: no such file or directory, open 'missing-product-file.json'",
+      }),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('product');
+  });
+
+  it('classifies command launcher missing as verification infrastructure', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'focused test',
+          command: 'pnpm vitest run src/foo.test.ts',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp', {
+      runVerificationCommandImpl: async () => ({
+        passed: false,
+        output: 'sh: pnpm: command not found',
+      }),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('verification-infrastructure');
+    expect(result.findings[0]?.code).toBe('verification-runner-missing');
+  });
+
   it('passes vacuously when no verificationTooling is declared', async () => {
     const spec = makeSpec({ verificationTooling: [] });
     const result = await verifyFunctional(spec, '/tmp');

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -123,19 +123,19 @@ describe('Tier 1 (Structural) — golden test', () => {
 // ─── Tier 2: Functional ──────────────────────────────────────────────────────
 
 describe('Tier 2 (Functional) — golden test', () => {
-  it('fails when a verification tool script exits with unexpected code', async () => {
+  it('fails when a verification command exits with unexpected code', async () => {
     const spec = makeSpec({
       verificationTooling: [
         {
           name: 'import-smoke',
-          scriptPath: 'node -e "require(\'./broken\')"',
+          command: 'node -e "require(\'./broken\')"',
           expectedExitCodes: [0],
         },
       ],
     });
 
     const result = await verifyFunctional(spec, '/tmp', {
-      runVerificationScriptImpl: async (_script, _cwd, expectedExitCodes) => ({
+      runVerificationCommandImpl: async (_command, _cwd, expectedExitCodes) => ({
         passed: !expectedExitCodes.includes(0),
         output: "Error: Cannot find module './broken'",
       }),
@@ -151,17 +151,35 @@ describe('Tier 2 (Functional) — golden test', () => {
   it('passes when all verification tools succeed', async () => {
     const spec = makeSpec({
       verificationTooling: [
-        { name: 'lint', scriptPath: 'pnpm lint', expectedExitCodes: [0] },
-        { name: 'typecheck', scriptPath: 'pnpm typecheck', expectedExitCodes: [0] },
+        { name: 'lint', command: 'pnpm lint', expectedExitCodes: [0] },
+        { name: 'typecheck', command: 'pnpm typecheck', expectedExitCodes: [0] },
       ],
     });
 
     const result = await verifyFunctional(spec, '/tmp', {
-      runVerificationScriptImpl: async () => ({ passed: true, output: '' }),
+      runVerificationCommandImpl: async () => ({ passed: true, output: '' }),
     });
 
     expect(result.passed).toBe(true);
     expect(result.evidence).toHaveLength(2);
+  });
+
+  it('classifies a bare test file path as verification infrastructure failure', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'bad-path',
+          command: 'apps/web/src/foo.test.ts',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp');
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('verification-infrastructure');
+    expect(result.findings[0]?.code).toBe('malformed-verification-command');
   });
 
   it('passes vacuously when no verificationTooling is declared', async () => {

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -134,10 +134,33 @@ export function verifyStructural(
 // ─── Tier 2: Functional ───────────────────────────────────────────────────────
 
 const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
+const LAUNCH_ERROR_MARKER = 'GOOSE_VERIFICATION_COMMAND_LAUNCH_ERROR';
 
-export function isBareVerificationPath(command: string): boolean {
+export function isBareVerificationPath(command: unknown): boolean {
+  if (typeof command !== 'string') return false;
   const trimmed = command.trim();
   return !/\s/.test(trimmed) && trimmed.includes('/') && BARE_REPO_PATH_PATTERN.test(trimmed);
+}
+
+function commandLauncher(command: string): string {
+  return (
+    command
+      .trim()
+      .split(/\s+/)[0]
+      ?.replace(/^['"`]/, '')
+      .replace(/['"`]$/, '') ?? ''
+  );
+}
+
+function isLauncherMissing(command: string, output: string): boolean {
+  if (output.includes(LAUNCH_ERROR_MARKER)) return true;
+  const launcher = commandLauncher(command);
+  if (launcher === '') return false;
+  const escaped = escapeRegex(launcher);
+  return new RegExp(
+    `(^|\\n|\\s)(?:sh:\\s+\\d+:\\s+)?${escaped}:\\s+(?:command not found|not found|no such file or directory)`,
+    'i',
+  ).test(output);
 }
 
 function classifyVerificationCommandFailure(
@@ -154,7 +177,7 @@ function classifyVerificationCommandFailure(
   ) {
     return { category: 'verification-infrastructure', code: 'verification-permission-denied' };
   }
-  if (/(command not found|not found:|enoent|no such file or directory)/i.test(detail)) {
+  if (isLauncherMissing(command, output)) {
     return { category: 'verification-infrastructure', code: 'verification-runner-missing' };
   }
   if (
@@ -191,7 +214,11 @@ async function defaultRunVerificationCommand(
       resolve({ passed: expectedExitCodes.includes(exitCode), output });
     });
     child.on('error', (err) => {
-      resolve({ passed: false, output: err.message });
+      const code = (err as NodeJS.ErrnoException).code;
+      resolve({
+        passed: false,
+        output: `${LAUNCH_ERROR_MARKER}${code != null ? ` ${code}` : ''}: ${err.message}`,
+      });
     });
   });
 }
@@ -215,6 +242,15 @@ export async function verifyFunctional(
   }
 
   for (const tool of spec.verificationTooling) {
+    if (typeof tool.command !== 'string' || tool.command.trim() === '') {
+      findings.push({
+        message: `Verification tool '${tool.name}' is missing executable command`,
+        severity: 'error',
+        category: 'verification-infrastructure',
+        code: 'malformed-verification-command',
+      });
+      continue;
+    }
     const result = await runCommand(tool.command, worktreePath, tool.expectedExitCodes);
     if (result.passed) {
       evidence.push(`tool-passed: ${tool.name}`);

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -18,6 +18,8 @@ export interface VerifyFinding {
   file?: string;
   line?: number;
   severity: 'error' | 'warning' | 'info';
+  category?: 'product' | 'verification-infrastructure';
+  code?: string;
 }
 
 export interface TierResult {
@@ -41,8 +43,8 @@ export interface RunArtifacts {
 export interface TierDeps {
   appendEvent?: (input: AppendEventInput) => AgentEvent;
   getLastWpStatusImpl?: (runId: string, wpId: string) => 'ok' | 'failed' | 'in-progress' | null;
-  runVerificationScriptImpl?: (
-    scriptPath: string,
+  runVerificationCommandImpl?: (
+    command: string,
     worktreePath: string,
     expectedExitCodes: number[],
   ) => Promise<{ passed: boolean; output: string }>;
@@ -131,14 +133,52 @@ export function verifyStructural(
 
 // ─── Tier 2: Functional ───────────────────────────────────────────────────────
 
-async function defaultRunVerificationScript(
-  scriptPath: string,
+const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
+
+export function isBareVerificationPath(command: string): boolean {
+  const trimmed = command.trim();
+  return !/\s/.test(trimmed) && trimmed.includes('/') && BARE_REPO_PATH_PATTERN.test(trimmed);
+}
+
+function classifyVerificationCommandFailure(
+  command: string,
+  output: string,
+): Pick<VerifyFinding, 'category' | 'code'> {
+  const detail = `${command}\n${output}`.toLowerCase();
+  if (isBareVerificationPath(command)) {
+    return { category: 'verification-infrastructure', code: 'malformed-verification-command' };
+  }
+  if (
+    /(permission denied|eacces)/i.test(detail) &&
+    /(?:^|\s|\/)(?:apps|src|core|slices|skills)\/|(?:\.test|\.spec)?\.[cm]?[jt]sx?\b/.test(detail)
+  ) {
+    return { category: 'verification-infrastructure', code: 'verification-permission-denied' };
+  }
+  if (/(command not found|not found:|enoent|no such file or directory)/i.test(detail)) {
+    return { category: 'verification-infrastructure', code: 'verification-runner-missing' };
+  }
+  if (
+    /(no test files found|missing script|err_pnpm_no_script|failed to load config)/i.test(detail)
+  ) {
+    return { category: 'verification-infrastructure', code: 'verification-harness-config' };
+  }
+  return { category: 'product' };
+}
+
+async function defaultRunVerificationCommand(
+  command: string,
   worktreePath: string,
   expectedExitCodes: number[],
 ): Promise<{ passed: boolean; output: string }> {
+  if (isBareVerificationPath(command)) {
+    return {
+      passed: false,
+      output: `Malformed verification command: expected an executable command, got bare file path '${command}'`,
+    };
+  }
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
-    const child = spawn('sh', ['-c', scriptPath], {
+    const child = spawn('sh', ['-c', command], {
       cwd: worktreePath,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, CI: '1' },
@@ -163,11 +203,11 @@ async function defaultRunVerificationScript(
 export async function verifyFunctional(
   spec: EngineeringSpec,
   worktreePath: string,
-  deps: Pick<TierDeps, 'runVerificationScriptImpl'> = {},
+  deps: Pick<TierDeps, 'runVerificationCommandImpl'> = {},
 ): Promise<TierResult> {
   const evidence: string[] = [];
   const findings: VerifyFinding[] = [];
-  const runScript = deps.runVerificationScriptImpl ?? defaultRunVerificationScript;
+  const runCommand = deps.runVerificationCommandImpl ?? defaultRunVerificationCommand;
 
   if (spec.verificationTooling.length === 0) {
     evidence.push('no-verification-tooling-declared');
@@ -175,13 +215,15 @@ export async function verifyFunctional(
   }
 
   for (const tool of spec.verificationTooling) {
-    const result = await runScript(tool.scriptPath, worktreePath, tool.expectedExitCodes);
+    const result = await runCommand(tool.command, worktreePath, tool.expectedExitCodes);
     if (result.passed) {
       evidence.push(`tool-passed: ${tool.name}`);
     } else {
+      const classification = classifyVerificationCommandFailure(tool.command, result.output);
       findings.push({
-        message: `Verification tool '${tool.name}' failed (script: ${tool.scriptPath}): ${result.output.slice(0, 256)}`,
+        message: `Verification tool '${tool.name}' failed (command: ${tool.command}): ${result.output.slice(0, 256)}`,
         severity: 'error',
+        ...classification,
       });
     }
   }

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -51,7 +51,7 @@ A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/
 6. **`interfaceContracts`** — paste-ready `signature` (function decl, type alias, or full Zod block) + `file` it lives in. ≥1 entry required when there are ≥2 WPs (cross-WP boundaries need typed contracts).
 7. **`workPackages`** — see rules below.
 8. **`executionOrder`** — DAG of batches: `[{batch: 0, wpIds: ['WP1', 'WP2']}, {batch: 1, wpIds: ['WP3']}]`. Every WP appears exactly once.
-9. **`verificationTooling`** — required when there are >2 WPs. Each tool: `name`, `scriptPath`, `expectedExitCodes`, optional `inputSpec`.
+9. **`verificationTooling`** — required when there are >2 WPs. Each tool: `name`, `command`, `expectedExitCodes`, optional `inputSpec`. `command` must be an executable repo-root command such as `pnpm vitest run apps/web/src/lib/lanes.config.test.ts`; never emit a bare file path.
 10. **`acceptanceCriteria`** — see rules below.
 11. **`constraints`** — see rules below.
 12. **`riskRegister`** — at least one risk when the spec touches `auth | session | crypto | secret` paths.
@@ -176,7 +176,7 @@ Emit: `[decision] PLAN: Wrote <N> falsifiable ACs covering <M> journey steps`
 
 ### Step 8 — Verification tooling and risk register
 
-If `>2` WPs, declare ≥1 verification tool with a `scriptPath` + `expectedExitCodes`. If any sensitive path is touched (`auth|session|crypto|secret`), declare ≥1 risk with mitigation.
+If `>2` WPs, declare ≥1 verification tool with a `command` + `expectedExitCodes`. If any sensitive path is touched (`auth|session|crypto|secret`), declare ≥1 risk with mitigation.
 
 Emit: `[decision] INSIGHT: Verification + risk coverage complete`
 
@@ -232,7 +232,7 @@ Live marker format: `[decision] KIND: <one sentence>`. Example: `[decision] PLAN
   ],
   "executionOrder": [{ "batch": 0, "wpIds": ["WP1"] }],
   "verificationTooling": [
-    { "name": "skill-contract audit", "scriptPath": "scripts/audit-skill-contracts.ts", "expectedExitCodes": [0] }
+    { "name": "skill-contract audit", "command": "pnpm tsx scripts/audit-skill-contracts.ts", "expectedExitCodes": [0] }
   ],
   "acceptanceCriteria": [
     {

--- a/skills/spec-author/schema.ts
+++ b/skills/spec-author/schema.ts
@@ -5,6 +5,8 @@ export { DecisionSummarySchema };
 
 const RepoRelativePathDescription =
   'Repo-root/worktree-root relative POSIX path. Do not use package-relative paths like src/... for files under apps/web; use apps/web/src/....';
+const VerificationCommandDescription =
+  'Executable repo-root/worktree-root command, for example: pnpm vitest run apps/web/src/lib/lanes.config.test.ts. Do not use a bare file path.';
 
 /**
  * Engineering Spec schema (M19.02, issue #559).
@@ -88,8 +90,8 @@ export const ExecutionBatchSchema = z.object({
 
 export const VerificationToolSchema = z.object({
   name: z.string().min(1),
-  /** Repo-root/worktree-root relative path to the script that runs this verification. */
-  scriptPath: z.string().min(1).describe(RepoRelativePathDescription),
+  /** Executable repo-root/worktree-root command that runs this verification. */
+  command: z.string().min(1).describe(VerificationCommandDescription),
   /** Exit codes that count as success. */
   expectedExitCodes: z.array(z.number().int()).min(1),
   /** Optional input format spec (e.g. JSON schema for stdin). */

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -620,6 +620,38 @@ describe('validateEngineeringSpec — repoRoot-backed checks', () => {
     if (result.ok) return;
     expect(result.errors.some((e) => e.rule === 'constraint-source-symbol-missing')).toBe(true);
   });
+
+  it('rejects package-relative verification command path arguments', () => {
+    mkdirSync(join(tmpRepo, 'apps/web/scripts'), { recursive: true });
+    writeFileSync(join(tmpRepo, 'apps/web/scripts/check.ts'), 'export {};\n');
+    const spec = baseSpec({
+      constraints: [
+        {
+          kind: 'phase',
+          name: 'healthz endpoint',
+          source: 'apps/server/src/routes/healthz.ts:healthzHandler',
+        },
+      ],
+      verificationTooling: [
+        {
+          name: 'web check',
+          command: 'pnpm tsx scripts/check.ts',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = validateEngineeringSpec(spec, { repoRoot: tmpRepo });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        rule: 'verification-tool-command-package-relative',
+        ref: 'verificationTooling[0].command',
+      }),
+    );
+  });
 });
 
 // ─── TDD contract: wp-missing-test-file ──────────────────────────────────────

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -150,7 +150,7 @@ describe('EngineeringSpecSchema (shape)', () => {
       verificationTooling: [
         {
           name: 'healthz-check',
-          scriptPath: 'scripts/check-healthz.ts',
+          command: 'pnpm tsx scripts/check-healthz.ts',
           expectedExitCodes: [0],
           inputSpec: null,
         },
@@ -216,6 +216,22 @@ describe('EngineeringSpecSchema (shape)', () => {
 
   it('accepts SpecAuthorSchema as alias for EngineeringSpecSchema (backwards-compat)', () => {
     const result = SpecAuthorSchema.safeParse(baseSpec());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts executable verification tooling commands', () => {
+    const result = EngineeringSpecSchema.safeParse(
+      baseSpec({
+        verificationTooling: [
+          {
+            name: 'focused vitest',
+            command: 'pnpm vitest run apps/web/src/lib/lanes.config.test.ts',
+            expectedExitCodes: [0],
+          },
+        ],
+      }),
+    );
+
     expect(result.success).toBe(true);
   });
 
@@ -491,6 +507,29 @@ describe('validateEngineeringSpec — hard rules', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.errors.some((e) => e.rule === 'self-check-verification-tooling')).toBe(true);
+  });
+
+  it('rejects verification tooling commands that are bare repo-relative file paths', () => {
+    const result = validateEngineeringSpec(
+      baseSpec({
+        verificationTooling: [
+          {
+            name: 'bad focused test',
+            command: 'apps/web/src/foo.test.ts',
+            expectedExitCodes: [0],
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        rule: 'verification-tool-command-malformed',
+        ref: 'verificationTooling[0].command',
+      }),
+    );
   });
 
   it('rejects self-check-builder-independence when WP changes is too short', () => {

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -1,5 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+  discoverPackageRoots,
+  normalizeRepoRelativePath,
+} from '@goose-hub/core/workspaces/path-normalization.js';
 import { CONSTRAINT_SOURCE_PATTERN, type EngineeringSpec } from './schema.js';
 
 /**
@@ -40,6 +44,7 @@ export type ValidationRule =
   | 'self-check-builder-independence'
   | 'self-check-verification-tooling'
   | 'verification-tool-command-malformed'
+  | 'verification-tool-command-package-relative'
   | 'wp-missing-test-file';
 
 export type ValidationResult = { ok: true } | { ok: false; errors: ValidationError[] };
@@ -67,6 +72,21 @@ const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
 function isBareRepoPathCommand(command: string): boolean {
   const trimmed = command.trim();
   return !/\s/.test(trimmed) && BARE_REPO_PATH_PATTERN.test(trimmed) && trimmed.includes('/');
+}
+
+function commandPathTokens(command: string): string[] {
+  const tokens = command
+    .trim()
+    .split(/\s+/)
+    .slice(1)
+    .map((token) => token.replace(/^['"`]/, '').replace(/['"`]$/, ''));
+  return tokens.filter(
+    (token) =>
+      !token.startsWith('-') &&
+      token.includes('/') &&
+      BARE_REPO_PATH_PATTERN.test(token) &&
+      !token.includes('*'),
+  );
 }
 
 export function validateEngineeringSpec(
@@ -282,6 +302,24 @@ export function validateEngineeringSpec(
         message: `verificationTooling[${index}].command must be an executable command, not a bare file path: ${tool.command}`,
         ref: `verificationTooling[${index}].command`,
       });
+    }
+    if (options.repoRoot != null) {
+      const packageRoots = discoverPackageRoots(options.repoRoot);
+      for (const pathToken of commandPathTokens(tool.command)) {
+        if (existsSync(join(options.repoRoot, pathToken))) continue;
+        const normalized = normalizeRepoRelativePath({
+          rawPath: pathToken,
+          worktreePath: options.repoRoot,
+          packageRoots,
+        });
+        if (normalized.source === 'package-root') {
+          errors.push({
+            rule: 'verification-tool-command-package-relative',
+            message: `verificationTooling[${index}].command uses package-relative path '${pathToken}'; use repo-root path '${normalized.path}'`,
+            ref: `verificationTooling[${index}].command`,
+          });
+        }
+      }
     }
   }
 

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -39,6 +39,7 @@ export type ValidationRule =
   | 'self-check-falsifiable-acs'
   | 'self-check-builder-independence'
   | 'self-check-verification-tooling'
+  | 'verification-tool-command-malformed'
   | 'wp-missing-test-file';
 
 export type ValidationResult = { ok: true } | { ok: false; errors: ValidationError[] };
@@ -61,6 +62,12 @@ export interface ValidationOptions {
 }
 
 const DEFAULT_SENSITIVE_PATTERN = /(auth|session|crypto|secret)/i;
+const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
+
+function isBareRepoPathCommand(command: string): boolean {
+  const trimmed = command.trim();
+  return !/\s/.test(trimmed) && BARE_REPO_PATH_PATTERN.test(trimmed) && trimmed.includes('/');
+}
 
 export function validateEngineeringSpec(
   spec: EngineeringSpec,
@@ -266,6 +273,16 @@ export function validateEngineeringSpec(
       rule: 'self-check-verification-tooling',
       message: `${spec.workPackages.length} WPs in spec but verificationTooling is empty (Steve self-check #6)`,
     });
+  }
+
+  for (const [index, tool] of spec.verificationTooling.entries()) {
+    if (isBareRepoPathCommand(tool.command)) {
+      errors.push({
+        rule: 'verification-tool-command-malformed',
+        message: `verificationTooling[${index}].command must be an executable command, not a bare file path: ${tool.command}`,
+        ref: `verificationTooling[${index}].command`,
+      });
+    }
   }
 
   // 3. Complete interfaces — every cross-WP boundary has a typed contract.

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -1746,6 +1746,22 @@ describe('runQaWorkflow', () => {
         ],
       };
     }
+    function makeInfrastructureFailingTier(tier: 1 | 2 | 3) {
+      return {
+        tier,
+        passed: false,
+        evidence: [],
+        findings: [
+          {
+            message:
+              "Verification tool 'bad-path' failed (command: apps/web/src/foo.test.ts): Permission denied",
+            severity: 'error' as const,
+            category: 'verification-infrastructure' as const,
+            code: 'malformed-verification-command',
+          },
+        ],
+      };
+    }
 
     it('runs deterministic tiers before invoking the QA agent when spec + worktree are present', async () => {
       const item = makeWorkItem();
@@ -1891,6 +1907,68 @@ describe('runQaWorkflow', () => {
         'factory:needs-qa',
         'factory:qa-failed',
       );
+    });
+
+    it('routes verification infrastructure failures to needs-human without qa.completed or retry escalation', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: { worktreePath: '/wt/abc', devRunId: 'dev-run-1' },
+          createdAt: '',
+        },
+        {
+          id: 2,
+          kind: 'qa.completed',
+          payload: { verdict: 'fail', overallScore: 0 },
+          createdAt: '',
+        },
+        {
+          id: 3,
+          kind: 'qa.completed',
+          payload: { verdict: 'fail', overallScore: 0 },
+          createdAt: '',
+        },
+      ]);
+      mockGetEngineeringSpec.mockReturnValue(makeSpecRow());
+
+      const runTierImpl = vi.fn(
+        async (tier: 1 | 2 | 3, _spec: unknown, _artifacts: unknown, _deps?: unknown) =>
+          tier === 2 ? makeInfrastructureFailingTier(2) : makePassingTier(tier),
+      );
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+        runTests: vi.fn().mockResolvedValue(null),
+        runTierImpl,
+      });
+
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-human',
+      );
+      expect(
+        vi.mocked(eventStore.appendEvent).mock.calls.some(([e]) => e.kind === 'qa.completed'),
+      ).toBe(false);
+      expect(
+        vi
+          .mocked(eventStore.appendEvent)
+          .mock.calls.some(([e]) => e.kind === 'agent.retry-escalated'),
+      ).toBe(false);
+      const blocked = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.verification-blocked');
+      expect(blocked).toBeDefined();
+      expect(blocked?.[0].payload).toMatchObject({
+        failedTier: 2,
+        reason: 'malformed-verification-command',
+        agentSkipped: true,
+      });
     });
 
     it('tier 3 fail with regressionPolicy=ignore continues to the agent', async () => {

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -17,7 +17,7 @@ import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import type { RegressionPolicy } from '@goose-hub/core/verify/tiers.js';
+import type { RegressionPolicy, TierResult } from '@goose-hub/core/verify/tiers.js';
 import { runTier as defaultRunTier } from '@goose-hub/core/verify/tiers.js';
 import { type QaOutput, QaOutputSchema, type TestRun } from '@goose-hub/skills/qa/schema.js';
 import type { EngineeringSpec } from '@goose-hub/skills/spec-author/schema.js';
@@ -58,6 +58,32 @@ export interface QaWorkflowDeps {
 }
 
 const DEFAULT_TEST_COMMAND = 'pnpm test --reporter=json';
+
+function classifyVerificationInfrastructureFailure(
+  result: TierResult | null,
+): { reason: string; findings: string[] } | null {
+  if (result == null || result.passed) return null;
+  const infrastructureFindings = result.findings.filter((finding) => {
+    if (finding.category === 'verification-infrastructure') return true;
+    const detail = `${finding.code ?? ''}\n${finding.message}`.toLowerCase();
+    return (
+      detail.includes('malformed verification command') ||
+      detail.includes('permission denied') ||
+      detail.includes('eacces') ||
+      detail.includes('command not found') ||
+      detail.includes('verification-runner-missing') ||
+      detail.includes('verification-harness-config') ||
+      detail.includes('no test files found') ||
+      detail.includes('missing script') ||
+      detail.includes('failed to load config')
+    );
+  });
+  if (infrastructureFindings.length === 0) return null;
+  return {
+    reason: infrastructureFindings[0]?.code ?? 'verification-infrastructure-failure',
+    findings: infrastructureFindings.map((finding) => finding.message),
+  };
+}
 
 /**
  * Runs the QA holdout workflow for a work item in `factory:needs-qa` state.
@@ -157,6 +183,60 @@ export async function runQaWorkflow(
     // escalates to needs-human exactly like a non-deterministic QA failure.
     if (deterministic?.shortCircuitTier != null) {
       const failedTier = deterministic.shortCircuitTier;
+      const infrastructureFailure = classifyVerificationInfrastructureFailure(
+        deterministic.tierResults[failedTier],
+      );
+      if (infrastructureFailure != null) {
+        eventStore.appendEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          kind: 'qa.verification-blocked',
+          payload: {
+            failedTier,
+            reason: infrastructureFailure.reason,
+            findings: infrastructureFailure.findings,
+            deterministic: true,
+            agentSkipped: true,
+            ...(prHints.pipelineRunId != null ? { pipelineRunId: prHints.pipelineRunId } : {}),
+          },
+          runId,
+        });
+        await stateSource.comment(
+          workItem.externalId,
+          buildAgentComment(
+            'QA',
+            'Verification Blocked',
+            'Deterministic verification failed because the verifier infrastructure is misconfigured. QA agent and fix-feedback were skipped.',
+            [
+              `Tier: ${failedTier}`,
+              `Reason: ${infrastructureFailure.reason}`,
+              'Next state: factory:needs-human',
+              ...infrastructureFailure.findings.slice(0, 3).map((finding) => `Finding: ${finding}`),
+            ],
+          ),
+        );
+        accumulatePersonaStats({
+          personaName: personaId,
+          role: 'qa',
+          outcome: 'failure',
+          qualityScore: 0,
+        });
+        await stateSource.transitionState(
+          workItem.externalId,
+          'factory:needs-qa',
+          'factory:needs-human',
+        );
+        emitStateTransitionEvent({
+          projectId: projectSlug,
+          workItemId: workItem.id,
+          from: 'factory:needs-qa',
+          to: 'factory:needs-human',
+          by: 'qa',
+          runId,
+        });
+        return;
+      }
+
       const synthetic = buildSyntheticQaOutput({
         tierResults: deterministic.tierResults,
         failedTier,

--- a/slices/spec-author/path-normalization.ts
+++ b/slices/spec-author/path-normalization.ts
@@ -27,7 +27,6 @@ export function normalizeEngineeringSpecPaths(input: {
   const referencePaths = [
     ...input.spec.workPackages.flatMap((wp) => wp.filesOwned),
     ...input.spec.interfaceContracts.map((contract) => contract.file),
-    ...input.spec.verificationTooling.map((tool) => tool.scriptPath),
     ...input.spec.schemaChanges.migrations,
     ...(input.referencePaths ?? []),
   ];
@@ -68,10 +67,6 @@ export function normalizeEngineeringSpecPaths(input: {
       filesOwned: wp.filesOwned.map((path, pathIndex) =>
         normalizeField(`workPackages[${wpIndex}].filesOwned[${pathIndex}]`, path),
       ),
-    })),
-    verificationTooling: input.spec.verificationTooling.map((tool, index) => ({
-      ...tool,
-      scriptPath: normalizeField(`verificationTooling[${index}].scriptPath`, tool.scriptPath),
     })),
   };
 

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -260,7 +260,7 @@ describe('runSpecAuthorWorkflow', () => {
           verificationTooling: [
             {
               name: 'spec-check',
-              scriptPath: 'scripts/spec-check.ts',
+              command: 'pnpm tsx scripts/spec-check.ts',
               expectedExitCodes: [0],
               inputSpec: null,
             },
@@ -345,7 +345,7 @@ describe('runSpecAuthorWorkflow', () => {
           verificationTooling: [
             {
               name: 'web-check',
-              scriptPath: 'scripts/check.ts',
+              command: 'pnpm tsx scripts/check.ts',
               expectedExitCodes: [0],
               inputSpec: null,
             },
@@ -362,12 +362,12 @@ describe('runSpecAuthorWorkflow', () => {
         schemaChanges: { migrations: string[] };
         interfaceContracts: Array<{ file: string }>;
         workPackages: Array<{ filesOwned: string[] }>;
-        verificationTooling: Array<{ scriptPath: string }>;
+        verificationTooling: Array<{ command: string }>;
       };
       expect(persistedSpec.schemaChanges.migrations).toEqual(['apps/web/migrations/001.sql']);
       expect(persistedSpec.interfaceContracts[0]?.file).toBe('apps/web/src/api.ts');
       expect(persistedSpec.workPackages[0]?.filesOwned).toEqual(['apps/web/src/api.ts']);
-      expect(persistedSpec.verificationTooling[0]?.scriptPath).toBe('apps/web/scripts/check.ts');
+      expect(persistedSpec.verificationTooling[0]?.command).toBe('pnpm tsx scripts/check.ts');
 
       const repaired = vi
         .mocked(eventStore.appendEvent)
@@ -392,12 +392,6 @@ describe('runSpecAuthorWorkflow', () => {
             field: 'workPackages[0].filesOwned[0]',
             from: 'src/api.ts',
             to: 'apps/web/src/api.ts',
-            source: 'package-root',
-          },
-          {
-            field: 'verificationTooling[0].scriptPath',
-            from: 'scripts/check.ts',
-            to: 'apps/web/scripts/check.ts',
             source: 'package-root',
           },
         ]),

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -396,6 +396,7 @@ export async function runSpecAuthorWorkflow(
         spec: normalized.spec,
         validation: validateEngineeringSpec(normalized.spec, {
           issueType: workItem.type === 'bug' ? 'bug' : 'feature',
+          repoRoot: worktreePath,
         }),
       };
     };

--- a/target-projects/goose-hub-self/agent-context/spec-author.md
+++ b/target-projects/goose-hub-self/agent-context/spec-author.md
@@ -13,6 +13,10 @@ is present.
 
 Put required tests and commands in `acceptanceCriteria.verifyCommand` and
 `verificationTooling`; do not create e2e file paths as the output artefact.
+Each `verificationTooling[]` entry must use `command`, not `scriptPath`, and
+the value must be a runnable repo-root command such as
+`pnpm vitest run apps/web/src/lib/lanes.config.test.ts`. Never emit a bare
+test/source file path.
 
 Strict shape reminders for fields that commonly fail schema validation:
 - Optional fields should be omitted when they do not apply. Do not emit `null`.


### PR DESCRIPTION
## Summary
- replace spec-author verificationTooling scriptPath with executable command and reject bare file paths
- run deterministic Tier 2 verification commands and classify verifier infrastructure failures
- route verification infrastructure failures to needs-human via qa.verification-blocked without burning fix-feedback retries
- infer terminal labels/status for parallel-implement and deterministic QA timeline run groups

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test skills/spec-author/slice.test.ts slices/spec-author/slice.test.ts core/verify/tiers.test.ts slices/qa/slice.test.ts apps/web/src/components/detail/components/TimelineSection.test.ts