### PR TITLE
Bridge live timeline events into issue cache

### DIFF
--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -409,6 +409,32 @@ describe('TimelineSection — expand/collapse all', () => {
     expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
   });
 
+  it('invalidates issue state caches, but not events, when a state transition arrives over SSE', async () => {
+    const { fetchEventsPage } = await import('@/lib/api');
+    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
+
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { TimelineSection } = await import('./TimelineSection');
+    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
+
+    await screen.findByText('No timeline events yet.');
+    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+
+    MockEventSource.instances[0].emitNamed(
+      makeEvent(2, 'state.transitioned', {
+        from: 'factory:decomposing',
+        to: 'factory:done',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['issue', 'p', '1'])).toBe(true);
+      expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['issues', 'p'])).toBe(true);
+    });
+    expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
+  });
+
   it('updates the Playwright capture section from live investigation SSE without refetching events', async () => {
     const { fetchEvents, fetchEventsPage } = await import('@/lib/api');
     vi.mocked(fetchEvents).mockResolvedValue([]);

--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -371,6 +371,7 @@ describe('TimelineSection — expand/collapse all', () => {
     });
 
     const queryClient = new QueryClient();
+    queryClient.setQueryData(['events', 'p', '1'], []);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const { TimelineSection } = await import('./TimelineSection');
     renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
@@ -390,6 +391,7 @@ describe('TimelineSection — expand/collapse all', () => {
     vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
 
     const queryClient = new QueryClient();
+    queryClient.setQueryData(['events', 'p', '1'], []);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const { TimelineSection } = await import('./TimelineSection');
     renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);

--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -47,6 +47,7 @@ class MockEventSource {
 
 beforeEach(() => {
   MockEventSource.instances = [];
+  vi.clearAllMocks();
   vi.stubGlobal('EventSource', MockEventSource);
 });
 
@@ -55,6 +56,7 @@ afterEach(() => {
 });
 
 vi.mock('@/lib/api', () => ({
+  fetchEvents: vi.fn().mockResolvedValue([]),
   fetchEventsPage: vi.fn().mockResolvedValue({ events: [], hasMore: false }),
   fetchIntervention: vi.fn(),
   fetchIssueInterventions: vi.fn().mockResolvedValue([]),
@@ -127,6 +129,13 @@ function makeCodexTransportWarning(id: number, runId: string): AgentEventDto {
       source: 'responses_websocket',
       message: 'failed to connect to websocket: 503 Service Unavailable',
     }),
+  });
+}
+
+function invalidatedQueryKey(calls: readonly (readonly unknown[])[], queryKey: readonly unknown[]) {
+  return calls.some(([input]) => {
+    const candidate = input as { queryKey?: unknown };
+    return JSON.stringify(candidate.queryKey) === JSON.stringify(queryKey);
   });
 }
 
@@ -321,7 +330,7 @@ describe('TimelineSection — expand/collapse all', () => {
     await screen.findByTestId('timeline-expand-all');
     fireEvent.click(screen.getByTestId('timeline-expand-all'));
 
-    expect(await screen.findByText('Complete')).toBeTruthy();
+    expect((await screen.findAllByText('Complete')).length).toBeGreaterThan(0);
     expect(
       await screen.findByText('Codex transport warning: websocket 503; run recovered'),
     ).toBeTruthy();
@@ -345,7 +354,7 @@ describe('TimelineSection — expand/collapse all', () => {
     await screen.findByTestId('timeline-expand-all');
     fireEvent.click(screen.getByTestId('timeline-expand-all'));
 
-    expect(await screen.findByText('Complete')).toBeTruthy();
+    expect((await screen.findAllByText('Complete')).length).toBeGreaterThan(0);
     expect(
       await screen.findByText('Codex transport warning: websocket 503; run recovered'),
     ).toBeTruthy();
@@ -374,6 +383,76 @@ describe('TimelineSection — expand/collapse all', () => {
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue-costs', 'p', '1'] });
     });
+  });
+
+  it('writes named issue timeline SSE events into the shared events cache without invalidating it', async () => {
+    const { fetchEventsPage } = await import('@/lib/api');
+    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
+
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { TimelineSection } = await import('./TimelineSection');
+    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
+
+    await screen.findByText('No timeline events yet.');
+    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+
+    const event = makeEvent(2, 'agent.investigation-complete', {
+      investigate: { findings: [] },
+    });
+    MockEventSource.instances[0].emitNamed(event);
+    MockEventSource.instances[0].emitNamed(event);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event]);
+    });
+    expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
+  });
+
+  it('updates the Playwright capture section from live investigation SSE without refetching events', async () => {
+    const { fetchEvents, fetchEventsPage } = await import('@/lib/api');
+    vi.mocked(fetchEvents).mockResolvedValue([]);
+    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
+
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { TimelineSection } = await import('./TimelineSection');
+    const { PlaywrightCaptureSection } = await import('./PlaywrightCaptureSection');
+    renderTimeline(
+      <>
+        <TimelineSection projectSlug="p" id="1" workItemId="w1" />
+        <PlaywrightCaptureSection projectSlug="p" id="1" itemType="bug" />
+      </>,
+      queryClient,
+    );
+
+    expect(await screen.findByText('Playwright capture has not run yet.')).toBeTruthy();
+    expect(fetchEvents).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+
+    MockEventSource.instances[0].emitNamed(
+      makeEvent(2, 'agent.investigation-complete', {
+        playwrightRepro: {
+          screenshots: [
+            {
+              path: '/tmp/repro.png',
+              caption: 'Live repro screenshot',
+              step: 1,
+            },
+          ],
+          gifPath: null,
+          consoleErrors: [],
+          reproSteps: ['Open the bug page'],
+          reproduced: true,
+          notes: 'Captured from the live investigation event.',
+        },
+      }),
+    );
+
+    expect(await screen.findByText('Open the bug page')).toBeTruthy();
+    expect(screen.getByText('Live repro screenshot')).toBeTruthy();
+    expect(fetchEvents).toHaveBeenCalledTimes(1);
+    expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
   });
 
   it('renders named SSE events that are visible in REST reloads', async () => {

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -117,6 +117,8 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
           void queryClient.invalidateQueries({ queryKey: ['issue-costs', projectSlug, id] });
         }
         if (parsed.kind === 'state.transitioned') {
+          void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, id] });
+          void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
           const payload = parsed.payload as {
             interventionId?: string;
             causedByInterventionId?: string;

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -10,6 +10,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Clock } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIssueCostsBreakdown } from '../lib/costs';
+import { upsertIssueEvent } from '../lib/live-events';
 import { groupEvents } from '../lib/timeline';
 import type { RenderItem } from '../lib/timeline';
 import { SectionEmptyState } from './SectionEmptyState';
