### PR TITLE
M19.XX: Open close chat bug

### DIFF
--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -31,6 +31,14 @@ async function openChatPanel(page: Page) {
   await expect(page.locator('[data-testid="chat-panel"]')).toHaveClass(/translate-x-0/);
 }
 
+async function closeChatPanelWithLauncher(page: Page) {
+  await hideDevtools(page);
+  const launcher = page.locator('[data-testid="chat-launcher"]');
+  await expect(launcher).toBeVisible();
+  await launcher.click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveClass(/translate-x-full/);
+}
+
 async function startNewConversation(page: Page) {
   await page.locator('[data-testid="chat-new-conversation"]').click();
 }
@@ -77,6 +85,20 @@ test.describe('hub-chat panel', () => {
       .locator('[data-testid="chat-user-message"]')
       .filter({ hasText: 'hello hub chat' });
     await expect(userBubble).toBeVisible();
+  });
+
+  test('reopens on the conversation list after launcher close', async ({ page }) => {
+    await page.goto('/projects/goose-hub-self');
+    await openChatPanel(page);
+    await startNewConversation(page);
+    await waitForChatReady(page);
+
+    await expect(page.locator('[data-testid="chat-conversation-list"]')).toHaveCount(0);
+
+    await closeChatPanelWithLauncher(page);
+    await openChatPanel(page);
+
+    await expect(page.locator('[data-testid="chat-conversation-list"]')).toBeVisible();
   });
 
   test('a read-only tool proposal auto-runs and renders a result card', async ({ page }) => {

--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,153 @@
+/** @vitest-environment jsdom */
+import { flushSync } from 'react-dom';
+import { type Root, createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+const conversation = {
+  id: 'conv_123',
+  scope: 'project',
+  projectId: 'goose-hub-self',
+  workItemId: null,
+  title: 'Saved conversation',
+  runtime: 'codex',
+  createdAt: '2026-05-18T00:00:00Z',
+  updatedAt: '2026-05-18T00:00:00Z',
+};
+
+const fetchConversation = vi.fn(async () => ({
+  conversation,
+  messages: [
+    {
+      id: 1,
+      conversationId: conversation.id,
+      role: 'user',
+      content: 'hello',
+      runId: null,
+      meta: null,
+      createdAt: '2026-05-18T00:00:00Z',
+    },
+  ],
+  invocations: [],
+}));
+
+const listConversations = vi.fn(async () => [conversation]);
+const fetchToolManifest = vi.fn(async () => []);
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: (...args: unknown[]) => fetchConversation(...args),
+  fetchToolManifest: (...args: unknown[]) => fetchToolManifest(...args),
+  listConversations: (...args: unknown[]) => listConversations(...args),
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+vi.mock('../lib/useChatEvents', () => ({
+  useChatEvents: () => [],
+}));
+
+vi.mock('./ChatThread', () => ({
+  ChatThread: () => <div data-testid="chat-thread-view">Thread view</div>,
+}));
+
+vi.mock('./ChatInput', () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  listConversations.mockClear();
+  fetchConversation.mockClear();
+  fetchToolManifest.mockClear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  flushSync(() => {
+    root.unmount();
+  });
+  container.remove();
+  localStorage.clear();
+});
+
+function renderDock() {
+  flushSync(() => {
+    root.render(
+      <MemoryRouter initialEntries={['/']}>
+        <ChatDock />
+      </MemoryRouter>,
+    );
+  });
+}
+
+function clickSelector(selector: string) {
+  const element = container.querySelector(selector);
+  expect(element).toBeTruthy();
+  flushSync(() => {
+    (element as HTMLButtonElement).click();
+  });
+}
+
+async function waitForCondition(check: () => boolean, message: string) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(message);
+}
+
+describe('ChatDock', () => {
+  it('preserves the active conversation when the panel close button is used', async () => {
+    localStorage.setItem('hub-chat-open', 'true');
+    localStorage.setItem('hub-chat-active-conversation-id', conversation.id);
+
+    renderDock();
+
+    await waitForCondition(
+      () => container.querySelector('[data-testid="chat-thread-view"]') != null,
+      'expected saved thread to be restored',
+    );
+
+    clickSelector('button[aria-label="Close chat"]');
+    expect(localStorage.getItem('hub-chat-open')).toBe('false');
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBe(conversation.id);
+
+    clickSelector('[data-testid="chat-launcher"]');
+    await waitForCondition(
+      () => container.querySelector('[data-testid="chat-thread-view"]') != null,
+      'expected thread view to return after normal reopen',
+    );
+  });
+
+  it('closes from the launcher by clearing the persisted active conversation and reopening on the list', async () => {
+    localStorage.setItem('hub-chat-open', 'true');
+    localStorage.setItem('hub-chat-active-conversation-id', conversation.id);
+
+    renderDock();
+
+    await waitForCondition(
+      () => container.querySelector('[data-testid="chat-thread-view"]') != null,
+      'expected saved thread to be restored',
+    );
+
+    clickSelector('[data-testid="chat-launcher"]');
+
+    expect(localStorage.getItem('hub-chat-open')).toBe('false');
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBeNull();
+
+    clickSelector('[data-testid="chat-launcher"]');
+    await waitForCondition(
+      () => container.querySelector('[data-testid="chat-conversation-list"]') != null,
+      'expected conversation list to show after reopen',
+    );
+    expect(container.querySelector('[data-testid="chat-thread-view"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ChatLauncher } from './ChatLauncher';
-import { ChatPanel } from './ChatPanel';
+import { ChatPanel, type ChatPanelCloseOptions } from './ChatPanel';
 
 const STORAGE_KEY = 'hub-chat-open';
 
@@ -17,6 +17,7 @@ export function ChatDock() {
       return false;
     }
   });
+  const [closeOptions, setCloseOptions] = useState<ChatPanelCloseOptions | null>(null);
 
   useEffect(() => {
     try {
@@ -24,10 +25,28 @@ export function ChatDock() {
     } catch {}
   }, [open]);
 
+  const handleOpen = useCallback(() => {
+    setCloseOptions(null);
+    setOpen(true);
+  }, []);
+
+  const handleClose = useCallback((options: ChatPanelCloseOptions = {}) => {
+    setCloseOptions(options.resetToList ? { resetToList: true } : null);
+    setOpen(false);
+  }, []);
+
+  const handleLauncherToggle = useCallback(() => {
+    if (open) {
+      handleClose({ resetToList: true });
+      return;
+    }
+    handleOpen();
+  }, [handleClose, handleOpen, open]);
+
   return (
     <>
-      <ChatPanel open={open} onClose={() => setOpen(false)} />
-      <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
+      <ChatPanel open={open} closeOptions={closeOptions} onClose={handleClose} />
+      <ChatLauncher open={open} onToggle={handleLauncherToggle} />
     </>
   );
 }

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -31,14 +31,19 @@ import { ConversationList } from './ConversationList';
 
 const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 
+export interface ChatPanelCloseOptions {
+  resetToList?: boolean;
+}
+
 interface ChatPanelProps {
   open: boolean;
-  onClose: () => void;
+  closeOptions?: ChatPanelCloseOptions | null;
+  onClose: (options?: ChatPanelCloseOptions) => void;
 }
 
 type View = 'thread' | 'list';
 
-export function ChatPanel({ open, onClose }: ChatPanelProps) {
+export function ChatPanel({ open, closeOptions = null, onClose }: ChatPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const resolved = useMemo(() => resolveScopeFromPath(location.pathname), [location.pathname]);
@@ -135,6 +140,36 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       // localStorage unavailable — accept the loss; selection is best-effort.
     }
   }, []);
+
+  const resetPanelState = useCallback(() => {
+    loadTokenRef.current += 1;
+    activeConversationIdRef.current = null;
+    inFlightRunByConversationRef.current.clear();
+    setConversation(null);
+    setMessages([]);
+    setInvocations([]);
+    setSendingConversationIds(new Set());
+    setPendingDecision(null);
+    setError(null);
+    setView('list');
+    writeActiveId(null);
+  }, [writeActiveId]);
+
+  const handleClose = useCallback(
+    (options: ChatPanelCloseOptions = {}) => {
+      if (options.resetToList) {
+        resetPanelState();
+      }
+      onClose(options);
+    },
+    [onClose, resetPanelState],
+  );
+
+  useEffect(() => {
+    if (!open && closeOptions?.resetToList) {
+      resetPanelState();
+    }
+  }, [closeOptions, open, resetPanelState]);
 
   useEffect(() => {
     if (!open || toolManifest.length > 0) return;
@@ -377,7 +412,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
           const path = (res.invocation.result as { path?: string }).path;
           if (typeof path === 'string' && path.startsWith('/')) {
             navigate(path);
-            onClose();
+            handleClose();
           }
         }
       } catch (err) {
@@ -386,7 +421,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         setPendingDecision(null);
       }
     },
-    [conversation, navigate, onClose],
+    [conversation, handleClose, navigate],
   );
 
   const handleReject = useCallback(
@@ -410,9 +445,9 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const handleNavigate = useCallback(
     (path: string) => {
       navigate(path);
-      onClose();
+      handleClose();
     },
-    [navigate, onClose],
+    [handleClose, navigate],
   );
 
   const toggleView = useCallback(() => {
@@ -463,7 +498,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         </select>
         <button
           type="button"
-          onClick={onClose}
+          onClick={() => handleClose()}
           aria-label="Close chat"
           className="p-1 text-fg-2 hover:text-fg rounded"
         >


### PR DESCRIPTION
## Summary

Open close chat bug

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chat/components/ChatDock.tsx:12-29` so the launcher no longer blindly toggles `open`; in
- ✓ **WP2**: Add a browser regression case in `apps/web/e2e/chat.spec.ts:24-63` and nearby helpers that opens Hub Chat, creates or se

Closes #969
