### PR TITLE
Add discover session grouping for Grill PRD

### DIFF
--- a/apps/server/src/domains/issues/prd-actions.test.ts
+++ b/apps/server/src/domains/issues/prd-actions.test.ts
@@ -293,6 +293,13 @@ describe('proceedToPrd', () => {
       state: 'factory:gate-pending',
     });
     vi.mocked(getSourceForSlug).mockResolvedValue(source);
+    eventStore.appendEvent({
+      projectId,
+      workItemId: item.id,
+      kind: 'grill.question-posted',
+      runId: 'workflow-1',
+      payload: { discoverSessionId: 'discover-session-proceed' },
+    });
 
     const result = await proceedToPrd(projectId, item.externalId);
     expect(result.ok).toBe(true);
@@ -306,6 +313,9 @@ describe('proceedToPrd', () => {
         e.kind === 'state.transitioned' && (e.payload as { to: string }).to === 'factory:grilling',
     );
     expect(transitioned).toBeDefined();
+    expect((transitioned?.payload as { discoverSessionId?: string }).discoverSessionId).toBe(
+      'discover-session-proceed',
+    );
 
     await Promise.resolve();
     expect(dispatchGrillAndPrdMock).toHaveBeenCalledWith(projectId, Number(item.externalId));

--- a/apps/server/src/domains/issues/prd-actions.ts
+++ b/apps/server/src/domains/issues/prd-actions.ts
@@ -13,6 +13,10 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
+import {
+  activeDiscoverSessionId,
+  latestDiscoverSessionId,
+} from '@goose-hub/core/workflows/grill-and-prd/discover-session.js';
 import type { PRDOutput } from '@goose-hub/skills/write-prd/schema.js';
 import { dispatchDecomposePrd, dispatchGrillAndPrd, dispatchRevisePrd } from '#shared/dispatch.js';
 import type { Result } from '#shared/middleware.js';
@@ -48,12 +52,15 @@ export async function approvePRD(slug: string, id: string): Promise<Result<{ ok:
   }
 
   await moveOrForce(source, id, 'factory:prd-review', 'factory:decomposing');
+  const discoverSessionId = latestDiscoverSessionId(slug, workItemId);
+  const sessionPayload =
+    discoverSessionId != null ? { discoverSessionId } : ({} as Record<string, never>);
 
   eventStore.appendEvent({
     projectId: slug,
     workItemId,
     kind: 'prd.approved',
-    payload: { source: 'ui' },
+    payload: { source: 'ui', ...sessionPayload },
   });
   emitStateTransitionEvent({
     projectId: slug,
@@ -61,6 +68,7 @@ export async function approvePRD(slug: string, id: string): Promise<Result<{ ok:
     from: 'factory:prd-review',
     to: 'factory:decomposing',
     by: 'ui',
+    extraPayload: sessionPayload,
   });
 
   // Fire decompose-prd outside the response path. Mirrors the
@@ -111,11 +119,16 @@ export async function revisePRD(
     return { ok: false, error: 'no PRD draft found for revision', status: 409 };
   }
 
+  const discoverSessionId = latestDiscoverSessionId(slug, workItemId);
   eventStore.appendEvent({
     projectId: slug,
     workItemId,
     kind: 'prd.revised',
-    payload: { source: 'ui', concerns },
+    payload: {
+      source: 'ui',
+      concerns,
+      ...(discoverSessionId != null ? { discoverSessionId } : {}),
+    },
   });
 
   // Re-dispatch write-prd with concerns; state stays prd-review.
@@ -146,12 +159,15 @@ export async function declinePRD(slug: string, id: string): Promise<Result<{ ok:
   }
 
   await moveOrForce(source, id, 'factory:prd-review', 'factory:done');
+  const discoverSessionId = latestDiscoverSessionId(slug, workItemId);
+  const sessionPayload =
+    discoverSessionId != null ? { discoverSessionId } : ({} as Record<string, never>);
 
   eventStore.appendEvent({
     projectId: slug,
     workItemId,
     kind: 'prd.declined',
-    payload: { source: 'ui' },
+    payload: { source: 'ui', ...sessionPayload },
   });
   emitStateTransitionEvent({
     projectId: slug,
@@ -159,6 +175,7 @@ export async function declinePRD(slug: string, id: string): Promise<Result<{ ok:
     from: 'factory:prd-review',
     to: 'factory:done',
     by: 'ui',
+    extraPayload: sessionPayload,
   });
 
   return { ok: true, data: { ok: true } };
@@ -180,6 +197,9 @@ export async function proceedToPrd(slug: string, id: string): Promise<Result<{ o
   }
 
   await moveOrForce(source, id, 'factory:gate-pending', 'factory:grilling');
+  const discoverSessionId = activeDiscoverSessionId(slug, workItemId);
+  const sessionPayload =
+    discoverSessionId != null ? { discoverSessionId } : ({} as Record<string, never>);
 
   emitStateTransitionEvent({
     projectId: slug,
@@ -187,6 +207,7 @@ export async function proceedToPrd(slug: string, id: string): Promise<Result<{ o
     from: 'factory:gate-pending',
     to: 'factory:grilling',
     by: 'ui-proceed',
+    extraPayload: sessionPayload,
   });
 
   // Dispatch grill-and-prd with readyForPRD forced by marking priorReplies as complete.

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -31,6 +31,8 @@ vi.mock('@goose-hub/core/state-machine/states.js', () => ({
   STATES: [
     'factory:triaging',
     'factory:accepted',
+    'factory:gate-pending',
+    'factory:grilling',
     'factory:in-progress',
     'factory:needs-human',
     'factory:done',
@@ -176,6 +178,46 @@ describe('transitionIssue — validation', () => {
       'verify',
       'resolve',
     ]);
+  });
+
+  it('attaches active discover session metadata to manual gate-pending → grilling transitions', async () => {
+    const discoverSessionId = 'discover-session-manual-resume';
+    vi.mocked(eventStore.replay).mockReturnValueOnce([
+      {
+        id: 1,
+        projectId: 'proj-manual-grill',
+        workItemId: 'github:owner/repo#888',
+        kind: 'grill.question-posted',
+        runId: 'workflow-1',
+        payload: { discoverSessionId },
+        createdAt: '2026-05-22T00:00:00Z',
+      },
+    ]);
+
+    const result = await transitionIssue(
+      'proj-manual-grill',
+      '888',
+      'factory:gate-pending',
+      'factory:grilling',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(eventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'state.transitioned',
+        payload: expect.objectContaining({ discoverSessionId }),
+      }),
+    );
+    const interventions = listInterventions({
+      projectId: 'proj-manual-grill',
+      workItemId: 'github:owner/repo#888',
+    });
+    expect(interventions[0].decidedActionPayload).toMatchObject({ discoverSessionId });
+    expect(interventions[0].applicationResult).toMatchObject({
+      result: { discoverSessionId },
+    });
+    const events = listInterventionEvents(interventions[0].id);
+    expect(events[0].payload).toMatchObject({ evidence: { discoverSessionId } });
   });
 
   it('supersedes stale active interventions when a manual transition archives the issue', async () => {

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -24,6 +24,7 @@ import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { STATES, TERMINAL_STATES } from '@goose-hub/core/state-machine/states.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { isLegalTransition, legalTargets } from '@goose-hub/core/state-machine/transitions.js';
+import { activeDiscoverSessionId } from '@goose-hub/core/workflows/grill-and-prd/discover-session.js';
 import { cleanupWorktree } from '@goose-hub/core/workspaces/worktree.js';
 import { CACHE_KEY, bustCache } from '#shared/cache.js';
 import { dispatchRetro } from '#shared/dispatch.js';
@@ -390,6 +391,12 @@ export async function transitionIssue(
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
 
   const workItemId = `github:${source.repoRef}#${id}`;
+  const discoverSessionId =
+    fromState === 'factory:gate-pending' && toState === 'factory:grilling'
+      ? activeDiscoverSessionId(slug, workItemId)
+      : null;
+  const sessionPayload =
+    discoverSessionId != null ? { discoverSessionId } : ({} as Record<string, never>);
   const manual = open({
     projectId: slug,
     workItemId,
@@ -398,11 +405,16 @@ export async function transitionIssue(
     reason: `Operator requested ${fromState} -> ${toState}`,
     rootCauseSignature: `manual_override|${slug}|${workItemId}|${fromState}|${toState}|${Date.now()}`,
     actor: 'ui',
-    evidence: { from: fromState, to: toState },
+    evidence: { from: fromState, to: toState, ...sessionPayload },
   });
   if (!manual.ok) return { ok: false, error: manual.error, status: manual.status };
 
-  const payload = { from: fromState, to: toState, reason: 'manual operator transition' };
+  const payload = {
+    from: fromState,
+    to: toState,
+    reason: 'manual operator transition',
+    ...sessionPayload,
+  };
   const validation = validateInterventionAction('manual_transition', payload);
   if (!validation.ok) return { ok: false, error: validation.error, status: 422 };
 
@@ -447,13 +459,14 @@ export async function transitionIssue(
       interventionId: manual.intervention.id,
       causedByInterventionId: manual.intervention.id,
       correlationId: manual.intervention.correlationId,
+      ...sessionPayload,
     },
   });
   const applied = recordApplicationResult({
     id: manual.intervention.id,
     expectedVersion: applying.intervention.version,
     ok: true,
-    result: { from: fromState, to: toState },
+    result: { from: fromState, to: toState, ...sessionPayload },
     actor: 'ui',
   });
   let manualResolved = false;

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -151,6 +151,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
         key={`phase-group-${item.phase}-${item.pipelineRunId}`}
         phase={item.phase}
         pipelineRunId={item.pipelineRunId}
+        idKind={item.idKind}
         items={item.items}
         status={item.status}
         startedAt={item.startedAt}

--- a/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
@@ -8,6 +8,7 @@ const STALL_MS = 15 * 60 * 1000;
 export function PhaseGroupWrapper({
   phase,
   pipelineRunId,
+  idKind,
   items,
   status,
   startedAt,
@@ -18,6 +19,7 @@ export function PhaseGroupWrapper({
 }: {
   phase: 'grill' | 'prd' | 'contract' | 'dev';
   pipelineRunId: string;
+  idKind: 'session' | 'workflow' | 'contract' | 'pipeline';
   items: RenderItem[];
   status: 'started' | 'live' | 'completed' | 'failed';
   startedAt: string | null;
@@ -59,7 +61,7 @@ export function PhaseGroupWrapper({
         : phase === 'contract'
           ? 'Contract Phase'
           : 'Dev Phase';
-  const idLabel = phase === 'contract' ? 'contract' : phase === 'dev' ? 'pipeline' : 'workflow';
+  const idLabel = idKind;
 
   const statusBadge = isStalled ? (
     <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -534,6 +534,135 @@ describe('groupEvents — discover phase groups', () => {
     ]);
   });
 
+  it('collapses multiple Grill rounds with different workflow ids into one session phase', () => {
+    const SID = 'discover-session-1';
+    const W1 = 'discover-workflow-round-1';
+    const W2 = 'discover-workflow-round-2';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', `${W1}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: W1, discoverSessionId: SID },
+      }),
+      makeEvent(2, 'agent.run-completed', `${W1}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: W1, discoverSessionId: SID },
+      }),
+      makeEvent(3, 'grill.question-posted', W1, {
+        payload: { displaySkill: 'grill-me', workflowRunId: W1, discoverSessionId: SID },
+      }),
+      makeEvent(4, 'agent.run-started', `${W2}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: W2, discoverSessionId: SID },
+      }),
+      makeEvent(5, 'agent.run-completed', `${W2}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: W2, discoverSessionId: SID },
+      }),
+      makeEvent(6, 'grill.completed', W2, {
+        payload: { displaySkill: 'grill-me', workflowRunId: W2, discoverSessionId: SID },
+      }),
+    ]);
+
+    const phaseGroups = result.filter((item) => item.kind === 'phase-group');
+    expect(phaseGroups).toHaveLength(1);
+    const grill = phaseGroups[0];
+    if (grill.kind !== 'phase-group') return;
+    expect(grill.phase).toBe('grill');
+    expect(grill.pipelineRunId).toBe(SID);
+    expect(grill.idKind).toBe('session');
+    expect(grill.items.filter((item) => item.kind === 'run-group')).toHaveLength(2);
+  });
+
+  it('nests manual Grill resume transitions and intervention groups in the session phase', () => {
+    const SID = 'discover-session-manual';
+    const WID = 'discover-workflow-manual';
+    const intervention = makeIntervention({
+      decidedActionPayload: {
+        from: 'factory:gate-pending',
+        to: 'factory:grilling',
+        discoverSessionId: SID,
+      },
+      applicationResult: {
+        ok: true,
+        result: {
+          from: 'factory:gate-pending',
+          to: 'factory:grilling',
+          discoverSessionId: SID,
+        },
+      },
+    });
+    const result = groupEvents(
+      [
+        makeEvent(1, 'grill.question-posted', WID, {
+          payload: { displaySkill: 'grill-me', workflowRunId: WID, discoverSessionId: SID },
+        }),
+        makeEvent(2, 'state.transitioned', null, {
+          payload: {
+            from: 'factory:gate-pending',
+            to: 'factory:grilling',
+            by: 'ui',
+            discoverSessionId: SID,
+          },
+        }),
+      ],
+      [
+        {
+          intervention,
+          events: [
+            makeInterventionEvent(1, 'open', '2026-05-04T10:00:00Z', {
+              payload: { evidence: { discoverSessionId: SID } },
+            }),
+            makeInterventionEvent(2, 'decide', '2026-05-04T10:01:00Z', {
+              payload: {
+                actionType: 'manual_transition',
+                actionPayload: { discoverSessionId: SID },
+              },
+            }),
+          ],
+        },
+      ],
+    );
+
+    expect(result).toHaveLength(1);
+    const grill = result[0];
+    expect(grill.kind).toBe('phase-group');
+    if (grill.kind !== 'phase-group') return;
+    expect(grill.phase).toBe('grill');
+    expect(grill.pipelineRunId).toBe(SID);
+    expect(
+      grill.items.some((item) => item.kind === 'event' && item.event.kind === 'state.transitioned'),
+    ).toBe(true);
+    expect(grill.items.some((item) => item.kind === 'intervention-group')).toBe(true);
+  });
+
+  it('keeps PRD separate from Grill while using the same discover session id', () => {
+    const SID = 'discover-session-prd';
+    const GRILL_WID = 'discover-workflow-grill-only';
+    const PRD_WID = 'discover-workflow-prd-only';
+    const result = groupEvents([
+      makeEvent(1, 'agent.run-started', `${GRILL_WID}:grill-me`, {
+        payload: { skill: 'grill-me', workflowRunId: GRILL_WID, discoverSessionId: SID },
+      }),
+      makeEvent(2, 'grill.completed', GRILL_WID, {
+        payload: { displaySkill: 'grill-me', workflowRunId: GRILL_WID, discoverSessionId: SID },
+      }),
+      makeEvent(3, 'agent.run-started', `${PRD_WID}:write-prd`, {
+        payload: { skill: 'write-prd', workflowRunId: PRD_WID, discoverSessionId: SID },
+      }),
+      makeEvent(4, 'prd.drafted', PRD_WID, {
+        payload: { displaySkill: 'write-prd', workflowRunId: PRD_WID, discoverSessionId: SID },
+      }),
+    ]);
+
+    const phaseGroups = result.filter((item) => item.kind === 'phase-group');
+    expect(phaseGroups).toHaveLength(2);
+    expect(phaseGroups.map((item) => (item.kind === 'phase-group' ? item.phase : null))).toEqual([
+      'prd',
+      'grill',
+    ]);
+    for (const phase of phaseGroups) {
+      if (phase.kind !== 'phase-group') continue;
+      expect(phase.pipelineRunId).toBe(SID);
+      expect(phase.idKind).toBe('session');
+    }
+  });
+
   it('hides grill reply manual actions from the timeline', () => {
     const result = groupEvents([
       makeEvent(1, 'manual.action', null, {

--- a/apps/web/src/components/detail/lib/timeline.ts
+++ b/apps/web/src/components/detail/lib/timeline.ts
@@ -256,6 +256,7 @@ export type RenderItem =
       kind: 'phase-group';
       phase: 'grill' | 'prd' | 'contract' | 'dev';
       pipelineRunId: string;
+      idKind: 'session' | 'workflow' | 'contract' | 'pipeline';
       items: RenderItem[];
       status: 'started' | 'live' | 'completed' | 'failed';
       startedAt: string | null;
@@ -312,6 +313,14 @@ function compareRenderItems(a: RenderItem, b: RenderItem): number {
   return 0;
 }
 
+function getDiscoverSessionId(event: AgentEventDto): string | null {
+  const payload = event.payload as { discoverSessionId?: unknown } | null;
+  if (typeof payload?.discoverSessionId === 'string' && payload.discoverSessionId.trim() !== '') {
+    return payload.discoverSessionId;
+  }
+  return null;
+}
+
 function getWorkflowRunId(event: AgentEventDto): string | null {
   const payload = event.payload as { workflowRunId?: unknown } | null;
   if (typeof payload?.workflowRunId === 'string' && payload.workflowRunId.trim() !== '') {
@@ -320,8 +329,20 @@ function getWorkflowRunId(event: AgentEventDto): string | null {
   return event.runId ?? null;
 }
 
+function getDiscoverPhaseId(
+  event: AgentEventDto,
+): { id: string; idKind: 'session' | 'workflow' } | null {
+  const discoverSessionId = getDiscoverSessionId(event);
+  if (discoverSessionId != null) return { id: discoverSessionId, idKind: 'session' };
+  const workflowRunId = getWorkflowRunId(event);
+  return workflowRunId != null ? { id: workflowRunId, idKind: 'workflow' } : null;
+}
+
 function isGrillPhaseEvent(event: AgentEventDto): boolean {
-  return event.kind.startsWith('grill.');
+  if (event.kind.startsWith('grill.')) return true;
+  if (event.kind !== 'state.transitioned' || getDiscoverSessionId(event) == null) return false;
+  const payload = event.payload as { from?: unknown; to?: unknown } | null;
+  return payload?.from === 'factory:gate-pending' && payload.to === 'factory:grilling';
 }
 
 function isPrdPhaseEvent(event: AgentEventDto): boolean {
@@ -350,60 +371,115 @@ function resolveDiscoverPhaseStatus(
 }
 
 function appendDiscoverPhaseItem(
-  phaseItems: Map<string, { grill: RenderItem[]; prd: RenderItem[] }>,
-  workflowRunId: string,
+  phaseItems: Map<
+    string,
+    { id: string; idKind: 'session' | 'workflow'; grill: RenderItem[]; prd: RenderItem[] }
+  >,
+  phaseId: { id: string; idKind: 'session' | 'workflow' },
   phase: 'grill' | 'prd',
   item: RenderItem,
 ): void {
-  const group = phaseItems.get(workflowRunId) ?? { grill: [], prd: [] };
+  const key = `${phaseId.idKind}:${phaseId.id}`;
+  const group = phaseItems.get(key) ?? { ...phaseId, grill: [], prd: [] };
   group[phase].push(item);
-  phaseItems.set(workflowRunId, group);
+  phaseItems.set(key, group);
+}
+
+function discoverSessionIdFromUnknown(value: unknown): string | null {
+  if (value == null || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.discoverSessionId === 'string' && record.discoverSessionId.trim() !== '') {
+    return record.discoverSessionId;
+  }
+  for (const key of ['evidence', 'actionPayload', 'result', 'verification']) {
+    const nested = discoverSessionIdFromUnknown(record[key]);
+    if (nested != null) return nested;
+  }
+  return null;
+}
+
+function interventionDiscoverSessionId(
+  item: Extract<RenderItem, { kind: 'intervention-group' }>,
+): string | null {
+  if (item.intervention.interventionType !== 'manual_override') return null;
+  for (const value of [
+    item.intervention.decidedActionPayload,
+    item.intervention.applicationResult,
+    item.intervention.verification,
+    ...item.events.map((event) => event.payload),
+  ]) {
+    const discoverSessionId = discoverSessionIdFromUnknown(value);
+    if (discoverSessionId != null) return discoverSessionId;
+  }
+  return null;
 }
 
 function childDiscoverPhase(
   item: RenderItem,
-): { workflowRunId: string; phase: 'grill' | 'prd' } | null {
+): { id: string; idKind: 'session' | 'workflow'; phase: 'grill' | 'prd' } | null {
+  if (item.kind === 'intervention-group') {
+    const discoverSessionId = interventionDiscoverSessionId(item);
+    if (discoverSessionId != null) {
+      return { id: discoverSessionId, idKind: 'session', phase: 'grill' };
+    }
+    return null;
+  }
   if (item.kind !== 'run-group') return null;
+  for (const event of eventFromRenderItem(item)) {
+    const phaseId = getDiscoverPhaseId(event);
+    if (phaseId == null) continue;
+    const payload = event.payload as { skill?: string } | null;
+    if (payload?.skill === 'grill-me') return { ...phaseId, phase: 'grill' };
+    if (payload?.skill === 'write-prd' || payload?.skill === 'advise-on-prd') {
+      return { ...phaseId, phase: 'prd' };
+    }
+  }
   if (item.runId.endsWith(':grill-me')) {
-    return { workflowRunId: item.runId.slice(0, -':grill-me'.length), phase: 'grill' };
+    return {
+      id: item.runId.slice(0, -':grill-me'.length),
+      idKind: 'workflow',
+      phase: 'grill',
+    };
   }
   if (item.runId.endsWith(':write-prd')) {
-    return { workflowRunId: item.runId.slice(0, -':write-prd'.length), phase: 'prd' };
+    return {
+      id: item.runId.slice(0, -':write-prd'.length),
+      idKind: 'workflow',
+      phase: 'prd',
+    };
   }
   if (item.runId.endsWith(':advise-on-prd')) {
-    return { workflowRunId: item.runId.slice(0, -':advise-on-prd'.length), phase: 'prd' };
-  }
-  for (const event of eventFromRenderItem(item)) {
-    const workflowRunId = getWorkflowRunId(event);
-    if (workflowRunId == null) continue;
-    const payload = event.payload as { skill?: string } | null;
-    if (payload?.skill === 'grill-me') return { workflowRunId, phase: 'grill' };
-    if (payload?.skill === 'write-prd' || payload?.skill === 'advise-on-prd') {
-      return { workflowRunId, phase: 'prd' };
-    }
+    return {
+      id: item.runId.slice(0, -':advise-on-prd'.length),
+      idKind: 'workflow',
+      phase: 'prd',
+    };
   }
   return null;
 }
 
 export function groupByDiscoverPhase(items: RenderItem[]): RenderItem[] {
-  const phaseItems = new Map<string, { grill: RenderItem[]; prd: RenderItem[] }>();
+  const phaseItems = new Map<
+    string,
+    { id: string; idKind: 'session' | 'workflow'; grill: RenderItem[]; prd: RenderItem[] }
+  >();
   const ungrouped: RenderItem[] = [];
 
   for (const item of items) {
     const childPhase = childDiscoverPhase(item);
     if (childPhase != null) {
-      appendDiscoverPhaseItem(phaseItems, childPhase.workflowRunId, childPhase.phase, item);
+      appendDiscoverPhaseItem(phaseItems, childPhase, childPhase.phase, item);
       continue;
     }
 
     if (item.kind === 'event') {
-      const workflowRunId = getWorkflowRunId(item.event);
-      if (workflowRunId != null && isGrillPhaseEvent(item.event)) {
-        appendDiscoverPhaseItem(phaseItems, workflowRunId, 'grill', item);
+      const phaseId = getDiscoverPhaseId(item.event);
+      if (phaseId != null && isGrillPhaseEvent(item.event)) {
+        appendDiscoverPhaseItem(phaseItems, phaseId, 'grill', item);
         continue;
       }
-      if (workflowRunId != null && isPrdPhaseEvent(item.event)) {
-        appendDiscoverPhaseItem(phaseItems, workflowRunId, 'prd', item);
+      if (phaseId != null && isPrdPhaseEvent(item.event)) {
+        appendDiscoverPhaseItem(phaseItems, phaseId, 'prd', item);
         continue;
       }
       ungrouped.push(item);
@@ -414,12 +490,12 @@ export function groupByDiscoverPhase(items: RenderItem[]): RenderItem[] {
       const remaining: RenderItem[] = [];
       let consumedDiscoverEvent = false;
       for (const event of eventFromRenderItem(item)) {
-        const workflowRunId = getWorkflowRunId(event);
-        if (workflowRunId != null && isGrillPhaseEvent(event)) {
-          appendDiscoverPhaseItem(phaseItems, workflowRunId, 'grill', { kind: 'event', event });
+        const phaseId = getDiscoverPhaseId(event);
+        if (phaseId != null && isGrillPhaseEvent(event)) {
+          appendDiscoverPhaseItem(phaseItems, phaseId, 'grill', { kind: 'event', event });
           consumedDiscoverEvent = true;
-        } else if (workflowRunId != null && isPrdPhaseEvent(event)) {
-          appendDiscoverPhaseItem(phaseItems, workflowRunId, 'prd', { kind: 'event', event });
+        } else if (phaseId != null && isPrdPhaseEvent(event)) {
+          appendDiscoverPhaseItem(phaseItems, phaseId, 'prd', { kind: 'event', event });
           consumedDiscoverEvent = true;
         } else {
           remaining.push({ kind: 'event', event });
@@ -437,7 +513,7 @@ export function groupByDiscoverPhase(items: RenderItem[]): RenderItem[] {
   }
 
   const phases: RenderItem[] = [];
-  for (const [workflowRunId, grouped] of phaseItems) {
+  for (const grouped of phaseItems.values()) {
     for (const phase of ['grill', 'prd'] as const) {
       const phaseItemList = grouped[phase];
       if (phaseItemList.length === 0) continue;
@@ -445,7 +521,8 @@ export function groupByDiscoverPhase(items: RenderItem[]): RenderItem[] {
       phases.push({
         kind: 'phase-group',
         phase,
-        pipelineRunId: workflowRunId,
+        pipelineRunId: grouped.id,
+        idKind: grouped.idKind,
         items: phaseItemList.sort(compareRenderItems),
         status: resolveDiscoverPhaseStatus(phase, phaseItemList),
         ...times,
@@ -506,6 +583,7 @@ export function groupByContractPhase(items: RenderItem[]): RenderItem[] {
       kind: 'phase-group',
       phase: 'contract',
       pipelineRunId: id,
+      idKind: 'contract',
       items: phaseItemList.sort(compareRenderItems),
       status: resolveContractPhaseStatus(phaseItemList),
       ...times,
@@ -577,6 +655,7 @@ export function groupByDevPhase(items: RenderItem[]): RenderItem[] {
       kind: 'phase-group',
       phase: 'dev',
       pipelineRunId: pid,
+      idKind: 'pipeline',
       items: phaseItemList,
       status: resolveDevPhaseStatus(pid, phaseItemList),
       ...times,
@@ -637,7 +716,10 @@ export function groupEvents(
   });
   const collapsed = collapseLogRuns(normalizedEvents);
   const grouped = groupByRunId(collapsed);
-  const withDiscoverPhases = groupByDiscoverPhase([...grouped].sort(compareRenderItems));
+  const interventionGroups = interventionDetails.map(buildInterventionGroup);
+  const withDiscoverPhases = groupByDiscoverPhase(
+    [...grouped, ...interventionGroups].sort(compareRenderItems),
+  );
   const withInvestigationPhases = groupByInvestigationPhase(
     [...withDiscoverPhases].sort(compareRenderItems),
   );
@@ -645,11 +727,7 @@ export function groupEvents(
     [...withInvestigationPhases].sort(compareRenderItems),
   );
   const withContractPhases = groupByContractPhase([...withReviewGroups].sort(compareRenderItems));
-  const withDevPhases = groupByDevPhase([...withContractPhases].sort(compareRenderItems));
-  if (interventionDetails.length === 0) return withDevPhases;
-  return [...withDevPhases, ...interventionDetails.map(buildInterventionGroup)].sort(
-    compareRenderItems,
-  );
+  return groupByDevPhase([...withContractPhases].sort(compareRenderItems));
 }
 
 function collapseLogRuns(events: AgentEventDto[]): RenderItem[] {

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -22,6 +22,7 @@ import type { StateSource, WorkItem } from '../state-source/interface.js';
 import type { ProjectConfig, StackConfig } from '../types.js';
 import { cleanupWorktree, createWorktree } from '../workspaces/worktree.js';
 import { runAdvisorReview } from './grill-and-prd/advisor-review.js';
+import { resolveDiscoverSessionId } from './grill-and-prd/discover-session.js';
 import { runGrillRound } from './grill-and-prd/grill-round.js';
 import { runPrdDraft } from './grill-and-prd/prd-draft.js';
 import { WorktreeCreationError, withManagedWorktree } from './grill-and-prd/worktree-lifecycle.js';
@@ -208,6 +209,7 @@ async function ensureGatePending(
   fromState: StateName,
   projectId: string,
   workItemId: string,
+  discoverSessionId: string,
 ): Promise<void> {
   if (fromState === 'factory:gate-pending') return;
   try {
@@ -221,6 +223,7 @@ async function ensureGatePending(
     from: fromState,
     to: 'factory:gate-pending',
     by: 'grill-and-prd',
+    extraPayload: { discoverSessionId },
   });
 }
 
@@ -237,6 +240,7 @@ export async function runGrillAndPrdWorkflow(
     deps = {},
   } = input;
   const workflowRunId = crypto.randomUUID();
+  const discoverSessionId = resolveDiscoverSessionId(projectId, workItem.id);
   const childRunId = (skill: string) => `${workflowRunId}:${skill}`;
   const runtime = deps.runtime;
   const totalSpendForSkill = deps.totalSpendForSkill ?? _totalSpendForSkill;
@@ -264,6 +268,7 @@ export async function runGrillAndPrdWorkflow(
       payload: {
         skill: 'grill-and-prd',
         workflowRunId,
+        discoverSessionId,
         error: `expected workItem.state in {${validStates.join(', ')}}, got '${workItem.state}'`,
       },
     });
@@ -301,6 +306,7 @@ export async function runGrillAndPrdWorkflow(
       stateSource,
       projectId,
       workflowRunId,
+      discoverSessionId,
       runtime,
       projectConfig,
       totalSpendForSkill,
@@ -317,6 +323,7 @@ export async function runGrillAndPrdWorkflow(
       stateSource,
       projectId,
       workflowRunId,
+      discoverSessionId,
       runtime,
       projectConfig,
       totalSpendForSkill,
@@ -341,6 +348,7 @@ export async function runGrillAndPrdWorkflow(
       payload: {
         skill: 'grill-and-prd',
         workflowRunId,
+        discoverSessionId,
         error: 'cannot create worktree: targetRepo.localPath is missing',
       },
     });
@@ -388,6 +396,7 @@ export async function runGrillAndPrdWorkflow(
           workItemId: workItem.id,
           runId: grillRunId,
           workflowRunId,
+          discoverSessionId,
           worktreePath,
           priorReplies: augmentedPriorReplies,
           projectContext: fullProjectContext,
@@ -405,7 +414,7 @@ export async function runGrillAndPrdWorkflow(
             projectId,
             workItemId: workItem.id,
             runId: grillRunId,
-            payload: { skill: 'grill-me', workflowRunId, error: outcome.error },
+            payload: { skill: 'grill-me', workflowRunId, discoverSessionId, error: outcome.error },
           });
           await stateSource.comment(workItem.externalId, `<!-- factory:system -->\n${errMsg}`);
           await ensureGatePending(
@@ -414,6 +423,7 @@ export async function runGrillAndPrdWorkflow(
             workItem.state,
             projectId,
             workItem.id,
+            discoverSessionId,
           );
           grillPhaseReturn = { phase: 'grilling' };
           return;
@@ -434,6 +444,7 @@ export async function runGrillAndPrdWorkflow(
             payload: {
               displaySkill: 'grill-me',
               workflowRunId,
+              discoverSessionId,
               roundNumber: roundNumber - 1,
               decision: grillOutput.crystallizedDecision.trim(),
             },
@@ -463,6 +474,7 @@ export async function runGrillAndPrdWorkflow(
             workItem.state,
             projectId,
             workItem.id,
+            discoverSessionId,
           );
           eventStore.appendEvent({
             kind: 'grill.question-posted',
@@ -472,6 +484,7 @@ export async function runGrillAndPrdWorkflow(
             payload: {
               displaySkill: 'grill-me',
               workflowRunId,
+              discoverSessionId,
               roundNumber,
               question: outcome.question,
             },
@@ -490,6 +503,7 @@ export async function runGrillAndPrdWorkflow(
           payload: {
             displaySkill: 'grill-me',
             workflowRunId,
+            discoverSessionId,
             refinedIntent: outcome.refinedIntent,
             rounds: roundNumber,
             ...(forced && { forced: true }),
@@ -506,6 +520,7 @@ export async function runGrillAndPrdWorkflow(
           payload: {
             skill: 'grill-and-prd',
             workflowRunId,
+            discoverSessionId,
             error: `worktree cleanup failed: ${String(err)}`,
           },
         });
@@ -522,6 +537,7 @@ export async function runGrillAndPrdWorkflow(
       payload: {
         skill: 'grill-and-prd',
         workflowRunId,
+        discoverSessionId,
         error: isWorktreeCreation
           ? `worktree creation failed: ${String(err)}`
           : `grill round failed: ${String(err)}`,
@@ -539,6 +555,7 @@ export async function runGrillAndPrdWorkflow(
       workItem.state,
       projectId,
       workItem.id,
+      discoverSessionId,
     );
     return { phase: 'grilling' };
   }
@@ -552,6 +569,7 @@ export async function runGrillAndPrdWorkflow(
     stateSource,
     projectId,
     workflowRunId,
+    discoverSessionId,
     runtime,
     projectConfig,
     totalSpendForSkill,
@@ -570,6 +588,7 @@ interface WritePrdStepInput {
   stateSource: StateSource;
   projectId: string;
   workflowRunId: string;
+  discoverSessionId: string;
   runtime?: AgentRuntime;
   projectConfig: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null | undefined;
   totalSpendForSkill: (projectId: string, skill: string) => number;
@@ -586,6 +605,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     stateSource,
     projectId,
     workflowRunId,
+    discoverSessionId,
     runtime,
     projectConfig,
     totalSpendForSkill,
@@ -618,6 +638,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     workItemId: workItem.id,
     runId: prdRunId,
     workflowRunId,
+    discoverSessionId,
     refinedIntent,
     fullProjectContext,
     projectConfig,
@@ -636,6 +657,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       payload: {
         skill: 'write-prd',
         workflowRunId,
+        discoverSessionId,
         error: prdDraftOutcome.error,
         ...(prdDraftOutcome.status === 'invalid' && prdDraftOutcome.issues != null
           ? { issues: prdDraftOutcome.issues }
@@ -663,6 +685,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     workItemId: workItem.id,
     runId: advisorRunId,
     workflowRunId,
+    discoverSessionId,
     prdOutput,
     projectConfig,
     totalSpendForSkill,
@@ -677,7 +700,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: workflowRunId,
-      payload: { workflowRunId, reason: advisorOutcome.reason },
+      payload: { workflowRunId, discoverSessionId, reason: advisorOutcome.reason },
     });
   } else if (advisorOutcome.status === 'invalid' || advisorOutcome.status === 'failed') {
     eventStore.appendEvent({
@@ -685,7 +708,12 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: advisorRunId,
-      payload: { skill: 'advise-on-prd', workflowRunId, error: advisorOutcome.error },
+      payload: {
+        skill: 'advise-on-prd',
+        workflowRunId,
+        discoverSessionId,
+        error: advisorOutcome.error,
+      },
     });
     await stateSource.forceState(workItem.externalId, 'factory:needs-human');
     return { phase: 'needs-human' };
@@ -720,7 +748,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: workflowRunId,
-      payload: { skill: 'grill-and-prd', workflowRunId, error: String(err) },
+      payload: { skill: 'grill-and-prd', workflowRunId, discoverSessionId, error: String(err) },
     });
     await stateSource.forceState(workItem.externalId, 'factory:needs-human');
     return { phase: 'needs-human' };
@@ -732,7 +760,13 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       projectId,
       workItemId: workItem.id,
       runId: workflowRunId,
-      payload: { displaySkill: 'write-prd', workflowRunId, prd: prdOutput, advisorConcerns },
+      payload: {
+        displaySkill: 'write-prd',
+        workflowRunId,
+        discoverSessionId,
+        prd: prdOutput,
+        advisorConcerns,
+      },
     });
   } catch (err) {
     eventStore.appendEvent({
@@ -743,6 +777,7 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       payload: {
         skill: 'write-prd',
         workflowRunId,
+        discoverSessionId,
         error: `prd.drafted emit failed: ${String(err)}`,
       },
     });

--- a/core/workflows/grill-and-prd/advisor-review.ts
+++ b/core/workflows/grill-and-prd/advisor-review.ts
@@ -32,6 +32,7 @@ export interface RunAdvisorReviewInput {
   workItemId: string;
   runId: string;
   workflowRunId: string;
+  discoverSessionId: string;
   prdOutput: PRDOutput;
   projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
   totalSpendForSkill: (projectId: string, skill: string) => number;
@@ -45,6 +46,7 @@ export async function runAdvisorReview(input: RunAdvisorReviewInput): Promise<Ad
     workItemId,
     runId,
     workflowRunId,
+    discoverSessionId,
     prdOutput,
     projectConfig,
     totalSpendForSkill,
@@ -87,7 +89,10 @@ export async function runAdvisorReview(input: RunAdvisorReviewInput): Promise<Ad
         prdOutput,
         priority: workItem.priority,
       },
-      overrides: { runtimeOverride: deps?.runtime, extraEventPayload: { workflowRunId } },
+      overrides: {
+        runtimeOverride: deps?.runtime,
+        extraEventPayload: { workflowRunId, discoverSessionId },
+      },
     });
   } catch (err) {
     if (err instanceof OutputValidationError) {

--- a/core/workflows/grill-and-prd/discover-session.ts
+++ b/core/workflows/grill-and-prd/discover-session.ts
@@ -1,0 +1,47 @@
+import type { AgentEvent } from '../../event-stream/store.js';
+import { eventStore } from '../../event-stream/store.js';
+
+const DISCOVER_SESSION_TERMINAL_EVENTS = new Set(['prd.drafted', 'prd.declined', 'prd.approved']);
+
+type DiscoverSessionPayload = {
+  discoverSessionId?: unknown;
+};
+
+function payloadDiscoverSessionId(event: AgentEvent): string | null {
+  const payload = event.payload as DiscoverSessionPayload | null;
+  return typeof payload?.discoverSessionId === 'string' && payload.discoverSessionId.trim() !== ''
+    ? payload.discoverSessionId
+    : null;
+}
+
+export function latestDiscoverSessionId(projectId: string, workItemId: string): string | null {
+  const events = eventStore.replay({ projectId, workItemId });
+  for (const event of [...events].reverse()) {
+    const discoverSessionId = payloadDiscoverSessionId(event);
+    if (discoverSessionId != null) return discoverSessionId;
+  }
+  return null;
+}
+
+export function activeDiscoverSessionId(projectId: string, workItemId: string): string | null {
+  const events = eventStore.replay({ projectId, workItemId });
+  let active: string | null = null;
+
+  for (const event of events) {
+    const discoverSessionId = payloadDiscoverSessionId(event);
+    if (discoverSessionId != null) active = discoverSessionId;
+    if (
+      active != null &&
+      discoverSessionId === active &&
+      DISCOVER_SESSION_TERMINAL_EVENTS.has(event.kind)
+    ) {
+      active = null;
+    }
+  }
+
+  return active;
+}
+
+export function resolveDiscoverSessionId(projectId: string, workItemId: string): string {
+  return activeDiscoverSessionId(projectId, workItemId) ?? crypto.randomUUID();
+}

--- a/core/workflows/grill-and-prd/grill-and-prd.test.ts
+++ b/core/workflows/grill-and-prd/grill-and-prd.test.ts
@@ -317,6 +317,7 @@ describe('runGrillRound', () => {
       workItemId: 'wi-1',
       runId: 'run-grill-1',
       workflowRunId: 'wf-1',
+      discoverSessionId: 'discover-session-1',
       worktreePath: '/wt/run-1',
       priorReplies: [] as Array<{ role: 'user' | 'agent'; content: string }>,
       projectContext: { stackSummary: '', contextMd: '', adrSummaries: [], claudeMd: '' },
@@ -435,6 +436,7 @@ describe('runPrdDraft', () => {
       workItemId: 'wi-1',
       runId: 'run-prd-1',
       workflowRunId: 'wf-1',
+      discoverSessionId: 'discover-session-1',
       refinedIntent: 'Do the thing.',
       fullProjectContext: { stackSummary: '', contextMd: '', adrSummaries: [], claudeMd: '' },
     };
@@ -512,6 +514,7 @@ describe('runAdvisorReview', () => {
       workItemId: 'wi-1',
       runId: 'run-advisor-1',
       workflowRunId: 'wf-1',
+      discoverSessionId: 'discover-session-1',
       prdOutput: minimalPrdOutput(),
       projectConfig: projectConfigWithBudget(10),
       totalSpendForSkill: vi.fn().mockReturnValue(0),

--- a/core/workflows/grill-and-prd/grill-round.ts
+++ b/core/workflows/grill-and-prd/grill-round.ts
@@ -18,6 +18,7 @@ export interface RunGrillRoundInput {
   workItemId: string;
   runId: string;
   workflowRunId: string;
+  discoverSessionId: string;
   worktreePath: string;
   priorReplies: Array<{ role: 'user' | 'agent'; content: string; crystallized?: string }>;
   projectContext: ProjectContextBundle;
@@ -32,6 +33,7 @@ export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRou
     workItemId,
     runId,
     workflowRunId,
+    discoverSessionId,
     worktreePath,
     priorReplies,
     projectContext,
@@ -66,7 +68,7 @@ export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRou
       overrides: {
         workspaceDir: worktreePath,
         runtimeOverride: deps?.runtime,
-        extraEventPayload: { roundNumber, workflowRunId },
+        extraEventPayload: { roundNumber, workflowRunId, discoverSessionId },
         ...(projectConfig != null && { projectConfigOverride: projectConfig }),
       },
     });

--- a/core/workflows/grill-and-prd/prd-draft.ts
+++ b/core/workflows/grill-and-prd/prd-draft.ts
@@ -30,6 +30,7 @@ export interface RunPrdDraftInput {
   workItemId: string;
   runId: string;
   workflowRunId: string;
+  discoverSessionId: string;
   refinedIntent: string;
   fullProjectContext: ProjectContextBundle;
   projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
@@ -46,6 +47,7 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
     workItemId,
     runId,
     workflowRunId,
+    discoverSessionId,
     refinedIntent,
     fullProjectContext,
     priorReplies,
@@ -77,7 +79,10 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
         ...(priorPrd != null ? { priorPrd } : {}),
         ...(humanConcerns != null ? { humanConcerns } : {}),
       },
-      overrides: { runtimeOverride: deps?.runtime, extraEventPayload: { workflowRunId } },
+      overrides: {
+        runtimeOverride: deps?.runtime,
+        extraEventPayload: { workflowRunId, discoverSessionId },
+      },
     });
   } catch (err) {
     if (err instanceof OutputValidationError) {

--- a/slices/grill-and-prd/slice.test.ts
+++ b/slices/grill-and-prd/slice.test.ts
@@ -384,6 +384,54 @@ describe('grill-and-prd: round 2 reaches PRD (advisor skipped by priority)', () 
     // grill-me + write-prd → 2 runtime calls (no advisor)
     expect(runtime.run).toHaveBeenCalledTimes(2);
   });
+
+  it('reuses the same discoverSessionId across resumed Grill invocations', async () => {
+    const projectId = uniqueProjectId('session-resume');
+    const source = new InMemoryLabelsSource(projectId, REPO_REF);
+    const item = await seedFeatureItem(source, { state: 'factory:grilling' });
+
+    const firstRuntime = makeQueuedRuntime([validGrillRound1NotReady()]);
+    await runGrillAndPrdWorkflow({
+      workItem: await source.getItem(item.externalId),
+      stateSource: source,
+      projectId,
+      priorReplies: [],
+      deps: { runtime: firstRuntime, projectConfig: injectedConfig(), ...noopWorktreeDeps() },
+    });
+
+    const secondRuntime = makeQueuedRuntime([validGrillReady(), validPRD()]);
+    await runGrillAndPrdWorkflow({
+      workItem: await source.getItem(item.externalId),
+      stateSource: source,
+      projectId,
+      priorReplies: [
+        { role: 'agent' as const, content: 'Round 1 question?' },
+        { role: 'user' as const, content: 'Reduce drop-off by 20% within 30 days.' },
+      ],
+      deps: { runtime: secondRuntime, projectConfig: injectedConfig(), ...noopWorktreeDeps() },
+    });
+
+    const evs = eventStore.replay({ projectId, workItemId: item.id });
+    const sessionIds = evs
+      .map((event) => (event.payload as { discoverSessionId?: string } | null)?.discoverSessionId)
+      .filter((value): value is string => typeof value === 'string');
+    expect(new Set(sessionIds).size).toBe(1);
+    expect(sessionIds.length).toBeGreaterThan(3);
+
+    const specs = [
+      ...(firstRuntime.run as ReturnType<typeof vi.fn>).mock.calls,
+      ...(secondRuntime.run as ReturnType<typeof vi.fn>).mock.calls,
+    ].map(([spec]) => spec as AgentSpec);
+    expect(
+      new Set(
+        specs.map(
+          (spec) =>
+            (spec.extraEventPayload as { discoverSessionId?: string } | undefined)
+              ?.discoverSessionId,
+        ),
+      ).size,
+    ).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add durable discoverSessionId recovery for Grill/PRD sessions
- thread discoverSessionId through Grill, PRD, child agent run, manual resume, and PRD action events
- update timeline grouping to prefer discover sessions, keep Grill/PRD separate, and nest matching manual override intervention groups inside Grill

## Verification
- pnpm vitest run slices/grill-and-prd/slice.test.ts
- pnpm vitest run apps/server/src/domains/issues/prd-actions.test.ts apps/server/src/domains/issues/service.test.ts
- pnpm vitest run apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineSection.test.ts
- pnpm vitest run core/workflows/grill-and-prd/grill-and-prd.test.ts
- pnpm exec biome check core/workflows/grill-and-prd.ts core/workflows/grill-and-prd/discover-session.ts core/workflows/grill-and-prd/grill-round.ts core/workflows/grill-and-prd/prd-draft.ts core/workflows/grill-and-prd/advisor-review.ts core/workflows/grill-and-prd/grill-and-prd.test.ts slices/grill-and-prd/slice.test.ts apps/server/src/domains/issues/prd-actions.ts apps/server/src/domains/issues/prd-actions.test.ts apps/server/src/domains/issues/transitions.ts apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/lib/timeline.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineEvents.tsx apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx