### PR TITLE
M19.XX: M956.01: implement type-aware idea promotion enhan

### DIFF
--- a/apps/server/src/domains/inbox/enhance.ts
+++ b/apps/server/src/domains/inbox/enhance.ts
@@ -9,6 +9,18 @@ import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { BugEnhanceOutputSchema } from '@goose-hub/skills/bug-enhance/schema.js';
 
 const jsonSchema = toJsonSchema(BugEnhanceOutputSchema);
+export const SUPPORTED_PROMOTION_TYPES = ['feature', 'bug', 'chore', 'research'] as const;
+
+export type PromotionType = (typeof SUPPORTED_PROMOTION_TYPES)[number];
+
+type EnhanceSkillName = 'bug-enhance' | 'idea-promotion-enhance';
+
+const ENHANCE_SKILL_BY_TYPE: Record<PromotionType, EnhanceSkillName> = {
+  bug: 'bug-enhance',
+  feature: 'idea-promotion-enhance',
+  chore: 'idea-promotion-enhance',
+  research: 'idea-promotion-enhance',
+};
 
 /**
  * Runs the bug-enhance agent on a UI/web bug report.
@@ -23,9 +35,40 @@ export async function runBugEnhance(
   title: string,
   body: string,
 ): Promise<string | null> {
+  return runEnhanceSkill({ projectId, inboxItemId, promotionType: 'bug', title, body });
+}
+
+export function isSupportedPromotionType(type: string | null | undefined): type is PromotionType {
+  return SUPPORTED_PROMOTION_TYPES.includes(type as PromotionType);
+}
+
+export async function runPromotionEnhance(
+  projectId: string,
+  inboxItemId: number,
+  promotionType: PromotionType,
+  title: string,
+  body: string,
+): Promise<string | null> {
+  return runEnhanceSkill({ projectId, inboxItemId, promotionType, title, body });
+}
+
+async function runEnhanceSkill({
+  projectId,
+  inboxItemId,
+  promotionType,
+  title,
+  body,
+}: {
+  projectId: string;
+  inboxItemId: number;
+  promotionType: PromotionType;
+  title: string;
+  body: string;
+}): Promise<string | null> {
+  const skill = ENHANCE_SKILL_BY_TYPE[promotionType];
   const projectConfig = await getProjectBySlug(projectId);
-  const bugEnhanceRuntime = resolveSkillRuntimeForProject({
-    skill: 'bug-enhance',
+  const enhanceRuntime = resolveSkillRuntimeForProject({
+    skill,
     projectBudgets: projectConfig?.budgets,
     projectId,
     configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
@@ -34,8 +77,8 @@ export async function runBugEnhance(
   });
   const runtime = selectRuntime({
     configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
-    model: bugEnhanceRuntime.modelOverride,
-    skillProvider: bugEnhanceRuntime.provider,
+    model: enhanceRuntime.modelOverride,
+    skillProvider: enhanceRuntime.provider,
   });
   const runId = crypto.randomUUID();
   const { personaId } = selectPersona(projectId, 'triager');
@@ -43,9 +86,9 @@ export async function runBugEnhance(
 
   let prompt: string;
   try {
-    prompt = readPromptWithContext('bug-enhance', projectId);
+    prompt = readPromptWithContext(skill, projectId);
   } catch (err) {
-    logger.error('bug-enhance: failed to read prompt', { err: String(err) });
+    logger.error('promotion-enhance: failed to read prompt', { err: String(err), promotionType });
     return null;
   }
 
@@ -53,14 +96,14 @@ export async function runBugEnhance(
     const result = await runtime.run({
       runId,
       role: 'triager',
-      skill: 'bug-enhance',
-      context: { projectId, workItemId, workItem: { title, body } },
+      skill,
+      context: { projectId, workItemId, workItem: { title, body, type: promotionType } },
       contextAllowlist: ['workItem'],
       freshContext: false,
       toolBundles: [],
       toolExtras: [],
-      budgets: bugEnhanceRuntime.budgets,
-      modelOverride: bugEnhanceRuntime.modelOverride,
+      budgets: enhanceRuntime.budgets,
+      modelOverride: enhanceRuntime.modelOverride,
       personaId,
       outputJsonSchema: jsonSchema,
       appendSystemPrompt: prompt,
@@ -68,23 +111,25 @@ export async function runBugEnhance(
 
     const parsed = safeParseOutputForSchema(BugEnhanceOutputSchema, result.output);
     if (!parsed.success) {
-      logger.warn('bug-enhance: output validation failed', {
+      logger.warn('promotion-enhance: output validation failed', {
         errors: parsed.error.issues,
         raw: JSON.stringify(result.output),
+        promotionType,
       });
       return null;
     }
 
     const content = parsed.data.enhancedContent.trim();
     if (content.length === 0) {
-      logger.warn('bug-enhance: enhancedContent empty after trim', {
+      logger.warn('promotion-enhance: enhancedContent empty after trim', {
         runId,
+        promotionType,
         decisions: parsed.data.decisionSummaries,
       });
     }
     return content.length > 0 ? content : null;
   } catch (err) {
-    logger.error('bug-enhance: agent run failed', { err: String(err) });
+    logger.error('promotion-enhance: agent run failed', { err: String(err), promotionType });
     return null;
   }
 }

--- a/apps/server/src/domains/inbox/service.test.ts
+++ b/apps/server/src/domains/inbox/service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { mockRunPromotionEnhance } = vi.hoisted(() => ({
+  mockRunPromotionEnhance: vi.fn(),
+}));
+
 vi.mock('../../shared/source.js', () => ({
   getSourceForSlug: vi.fn(),
 }));
@@ -21,8 +25,15 @@ vi.mock('@goose-hub/core/db/db.js', () => ({
   },
 }));
 
+vi.mock('./enhance.js', () => ({
+  isSupportedPromotionType: (type: string | null | undefined) =>
+    ['feature', 'bug', 'chore', 'research'].includes(type ?? ''),
+  runPromotionEnhance: mockRunPromotionEnhance,
+}));
+
 import { dispatchTriageBatch } from '#shared/dispatch.js';
 import { getSourceForSlug } from '#shared/source.js';
+import { runPromotionEnhance } from './enhance.js';
 import { deleteInboxItem, getInboxItem, insertInboxItem, listInboxItems } from './repository.js';
 import {
   createInboxItem,
@@ -32,11 +43,17 @@ import {
 } from './service.js';
 
 const mockItem = { id: 1, title: 'Fix bug', body: '', type: 'bug', createdAt: '2026-05-01' };
-const mockSource = { createIssue: vi.fn().mockResolvedValue(undefined) };
+const mockSource = {
+  createIssue: vi.fn().mockResolvedValue(undefined),
+  projectId: 'project-123',
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSource.createIssue.mockReset();
+  mockSource.createIssue.mockResolvedValue(undefined);
   vi.mocked(getSourceForSlug).mockResolvedValue(mockSource as never);
+  vi.mocked(runPromotionEnhance).mockResolvedValue(null);
 });
 
 describe('createInboxItem', () => {
@@ -148,6 +165,117 @@ describe('promoteInboxItem', () => {
     vi.mocked(getInboxItem).mockResolvedValueOnce(itemWithNullBody);
     await promoteInboxItem(3, 'my-proj');
     expect(mockSource.createIssue).toHaveBeenCalledWith(expect.objectContaining({ body: '' }));
+  });
+
+  it('bypasses enhancement when enhance is false', async () => {
+    const item = {
+      id: 4,
+      title: 'Feature request',
+      body: 'Original body',
+      type: 'feature',
+      createdAt: '2026-05-01',
+    };
+    vi.mocked(getInboxItem).mockResolvedValueOnce(item);
+
+    await promoteInboxItem(4, 'my-proj', undefined, false);
+
+    expect(runPromotionEnhance).not.toHaveBeenCalled();
+    expect(mockSource.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Original body', type: 'feature' }),
+    );
+    expect(dispatchTriageBatch).toHaveBeenCalledWith('my-proj');
+    expect(deleteInboxItem).toHaveBeenCalledWith(4);
+  });
+
+  it('rejects enhancement when item type is missing', async () => {
+    const itemWithoutType = {
+      id: 5,
+      title: 'Missing type',
+      body: 'Body',
+      type: undefined,
+      createdAt: '2026-05-01',
+    };
+    vi.mocked(getInboxItem).mockResolvedValueOnce(itemWithoutType as never);
+
+    const result = await promoteInboxItem(5, 'my-proj', undefined, true);
+
+    expect(result).toEqual({ ok: false, error: 'unsupported promotion type', status: 400 });
+    expect(runPromotionEnhance).not.toHaveBeenCalled();
+    expect(mockSource.createIssue).not.toHaveBeenCalled();
+    expect(dispatchTriageBatch).not.toHaveBeenCalled();
+    expect(deleteInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('rejects enhancement when item type is unsupported', async () => {
+    const invalidItem = {
+      id: 6,
+      title: 'Unsupported type',
+      body: 'Body',
+      type: 'incident',
+      createdAt: '2026-05-01',
+    };
+    vi.mocked(getInboxItem).mockResolvedValueOnce(invalidItem as never);
+
+    const result = await promoteInboxItem(6, 'my-proj', undefined, true);
+
+    expect(result).toEqual({ ok: false, error: 'unsupported promotion type', status: 400 });
+    expect(runPromotionEnhance).not.toHaveBeenCalled();
+    expect(mockSource.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('preserves bug separator behaviour when enhancement succeeds', async () => {
+    const bugItem = {
+      id: 7,
+      title: 'Fix login bug',
+      body: 'Original bug body',
+      type: 'bug',
+      createdAt: '2026-05-01',
+    };
+    vi.mocked(getInboxItem).mockResolvedValueOnce(bugItem);
+    vi.mocked(runPromotionEnhance).mockResolvedValueOnce('## Added repro details');
+
+    await promoteInboxItem(7, 'my-proj', undefined, true);
+
+    expect(runPromotionEnhance).toHaveBeenCalledWith(
+      'project-123',
+      7,
+      'bug',
+      'Fix login bug',
+      'Original bug body',
+    );
+    expect(mockSource.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Original bug body\n\n---\n\n## Added repro details',
+        type: 'bug',
+      }),
+    );
+  });
+
+  it('uses enhancement output for supported non-bug types', async () => {
+    const featureItem = {
+      id: 8,
+      title: 'Feature request',
+      body: 'Original idea',
+      type: 'feature',
+      createdAt: '2026-05-01',
+    };
+    vi.mocked(getInboxItem).mockResolvedValueOnce(featureItem);
+    vi.mocked(runPromotionEnhance).mockResolvedValueOnce('## Refined feature proposal');
+
+    await promoteInboxItem(8, 'my-proj', undefined, true);
+
+    expect(runPromotionEnhance).toHaveBeenCalledWith(
+      'project-123',
+      8,
+      'feature',
+      'Feature request',
+      'Original idea',
+    );
+    expect(mockSource.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ body: '## Refined feature proposal', type: 'feature' }),
+    );
+    expect(dispatchTriageBatch).toHaveBeenCalledWith('my-proj');
+    expect(deleteInboxItem).toHaveBeenCalledWith(8);
   });
 });
 

--- a/apps/server/src/domains/inbox/service.ts
+++ b/apps/server/src/domains/inbox/service.ts
@@ -5,7 +5,7 @@ import { eq } from 'drizzle-orm';
 import { dispatchTriageBatch } from '#shared/dispatch.js';
 import type { Result } from '#shared/middleware.js';
 import { getSourceForSlug } from '#shared/source.js';
-import { runBugEnhance } from './enhance.js';
+import { type PromotionType, isSupportedPromotionType, runPromotionEnhance } from './enhance.js';
 import {
   type InboxItem,
   getInboxItem,
@@ -14,15 +14,13 @@ import {
   deleteInboxItem as repoDeleteInboxItem,
 } from './repository.js';
 
-const VALID_TYPES = ['feature', 'bug', 'chore', 'research'] as const;
-
 export async function createInboxItem(
   title: string | undefined,
   body: string | undefined,
   type: string | undefined,
 ): Promise<Result<{ item: InboxItem }>> {
   if (!title?.trim()) return { ok: false, error: 'title is required', status: 400 };
-  const safeType = VALID_TYPES.includes(type as never) ? (type as string) : 'feature';
+  const safeType = isSupportedPromotionType(type) ? type : 'feature';
   const item = await insertInboxItem({ title: title.trim(), body: body ?? '', type: safeType });
   return { ok: true, data: { item } };
 }
@@ -57,20 +55,34 @@ export async function promoteInboxItem(
     effectiveMilestoneNumber = stateRows[0]?.activeMilestoneNumber ?? null;
   }
 
+  if (!isSupportedPromotionType(item.type)) {
+    return { ok: false, error: 'unsupported promotion type', status: 400 };
+  }
+
+  const promotionType: PromotionType = item.type;
   let body = item.body ?? '';
-  if (enhance && item.type === 'bug') {
-    const enhancement = await runBugEnhance(source.projectId, item.id, item.title, body);
+  if (enhance) {
+    const enhancement = await runPromotionEnhance(
+      source.projectId,
+      item.id,
+      promotionType,
+      item.title,
+      body,
+    );
     if (enhancement != null) {
-      body = `${body}\n\n---\n\n${enhancement}`;
+      body = promotionType === 'bug' ? `${body}\n\n---\n\n${enhancement}` : enhancement;
     } else {
-      logger.warn('bug-enhance: no enhancement produced, using original body', { id });
+      logger.warn('promotion-enhance: no enhancement produced, using original body', {
+        id,
+        promotionType,
+      });
     }
   }
 
   await source.createIssue({
     title: item.title,
     body,
-    type: item.type as 'feature' | 'bug' | 'chore' | 'research',
+    type: promotionType,
     ...(effectiveMilestoneNumber != null ? { milestoneId: String(effectiveMilestoneNumber) } : {}),
   });
   void dispatchTriageBatch(projectSlug);

--- a/apps/server/src/domains/inbox/slice.test.ts
+++ b/apps/server/src/domains/inbox/slice.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRunPromotionEnhance } = vi.hoisted(() => ({
+  mockRunPromotionEnhance: vi.fn(),
+}));
+
+vi.mock('../../shared/source.js', () => ({
+  getSourceForSlug: vi.fn(),
+}));
+
+vi.mock('../../shared/dispatch.js', () => ({
+  dispatchTriageBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./repository.js', () => ({
+  getInboxItem: vi.fn(),
+  deleteInboxItem: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./enhance.js', () => ({
+  isSupportedPromotionType: (type: string | null | undefined) =>
+    ['feature', 'bug', 'chore', 'research'].includes(type ?? ''),
+  runPromotionEnhance: mockRunPromotionEnhance,
+}));
+
+vi.mock('@goose-hub/core/db/db.js', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ all: () => [] }) }) }),
+  },
+}));
+
+import { dispatchTriageBatch } from '#shared/dispatch.js';
+import { getSourceForSlug } from '#shared/source.js';
+import { runPromotionEnhance } from './enhance.js';
+import { deleteInboxItem, getInboxItem } from './repository.js';
+import { promoteInboxItem } from './service.js';
+
+const mockSource = { createIssue: vi.fn().mockResolvedValue(undefined), projectId: 'project-123' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSource.createIssue.mockReset();
+  mockSource.createIssue.mockResolvedValue(undefined);
+  vi.mocked(getSourceForSlug).mockResolvedValue(mockSource as never);
+  vi.mocked(runPromotionEnhance).mockResolvedValue('## Enhanced proposal');
+});
+
+describe('inbox promotion slice', () => {
+  it.each(['feature', 'chore', 'research'] as const)(
+    'routes supported %s promotions through enhancement and cleanup',
+    async (type) => {
+      vi.mocked(getInboxItem).mockResolvedValueOnce({
+        id: 10,
+        title: `${type} title`,
+        body: `${type} body`,
+        type,
+        createdAt: '2026-05-01',
+      } as never);
+
+      const result = await promoteInboxItem(10, 'my-proj', undefined, true);
+
+      expect(result).toEqual({ ok: true, data: { ok: true } });
+      expect(runPromotionEnhance).toHaveBeenCalledWith(
+        'project-123',
+        10,
+        type,
+        `${type} title`,
+        `${type} body`,
+      );
+      expect(mockSource.createIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ body: '## Enhanced proposal', type }),
+      );
+      expect(dispatchTriageBatch).toHaveBeenCalledWith('my-proj');
+      expect(deleteInboxItem).toHaveBeenCalledWith(10);
+    },
+  );
+
+  it('keeps the original body when enhancement is disabled', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce({
+      id: 11,
+      title: 'Research title',
+      body: 'Original body',
+      type: 'research',
+      createdAt: '2026-05-01',
+    } as never);
+
+    const result = await promoteInboxItem(11, 'my-proj', undefined, false);
+
+    expect(result).toEqual({ ok: true, data: { ok: true } });
+    expect(runPromotionEnhance).not.toHaveBeenCalled();
+    expect(mockSource.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Original body', type: 'research' }),
+    );
+  });
+
+  it('rejects unsupported types before enhancement starts', async () => {
+    vi.mocked(getInboxItem).mockResolvedValueOnce({
+      id: 12,
+      title: 'Unsupported title',
+      body: 'Original body',
+      type: 'incident',
+      createdAt: '2026-05-01',
+    } as never);
+
+    await expect(promoteInboxItem(12, 'my-proj', undefined, true)).resolves.toEqual({
+      ok: false,
+      error: 'unsupported promotion type',
+      status: 400,
+    });
+    expect(runPromotionEnhance).not.toHaveBeenCalled();
+    expect(mockSource.createIssue).not.toHaveBeenCalled();
+    expect(dispatchTriageBatch).not.toHaveBeenCalled();
+    expect(deleteInboxItem).not.toHaveBeenCalled();
+  });
+});

--- a/core/agent-runtime/budgets.test.ts
+++ b/core/agent-runtime/budgets.test.ts
@@ -6,6 +6,7 @@ describe('SKILL_BUDGETS', () => {
     const expected = [
       'triage',
       'repo-match',
+      'idea-promotion-enhance',
       'bug-enhance',
       'evidence-post',
       'implement',
@@ -30,6 +31,15 @@ describe('SKILL_BUDGETS', () => {
       expect(budget.maxBudgetUsd, `${skill}.maxBudgetUsd`).toBeGreaterThan(0);
       expect(budget.timeoutMs, `${skill}.timeoutMs`).toBeGreaterThan(0);
     }
+  });
+
+  it('registers idea-promotion-enhance with the same bounded runtime profile as bug-enhance', () => {
+    expect(SKILL_BUDGETS['idea-promotion-enhance']).toMatchObject({
+      maxTurns: 20,
+      maxBudgetUsd: 1,
+      timeoutMs: 120_000,
+      modelTier: 'haiku',
+    });
   });
 
   it('keeps scout-schema bounded enough to force early exit instead of runtime tracing', () => {

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -51,6 +51,12 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
   triage: { maxTurns: 25, maxBudgetUsd: 1, timeoutMs: 120_000, modelTier: 'haiku' },
   'repo-match': { maxTurns: 25, maxBudgetUsd: 1, timeoutMs: 60_000, modelTier: 'haiku' },
   'bug-enhance': { maxTurns: 20, maxBudgetUsd: 1, timeoutMs: 120_000, modelTier: 'haiku' },
+  'idea-promotion-enhance': {
+    maxTurns: 20,
+    maxBudgetUsd: 1,
+    timeoutMs: 120_000,
+    modelTier: 'haiku',
+  },
   'evidence-post': { maxTurns: 60, maxBudgetUsd: 2.0, timeoutMs: 300_000, modelTier: 'haiku' },
   implement: {
     maxTurns: 150,

--- a/core/agent-runtime/mock-outputs.test.ts
+++ b/core/agent-runtime/mock-outputs.test.ts
@@ -98,6 +98,35 @@ describe('resolveMockOutput — review', () => {
   });
 });
 
+describe('resolveMockOutput — idea-promotion-enhance', () => {
+  it('returns deterministic enhanced content for supported promotion types', () => {
+    for (const type of ['feature', 'chore', 'research'] as const) {
+      const r = resolveMockOutput(
+        makeSpec({
+          skill: 'idea-promotion-enhance',
+          context: { workItem: { type, title: `${type} title`, body: `${type} body` } },
+        }),
+      );
+      const out = r.output as {
+        enhancedContent: string;
+        decisionSummaries: Array<{ summary: string }>;
+      };
+      expect(out.enhancedContent).toContain(`**${type[0].toUpperCase()}${type.slice(1)} Summary**`);
+      expect(out.decisionSummaries[0]?.summary).toContain(type);
+      expect(r.decisionSummaries[0]?.summary).toContain(type);
+    }
+  });
+
+  it('falls back to chore framing when the type is omitted in MOCK_AGENTS mode', () => {
+    const r = resolveMockOutput(
+      makeSpec({ skill: 'idea-promotion-enhance', context: { workItem: {} } }),
+    );
+    expect((r.output as { enhancedContent: string }).enhancedContent).toContain(
+      '**Chore Summary**',
+    );
+  });
+});
+
 describe('resolveMockOutput — unknown skill', () => {
   it('throws when no preset matches', () => {
     expect(() => resolveMockOutput(makeSpec({ skill: 'made-up-skill' }))).toThrow(

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -612,6 +612,33 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
         events: [],
       };
 
+    case 'idea-promotion-enhance': {
+      const workItem = (spec.context?.workItem ?? {}) as { type?: string };
+      const type =
+        workItem.type === 'feature' || workItem.type === 'research' || workItem.type === 'chore'
+          ? workItem.type
+          : 'chore';
+      const titleCaseType = `${type[0]?.toUpperCase() ?? 'C'}${type.slice(1)}`;
+      const trailingSection =
+        type === 'feature'
+          ? 'Acceptance Notes'
+          : type === 'research'
+            ? 'Investigation Notes'
+            : 'Execution Notes';
+      return {
+        output: {
+          enhancedContent: `**${titleCaseType} Summary**\n\nMock ${type} enhancement\n\n**${trailingSection}**\n- Mock ${type} detail`,
+          decisionSummaries: [
+            { kind: 'INSIGHT', summary: `Mock idea-promotion-enhance for ${type} e2e test` },
+          ],
+        },
+        decisionSummaries: [
+          { kind: 'INSIGHT', summary: `Mock idea-promotion-enhance for ${type} e2e test` },
+        ],
+        events: [],
+      };
+    }
+
     // retrospective-cross-run — triggered by the nightly playbook service.
     case 'retrospective-cross-run': {
       const now = new Date().toISOString();

--- a/skills/idea-promotion-enhance/README.md
+++ b/skills/idea-promotion-enhance/README.md
@@ -1,0 +1,33 @@
+# idea-promotion-enhance skill
+
+Enhances promoted inbox ideas for non-bug work-item types by appending structured markdown that makes a feature, chore, or research issue actionable before it is created.
+
+## When it runs
+
+Triggered at inbox promotion time when the operator enables enhancement for a `feature`, `chore`, or `research` promotion. It preserves the existing `bug-enhance` path for bug reports and only handles the non-bug branch.
+
+## Input context
+
+| Field | Description |
+|---|---|
+| `workItem.type` | Promotion type: `feature`, `chore`, or `research` |
+| `workItem.title` | Promoted work-item title |
+| `workItem.body` | Original idea body from the inbox item |
+
+## Output
+
+| Field | Description |
+|---|---|
+| `enhancedContent` | Markdown string containing only the new sections to append |
+| `decisionSummaries` | One or more entries describing the framing that was added |
+
+## Behaviour
+
+- Rejects missing or unsupported promotion types through the context schema.
+- Keeps the original body intact and returns only append-only enhancement content.
+- Uses a different template for `feature`, `chore`, and `research` promotions.
+- Avoids repeating information already present in the original body.
+
+## Model / role
+
+`sonnet` / `triager` — text-only enhancement with no tool access.

--- a/skills/idea-promotion-enhance/prompt.md
+++ b/skills/idea-promotion-enhance/prompt.md
@@ -1,0 +1,74 @@
+# idea-promotion-enhance skill
+
+You are an idea promotion enhancer. Your job is to turn a promoted inbox idea into an actionable non-bug work item by appending the minimum structured markdown needed for downstream triage and implementation.
+
+## Context
+
+The context contains `<workItem>` as a JSON payload with:
+
+- `type`: one of `feature`, `chore`, or `research`
+- `title`: promoted work-item title
+- `body`: original idea body
+
+This skill is only for non-bug promotions. Bug promotions stay on the existing `bug-enhance` path.
+
+## Step 1 - Validate the promotion type
+
+Read the title and body carefully, then confirm the provided type is one of the supported non-bug types.
+
+If the type is missing or unsupported, return an empty enhancement and a blocker-style summary describing the invalid type. Do not attempt to enhance the content.
+
+## Step 2 - Add the right template for the type
+
+Return only the sections that should be appended after the original body. Do not rewrite the original body.
+
+### `feature`
+
+Focus on clarifying the user-facing change and the success conditions.
+
+Preferred sections:
+
+- `**Feature Summary**` - one short paragraph describing the capability or user problem
+- `**Acceptance Notes**` - 2-4 bullets describing observable outcomes or constraints
+
+### `chore`
+
+Focus on maintenance intent, operational constraints, or housekeeping details.
+
+Preferred sections:
+
+- `**Chore Summary**` - one short paragraph describing the maintenance or cleanup goal
+- `**Execution Notes**` - 2-4 bullets covering scope limits, sequencing, or safety considerations
+
+### `research`
+
+Focus on the question to answer and the output expected from the investigation.
+
+Preferred sections:
+
+- `**Research Goal**` - one short paragraph describing the unknown to resolve
+- `**Investigation Notes**` - 2-4 bullets covering hypotheses, constraints, or expected deliverables
+
+## Rules
+
+- Preserve the original meaning of the idea; clarify it, do not expand scope.
+- Only add information that is missing or too vague in the original body.
+- Do not repeat text that is already clear and complete in the body.
+- Keep the enhancement concise and append-only.
+- Format the output as GitHub-flavoured markdown.
+- Do not add bug-oriented sections such as repro steps or expected/actual behaviour.
+
+Emit: `[decision] PLAN: Added <section names> for <type> promotion - <one sentence about what was clarified>`
+
+Emit: `[decision] VERDICT: Produced append-only enhancement content for the supported promotion type`
+
+Then return only the JSON object below.
+
+```json
+{
+  "enhancedContent": "<markdown string containing only the appended sections>",
+  "decisionSummaries": [
+    { "kind": "PLAN", "summary": "Added <section names> for the <type> promotion.", "evidence": "<quote or paraphrase from the original idea body>" }
+  ]
+}
+```

--- a/skills/idea-promotion-enhance/schema.ts
+++ b/skills/idea-promotion-enhance/schema.ts
@@ -1,0 +1,13 @@
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+import { z } from 'zod';
+
+export { DecisionSummarySchema };
+
+export const IdeaPromotionEnhanceOutputSchema = z.object({
+  enhancedContent: z
+    .string()
+    .describe('Structured markdown sections to append after the original promoted idea body'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
+});
+
+export type IdeaPromotionEnhanceOutput = z.infer<typeof IdeaPromotionEnhanceOutputSchema>;

--- a/skills/idea-promotion-enhance/skill.config.ts
+++ b/skills/idea-promotion-enhance/skill.config.ts
@@ -1,0 +1,25 @@
+import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
+import { z } from 'zod';
+import { IdeaPromotionEnhanceOutputSchema } from './schema.js';
+
+const SupportedPromotionTypeSchema = z.enum(['feature', 'chore', 'research']);
+
+export const IdeaPromotionEnhanceContextSchema = z.object({
+  workItem: z.object({
+    type: SupportedPromotionTypeSchema,
+    title: z.string(),
+    body: z.string(),
+  }),
+});
+
+const config: SkillConfig = {
+  contextSchema: IdeaPromotionEnhanceContextSchema,
+  outputSchema: IdeaPromotionEnhanceOutputSchema,
+  contextAllowlist: ['workItem'],
+  toolBundles: [],
+  modelPin: 'sonnet',
+  freshContext: false,
+  role: 'triager',
+};
+
+export default config;

--- a/skills/idea-promotion-enhance/slice.test.ts
+++ b/skills/idea-promotion-enhance/slice.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { IdeaPromotionEnhanceOutputSchema } from './schema.js';
+import ideaPromotionEnhanceConfig, { IdeaPromotionEnhanceContextSchema } from './skill.config.js';
+
+describe('skills/idea-promotion-enhance skill.config', () => {
+  it('accepts the supported non-bug promotion types', () => {
+    for (const type of ['feature', 'chore', 'research'] as const) {
+      expect(() =>
+        IdeaPromotionEnhanceContextSchema.parse({
+          workItem: { type, title: `${type} title`, body: `${type} body` },
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it('rejects bug and missing types so the non-bug enhancer is not misrouted', () => {
+    expect(() =>
+      IdeaPromotionEnhanceContextSchema.parse({
+        workItem: { type: 'bug', title: 'bug title', body: 'bug body' },
+      }),
+    ).toThrow();
+    expect(() =>
+      IdeaPromotionEnhanceContextSchema.parse({
+        workItem: { title: 'missing type', body: 'body' },
+      }),
+    ).toThrow();
+  });
+
+  it('keeps the runtime contract aligned with bug-enhance', () => {
+    expect(ideaPromotionEnhanceConfig.contextAllowlist).toEqual(['workItem']);
+    expect(ideaPromotionEnhanceConfig.toolBundles).toEqual([]);
+    expect(ideaPromotionEnhanceConfig.modelPin).toBe('sonnet');
+    expect(ideaPromotionEnhanceConfig.role).toBe('triager');
+    expect(ideaPromotionEnhanceConfig.freshContext).toBe(false);
+  });
+
+  it('documents type-specific instructions in the prompt', () => {
+    const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+    expect(prompt).toContain('feature');
+    expect(prompt).toContain('chore');
+    expect(prompt).toContain('research');
+    expect(prompt).toContain('Feature Summary');
+    expect(prompt).toContain('Execution Notes');
+    expect(prompt).toContain('Research Goal');
+  });
+});
+
+describe('IdeaPromotionEnhanceOutputSchema', () => {
+  it('accepts enhanced markdown for a supported promotion', () => {
+    const result = IdeaPromotionEnhanceOutputSchema.safeParse({
+      enhancedContent:
+        '**Feature Summary**\nClarifies the user-facing problem.\n\n**Acceptance Notes**\n- Capture the expected workflow.',
+      decisionSummaries: [
+        {
+          kind: 'PLAN',
+          summary: 'Added feature framing for the promoted idea',
+          evidence: 'Original idea asked for clearer workflow goals',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('requires at least one decision summary', () => {
+    const result = IdeaPromotionEnhanceOutputSchema.safeParse({
+      enhancedContent: '**Chore Summary**\nRoutine maintenance context.',
+      decisionSummaries: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

M956.01: implement type-aware idea promotion enhancement service

## Work Packages

- ✓ **WP1**: `core/agent-runtime/budgets.ts:53` only registers `bug-enhance` today; add a dedicated `idea-promotion-enhance` skill bu
- ✓ **WP2**: `apps/server/src/domains/inbox/enhance.ts:20` currently exposes only `runBugEnhance`; expand it into a promotion enhance

Closes #957
