### PR TITLE
M7.XX: The items in the kanban lanes order is wrong 1

### DIFF
--- a/apps/web/e2e/issue-955.spec.ts
+++ b/apps/web/e2e/issue-955.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from '@playwright/test';
+
+const projectSlug = 'goose-hub-self';
+
+function costSummary() {
+  return {
+    projectId: projectSlug,
+    dailyTokensUsed: 0,
+    dailyTokensLimit: 10_000,
+    dailyCostUsd: 0,
+    dailyBudgetExceeded: false,
+    resetsAtUtc: '2026-05-23T00:00:00.000Z',
+    lastExceededAt: null,
+    windows: {
+      week: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+      month: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+    },
+    byStage: [],
+    byProvider: {
+      claude: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+      codex: { totalUsd: 0, totalRuns: 0, hasEstimated: false },
+    },
+    symbolIndex: {
+      lookupCount: 0,
+      averageIdentifiersPerLookup: 0,
+      averageHintsPerLookup: 0,
+      staleRate: 0,
+      hintsUsedEventCount: 0,
+      usedHintCount: 0,
+      hintsByConsumerSkill: {},
+    },
+  };
+}
+
+test('kanban lanes render newest items first', async ({ page }) => {
+  await page.route('**/api/projects/goose-hub-self/issues**', async (route) => {
+    const items = [
+      {
+        id: 'github:org/repo#101',
+        externalId: '101',
+        repoRef: 'org/repo',
+        title: 'Newest triage item',
+        body: '',
+        type: 'bug',
+        priority: 'medium',
+        mode: 'supervised',
+        state: 'factory:triaging',
+        authorIsOwner: true,
+        schedule: 'current',
+        exec: 'serial',
+        dependsOn: [],
+        blocks: [],
+        createdAt: '2026-05-22T03:00:00.000Z',
+      },
+      {
+        id: 'github:org/repo#99',
+        externalId: '99',
+        repoRef: 'org/repo',
+        title: 'Middle triage item',
+        body: '',
+        type: 'bug',
+        priority: 'medium',
+        mode: 'supervised',
+        state: 'factory:triaging',
+        authorIsOwner: true,
+        schedule: 'current',
+        exec: 'serial',
+        dependsOn: [],
+        blocks: [],
+        createdAt: '2026-05-22T02:00:00.000Z',
+      },
+      {
+        id: 'github:org/repo#88',
+        externalId: '88',
+        repoRef: 'org/repo',
+        title: 'Oldest triage item',
+        body: '',
+        type: 'bug',
+        priority: 'medium',
+        mode: 'supervised',
+        state: 'factory:triaging',
+        authorIsOwner: true,
+        schedule: 'current',
+        exec: 'serial',
+        dependsOn: [],
+        blocks: [],
+        createdAt: '2026-05-22T01:00:00.000Z',
+      },
+    ];
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items }),
+    });
+  });
+
+  await page.route('**/api/projects/goose-hub-self/milestones**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ milestones: [] }),
+    });
+  });
+
+  await page.route('**/api/projects/goose-hub-self/active-milestone**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ milestoneNumber: null, source: 'db' }),
+    });
+  });
+
+  await page.route('**/api/projects/goose-hub-self/costs**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(costSummary()),
+    });
+  });
+
+  await page.route('**/events*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'retry: 1000\n\n',
+    });
+  });
+
+  await page.goto('/projects/goose-hub-self');
+
+  const lane = page.getByTestId('lane-triage');
+  await expect(lane).toBeVisible();
+
+  const issueNumbers = await lane
+    .getByTestId('issue-card')
+    .evaluateAll((cards) => cards.map((card) => card.getAttribute('data-issue-number')));
+
+  expect(issueNumbers).toEqual(['101', '99', '88']);
+});

--- a/apps/web/src/components/board/slice.test.ts
+++ b/apps/web/src/components/board/slice.test.ts
@@ -8,15 +8,23 @@ import type { WorkItemWithProject } from './lib/all-projects';
 // Here we lock the sort/ordering rule and grouping logic.
 
 describe('issue card lane ordering', () => {
-  it('orders by priority desc, then issue number asc', () => {
+  it('orders newest items first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      {
+        externalId: '40',
+        priority: 'medium',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        externalId: '12',
+        priority: 'low',
+        createdAt: '2024-01-04T00:00:00.000Z',
+      },
+      { externalId: '7', priority: 'high', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '99', priority: 'critical', createdAt: '2024-01-05T00:00:00.000Z' },
+      { externalId: '5', priority: 'high', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '12', '7', '5', '40']);
   });
 });
 
@@ -32,7 +40,7 @@ function makeItem(overrides: Partial<WorkItemWithProject> = {}): WorkItemWithPro
     mode: 'supervised',
     state: 'factory:triaging',
     authorIsOwner: true,
-    schedule: 'current',
+    schedule: 'serial',
     exec: 'serial',
     dependsOn: [],
     blocks: [],

