### PR TITLE
M19: wire legacy fix-issue quality lifecycle

### DIFF
--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -802,6 +802,56 @@ describe('approveIssue / rejectIssue (#186)', () => {
     expect(cleanupWorktree).toHaveBeenCalledWith('dev-run-123');
   });
 
+  it('approveIssue runs merge-decision and emits its result for a legacy pipelineRunId', async () => {
+    const prOpenedEvent = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+      kind: 'pr.opened',
+      runId: 'legacy-dev-run',
+      payload: {
+        prNumber: 99,
+        prUrl: 'u',
+        branch: 'b',
+        worktreePath: '/wt/legacy-dev-run',
+        devRunId: 'legacy-dev-run',
+        pipelineRunId: 'legacy-dev-run',
+      },
+      createdAt: '2026-05-02T22:00:00Z',
+    };
+    vi.mocked(eventStore.replay).mockReturnValue([prOpenedEvent] as never);
+    const mergePRImpl = vi.fn().mockResolvedValueOnce({ sha: 'abc1234', merged: true });
+    const runMergeDecisionImpl = vi.fn().mockReturnValueOnce({
+      passed: true,
+      score: 100,
+      reason: 'score-only-pass',
+    });
+
+    const { approveIssue } = await import('./service.js');
+    const result = await approveIssue('proj', '1', {
+      mergePRImpl,
+      runMergeDecisionImpl,
+      pipelineEnabledOverride: true,
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(runMergeDecisionImpl).toHaveBeenCalledWith({
+      pipelineRunId: 'legacy-dev-run',
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+    });
+    const mergeDecision = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([event]) => event.kind === 'merge-decision.completed');
+    expect(mergeDecision?.[0].payload).toMatchObject({
+      passed: true,
+      score: 100,
+      reason: 'score-only-pass',
+      pipelineRunId: 'legacy-dev-run',
+      prNumber: 99,
+    });
+  });
+
   it('approveIssue returns 409 and transitions to merge-conflict when GitHub 405', async () => {
     vi.mocked(eventStore.replay).mockReturnValueOnce([
       {

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -116,6 +116,8 @@ export async function approveIssue(
   id: string,
   options: {
     mergePRImpl?: typeof defaultMergePR;
+    runMergeDecisionImpl?: RunMergeDecisionFn;
+    pipelineEnabledOverride?: boolean;
     intervention?: { id: string; correlationId: string };
   } = {},
 ): Promise<Result<{ ok: true; sha: string; prNumber: number }>> {
@@ -156,12 +158,14 @@ export async function approveIssue(
   // Human escape hatch: merging directly via the GitHub UI bypasses this gate
   // entirely (we only run it inside the Goose Hub approve action).
   const projectCfg = await getProjectBySlug(slug);
-  const pipelineEnabled = projectCfg != null ? getUseMultiAgentPipeline(projectCfg.id) : false;
+  const pipelineEnabled =
+    options.pipelineEnabledOverride ??
+    (projectCfg != null ? getUseMultiAgentPipeline(projectCfg.id) : false);
 
   if (pipelineEnabled && pipelineRunId != null) {
     let decision: MergeDecisionResult;
     try {
-      const runMergeDecisionFn = await loadMergeDecision();
+      const runMergeDecisionFn = options.runMergeDecisionImpl ?? (await loadMergeDecision());
       decision = runMergeDecisionFn({
         pipelineRunId,
         // Use the slug — that's the same key all qa.completed/review.completed

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -861,6 +861,9 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
       baseBranch: prResult.base,
       worktreePath,
       devRunId: runId,
+      // Legacy fix-issue has a single developer run, so the delivery
+      // lifecycle intentionally aliases the dev run id for M19 scoring.
+      pipelineRunId: runId,
     },
     runId,
   });

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -510,7 +510,7 @@ describe('runFixIssueWorkflow (#183)', () => {
     );
     // worktree persists until merge — NOT cleaned up after PR open
     expect(cleanupWorktreeImpl).not.toHaveBeenCalled();
-    // pr.opened event recorded with worktreePath and devRunId for QA and merge cleanup
+    // pr.opened event recorded with lifecycle ids for QA, review, merge scoring, and cleanup.
     const opened = vi
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'pr.opened');
@@ -518,6 +518,7 @@ describe('runFixIssueWorkflow (#183)', () => {
     const openedPayload = opened?.[0].payload as Record<string, unknown>;
     expect(openedPayload).toHaveProperty('worktreePath');
     expect(openedPayload).toHaveProperty('devRunId');
+    expect(openedPayload).toHaveProperty('pipelineRunId', openedPayload.devRunId);
     expect(openedPayload).toHaveProperty('baseBranch', 'main');
     expect(mockAccumulatePersonaStats).toHaveBeenCalledWith({
       personaName: 'proj/developer/0',

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -315,6 +315,28 @@ describe('qa helpers', () => {
     });
   });
 
+  it('reads pipelineRunId from a legacy fix-issue pr.opened payload', async () => {
+    mockReplay.mockReturnValue([
+      {
+        id: 1,
+        kind: 'pr.opened',
+        payload: {
+          worktreePath: '/wt/legacy',
+          devRunId: 'legacy-dev-run',
+          pipelineRunId: 'legacy-dev-run',
+        },
+        createdAt: '',
+      },
+    ]);
+
+    const { findPrOpenedHints } = await import('./qa-helpers.js');
+
+    expect(findPrOpenedHints('github:owner/repo#42')).toMatchObject({
+      devRunId: 'legacy-dev-run',
+      pipelineRunId: 'legacy-dev-run',
+    });
+  });
+
   it('classifies significant UI changes from changed file paths', async () => {
     const { classifyUiChanges } = await import('./qa-helpers.js');
 
@@ -1192,6 +1214,36 @@ describe('runQaWorkflow', () => {
       expect(runTests).toHaveBeenCalledWith('/wt/parallel-abc', expect.any(String));
       const spec = mockRun.mock.calls[0][0] as { workspaceDir?: string };
       expect(spec.workspaceDir).toBe('/wt/parallel-abc');
+    });
+
+    it('emits qa.completed with pipelineRunId from a legacy fix-issue pr.opened payload', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: {
+            prNumber: 99,
+            prUrl: 'https://github.com/owner/repo/pull/99',
+            branch: 'factory/legacy-dev-run',
+            worktreePath: '/wt/legacy',
+            devRunId: 'legacy-dev-run',
+            pipelineRunId: 'legacy-dev-run',
+          },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const completed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([event]) => event.kind === 'qa.completed');
+      expect(completed?.[0].payload).toMatchObject({ pipelineRunId: 'legacy-dev-run' });
     });
 
     it('does not feed non-node stack test commands through the Vitest JSON runner', async () => {

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -868,6 +868,18 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
     const source = makeMockSource({
       getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
     });
+    mockReplay.mockReturnValue([
+      {
+        id: 1,
+        projectId: 'test-project',
+        workItemId: 'github:owner/repo#42',
+        kind: 'pr.opened',
+        payload: { devRunId: 'legacy-dev-run', pipelineRunId: 'legacy-dev-run' },
+        runId: null,
+        personaId: null,
+        createdAt: '2026-05-11T00:00:00Z',
+      },
+    ]);
 
     // 3 rounds × 2 reviewers all returning approved with no findings → converge at round 3
     for (let i = 0; i < 6; i++) mockRun.mockResolvedValueOnce(makeApprovedResultNoFindings());
@@ -880,7 +892,10 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
       .mocked(eventStore.appendEvent)
       .mock.calls.filter(([e]) => e.kind === 'review.completed');
     expect(completedEvents).toHaveLength(1);
-    expect(completedEvents[0]?.[0].payload).toMatchObject({ verdict: 'approved' });
+    expect(completedEvents[0]?.[0].payload).toMatchObject({
+      verdict: 'approved',
+      pipelineRunId: 'legacy-dev-run',
+    });
   });
 
   it('shares one reviewWorkflowRunId across review lifecycle, state transition, and child output events', async () => {


### PR DESCRIPTION
## Summary
- add pipelineRunId to legacy fix-issue pr.opened events, aliasing the single developer run id as the delivery lifecycle id
- cover QA, convergent review, and approve/merge-decision propagation for legacy lifecycle ids
- add an approve service regression seam for merge-decision gate coverage

## Source spec
- docs/prds/quality-trend-fix-issue.md

## Tests
- pnpm vitest run slices/fix-issue/slice.test.ts slices/qa/slice.test.ts slices/review/slice.test.ts apps/server/src/domains/issues/service.test.ts
- pnpm typecheck
- pnpm exec biome check apps/server/src/domains/issues/service.test.ts apps/server/src/domains/issues/transitions.ts slices/fix-issue/implement-phase.ts slices/fix-issue/slice.test.ts slices/qa/slice.test.ts slices/review/slice.test.ts