### PR TITLE
M19.XX: Remove text local from sidebar

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -195,9 +195,6 @@ export function Sidebar({ activeSlug }: SidebarProps) {
           collapsed ? 'flex justify-center py-2' : 'flex items-center px-3 py-2',
         )}
       >
-        {!collapsed && (
-          <span className="text-[11px] text-fg-2 flex-1 whitespace-nowrap">Local-first</span>
-        )}
         <button
           type="button"
           onClick={toggle}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -21,6 +21,10 @@ describe('chrome slice — sidebar brand label', () => {
     expect(sidebarSource).toContain('Goose Hub');
   });
 
+  it('sidebar source no longer includes the Local-first footer copy', () => {
+    expect(sidebarSource).not.toContain('Local-first');
+  });
+
   it('sidebar header does not read "Agentic OS"', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
     expect(labelMatch?.[0]).not.toContain('Agentic OS');


### PR DESCRIPTION
## Summary

Remove text local from sidebar

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chrome/Sidebar.tsx:199` to remove the expanded-footer `Local-first` label while preservi

Closes #967