@@ -107,6 +108,7 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
       try {
         const parsed = JSON.parse(msg.data) as AgentEventDto;
         if (!isIssueTimelineEvent(parsed)) return;
+        upsertIssueEvent(queryClient, projectSlug, id, parsed);
         setEvents((prev) => {
           if (prev.find((e) => e.id === parsed.id) != null) return prev;
           return [parsed, ...prev];

--- a/apps/web/src/components/detail/lib/live-events.test.ts
+++ b/apps/web/src/components/detail/lib/live-events.test.ts
@@ -15,9 +15,19 @@ function makeEvent(id: number, kind = 'agent.investigation-complete'): AgentEven
 }
 
 describe('upsertIssueEvent', () => {
-  it('inserts a live event into the issue events cache', () => {
+  it('does not seed the issue events cache before the full events query loads', () => {
     const queryClient = new QueryClient();
     const event = makeEvent(2);
+
+    upsertIssueEvent(queryClient, 'p', '1', event);
+
+    expect(queryClient.getQueryData(['events', 'p', '1'])).toBeUndefined();
+  });
+
+  it('inserts a live event into an existing issue events cache', () => {
+    const queryClient = new QueryClient();
+    const event = makeEvent(2);
+    queryClient.setQueryData(['events', 'p', '1'], []);
 
     upsertIssueEvent(queryClient, 'p', '1', event);
 
@@ -28,6 +38,7 @@ describe('upsertIssueEvent', () => {
     const queryClient = new QueryClient();
     const event = makeEvent(2);
     const duplicate = { ...event, payload: { changed: true } };
+    queryClient.setQueryData(['events', 'p', '1'], []);
 
     upsertIssueEvent(queryClient, 'p', '1', event);
     upsertIssueEvent(queryClient, 'p', '1', duplicate);

--- a/apps/web/src/components/detail/lib/live-events.test.ts
+++ b/apps/web/src/components/detail/lib/live-events.test.ts
@@ -1,0 +1,59 @@
+import type { AgentEventDto } from '@/lib/types';
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { upsertIssueEvent } from './live-events';
+
+function makeEvent(id: number, kind = 'agent.investigation-complete'): AgentEventDto {
+  return {
+    id,
+    projectId: 'p',
+    workItemId: 'w1',
+    kind,
+    payload: {},
+    createdAt: new Date(Date.now() + id * 1000).toISOString(),
+  };
+}
+
+describe('upsertIssueEvent', () => {
+  it('inserts a live event into the issue events cache', () => {
+    const queryClient = new QueryClient();
+    const event = makeEvent(2);
+
+    upsertIssueEvent(queryClient, 'p', '1', event);
+
+    expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event]);
+  });
+
+  it('dedupes repeated event ids without replacing the cached row', () => {
+    const queryClient = new QueryClient();
+    const event = makeEvent(2);
+    const duplicate = { ...event, payload: { changed: true } };
+
+    upsertIssueEvent(queryClient, 'p', '1', event);
+    upsertIssueEvent(queryClient, 'p', '1', duplicate);
+
+    expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event]);
+  });
+
+  it('keeps issue event rows newest-first by event id', () => {
+    const queryClient = new QueryClient();
+    const event1 = makeEvent(1);
+    const event3 = makeEvent(3);
+    const event2 = makeEvent(2);
+    queryClient.setQueryData(['events', 'p', '1'], [event1, event3]);
+
+    upsertIssueEvent(queryClient, 'p', '1', event2);
+
+    expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event3, event2, event1]);
+  });
+
+  it('leaves unrelated event cache keys untouched', () => {
+    const queryClient = new QueryClient();
+    const otherEvent = makeEvent(9);
+    queryClient.setQueryData(['events', 'p', '2'], [otherEvent]);
+
+    upsertIssueEvent(queryClient, 'p', '1', makeEvent(2));
+
+    expect(queryClient.getQueryData(['events', 'p', '2'])).toEqual([otherEvent]);
+  });
+});

--- a/apps/web/src/components/detail/lib/live-events.ts
+++ b/apps/web/src/components/detail/lib/live-events.ts
@@ -1,0 +1,15 @@
+import type { AgentEventDto } from '@/lib/types';
+import type { QueryClient } from '@tanstack/react-query';
+
+export function upsertIssueEvent(
+  queryClient: QueryClient,
+  projectSlug: string,
+  issueId: string,
+  event: AgentEventDto,
+): void {
+  queryClient.setQueryData<AgentEventDto[]>(['events', projectSlug, issueId], (existing) => {
+    if (existing == null) return [event];
+    if (existing.some((candidate) => candidate.id === event.id)) return existing;
+    return [event, ...existing].sort((a, b) => b.id - a.id);
+  });
+}

--- a/apps/web/src/components/detail/lib/live-events.ts
+++ b/apps/web/src/components/detail/lib/live-events.ts
@@ -8,7 +8,8 @@ export function upsertIssueEvent(
   event: AgentEventDto,
 ): void {
   queryClient.setQueryData<AgentEventDto[]>(['events', projectSlug, issueId], (existing) => {
-    if (existing == null) return [event];
+    // Avoid seeding a partial SSE-only cache before the full events query has loaded.
+    if (existing == null) return existing;
     if (existing.some((candidate) => candidate.id === event.id)) return existing;
     return [event, ...existing].sort((a, b) => b.id - a.id);
   });


### PR DESCRIPTION
## Summary
- add a detail-page helper that upserts live issue events into the shared React Query events cache
- bridge TimelineSection SSE events into ['events', projectSlug, issueId] without invalidating the events query
- add focused cache and component coverage for duplicate SSE delivery, Playwright capture live updates, and existing issue-cost invalidation

## Verification
- pnpm exec biome check apps/web/src/components/detail/lib/live-events.ts apps/web/src/components/detail/lib/live-events.test.ts apps/web/src/components/detail/components/TimelineSection.tsx apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
- pnpm --filter @goose-hub/web exec vitest run src/components/detail/lib/live-events.test.ts src/components/detail/components/TimelineExpandCollapse.test.tsx src/components/detail/components/PlaywrightCaptureSection.test.tsx
- pnpm --filter @goose-hub/web build

## Non-goal
- Does not change Playwright capture ordering/latest-selection behavior.