### PR TITLE
M20: group discover timeline phases

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -148,7 +148,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
   if (item.kind === 'phase-group') {
     return (
       <PhaseGroupWrapper
-        key={`phase-group-${item.pipelineRunId}`}
+        key={`phase-group-${item.phase}-${item.pipelineRunId}`}
         phase={item.phase}
         pipelineRunId={item.pipelineRunId}
         items={item.items}

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -495,6 +495,37 @@ describe('groupEvents — run-group metadata', () => {
     }
   });
 
+  it('labels parent grill workflow groups from display skill metadata', () => {
+    const events: AgentEventDto[] = [
+      {
+        ...makeRunEvent(1, 'workflow-run', 'grill.decision-crystallized'),
+        payload: {
+          displaySkill: 'grill-me',
+          workflowRunId: 'workflow-run',
+          roundNumber: 1,
+          decision: 'Reuse the existing enhancement flow.',
+        },
+      },
+      {
+        ...makeRunEvent(2, 'workflow-run', 'grill.question-posted'),
+        payload: {
+          displaySkill: 'grill-me',
+          workflowRunId: 'workflow-run',
+          roundNumber: 2,
+          question: 'Should enhancement be generic or type-specific?',
+        },
+      },
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    if (result[0].kind === 'phase-group') {
+      expect(result[0].phase).toBe('grill');
+      expect(result[0].items).toHaveLength(2);
+    }
+  });
+
   it('infers fix-feedback display skill from the completion marker for legacy runs', () => {
     const events: AgentEventDto[] = [
       makeRunEvent(3, 'run-fix', 'agent.fix-feedback-complete'),

--- a/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
@@ -16,7 +16,7 @@ export function PhaseGroupWrapper({
   context,
   renderItem,
 }: {
-  phase: 'contract' | 'dev';
+  phase: 'grill' | 'prd' | 'contract' | 'dev';
   pipelineRunId: string;
   items: RenderItem[];
   status: 'started' | 'live' | 'completed' | 'failed';
@@ -51,8 +51,15 @@ export function PhaseGroupWrapper({
   const completeDuration =
     startMs != null && endMs != null ? formatDuration((lastMs ?? endMs) - startMs) : null;
   const shortId = pipelineRunId.length > 8 ? pipelineRunId.slice(0, 8) : pipelineRunId;
-  const phaseLabel = phase === 'contract' ? 'Contract Phase' : 'Dev Phase';
-  const idLabel = phase === 'contract' ? 'contract' : 'pipeline';
+  const phaseLabel =
+    phase === 'grill'
+      ? 'Grill Phase'
+      : phase === 'prd'
+        ? 'PRD Phase'
+        : phase === 'contract'
+          ? 'Contract Phase'
+          : 'Dev Phase';
+  const idLabel = phase === 'contract' ? 'contract' : phase === 'dev' ? 'pipeline' : 'workflow';
 
   const statusBadge = isStalled ? (
     <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -430,6 +430,131 @@ describe('computeIsWritePrdStuck', () => {
   });
 });
 
+describe('groupEvents — discover phase groups', () => {
+  it('wraps grill child runs and parent grill workflow events into a grill phase', () => {
+    const WID = 'discover-workflow-grill';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', `${WID}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: WID },
+      }),
+      makeEvent(2, 'agent.run-completed', `${WID}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: WID },
+      }),
+      makeEvent(3, 'grill.decision-crystallized', WID, {
+        payload: {
+          displaySkill: 'grill-me',
+          workflowRunId: WID,
+          roundNumber: 1,
+          decision: 'Use the generic enhancement flow.',
+        },
+      }),
+      makeEvent(4, 'grill.completed', WID, {
+        payload: { displaySkill: 'grill-me', workflowRunId: WID, refinedIntent: 'Ship it.' },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('phase-group');
+    if (result[0].kind !== 'phase-group') return;
+    expect(result[0].phase).toBe('grill');
+    expect(result[0].pipelineRunId).toBe(WID);
+    expect(result[0].status).toBe('completed');
+    expect(
+      result[0].items.some((item) => item.kind === 'run-group' && item.runId.endsWith(':grill-me')),
+    ).toBe(true);
+    expect(
+      result[0].items.some(
+        (item) => item.kind === 'event' && item.event.kind === 'grill.completed',
+      ),
+    ).toBe(true);
+  });
+
+  it('wraps write-prd and advisor activity with parent PRD events into a PRD phase', () => {
+    const WID = 'discover-workflow-prd';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', `${WID}:write-prd`, {
+        payload: { skill: 'write-prd', workflowRunId: WID },
+      }),
+      makeEvent(2, 'agent.run-completed', `${WID}:write-prd`, {
+        payload: { skill: 'write-prd', workflowRunId: WID },
+      }),
+      makeEvent(3, 'prd.advisor-skipped', WID, {
+        payload: { workflowRunId: WID, reason: 'priority' },
+      }),
+      makeEvent(4, 'prd.drafted', WID, {
+        payload: { displaySkill: 'write-prd', workflowRunId: WID, prd: { title: 'Draft' } },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('phase-group');
+    if (result[0].kind !== 'phase-group') return;
+    expect(result[0].phase).toBe('prd');
+    expect(result[0].pipelineRunId).toBe(WID);
+    expect(result[0].status).toBe('completed');
+    expect(
+      result[0].items.some(
+        (item) => item.kind === 'run-group' && item.runId.endsWith(':write-prd'),
+      ),
+    ).toBe(true);
+    const prdEventKinds = result[0].items.flatMap((item) =>
+      item.kind === 'event' ? [item.event.kind] : [],
+    );
+    expect(prdEventKinds).toEqual(expect.arrayContaining(['prd.advisor-skipped', 'prd.drafted']));
+  });
+
+  it('keeps Grill and PRD phases separate for the same discover workflow', () => {
+    const WID = 'discover-workflow-complete';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', `${WID}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: WID },
+      }),
+      makeEvent(2, 'agent.run-completed', `${WID}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: WID },
+      }),
+      makeEvent(3, 'grill.completed', WID, {
+        payload: { displaySkill: 'grill-me', workflowRunId: WID, refinedIntent: 'Draft it.' },
+      }),
+      makeEvent(4, 'agent.run-started', `${WID}:write-prd`, {
+        payload: { skill: 'write-prd', workflowRunId: WID },
+      }),
+      makeEvent(5, 'agent.run-completed', `${WID}:write-prd`, {
+        payload: { skill: 'write-prd', workflowRunId: WID },
+      }),
+      makeEvent(6, 'prd.drafted', WID, {
+        payload: { displaySkill: 'write-prd', workflowRunId: WID, prd: { title: 'Draft' } },
+      }),
+    ]);
+
+    const phaseGroups = result.filter((item) => item.kind === 'phase-group');
+    expect(phaseGroups).toHaveLength(2);
+    expect(phaseGroups.map((item) => (item.kind === 'phase-group' ? item.phase : null))).toEqual([
+      'prd',
+      'grill',
+    ]);
+  });
+
+  it('hides grill reply manual actions from the timeline', () => {
+    const result = groupEvents([
+      makeEvent(1, 'manual.action', null, {
+        payload: {
+          action: 'comment',
+          preview: '<!-- factory:grill-reply -->\nRecommended: Proceed.',
+        },
+      }),
+      makeEvent(2, 'state.transitioned', null, {
+        payload: { from: 'factory:gate-pending', to: 'factory:grilling', by: 'ui' },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('event');
+    if (result[0].kind === 'event') {
+      expect(result[0].event.kind).toBe('state.transitioned');
+    }
+  });
+});
+
 describe('groupByDevPhase', () => {
   it('returns items unchanged when no spec.completed event exists', () => {
     const events: AgentEventDto[] = [

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -1,4 +1,5 @@
 import type { AgentEventDto, CostRowDto, InterventionDto, InterventionEventDto } from '@/lib/types';
+import { GRILL_REPLY_MARKER } from './grill-comments';
 
 export type TimelineContext = {
   slug: string;
@@ -24,6 +25,7 @@ export type InterventionTimelineDetail = {
  * NOTE: this is event-kind labelling. `STATE_LABEL` in `@/lib/constants`
  * separately maps `factory:*` work-item state names; keep them apart.
  */
+
 export const EVENT_KIND_LABEL: Record<string, string> = {
   'state.transitioned': 'State transitioned',
   'milestone.activated': 'Milestone activated',
@@ -210,6 +212,12 @@ export function isCodexTransportWarningLog(event: AgentEventDto): boolean {
   );
 }
 
+function isGrillReplyManualAction(event: AgentEventDto): boolean {
+  if (event.kind !== 'manual.action') return false;
+  const payload = event.payload as { preview?: unknown } | null;
+  return typeof payload?.preview === 'string' && payload.preview.startsWith(GRILL_REPLY_MARKER);
+}
+
 // ─── grouping ────────────────────────────────────────────────────────────────
 
 export type RenderItem =
@@ -246,7 +254,7 @@ export type RenderItem =
     }
   | {
       kind: 'phase-group';
-      phase: 'contract' | 'dev';
+      phase: 'grill' | 'prd' | 'contract' | 'dev';
       pipelineRunId: string;
       items: RenderItem[];
       status: 'started' | 'live' | 'completed' | 'failed';
@@ -302,6 +310,150 @@ function compareRenderItems(a: RenderItem, b: RenderItem): number {
   }
 
   return 0;
+}
+
+function getWorkflowRunId(event: AgentEventDto): string | null {
+  const payload = event.payload as { workflowRunId?: unknown } | null;
+  if (typeof payload?.workflowRunId === 'string' && payload.workflowRunId.trim() !== '') {
+    return payload.workflowRunId;
+  }
+  return event.runId ?? null;
+}
+
+function isGrillPhaseEvent(event: AgentEventDto): boolean {
+  return event.kind.startsWith('grill.');
+}
+
+function isPrdPhaseEvent(event: AgentEventDto): boolean {
+  return event.kind.startsWith('prd.');
+}
+
+function resolveDiscoverPhaseStatus(
+  phase: 'grill' | 'prd',
+  items: RenderItem[],
+): 'started' | 'live' | 'completed' | 'failed' {
+  const events = items.flatMap(eventFromRenderItem);
+  if (events.some((event) => event.kind === 'agent.run-failed')) return 'failed';
+  if (phase === 'grill') {
+    if (events.some((event) => event.kind === 'grill.completed')) return 'completed';
+    if (events.some((event) => event.kind === 'grill.question-posted')) return 'completed';
+  } else if (
+    events.some((event) =>
+      ['prd.drafted', 'prd.approved', 'prd.rejected', 'prd.revised', 'prd.declined'].includes(
+        event.kind,
+      ),
+    )
+  ) {
+    return 'completed';
+  }
+  return items.some(hasLiveRunGroup) ? 'live' : 'started';
+}
+
+function appendDiscoverPhaseItem(
+  phaseItems: Map<string, { grill: RenderItem[]; prd: RenderItem[] }>,
+  workflowRunId: string,
+  phase: 'grill' | 'prd',
+  item: RenderItem,
+): void {
+  const group = phaseItems.get(workflowRunId) ?? { grill: [], prd: [] };
+  group[phase].push(item);
+  phaseItems.set(workflowRunId, group);
+}
+
+function childDiscoverPhase(
+  item: RenderItem,
+): { workflowRunId: string; phase: 'grill' | 'prd' } | null {
+  if (item.kind !== 'run-group') return null;
+  if (item.runId.endsWith(':grill-me')) {
+    return { workflowRunId: item.runId.slice(0, -':grill-me'.length), phase: 'grill' };
+  }
+  if (item.runId.endsWith(':write-prd')) {
+    return { workflowRunId: item.runId.slice(0, -':write-prd'.length), phase: 'prd' };
+  }
+  if (item.runId.endsWith(':advise-on-prd')) {
+    return { workflowRunId: item.runId.slice(0, -':advise-on-prd'.length), phase: 'prd' };
+  }
+  for (const event of eventFromRenderItem(item)) {
+    const workflowRunId = getWorkflowRunId(event);
+    if (workflowRunId == null) continue;
+    const payload = event.payload as { skill?: string } | null;
+    if (payload?.skill === 'grill-me') return { workflowRunId, phase: 'grill' };
+    if (payload?.skill === 'write-prd' || payload?.skill === 'advise-on-prd') {
+      return { workflowRunId, phase: 'prd' };
+    }
+  }
+  return null;
+}
+
+export function groupByDiscoverPhase(items: RenderItem[]): RenderItem[] {
+  const phaseItems = new Map<string, { grill: RenderItem[]; prd: RenderItem[] }>();
+  const ungrouped: RenderItem[] = [];
+
+  for (const item of items) {
+    const childPhase = childDiscoverPhase(item);
+    if (childPhase != null) {
+      appendDiscoverPhaseItem(phaseItems, childPhase.workflowRunId, childPhase.phase, item);
+      continue;
+    }
+
+    if (item.kind === 'event') {
+      const workflowRunId = getWorkflowRunId(item.event);
+      if (workflowRunId != null && isGrillPhaseEvent(item.event)) {
+        appendDiscoverPhaseItem(phaseItems, workflowRunId, 'grill', item);
+        continue;
+      }
+      if (workflowRunId != null && isPrdPhaseEvent(item.event)) {
+        appendDiscoverPhaseItem(phaseItems, workflowRunId, 'prd', item);
+        continue;
+      }
+      ungrouped.push(item);
+      continue;
+    }
+
+    if (item.kind === 'run-group') {
+      const remaining: RenderItem[] = [];
+      let consumedDiscoverEvent = false;
+      for (const event of eventFromRenderItem(item)) {
+        const workflowRunId = getWorkflowRunId(event);
+        if (workflowRunId != null && isGrillPhaseEvent(event)) {
+          appendDiscoverPhaseItem(phaseItems, workflowRunId, 'grill', { kind: 'event', event });
+          consumedDiscoverEvent = true;
+        } else if (workflowRunId != null && isPrdPhaseEvent(event)) {
+          appendDiscoverPhaseItem(phaseItems, workflowRunId, 'prd', { kind: 'event', event });
+          consumedDiscoverEvent = true;
+        } else {
+          remaining.push({ kind: 'event', event });
+        }
+      }
+      if (consumedDiscoverEvent) {
+        ungrouped.push(...remaining);
+      } else {
+        ungrouped.push(item);
+      }
+      continue;
+    }
+
+    ungrouped.push(item);
+  }
+
+  const phases: RenderItem[] = [];
+  for (const [workflowRunId, grouped] of phaseItems) {
+    for (const phase of ['grill', 'prd'] as const) {
+      const phaseItemList = grouped[phase];
+      if (phaseItemList.length === 0) continue;
+      const times = extractPhaseTimes(phaseItemList);
+      phases.push({
+        kind: 'phase-group',
+        phase,
+        pipelineRunId: workflowRunId,
+        items: phaseItemList.sort(compareRenderItems),
+        status: resolveDiscoverPhaseStatus(phase, phaseItemList),
+        ...times,
+      });
+    }
+  }
+
+  return [...ungrouped, ...phases].sort(compareRenderItems);
 }
 
 function isContractPhaseItem(item: RenderItem): boolean {
@@ -479,12 +631,16 @@ export function groupEvents(
   interventionDetails: InterventionTimelineDetail[] = [],
 ): RenderItem[] {
   const normalizedEvents = events.flatMap((event) => {
+    if (isGrillReplyManualAction(event)) return [];
     const normalized = normalizeAgentLogEvent(event);
     return normalized == null ? [] : [normalized];
   });
   const collapsed = collapseLogRuns(normalizedEvents);
   const grouped = groupByRunId(collapsed);
-  const withInvestigationPhases = groupByInvestigationPhase([...grouped].sort(compareRenderItems));
+  const withDiscoverPhases = groupByDiscoverPhase([...grouped].sort(compareRenderItems));
+  const withInvestigationPhases = groupByInvestigationPhase(
+    [...withDiscoverPhases].sort(compareRenderItems),
+  );
   const withReviewGroups = groupByReviewWorkflow(
     [...withInvestigationPhases].sort(compareRenderItems),
   );

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -432,6 +432,7 @@ export async function runGrillAndPrdWorkflow(
             workItemId: workItem.id,
             runId: workflowRunId,
             payload: {
+              displaySkill: 'grill-me',
               workflowRunId,
               roundNumber: roundNumber - 1,
               decision: grillOutput.crystallizedDecision.trim(),
@@ -468,7 +469,12 @@ export async function runGrillAndPrdWorkflow(
             projectId,
             workItemId: workItem.id,
             runId: workflowRunId,
-            payload: { workflowRunId, roundNumber, question: outcome.question },
+            payload: {
+              displaySkill: 'grill-me',
+              workflowRunId,
+              roundNumber,
+              question: outcome.question,
+            },
           });
           grillPhaseReturn = { phase: 'grilling', questionPosted: outcome.question };
           return;
@@ -482,6 +488,7 @@ export async function runGrillAndPrdWorkflow(
           workItemId: workItem.id,
           runId: workflowRunId,
           payload: {
+            displaySkill: 'grill-me',
             workflowRunId,
             refinedIntent: outcome.refinedIntent,
             rounds: roundNumber,
@@ -725,7 +732,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: workflowRunId,
-      payload: { workflowRunId, prd: prdOutput, advisorConcerns },
+      payload: { displaySkill: 'write-prd', workflowRunId, prd: prdOutput, advisorConcerns },
     });
   } catch (err) {
     eventStore.appendEvent({

--- a/slices/grill-and-prd/slice.test.ts
+++ b/slices/grill-and-prd/slice.test.ts
@@ -320,6 +320,7 @@ describe('grill-and-prd: round 1 (not ready)', () => {
     const qPosted = evs.find((e) => e.kind === 'grill.question-posted');
     expect(qPosted).toBeDefined();
     expect((qPosted?.payload as { roundNumber: number }).roundNumber).toBe(1);
+    expect((qPosted?.payload as { displaySkill?: string }).displaySkill).toBe('grill-me');
 
     // No write-prd or advisor calls happened
     expect(runtime.run).toHaveBeenCalledTimes(1);
@@ -373,7 +374,9 @@ describe('grill-and-prd: round 2 reaches PRD (advisor skipped by priority)', () 
     // grill.completed and prd.drafted events emitted; advisor skipped with reason 'priority'
     const evs = eventStore.replay({ projectId, workItemId: workItem.id });
     expect(evs.find((e) => e.kind === 'grill.completed')).toBeDefined();
-    expect(evs.find((e) => e.kind === 'prd.drafted')).toBeDefined();
+    const drafted = evs.find((e) => e.kind === 'prd.drafted');
+    expect(drafted).toBeDefined();
+    expect((drafted?.payload as { displaySkill?: string }).displaySkill).toBe('write-prd');
     const skipped = evs.find((e) => e.kind === 'prd.advisor-skipped');
     expect(skipped).toBeDefined();
     expect((skipped?.payload as { reason: string }).reason).toBe('priority');
@@ -602,6 +605,7 @@ describe('grill-and-prd: max rounds reached, proceed straight to PRD', () => {
     const completed = evs.find((e) => e.kind === 'grill.completed');
     expect(completed).toBeDefined();
     expect((completed?.payload as { rounds: number }).rounds).toBe(8); // 7 prior + this round
+    expect((completed?.payload as { displaySkill?: string }).displaySkill).toBe('grill-me');
 
     // No new question-posted event
     expect(evs.find((e) => e.kind === 'grill.question-posted')).toBeUndefined();
@@ -866,6 +870,7 @@ describe('grill-and-prd: crystallization', () => {
     expect(crystEv).toBeDefined();
     expect((crystEv?.payload as { roundNumber: number }).roundNumber).toBe(1);
     expect((crystEv?.payload as { decision: string }).decision).toBe('Audience: admin users only.');
+    expect((crystEv?.payload as { displaySkill?: string }).displaySkill).toBe('grill-me');
   });
 
   it('attaches prior crystallizations to priorReplies before invoking grill-me', async () => {


### PR DESCRIPTION
## Summary
- add display metadata for Grill and PRD workflow parent events
- group Grill and PRD workflow activity into separate timeline phase accordions
- hide grill-reply manual actions from the timeline while keeping them persisted

## Verification
- pnpm vitest run apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineSection.test.ts slices/grill-and-prd/slice.test.ts
- pnpm exec biome check apps/web/src/components/detail/lib/timeline.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx apps/web/src/components/detail/components/TimelineEvents.tsx apps/web/src/components/detail/components/TimelineSection.test.ts core/workflows/grill-and-prd.ts slices/grill-and-prd/slice.test.ts