### PR TITLE
Centralize issue event stream handling

### DIFF
--- a/apps/server/src/domains/chat/tools.ts
+++ b/apps/server/src/domains/chat/tools.ts
@@ -9,9 +9,11 @@ import {
   readProjectSettings,
   writeProjectSettings,
 } from '@goose-hub/core/db/repositories/project-settings.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
+import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import { skillsRoot } from '@goose-hub/skills';
 import { runBootstrapViaBridge } from '#shared/bootstrap-bridge.js';
 import { searchPrsOrLog } from '#shared/github-pr-search.js';
@@ -424,8 +426,17 @@ async function transitionIssue(input: {
   const id = String(input.issueNumber);
   const current = await source.getItem(id);
   try {
-    // biome-ignore lint/suspicious/noExplicitAny: StateName narrowing handled by transitionState
-    await source.transitionState(id, current.state as any, input.toState as any);
+    await transitionAndEmitState({
+      mode: 'legal',
+      source,
+      itemId: id,
+      projectId: input.projectSlug,
+      workItemId: current.id,
+      from: current.state,
+      to: input.toState as StateName,
+      by: 'chat.transition_issue',
+      extraPayload: { rationale: input.rationale },
+    });
   } catch (err) {
     throw new ToolExecutionError(`transition failed: ${String(err)}`, 400);
   }

--- a/apps/server/src/domains/interventions/applier-worker.test.ts
+++ b/apps/server/src/domains/interventions/applier-worker.test.ts
@@ -8,10 +8,12 @@ const mocks = vi.hoisted(() => ({
   emitStateTransitionEvent: vi.fn(),
   getSourceForSlug: vi.fn(),
   rejectIssue: vi.fn(),
+  transitionAndEmitState: vi.fn(),
 }));
 
 vi.mock('@goose-hub/core/event-stream/state-transition.js', () => ({
   emitStateTransitionEvent: mocks.emitStateTransitionEvent,
+  transitionAndEmitState: mocks.transitionAndEmitState,
 }));
 
 vi.mock('#shared/cache.js', () => ({
@@ -45,6 +47,7 @@ describe('server intervention applier deps', () => {
     vi.clearAllMocks();
     source.getItem.mockResolvedValue({ state: 'factory:needs-human' });
     source.transitionState.mockResolvedValue(undefined);
+    mocks.transitionAndEmitState.mockResolvedValue(undefined);
     mocks.getSourceForSlug.mockResolvedValue(source);
     mocks.approveIssue.mockResolvedValue({ ok: true, data: { ok: true, sha: 'abc', prNumber: 1 } });
     mocks.rejectIssue.mockResolvedValue({ ok: true, data: { ok: true } });
@@ -65,18 +68,17 @@ describe('server intervention applier deps', () => {
       reason: 'retry triage',
     });
 
-    expect(source.transitionState).toHaveBeenCalledWith(
-      'github:owner/repo#42',
-      'factory:needs-human',
-      'factory:triaging',
-      'retry triage',
-    );
-    expect(mocks.emitStateTransitionEvent).toHaveBeenCalledWith(
+    expect(mocks.transitionAndEmitState).toHaveBeenCalledWith(
       expect.objectContaining({
+        source,
         projectId: 'proj',
+        itemId: 'github:owner/repo#42',
         workItemId: 'github:owner/repo#42',
         from: 'factory:needs-human',
         to: 'factory:triaging',
+        by: 'intervention-applier',
+        mode: 'legal',
+        note: 'retry triage',
         extraPayload: {
           interventionId: 'i1',
           causedByInterventionId: 'i1',
@@ -103,6 +105,7 @@ describe('server intervention applier deps', () => {
 
     expect(source.transitionState).not.toHaveBeenCalled();
     expect(mocks.emitStateTransitionEvent).not.toHaveBeenCalled();
+    expect(mocks.transitionAndEmitState).not.toHaveBeenCalled();
   });
 
   it('passes intervention identity into gate appliers and resume dispatch', async () => {

--- a/apps/server/src/domains/interventions/applier-worker.ts
+++ b/apps/server/src/domains/interventions/applier-worker.ts
@@ -1,4 +1,4 @@
-import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import {
   type InterventionApplierDeps,
   startInterventionApplierWorker,
@@ -33,18 +33,16 @@ export function createServerInterventionApplierDeps(): InterventionApplierDeps {
           `state changed before apply: expected ${input.from}, found ${current.state}`,
         );
       }
-      await source.transitionState(
-        input.workItemId,
-        input.from,
-        input.to,
-        input.reason ?? 'operator intervention',
-      );
-      emitStateTransitionEvent({
+      await transitionAndEmitState({
+        source,
         projectId: input.projectId,
+        itemId: input.workItemId,
         workItemId: input.workItemId,
         from: input.from,
         to: input.to,
         by: 'intervention-applier',
+        mode: 'legal',
+        note: input.reason ?? 'operator intervention',
         extraPayload: {
           interventionId: input.interventionId,
           causedByInterventionId: input.interventionId,

--- a/apps/server/src/domains/issues/prd-actions.ts
+++ b/apps/server/src/domains/issues/prd-actions.ts
@@ -8,7 +8,10 @@
  * `rejectPRD` is kept for backwards compatibility but is a no-op alias for
  * `declinePRD`.
  */
-import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
+import {
+  emitStateTransitionEvent,
+  transitionAndEmitState,
+} from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
@@ -115,7 +118,17 @@ export async function revisePRD(
       id,
       'revise-prd: no PRD draft found for this issue. Returning to needs-human.',
     );
-    await source.forceState(id, 'factory:needs-human');
+    await transitionAndEmitState({
+      source,
+      projectId: slug,
+      itemId: id,
+      workItemId,
+      from: 'factory:prd-review',
+      to: 'factory:needs-human',
+      by: 'ui',
+      mode: 'forced',
+      reason: 'no PRD draft found for revision',
+    });
     return { ok: false, error: 'no PRD draft found for revision', status: 409 };
   }
 

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -53,9 +53,14 @@ router.get('/:slug/issues/:id/legal-targets', async (c) => {
 router.get('/:slug/issues/:id/events', async (c) => {
   const limitStr = c.req.query('limit');
   const beforeStr = c.req.query('before');
+  const afterStr = c.req.query('after');
   const opts =
     limitStr != null
-      ? { limit: Number(limitStr), before: beforeStr != null ? Number(beforeStr) : undefined }
+      ? {
+          limit: Number(limitStr),
+          before: beforeStr != null ? Number(beforeStr) : undefined,
+          after: afterStr != null ? Number(afterStr) : undefined,
+        }
       : undefined;
   const result = await getIssueEvents(c.req.param('slug'), c.req.param('id'), opts);
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -1009,6 +1009,60 @@ describe('getIssueEvents', () => {
       expect(result.data.hasMore).toBe(true);
     }
   });
+
+  it('keeps after-cursor backfill pages full after filtering hidden rows', async () => {
+    vi.mocked(eventStore.replay)
+      .mockReturnValueOnce(
+        Array.from({ length: 100 }, (_, index) => ({
+          id: 11 + index,
+          kind: 'chat.agent-message',
+          payload: { conversationId: 'conv_1' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          createdAt: '2026-01-01T00:00:11Z',
+        })) as never,
+      )
+      .mockReturnValueOnce([
+        {
+          id: 111,
+          kind: 'state.transitioned',
+          payload: { to: 'factory:triaging' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          createdAt: '2026-01-01T00:00:13Z',
+        },
+        {
+          id: 112,
+          kind: 'agent.run-started',
+          payload: { skill: 'investigate', runId: 'run_1' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          createdAt: '2026-01-01T00:00:14Z',
+        },
+        {
+          id: 113,
+          kind: 'agent.run-completed',
+          payload: { skill: 'investigate', runId: 'run_1' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          createdAt: '2026-01-01T00:00:15Z',
+        },
+      ] as never);
+
+    const { getIssueEvents } = await import('./service.js');
+    const result = await getIssueEvents('proj', '1', { limit: 1, after: 10 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const events = result.data.events as Array<{ id: number }>;
+      expect(events.map((event) => event.id)).toEqual([111]);
+      expect(result.data.hasMore).toBe(true);
+      expect(eventStore.replay).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ sinceId: 110 }),
+      );
+    }
+  });
 });
 
 describe('getIssueArtifact', () => {

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -283,7 +283,7 @@ export async function getIssueArtifact(
 export async function getIssueEvents(
   slug: string,
   id: string,
-  opts?: { limit?: number; before?: number },
+  opts?: { limit?: number; before?: number; after?: number },
 ): Promise<Result<{ events: unknown[]; hasMore: boolean }>> {
   const source = await getSourceForSlug(slug);
   if (source == null) return { ok: false, error: 'project not found', status: 404 };
@@ -296,6 +296,7 @@ export async function getIssueEvents(
       workItemId,
       limit: opts.limit + 1,
       before: opts.before,
+      after: opts.after,
     });
     const hasMore = fetched.length > opts.limit;
     return {
@@ -316,7 +317,31 @@ function fetchVisibleIssueTimelineEvents(input: {
   workItemId: string;
   limit: number;
   before?: number;
+  after?: number;
 }): AgentEvent[] {
+  if (input.after != null) {
+    const visible: AgentEvent[] = [];
+    let sinceId = input.after;
+    const batchSize = Math.max(input.limit, 100);
+
+    while (visible.length < input.limit) {
+      const batch = eventStore.replay({
+        projectId: input.projectId,
+        workItemId: input.workItemId,
+        sinceId,
+        limit: batchSize,
+      });
+      if (batch.length === 0) break;
+      visible.push(...batch.filter(isIssueTimelineEvent));
+      const lastId = batch.at(-1)?.id;
+      if (lastId == null || lastId <= sinceId) break;
+      sinceId = lastId;
+      if (batch.length < batchSize) break;
+    }
+
+    return visible;
+  }
+
   const visible: AgentEvent[] = [];
   let before = input.before;
   const batchSize = Math.max(input.limit, 100);

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -5,7 +5,7 @@ import {
   mergePR as defaultMergePR,
 } from '@goose-hub/core/connectors/github/merge-pr.js';
 import { getUseMultiAgentPipeline } from '@goose-hub/core/db/repositories/project-settings.js';
-import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { validateInterventionAction } from '@goose-hub/core/interventions/actions.js';
 import {
@@ -205,8 +205,10 @@ export async function approveIssue(
           decision.detail,
         ]),
       );
-      await source.transitionState(id, 'factory:approved', 'factory:needs-human');
-      emitStateTransitionEvent({
+      await transitionAndEmitState({
+        mode: 'legal',
+        source,
+        itemId: id,
         projectId: slug,
         workItemId,
         from: 'factory:approved',
@@ -229,8 +231,10 @@ export async function approveIssue(
       kind: 'merge.conflict',
       payload: { prNumber, ...interventionEventPayload(options.intervention) },
     });
-    await source.transitionState(id, 'factory:approved', 'factory:merge-conflict');
-    emitStateTransitionEvent({
+    await transitionAndEmitState({
+      mode: 'legal',
+      source,
+      itemId: id,
       projectId: slug,
       workItemId,
       from: 'factory:approved',
@@ -252,8 +256,10 @@ export async function approveIssue(
         kind: 'merge.conflict',
         payload: { prNumber, ...interventionEventPayload(options.intervention) },
       });
-      await source.transitionState(id, 'factory:approved', 'factory:merge-conflict');
-      emitStateTransitionEvent({
+      await transitionAndEmitState({
+        mode: 'legal',
+        source,
+        itemId: id,
         projectId: slug,
         workItemId,
         from: 'factory:approved',
@@ -290,7 +296,17 @@ export async function approveIssue(
     if (typeof devRunId === 'string') cleanupWorktree(devRunId);
   }
 
-  await source.transitionState(id, 'factory:approved', 'factory:retrospecting');
+  await transitionAndEmitState({
+    mode: 'legal',
+    source,
+    itemId: id,
+    projectId: slug,
+    workItemId,
+    from: 'factory:approved',
+    to: 'factory:retrospecting',
+    by: 'ui',
+    extraPayload: interventionEventPayload(options.intervention),
+  });
   await source.comment(
     id,
     buildAgentComment('Gate', 'Approved', `PR #${prNumber} merged via Goose Hub UI`, [
@@ -339,8 +355,10 @@ export async function rejectIssue(
     id,
     buildAgentComment('Gate', 'Rejected', 'Rejected at approval gate', [`Reason: ${reason}`]),
   );
-  await source.transitionState(id, 'factory:approved', 'factory:needs-fix');
-  emitStateTransitionEvent({
+  await transitionAndEmitState({
+    mode: 'legal',
+    source,
+    itemId: id,
     projectId: slug,
     workItemId,
     from: 'factory:approved',
@@ -441,7 +459,22 @@ export async function transitionIssue(
   if (!applying.ok) return { ok: false, error: applying.error, status: applying.status };
 
   try {
-    await source.transitionState(workItemId, fromState, toState);
+    await transitionAndEmitState({
+      mode: 'legal',
+      source,
+      itemId: workItemId,
+      projectId: slug,
+      workItemId,
+      from: fromState,
+      to: toState,
+      by: 'ui',
+      extraPayload: {
+        interventionId: manual.intervention.id,
+        causedByInterventionId: manual.intervention.id,
+        correlationId: manual.intervention.correlationId,
+        ...sessionPayload,
+      },
+    });
   } catch (err) {
     recordApplicationResult({
       id: manual.intervention.id,
@@ -453,19 +486,6 @@ export async function transitionIssue(
     throw err;
   }
 
-  emitStateTransitionEvent({
-    projectId: slug,
-    workItemId,
-    from: fromState,
-    to: toState,
-    by: 'ui',
-    extraPayload: {
-      interventionId: manual.intervention.id,
-      causedByInterventionId: manual.intervention.id,
-      correlationId: manual.intervention.correlationId,
-      ...sessionPayload,
-    },
-  });
   const applied = recordApplicationResult({
     id: manual.intervention.id,
     expectedVersion: applying.intervention.version,

--- a/apps/server/src/shared/dispatch-discover.ts
+++ b/apps/server/src/shared/dispatch-discover.ts
@@ -1,3 +1,4 @@
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import { parallelLock } from '@goose-hub/core/projects/parallel-lock.js';
@@ -206,7 +207,17 @@ export async function dispatchDecomposePrd(slug: string, issueNumber: number): P
           issueNumber.toString(),
           'decompose-prd: no PRD draft found on this issue. Returning to needs-human.',
         );
-        await source.forceState(issueNumber.toString(), 'factory:needs-human');
+        await transitionAndEmitState({
+          source,
+          projectId: slug,
+          itemId: item.id,
+          workItemId: item.id,
+          from: 'factory:decomposing',
+          to: 'factory:needs-human',
+          by: 'decompose-prd',
+          mode: 'forced',
+          reason: 'no PRD draft found',
+        });
         return;
       }
       if (prdOutput.prd == null) {
@@ -219,7 +230,17 @@ export async function dispatchDecomposePrd(slug: string, issueNumber: number): P
           issueNumber.toString(),
           'decompose-prd: PRD draft could not be parsed. Returning to needs-human.',
         );
-        await source.forceState(issueNumber.toString(), 'factory:needs-human');
+        await transitionAndEmitState({
+          source,
+          projectId: slug,
+          itemId: item.id,
+          workItemId: item.id,
+          from: 'factory:decomposing',
+          to: 'factory:needs-human',
+          by: 'decompose-prd',
+          mode: 'forced',
+          reason: 'PRD draft could not be parsed',
+        });
         return;
       }
       await runDecomposePrdWorkflow({

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -1,13 +1,22 @@
 import { ProjectBudgetBanner } from '@/components/ui/ProjectBudgetBanner';
-import { fetchIssue, fetchIssues } from '@/lib/api';
+import { fetchEventsPage, fetchIssue, fetchIssues } from '@/lib/api';
 import { LANES, laneForState, sortLaneItems } from '@/lib/lanes.config';
 import { useProjectBudgetStatus } from '@/lib/project-budget';
+import type { AgentEventDto } from '@/lib/types';
+import { ISSUE_TIMELINE_EVENT_KINDS } from '@goose-hub/core/event-stream/issue-timeline.js';
 import { useActiveMilestone } from '@/state/active-milestone';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import {
+  applyLatestEventState,
+  applyIssueTimelineEvent,
+  backfillIssueTimelineEvents,
+  mergeIssueEvents,
+} from '../lib/live-events';
 import { SECTIONS } from '../lib/sections';
+import { computeIsLive } from '../lib/timeline';
 import { useHasOpenDep } from '../lib/useHasOpenDep';
 import { ApprovalGateSection } from './ApprovalGateSection';
 import { CodeDiffSection } from './CodeDiffSection';
@@ -27,6 +36,8 @@ import { TaskHeader } from './TaskHeader';
 import { TimelineSection } from './TimelineSection';
 import { TriageResultsSection } from './TriageResultsSection';
 
+const TIMELINE_PAGE_SIZE = 200;
+
 interface DetailPageProps {
   section?: string;
 }
@@ -43,17 +54,38 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
     // isLoading,
     isError,
     error,
-    refetch,
   } = useQuery({
     queryKey: ['issue', slug, id],
-    queryFn: () => fetchIssue(slug, id),
+    queryFn: async () =>
+      applyLatestEventState(
+        await fetchIssue(slug, id),
+        queryClient.getQueryData<AgentEventDto[]>(['events', slug, id]),
+      ),
+    enabled: id.length > 0,
+  });
+
+  const eventsQuery = useQuery({
+    queryKey: ['events', slug, id],
+    queryFn: async ({ signal }) => {
+      const { events } = await fetchEventsPage(slug, id, { limit: TIMELINE_PAGE_SIZE }, signal);
+      return mergeIssueEvents(
+        queryClient.getQueryData<AgentEventDto[]>(['events', slug, id]),
+        events,
+      );
+    },
     enabled: id.length > 0,
   });
 
   // Reuse the board's cached issues list for sibling navigation — no extra fetch.
   const { data: allIssues = [] } = useQuery({
     queryKey: ['issues', slug],
-    queryFn: () => fetchIssues(slug),
+    queryFn: async () => {
+      const issues = await fetchIssues(slug);
+      const issueEvents = queryClient.getQueryData<AgentEventDto[]>(['events', slug, id]);
+      return issues.map((issue) =>
+        issue.externalId === id ? applyLatestEventState(issue, issueEvents) : issue,
+      );
+    },
   });
 
   const siblings = useMemo(() => {
@@ -116,27 +148,80 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
   const currentSection = SECTIONS.find((s) => s.key === section) ?? SECTIONS[0];
   const workItemId = item != null ? `github:${item.repoRef}#${item.externalId}` : '';
 
-  const refetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Re-fetch the issue when an agent transitions its state (e.g. after triage).
+  const safetyRefetchTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const backfillMissedEvents = useCallback(
+    () =>
+      backfillIssueTimelineEvents({
+        queryClient,
+        projectSlug: slug,
+        issueId: id,
+        fetchPage: fetchEventsPage,
+        limit: TIMELINE_PAGE_SIZE,
+      }),
+    [queryClient, slug, id],
+  );
+
   useEffect(() => {
-    if (!workItemId) return;
-    const url = `/events?projectId=${encodeURIComponent(slug)}&workItemId=${encodeURIComponent(workItemId)}`;
-    const es = new EventSource(url);
-    const onTransitioned = () => {
-      if (refetchTimer.current) clearTimeout(refetchTimer.current);
-      refetchTimer.current = setTimeout(() => {
-        void refetch();
-      }, 150);
-    };
-    es.addEventListener('state.transitioned', onTransitioned);
-    es.addEventListener('gate.rejected', onTransitioned);
+    if (!computeIsLive(eventsQuery.data ?? [])) return;
+    safetyRefetchTimer.current = setInterval(() => {
+      void eventsQuery.refetch();
+    }, 30_000);
     return () => {
-      if (refetchTimer.current) clearTimeout(refetchTimer.current);
-      es.removeEventListener('state.transitioned', onTransitioned);
-      es.removeEventListener('gate.rejected', onTransitioned);
+      if (safetyRefetchTimer.current != null) clearInterval(safetyRefetchTimer.current);
+      safetyRefetchTimer.current = null;
+    };
+  }, [eventsQuery.data, eventsQuery.refetch]);
+
+  // DetailPage owns the issue-level SSE stream. Child sections consume the
+  // shared ['events', slug, id] cache and their own query invalidations.
+  useEffect(() => {
+    if (!workItemId || !eventsQuery.isSuccess) return;
+    const cached = queryClient.getQueryData<AgentEventDto[]>(['events', slug, id]) ?? [];
+    const lastEventId = cached[0]?.id ?? 0;
+    const params = new URLSearchParams({
+      projectId: slug,
+      workItemId,
+      lastEventId: String(lastEventId),
+    });
+    const es = new EventSource(`/events?${params}`);
+    let hadConnectionError = false;
+
+    const handleEvent = (msg: MessageEvent<string>) => {
+      try {
+        const parsed = JSON.parse(msg.data) as AgentEventDto;
+        applyIssueTimelineEvent(queryClient, slug, id, parsed);
+      } catch {
+        // Ignore malformed SSE payloads; the next backfill/refetch recovers.
+      }
+    };
+
+    for (const kind of ISSUE_TIMELINE_EVENT_KINDS) {
+      es.addEventListener(kind, handleEvent as EventListener);
+    }
+    es.onmessage = handleEvent;
+    es.onopen = () => {
+      if (!hadConnectionError) return;
+      hadConnectionError = false;
+      void backfillMissedEvents();
+    };
+    es.onerror = () => {
+      hadConnectionError = true;
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') void backfillMissedEvents();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      for (const kind of ISSUE_TIMELINE_EVENT_KINDS) {
+        es.removeEventListener(kind, handleEvent as EventListener);
+      }
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       es.close();
     };
-  }, [slug, workItemId, refetch]);
+  }, [slug, id, workItemId, eventsQuery.isSuccess, queryClient, backfillMissedEvents]);
 
   if (isError) {
     return (
@@ -231,7 +316,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
             ) : currentSection.key === 'repo' ? (
               <TriageResultsSection projectSlug={slug} id={id} />
             ) : currentSection.key === 'timeline' ? (
-              <TimelineSection projectSlug={slug} id={id} workItemId={workItemId} />
+              <TimelineSection projectSlug={slug} id={id} />
             ) : currentSection.key === 'investigation' ? (
               <InvestigationSection
                 projectSlug={slug}

--- a/apps/web/src/components/detail/components/GrillSection.test.tsx
+++ b/apps/web/src/components/detail/components/GrillSection.test.tsx
@@ -176,6 +176,42 @@ describe('GrillSection', () => {
     expect(transitionState).not.toHaveBeenCalled();
   });
 
+  it('shows the reply form when raw state is stale but the latest grill comment is unanswered', async () => {
+    vi.mocked(fetchComments).mockResolvedValue([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
+
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+
+    await waitFor(() => expect(screen.getByTestId('grill-reply-form')).toBeTruthy());
+    expect(screen.queryByTestId('grill-processing-footer')).toBeNull();
+  });
+
+  it('uses effective gate-pending state when replying after a stale factory:grilling render', async () => {
+    vi.mocked(fetchComments).mockResolvedValue([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
+    vi.mocked(addComment).mockResolvedValueOnce(undefined);
+    vi.mocked(transitionState).mockResolvedValueOnce({
+      status: 200,
+      data: { ok: true },
+    });
+
+    render_(<GrillSection projectSlug="proj" externalId="42" id="42" state="factory:grilling" />);
+    await waitFor(() => expect(screen.getByTestId('grill-reply-input')).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId('grill-reply-input'), { target: { value: 'Answer.' } });
+    await waitFor(() => {
+      expect((screen.getByTestId('grill-send-btn') as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId('grill-send-btn'));
+
+    await waitFor(() => {
+      expect(transitionState).toHaveBeenCalledWith(
+        'proj',
+        '42',
+        'factory:gate-pending',
+        'factory:grilling',
+      );
+    });
+  });
+
   it('shows the optimistic reply in the thread before round-trip resolves', async () => {
     vi.mocked(fetchComments).mockResolvedValue([comment(1, `${GRILL_QUESTION_MARKER}\nQ?`)]);
     const pending = new Promise<void>((resolve) => {

--- a/apps/web/src/components/detail/components/GrillSection.tsx
+++ b/apps/web/src/components/detail/components/GrillSection.tsx
@@ -46,12 +46,13 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
   }, [state, projectSlug, id, queryClient]);
 
   const send = useMutation({
-    mutationFn: async (body: string) => {
+    mutationFn: async (input: { body: string; shouldTransitionToGrilling: boolean }) => {
+      const { body, shouldTransitionToGrilling } = input;
       await addComment(projectSlug, externalId, body);
       // After posting a reply during gate-pending, advance the issue back to
       // grilling so the orchestrator can pick it up on the next tick. This is
       // a no-op when the issue is already in a non-gate state.
-      if (state === 'factory:gate-pending') {
+      if (shouldTransitionToGrilling) {
         await transitionState(projectSlug, id, 'factory:gate-pending', 'factory:grilling');
       }
     },
@@ -82,20 +83,25 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
 
   const grillComments = selectGrillThreadComments(comments);
   const merged: Array<IssueCommentDto | OptimisticReply> = [...grillComments, ...optimisticReplies];
+  const latestThreadComment = merged.at(-1);
+  const hasLatestUnansweredQuestion =
+    latestThreadComment != null && isGrillQuestion(latestThreadComment.body);
+  const effectiveState =
+    state === 'factory:grilling' && hasLatestUnansweredQuestion ? 'factory:gate-pending' : state;
 
   // The last agent question in the thread (used for recommended-answer pill).
   const lastAgentQuestionId = [...merged].reverse().find((c) => isGrillQuestion(c.body))?.id;
 
   const grillingComplete =
-    state === 'factory:prd-drafting' ||
-    state === 'factory:prd-review' ||
-    state === 'factory:decomposing' ||
-    state === 'factory:issues-created' ||
-    state === 'factory:done';
+    effectiveState === 'factory:prd-drafting' ||
+    effectiveState === 'factory:prd-review' ||
+    effectiveState === 'factory:decomposing' ||
+    effectiveState === 'factory:issues-created' ||
+    effectiveState === 'factory:done';
 
   // Griller is processing a reply — hide the form but don't show "complete" yet.
-  const grillingInProgress = state === 'factory:grilling';
-  const awaitingReply = state === 'factory:gate-pending';
+  const grillingInProgress = effectiveState === 'factory:grilling';
+  const awaitingReply = effectiveState === 'factory:gate-pending';
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -103,6 +109,7 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
     if (trimmed.length === 0 || send.isPending) return;
     const replyBody = `${GRILL_REPLY_MARKER}\n${trimmed}`;
     setErrorMsg(null);
+    const shouldTransitionToGrilling = effectiveState === 'factory:gate-pending';
     // Optimistic insert.
     const reply: OptimisticReply = {
       id: -Date.now(),
@@ -112,7 +119,7 @@ export function GrillSection({ projectSlug, externalId, id, state }: GrillSectio
       __optimistic: true,
     };
     setOptimisticReplies((prev) => [...prev, reply]);
-    send.mutate(replyBody);
+    send.mutate({ body: replyBody, shouldTransitionToGrilling });
   };
 
   if (isLoading) {

--- a/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
+++ b/apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx
@@ -363,87 +363,67 @@ describe('TimelineSection — expand/collapse all', () => {
     ).toBeNull();
   });
 
-  it('invalidates issue costs when a run terminal event arrives over SSE', async () => {
-    const { fetchEventsPage } = await import('@/lib/api');
-    vi.mocked(fetchEventsPage).mockResolvedValue({
-      events: [makeRunEvent(1, 'run-live', 'agent.run-started')],
-      hasMore: false,
-    });
-
-    const queryClient = new QueryClient();
-    queryClient.setQueryData(['events', 'p', '1'], []);
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const { TimelineSection } = await import('./TimelineSection');
-    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
-
-    await screen.findByTestId('timeline-section');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(makeRunEvent(2, 'run-live', 'agent.run-completed'));
-
-    await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue-costs', 'p', '1'] });
-    });
-  });
-
-  it('writes named issue timeline SSE events into the shared events cache without invalidating it', async () => {
+  it('does not create its own EventSource', async () => {
     const { fetchEventsPage } = await import('@/lib/api');
     vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
 
+    const { TimelineSection } = await import('./TimelineSection');
+    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
+
+    await screen.findByText('No timeline events yet.');
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('renders named events from the shared events cache', async () => {
+    const { fetchEventsPage } = await import('@/lib/api');
+    const event = makeEvent(2, 'grill.decision-crystallized', {
+      roundNumber: 2,
+      decision: 'Use the shared event-kind contract.',
+    });
+    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [event], hasMore: false });
+
     const queryClient = new QueryClient();
-    queryClient.setQueryData(['events', 'p', '1'], []);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const { TimelineSection } = await import('./TimelineSection');
     renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
 
-    await screen.findByText('No timeline events yet.');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    const event = makeEvent(2, 'agent.investigation-complete', {
-      investigate: { findings: [] },
-    });
-    MockEventSource.instances[0].emitNamed(event);
-    MockEventSource.instances[0].emitNamed(event);
-
-    await waitFor(() => {
-      expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event]);
-    });
+    expect(await screen.findByText('Decision crystallized')).toBeTruthy();
+    expect(screen.getByText('Use the shared event-kind contract.')).toBeTruthy();
+    expect(MockEventSource.instances).toHaveLength(0);
     expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
   });
 
-  it('invalidates issue state caches, but not events, when a state transition arrives over SSE', async () => {
+  it('renders the Playwright capture section from the shared events cache', async () => {
     const { fetchEventsPage } = await import('@/lib/api');
     vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
 
     const queryClient = new QueryClient();
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const { TimelineSection } = await import('./TimelineSection');
-    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />, queryClient);
-
-    await screen.findByText('No timeline events yet.');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(
-      makeEvent(2, 'state.transitioned', {
-        from: 'factory:decomposing',
-        to: 'factory:done',
-      }),
+    queryClient.setQueryData(
+      ['events', 'p', '1'],
+      [
+        makeEvent(2, 'state.transitioned', {
+          from: 'factory:decomposing',
+          to: 'factory:done',
+        }),
+        makeEvent(3, 'agent.investigation-complete', {
+          playwrightRepro: {
+            screenshots: [
+              {
+                path: '/tmp/repro.png',
+                caption: 'Live repro screenshot',
+                step: 1,
+              },
+            ],
+            gifPath: null,
+            consoleErrors: [],
+            reproSteps: ['Open the bug page'],
+            reproduced: true,
+            notes: 'Captured from the live investigation event.',
+          },
+        }),
+      ],
     );
 
-    await waitFor(() => {
-      expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['issue', 'p', '1'])).toBe(true);
-      expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['issues', 'p'])).toBe(true);
-    });
-    expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
-  });
-
-  it('updates the Playwright capture section from live investigation SSE without refetching events', async () => {
-    const { fetchEvents, fetchEventsPage } = await import('@/lib/api');
-    vi.mocked(fetchEvents).mockResolvedValue([]);
-    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
-
-    const queryClient = new QueryClient();
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const { TimelineSection } = await import('./TimelineSection');
     const { PlaywrightCaptureSection } = await import('./PlaywrightCaptureSection');
     renderTimeline(
@@ -454,97 +434,50 @@ describe('TimelineSection — expand/collapse all', () => {
       queryClient,
     );
 
-    expect(await screen.findByText('Playwright capture has not run yet.')).toBeTruthy();
-    expect(fetchEvents).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(
-      makeEvent(2, 'agent.investigation-complete', {
-        playwrightRepro: {
-          screenshots: [
-            {
-              path: '/tmp/repro.png',
-              caption: 'Live repro screenshot',
-              step: 1,
-            },
-          ],
-          gifPath: null,
-          consoleErrors: [],
-          reproSteps: ['Open the bug page'],
-          reproduced: true,
-          notes: 'Captured from the live investigation event.',
-        },
-      }),
-    );
-
     expect(await screen.findByText('Open the bug page')).toBeTruthy();
     expect(screen.getByText('Live repro screenshot')).toBeTruthy();
-    expect(fetchEvents).toHaveBeenCalledTimes(1);
-    expect(invalidatedQueryKey(invalidateSpy.mock.calls, ['events', 'p', '1'])).toBe(false);
-  });
-
-  it('renders named SSE events that are visible in REST reloads', async () => {
-    const { fetchEventsPage } = await import('@/lib/api');
-    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
-
-    const { TimelineSection } = await import('./TimelineSection');
-    renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
-
-    await screen.findByText('No timeline events yet.');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(
-      makeEvent(2, 'grill.decision-crystallized', {
-        roundNumber: 2,
-        decision: 'Use the shared event-kind contract.',
-      }),
-    );
-
-    expect(await screen.findByText('Decision crystallized')).toBeTruthy();
-    expect(screen.getByText('Use the shared event-kind contract.')).toBeTruthy();
+    expect(MockEventSource.instances).toHaveLength(0);
   });
 
   it('does not render named chat events in issue timelines', async () => {
     const { fetchEventsPage } = await import('@/lib/api');
-    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
+    vi.mocked(fetchEventsPage).mockResolvedValue({
+      events: [
+        makeEvent(2, 'chat.agent-message', {
+          conversationId: 'conv_1',
+          text: 'chat reply should stay in chat',
+        }),
+      ],
+      hasMore: false,
+    });
 
     const { TimelineSection } = await import('./TimelineSection');
     renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
 
     await screen.findByText('No timeline events yet.');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(
-      makeEvent(2, 'chat.agent-message', {
-        conversationId: 'conv_1',
-        text: 'chat reply should stay in chat',
-      }),
-    );
-
     expect(screen.queryByText('chat reply should stay in chat')).toBeNull();
-    expect(screen.getByText('No timeline events yet.')).toBeTruthy();
+    expect(MockEventSource.instances).toHaveLength(0);
   });
 
-  it('does not render live non-chat events emitted by the hub-chat skill', async () => {
+  it('does not render non-chat events emitted by the hub-chat skill', async () => {
     const { fetchEventsPage } = await import('@/lib/api');
-    vi.mocked(fetchEventsPage).mockResolvedValue({ events: [], hasMore: false });
+    vi.mocked(fetchEventsPage).mockResolvedValue({
+      events: [
+        makeRunEvent(2, 'chat-run', 'agent.run-started', {
+          skill: 'hub-chat',
+          modelId: 'gpt-5.4',
+          runtime: 'codex-cli',
+        }),
+      ],
+      hasMore: false,
+    });
 
     const { TimelineSection } = await import('./TimelineSection');
     renderTimeline(<TimelineSection projectSlug="p" id="1" workItemId="w1" />);
 
     await screen.findByText('No timeline events yet.');
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-
-    MockEventSource.instances[0].emitNamed(
-      makeRunEvent(2, 'chat-run', 'agent.run-started', {
-        skill: 'hub-chat',
-        modelId: 'gpt-5.4',
-        runtime: 'codex-cli',
-      }),
-    );
-
     expect(screen.queryByText('hub-chat')).toBeNull();
-    expect(screen.getByText('No timeline events yet.')).toBeTruthy();
+    expect(MockEventSource.instances).toHaveLength(0);
   });
 
   it('renders intervention groups inside the main timeline instead of a top audit panel', async () => {

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -2,15 +2,12 @@ import { fetchEventsPage, fetchIntervention, fetchIssueInterventions } from '@/l
 import type { InterventionDetailDto } from '@/lib/api/interventions';
 import { interventionKeys } from '@/lib/query-keys';
 import type { AgentEventDto } from '@/lib/types';
-import {
-  ISSUE_TIMELINE_EVENT_KINDS,
-  isIssueTimelineEvent,
-} from '@goose-hub/core/event-stream/issue-timeline.js';
+import { isIssueTimelineEvent } from '@goose-hub/core/event-stream/issue-timeline.js';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Clock } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useIssueCostsBreakdown } from '../lib/costs';
-import { upsertIssueEvent } from '../lib/live-events';
+import { mergeIssueEvents } from '../lib/live-events';
 import { groupEvents } from '../lib/timeline';
 import type { RenderItem } from '../lib/timeline';
 import { SectionEmptyState } from './SectionEmptyState';
@@ -23,20 +20,33 @@ const PAGE_SIZE = 200;
 interface TimelineSectionProps {
   projectSlug: string;
   id: string;
-  workItemId: string;
+  workItemId?: string;
 }
 
-export function TimelineSection({ projectSlug, id, workItemId }: TimelineSectionProps) {
-  const [events, setEvents] = useState<AgentEventDto[]>([]);
-  const [loading, setLoading] = useState(true);
+export function TimelineSection({ projectSlug, id }: TimelineSectionProps) {
   const [loadingMore, setLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [cursor, setCursor] = useState<number | undefined>(undefined);
-  const [error, setError] = useState<string | null>(null);
-  // Set to max event id after initial REST fetch; triggers SSE open with lastEventId.
-  const [sseReadyAfter, setSseReadyAfter] = useState<number | null>(null);
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const [hasMore, setHasMore] = useState(true);
   const queryClient = useQueryClient();
+  const {
+    data: events = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['events', projectSlug, id],
+    queryFn: async ({ signal }) => {
+      const { events: list, hasMore: more } = await fetchEventsPage(
+        projectSlug,
+        id,
+        { limit: PAGE_SIZE },
+        signal,
+      );
+      setHasMore(more);
+      return mergeIssueEvents(
+        queryClient.getQueryData<AgentEventDto[]>(['events', projectSlug, id]),
+        list,
+      );
+    },
+  });
   const { byRun: runCosts } = useIssueCostsBreakdown(projectSlug, id);
   const { data: interventionDetails = [], isLoading: interventionsLoading } = useQuery({
     queryKey: interventionKeys.timeline(projectSlug, id),
@@ -50,34 +60,8 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
     open: true,
   });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setSseReadyAfter(null);
-    fetchEventsPage(projectSlug, id, { limit: PAGE_SIZE }, controller.signal)
-      .then(({ events: list, hasMore: more }) => {
-        if (cancelled) return;
-        setEvents(list);
-        setHasMore(more);
-        setCursor(list.at(-1)?.id);
-        // Open SSE from here — skip replay of events we already have.
-        setSseReadyAfter(list[0]?.id ?? 0);
-        setLoading(false);
-      })
-      .catch((err: Error) => {
-        if (cancelled) return;
-        setError(err.message);
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [projectSlug, id]);
-
   const loadMore = useCallback(async () => {
+    const cursor = events.at(-1)?.id;
     if (!hasMore || loadingMore || cursor == null) return;
     setLoadingMore(true);
     try {
@@ -85,79 +69,29 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
         limit: PAGE_SIZE,
         before: cursor,
       });
-      setEvents((prev) => [...prev, ...older]);
+      queryClient.setQueryData<AgentEventDto[]>(['events', projectSlug, id], (prev) =>
+        mergeIssueEvents(prev, older),
+      );
       setHasMore(more);
-      setCursor(older.at(-1)?.id);
     } finally {
       setLoadingMore(false);
     }
-  }, [hasMore, loadingMore, cursor, projectSlug, id]);
+  }, [events, hasMore, loadingMore, projectSlug, id, queryClient]);
 
-  // Live updates via SSE. Opens only after initial REST fetch so lastEventId
-  // skips the replay of events already loaded — no double-fetch.
-  useEffect(() => {
-    if (sseReadyAfter === null || !workItemId) return;
-    const params = new URLSearchParams({
-      projectId: projectSlug,
-      workItemId,
-      lastEventId: String(sseReadyAfter),
-    });
-    const es = new EventSource(`/events?${params}`);
-    eventSourceRef.current = es;
-    const handler = (msg: MessageEvent<string>) => {
-      try {
-        const parsed = JSON.parse(msg.data) as AgentEventDto;
-        if (!isIssueTimelineEvent(parsed)) return;
-        upsertIssueEvent(queryClient, projectSlug, id, parsed);
-        setEvents((prev) => {
-          if (prev.find((e) => e.id === parsed.id) != null) return prev;
-          return [parsed, ...prev];
-        });
-        if (parsed.kind === 'agent.run-completed' || parsed.kind === 'agent.run-failed') {
-          void queryClient.invalidateQueries({ queryKey: ['issue-costs', projectSlug, id] });
-        }
-        if (parsed.kind === 'state.transitioned') {
-          void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, id] });
-          void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
-          const payload = parsed.payload as {
-            interventionId?: string;
-            causedByInterventionId?: string;
-          } | null;
-          if (payload?.interventionId != null || payload?.causedByInterventionId != null) {
-            void queryClient.invalidateQueries({
-              queryKey: interventionKeys.timeline(projectSlug, id),
-            });
-          }
-        }
-      } catch {
-        // ignore
-      }
-    };
-    // Default 'message' fires only for SSE records without an `event:` field;
-    // named events fire on their event type.
-    for (const kind of ISSUE_TIMELINE_EVENT_KINDS) {
-      es.addEventListener(kind, handler as EventListener);
-    }
-    es.onmessage = handler;
-    es.onerror = () => {
-      // Connection blip; EventSource auto-reconnects.
-    };
-    return () => {
-      es.close();
-      eventSourceRef.current = null;
-    };
-  }, [projectSlug, workItemId, sseReadyAfter, queryClient, id]);
+  const visibleEvents = events.filter(isIssueTimelineEvent);
 
-  if (loading || (events.length === 0 && interventionsLoading)) {
+  if (isLoading || (visibleEvents.length === 0 && interventionsLoading)) {
     return <div className="px-8 py-6 text-fg-3">Loading timeline…</div>;
   }
 
   if (error != null) {
     return (
-      <div className="px-8 py-6 text-[color:var(--danger)]">Couldn't load timeline: {error}</div>
+      <div className="px-8 py-6 text-[color:var(--danger)]">
+        Couldn't load timeline: {error instanceof Error ? error.message : String(error)}
+      </div>
     );
   }
-  const items = groupEvents(events, interventionDetails);
+  const items = groupEvents(visibleEvents, interventionDetails);
   if (items.length === 0) {
     return (
       <div data-testid="timeline-section" className="px-8 py-6">
@@ -227,7 +161,7 @@ export function TimelineSection({ projectSlug, id, workItemId }: TimelineSection
         {items.map((item: RenderItem, idx: number) => renderTimelineItem(item, idx, context))}
       </ol>
 
-      {hasMore && (
+      {hasMore && visibleEvents.length >= PAGE_SIZE && (
         <div className="mt-4 flex justify-center">
           <button
             type="button"

--- a/apps/web/src/components/detail/lib/live-events.test.ts
+++ b/apps/web/src/components/detail/lib/live-events.test.ts
@@ -1,27 +1,35 @@
-import type { AgentEventDto } from '@/lib/types';
+import type { AgentEventDto, WorkItemDto } from '@/lib/types';
 import { QueryClient } from '@tanstack/react-query';
-import { describe, expect, it } from 'vitest';
-import { upsertIssueEvent } from './live-events';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyIssueTimelineEvent,
+  backfillIssueTimelineEvents,
+  upsertIssueEvent,
+} from './live-events';
 
-function makeEvent(id: number, kind = 'agent.investigation-complete'): AgentEventDto {
+function makeEvent(
+  id: number,
+  kind = 'agent.investigation-complete',
+  payload: AgentEventDto['payload'] = {},
+): AgentEventDto {
   return {
     id,
     projectId: 'p',
     workItemId: 'w1',
     kind,
-    payload: {},
+    payload,
     createdAt: new Date(Date.now() + id * 1000).toISOString(),
   };
 }
 
 describe('upsertIssueEvent', () => {
-  it('does not seed the issue events cache before the full events query loads', () => {
+  it('seeds the shared issue events cache when the first live event arrives', () => {
     const queryClient = new QueryClient();
     const event = makeEvent(2);
 
     upsertIssueEvent(queryClient, 'p', '1', event);
 
-    expect(queryClient.getQueryData(['events', 'p', '1'])).toBeUndefined();
+    expect(queryClient.getQueryData(['events', 'p', '1'])).toEqual([event]);
   });
 
   it('inserts a live event into an existing issue events cache', () => {
@@ -66,5 +74,94 @@ describe('upsertIssueEvent', () => {
     upsertIssueEvent(queryClient, 'p', '1', makeEvent(2));
 
     expect(queryClient.getQueryData(['events', 'p', '2'])).toEqual([otherEvent]);
+  });
+});
+
+describe('applyIssueTimelineEvent', () => {
+  it('patches state and invalidates dependent issue queries', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const issue = {
+      externalId: '1',
+      state: 'factory:in-progress',
+    } as WorkItemDto;
+    queryClient.setQueryData(['issue', 'p', '1'], issue);
+    queryClient.setQueryData(['issues', 'p'], [issue]);
+
+    applyIssueTimelineEvent(
+      queryClient,
+      'p',
+      '1',
+      makeEvent(2, 'state.transitioned', {
+        to: 'factory:needs-qa',
+        interventionId: 'int_1',
+      }),
+    );
+
+    expect(queryClient.getQueryData<WorkItemDto>(['issue', 'p', '1'])?.state).toBe(
+      'factory:needs-qa',
+    );
+    expect(queryClient.getQueryData<WorkItemDto[]>(['issues', 'p'])?.[0]?.state).toBe(
+      'factory:needs-qa',
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue', 'p', '1'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issues', 'p'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['intervention-timeline', 'p', '1'],
+    });
+  });
+
+  it('invalidates comments and costs for matching event kinds', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    applyIssueTimelineEvent(queryClient, 'p', '1', makeEvent(2, 'pr.opened'));
+    applyIssueTimelineEvent(queryClient, 'p', '1', makeEvent(3, 'agent.run-completed'));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['comments', 'p', '1'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue-costs', 'p', '1'] });
+  });
+});
+
+describe('backfillIssueTimelineEvents', () => {
+  it('pages after the cached cursor and applies transitions chronologically', async () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    queryClient.setQueryData(['events', 'p', '1'], [makeEvent(1, 'agent.run-started')]);
+    queryClient.setQueryData(['issue', 'p', '1'], {
+      externalId: '1',
+      state: 'factory:in-progress',
+    } as WorkItemDto);
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        events: [
+          makeEvent(3, 'state.transitioned', { to: 'factory:needs-qa' }),
+          makeEvent(2, 'pr.opened'),
+        ],
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        events: [makeEvent(5, 'state.transitioned', { to: 'factory:approved' })],
+        hasMore: false,
+      });
+
+    await backfillIssueTimelineEvents({
+      queryClient,
+      projectSlug: 'p',
+      issueId: '1',
+      fetchPage,
+      limit: 2,
+    });
+
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 'p', '1', { after: 1, limit: 2 });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 'p', '1', { after: 3, limit: 2 });
+    expect(queryClient.getQueryData<WorkItemDto>(['issue', 'p', '1'])?.state).toBe(
+      'factory:approved',
+    );
+    expect(
+      queryClient.getQueryData<AgentEventDto[]>(['events', 'p', '1'])?.map((e) => e.id),
+    ).toEqual([5, 3, 2, 1]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['comments', 'p', '1'] });
   });
 });

--- a/apps/web/src/components/detail/lib/live-events.ts
+++ b/apps/web/src/components/detail/lib/live-events.ts
@@ -1,5 +1,27 @@
-import type { AgentEventDto } from '@/lib/types';
+import type { AgentEventDto, WorkItemDto } from '@/lib/types';
+import { interventionKeys } from '@/lib/query-keys';
+import { isIssueTimelineEvent } from '@goose-hub/core/event-stream/issue-timeline.js';
 import type { QueryClient } from '@tanstack/react-query';
+
+type StateTransitionPayload = {
+  to?: unknown;
+};
+
+type FetchEventsPage = (
+  projectSlug: string,
+  issueId: string,
+  opts: { limit?: number; after?: number },
+) => Promise<{ events: AgentEventDto[]; hasMore: boolean }>;
+
+export function mergeIssueEvents(
+  existing: AgentEventDto[] | undefined,
+  incoming: AgentEventDto[],
+): AgentEventDto[] {
+  const byId = new Map<number, AgentEventDto>();
+  for (const event of existing ?? []) byId.set(event.id, event);
+  for (const event of incoming) byId.set(event.id, event);
+  return [...byId.values()].sort((a, b) => b.id - a.id);
+}
 
 export function upsertIssueEvent(
   queryClient: QueryClient,
@@ -8,9 +30,127 @@ export function upsertIssueEvent(
   event: AgentEventDto,
 ): void {
   queryClient.setQueryData<AgentEventDto[]>(['events', projectSlug, issueId], (existing) => {
-    // Avoid seeding a partial SSE-only cache before the full events query has loaded.
-    if (existing == null) return existing;
-    if (existing.some((candidate) => candidate.id === event.id)) return existing;
-    return [event, ...existing].sort((a, b) => b.id - a.id);
+    if (existing?.some((candidate) => candidate.id === event.id)) return existing;
+    return mergeIssueEvents(existing, [event]);
   });
+}
+
+export function latestTransitionState(events: AgentEventDto[] | undefined): string | null {
+  const latest = (events ?? []).find((event) => event.kind === 'state.transitioned');
+  const payload = latest?.payload as StateTransitionPayload | null | undefined;
+  return typeof payload?.to === 'string' ? payload.to : null;
+}
+
+export function applyLatestEventState<T extends WorkItemDto>(
+  item: T,
+  events: AgentEventDto[] | undefined,
+): T {
+  const state = latestTransitionState(events);
+  return state != null && item.state !== state ? { ...item, state } : item;
+}
+
+export function patchIssueStateFromTransition(
+  queryClient: QueryClient,
+  projectSlug: string,
+  issueId: string,
+  event: AgentEventDto,
+): void {
+  if (event.kind !== 'state.transitioned') return;
+  const payload = event.payload as StateTransitionPayload | null | undefined;
+  if (typeof payload?.to !== 'string') return;
+
+  queryClient.setQueryData<WorkItemDto>(['issue', projectSlug, issueId], (existing) =>
+    existing == null ? existing : { ...existing, state: payload.to as string },
+  );
+  queryClient.setQueryData<WorkItemDto[]>(['issues', projectSlug], (existing) =>
+    existing?.map((item) =>
+      item.externalId === issueId ? { ...item, state: payload.to as string } : item,
+    ),
+  );
+}
+
+export function applyIssueTimelineEvent(
+  queryClient: QueryClient,
+  projectSlug: string,
+  issueId: string,
+  event: AgentEventDto,
+): boolean {
+  if (!isIssueTimelineEvent(event)) return false;
+
+  upsertIssueEvent(queryClient, projectSlug, issueId, event);
+
+  if (event.kind === 'state.transitioned') {
+    patchIssueStateFromTransition(queryClient, projectSlug, issueId, event);
+    void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, issueId] });
+    void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
+    const payload = event.payload as {
+      interventionId?: string;
+      causedByInterventionId?: string;
+    } | null;
+    if (payload?.interventionId != null || payload?.causedByInterventionId != null) {
+      void queryClient.invalidateQueries({
+        queryKey: interventionKeys.timeline(projectSlug, issueId),
+      });
+    }
+  }
+
+  if (
+    event.kind === 'grill.question-posted' ||
+    event.kind === 'gate.awaiting-human' ||
+    event.kind === 'gate.approved' ||
+    event.kind === 'gate.rejected' ||
+    event.kind === 'prd.drafted' ||
+    event.kind === 'evidence.posted' ||
+    event.kind === 'evidence.post-failed' ||
+    event.kind === 'pr.opened' ||
+    event.kind === 'pr.merged' ||
+    event.kind === 'merge.conflict'
+  ) {
+    void queryClient.invalidateQueries({ queryKey: ['comments', projectSlug, issueId] });
+  }
+
+  if (
+    event.kind === 'agent.run-completed' ||
+    event.kind === 'agent.run-failed' ||
+    event.kind === 'agent.budget-exceeded' ||
+    event.kind === 'agent.discovery-budget-exceeded' ||
+    event.kind === 'project.budget-exceeded'
+  ) {
+    void queryClient.invalidateQueries({ queryKey: ['issue-costs', projectSlug, issueId] });
+  }
+
+  return true;
+}
+
+export async function backfillIssueTimelineEvents(input: {
+  queryClient: QueryClient;
+  projectSlug: string;
+  issueId: string;
+  fetchPage: FetchEventsPage;
+  limit: number;
+}): Promise<void> {
+  const cached =
+    input.queryClient.getQueryData<AgentEventDto[]>(['events', input.projectSlug, input.issueId]) ??
+    [];
+  let after = cached[0]?.id;
+  if (after == null) return;
+
+  for (;;) {
+    const page = await input.fetchPage(input.projectSlug, input.issueId, {
+      after,
+      limit: input.limit,
+    });
+    if (page.events.length === 0) break;
+
+    const chronological = page.events
+      .filter(isIssueTimelineEvent)
+      .sort((left, right) => left.id - right.id);
+    for (const event of chronological) {
+      applyIssueTimelineEvent(input.queryClient, input.projectSlug, input.issueId, event);
+    }
+
+    const newestSeen = page.events.reduce((max, event) => Math.max(max, event.id), after);
+    if (!page.hasMore || newestSeen <= after) break;
+    after = newestSeen;
+  }
 }

--- a/apps/web/src/lib/api/issues.ts
+++ b/apps/web/src/lib/api/issues.ts
@@ -104,11 +104,12 @@ export async function fetchEvents(
 export async function fetchEventsPage(
   slug: string,
   id: string,
-  opts?: { limit?: number; before?: number },
+  opts?: { limit?: number; before?: number; after?: number },
   signal?: AbortSignal,
 ): Promise<{ events: AgentEventDto[]; hasMore: boolean }> {
   const params = new URLSearchParams({ limit: String(opts?.limit ?? 200) });
   if (opts?.before != null) params.set('before', String(opts.before));
+  if (opts?.after != null) params.set('after', String(opts.after));
   return getJson<{ events: AgentEventDto[]; hasMore: boolean }>(
     `/projects/${slug}/issues/${id}/events?${params}`,
     signal,

--- a/core/event-stream/state-transition.test.ts
+++ b/core/event-stream/state-transition.test.ts
@@ -1,0 +1,164 @@
+import { sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { db } from '../db/db.js';
+import { events } from '../db/schema.js';
+import type { StateName } from '../state-machine/states.js';
+import type { StateSource } from '../state-source/interface.js';
+import { eventStore } from './store.js';
+import { transitionAndEmitState } from './state-transition.js';
+
+const PROJECT = 'test-state-transition-wrapper';
+const WORK_ITEM_ID = 'github:owner/repo#42';
+
+function makeSource(overrides: Partial<StateSource> = {}): StateSource {
+  return {
+    projectId: PROJECT,
+    repoRef: 'owner/repo',
+    listOpenWork: vi.fn(),
+    listClosedWorkByMilestone: vi.fn(),
+    listWorkByMilestone: vi.fn(),
+    getItem: vi.fn(),
+    listMilestones: vi.fn(),
+    getActiveMilestone: vi.fn(),
+    transitionState: vi.fn().mockResolvedValue(undefined),
+    forceState: vi.fn().mockResolvedValue(undefined),
+    comment: vi.fn(),
+    listComments: vi.fn(),
+    setMilestone: vi.fn(),
+    setLabelInGroup: vi.fn(),
+    addLabels: vi.fn(),
+    removeLabel: vi.fn(),
+    attach: vi.fn(),
+    createIssue: vi.fn(),
+    createMilestone: vi.fn(),
+    updateMilestone: vi.fn(),
+    deleteMilestone: vi.fn(),
+    getPrDiff: vi.fn(),
+    watchForUpdates: vi.fn(),
+    ...overrides,
+  } as StateSource;
+}
+
+describe('transitionAndEmitState', () => {
+  beforeAll(() => {
+    db.run(sql`CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      project_id TEXT NOT NULL,
+      work_item_id TEXT,
+      kind TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      run_id TEXT,
+      persona_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (current_timestamp)
+    )`);
+    db.delete(events).where(sql`project_id = ${PROJECT}`).run();
+  });
+
+  it('uses legal transitionState and emits after the mutation succeeds', async () => {
+    const source = makeSource();
+
+    await transitionAndEmitState({
+      mode: 'legal',
+      source,
+      itemId: '42',
+      projectId: PROJECT,
+      workItemId: WORK_ITEM_ID,
+      from: 'factory:prd-drafting',
+      to: 'factory:prd-review',
+      by: 'write-prd',
+      runId: 'run-1',
+    });
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:prd-drafting',
+      'factory:prd-review',
+    );
+    expect(source.forceState).not.toHaveBeenCalled();
+    const [event] = eventStore.replay({ projectId: PROJECT, runId: 'run-1' });
+    expect(event).toMatchObject({
+      kind: 'state.transitioned',
+      workItemId: WORK_ITEM_ID,
+      payload: {
+        from: 'factory:prd-drafting',
+        to: 'factory:prd-review',
+        by: 'write-prd',
+      },
+    });
+  });
+
+  it('uses forceState and marks known forced transitions', async () => {
+    const source = makeSource();
+
+    await transitionAndEmitState({
+      mode: 'forced',
+      source,
+      itemId: '42',
+      projectId: PROJECT,
+      workItemId: WORK_ITEM_ID,
+      from: 'factory:decomposing',
+      to: 'factory:needs-human',
+      by: 'decompose-prd',
+      runId: 'run-forced',
+      reason: 'schema failed',
+    });
+
+    expect(source.forceState).toHaveBeenCalledWith('42', 'factory:needs-human');
+    const [event] = eventStore.replay({ projectId: PROJECT, runId: 'run-forced' });
+    expect(event?.payload).toMatchObject({
+      from: 'factory:decomposing',
+      to: 'factory:needs-human',
+      by: 'decompose-prd',
+      forced: true,
+      previousStateKnown: true,
+      reason: 'schema failed',
+    });
+  });
+
+  it('marks forced transitions when the previous state is unknown', async () => {
+    const source = makeSource();
+
+    await transitionAndEmitState({
+      mode: 'forced',
+      source,
+      itemId: '42',
+      projectId: PROJECT,
+      workItemId: WORK_ITEM_ID,
+      to: 'factory:needs-human',
+      by: 'manual-recovery',
+      runId: 'run-unknown',
+    });
+
+    const [event] = eventStore.replay({ projectId: PROJECT, runId: 'run-unknown' });
+    expect(event?.payload).toMatchObject({
+      from: null,
+      to: 'factory:needs-human',
+      forced: true,
+      previousStateKnown: false,
+    });
+  });
+
+  it('does not emit state.transitioned when the source mutation fails', async () => {
+    const source = makeSource({
+      transitionState: vi.fn().mockRejectedValue(new Error('illegal transition')),
+    });
+    const before = eventStore.replay({ projectId: PROJECT }).length;
+
+    await expect(
+      transitionAndEmitState({
+        mode: 'legal',
+        source,
+        itemId: '42',
+        projectId: PROJECT,
+        workItemId: WORK_ITEM_ID,
+        from: 'factory:accepted' as StateName,
+        to: 'factory:done',
+        by: 'test',
+        runId: 'run-fail',
+      }),
+    ).rejects.toThrow('illegal transition');
+
+    const after = eventStore.replay({ projectId: PROJECT }).length;
+    expect(after).toBe(before);
+  });
+});

--- a/core/event-stream/state-transition.ts
+++ b/core/event-stream/state-transition.ts
@@ -1,10 +1,11 @@
 import type { StateName } from '../state-machine/states.js';
+import type { StateSource } from '../state-source/interface.js';
 import { eventStore } from './store.js';
 
 export interface EmitStateTransitionEventInput {
   projectId: string;
   workItemId: string;
-  from: StateName;
+  from?: StateName;
   to: StateName;
   by: string;
   runId?: string;
@@ -16,7 +17,71 @@ export function emitStateTransitionEvent(input: EmitStateTransitionEventInput): 
     projectId: input.projectId,
     workItemId: input.workItemId,
     kind: 'state.transitioned',
-    payload: { ...input.extraPayload, from: input.from, to: input.to, by: input.by },
+    payload: {
+      ...input.extraPayload,
+      from: input.from ?? null,
+      to: input.to,
+      by: input.by,
+    },
     ...(input.runId != null ? { runId: input.runId } : {}),
+  });
+}
+
+interface TransitionEventFields {
+  source: StateSource;
+  itemId: string;
+  projectId: string;
+  workItemId: string;
+  to: StateName;
+  by: string;
+  runId?: string;
+  note?: string;
+  extraPayload?: Record<string, unknown>;
+}
+
+export type TransitionAndEmitStateInput =
+  | (TransitionEventFields & {
+      mode: 'legal';
+      from: StateName;
+    })
+  | (TransitionEventFields & {
+      mode: 'forced';
+      from?: StateName;
+      reason?: string;
+    });
+
+export async function transitionAndEmitState(input: TransitionAndEmitStateInput): Promise<void> {
+  if (input.mode === 'legal') {
+    if (input.note != null) {
+      await input.source.transitionState(input.itemId, input.from, input.to, input.note);
+    } else {
+      await input.source.transitionState(input.itemId, input.from, input.to);
+    }
+    emitStateTransitionEvent({
+      projectId: input.projectId,
+      workItemId: input.workItemId,
+      from: input.from,
+      to: input.to,
+      by: input.by,
+      runId: input.runId,
+      extraPayload: input.extraPayload,
+    });
+    return;
+  }
+
+  await input.source.forceState(input.itemId, input.to);
+  emitStateTransitionEvent({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    from: input.from,
+    to: input.to,
+    by: input.by,
+    runId: input.runId,
+    extraPayload: {
+      ...input.extraPayload,
+      forced: true,
+      previousStateKnown: input.from != null,
+      ...(input.reason != null ? { reason: input.reason } : {}),
+    },
   });
 }

--- a/core/tool-layer/mcp/tools/workflow.ts
+++ b/core/tool-layer/mcp/tools/workflow.ts
@@ -18,6 +18,7 @@
  */
 import type { z } from 'zod';
 import { openPR } from '../../../connectors/github/open-pr.js';
+import { transitionAndEmitState } from '../../../event-stream/state-transition.js';
 import type { StateName } from '../../../state-machine/states.js';
 import { emitBlockedToolCall, emitToolCall } from '../audit.js';
 import { type CommandResult, minimalEnv, runCommand } from '../command-policy.js';
@@ -325,7 +326,17 @@ export async function transitionStateTool(
   const itemId = `github:${source.repoRef}#${input.issueNumber}`;
   const current = await source.getItem(itemId);
   const to = input.to as StateName;
-  await source.transitionState(itemId, current.state, to);
+  await transitionAndEmitState({
+    mode: 'legal',
+    source,
+    itemId,
+    projectId: ctx.projectId,
+    workItemId: current.id,
+    from: current.state,
+    to,
+    by: 'mcp.transition_state',
+    runId: ctx.runId,
+  });
 
   emitToolCall(ctx, {
     tool: 'transition_state',

--- a/core/workflows/decompose-prd.ts
+++ b/core/workflows/decompose-prd.ts
@@ -6,6 +6,7 @@ import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions
 import { resolveProjectAgentExecution } from '../agent-runtime/resolve-runtime-for-project.js';
 import { toJsonSchema } from '../agent-runtime/schema-bridge.js';
 import { selectPersona } from '../agent-runtime/select-persona.js';
+import { transitionAndEmitState } from '../event-stream/state-transition.js';
 import { eventStore } from '../event-stream/store.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { StateSource, WorkItem } from '../state-source/interface.js';
@@ -113,7 +114,18 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
       });
       // factory:decomposing only allows factory:issues-created or factory:archived as
       // legal transitions, so we use forceState to escape to factory:needs-human.
-      await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+      await transitionAndEmitState({
+        mode: 'forced',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:decomposing',
+        to: 'factory:needs-human',
+        by: skillName,
+        runId,
+        reason: 'invalid-output',
+      });
       return { childIssueNumbers: [] };
     }
 
@@ -130,7 +142,18 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
         );
         // Use forceState because factory:decomposing → factory:needs-human is not a
         // legal transition in the state machine; forceState bypasses the guard.
-        await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+        await transitionAndEmitState({
+          mode: 'forced',
+          source: stateSource,
+          itemId: workItem.externalId,
+          projectId,
+          workItemId: workItem.id,
+          from: 'factory:decomposing',
+          to: 'factory:needs-human',
+          by: skillName,
+          runId,
+          reason: 'duplicate-child-title',
+        });
         return { childIssueNumbers: [] };
       }
       seen.add(title);
@@ -275,16 +298,28 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
     // setLabelInGroup only supports 'priority' | 'schedule' | 'type', so
     // 'factory:issues-created' cannot be applied via that method.
     // Posting a comment to note the intended label, then transitioning state.
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:decomposing',
-      'factory:issues-created',
-    );
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:issues-created',
-      'factory:done',
-    );
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:decomposing',
+      to: 'factory:issues-created',
+      by: skillName,
+      runId,
+    });
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:issues-created',
+      to: 'factory:done',
+      by: skillName,
+      runId,
+    });
 
     // Step 8: Emit decision summaries
     reconcileDecisionSummaries(runId, projectId, workItem.id, skillName, decisionSummaries);
@@ -307,7 +342,18 @@ export async function runDecomposePrdWorkflow(input: RunDecomposeInput): Promise
       runId,
       payload: { skill: skillName, error: String(err) },
     });
-    await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:decomposing',
+      to: 'factory:needs-human',
+      by: skillName,
+      runId,
+      reason: 'workflow-error',
+    });
     throw err;
   }
 }

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -14,7 +14,7 @@ import type { PRDOutput } from '../../skills/write-prd/schema.js';
 import type { AgentRuntime } from '../agent-runtime/interface.js';
 import { reconcileDecisionSummaries } from '../agent-runtime/reconcile-decisions.js';
 import { totalSpendForSkill as _totalSpendForSkill } from '../cost/repository.js';
-import { emitStateTransitionEvent } from '../event-stream/state-transition.js';
+import { transitionAndEmitState } from '../event-stream/state-transition.js';
 import { eventStore } from '../event-stream/store.js';
 import { getProjectBySlug } from '../projects/loader.js';
 import type { StateName } from '../state-machine/states.js';
@@ -213,18 +213,31 @@ async function ensureGatePending(
 ): Promise<void> {
   if (fromState === 'factory:gate-pending') return;
   try {
-    await stateSource.transitionState(externalId, fromState, 'factory:gate-pending');
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: externalId,
+      projectId,
+      workItemId,
+      from: fromState,
+      to: 'factory:gate-pending',
+      by: 'grill-and-prd',
+      extraPayload: { discoverSessionId },
+    });
   } catch {
-    await stateSource.forceState(externalId, 'factory:gate-pending');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: externalId,
+      projectId,
+      workItemId,
+      from: fromState,
+      to: 'factory:gate-pending',
+      by: 'grill-and-prd',
+      reason: 'gate-pending-legal-transition-unavailable',
+      extraPayload: { discoverSessionId },
+    });
   }
-  emitStateTransitionEvent({
-    projectId,
-    workItemId,
-    from: fromState,
-    to: 'factory:gate-pending',
-    by: 'grill-and-prd',
-    extraPayload: { discoverSessionId },
-  });
 }
 
 export async function runGrillAndPrdWorkflow(
@@ -356,7 +369,18 @@ export async function runGrillAndPrdWorkflow(
       workItem.externalId,
       '<!-- factory:system -->\nGrill cannot run: project is missing `targetRepo.localPath`. Configure it in `target-projects/<slug>/project.config.ts` and resume.',
     );
-    await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: workItem.state,
+      to: 'factory:needs-human',
+      by: 'grill-and-prd',
+      runId: workflowRunId,
+      reason: 'target-repo-local-path-missing',
+    });
     return { phase: 'needs-human' };
   }
 
@@ -618,16 +642,44 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
 
   try {
     if (workItem.state === 'factory:grilling') {
-      await stateSource.transitionState(
-        workItem.externalId,
-        'factory:grilling',
-        'factory:prd-drafting',
-      );
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:grilling',
+        to: 'factory:prd-drafting',
+        by: 'grill-and-prd',
+        runId: workflowRunId,
+      });
     } else {
-      await stateSource.forceState(workItem.externalId, 'factory:prd-drafting');
+      await transitionAndEmitState({
+        mode: 'forced',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: workItem.state,
+        to: 'factory:prd-drafting',
+        by: 'grill-and-prd',
+        runId: workflowRunId,
+        reason: 'resume-prd-draft',
+      });
     }
   } catch {
-    await stateSource.forceState(workItem.externalId, 'factory:prd-drafting');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: workItem.state,
+      to: 'factory:prd-drafting',
+      by: 'grill-and-prd',
+      runId: workflowRunId,
+      reason: 'legal-draft-transition-failed',
+    });
   }
 
   const prdRunId = `${workflowRunId}:write-prd`;
@@ -715,7 +767,18 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
         error: advisorOutcome.error,
       },
     });
-    await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:prd-drafting',
+      to: 'factory:needs-human',
+      by: 'write-prd',
+      runId: advisorRunId,
+      reason: 'advisor-failed',
+    });
     return { phase: 'needs-human' };
   } else {
     prdOutput = advisorOutcome.prdOutput;
@@ -737,11 +800,17 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
 
   try {
     await stateSource.comment(workItem.externalId, commentBody);
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:prd-drafting',
-      'factory:prd-review',
-    );
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:prd-drafting',
+      to: 'factory:prd-review',
+      by: 'write-prd',
+      runId: prdRunId,
+    });
   } catch (err) {
     eventStore.appendEvent({
       kind: 'agent.run-failed',
@@ -750,7 +819,18 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
       runId: workflowRunId,
       payload: { skill: 'grill-and-prd', workflowRunId, discoverSessionId, error: String(err) },
     });
-    await stateSource.forceState(workItem.externalId, 'factory:needs-human');
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:prd-drafting',
+      to: 'factory:needs-human',
+      by: 'write-prd',
+      runId: prdRunId,
+      reason: 'prd-comment-or-transition-failed',
+    });
     return { phase: 'needs-human' };
   }
 

--- a/core/workflows/retrospective.ts
+++ b/core/workflows/retrospective.ts
@@ -10,6 +10,7 @@ import { selectPersona } from '../agent-runtime/select-persona.js';
 import { runCodeQualityAudit } from '../audit/run-audit.js';
 import { db } from '../db/db.js';
 import { improvementCandidates } from '../db/schema.js';
+import { transitionAndEmitState } from '../event-stream/state-transition.js';
 import { eventStore } from '../event-stream/store.js';
 import { archiveLifecycle } from '../learning/archive.js';
 import { computeTrend } from '../learning/convergence.js';
@@ -205,11 +206,17 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
         payload: { skill: skillName, error: parsed.error.message },
       });
       accumulatePersonaStats({ personaName: personaId, role: 'retrospector', outcome: 'failure' });
-      await stateSource.transitionState(
-        workItem.externalId,
-        'factory:retrospecting',
-        'factory:needs-human',
-      );
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:retrospecting',
+        to: 'factory:needs-human',
+        by: skillName,
+        runId,
+      });
       return;
     }
 
@@ -276,16 +283,33 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
     }
 
     if (auditAutonomyGateFired) {
-      await stateSource.transitionState(
-        workItem.externalId,
-        'factory:retrospecting',
-        'factory:needs-human',
-      );
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:retrospecting',
+        to: 'factory:needs-human',
+        by: skillName,
+        runId,
+        extraPayload: { auditAutonomyGateFired: true },
+      });
       // Skip archive — the lifecycle hasn't reached factory:done.
       return;
     }
 
-    await stateSource.transitionState(workItem.externalId, 'factory:retrospecting', 'factory:done');
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:retrospecting',
+      to: 'factory:done',
+      by: skillName,
+      runId,
+    });
     // Archive only after the state transition succeeds — otherwise a transition
     // failure would leave a phantom archive row for a lifecycle that never
     // reached factory:done, skewing future mining and trend output.
@@ -309,10 +333,16 @@ export async function runRetrospectiveWorkflow(input: RunRetrospectiveInput): Pr
       runId,
       payload: { skill: skillName, error: String(err) },
     });
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:retrospecting',
-      'factory:needs-human',
-    );
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:retrospecting',
+      to: 'factory:needs-human',
+      by: skillName,
+      runId,
+    });
   }
 }

--- a/skills/playwright-repro/schema.ts
+++ b/skills/playwright-repro/schema.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod';
+import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
+
+export { DecisionSummarySchema };
 
 const RepoRelativePathDescription =
   'Repo-root/worktree-root relative POSIX path. Do not use package-relative paths like src/... for files under apps/web; use apps/web/src/....';
@@ -33,6 +36,7 @@ export const PlaywrightReproSpecSchema = z.object({
     .string()
     .describe('Short statement of the evidence this spec is intended to capture'),
   notes: z.string().optional(),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
 });
 
 export const PlaywrightReproSchema = z.object({
@@ -75,6 +79,7 @@ export const PlaywrightReproSchema = z.object({
     .url()
     .optional()
     .describe('Permalink to the BEFORE-state comment posted on the linked issue'),
+  decisionSummaries: z.array(DecisionSummarySchema).min(1),
 });
 
 export type InvestigationReproPacket = z.infer<typeof InvestigationReproPacketSchema>;

--- a/skills/playwright-repro/slice.test.ts
+++ b/skills/playwright-repro/slice.test.ts
@@ -7,6 +7,7 @@ import { PlaywrightReproSchema, PlaywrightReproSpecSchema } from './schema.js';
 import config, { PlaywrightReproContextSchema } from './skill.config.js';
 
 const PROMPT = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'prompt.md'), 'utf8');
+const decisionSummaries = [{ kind: 'PLAN', summary: 'Captured browser repro evidence.' }];
 
 describe('playwright-repro schema', () => {
   it('accepts valid spec-plan output', () => {
@@ -19,6 +20,7 @@ describe('playwright-repro schema', () => {
       expectedAssertion: 'Login error remains visible after submit',
       reproSteps: ['Navigate to /login', 'Submit credentials'],
       evidenceIntent: 'Capture the login error before the fix.',
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -51,6 +53,7 @@ describe('playwright-repro schema', () => {
       reproduced: true,
       notes: 'Bug reproduced consistently on step 2.',
       commentUrl: 'https://github.com/shaunnez/goose-hub/issues/42#issuecomment-9876543210',
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -63,6 +66,7 @@ describe('playwright-repro schema', () => {
       reproSteps: ['Navigate to /login', 'Enter credentials'],
       reproduced: false,
       notes: 'Could not reproduce — login succeeded with provided credentials.',
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -74,6 +78,7 @@ describe('playwright-repro schema', () => {
       consoleErrors: [],
       reproSteps: ['Navigate to /dashboard'],
       reproduced: true,
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -85,6 +90,7 @@ describe('playwright-repro schema', () => {
       consoleErrors: [],
       reproSteps: ['Navigate to /home'],
       reproduced: false,
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -96,6 +102,7 @@ describe('playwright-repro schema', () => {
       consoleErrors: [{ message: 'Warning: something deprecated', type: 'warning' }],
       reproSteps: ['Navigate to /settings'],
       reproduced: false,
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });
@@ -111,6 +118,7 @@ describe('playwright-repro schema', () => {
       ],
       reproSteps: ['Navigate to /'],
       reproduced: false,
+      decisionSummaries,
     });
     expect(result.success).toBe(true);
   });

--- a/slices/fix-issue/pr-helpers.ts
+++ b/slices/fix-issue/pr-helpers.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { findFreePort } from '@goose-hub/core/agent-runtime/find-free-port.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { getEvidencePostEnabled } from '@goose-hub/core/db/repositories/project-settings.js';
@@ -155,6 +156,13 @@ export async function runEvidencePost(input: RunEvidencePostInput): Promise<void
     if (!parsed.data.commentUrl) {
       throw new Error('evidence-post returned no commentUrl — evidence comment was not posted');
     }
+    reconcileDecisionSummaries(
+      evidenceRunId,
+      input.projectId,
+      input.workItem.id,
+      'evidence-post',
+      parsed.data.decisionSummaries,
+    );
     eventStore.appendEvent({
       projectId: input.projectId,
       workItemId: input.workItem.id,

--- a/slices/investigate/playwright-repro-evidence.test.ts
+++ b/slices/investigate/playwright-repro-evidence.test.ts
@@ -70,6 +70,7 @@ describe('playwright repro evidence workflow helper', () => {
         expectedAssertion: 'Error banner remains visible',
         reproSteps: ['Navigate to /login'],
         evidenceIntent: 'Capture the BEFORE login error.',
+        decisionSummaries: [{ kind: 'PLAN', summary: 'Generate a browser repro spec.' }],
       },
       publisher: { execFileSync: execFileSync as never, spawnSync: spawnSync as never, collect },
     });
@@ -110,6 +111,7 @@ describe('playwright repro evidence workflow helper', () => {
         expectedAssertion: 'Error banner remains visible',
         reproSteps: ['Navigate to /login'],
         evidenceIntent: 'Capture the BEFORE login error.',
+        decisionSummaries: [{ kind: 'PLAN', summary: 'Assemble browser repro evidence.' }],
       },
       evidence: {
         issue: 42,
@@ -154,6 +156,7 @@ describe('playwright repro evidence workflow helper', () => {
           expectedAssertion: 'Error banner remains visible',
           reproSteps: ['Navigate to /login'],
           evidenceIntent: 'Capture the BEFORE login error.',
+          decisionSummaries: [{ kind: 'PLAN', summary: 'Reject unsafe repro paths.' }],
         },
         publisher: { spawnSync: spawnSync as never },
       }),

--- a/slices/investigate/playwright-repro-evidence.ts
+++ b/slices/investigate/playwright-repro-evidence.ts
@@ -193,6 +193,7 @@ export function assemblePlaywrightReproPayload(params: {
     reproduced: params.evidence.classification === 'reproduced',
     notes: params.evidence.notes,
     ...(params.commentUrl != null ? { commentUrl: params.commentUrl } : {}),
+    decisionSummaries: params.plan.decisionSummaries,
   };
 }
 

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -23,7 +23,7 @@ import {
   getPlaywrightReproEnabled,
   getUseInvestigationSwarm,
 } from '@goose-hub/core/db/repositories/project-settings.js';
-import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
@@ -460,11 +460,18 @@ export async function runInvestigateWorkflow(
             [`Failed scouts: ${wave1Result.failedScouts.join(', ')}`],
           ),
         );
-        await stateSource.transitionState(
-          workItem.externalId,
-          'factory:investigating',
-          'factory:needs-human',
-        );
+        await transitionAndEmitState({
+          mode: 'legal',
+          source: stateSource,
+          itemId: workItem.externalId,
+          projectId,
+          workItemId: workItem.id,
+          from: 'factory:investigating',
+          to: 'factory:needs-human',
+          by: 'investigate',
+          runId,
+          extraPayload: { reason: 'wave-halted' },
+        });
         return;
       }
       if (!wave1Result.shouldAdvance) {
@@ -491,11 +498,18 @@ export async function runInvestigateWorkflow(
             ],
           ),
         );
-        await stateSource.transitionState(
-          workItem.externalId,
-          'factory:investigating',
-          'factory:needs-human',
-        );
+        await transitionAndEmitState({
+          mode: 'legal',
+          source: stateSource,
+          itemId: workItem.externalId,
+          projectId,
+          workItemId: workItem.id,
+          from: 'factory:investigating',
+          to: 'factory:needs-human',
+          by: 'investigate',
+          runId,
+          extraPayload: { reason: 'wave-incomplete' },
+        });
         return;
       }
 
@@ -744,6 +758,13 @@ export async function runInvestigateWorkflow(
             playwrightResult.output,
           );
           if (planParsed.success) {
+            reconcileDecisionSummaries(
+              playwrightRunId,
+              projectId,
+              workItem.id,
+              'playwright-repro',
+              planParsed.data.decisionSummaries,
+            );
             reproOutput = (deps.playwrightEvidenceRunner ?? runPlaywrightReproPlan)({
               plan: planParsed.data,
               workspaceDir: worktreePath,
@@ -752,6 +773,13 @@ export async function runInvestigateWorkflow(
             });
           } else if (finalParsed.success) {
             // Backward-compatible while older agents still return the final payload.
+            reconcileDecisionSummaries(
+              playwrightRunId,
+              projectId,
+              workItem.id,
+              'playwright-repro',
+              finalParsed.data.decisionSummaries,
+            );
             reproOutput = finalParsed.data;
           } else {
             const preview =
@@ -820,17 +848,15 @@ export async function runInvestigateWorkflow(
     });
 
     accumulatePersonaStats({ personaName: personaId, role: 'investigator', outcome: 'success' });
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:investigating',
-      'factory:investigation-complete',
-    );
-    emitStateTransitionEvent({
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
       projectId,
       workItemId: workItem.id,
       from: 'factory:investigating',
       to: 'factory:investigation-complete',
-      by: 'agent',
+      by: 'investigate',
       runId,
     });
   } catch (err) {
@@ -858,11 +884,18 @@ export async function runInvestigateWorkflow(
       ),
     );
 
-    await stateSource.transitionState(
-      workItem.externalId,
-      'factory:investigating',
-      'factory:needs-human',
-    );
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:investigating',
+      to: 'factory:needs-human',
+      by: 'investigate',
+      runId,
+      extraPayload: { reason: 'workflow-error' },
+    });
   } finally {
     cleanupWorktree(runId);
   }

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -7,6 +7,7 @@ import type {
 } from '@goose-hub/core/agent-runtime/interface.js';
 import type { InvestigationContext } from '@goose-hub/core/agent-runtime/investigation-context.js';
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
+import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
 import { getRecordDecisionTool } from '@goose-hub/core/db/repositories/project-settings.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -398,6 +399,13 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     return { status: 'failed', wpId: wp.id, errorReason: reason, runId: wpRunId };
   }
   const output = ImplementWpSchema.parse(normalized.output);
+  reconcileDecisionSummaries(
+    wpRunId,
+    projectId,
+    workItemId ?? null,
+    'implement-wp',
+    output.decisionSummaries,
+  );
 
   // Build succeeded — return files for the serial commit phase.
   const commitMsg = `M:${wp.id} ${wp.changes.slice(0, 60)}\n\nBuilt by ${opts.personaId}`;

--- a/slices/resolve-conflict/slice.test.ts
+++ b/slices/resolve-conflict/slice.test.ts
@@ -110,6 +110,28 @@ const SUCCESS_AGENT_OUTPUT: AgentResult = {
   events: [],
 };
 
+function expectStateTransitionEvent(to: string) {
+  const event = vi
+    .mocked(eventStore.appendEvent)
+    .mock.calls.find(
+      ([candidate]) =>
+        candidate.kind === 'state.transitioned' &&
+        (candidate.payload as { to?: string } | undefined)?.to === to,
+    )?.[0];
+  expect(event).toEqual(
+    expect.objectContaining({
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#42',
+      kind: 'state.transitioned',
+      payload: expect.objectContaining({
+        from: 'factory:merge-conflict',
+        to,
+        by: 'resolve-conflict',
+      }),
+    }),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // Default: file content is clean (no conflict markers).
@@ -131,6 +153,7 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:needs-human',
     );
+    expectStateTransitionEvent('factory:needs-human');
     expect(source.comment).toHaveBeenCalledWith(
       '42',
       expect.stringContaining('No pr.opened event found'),
@@ -171,6 +194,7 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:retrospecting',
     );
+    expectStateTransitionEvent('factory:retrospecting');
     const resolvedEvent = vi
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'merge.conflict-resolved');
@@ -220,6 +244,7 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:needs-human',
     );
+    expectStateTransitionEvent('factory:needs-human');
     expect(source.comment).toHaveBeenCalledWith(
       '42',
       expect.stringContaining('https://github.com/owner/repo/pull/99'),
@@ -265,6 +290,7 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:needs-human',
     );
+    expectStateTransitionEvent('factory:needs-human');
   });
 
   it('defensive scan: resolved file still has markers → transitions to needs-human', async () => {
@@ -304,6 +330,7 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:needs-human',
     );
+    expectStateTransitionEvent('factory:needs-human');
     const unresolvable = vi
       .mocked(eventStore.appendEvent)
       .mock.calls.find(([e]) => e.kind === 'merge.conflict-unresolvable');
@@ -334,5 +361,6 @@ describe('runResolveConflictWorkflow', () => {
       'factory:merge-conflict',
       'factory:needs-human',
     );
+    expectStateTransitionEvent('factory:needs-human');
   });
 });

--- a/slices/resolve-conflict/workflow.ts
+++ b/slices/resolve-conflict/workflow.ts
@@ -13,6 +13,7 @@ import {
   type MergePrInput,
   mergePR as defaultMergePR,
 } from '@goose-hub/core/connectors/github/merge-pr.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -61,7 +62,16 @@ export async function runResolveConflictWorkflow(
   const events = eventStore.replay({ workItemId });
   const prEvent = [...events].reverse().find((e) => e.kind === 'pr.opened');
   if (prEvent == null) {
-    await stateSource.transitionState(issueNumber, 'factory:merge-conflict', 'factory:needs-human');
+    await transitionAndEmitState({
+      source: stateSource,
+      projectId: slug,
+      itemId: issueNumber,
+      workItemId,
+      from: 'factory:merge-conflict',
+      to: 'factory:needs-human',
+      by: 'resolve-conflict',
+      mode: 'legal',
+    });
     await stateSource.comment(
       issueNumber,
       buildAgentComment(
@@ -190,11 +200,16 @@ export async function runResolveConflictWorkflow(
       payload: { prNumber, sha: merged.sha },
     });
 
-    await stateSource.transitionState(
-      issueNumber,
-      'factory:merge-conflict',
-      'factory:retrospecting',
-    );
+    await transitionAndEmitState({
+      source: stateSource,
+      projectId: slug,
+      itemId: issueNumber,
+      workItemId,
+      from: 'factory:merge-conflict',
+      to: 'factory:retrospecting',
+      by: 'resolve-conflict',
+      mode: 'legal',
+    });
     await stateSource.comment(
       issueNumber,
       buildAgentComment(
@@ -211,7 +226,16 @@ export async function runResolveConflictWorkflow(
       kind: 'merge.conflict-unresolvable',
       payload: { prNumber, prUrl, error: String(err) },
     });
-    await stateSource.transitionState(issueNumber, 'factory:merge-conflict', 'factory:needs-human');
+    await transitionAndEmitState({
+      source: stateSource,
+      projectId: slug,
+      itemId: issueNumber,
+      workItemId,
+      from: 'factory:merge-conflict',
+      to: 'factory:needs-human',
+      by: 'resolve-conflict',
+      mode: 'legal',
+    });
     await stateSource.comment(
       issueNumber,
       buildAgentComment(


### PR DESCRIPTION
## Summary
- centralize detail-page issue SSE ownership in `DetailPage` and make `TimelineSection` consume the shared events cache
- add event backfill support with an `after` cursor and protect issue state from stale refetches using latest transition events
- add `transitionAndEmitState` and migrate the PRD-named workflow/server transition call sites where the wrapper is the right ownership boundary
- reconcile decision summaries for `implement-wp`, `evidence-post`, and `playwright-repro` outputs
- fix stale grill state so pending griller questions still expose the reply flow

## Verification
- `pnpm vitest run core/event-stream/state-transition.test.ts apps/web/src/components/detail/components/GrillSection.test.tsx apps/web/src/components/detail/components/TimelineExpandCollapse.test.tsx apps/web/src/components/detail/components/TimelineSection.test.ts apps/web/src/components/detail/lib/live-events.test.ts skills/playwright-repro/slice.test.ts slices/investigate/playwright-repro-evidence.test.ts`
- `pnpm vitest run core/event-stream/state-transition.test.ts apps/server/src/domains/interventions/applier-worker.test.ts apps/server/src/domains/issues/prd-actions.test.ts`
- `pnpm vitest run slices/resolve-conflict/slice.test.ts core/event-stream/state-transition.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`

## PRD-named surface audit
| Surface | Status | Evidence / reason |
| --- | --- | --- |
| Detail page SSE ownership | Migrated | `DetailPage.tsx` owns the issue `EventSource`; `TimelineSection.tsx` no longer creates one. |
| Timeline shared cache, pagination, grouping | Migrated | `TimelineSection.tsx` reads/writes `['events', slug, id]`, preserves older-event loading and grouping. |
| SSE reconnect / visibility backfill | Migrated | `DetailPage.tsx` backfills with `fetchEventsPage(..., { after: lastEventId })`; server and web API accept `after`. |
| State patching from `state.transitioned` | Migrated | `live-events.ts` patches issue/list state and guards stale refetches with latest cached transition state. |
| Detail-page side effects | Migrated | `DetailPage.tsx` invalidates comments, costs, and interventions from the centralized event handler. |
| Canonical transition wrapper | Migrated | `core/event-stream/state-transition.ts` exposes `transitionAndEmitState`; tests cover legal, forced-known, forced-unknown, and failed-mutation no-emit cases. |
| Grill / write-PRD workflow | Migrated | `core/workflows/grill-and-prd.ts` uses `transitionAndEmitState` for gate-pending, PRD drafting/review, forced resume, and failure paths. |
| PRD action endpoints | Partially migrated / intentionally direct | `revisePRD` no-draft failure now uses the wrapper. `approvePRD`, `declinePRD`, and `proceedToPrd` keep `moveOrForce` because they must preserve existing UI-specific `prd.*` event ordering and already emit `state.transitioned` immediately after mutation. |
| Decompose workflow and dispatch preflight | Migrated | `core/workflows/decompose-prd.ts` uses the wrapper; `dispatchDecomposePrd` pre-workflow no-draft / parse-failure paths now emit via the wrapper. |
| Investigate workflow | Migrated | `slices/investigate/workflow.ts` uses the wrapper for wave halted/incomplete, success, and failure paths. |
| Approve / merge / reject issue transitions | Migrated | `apps/server/src/domains/issues/transitions.ts` uses the wrapper for merge gates, approved-to-retrospecting, reject-to-needs-fix, and manual intervention transitions. |
| Resolve-conflict workflow | Migrated | `slices/resolve-conflict/workflow.ts` uses the wrapper for no-PR escalation, successful conflict resolution to retrospection, and unresolvable/error escalation. |
| Retrospective workflow | Migrated | `core/workflows/retrospective.ts` uses the wrapper for success and failure paths. |
| Dispatch fallbacks / resume routing | Intentionally direct | `apps/server/src/shared/dispatch-routing.ts` force-resume paths still call `forceState` directly, but every mutation is immediately followed by `emitStateTransitionEvent` with resume/intervention metadata. |
| MCP transition tool | Migrated | `core/tool-layer/mcp/tools/workflow.ts` uses the wrapper. |
| Chat transition tool | Migrated | `apps/server/src/domains/chat/tools.ts` uses the wrapper. |
| Intervention applier | Migrated | `apps/server/src/domains/interventions/applier-worker.ts` now uses the wrapper for manual transition applies. |
| `implement-wp` decisions | Migrated | `slices/parallel-implement/wp-builder.ts` reconciles parsed `decisionSummaries`. |
| `evidence-post` decisions | Migrated | `slices/fix-issue/pr-helpers.ts` reconciles final output `decisionSummaries`. |
| `playwright-repro` decisions | Migrated | `skills/playwright-repro/schema.ts` requires decision summaries; investigate reconciles them and carries plan decisions into evidence assembly. |
| Grill stale-state UI | Migrated | `GrillSection.tsx` derives effective state from the latest unanswered griller question and sends the reply transition from that effective state. |

## Remaining direct transition call buckets
| Bucket | Remaining files | Why safe |
| --- | --- | --- |
| StateSource internals | `core/state-source/interface.ts`, `core/state-source/github-labels.ts`, `core/state-source/in-memory-labels.ts`, wrapper internals in `core/event-stream/state-transition.ts` | These define or compose the source-of-truth mutation API; the PRD explicitly says not to move event emission into `StateSource`. |
| Tests / fixtures / docs examples | `core/state-source/*.test.ts`, `apps/server/src/shared/source.fetch-guard.test.ts`, `slices/discover-lane-e2e/slice.test.ts`, intervention deps tests, README/prompt mentions | Test setup and documentation examples are not production issue timeline mutations. |
| Bootstrap / sweep / setup paths | `apps/cli/src/commands/sweep.ts`, `core/projects/dependency-scheduler.ts` | These are maintenance/setup paths intentionally outside live issue-detail timeline emission. |
| Workflows that already emit `state.transitioned` correctly | `apps/server/src/shared/dispatch-dev.ts`, `apps/server/src/shared/dispatch-qa-review.ts`, `apps/server/src/shared/dispatch-routing.ts`, `apps/server/src/domains/issues/prd-actions.ts`, `apps/server/src/domains/workflows/triage-batch.ts`, `slices/fix-issue/*`, `slices/fix-feedback/*`, `slices/qa/*`, `slices/review/*`, `slices/spec-author/*` | These remaining direct mutations already have paired `emitStateTransitionEvent` calls after successful source mutation; converting all legacy slices to the new wrapper is a larger mechanical migration outside this PRD pass. |
