### PR TITLE
M19.XX: The items in the kanban lanes order is wrong 2

### DIFF
--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -8,7 +8,7 @@ import type { WorkItemWithProject } from './lib/all-projects';
 // Here we lock the sort/ordering rule and grouping logic.
 
 describe('issue card lane ordering', () => {
-  it('orders by priority desc, then issue number asc', () => {
+  it('orders by priority, then newest issue number first within a priority', () => {
     const sorted = sortLaneItems([
       { externalId: '40', priority: 'medium' },
       { externalId: '12', priority: 'low' },
@@ -16,7 +16,7 @@ describe('issue card lane ordering', () => {
       { externalId: '99', priority: 'critical' },
       { externalId: '5', priority: 'high' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '5', '40', '12']);
   });
 });
 
@@ -74,6 +74,7 @@ describe('groupAllProjectsItems (#284)', () => {
     const map = groupAllProjectsItems(items, LANES);
     const triageLane = map.get('triage') ?? [];
     expect(triageLane).toHaveLength(2);
+    expect(triageLane.map((i) => i.externalId)).toEqual(['20', '10']);
     expect(triageLane.map((i) => i.projectSlug)).toContain('proj-a');
     expect(triageLane.map((i) => i.projectSlug)).toContain('proj-b');
   });

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,7 +23,7 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts by priority then newest issue number first', () => {
     const sorted = sortLaneItems([
       { externalId: '40', priority: 'medium' },
       { externalId: '12', priority: 'low' },
@@ -31,29 +31,37 @@ describe('lanes config', () => {
       { externalId: '99', priority: 'critical' },
       { externalId: '5', priority: 'high' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '5', '40', '12']);
   });
 
   it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
-    // Line 126: the ?? 9 fallback branch — items with unknown priority rank last
     const sorted = sortLaneItems([
       { externalId: '1', priority: 'high' },
       { externalId: '2', priority: 'unknown-future-priority' },
       { externalId: '3', priority: 'critical' },
     ]);
-    // critical(0) < high(1) < unknown(9)
     expect(sorted[0].externalId).toBe('3');
     expect(sorted[1].externalId).toBe('1');
     expect(sorted[2].externalId).toBe('2');
   });
 
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
+  it('sortLaneItems orders items with the same priority by externalId descending', () => {
     const sorted = sortLaneItems([
       { externalId: '30', priority: 'medium' },
       { externalId: '10', priority: 'medium' },
       { externalId: '20', priority: 'medium' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['30', '20', '10']);
+  });
+
+  it('sortLaneItems does not fall back to ascending externalId ordering within a lane', () => {
+    const sorted = sortLaneItems([
+      { externalId: '101', priority: 'high' },
+      { externalId: '103', priority: 'high' },
+      { externalId: '102', priority: 'high' },
+    ]);
+    expect(sorted.map((s) => s.externalId)).not.toEqual(['101', '102', '103']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['103', '102', '101']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -124,13 +124,13 @@ interface SortableItem {
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Order matches kanban display order: highest priority first, then newest issue
+ * number first within each priority bucket.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
     const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
     if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    return Number(b.externalId) - Number(a.externalId);
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanban lanes order is wrong 2

## Work Packages

- ✓ **WP1**: In `apps/web/src/lib/lanes.config.ts:sortLaneItems`, replace the current ascending-`externalId` lane ordering with newes
- ✓ **WP2**: Update `apps/web/src/components/board/slice.test.ts` so the board-level ordering contract matches the revised shared hel

Closes #936
