### PR TITLE
fix(runtime): align output schema validation

### DIFF
--- a/apps/server/src/domains/inbox/enhance.ts
+++ b/apps/server/src/domains/inbox/enhance.ts
@@ -1,4 +1,4 @@
-import { omitNullObjectProperties } from '@goose-hub/core/agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
@@ -66,7 +66,7 @@ export async function runBugEnhance(
       appendSystemPrompt: prompt,
     });
 
-    const parsed = BugEnhanceOutputSchema.safeParse(omitNullObjectProperties(result.output));
+    const parsed = safeParseOutputForSchema(BugEnhanceOutputSchema, result.output);
     if (!parsed.success) {
       logger.warn('bug-enhance: output validation failed', {
         errors: parsed.error.issues,

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { omitNullObjectProperties } from '@goose-hub/core/agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
@@ -144,9 +144,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       appendSystemPrompt: triagePrompt,
     });
 
-    const triageParsed = TriageOutputSchema.safeParse(
-      omitNullObjectProperties(triageResult.output),
-    );
+    const triageParsed = safeParseOutputForSchema(TriageOutputSchema, triageResult.output);
     if (!triageParsed.success) {
       logger.error('triage-batch triage output invalid', {
         slug,
@@ -234,9 +232,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       appendSystemPrompt: repoMatchPrompt,
     });
 
-    const repoMatchParsed = RepoMatchOutputSchema.safeParse(
-      omitNullObjectProperties(repoMatchResult.output),
-    );
+    const repoMatchParsed = safeParseOutputForSchema(RepoMatchOutputSchema, repoMatchResult.output);
     if (!repoMatchParsed.success) {
       logger.warn('triage-batch repo-match output invalid, using empty candidates', {
         slug,

--- a/core/agent-runtime/advisor.ts
+++ b/core/agent-runtime/advisor.ts
@@ -6,6 +6,7 @@ import { eventStore } from '../event-stream/store.js';
 import type { AgentRuntime } from './interface.js';
 import type { AgentResult } from './interface.js';
 import { OutputValidationError, invokeSkill } from './invoke-skill.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
 import { reconcileDecisionSummaries } from './reconcile-decisions.js';
 import { ADVISOR_GATED_PRIORITIES } from './roles.js';
 
@@ -75,15 +76,18 @@ export async function adviseOnPlan(input: AdviseOnPlanInput): Promise<AdviseOnPl
   }
 
   // invokeSkill already validated result.output against AdviseOnPlanSchema via outputSchema
-  const parsed = AdviseOnPlanSchema.parse(result.output);
+  const parsed = safeParseOutputForSchema(AdviseOnPlanSchema, result.output);
+  if (!parsed.success) {
+    throw new Error('advise-on-plan output validation failed');
+  }
 
   reconcileDecisionSummaries(
     input.runId,
     input.projectId,
     input.workItemId,
     'advise-on-plan',
-    parsed.decisionSummaries,
+    parsed.data.decisionSummaries,
   );
 
-  return parsed;
+  return parsed.data;
 }

--- a/core/agent-runtime/dev-review-advisor.ts
+++ b/core/agent-runtime/dev-review-advisor.ts
@@ -26,7 +26,7 @@ import type { AgentConfig } from '../types.js';
 import { GIT_ENV } from '../workspaces/git-env.js';
 import { type DiffDigest, buildDiffDigest, formatDiffDigestSummary } from './diff-digest.js';
 import type { AgentRuntime } from './interface.js';
-import { omitNullObjectProperties } from './output-normalization.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
 import { readPromptWithContext } from './read-prompt.js';
 import { reconcileDecisionSummaries } from './reconcile-decisions.js';
 import { resolveBudgetsForProject } from './resolve-for-project.js';
@@ -313,7 +313,7 @@ export async function runDevReview(input: RunDevReviewInput): Promise<DevReviewO
     appendEvent: input.appendEvent,
   });
 
-  const parsed = DevReviewOutputSchema.safeParse(omitNullObjectProperties(result.output));
+  const parsed = safeParseOutputForSchema(DevReviewOutputSchema, result.output);
   if (!parsed.success) {
     input.appendEvent({
       projectId: input.projectId,
@@ -438,7 +438,7 @@ export async function runDevReviewResponse(
     workspaceDir: input.worktreePath,
   });
 
-  const parsed = DevReviewResponseOutputSchema.safeParse(omitNullObjectProperties(result.output));
+  const parsed = safeParseOutputForSchema(DevReviewResponseOutputSchema, result.output);
   if (!parsed.success) {
     input.appendEvent({
       projectId: input.projectId,

--- a/core/agent-runtime/invoke-skill.ts
+++ b/core/agent-runtime/invoke-skill.ts
@@ -5,7 +5,7 @@ import { getProjectBySlug } from '../projects/loader.js';
 import type { ProjectConfig } from '../types.js';
 import type { ResolvedBudget } from './budgets.js';
 import type { AgentResult, AgentRuntime, SkillConfig } from './interface.js';
-import { omitNullObjectProperties } from './output-normalization.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
 import { readPromptWithContext } from './read-prompt.js';
 import { toJsonSchema } from './schema-bridge.js';
 import { selectPersona } from './select-persona.js';
@@ -190,8 +190,7 @@ export async function invokeSkill(input: InvokeSkillInput): Promise<InvokeSkillR
   // 11. Validate output when skill declares an outputSchema
   let output = result.output;
   if (skillConfig.outputSchema != null) {
-    output = omitNullObjectProperties(result.output);
-    const outResult = skillConfig.outputSchema.safeParse(output);
+    const outResult = safeParseOutputForSchema(skillConfig.outputSchema, result.output);
     if (!outResult.success) {
       throw new OutputValidationError(
         outResult.error.issues.map((i) => ({

--- a/core/agent-runtime/output-normalization.test.ts
+++ b/core/agent-runtime/output-normalization.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { ImplementSchema } from '../../skills/implement/schema.js';
+import { DecisionSummarySchema } from '../retrospective/schemas.js';
+import { normalizeOutputForSchema, safeParseOutputForSchema } from './output-normalization.js';
+import { ScoutOutputSchema } from './scout-output.js';
+
+describe('normalizeOutputForSchema', () => {
+  it('omits null for optional string fields', () => {
+    const schema = z.object({ value: z.string().optional() });
+
+    expect(normalizeOutputForSchema(schema, { value: null })).toEqual({});
+  });
+
+  it('preserves null for required nullable string fields', () => {
+    const schema = z.object({ value: z.string().nullable() });
+
+    expect(normalizeOutputForSchema(schema, { value: null })).toEqual({ value: null });
+  });
+
+  it('omits null for optional nullable string fields by repo convention', () => {
+    const schema = z.object({ value: z.string().nullable().optional() });
+
+    expect(normalizeOutputForSchema(schema, { value: null })).toEqual({});
+  });
+
+  it('preserves null for required non-nullable fields so Zod rejects them', () => {
+    const schema = z.object({ value: z.string() });
+    const normalized = normalizeOutputForSchema(schema, { value: null });
+
+    expect(normalized).toEqual({ value: null });
+    expect(safeParseOutputForSchema(schema, { value: null }).success).toBe(false);
+  });
+
+  it('normalizes nested object optional fields without dropping required nullable fields', () => {
+    const schema = z.object({
+      nested: z.object({
+        optional: z.string().optional(),
+        requiredNullable: z.string().nullable(),
+      }),
+    });
+
+    expect(
+      normalizeOutputForSchema(schema, {
+        nested: { optional: null, requiredNullable: null },
+      }),
+    ).toEqual({ nested: { requiredNullable: null } });
+  });
+
+  it('normalizes arrays of objects item by item', () => {
+    const schema = z.object({
+      items: z.array(z.object({ optional: z.string().optional(), required: z.string() })),
+    });
+
+    expect(
+      normalizeOutputForSchema(schema, {
+        items: [
+          { optional: null, required: 'a' },
+          { optional: 'kept', required: 'b' },
+        ],
+      }),
+    ).toEqual({
+      items: [{ required: 'a' }, { optional: 'kept', required: 'b' }],
+    });
+  });
+
+  it('preserves unknown non-null object keys and omits unknown null keys', () => {
+    const schema = z.object({ known: z.string() });
+
+    expect(
+      normalizeOutputForSchema(schema, {
+        known: 'x',
+        extra: { keep: 'y', drop: null },
+        nullExtra: null,
+      }),
+    ).toEqual({ known: 'x', extra: { keep: 'y' } });
+  });
+
+  it('omits QA/scout-style optional nullable line values', () => {
+    const parsed = safeParseOutputForSchema(ScoutOutputSchema, {
+      status: 'ok',
+      findings: [
+        { file: 'core/db/schema.ts', line: null, fact: 'uses sqlite', confidence: 'high' },
+      ],
+      decisionSummaries: [{ kind: 'READ', summary: 'inspected core/db/schema.ts' }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.findings[0]).not.toHaveProperty('line');
+  });
+
+  it('keeps implement required nullable evidenceSpecPath null through validation', () => {
+    const parsed = safeParseOutputForSchema(ImplementSchema, {
+      plan: 'Backend-only fix',
+      filesWritten: [
+        { path: 'core/agent-runtime/output-normalization.ts', reason: 'Added helper' },
+      ],
+      testsWritten: [],
+      testsRun: {
+        command: 'pnpm vitest run core/agent-runtime/output-normalization.test.ts',
+        paths: [],
+      },
+      prUrl: 'https://github.com/shaunnez/goose-hub/pull/1',
+      evidenceSpecPath: null,
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Backend-only validation change' }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.evidenceSpecPath).toBeNull();
+  });
+
+  it('omits optional decision summary evidence null values', () => {
+    const schema = z.object({ decisionSummaries: z.array(DecisionSummarySchema) });
+    const parsed = safeParseOutputForSchema(schema, {
+      decisionSummaries: [{ kind: 'PLAN', summary: 'classified item', evidence: null }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.decisionSummaries[0]).not.toHaveProperty('evidence');
+  });
+});

--- a/core/agent-runtime/output-normalization.ts
+++ b/core/agent-runtime/output-normalization.ts
@@ -1,13 +1,101 @@
-export function omitNullObjectProperties(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(omitNullObjectProperties);
-  if (!isRecord(value)) return value;
+import { type ZodType, toJSONSchema } from 'zod';
 
+type JsonSchema = Record<string, unknown>;
+
+export function normalizeOutputForSchema(schema: ZodType, output: unknown): unknown {
+  return normalizeValue(toJSONSchema(schema) as JsonSchema, output);
+}
+
+export function safeParseOutputForSchema<T>(schema: ZodType<T>, output: unknown) {
+  return schema.safeParse(normalizeOutputForSchema(schema, output));
+}
+
+function normalizeValue(schema: unknown, value: unknown): unknown {
+  const effectiveSchema = selectEffectiveSchema(schema, value);
+  if (Array.isArray(value)) return normalizeArray(effectiveSchema, value);
+  if (!isRecord(value)) return value;
+  if (!isRecord(effectiveSchema) || !isObjectSchema(effectiveSchema)) {
+    return normalizeUnknownObject(value);
+  }
+
+  const properties = isRecord(effectiveSchema.properties) ? effectiveSchema.properties : {};
+  const required = new Set(requiredKeys(effectiveSchema));
+  const next: Record<string, unknown> = {};
+
+  for (const [key, child] of Object.entries(value)) {
+    if (Object.hasOwn(properties, key)) {
+      if (child === null && !required.has(key)) continue;
+      next[key] = normalizeValue(properties[key], child);
+      continue;
+    }
+
+    if (child === null) continue;
+    next[key] = normalizeValue(undefined, child);
+  }
+
+  return next;
+}
+
+function normalizeArray(schema: unknown, value: unknown[]): unknown[] {
+  const itemSchema = isRecord(schema) ? schema.items : undefined;
+  return value.map((item) => normalizeValue(itemSchema, item));
+}
+
+function normalizeUnknownObject(value: Record<string, unknown>): Record<string, unknown> {
   const next: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {
     if (child === null) continue;
-    next[key] = omitNullObjectProperties(child);
+    next[key] = normalizeValue(undefined, child);
   }
   return next;
+}
+
+function selectEffectiveSchema(schema: unknown, value: unknown): unknown {
+  if (!isRecord(schema)) return schema;
+
+  const variants = getSchemaVariants(schema);
+  if (variants.length === 0) return schema;
+
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant));
+  if (nonNullVariants.length === 0) return schema;
+
+  if (Array.isArray(value)) {
+    return nonNullVariants.find((variant) => isRecord(variant) && isArraySchema(variant)) ?? schema;
+  }
+  if (isRecord(value)) {
+    return (
+      nonNullVariants.find((variant) => isRecord(variant) && isObjectSchema(variant)) ?? schema
+    );
+  }
+
+  return nonNullVariants[0] ?? schema;
+}
+
+function getSchemaVariants(schema: Record<string, unknown>): unknown[] {
+  if (Array.isArray(schema.anyOf)) return schema.anyOf;
+  if (Array.isArray(schema.oneOf)) return schema.oneOf;
+  if (Array.isArray(schema.allOf)) return schema.allOf;
+  return [];
+}
+
+function isObjectSchema(schema: Record<string, unknown>): boolean {
+  return schema.type === 'object' || isRecord(schema.properties);
+}
+
+function isArraySchema(schema: Record<string, unknown>): boolean {
+  return schema.type === 'array' || schema.items != null;
+}
+
+function isNullSchema(schema: unknown): boolean {
+  if (!isRecord(schema)) return false;
+  if (schema.type === 'null') return true;
+  return Array.isArray(schema.type) && schema.type.length === 1 && schema.type[0] === 'null';
+}
+
+function requiredKeys(schema: Record<string, unknown>): string[] {
+  return Array.isArray(schema.required)
+    ? schema.required.filter((key): key is string => typeof key === 'string')
+    : [];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/core/agent-runtime/output-validator.ts
+++ b/core/agent-runtime/output-validator.ts
@@ -1,4 +1,5 @@
 import type { ZodType } from 'zod';
+import { safeParseOutputForSchema } from './output-normalization.js';
 
 export class OutputValidationError extends Error {
   constructor(
@@ -22,7 +23,7 @@ export function validateOutput<T>(raw: string, schema: ZodType<T>): T {
     throw new OutputValidationError(raw, [`Invalid JSON: ${raw.slice(0, 200)}`]);
   }
 
-  const result = schema.safeParse(parsed);
+  const result = safeParseOutputForSchema(schema, parsed);
   if (!result.success) {
     const errors = (result as { success: false; error: { issues: unknown[] } }).error.issues;
     throw new OutputValidationError(raw, errors);

--- a/core/agent-runtime/schema-bridge.test.ts
+++ b/core/agent-runtime/schema-bridge.test.ts
@@ -1,5 +1,10 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { skillsRoot } from '@goose-hub/skills';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { AdviseOnPlanSchema } from '../../skills/advise-on-plan/schema.js';
 import { ImplementSchema } from '../../skills/implement/schema.js';
 import { InterventionProposerOutputSchema } from '../../skills/intervention-proposer/schema.js';
 import { ReviewOutputSchema } from '../../skills/review/schema.js';
@@ -172,7 +177,7 @@ describe('toJsonSchema', () => {
     expect(JSON.stringify(result)).not.toContain('"payload":{}');
   });
 
-  it('collapses top-level object unions into an object schema for Codex response formats', () => {
+  it('keeps review escalationReason visible in the Codex response schema', () => {
     const result = toJsonSchema(ReviewOutputSchema);
 
     expect(result.type).toBe('object');
@@ -185,9 +190,48 @@ describe('toJsonSchema', () => {
         findings: { type: 'array' },
         decisionSummaries: { type: 'array' },
       },
-      required: ['verdict', 'confidence', 'criteriaChecks', 'findings', 'decisionSummaries'],
+      required: [
+        'verdict',
+        'confidence',
+        'criteriaChecks',
+        'findings',
+        'decisionSummaries',
+        'escalationReason',
+      ],
       additionalProperties: false,
     });
+    const properties = result.properties as Record<string, unknown>;
+    expect(schemaAllowsNull(properties.escalationReason)).toBe(true);
+  });
+
+  it('keeps advise-on-plan top-level schema composition-free for Codex', () => {
+    const result = toJsonSchema(AdviseOnPlanSchema);
+
+    expect(result.type).toBe('object');
+    expect(result).not.toHaveProperty('oneOf');
+    expect(result).not.toHaveProperty('anyOf');
+    expect(result).not.toHaveProperty('allOf');
+    expect(result).toMatchObject({
+      properties: {
+        verdict: { type: 'string', enum: ['proceed', 'revise', 'abort'] },
+      },
+      required: ['verdict', 'confidence', 'feedback', 'reason', 'decisionSummaries'],
+      additionalProperties: false,
+    });
+    const properties = result.properties as Record<string, unknown>;
+    expect(schemaAllowsNull(properties.feedback)).toBe(true);
+    expect(schemaAllowsNull(properties.reason)).toBe(true);
+  });
+
+  it('keeps active skill output schemas strict enough for Codex response schemas', async () => {
+    const configs = await loadActiveSkillConfigs();
+
+    const issues = configs.flatMap(({ skillName, outputSchema }) => {
+      if (outputSchema == null) return [];
+      return assertCodexCompatibleSchema(skillName, toJsonSchema(outputSchema));
+    });
+
+    expect(issues).toEqual([]);
   });
 
   it('returns an empty schema and warns when conversion throws', () => {
@@ -205,3 +249,84 @@ describe('toJsonSchema', () => {
     warnSpy.mockRestore();
   });
 });
+
+async function loadActiveSkillConfigs(): Promise<
+  Array<{ skillName: string; outputSchema?: z.ZodType }>
+> {
+  const skillNames = readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  const configs: Array<{ skillName: string; outputSchema?: z.ZodType }> = [];
+  for (const skillName of skillNames) {
+    const configPath = join(skillsRoot, skillName, 'skill.config.ts');
+    const mod = (await import(pathToFileURL(configPath).href)) as {
+      default?: { outputSchema?: unknown };
+    };
+    configs.push({
+      skillName,
+      outputSchema: mod.default?.outputSchema as z.ZodType | undefined,
+    });
+  }
+  return configs;
+}
+
+function assertCodexCompatibleSchema(skillName: string, schema: Record<string, unknown>): string[] {
+  const issues: string[] = [];
+  if ('oneOf' in schema) issues.push(`${skillName}: top-level oneOf is not allowed`);
+  if ('anyOf' in schema) issues.push(`${skillName}: top-level anyOf is not allowed`);
+  if ('allOf' in schema) issues.push(`${skillName}: top-level allOf is not allowed`);
+  visitSchema(skillName, schema, skillName, issues);
+  return issues;
+}
+
+function visitSchema(skillName: string, node: unknown, path: string, issues: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((child, index) => visitSchema(skillName, child, `${path}[${index}]`, issues));
+    return;
+  }
+  if (!isRecord(node)) return;
+
+  if ('propertyNames' in node) issues.push(`${path}: propertyNames is not allowed`);
+  if (node.format === 'uri') issues.push(`${path}: format uri is not allowed`);
+
+  if (isObjectSchema(node)) {
+    const properties = isRecord(node.properties) ? node.properties : {};
+    const required = Array.isArray(node.required)
+      ? node.required.filter((key): key is string => typeof key === 'string')
+      : [];
+    const propertyKeys = Object.keys(properties);
+    const missingRequired = propertyKeys.filter((key) => !required.includes(key));
+    if (missingRequired.length > 0) {
+      issues.push(`${path}: properties missing from required: ${missingRequired.join(', ')}`);
+    }
+    if (node.additionalProperties !== false) {
+      issues.push(`${path}: additionalProperties must be false`);
+    }
+  }
+
+  for (const [key, child] of Object.entries(node)) {
+    visitSchema(skillName, child, `${path}.${key}`, issues);
+  }
+}
+
+function isObjectSchema(node: Record<string, unknown>): boolean {
+  return node.type === 'object' || isRecord(node.properties) || node.additionalProperties != null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function schemaAllowsNull(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.type === 'null') return true;
+  if (Array.isArray(value.type) && value.type.includes('null')) return true;
+  const variants = Array.isArray(value.anyOf)
+    ? value.anyOf
+    : Array.isArray(value.oneOf)
+      ? value.oneOf
+      : [];
+  return variants.some(schemaAllowsNull);
+}

--- a/core/agent-runtime/schema-bridge.ts
+++ b/core/agent-runtime/schema-bridge.ts
@@ -22,73 +22,7 @@ export function toJsonSchema(schema: ZodType): JsonSchema {
 }
 
 function toCodexResponseSchema(schema: JsonSchema): JsonSchema {
-  return normalizeTopLevelResponseSchema(sanitizeSchemaNode(schema)) as JsonSchema;
-}
-
-function normalizeTopLevelResponseSchema(value: unknown): unknown {
-  if (!isRecord(value)) return value;
-  const variants = getObjectUnionVariants(value);
-  if (variants == null) return value;
-
-  const firstRequired = requiredKeys(variants[0]);
-  const commonRequired = firstRequired.filter((key) =>
-    variants.every((variant) => requiredKeys(variant).includes(key)),
-  );
-  const propertiesByVariant = variants.map((variant) =>
-    isRecord(variant.properties) ? variant.properties : {},
-  );
-  const properties: Record<string, unknown> = {};
-
-  for (const key of commonRequired) {
-    const schemas = propertiesByVariant.map((variantProperties) => variantProperties[key]);
-    if (schemas.every(isRecord)) properties[key] = mergeCommonPropertySchemas(schemas);
-  }
-
-  const { oneOf: _oneOf, anyOf: _anyOf, ...base } = value;
-  return {
-    ...base,
-    type: 'object',
-    properties,
-    required: Object.keys(properties),
-    additionalProperties: false,
-  };
-}
-
-function getObjectUnionVariants(value: Record<string, unknown>): Record<string, unknown>[] | null {
-  const union = Array.isArray(value.oneOf)
-    ? value.oneOf
-    : Array.isArray(value.anyOf)
-      ? value.anyOf
-      : null;
-  if (union == null || union.length === 0) return null;
-  if (!union.every(isRecord)) return null;
-
-  const variants = union as Record<string, unknown>[];
-  return variants.every((variant) => variant.type === 'object' && isRecord(variant.properties))
-    ? variants
-    : null;
-}
-
-function requiredKeys(value: Record<string, unknown>): string[] {
-  return Array.isArray(value.required)
-    ? value.required.filter((key): key is string => typeof key === 'string')
-    : [];
-}
-
-function mergeCommonPropertySchemas(schemas: Record<string, unknown>[]): unknown {
-  const [first] = schemas;
-  if (first == null) return {};
-  if (schemas.every((schema) => JSON.stringify(schema) === JSON.stringify(first))) return first;
-
-  const constValues = schemas.map((schema) => schema.const);
-  if (constValues.every((value) => typeof value === 'string')) {
-    return {
-      type: 'string',
-      enum: [...new Set(constValues as string[])],
-    };
-  }
-
-  return first;
+  return sanitizeSchemaNode(schema) as JsonSchema;
 }
 
 function sanitizeSchemaNode(value: unknown): unknown {
@@ -162,6 +96,12 @@ function allowNullSchema(value: unknown): unknown {
 function schemaAllowsNull(value: Record<string, unknown>): boolean {
   if (value.type === 'null') return true;
   if (Array.isArray(value.type) && value.type.includes('null')) return true;
+  const variants = Array.isArray(value.anyOf)
+    ? value.anyOf
+    : Array.isArray(value.oneOf)
+      ? value.oneOf
+      : [];
+  if (variants.some((variant) => isRecord(variant) && schemaAllowsNull(variant))) return true;
   return false;
 }
 

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -2,7 +2,7 @@ import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
 import type { ResolvedBudget, SkillBudgetOverride } from './budgets.js';
 import { assembleSpawnContext } from './context-assembly.js';
 import type { AgentResult, AgentRuntime, AgentSpec, DecisionSummary } from './interface.js';
-import { omitNullObjectProperties } from './output-normalization.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
 import { resolveBudgetsForProject } from './resolve-for-project.js';
 import { ScoutOutputSchema, normalizeScoutOutput } from './scout-output.js';
 
@@ -220,7 +220,7 @@ export async function runOneScout(
   // scout that ran without `--json-schema` could return arbitrary text and
   // the swarm would silently treat it as an empty-findings success — which
   // would let invalid Wave-1 results drive Wave-2 dispatch.
-  const parsed = ScoutOutputSchema.safeParse(omitNullObjectProperties(result.output));
+  const parsed = safeParseOutputForSchema(ScoutOutputSchema, result.output);
   if (!parsed.success) {
     const reason = `scout output failed schema validation: ${parsed.error.issues
       .map((i) => `${i.path.join('.')}: ${i.message}`)

--- a/core/agent-runtime/with-escalation.ts
+++ b/core/agent-runtime/with-escalation.ts
@@ -6,7 +6,7 @@ import type { SkillBudgetOverride } from './budgets.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { HoldoutFallbackForbiddenError } from './interface.js';
 import { defaultModelForTierAndProvider, providerOf, tierOf } from './models.js';
-import { omitNullObjectProperties } from './output-normalization.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
 import { resolveEscalatedBudgetsForProject } from './resolve-for-project.js';
 import { HOLDOUT_ROLES } from './roles.js';
 
@@ -59,7 +59,7 @@ export async function runWithEscalation<T>(
   const { runtime, spec, schema, projectId, workItemId, projectBudgets } = input;
 
   const result = await runtime.run(spec);
-  const parsed = schema.safeParse(omitNullObjectProperties(result.output));
+  const parsed = safeParseOutputForSchema(schema, result.output);
   if (parsed.success) {
     return { output: parsed.data, result, escalated: false };
   }
@@ -119,7 +119,7 @@ export async function runWithEscalation<T>(
   });
 
   const retryResult = await runtime.run(retrySpec);
-  const retryParsed = schema.safeParse(omitNullObjectProperties(retryResult.output));
+  const retryParsed = safeParseOutputForSchema(schema, retryResult.output);
   if (!retryParsed.success) {
     eventStore.appendEvent({
       projectId,

--- a/core/audit/run-audit.ts
+++ b/core/audit/run-audit.ts
@@ -23,6 +23,7 @@ import {
   type Recommendation,
 } from '../../skills/code-quality-audit/schema.js';
 import { OutputValidationError, invokeSkill } from '../agent-runtime/invoke-skill.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { eventStore } from '../event-stream/store.js';
 import { insertAuditOnlyRow, updateAuditScoreByPipelineRun } from '../quality-score/repository.js';
 import type { ImprovementCandidate } from '../retrospective/schemas.js';
@@ -156,7 +157,7 @@ export async function runCodeQualityAudit(input: RunAuditInput): Promise<AuditRe
         extraEventPayload: { trigger: input.trigger, pipelineRunId },
       },
     });
-    const parsed = CodeQualityAuditOutputSchema.safeParse(result.output);
+    const parsed = safeParseOutputForSchema(CodeQualityAuditOutputSchema, result.output);
     if (!parsed.success) {
       throw new OutputValidationError(
         parsed.error.issues.map((i) => ({

--- a/core/workflows/cross-run-retro.ts
+++ b/core/workflows/cross-run-retro.ts
@@ -4,7 +4,7 @@ import {
   CrossRunRetroOutputSchema,
 } from '../../skills/retrospective-cross-run/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { omitNullObjectProperties } from '../agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
@@ -352,7 +352,7 @@ export async function runCrossRunRetroWorkflow(
       },
     });
 
-    const parsed = CrossRunRetroOutputSchema.safeParse(omitNullObjectProperties(result.output));
+    const parsed = safeParseOutputForSchema(CrossRunRetroOutputSchema, result.output);
     if (!parsed.success) {
       eventStore.appendEvent({
         kind: 'agent.run-failed',

--- a/core/workflows/decompose-prd.ts
+++ b/core/workflows/decompose-prd.ts
@@ -1,6 +1,6 @@
 import { DecomposeOutputSchema } from '../../skills/decompose-issues/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { omitNullObjectProperties } from '../agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
@@ -101,7 +101,7 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
       outputJsonSchema: jsonSchema,
     });
 
-    const parsed = DecomposeOutputSchema.safeParse(omitNullObjectProperties(result.output));
+    const parsed = safeParseOutputForSchema(DecomposeOutputSchema, result.output);
 
     if (!parsed.success) {
       eventStore.appendEvent({

--- a/core/workflows/grill-and-prd/advisor-review.ts
+++ b/core/workflows/grill-and-prd/advisor-review.ts
@@ -3,6 +3,7 @@ import { AdvisePRDOutputSchema } from '../../../skills/advise-on-prd/schema.js';
 import type { PRDOutput } from '../../../skills/write-prd/schema.js';
 import type { AgentRuntime } from '../../agent-runtime/interface.js';
 import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import { safeParseOutputForSchema } from '../../agent-runtime/output-normalization.js';
 import {
   resolveBudgetsForProject,
   resolveGlobalSettingsForProject,
@@ -95,7 +96,7 @@ export async function runAdvisorReview(input: RunAdvisorReviewInput): Promise<Ad
     return { status: 'failed', error: String(err) };
   }
 
-  const parsed = AdvisePRDOutputSchema.safeParse(result.output);
+  const parsed = safeParseOutputForSchema(AdvisePRDOutputSchema, result.output);
   if (!parsed.success) {
     return { status: 'invalid', error: parsed.error.message };
   }

--- a/core/workflows/grill-and-prd/grill-round.ts
+++ b/core/workflows/grill-and-prd/grill-round.ts
@@ -2,6 +2,7 @@ import type { GrillMeOutput } from '../../../skills/grill-me/schema.js';
 import { GrillMeOutputSchema } from '../../../skills/grill-me/schema.js';
 import type { AgentRuntime } from '../../agent-runtime/interface.js';
 import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import { safeParseOutputForSchema } from '../../agent-runtime/output-normalization.js';
 import type { ProjectConfig } from '../../types.js';
 import type { ProjectContextBundle } from '../grill-and-prd.js';
 
@@ -76,7 +77,7 @@ export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRou
     return { status: 'failed', error: String(err) };
   }
 
-  const parsed = GrillMeOutputSchema.safeParse(result.output);
+  const parsed = safeParseOutputForSchema(GrillMeOutputSchema, result.output);
   if (!parsed.success) {
     return { status: 'invalid', error: parsed.error.message };
   }

--- a/core/workflows/grill-and-prd/prd-draft.ts
+++ b/core/workflows/grill-and-prd/prd-draft.ts
@@ -2,6 +2,7 @@ import type { PRDOutput } from '../../../skills/write-prd/schema.js';
 import { PRDOutputSchema } from '../../../skills/write-prd/schema.js';
 import type { AgentRuntime } from '../../agent-runtime/interface.js';
 import { OutputValidationError, invokeSkill } from '../../agent-runtime/invoke-skill.js';
+import { safeParseOutputForSchema } from '../../agent-runtime/output-normalization.js';
 import type { Priority } from '../../state-source/interface.js';
 import type { ProjectConfig } from '../../types.js';
 import type { ProjectContextBundle } from '../grill-and-prd.js';
@@ -85,7 +86,7 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
     return { status: 'failed', error: String(err) };
   }
 
-  const parsed = PRDOutputSchema.safeParse(result.output);
+  const parsed = safeParseOutputForSchema(PRDOutputSchema, result.output);
   if (!parsed.success) {
     return { status: 'invalid', error: parsed.error.message };
   }

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -1,7 +1,7 @@
 import { DeepRetroSchema } from '../../skills/retrospective-deep/schema.js';
 import { LightRetroSchema } from '../../skills/retrospective-light/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { omitNullObjectProperties } from '../agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
@@ -191,9 +191,10 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
       extraEventPayload: { tier },
     });
 
-    const output = omitNullObjectProperties(result.output);
     const parsed =
-      tier === 'deep' ? DeepRetroSchema.safeParse(output) : LightRetroSchema.safeParse(output);
+      tier === 'deep'
+        ? safeParseOutputForSchema(DeepRetroSchema, result.output)
+        : safeParseOutputForSchema(LightRetroSchema, result.output);
 
     if (!parsed.success) {
       eventStore.appendEvent({

--- a/core/workflows/skill-coaching.ts
+++ b/core/workflows/skill-coaching.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { eq, inArray } from 'drizzle-orm';
 import { SkillCoachOutputSchema } from '../../skills/skill-coach/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { omitNullObjectProperties } from '../agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
@@ -219,7 +219,7 @@ export async function runSkillCoachingWorkflow(
       },
     });
 
-    const parsed = SkillCoachOutputSchema.safeParse(omitNullObjectProperties(result.output));
+    const parsed = safeParseOutputForSchema(SkillCoachOutputSchema, result.output);
     if (!parsed.success) {
       eventStore.appendEvent({
         kind: 'agent.run-failed',

--- a/core/workflows/sprint-review.ts
+++ b/core/workflows/sprint-review.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { SprintReviewOutputSchema } from '../../skills/sprint-review/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
-import { omitNullObjectProperties } from '../agent-runtime/output-normalization.js';
+import { safeParseOutputForSchema } from '../agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '../agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
@@ -128,7 +128,7 @@ export async function runSprintReviewWorkflow(input: RunSprintReviewInput): Prom
       outputJsonSchema: jsonSchema,
     });
 
-    const parsed = SprintReviewOutputSchema.safeParse(omitNullObjectProperties(result.output));
+    const parsed = safeParseOutputForSchema(SprintReviewOutputSchema, result.output);
 
     if (!parsed.success) {
       eventStore.appendEvent({

--- a/skills/advise-on-plan/README.md
+++ b/skills/advise-on-plan/README.md
@@ -25,7 +25,7 @@ Reviews a developer's plan for `priority:high` and `priority:critical` work item
 
 ## Outputs
 
-`AdviseOnPlanSchema` is a discriminated union on `verdict`:
+`AdviseOnPlanSchema` is a single object for Codex response-schema compatibility, with verdict-specific semantic validation:
 
 | Verdict | Required fields | Meaning |
 |---|---|---|

--- a/skills/advise-on-plan/prompt.md
+++ b/skills/advise-on-plan/prompt.md
@@ -43,7 +43,7 @@ The context contains a `<task>` block with:
 
 ## Output format
 
-Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discriminated union — only the variant matching your `verdict` is valid.
+Return a JSON object conforming to `AdviseOnPlanSchema`. `revise` requires non-blank `feedback`; `abort` requires a non-blank `reason`. Use `null` for irrelevant optional fields when the response schema requires a value.
 
 ### proceed
 
@@ -52,6 +52,8 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
 {
   "verdict": "proceed",
   "confidence": "high",
+  "feedback": null,
+  "reason": null,
   "decisionSummaries": [
     { "kind": "VERDICT", "summary": "Plan correctly targets src/api/handlers.ts; no conflicts with existing patterns" }
   ]
@@ -66,6 +68,7 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
   "verdict": "revise",
   "confidence": "medium",
   "feedback": "The plan adds a new validation helper, but core/validation/zod.ts:42 already exposes parseZodSafe() with the same shape. Re-use the existing helper instead of duplicating.",
+  "reason": null,
   "decisionSummaries": [
     { "kind": "VERDICT", "summary": "Plan duplicates existing validation helper in core/validation/zod.ts:42" }
   ]
@@ -79,6 +82,7 @@ Return a JSON object conforming to `AdviseOnPlanSchema`. The schema is a discrim
 {
   "verdict": "abort",
   "confidence": "high",
+  "feedback": null,
   "reason": "Plan proposes modifying FACTORY_RULES.md to relax rule 12, but per rule 12 itself governance files are immutable from Factory PRs.",
   "decisionSummaries": [
     { "kind": "VERDICT", "summary": "Plan violates FACTORY_RULES rule 12 (governance immutability); not revisable" }

--- a/skills/advise-on-plan/schema.ts
+++ b/skills/advise-on-plan/schema.ts
@@ -5,39 +5,59 @@ export { DecisionSummarySchema };
 
 const ConfidenceSchema = z.enum(['low', 'medium', 'high']);
 
-/**
- * Advisor verdict — canonical typed union per CONTEXT.md "Advisor Flow".
- *
- * - `proceed`: plan is sound; primary continues.
- * - `revise`: plan has a fixable issue; primary re-spawned with `feedback`.
- * - `abort`:  plan is unsafe / out of scope; immediate escalation. NOT revisable.
- *
- * Pass discipline: at most one revise pass before escalation
- * (FACTORY_RULES rule 21, CONTEXT.md state-machine table).
- */
-export const AdvisorVerdictSchema = z.discriminatedUnion('verdict', [
-  z.object({
-    verdict: z.literal('proceed'),
-    confidence: ConfidenceSchema,
-  }),
-  z.object({
-    verdict: z.literal('revise'),
-    feedback: z.string().min(1).describe('Concrete feedback the primary must address on retry'),
-    confidence: ConfidenceSchema,
-  }),
-  z.object({
-    verdict: z.literal('abort'),
-    reason: z.string().min(1).describe('Why this plan is unsafe; surfaced to human reviewer'),
-    confidence: ConfidenceSchema,
-  }),
-]);
+const AdvisorVerdictBaseSchema = z.object({
+  verdict: z.enum(['proceed', 'revise', 'abort']),
+  confidence: ConfidenceSchema,
+  feedback: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Concrete feedback the primary must address on retry'),
+  reason: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Why this plan is unsafe; surfaced to human reviewer'),
+});
 
-export const AdviseOnPlanSchema = z.intersection(
-  AdvisorVerdictSchema,
-  z.object({
+function refineAdvisorVerdict(val: z.infer<typeof AdvisorVerdictBaseSchema>, ctx: z.RefinementCtx) {
+  if (val.verdict === 'revise') {
+    if (typeof val.feedback === 'string' && val.feedback.trim().length > 0) return;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'revise verdicts must include non-blank feedback',
+      path: ['feedback'],
+    });
+  }
+  if (val.verdict === 'abort') {
+    if (typeof val.reason === 'string' && val.reason.trim().length > 0) return;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'abort verdicts must include a non-blank reason',
+      path: ['reason'],
+    });
+  }
+}
+
+export const AdvisorVerdictSchema = AdvisorVerdictBaseSchema.superRefine(refineAdvisorVerdict);
+
+export const AdviseOnPlanSchema = z
+  .object({
+    verdict: z.enum(['proceed', 'revise', 'abort']),
+    confidence: ConfidenceSchema,
+    feedback: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Concrete feedback the primary must address on retry'),
+    reason: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Why this plan is unsafe; surfaced to human reviewer'),
     decisionSummaries: z.array(DecisionSummarySchema).min(1),
-  }),
-);
+  })
+  .superRefine(refineAdvisorVerdict);
 
 export type AdvisorVerdict = z.infer<typeof AdvisorVerdictSchema>;
 export type AdviseOnPlanOutput = z.infer<typeof AdviseOnPlanSchema>;

--- a/skills/advise-on-plan/slice.test.ts
+++ b/skills/advise-on-plan/slice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toJSONSchema } from 'zod';
+import { toJsonSchema } from '../../core/agent-runtime/schema-bridge.js';
 import { AdviseOnPlanSchema, AdvisorVerdictSchema } from './schema.js';
 import config, { AdviseOnPlanContextSchema } from './skill.config.js';
 
@@ -52,6 +52,26 @@ describe('advise-on-plan output schema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects revise with whitespace-only feedback', () => {
+    const result = AdviseOnPlanSchema.safeParse({
+      verdict: 'revise',
+      confidence: 'medium',
+      feedback: ' ',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'something' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects revise with null feedback from Codex-shaped output', () => {
+    const result = AdviseOnPlanSchema.safeParse({
+      verdict: 'revise',
+      confidence: 'medium',
+      feedback: null,
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'something' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('rejects abort without reason', () => {
     const result = AdviseOnPlanSchema.safeParse({
       verdict: 'abort',
@@ -71,16 +91,33 @@ describe('advise-on-plan output schema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects proceed with extra revise/abort fields', () => {
-    // discriminated union strictly excludes fields not on the matched variant.
+  it('rejects abort with whitespace-only reason', () => {
+    const result = AdviseOnPlanSchema.safeParse({
+      verdict: 'abort',
+      confidence: 'high',
+      reason: ' ',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'something' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects abort with null reason from Codex-shaped output', () => {
+    const result = AdviseOnPlanSchema.safeParse({
+      verdict: 'abort',
+      confidence: 'high',
+      reason: null,
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'something' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts proceed with irrelevant optional revise/abort fields', () => {
     const result = AdviseOnPlanSchema.safeParse({
       verdict: 'proceed',
       confidence: 'high',
       feedback: 'extra field that should not be present',
       decisionSummaries: [{ kind: 'VERDICT', summary: 'something' }],
     });
-    // Zod discriminated unions are non-strict by default — extra fields pass.
-    // What we *must* reject is `verdict` not being one of the three literals.
     expect(result.success).toBe(true);
   });
 
@@ -111,10 +148,13 @@ describe('advise-on-plan output schema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('zod toJSONSchema roundtrip produces a valid JSON Schema object', () => {
-    const jsonSchema = toJSONSchema(AdviseOnPlanSchema);
+  it('generated Codex schema has no top-level composition', () => {
+    const jsonSchema = toJsonSchema(AdviseOnPlanSchema);
     expect(typeof jsonSchema).toBe('object');
     expect(jsonSchema).not.toBeNull();
+    expect(jsonSchema).not.toHaveProperty('oneOf');
+    expect(jsonSchema).not.toHaveProperty('anyOf');
+    expect(jsonSchema).not.toHaveProperty('allOf');
   });
 
   it('AdvisorVerdictSchema is exported and usable independently', () => {

--- a/skills/review/README.md
+++ b/skills/review/README.md
@@ -92,7 +92,7 @@ When `needs-human` is returned, the `escalationReason` field is **mandatory** an
 
 ## Schema
 
-Output is validated against `ReviewOutputSchema` in `schema.ts`. The schema uses a Zod `discriminatedUnion` on `verdict` so that `needs-human` structurally requires `escalationReason` — the other two verdicts do not have this field.
+Output is validated against `ReviewOutputSchema` in `schema.ts`. The schema is a single Zod object for Codex response-schema compatibility, with `superRefine` requiring a non-blank `escalationReason` when `verdict === 'needs-human'`.
 
 ```typescript
 import { ReviewOutputSchema, type ReviewOutput } from './schema.js';

--- a/skills/review/prompt.md
+++ b/skills/review/prompt.md
@@ -270,7 +270,8 @@ For `approved` or `needs-fix`:
     { "kind": "DIFF_READ", "summary": "Read PR diff: 5 files changed in skills/review/" },
     { "kind": "CRITERIA_CHECK", "summary": "All 5 criteria met: schema, config, tests, prompt.md, README present" },
     { "kind": "VERDICT", "summary": "Verdict: approved, confidence 0.92 — all criteria met, no blockers" }
-  ]
+  ],
+  "escalationReason": null
 }
 ```
 
@@ -314,5 +315,5 @@ For `needs-human` (escalationReason is REQUIRED):
 - `confidence` is your honest assessment, not what you wish it were.
 - If a criterion appears trivially met, still document why — "README.md present with all required sections on lines 1–45."
 - The QA verdict is context, not directive. A QA `pass` does not guarantee your `approved`.
-- **Optional fields must be OMITTED, not null.** When a finding has no specific source location, omit `file` and `line` entirely — never write `"file": null` or `"line": null`. Same applies to `escalationReason` on non-`needs-human` verdicts — omit it entirely.
+- **Optional fields that do not apply should be omitted when possible.** If the response schema requires a value for an irrelevant optional field, use `null`. Same applies to `escalationReason` on non-`needs-human` verdicts.
 - **`criteriaChecks` must have one entry per criterion from Step 1.** `criteriaChecks: []` is never valid when criteria exist — populate it from your Step 3 verification before returning.

--- a/skills/review/prompt.unconstrained.md
+++ b/skills/review/prompt.unconstrained.md
@@ -113,7 +113,7 @@ Return a JSON object with the same schema as the constrained reviewer:
 }
 ```
 
-`needs-human` requires a non-empty `escalationReason`. Optional fields must be OMITTED, not null.
+`needs-human` requires a non-empty `escalationReason`. Optional fields that do not apply should be omitted when possible; if the response schema requires a value, use `null`.
 
 ## Important reminders
 

--- a/skills/review/schema.ts
+++ b/skills/review/schema.ts
@@ -59,34 +59,26 @@ export const ReviewFindingSchema = z
     }
   });
 
-/**
- * Discriminated union on `verdict` so that `needs-human` REQUIRES
- * `escalationReason` — the other two verdicts do not have this field.
- */
-export const ReviewOutputSchema = z.discriminatedUnion('verdict', [
-  z.object({
-    verdict: z.literal('approved'),
+export const ReviewOutputSchema = z
+  .object({
+    verdict: z.enum(['approved', 'needs-fix', 'needs-human']),
     confidence: z.number().min(0).max(1),
     criteriaChecks: z.array(CriterionCheckSchema),
     findings: z.array(ReviewFindingSchema),
     decisionSummaries: z.array(DecisionSummarySchema),
-  }),
-  z.object({
-    verdict: z.literal('needs-fix'),
-    confidence: z.number().min(0).max(1),
-    criteriaChecks: z.array(CriterionCheckSchema),
-    findings: z.array(ReviewFindingSchema),
-    decisionSummaries: z.array(DecisionSummarySchema),
-  }),
-  z.object({
-    verdict: z.literal('needs-human'),
-    confidence: z.number().min(0).max(1),
-    criteriaChecks: z.array(CriterionCheckSchema),
-    findings: z.array(ReviewFindingSchema),
-    decisionSummaries: z.array(DecisionSummarySchema),
-    escalationReason: z.string().min(1),
-  }),
-]);
+    escalationReason: z.string().nullable().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.verdict !== 'needs-human') return;
+    if (typeof val.escalationReason === 'string' && val.escalationReason.trim().length > 0) {
+      return;
+    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'needs-human verdicts must include a non-blank escalationReason',
+      path: ['escalationReason'],
+    });
+  });
 
 export type { Disposition } from '@goose-hub/core/findings/disposition.js';
 export type { Priority } from '@goose-hub/core/findings/priority.js';

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -88,6 +88,11 @@ describe('ReviewOutputSchema — approved verdict', () => {
     expect(result.success).toBe(true);
   });
 
+  it('approved result accepts null escalationReason from Codex-shaped output', () => {
+    const result = ReviewOutputSchema.safeParse(makeApprovedOutput({ escalationReason: null }));
+    expect(result.success).toBe(true);
+  });
+
   it('accepts decision summaries with valid kinds (#466)', () => {
     const result = ReviewOutputSchema.safeParse(
       makeApprovedOutput({
@@ -135,6 +140,11 @@ describe('ReviewOutputSchema — needs-fix verdict', () => {
     const result = ReviewOutputSchema.safeParse(output);
     expect(result.success).toBe(true);
   });
+
+  it('needs-fix result accepts null escalationReason from Codex-shaped output', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsFixOutput({ escalationReason: null }));
+    expect(result.success).toBe(true);
+  });
 });
 
 // ─── ReviewOutputSchema — needs-human ────────────────────────────────────────
@@ -156,11 +166,14 @@ describe('ReviewOutputSchema — needs-human verdict', () => {
     expect(result.success).toBe(false);
   });
 
-  it('needs-human with whitespace-only escalationReason passes min(1) check', () => {
-    // min(1) means at least 1 character; a space technically passes
-    // This tests the literal schema constraint, not business logic
+  it('needs-human with null escalationReason is REJECTED', () => {
+    const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput({ escalationReason: null }));
+    expect(result.success).toBe(false);
+  });
+
+  it('needs-human with whitespace-only escalationReason is REJECTED', () => {
     const result = ReviewOutputSchema.safeParse(makeNeedsHumanOutput({ escalationReason: ' ' }));
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 });
 

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -7,6 +7,7 @@
  */
 import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import { defaultModelForTierAndProvider } from '@goose-hub/core/agent-runtime/models.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { listToolManifests } from '@goose-hub/core/chat-tools/registry.js';
 import { listToolInvocations } from '@goose-hub/core/conversations/repository.js';
 import type {
@@ -430,7 +431,7 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
     telemetry.durationMs.modelInvocation = elapsedSince(modelStarted);
     emitThinking(conversation, runId, 'structured-output-received');
     const parsingStarted = Date.now();
-    const parsed = HubChatOutputSchema.safeParse(result.output);
+    const parsed = safeParseOutputForSchema(HubChatOutputSchema, result.output);
     if (!parsed.success) {
       telemetry.durationMs.postModelParsing = elapsedSince(parsingStarted);
       telemetry.durationMs.total = elapsedSince(totalStarted);

--- a/slices/fix-issue/pr-helpers.ts
+++ b/slices/fix-issue/pr-helpers.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { findFreePort } from '@goose-hub/core/agent-runtime/find-free-port.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { getEvidencePostEnabled } from '@goose-hub/core/db/repositories/project-settings.js';
@@ -130,8 +131,8 @@ export async function runEvidencePost(input: RunEvidencePostInput): Promise<void
       appendSystemPrompt: input.appendSystemPrompt,
     });
 
-    const planParsed = EvidencePostPlanSchema.safeParse(result.output);
-    const finalParsed = EvidencePostSchema.safeParse(result.output);
+    const planParsed = safeParseOutputForSchema(EvidencePostPlanSchema, result.output);
+    const finalParsed = safeParseOutputForSchema(EvidencePostSchema, result.output);
     const output = planParsed.success
       ? runEvidencePostPlan({
           plan: planParsed.data,

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -269,6 +269,9 @@ export async function runFixIssueWorkflow(
       }
 
       if (verdict.verdict === 'revise') {
+        if (typeof verdict.feedback !== 'string' || verdict.feedback.trim().length === 0) {
+          throw new Error('advise-on-plan revise verdict missing feedback after validation');
+        }
         advisorFeedback = verdict.feedback;
         revisionPass = 1;
         // Fall through to step 4 to re-spawn implement with the feedback.

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -9,6 +9,7 @@ import {
   tierOf,
   tryProviderOf,
 } from '@goose-hub/core/agent-runtime/models.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
@@ -734,8 +735,14 @@ export async function runInvestigateWorkflow(
             appendSystemPrompt: playwrightReproPrompt,
           });
 
-          const planParsed = PlaywrightReproSpecSchema.safeParse(playwrightResult.output);
-          const finalParsed = PlaywrightReproSchema.safeParse(playwrightResult.output);
+          const planParsed = safeParseOutputForSchema(
+            PlaywrightReproSpecSchema,
+            playwrightResult.output,
+          );
+          const finalParsed = safeParseOutputForSchema(
+            PlaywrightReproSchema,
+            playwrightResult.output,
+          );
           if (planParsed.success) {
             reproOutput = (deps.playwrightEvidenceRunner ?? runPlaywrightReproPlan)({
               plan: planParsed.data,

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -6,6 +6,7 @@ import type {
   AgentSpec,
 } from '@goose-hub/core/agent-runtime/interface.js';
 import type { InvestigationContext } from '@goose-hub/core/agent-runtime/investigation-context.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { getRecordDecisionTool } from '@goose-hub/core/db/repositories/project-settings.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -345,7 +346,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     return { status: 'failed', wpId: wp.id, errorReason: errorReason ?? 'unknown', runId: wpRunId };
   }
 
-  const parsed = ImplementWpSchema.safeParse(result.output);
+  const parsed = safeParseOutputForSchema(ImplementWpSchema, result.output);
   if (!parsed.success) {
     const reason = `schema validation failed: ${parsed.error.issues
       .map((i) => `${i.path.join('.')}: ${i.message}`)

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -4,6 +4,7 @@ import type { AcceptanceContract } from '@goose-hub/core/acceptance-contracts/ty
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { findFreePort } from '@goose-hub/core/agent-runtime/find-free-port.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
@@ -440,7 +441,7 @@ export async function runQaWorkflow(
       appendSystemPrompt: qaPrompt,
     });
 
-    const qaParsed = QaOutputSchema.safeParse(qaResult.output);
+    const qaParsed = safeParseOutputForSchema(QaOutputSchema, qaResult.output);
     if (!qaParsed.success) {
       throw new Error(`QA output validation failed: ${JSON.stringify(qaParsed.error.issues)}`);
     }

--- a/slices/resolve-conflict/workflow.ts
+++ b/slices/resolve-conflict/workflow.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
@@ -139,7 +140,7 @@ export async function runResolveConflictWorkflow(
           workspaceDir: wtPath,
         });
 
-        const parsed = ResolveConflictSchema.safeParse(agentResult.output);
+        const parsed = safeParseOutputForSchema(ResolveConflictSchema, agentResult.output);
         if (!parsed.success) {
           throw new Error('Agent output failed schema validation');
         }

--- a/slices/review/convergent-review.ts
+++ b/slices/review/convergent-review.ts
@@ -3,6 +3,7 @@ import { resolveAcceptanceContract } from '@goose-hub/core/acceptance-contracts/
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { assembleSpawnContext } from '@goose-hub/core/agent-runtime/context-assembly.js';
 import type { AgentResult, AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
@@ -132,7 +133,7 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
   );
 
   const parsed = rawResults.map((r) =>
-    r instanceof Error ? null : ReviewOutputSchema.safeParse((r as AgentResult).output),
+    r instanceof Error ? null : safeParseOutputForSchema(ReviewOutputSchema, r.output),
   );
 
   const successfulReviewerOutputs = parsed.flatMap((p, i) => {

--- a/slices/review/workflow.ts
+++ b/slices/review/workflow.ts
@@ -1,6 +1,7 @@
 import { resolveAcceptanceContract } from '@goose-hub/core/acceptance-contracts/resolver.js';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
@@ -116,7 +117,7 @@ export async function runReviewWorkflow(
     });
     const result = await runtime.run(spec);
 
-    const parsed = ReviewOutputSchema.safeParse(result.output);
+    const parsed = safeParseOutputForSchema(ReviewOutputSchema, result.output);
     if (!parsed.success) {
       throw new Error(`Review output validation failed: ${JSON.stringify(parsed.error.issues)}`);
     }


### PR DESCRIPTION
## Summary
- add schema-aware terminal output normalization before Zod product validation
- route schema-backed agent output parsing through the new helper instead of blanket null stripping
- convert review and advise-on-plan schemas to Codex-safe single-object shapes with semantic superRefine checks
- remove top-level object-union collapsing from the Codex schema bridge and add strict active-skill response-schema guards

## Verification
- pnpm vitest run core/agent-runtime/output-normalization.test.ts core/agent-runtime/schema-bridge.test.ts core/agent-runtime/invoke-skill.test.ts core/agent-runtime/with-escalation.test.ts
- pnpm vitest run skills/review/slice.test.ts skills/advise-on-plan/slice.test.ts apps/server/src/domains/workflows/triage-batch.test.ts
- pnpm vitest run slices/fix-issue/slice.test.ts slices/review/slice.test.ts slices/qa/slice.test.ts slices/investigate/slice.test.ts slices/parallel-implement/slice.test.ts
- pnpm skill-contract:audit
- pnpm typecheck
- pnpm lint