### PR TITLE
M19.XX: The items in the kanban lanes order is wrong

### DIFF
--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -8,7 +8,7 @@ import type { WorkItemWithProject } from './lib/all-projects';
 // Here we lock the sort/ordering rule and grouping logic.
 
 describe('issue card lane ordering', () => {
-  it('orders by priority desc, then issue number asc', () => {
+  it('orders by priority desc, then newest issue number first', () => {
     const sorted = sortLaneItems([
       { externalId: '40', priority: 'medium' },
       { externalId: '12', priority: 'low' },
@@ -16,7 +16,7 @@ describe('issue card lane ordering', () => {
       { externalId: '99', priority: 'critical' },
       { externalId: '5', priority: 'high' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '5', '40', '12']);
   });
 });
 

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,7 +23,7 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts by priority then newest issue number first', () => {
     const sorted = sortLaneItems([
       { externalId: '40', priority: 'medium' },
       { externalId: '12', priority: 'low' },
@@ -31,7 +31,7 @@ describe('lanes config', () => {
       { externalId: '99', priority: 'critical' },
       { externalId: '5', priority: 'high' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '7', '5', '40', '12']);
   });
 
   it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
@@ -47,13 +47,13 @@ describe('lanes config', () => {
     expect(sorted[2].externalId).toBe('2');
   });
 
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
+  it('sortLaneItems stable-sorts items with the same priority by externalId descending', () => {
     const sorted = sortLaneItems([
       { externalId: '30', priority: 'medium' },
       { externalId: '10', priority: 'medium' },
       { externalId: '20', priority: 'medium' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['30', '20', '10']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -124,13 +124,13 @@ interface SortableItem {
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Order lane items by priority rank first, then newer issue numbers before
+ * older ones within the same priority bucket.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
     const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
     if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    return Number(b.externalId) - Number(a.externalId);
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanban lanes order is wrong

## Work Packages

- ✓ **WP1**: Update `sortLaneItems()` in `apps/web/src/lib/lanes.config.ts:130` so the priority-rank comparison remains first, but th

Closes #945