--- a/apps/web/src/lib/lanes.config.test.ts
+++ b/apps/web/src/lib/lanes.config.test.ts
@@ -23,37 +23,37 @@ describe('lanes config', () => {
     expect(laneForState('factory:merge-conflict')).toBe('review');
   });
 
-  it('sortLaneItems sorts by priority then issue number', () => {
+  it('sortLaneItems sorts newest items first', () => {
     const sorted = sortLaneItems([
-      { externalId: '40', priority: 'medium' },
-      { externalId: '12', priority: 'low' },
-      { externalId: '7', priority: 'high' },
-      { externalId: '99', priority: 'critical' },
-      { externalId: '5', priority: 'high' },
+      { externalId: '40', priority: 'medium', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '12', priority: 'low', createdAt: '2024-01-04T00:00:00.000Z' },
+      { externalId: '7', priority: 'high', createdAt: '2024-01-03T00:00:00.000Z' },
+      { externalId: '99', priority: 'critical', createdAt: '2024-01-05T00:00:00.000Z' },
+      { externalId: '5', priority: 'high', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['99', '5', '7', '40', '12']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['99', '12', '7', '5', '40']);
   });
 
-  it('sortLaneItems treats unknown priority as rank 9 (sorts last)', () => {
-    // Line 126: the ?? 9 fallback branch — items with unknown priority rank last
+  it('sortLaneItems orders unknown-priority items by recency too', () => {
     const sorted = sortLaneItems([
-      { externalId: '1', priority: 'high' },
-      { externalId: '2', priority: 'unknown-future-priority' },
-      { externalId: '3', priority: 'critical' },
+      { externalId: '1', priority: 'high', createdAt: '2024-01-01T00:00:00.000Z' },
+      {
+        externalId: '2',
+        priority: 'unknown-future-priority',
+        createdAt: '2024-01-03T00:00:00.000Z',
+      },
+      { externalId: '3', priority: 'critical', createdAt: '2024-01-02T00:00:00.000Z' },
     ]);
-    // critical(0) < high(1) < unknown(9)
-    expect(sorted[0].externalId).toBe('3');
-    expect(sorted[1].externalId).toBe('1');
-    expect(sorted[2].externalId).toBe('2');
+    expect(sorted.map((s) => s.externalId)).toEqual(['2', '3', '1']);
   });
 
-  it('sortLaneItems stable-sorts items with the same priority by externalId ascending', () => {
+  it('sortLaneItems breaks createdAt ties by externalId descending', () => {
     const sorted = sortLaneItems([
-      { externalId: '30', priority: 'medium' },
-      { externalId: '10', priority: 'medium' },
-      { externalId: '20', priority: 'medium' },
+      { externalId: '30', priority: 'medium', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '10', priority: 'medium', createdAt: '2024-01-01T00:00:00.000Z' },
+      { externalId: '20', priority: 'medium', createdAt: '2024-01-01T00:00:00.000Z' },
     ]);
-    expect(sorted.map((s) => s.externalId)).toEqual(['10', '20', '30']);
+    expect(sorted.map((s) => s.externalId)).toEqual(['30', '20', '10']);
   });
 
   it('laneForState returns undefined for an unknown state', () => {

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -111,26 +111,24 @@ export function laneForState(state: string): string | undefined {
   return STATE_TO_LANE.get(state);
 }
 
-const PRIORITY_RANK: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-};
-
 interface SortableItem {
   externalId: string;
-  priority: string;
+  createdAt: string;
+}
+
+function toTimestamp(createdAt: string): number {
+  const ts = Date.parse(createdAt);
+  return Number.isNaN(ts) ? 0 : ts;
 }
 
 /**
- * Order matches the scheduler's eligibility sort: priority desc, then issue
- * number asc.
+ * Order matches the kanban UI: newest items first, then higher issue number
+ * when creation time ties.
  */
 export function sortLaneItems<T extends SortableItem>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => {
-    const prDiff = (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9);
-    if (prDiff !== 0) return prDiff;
-    return Number(a.externalId) - Number(b.externalId);
+    const timeDiff = toTimestamp(b.createdAt) - toTimestamp(a.createdAt);
+    if (timeDiff !== 0) return timeDiff;
+    return Number(b.externalId) - Number(a.externalId);
   });
 }


### PR DESCRIPTION
## Summary

The items in the kanban lanes order is wrong 1

## Files
- `apps/web/src/components/board/slice.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.test.ts` — observed modified change
- `apps/web/src/lib/lanes.config.ts` — observed modified change
- `apps/web/e2e/issue-955.spec.ts` — observed untracked change

## Tests
- `apps/web/src/lib/lanes.config.test.ts` (3 cases)
- `apps/web/src/components/board/slice.test.ts` (1 cases)
- `apps/web/e2e/issue-955.spec.ts` (1 cases)

Closes #955
