### PR TITLE
fix(spec-author): document TDD ownership contract

### DIFF
--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -64,6 +64,18 @@ The same file path **cannot appear in `filesOwned` of two WPs anywhere in the sp
 
 (Steve `03-lifecycle-harness.md:155-156` — "file ownership prevents conflicts", no scoping qualifier.)
 
+#### TDD ownership
+
+If a WP owns production `.ts` or `.tsx` files, that same WP must also include a
+relevant `*.test.ts`, `*.test.tsx`, `*.spec.ts`, or `*.spec.tsx` file in
+`filesOwned`. Do not put the test file only in `verificationTooling` or
+`acceptanceCriteria`; it must be owned by the WP that owns the production edit.
+
+Test-only WPs are allowed. Files that are not implementation surfaces, such as
+`*.config.ts`, `*.d.ts`, `*types.ts`, `*interfaces.ts`, `*schema.ts`,
+`*index.ts`, `*constants.ts`, and `*errors.ts`, do not need a paired test file
+unless the work item genuinely changes executable behavior there.
+
 #### Constraint inventory cites real code
 
 Every entry in `constraints` must have `source` in the form `path/to/file.ts:LINE` or `path/to/file.ts:SYMBOL`. The validator checks the file exists and contains the cited symbol. Mocked or pseudo references are rejected.
@@ -113,6 +125,8 @@ The validator runs:
 4. **Falsifiable ACs** — schema-enforced (`verifyCommand: z.string().min(1)`).
 5. **Builder independence** — `changes` field non-trivial.
 6. **Verification tooling** — >2 WPs ⇒ ≥1 `verificationTooling` entry.
+7. **TDD ownership** — each WP that owns production `.ts` or `.tsx` files also
+   owns a relevant test/spec file.
 
 ## Process
 
@@ -151,6 +165,8 @@ Decompose the change into WPs. Each WP names the files it owns; **no path appear
 For each WP:
 - `id`: `WP1`, `WP2`, ... (deterministic ordering).
 - `filesOwned`: array of repo-root/worktree-root relative POSIX paths. ≥1 required.
+- If `filesOwned` includes production `.ts`/`.tsx`, include the relevant test
+  or spec file in the same WP.
 - `changes`: file:line citations + before/after sketch. Builder must be able to act without re-exploring.
 - `dependsOn`: WP ids this one depends on.
 - `builderTier`: `haiku` for mechanical edits, `sonnet` for moderate logic, `opus` for novel design.

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -657,6 +657,17 @@ describe('validateEngineeringSpec — repoRoot-backed checks', () => {
 // ─── TDD contract: wp-missing-test-file ──────────────────────────────────────
 
 describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () => {
+  it('documents TDD ownership in the spec-author prompt', () => {
+    const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+
+    expect(prompt).toContain('#### TDD ownership');
+    expect(prompt).toContain('production `.ts` or `.tsx` files');
+    expect(prompt).toContain('`*.test.ts`');
+    expect(prompt).toContain('`*.spec.ts`');
+    expect(prompt).toContain('Do not put the test file only in `verificationTooling`');
+    expect(prompt).toContain('Test-only WPs are allowed');
+  });
+
   it('rejects WP with production .ts files but no test file', () => {
     const spec = baseSpec({
       workPackages: [


### PR DESCRIPTION
## Summary
- Add the TDD ownership rule to the global spec-author prompt so WPs owning production TypeScript also own relevant test/spec files.
- Add prompt drift coverage alongside the existing spec-author TDD validator tests.

## Verification
- pnpm vitest run skills/spec-author/slice.test.ts
- pnpm tsx scripts/audit-skill-contracts.ts --strict
- git diff --check