### PR TITLE
M19.XX: Open close chat bug

### DIFF
--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -63,6 +63,30 @@ test.describe('hub-chat panel', () => {
     await expect(panel).toHaveClass(/translate-x-full/);
   });
 
+  test('launcher close resets reopened chat to list view', async ({ page }) => {
+    await page.goto('/projects/goose-hub-self');
+    await openChatPanel(page);
+    await startNewConversation(page);
+    await waitForChatReady(page);
+
+    await page.locator('[data-testid="chat-toggle-view"]').click();
+    const list = page.locator('[data-testid="chat-conversation-list"]');
+    await expect(list).toBeVisible();
+
+    const firstConversation = list.locator('[data-testid="chat-conversation-select"]').first();
+    await firstConversation.click();
+    await expect(page.locator('[data-testid="chat-input"]')).toBeVisible();
+
+    const launcher = page.locator('[data-testid="chat-launcher"]');
+    await launcher.click();
+    await expect(page.locator('[data-testid="chat-panel"]')).toHaveClass(/translate-x-full/);
+
+    await launcher.click();
+    await expect(page.locator('[data-testid="chat-panel"]')).toHaveClass(/translate-x-0/);
+    await expect(page.locator('[data-testid="chat-conversation-list"]')).toBeVisible();
+    await expect(page.locator('[data-testid="chat-input"]')).toHaveCount(0);
+  });
+
   test('sending a message persists it and the user bubble renders', async ({ page }) => {
     await page.goto('/projects/goose-hub-self');
     await openChatPanel(page);

--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,94 @@
+/** @vitest-environment jsdom */
+import { flushSync } from 'react-dom';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
+const OPEN_STORAGE_KEY = 'hub-chat-open';
+
+vi.mock('./ChatLauncher', () => ({
+  ChatLauncher: ({ open, onToggle }: { open: boolean; onToggle: () => void }) => (
+    <button
+      type="button"
+      data-testid="chat-launcher"
+      aria-pressed={String(open)}
+      onClick={onToggle}
+    >
+      Toggle
+    </button>
+  ),
+}));
+
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: ({ open }: { open: boolean }) =>
+    open ? (
+      <div data-testid="chat-panel-view">
+        {localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY) == null ? 'list' : 'thread'}
+      </div>
+    ) : null,
+}));
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function renderChatDock() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  flushSync(() => {
+    root?.render(<ChatDock />);
+  });
+}
+
+function clickLauncher() {
+  const launcher = container?.querySelector('[data-testid="chat-launcher"]');
+  expect(launcher).not.toBeNull();
+  flushSync(() => {
+    (launcher as HTMLButtonElement).click();
+  });
+}
+
+function panelViewText() {
+  return container?.querySelector('[data-testid="chat-panel-view"]')?.textContent ?? null;
+}
+
+afterEach(() => {
+  flushSync(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  localStorage.clear();
+});
+
+describe('ChatDock', () => {
+  it('clears the persisted active conversation when the launcher closes the panel', async () => {
+    localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, 'conv-123');
+    renderChatDock();
+
+    clickLauncher();
+    expect(panelViewText()).toBe('thread');
+
+    clickLauncher();
+
+    expect(localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('reopens on the list view after the launcher closes an active thread', async () => {
+    localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, 'conv-123');
+    renderChatDock();
+
+    clickLauncher();
+    expect(panelViewText()).toBe('thread');
+
+    clickLauncher();
+    expect(panelViewText()).toBeNull();
+
+    clickLauncher();
+
+    expect(panelViewText()).toBe('list');
+    expect(localStorage.getItem(OPEN_STORAGE_KEY)).toBe('true');
+  });
+});

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -3,6 +3,7 @@ import { ChatLauncher } from './ChatLauncher';
 import { ChatPanel } from './ChatPanel';
 
 const STORAGE_KEY = 'hub-chat-open';
+const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 
 /**
  * Top-level entry point: hosts the slide-out chat panel + the floating
@@ -24,10 +25,21 @@ export function ChatDock() {
     } catch {}
   }, [open]);
 
+  const handleLauncherToggle = () => {
+    if (open) {
+      try {
+        localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+      } catch {}
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+  };
+
   return (
     <>
       <ChatPanel open={open} onClose={() => setOpen(false)} />
-      <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
+      <ChatLauncher open={open} onToggle={handleLauncherToggle} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Open close chat bug

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chat/components/ChatDock.tsx:12-29` so the floating launcher close path clears the persi

Closes #969
