### PR TITLE
M19.XX: Workflow snapshot grid 2

### DIFF
--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -1,14 +1,25 @@
-import { fetchEvents, fetchIssueDiff } from '@/lib/api';
+import { fetchEvents, fetchIssueDiff, fetchTriageResult } from '@/lib/api';
 import { laneForState } from '@/lib/lanes.config';
 import { renderMarkdownToHtml } from '@/lib/markdown';
-import type { AgentEventDto, IssueDiffDto, WorkItemDto } from '@/lib/types';
+import type { AgentEventDto, IssueDiffDto, TriageResultDto, WorkItemDto } from '@/lib/types';
 import { getPersonaInitials, getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
 import { formatCost, formatTokens } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { parseDiff } from '../lib/code-diff';
+import type { IssueCostsBreakdown, StageBreakdown } from '../lib/costs';
 import { useIssueCostsBreakdown } from '../lib/costs';
+import {
+  READ_TOOLS,
+  SEARCH_TOOLS,
+  countToolCalls,
+  extractInvestigationPayload,
+  latestInvestigationEvent,
+} from '../lib/investigation';
+import type { ParsedPRDView } from '../lib/parse-prd-comment';
+import type { DeepRetroPayload, RetroPayload } from '../lib/retrospective';
+import type { ReviewFinding, ReviewPayload, ReviewVerdict } from '../lib/review';
 import { CommentsSection } from './CommentsSection';
 import { DependenciesSection } from './DependenciesSection';
 import { StatCard } from './StatCard';
@@ -16,6 +27,562 @@ import { StatCard } from './StatCard';
 interface OverviewSectionProps {
   item?: WorkItemDto;
   projectSlug?: string;
+}
+
+type OverviewWorkflowCardKey = 'triage' | 'investigation' | 'grill' | 'prd' | 'review' | 'retro';
+
+type WorkflowTone = 'neutral' | 'active' | 'success' | 'warning' | 'danger' | 'muted';
+
+export interface OverviewWorkflowCard {
+  key: OverviewWorkflowCardKey;
+  title: string;
+  status: string;
+  statusTone: WorkflowTone;
+  metrics: Array<{ label: string; value: string; tone?: WorkflowTone }>;
+  footer?: { tokens: number; usd: number; label: 'exact' | 'estimated' };
+  hrefSection?: string;
+}
+
+export interface BuildOverviewWorkflowSummaryInput {
+  item?: WorkItemDto;
+  events: AgentEventDto[];
+  triage?: TriageResultDto | null;
+  costs?: Pick<IssueCostsBreakdown, 'byStage'> & {
+    bySkill?: Map<string, StageBreakdown>;
+  };
+}
+
+type EventPayload = Record<string, unknown>;
+
+const WORKFLOW_CARD_ORDER: OverviewWorkflowCardKey[] = [
+  'triage',
+  'investigation',
+  'grill',
+  'prd',
+  'review',
+  'retro',
+];
+
+const WORKFLOW_CARD_TITLES: Record<OverviewWorkflowCardKey, string> = {
+  triage: 'Triage',
+  investigation: 'Investigation',
+  grill: 'Grill',
+  prd: 'PRD',
+  review: 'Review',
+  retro: 'Retro',
+};
+
+const WORKFLOW_CARD_SECTIONS: Record<OverviewWorkflowCardKey, string> = {
+  triage: 'repo',
+  investigation: 'investigation',
+  grill: 'grill',
+  prd: 'prd',
+  review: 'review',
+  retro: 'retrospective',
+};
+
+const TONE_CLASS: Record<WorkflowTone, string> = {
+  neutral: 'border-line bg-bg text-fg-2',
+  active: 'border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
+  success:
+    'border-[color:var(--success)]/30 bg-[color:var(--success)]/10 text-[color:var(--success)]',
+  warning:
+    'border-[color:var(--warning)]/30 bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+  danger: 'border-[color:var(--danger)]/30 bg-[color:var(--danger)]/10 text-[color:var(--danger)]',
+  muted: 'border-line bg-bg-elev-2 text-fg-3',
+};
+
+function metric(label: string, value: string, tone?: WorkflowTone) {
+  return { label, value, ...(tone ? { tone } : {}) };
+}
+
+function safeCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function formatPercent(value: unknown): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  const pct = value <= 1 ? value * 100 : value;
+  return `${Math.round(pct)}%`;
+}
+
+function formatConfidenceLabel(value: unknown): string {
+  return typeof value === 'string' && value.length > 0 ? value : '—';
+}
+
+function formatBoolean(value: unknown, truthy = 'Yes', falsy = 'No'): string {
+  return value === true ? truthy : value === false ? falsy : '—';
+}
+
+function formatNumber(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : '—';
+}
+
+function latestEvent(events: AgentEventDto[], kind: string): AgentEventDto | null {
+  return events
+    .filter((event) => event.kind === kind)
+    .reduce<AgentEventDto | null>((latest, event) => {
+      if (latest == null) return event;
+      if (event.id !== latest.id) return event.id > latest.id ? event : latest;
+      return event.createdAt > latest.createdAt ? event : latest;
+    }, null);
+}
+
+function payloadOf(event: AgentEventDto | null): EventPayload | null {
+  if (event == null || event.payload == null || typeof event.payload !== 'object') return null;
+  return event.payload as EventPayload;
+}
+
+function firstString(values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+  }
+  return null;
+}
+
+function isDiscoverApplicable(item?: WorkItemDto, events: AgentEventDto[] = []): boolean {
+  if (item?.type === 'feature') return true;
+  if (
+    item?.state != null &&
+    ['factory:grilling', 'factory:gate-pending', 'factory:prd-drafting', 'factory:prd-review'].some(
+      (state) => item.state === state,
+    )
+  ) {
+    return true;
+  }
+  return events.some((event) =>
+    ['grill.question-posted', 'grill.completed', 'prd.drafted'].includes(event.kind),
+  );
+}
+
+function costForStage(
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+  stage: string,
+  skill?: string,
+): OverviewWorkflowCard['footer'] | undefined {
+  const bySkill = costs?.bySkill;
+  const breakdown = (skill != null ? bySkill?.get(skill) : undefined) ?? costs?.byStage.get(stage);
+  if (breakdown == null) return undefined;
+  return { tokens: breakdown.tokens, usd: breakdown.usd, label: breakdown.label };
+}
+
+function toneForVerdict(verdict: ReviewVerdict | string | undefined): WorkflowTone {
+  if (verdict === 'approved') return 'success';
+  if (verdict === 'needs-fix') return 'warning';
+  if (verdict === 'needs-human') return 'danger';
+  return 'neutral';
+}
+
+function prdStatus(
+  itemState: string | undefined,
+  event: AgentEventDto | null,
+): [string, WorkflowTone] {
+  if (event != null && itemState !== 'factory:prd-drafting') {
+    if (itemState === 'factory:prd-review') return ['In review', 'active'];
+    if (itemState === 'factory:decomposing' || itemState === 'factory:issues-created') {
+      return ['Approved', 'success'];
+    }
+    if (itemState === 'factory:done') return ['Done', 'success'];
+    return ['Drafted', 'success'];
+  }
+  if (itemState === 'factory:prd-drafting') return ['Drafting', 'active'];
+  return ['Not run', 'neutral'];
+}
+
+function buildTriageCard(
+  item: WorkItemDto | undefined,
+  triage: TriageResultDto | null | undefined,
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const fallbackPayload = payloadOf(latestEvent(events, 'agent.triage-complete'));
+  const fallbackCandidates = Array.isArray(fallbackPayload?.candidates)
+    ? (fallbackPayload.candidates as Array<Record<string, unknown>>)
+    : [];
+  const pickedRepo =
+    triage?.overrideRepo ??
+    triage?.candidates[0]?.repo ??
+    firstString([
+      fallbackPayload?.overrideRepo,
+      fallbackPayload?.pickedRepo,
+      fallbackCandidates[0]?.repo,
+      item?.repoRef,
+    ]);
+  const confidence =
+    triage?.candidates[0]?.confidence ??
+    (typeof fallbackPayload?.confidence === 'number' ? fallbackPayload.confidence : undefined) ??
+    (typeof fallbackCandidates[0]?.confidence === 'number'
+      ? (fallbackCandidates[0]?.confidence as number)
+      : undefined);
+  const candidateCount = triage?.candidates.length ?? fallbackCandidates.length;
+  const overrideValue = triage?.overrideRepo ?? fallbackPayload?.overrideRepo;
+  const didRun = triage != null || fallbackPayload != null;
+
+  return {
+    key: 'triage',
+    title: WORKFLOW_CARD_TITLES.triage,
+    status: didRun ? 'Complete' : 'Not run',
+    statusTone: didRun ? 'success' : 'neutral',
+    hrefSection: WORKFLOW_CARD_SECTIONS.triage,
+    footer: costForStage(costs, 'triage'),
+    metrics: [
+      metric(
+        'Priority',
+        triage?.priority ?? firstString([fallbackPayload?.priority, item?.priority]) ?? '—',
+      ),
+      metric('Type', triage?.type ?? firstString([fallbackPayload?.type, item?.type]) ?? '—'),
+      metric('Repo', pickedRepo ?? '—'),
+      metric('Conf', confidence == null ? '—' : formatPercent(confidence)),
+      metric('Candidates', candidateCount > 0 ? String(candidateCount) : '—'),
+      metric('Override', formatBoolean(overrideValue != null && String(overrideValue).length > 0)),
+    ],
+  };
+}
+
+function buildInvestigationCard(
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const latest = latestInvestigationEvent(events);
+  const payload = latest != null ? extractInvestigationPayload(latest) : null;
+  if (payload == null) {
+    return {
+      key: 'investigation',
+      title: WORKFLOW_CARD_TITLES.investigation,
+      status: 'Not run',
+      statusTone: 'neutral',
+      hrefSection: WORKFLOW_CARD_SECTIONS.investigation,
+      footer: costForStage(costs, 'investigate'),
+      metrics: [
+        metric('Conf', '—'),
+        metric('Key files', '—'),
+        metric('Questions', '—'),
+        metric('Reads', '—'),
+        metric('Searches', '—'),
+        metric('Repro', '—'),
+      ],
+    };
+  }
+
+  const runEvents =
+    latest?.runId != null ? events.filter((event) => event.runId === latest.runId) : events;
+  const runPayload = payloadOf(latest);
+  const playwrightRepro = payloadOf(latest)?.playwrightRepro as Record<string, unknown> | undefined;
+  const reproduced = playwrightRepro?.reproduced;
+
+  return {
+    key: 'investigation',
+    title: WORKFLOW_CARD_TITLES.investigation,
+    status: 'Complete',
+    statusTone: payload.investigate.confidence === 'high' ? 'success' : 'warning',
+    hrefSection: WORKFLOW_CARD_SECTIONS.investigation,
+    footer: costForStage(costs, 'investigate'),
+    metrics: [
+      metric('Conf', formatConfidenceLabel(payload.investigate.confidence)),
+      metric('Key files', String(payload.investigate.keyFiles.length)),
+      metric('Questions', String(payload.investigate.openQuestions.length)),
+      metric('Reads', String(countToolCalls(runEvents, READ_TOOLS))),
+      metric('Searches', String(countToolCalls(runEvents, SEARCH_TOOLS))),
+      metric(
+        'Repro',
+        formatBoolean(typeof reproduced === 'boolean' ? reproduced : runPayload?.reproduced),
+      ),
+    ],
+  };
+}
+
+function buildGrillCard(
+  item: WorkItemDto | undefined,
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const applicable = isDiscoverApplicable(item, events);
+  const questions = events.filter((event) => event.kind === 'grill.question-posted').length;
+  const completed = payloadOf(latestEvent(events, 'grill.completed'));
+  if (!applicable) {
+    return {
+      key: 'grill',
+      title: WORKFLOW_CARD_TITLES.grill,
+      status: 'N/A',
+      statusTone: 'muted',
+      hrefSection: WORKFLOW_CARD_SECTIONS.grill,
+      footer: costForStage(costs, 'discover', 'grill-me'),
+      metrics: [
+        metric('Questions', '—'),
+        metric('Rounds', '—'),
+        metric('Forced', '—'),
+        metric('State', '—'),
+      ],
+    };
+  }
+
+  const status =
+    completed != null
+      ? 'Complete'
+      : item?.state === 'factory:grilling' || item?.state === 'factory:gate-pending'
+        ? 'In progress'
+        : questions > 0
+          ? 'Started'
+          : 'Not run';
+  const tone: WorkflowTone =
+    completed != null ? 'success' : status === 'In progress' ? 'active' : 'neutral';
+
+  return {
+    key: 'grill',
+    title: WORKFLOW_CARD_TITLES.grill,
+    status,
+    statusTone: tone,
+    hrefSection: WORKFLOW_CARD_SECTIONS.grill,
+    footer: costForStage(costs, 'discover', 'grill-me'),
+    metrics: [
+      metric('Questions', questions > 0 ? String(questions) : '—'),
+      metric('Rounds', formatNumber(completed?.rounds)),
+      metric('Forced', formatBoolean(completed?.forcedCompletion)),
+      metric('State', item?.state ?? '—'),
+    ],
+  };
+}
+
+function buildPrdCard(
+  item: WorkItemDto | undefined,
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const applicable = isDiscoverApplicable(item, events);
+  const draftedEvent = latestEvent(events, 'prd.drafted');
+  const drafted = payloadOf(draftedEvent);
+  const prd = (drafted?.prd ?? drafted) as ParsedPRDView | null | undefined;
+  const advisorConcerns = Array.isArray(drafted?.advisorConcerns)
+    ? drafted?.advisorConcerns
+    : typeof drafted?.advisorConcerns === 'string' && drafted.advisorConcerns.length > 0
+      ? drafted.advisorConcerns.split('\n').filter((line) => line.trim().length > 0)
+      : [];
+
+  if (!applicable) {
+    return {
+      key: 'prd',
+      title: WORKFLOW_CARD_TITLES.prd,
+      status: 'N/A',
+      statusTone: 'muted',
+      hrefSection: WORKFLOW_CARD_SECTIONS.prd,
+      footer: costForStage(costs, 'discover', 'write-prd'),
+      metrics: [
+        metric('Complexity', '—'),
+        metric('ACs', '—'),
+        metric('Journeys', '—'),
+        metric('Slices', '—'),
+        metric('Concerns', '—'),
+      ],
+    };
+  }
+
+  const [status, statusTone] = prdStatus(item?.state, draftedEvent);
+
+  return {
+    key: 'prd',
+    title: WORKFLOW_CARD_TITLES.prd,
+    status,
+    statusTone,
+    hrefSection: WORKFLOW_CARD_SECTIONS.prd,
+    footer: costForStage(costs, 'discover', 'write-prd'),
+    metrics: [
+      metric('Complexity', prd?.estimatedComplexity ?? '—'),
+      metric('ACs', prd?.acceptanceCriteria != null ? String(prd.acceptanceCriteria.length) : '—'),
+      metric('Journeys', prd?.journeys != null ? String(prd.journeys.length) : '—'),
+      metric('Slices', prd?.verticalSlices != null ? String(prd.verticalSlices.length) : '—'),
+      metric('Concerns', advisorConcerns.length > 0 ? String(advisorConcerns.length) : '—'),
+    ],
+  };
+}
+
+function buildReviewCard(
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const completed = latestEvent(events, 'review.completed');
+  const review = payloadOf(completed) as ReviewPayload | null;
+  const prOpened = payloadOf(latestEvent(events, 'pr.opened'));
+  if (review == null) {
+    return {
+      key: 'review',
+      title: WORKFLOW_CARD_TITLES.review,
+      status: 'Not run',
+      statusTone: 'neutral',
+      hrefSection: WORKFLOW_CARD_SECTIONS.review,
+      footer: costForStage(costs, 'review'),
+      metrics: [
+        metric('Verdict', '—'),
+        metric('Conf', '—'),
+        metric('Checks', '—'),
+        metric('Blockers', '—'),
+        metric('Majors', '—'),
+        metric('PR', '—'),
+      ],
+    };
+  }
+
+  const findings = Array.isArray(review.findings) ? (review.findings as ReviewFinding[]) : [];
+  const blockers = findings.filter((finding) => finding.severity === 'blocker').length;
+  const majors = findings.filter((finding) => finding.severity === 'major').length;
+  const metCount = (review.criteriaChecks ?? []).filter((check) => check.status === 'met').length;
+
+  return {
+    key: 'review',
+    title: WORKFLOW_CARD_TITLES.review,
+    status: firstString([review.verdict]) ?? 'Complete',
+    statusTone: toneForVerdict(review.verdict),
+    hrefSection: WORKFLOW_CARD_SECTIONS.review,
+    footer: costForStage(costs, 'review'),
+    metrics: [
+      metric('Verdict', firstString([review.verdict]) ?? '—'),
+      metric('Conf', formatPercent(review.confidence)),
+      metric(
+        'Checks',
+        review.criteriaChecks != null ? `${metCount}/${review.criteriaChecks.length}` : '—',
+      ),
+      metric('Blockers', blockers > 0 ? String(blockers) : '0'),
+      metric('Majors', majors > 0 ? String(majors) : '0'),
+      metric('PR', prOpened?.prNumber != null ? `#${String(prOpened.prNumber)}` : '—'),
+    ],
+  };
+}
+
+function buildRetroCard(
+  events: AgentEventDto[],
+  costs: BuildOverviewWorkflowSummaryInput['costs'],
+): OverviewWorkflowCard {
+  const completed = latestEvent(events, 'retrospective.completed');
+  const retro = payloadOf(completed) as RetroPayload | null;
+  if (retro == null) {
+    return {
+      key: 'retro',
+      title: WORKFLOW_CARD_TITLES.retro,
+      status: 'Not run',
+      statusTone: 'neutral',
+      hrefSection: WORKFLOW_CARD_SECTIONS.retro,
+      footer: costForStage(costs, 'retrospective'),
+      metrics: [
+        metric('Tier', '—'),
+        metric('Outcome', '—'),
+        metric('Candidates', '—'),
+        metric('High conf', '—'),
+        metric('Patterns', '—'),
+        metric('Learnings', '—'),
+      ],
+    };
+  }
+
+  const output = retro.output;
+  const highConfidence = output.improvementCandidates.filter(
+    (candidate) => candidate.confidence === 'high',
+  ).length;
+  const isDeep = retro.tier === 'deep';
+  const deepRetro = retro as DeepRetroPayload;
+
+  return {
+    key: 'retro',
+    title: WORKFLOW_CARD_TITLES.retro,
+    status: 'Complete',
+    statusTone: 'success',
+    hrefSection: WORKFLOW_CARD_SECTIONS.retro,
+    footer: costForStage(costs, 'retrospective'),
+    metrics: [
+      metric('Tier', retro.tier),
+      metric('Outcome', output.outcome),
+      metric('Candidates', String(output.improvementCandidates.length)),
+      metric('High conf', String(highConfidence)),
+      metric(
+        'Patterns',
+        isDeep ? String(safeCount(deepRetro.output.decisionPatterns)) : '—',
+        isDeep ? undefined : 'muted',
+      ),
+      metric(
+        'Learnings',
+        isDeep ? String(safeCount(deepRetro.output.learningEntries)) : '—',
+        isDeep ? undefined : 'muted',
+      ),
+    ],
+  };
+}
+
+export function buildOverviewWorkflowSummary({
+  item,
+  events,
+  triage,
+  costs,
+}: BuildOverviewWorkflowSummaryInput): OverviewWorkflowCard[] {
+  const cards = [
+    buildTriageCard(item, triage, events, costs),
+    buildInvestigationCard(events, costs),
+    buildGrillCard(item, events, costs),
+    buildPrdCard(item, events, costs),
+    buildReviewCard(events, costs),
+    buildRetroCard(events, costs),
+  ];
+
+  return cards.sort(
+    (left, right) => WORKFLOW_CARD_ORDER.indexOf(left.key) - WORKFLOW_CARD_ORDER.indexOf(right.key),
+  );
+}
+
+function WorkflowSummaryCard({
+  card,
+  slug,
+  id,
+}: {
+  card: OverviewWorkflowCard;
+  slug: string;
+  id: string;
+}) {
+  const body = (
+    <div className="rounded-lg border border-line bg-bg-elev overflow-hidden h-full">
+      <div className="px-4 py-3 border-b border-line bg-bg-elev-2 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[12.5px] font-semibold text-fg truncate">{card.title}</div>
+          {card.hrefSection && (
+            <div className="text-[10.5px] uppercase tracking-wider text-fg-3">Open section</div>
+          )}
+        </div>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10.5px] font-medium ${TONE_CLASS[card.statusTone]}`}
+        >
+          {card.status}
+        </span>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-2 px-4 py-3">
+        {card.metrics.map((entry) => (
+          <div key={`${card.key}-${entry.label}`} className="min-w-0">
+            <dt className="text-[10.5px] uppercase tracking-wider text-fg-3">{entry.label}</dt>
+            <dd
+              className={`mt-0.5 text-[12.5px] leading-snug ${
+                entry.tone === 'muted' ? 'text-fg-3' : 'text-fg-2'
+              }`}
+            >
+              {entry.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {card.footer && (
+        <div className="px-4 py-2 border-t border-line text-[11px] text-fg-3 flex items-center justify-between gap-2">
+          <span>{formatTokens(card.footer.tokens)} tokens</span>
+          <span>{formatCost(card.footer.usd, card.footer.label)}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  if (card.hrefSection == null) return body;
+
+  return (
+    <Link
+      to={`/projects/${slug}/items/${id}/${card.hrefSection}`}
+      data-testid={`overview-workflow-link-${card.key}`}
+      className="block h-full"
+    >
+      {body}
+    </Link>
+  );
 }
 
 export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
@@ -51,10 +618,32 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
     staleTime: 10_000,
     enabled: id !== '',
   });
+  const { data: triage } = useQuery<TriageResultDto | null>({
+    queryKey: ['triage', slug, id],
+    queryFn: () => fetchTriageResult(slug, id),
+    staleTime: 10_000,
+    enabled: id !== '',
+  });
   const qaPayload = events.find((e) => e.kind === 'qa.completed')?.payload as
     | { testRun?: { passed: number; failed: number; skipped: number } }
     | undefined;
   const testRun = qaPayload?.testRun ?? null;
+  const workflowCards = useMemo(
+    () =>
+      buildOverviewWorkflowSummary({
+        item,
+        events,
+        triage,
+        costs:
+          'byStage' in costs
+            ? {
+                byStage: costs.byStage,
+                bySkill: (costs as { bySkill?: Map<string, StageBreakdown> }).bySkill,
+              }
+            : undefined,
+      }),
+    [costs, events, item, triage],
+  );
 
   return (
     <div data-testid="overview-section" className="px-8 py-6 flex flex-col gap-5">
@@ -97,6 +686,15 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
         />
         <StatCard label="Last agent" value={lastAgentLabel} />
         <StatCard label="Spent" value={spentValue} sub={spentSub} />
+      </div>
+
+      <div
+        data-testid="overview-workflow-grid"
+        className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3"
+      >
+        {workflowCards.map((card) => (
+          <WorkflowSummaryCard key={card.key} card={card} slug={slug} id={id} />
+        ))}
       </div>
 
       {/* Main content grid */}

--- a/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
@@ -1,19 +1,8 @@
-/** @vitest-environment jsdom */
-import { fetchTriageResult, setRepoOverride } from '@/lib/api';
 import type { TriageResultDto } from '@/lib/types';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TriageResultsSection } from './TriageResultsSection';
+import { describe, expect, it } from 'vitest';
+import { getCanonicalTriageSummary, getTriageResultQueryKey } from './TriageResultsSection';
 
-afterEach(cleanup);
-
-vi.mock('@/lib/api', () => ({
-  fetchTriageResult: vi.fn(),
-  setRepoOverride: vi.fn(),
-}));
-
-const TRIAGE_DATA: TriageResultDto = {
+const BASE_TRIAGE: TriageResultDto = {
   priority: 'high',
   type: 'bug',
   candidates: [
@@ -23,62 +12,81 @@ const TRIAGE_DATA: TriageResultDto = {
       tier: 1,
       evidence: 'Keyword match in src/lib/',
     },
+    {
+      repo: 'shaunnez/docs',
+      confidence: 55,
+      tier: 2,
+      evidence: 'Secondary ownership signal',
+    },
   ],
   overrideRepo: null,
 };
 
-function renderSection(slug = 'proj', id = '42') {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  render(
-    <QueryClientProvider client={qc}>
-      <TriageResultsSection projectSlug={slug} id={id} />
-    </QueryClientProvider>,
-  );
-  return qc;
-}
-
-describe('TriageResultsSection — empty state', () => {
-  it('renders empty state when fetch returns null', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
-    renderSection();
-    const el = await screen.findByTestId('triage-empty-state');
-    expect(el).toBeTruthy();
-  });
-
-  it('shows "No triage result yet" heading in empty state', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
-    renderSection();
-    await screen.findByTestId('triage-empty-state');
-    expect(screen.getByText('No triage result yet')).toBeTruthy();
-  });
-
-  it('shows section header in empty state', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
-    renderSection();
-    await screen.findByTestId('triage-empty-state');
-    expect(screen.getByText('Repo candidates & classification')).toBeTruthy();
-  });
-
-  it('shows descriptive sub-copy in empty state', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(null);
-    renderSection();
-    await screen.findByTestId('triage-empty-state');
-    expect(screen.getByTestId('triage-empty-description')).toBeTruthy();
+describe('getTriageResultQueryKey', () => {
+  it('keeps the canonical overview cache key stable', () => {
+    expect(getTriageResultQueryKey('proj', '42')).toEqual(['triage', 'proj', '42']);
   });
 });
 
-describe('TriageResultsSection — with data', () => {
-  it('renders triage section when data is present', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(TRIAGE_DATA);
-    renderSection();
-    const el = await screen.findByTestId('triage-results-section');
-    expect(el).toBeTruthy();
+describe('getCanonicalTriageSummary', () => {
+  it('returns priority, type, candidate count, picked repo, and confidence from canonical triage data', () => {
+    expect(getCanonicalTriageSummary(BASE_TRIAGE)).toEqual({
+      priority: 'high',
+      type: 'bug',
+      candidateCount: 2,
+      pickedRepo: 'shaunnez/goose-hub',
+      confidence: 85,
+      isOverride: false,
+    });
   });
 
-  it('does not render empty state when data is present', async () => {
-    vi.mocked(fetchTriageResult).mockResolvedValueOnce(TRIAGE_DATA);
-    renderSection();
-    await screen.findByTestId('triage-results-section');
-    expect(screen.queryByTestId('triage-empty-state')).toBeNull();
+  it('prefers the override repo and marks the summary as overridden', () => {
+    expect(
+      getCanonicalTriageSummary({
+        ...BASE_TRIAGE,
+        overrideRepo: 'shaunnez/docs',
+      }),
+    ).toEqual({
+      priority: 'high',
+      type: 'bug',
+      candidateCount: 2,
+      pickedRepo: 'shaunnez/docs',
+      confidence: 55,
+      isOverride: true,
+    });
+  });
+
+  it('keeps the override repo visible even if it is not in the candidate list', () => {
+    expect(
+      getCanonicalTriageSummary({
+        ...BASE_TRIAGE,
+        overrideRepo: 'shaunnez/ops',
+      }),
+    ).toEqual({
+      priority: 'high',
+      type: 'bug',
+      candidateCount: 2,
+      pickedRepo: 'shaunnez/ops',
+      confidence: 85,
+      isOverride: true,
+    });
+  });
+
+  it('returns null repo and confidence when triage produced no candidates', () => {
+    expect(
+      getCanonicalTriageSummary({
+        priority: 'medium',
+        type: 'task',
+        candidates: [],
+        overrideRepo: null,
+      }),
+    ).toEqual({
+      priority: 'medium',
+      type: 'task',
+      candidateCount: 0,
+      pickedRepo: null,
+      confidence: null,
+      isOverride: false,
+    });
   });
 });

--- a/apps/web/src/components/detail/components/TriageResultsSection.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.tsx
@@ -13,6 +13,38 @@ interface TriageResultsSectionProps {
 // Static allowlist — mirrors target-projects/goose-hub-self/repos.md
 const ALLOWLISTED_REPOS = ['shaunnez/goose-hub'];
 
+export function getTriageResultQueryKey(projectSlug: string, id: string) {
+  return ['triage', projectSlug, id] as const;
+}
+
+export interface CanonicalTriageSummary {
+  priority: string;
+  type: string;
+  candidateCount: number;
+  pickedRepo: string | null;
+  confidence: number | null;
+  isOverride: boolean;
+}
+
+export function getCanonicalTriageSummary(triage: TriageResultDto): CanonicalTriageSummary {
+  const pickedRepo = triage.overrideRepo ?? triage.candidates[0]?.repo ?? null;
+  const pickedCandidate =
+    (pickedRepo != null
+      ? triage.candidates.find((candidate) => candidate.repo === pickedRepo)
+      : null) ??
+    triage.candidates[0] ??
+    null;
+
+  return {
+    priority: triage.priority,
+    type: triage.type,
+    candidateCount: triage.candidates.length,
+    pickedRepo,
+    confidence: pickedCandidate?.confidence ?? null,
+    isOverride: triage.overrideRepo != null,
+  };
+}
+
 function ScoreBar({ value }: { value: number }) {
   const pct = Math.max(0, Math.min(100, value));
   const color = pct >= 70 ? 'var(--accent)' : pct >= 40 ? 'oklch(0.74 0.15 200)' : 'var(--fg-4)';
@@ -32,14 +64,14 @@ export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionPr
   const [selectedRepo, setSelectedRepo] = useState('');
 
   const { data, isLoading } = useQuery<TriageResultDto | null>({
-    queryKey: ['triage', projectSlug, id],
+    queryKey: getTriageResultQueryKey(projectSlug, id),
     queryFn: () => fetchTriageResult(projectSlug, id),
   });
 
   const overrideMutation = useMutation({
     mutationFn: (repo: string) => setRepoOverride(projectSlug, id, repo),
     onSuccess: (updated) => {
-      queryClient.setQueryData(['triage', projectSlug, id], updated);
+      queryClient.setQueryData(getTriageResultQueryKey(projectSlug, id), updated);
       setSelectedRepo('');
       setOverrideMode(false);
     },
@@ -85,7 +117,8 @@ export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionPr
   }
 
   const triage: TriageResultDto = data;
-  const pickedRepo = triage.overrideRepo ?? triage.candidates[0]?.repo;
+  const triageSummary = getCanonicalTriageSummary(triage);
+  const pickedRepo = triageSummary.pickedRepo;
 
   const priorityColor = PRIORITY_COLOR[triage.priority];
   const priorityBg = PRIORITY_BG[triage.priority];

--- a/apps/web/src/components/detail/lib/costs.test.ts
+++ b/apps/web/src/components/detail/lib/costs.test.ts
@@ -46,6 +46,7 @@ describe('useIssueCostsBreakdown', () => {
     expect(result.current.runCount).toBe(0);
     expect(result.current.byRun.size).toBe(0);
     expect(result.current.byStage.size).toBe(0);
+    expect(result.current.bySkill.size).toBe(0);
   });
 
   it('keys cost rows by runId and aggregates by stage', async () => {
@@ -99,5 +100,103 @@ describe('useIssueCostsBreakdown', () => {
 
     expect(result.current.totalLabel).toBe('estimated');
     expect(result.current.byStage.get('review')?.label).toBe('estimated');
+  });
+
+  it('aggregates discover costs by skill while preserving byStage totals', async () => {
+    const data: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.17,
+      hasEstimated: false,
+      rows: [
+        row({
+          runId: 'r-grill-1',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.03,
+          inputTokens: 120,
+          outputTokens: 80,
+        }),
+        row({
+          runId: 'r-grill-2',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.02,
+          inputTokens: 90,
+          outputTokens: 60,
+        }),
+        row({
+          runId: 'r-prd-1',
+          stage: 'discover',
+          skill: 'write-prd',
+          costUsd: 0.12,
+          inputTokens: 400,
+          outputTokens: 250,
+        }),
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', '42'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.runCount).toBe(3);
+    });
+
+    const discover = result.current.byStage.get('discover');
+    expect(discover?.runCount).toBe(3);
+    expect(discover?.usd).toBeCloseTo(0.17, 5);
+    expect(discover?.tokens).toBe(1000);
+
+    const grill = result.current.bySkill.get('grill-me');
+    expect(grill?.stage).toBe('discover');
+    expect(grill?.runCount).toBe(2);
+    expect(grill?.usd).toBeCloseTo(0.05, 5);
+    expect(grill?.tokens).toBe(350);
+
+    const prd = result.current.bySkill.get('write-prd');
+    expect(prd?.stage).toBe('discover');
+    expect(prd?.runCount).toBe(1);
+    expect(prd?.usd).toBeCloseTo(0.12, 5);
+    expect(prd?.tokens).toBe(650);
+  });
+
+  it("flips a skill label to 'estimated' when any row in it is estimated", async () => {
+    const data: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.2,
+      hasEstimated: true,
+      rows: [
+        row({
+          runId: 'r-grill-1',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.04,
+          costLabel: 'exact',
+        }),
+        row({
+          runId: 'r-grill-2',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.06,
+          costLabel: 'estimated',
+        }),
+        row({
+          runId: 'r-prd-1',
+          stage: 'discover',
+          skill: 'write-prd',
+          costUsd: 0.1,
+          costLabel: 'exact',
+        }),
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', '42'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.runCount).toBe(3);
+    });
+
+    expect(result.current.byStage.get('discover')?.label).toBe('estimated');
+    expect(result.current.bySkill.get('grill-me')?.label).toBe('estimated');
+    expect(result.current.bySkill.get('write-prd')?.label).toBe('exact');
   });
 });

--- a/apps/web/src/components/detail/lib/costs.ts
+++ b/apps/web/src/components/detail/lib/costs.ts
@@ -14,6 +14,7 @@ export type StageBreakdown = {
 export interface IssueCostsBreakdown {
   byRun: Map<string, CostRowDto>;
   byStage: Map<CostRowDto['stage'], StageBreakdown>;
+  bySkill: Map<string, StageBreakdown>;
   total: number;
   totalTokens: number;
   hasEstimated: boolean;
@@ -25,6 +26,7 @@ export interface IssueCostsBreakdown {
 const EMPTY: Omit<IssueCostsBreakdown, 'isLoading'> = {
   byRun: new Map(),
   byStage: new Map(),
+  bySkill: new Map(),
   total: 0,
   totalTokens: 0,
   hasEstimated: false,
@@ -51,6 +53,7 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
 
     const byRun = new Map<string, CostRowDto>();
     const byStage = new Map<CostRowDto['stage'], StageBreakdown>();
+    const bySkill = new Map<string, StageBreakdown>();
     let totalTokens = 0;
 
     for (const row of data.rows) {
@@ -58,26 +61,14 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
       const tokens = row.inputTokens + row.outputTokens;
       totalTokens += tokens;
 
-      const existing = byStage.get(row.stage);
-      if (existing) {
-        existing.usd += row.costUsd;
-        existing.tokens += tokens;
-        existing.runCount += 1;
-        if (row.costLabel === 'estimated') existing.label = 'estimated';
-      } else {
-        byStage.set(row.stage, {
-          stage: row.stage,
-          usd: row.costUsd,
-          tokens,
-          label: row.costLabel,
-          runCount: 1,
-        });
-      }
+      accumulateBreakdown(byStage, row.stage, row, tokens);
+      accumulateBreakdown(bySkill, row.skill, row, tokens);
     }
 
     return {
       byRun,
       byStage,
+      bySkill,
       total: data.totalUsd,
       totalTokens,
       hasEstimated: data.hasEstimated,
@@ -86,4 +77,28 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
       isLoading,
     };
   }, [data, isLoading, enabled]);
+}
+
+function accumulateBreakdown(
+  bucket: Map<string, StageBreakdown>,
+  key: string,
+  row: CostRowDto,
+  tokens: number,
+): void {
+  const existing = bucket.get(key);
+  if (existing) {
+    existing.usd += row.costUsd;
+    existing.tokens += tokens;
+    existing.runCount += 1;
+    if (row.costLabel === 'estimated') existing.label = 'estimated';
+    return;
+  }
+
+  bucket.set(key, {
+    stage: row.stage,
+    usd: row.costUsd,
+    tokens,
+    label: row.costLabel,
+    runCount: 1,
+  });
 }

--- a/apps/web/src/components/detail/lib/investigation.test.ts
+++ b/apps/web/src/components/detail/lib/investigation.test.ts
@@ -10,6 +10,7 @@ import {
   countToolCalls,
   decisionLabel,
   extractInvestigationPayload,
+  getInvestigationSummary,
   latestInvestigationEvent,
 } from './investigation';
 
@@ -166,6 +167,86 @@ describe('latestInvestigationEvent', () => {
 
     expect(latestInvestigationEvent([newer, older])).toBe(newer);
     expect(latestInvestigationEvent([older, newer])).toBe(newer);
+  });
+});
+
+describe('getInvestigationSummary', () => {
+  it('uses the latest terminal investigation event and derives counts from the full event history', () => {
+    const older = event({
+      id: 10,
+      kind: 'agent.investigation-complete',
+      createdAt: '2026-05-18T01:00:00Z',
+      payload: {
+        investigate: {
+          findings: 'older',
+          keyFiles: [{ path: 'src/old.ts', reason: 'old' }],
+          confidence: 'low',
+          openQuestions: ['first'],
+          decisionSummaries: [],
+          repro: { status: 'not_reproduced' },
+        },
+      },
+    });
+    const newer = event({
+      id: 11,
+      kind: 'agent.investigation-complete',
+      createdAt: '2026-05-18T02:00:00Z',
+      payload: {
+        investigate: {
+          findings: 'newer',
+          keyFiles: [
+            { path: 'src/a.ts', reason: 'a' },
+            { path: 'src/b.ts', reason: 'b' },
+          ],
+          confidence: 'high',
+          openQuestions: ['first', 'second'],
+          decisionSummaries: [],
+          repro: { status: 'reproduced' },
+        },
+      },
+    });
+
+    const summary = getInvestigationSummary([
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Read' } }),
+      event({ kind: 'agent.tool-call', payload: { tool_name: 'Grep' } }),
+      older,
+      newer,
+    ]);
+
+    expect(summary).toMatchObject({
+      confidence: 'high',
+      keyFileCount: 2,
+      openQuestionCount: 2,
+      readCount: 1,
+      searchCount: 1,
+      reproStatus: 'reproduced',
+    });
+    expect(summary?.event).toBe(newer);
+  });
+
+  it('handles missing repro and array fields safely', () => {
+    const summary = getInvestigationSummary([
+      event({
+        id: 12,
+        kind: 'agent.investigation-complete',
+        payload: {
+          investigate: {
+            findings: 'partial',
+            confidence: 'medium',
+            decisionSummaries: [],
+          },
+        },
+      }),
+    ]);
+
+    expect(summary).toMatchObject({
+      confidence: 'medium',
+      keyFileCount: 0,
+      openQuestionCount: 0,
+      readCount: 0,
+      searchCount: 0,
+      reproStatus: 'unknown',
+    });
   });
 });
 

--- a/apps/web/src/components/detail/lib/investigation.ts
+++ b/apps/web/src/components/detail/lib/investigation.ts
@@ -20,11 +20,25 @@ export interface DecisionSummaryWire {
 export interface InvestigationPayload {
   investigate: {
     findings: string;
-    keyFiles: KeyFile[];
-    confidence: 'low' | 'medium' | 'high';
-    openQuestions: string[];
-    decisionSummaries: DecisionSummaryWire[];
+    keyFiles?: KeyFile[];
+    confidence?: 'low' | 'medium' | 'high';
+    openQuestions?: string[];
+    decisionSummaries?: DecisionSummaryWire[];
+    repro?: {
+      status?: string;
+    };
   };
+}
+
+export interface InvestigationSummary {
+  event: AgentEventDto;
+  payload: InvestigationPayload['investigate'];
+  confidence: 'low' | 'medium' | 'high' | 'unknown';
+  keyFileCount: number;
+  openQuestionCount: number;
+  readCount: number;
+  searchCount: number;
+  reproStatus: string;
 }
 
 /** Returns `kind` (new) or `step` (legacy) for backward compatibility (#466). */
@@ -70,6 +84,10 @@ export function extractInvestigationPayload(event: AgentEventDto): Investigation
   return p as unknown as InvestigationPayload;
 }
 
+function asArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
 export function latestInvestigationEvent(events: AgentEventDto[]): AgentEventDto | null {
   return events
     .filter((e) => e.kind === 'agent.investigation-complete')
@@ -78,6 +96,24 @@ export function latestInvestigationEvent(events: AgentEventDto[]): AgentEventDto
       if (event.id !== latest.id) return event.id > latest.id ? event : latest;
       return event.createdAt > latest.createdAt ? event : latest;
     }, null);
+}
+
+export function getInvestigationSummary(events: AgentEventDto[]): InvestigationSummary | null {
+  const event = latestInvestigationEvent(events);
+  if (event == null) return null;
+  const payload = extractInvestigationPayload(event)?.investigate;
+  if (payload == null) return null;
+
+  return {
+    event,
+    payload,
+    confidence: payload.confidence ?? 'unknown',
+    keyFileCount: asArray(payload.keyFiles).length,
+    openQuestionCount: asArray(payload.openQuestions).length,
+    readCount: countToolCalls(events, READ_TOOLS),
+    searchCount: countToolCalls(events, SEARCH_TOOLS),
+    reproStatus: payload.repro?.status ?? 'unknown',
+  };
 }
 
 function isReadBucket(names: Set<string>): boolean {

--- a/apps/web/src/components/detail/lib/retrospective.test.ts
+++ b/apps/web/src/components/detail/lib/retrospective.test.ts
@@ -1,6 +1,12 @@
 import { AlertCircle, CheckCircle, XCircle } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
-import { CONFIDENCE_COLOR, outcomeMeta, scoreGrade } from './retrospective';
+import {
+  CONFIDENCE_COLOR,
+  getRetrospectiveSummary,
+  latestRetrospectivePayload,
+  outcomeMeta,
+  scoreGrade,
+} from './retrospective';
 
 describe('scoreGrade', () => {
   it('returns "Excellent" for scores >= 0.9', () => {
@@ -60,5 +66,143 @@ describe('CONFIDENCE_COLOR', () => {
     expect(CONFIDENCE_COLOR.high).toContain('green');
     expect(CONFIDENCE_COLOR.medium).toContain('yellow');
     expect(CONFIDENCE_COLOR.low).toContain('blue');
+  });
+});
+
+describe('latestRetrospectivePayload', () => {
+  it('prefers the latest retrospective completion payload', () => {
+    const older = latestRetrospectivePayload([
+      {
+        id: 1,
+        kind: 'retrospective.completed',
+        payload: {
+          retrospective: {
+            tier: 'light',
+            output: {
+              outcome: 'partial',
+              workItemNumber: 980,
+              summary: { wentWell: '', didNotGoWell: '', architecturalTakeaway: '' },
+              improvementCandidates: [],
+              decisionSummaries: [],
+            },
+          },
+        },
+        projectId: 'proj',
+        workItemId: 'wi-1',
+        createdAt: '2026-05-18T01:00:00Z',
+      },
+      {
+        id: 2,
+        kind: 'retrospective.completed',
+        payload: {
+          retrospective: {
+            tier: 'deep',
+            output: {
+              outcome: 'success',
+              workItemNumber: 980,
+              summary: { wentWell: '', didNotGoWell: '', architecturalTakeaway: '' },
+              improvementCandidates: [],
+              decisionSummaries: [],
+              triggerReasons: [],
+              personaQualityScores: [],
+              learningEntries: [],
+              decisionPatterns: [],
+            },
+          },
+        },
+        projectId: 'proj',
+        workItemId: 'wi-1',
+        createdAt: '2026-05-18T02:00:00Z',
+      },
+    ] as never);
+
+    expect(older?.tier).toBe('deep');
+  });
+});
+
+describe('getRetrospectiveSummary', () => {
+  it('omits deep-only metrics for light retrospectives and counts high-confidence candidates', () => {
+    const summary = getRetrospectiveSummary({
+      tier: 'light',
+      output: {
+        outcome: 'partial',
+        workItemNumber: 980,
+        summary: { wentWell: 'a', didNotGoWell: 'b', architecturalTakeaway: 'c' },
+        decisionSummaries: [],
+        improvementCandidates: [
+          {
+            kind: 'workflow',
+            targetPath: 'docs/a.md',
+            suggestionText: 'a',
+            confidence: 'high',
+          },
+          {
+            kind: 'persona',
+            targetPath: 'docs/b.md',
+            suggestionText: 'b',
+            confidence: 'medium',
+          },
+        ],
+      },
+    });
+
+    expect(summary).toMatchObject({
+      tier: 'light',
+      outcome: 'partial',
+      candidateCount: 2,
+      highConfidenceCandidateCount: 1,
+      qualityScoreCount: 0,
+      patternCount: 0,
+      learningCount: 0,
+    });
+  });
+
+  it('includes deep-only metrics for deep retrospectives', () => {
+    const summary = getRetrospectiveSummary({
+      tier: 'deep',
+      output: {
+        outcome: 'success',
+        workItemNumber: 980,
+        summary: { wentWell: 'a', didNotGoWell: 'b', architecturalTakeaway: 'c' },
+        decisionSummaries: [],
+        improvementCandidates: [
+          {
+            kind: 'workflow',
+            targetPath: 'docs/a.md',
+            suggestionText: 'a',
+            confidence: 'high',
+          },
+        ],
+        triggerReasons: ['quality'],
+        personaQualityScores: [
+          {
+            personaId: 'reviewer',
+            score: 0.8,
+            trend: 'improving',
+            sampleCount: 3,
+          },
+        ],
+        learningEntries: [
+          {
+            observation: 'o',
+            rationale: 'r',
+            improvementKind: 'workflow',
+            confidence: 'medium',
+          },
+        ],
+        decisionPatterns: [{ pattern: 'p', occurrences: 2, confidence: 'high' }],
+      },
+    });
+
+    expect(summary).toMatchObject({
+      tier: 'deep',
+      outcome: 'success',
+      candidateCount: 1,
+      highConfidenceCandidateCount: 1,
+      qualityScoreCount: 1,
+      patternCount: 1,
+      learningCount: 1,
+      triggerReasonCount: 1,
+    });
   });
 });

--- a/apps/web/src/components/detail/lib/retrospective.ts
+++ b/apps/web/src/components/detail/lib/retrospective.ts
@@ -1,3 +1,4 @@
+import type { AgentEventDto } from '@/lib/types';
 import { AlertCircle, CheckCircle, XCircle } from 'lucide-react';
 
 export type Confidence = 'low' | 'medium' | 'high';
@@ -81,6 +82,17 @@ export interface DeepRetroPayload {
 
 export type RetroPayload = LightRetroPayload | DeepRetroPayload;
 
+export interface RetrospectiveSummary {
+  tier: RetroPayload['tier'];
+  outcome: Outcome;
+  candidateCount: number;
+  highConfidenceCandidateCount: number;
+  qualityScoreCount: number;
+  learningCount: number;
+  patternCount: number;
+  triggerReasonCount: number;
+}
+
 export const CONFIDENCE_COLOR: Record<Confidence, string> = {
   high: 'bg-green-500/15 text-green-400',
   medium: 'bg-yellow-500/15 text-yellow-400',
@@ -100,4 +112,55 @@ export function outcomeMeta(outcome: Outcome) {
     return { icon: CheckCircle, color: 'var(--success)', label: 'Success' };
   if (outcome === 'failure') return { icon: XCircle, color: 'var(--danger)', label: 'Failure' };
   return { icon: AlertCircle, color: 'var(--warning)', label: 'Partial' };
+}
+
+function extractRetrospectivePayload(event: AgentEventDto): RetroPayload | null {
+  const payload = event.payload;
+  if (payload == null || typeof payload !== 'object') return null;
+  const retrospective = (payload as { retrospective?: unknown }).retrospective;
+  if (retrospective == null || typeof retrospective !== 'object') return null;
+  return retrospective as RetroPayload;
+}
+
+export function latestRetrospectivePayload(events: AgentEventDto[]): RetroPayload | null {
+  const event = events
+    .filter((candidate) => candidate.kind === 'retrospective.completed')
+    .reduce<AgentEventDto | null>((latest, candidate) => {
+      if (latest == null) return candidate;
+      if (candidate.id !== latest.id) return candidate.id > latest.id ? candidate : latest;
+      return candidate.createdAt > latest.createdAt ? candidate : latest;
+    }, null);
+
+  return event == null ? null : extractRetrospectivePayload(event);
+}
+
+export function getRetrospectiveSummary(payload: RetroPayload): RetrospectiveSummary {
+  const candidateCount = payload.output.improvementCandidates.length;
+  const highConfidenceCandidateCount = payload.output.improvementCandidates.filter(
+    (candidate) => candidate.confidence === 'high',
+  ).length;
+
+  if (payload.tier === 'light') {
+    return {
+      tier: payload.tier,
+      outcome: payload.output.outcome,
+      candidateCount,
+      highConfidenceCandidateCount,
+      qualityScoreCount: 0,
+      learningCount: 0,
+      patternCount: 0,
+      triggerReasonCount: 0,
+    };
+  }
+
+  return {
+    tier: payload.tier,
+    outcome: payload.output.outcome,
+    candidateCount,
+    highConfidenceCandidateCount,
+    qualityScoreCount: payload.output.personaQualityScores.length,
+    learningCount: payload.output.learningEntries.length,
+    patternCount: payload.output.decisionPatterns.length,
+    triggerReasonCount: payload.output.triggerReasons.length,
+  };
 }

--- a/apps/web/src/components/detail/slice.test.ts
+++ b/apps/web/src/components/detail/slice.test.ts
@@ -1,9 +1,28 @@
+/** @vitest-environment jsdom */
 import { GATE_STATES } from '@/lib/constants';
 import { parseDependencies } from '@/lib/dependency-parser';
 import { renderMarkdownToHtml } from '@/lib/markdown';
-import { describe, expect, it } from 'vitest';
+import type { AgentEventDto, TriageResultDto, WorkItemDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OverviewSection, buildOverviewWorkflowSummary } from './components/OverviewSection';
 import { extractPlaywrightRepro } from './lib/playwright-capture';
 import { SECTIONS } from './lib/sections';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+vi.mock('@/lib/api', () => ({
+  fetchEvents: vi.fn().mockResolvedValue([]),
+  fetchIssueDiff: vi.fn().mockResolvedValue({ diff: null, runId: null }),
+  fetchIssueCosts: vi.fn().mockResolvedValue({ rows: [], totalUsd: 0, hasEstimated: false }),
+  fetchPersonaNames: vi.fn().mockResolvedValue([]),
+  fetchTriageResult: vi.fn().mockResolvedValue(null),
+}));
 
 describe('detail page — sections config', () => {
   it('lists the 11 design sections in order (chat removed post-M20)', () => {
@@ -217,5 +236,308 @@ describe('dependency-parser — web lib', () => {
       { type: 'depends-on', repoRef: null, issueNumber: 291 },
       { type: 'blocks', repoRef: null, issueNumber: 300 },
     ]);
+  });
+});
+
+const BASE_ITEM: WorkItemDto = {
+  id: 'wi-42',
+  externalId: '42',
+  repoRef: 'shaunnez/goose-hub',
+  title: 'Workflow snapshot grid',
+  body: 'Body',
+  type: 'bug',
+  priority: 'medium',
+  mode: 'manual',
+  state: 'factory:triaging',
+  authorIsOwner: false,
+  schedule: 'queued',
+  exec: 'todo',
+  dependsOn: [],
+  blocks: [],
+  createdAt: '2026-05-23T00:00:00.000Z',
+  lastPersonaId: null,
+};
+
+const TRIAGE_RESULT: TriageResultDto = {
+  priority: 'high',
+  type: 'bug',
+  candidates: [
+    { repo: 'shaunnez/goose-hub', confidence: 88, evidence: 'matched', tier: 1 },
+    { repo: 'shaunnez/other-repo', confidence: 41, evidence: 'fallback', tier: 2 },
+  ],
+  overrideRepo: 'shaunnez/goose-hub',
+};
+
+function makeEvent(
+  id: number,
+  kind: string,
+  payload: unknown,
+  extras: Partial<AgentEventDto> = {},
+): AgentEventDto {
+  return {
+    id,
+    projectId: 'proj',
+    workItemId: 'github:shaunnez/goose-hub#42',
+    kind,
+    payload,
+    runId: extras.runId ?? null,
+    personaId: extras.personaId ?? null,
+    createdAt: extras.createdAt ?? `2026-05-23T00:00:0${id}.000Z`,
+  };
+}
+
+describe('overview workflow summary', () => {
+  it('returns six cards in order with safe defaults when events are empty', () => {
+    const cards = buildOverviewWorkflowSummary({ item: BASE_ITEM, events: [] });
+    expect(cards.map((card) => card.title)).toEqual([
+      'Triage',
+      'Investigation',
+      'Grill',
+      'PRD',
+      'Review',
+      'Retro',
+    ]);
+    expect(cards[0].status).toBe('Not run');
+    expect(cards[2].status).toBe('N/A');
+    expect(cards[2].statusTone).toBe('muted');
+    expect(cards[3].status).toBe('N/A');
+    expect(cards[3].statusTone).toBe('muted');
+  });
+
+  it('uses canonical triage data for triage metrics', () => {
+    const cards = buildOverviewWorkflowSummary({
+      item: BASE_ITEM,
+      events: [],
+      triage: TRIAGE_RESULT,
+    });
+    const triageCard = cards[0];
+    expect(triageCard.metrics.map((entry) => entry.label)).toEqual([
+      'Priority',
+      'Type',
+      'Repo',
+      'Conf',
+      'Candidates',
+      'Override',
+    ]);
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('high');
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('bug');
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('shaunnez/goose-hub');
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('88%');
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('2');
+    expect(triageCard.metrics.map((entry) => entry.value)).toContain('Yes');
+  });
+
+  it('falls back to triage-complete events and latest investigation/review outputs', () => {
+    const events = [
+      makeEvent(1, 'agent.triage-complete', {
+        priority: 'low',
+        type: 'bug',
+        overrideRepo: null,
+        pickedRepo: 'shaunnez/goose-hub',
+        confidence: 67,
+        candidates: [{ repo: 'shaunnez/goose-hub', confidence: 67 }],
+      }),
+      makeEvent(
+        2,
+        'agent.investigation-complete',
+        {
+          investigate: {
+            findings: 'old',
+            keyFiles: [],
+            confidence: 'low',
+            openQuestions: [],
+            decisionSummaries: [],
+          },
+        },
+        { runId: 'run-old' },
+      ),
+      makeEvent(
+        3,
+        'agent.investigation-complete',
+        {
+          investigate: {
+            findings: 'new',
+            keyFiles: [
+              { path: 'src/a.ts', reason: 'entry' },
+              { path: 'src/b.ts', reason: 'helper' },
+            ],
+            confidence: 'high',
+            openQuestions: ['why'],
+            decisionSummaries: [],
+          },
+          playwrightRepro: { reproduced: true },
+        },
+        { runId: 'run-new' },
+      ),
+      makeEvent(4, 'agent.tool-call', { tool_name: 'Read' }, { runId: 'run-new' }),
+      makeEvent(5, 'agent.tool-call', { tool_name: 'rg' }, { runId: 'run-new' }),
+      makeEvent(6, 'review.completed', {
+        verdict: 'needs-fix',
+        confidence: 0.51,
+        criteriaChecks: [{ criterion: 'A', status: 'unmet' }],
+        findings: [{ severity: 'major', description: 'Issue' }],
+      }),
+      makeEvent(7, 'review.completed', {
+        verdict: 'approved',
+        confidence: 0.91,
+        criteriaChecks: [
+          { criterion: 'A', status: 'met' },
+          { criterion: 'B', status: 'met' },
+        ],
+        findings: [
+          { severity: 'blocker', description: 'Fixed' },
+          { severity: 'major', description: 'Tracked' },
+        ],
+      }),
+      makeEvent(8, 'pr.opened', { prNumber: 123 }),
+    ];
+
+    const cards = buildOverviewWorkflowSummary({ item: BASE_ITEM, events });
+    const triageCard = cards[0];
+    const investigationCard = cards[1];
+    const reviewCard = cards[4];
+
+    expect(triageCard.metrics.find((entry) => entry.label === 'Conf')?.value).toBe('67%');
+    expect(investigationCard.metrics.find((entry) => entry.label === 'Key files')?.value).toBe('2');
+    expect(investigationCard.metrics.find((entry) => entry.label === 'Reads')?.value).toBe('1');
+    expect(investigationCard.metrics.find((entry) => entry.label === 'Searches')?.value).toBe('1');
+    expect(investigationCard.metrics.find((entry) => entry.label === 'Repro')?.value).toBe('Yes');
+    expect(reviewCard.status).toBe('approved');
+    expect(reviewCard.metrics.find((entry) => entry.label === 'Checks')?.value).toBe('2/2');
+    expect(reviewCard.metrics.find((entry) => entry.label === 'PR')?.value).toBe('#123');
+  });
+
+  it('treats discover lane cards as applicable for feature work and counts PRD/retro details', () => {
+    const item = { ...BASE_ITEM, type: 'feature', state: 'factory:prd-review' };
+    const events = [
+      makeEvent(1, 'grill.question-posted', { question: 'First?' }),
+      makeEvent(2, 'grill.question-posted', { question: 'Second?' }),
+      makeEvent(3, 'grill.completed', { rounds: 2, forcedCompletion: false }),
+      makeEvent(4, 'prd.drafted', {
+        prd: {
+          estimatedComplexity: 'medium',
+          acceptanceCriteria: [
+            { id: 'AC-1', statement: 'One' },
+            { id: 'AC-2', statement: 'Two' },
+          ],
+          journeys: [
+            {
+              id: 'J-1',
+              persona: 'Dev',
+              trigger: 'Open',
+              steps: [],
+              successState: 'Done',
+              errorStates: [],
+              edgeCases: [],
+            },
+          ],
+          verticalSlices: [
+            { title: 'Slice', goal: 'Goal', estimatedSize: 'M', journeyRefs: ['J-1'] },
+          ],
+        },
+        advisorConcerns: ['Need analytics'],
+      }),
+      makeEvent(5, 'retrospective.completed', {
+        tier: 'deep',
+        output: {
+          outcome: 'partial',
+          workItemNumber: 42,
+          summary: { wentWell: 'a', didNotGoWell: 'b', architecturalTakeaway: 'c' },
+          improvementCandidates: [
+            { kind: 'workflow', targetPath: 'a', suggestionText: 'x', confidence: 'high' },
+            { kind: 'skill-prompt', targetPath: 'b', suggestionText: 'y', confidence: 'medium' },
+          ],
+          decisionSummaries: [],
+          triggerReasons: ['many-failures'],
+          personaQualityScores: [],
+          learningEntries: [
+            {
+              observation: 'obs',
+              rationale: 'rat',
+              improvementKind: 'workflow',
+              confidence: 'high',
+            },
+          ],
+          decisionPatterns: [{ pattern: 'pattern', occurrences: 2, confidence: 'medium' }],
+        },
+      }),
+    ];
+
+    const cards = buildOverviewWorkflowSummary({ item, events });
+    const grillCard = cards[2];
+    const prdCard = cards[3];
+    const retroCard = cards[5];
+
+    expect(grillCard.status).toBe('Complete');
+    expect(grillCard.metrics.find((entry) => entry.label === 'Questions')?.value).toBe('2');
+    expect(prdCard.status).toBe('In review');
+    expect(prdCard.metrics.find((entry) => entry.label === 'ACs')?.value).toBe('2');
+    expect(prdCard.metrics.find((entry) => entry.label === 'Journeys')?.value).toBe('1');
+    expect(prdCard.metrics.find((entry) => entry.label === 'Slices')?.value).toBe('1');
+    expect(prdCard.metrics.find((entry) => entry.label === 'Concerns')?.value).toBe('1');
+    expect(retroCard.metrics.find((entry) => entry.label === 'Tier')?.value).toBe('deep');
+    expect(retroCard.metrics.find((entry) => entry.label === 'Patterns')?.value).toBe('1');
+    expect(retroCard.metrics.find((entry) => entry.label === 'Learnings')?.value).toBe('1');
+  });
+});
+
+describe('OverviewSection workflow grid', () => {
+  it('renders six readable cards with section links even when event data is partial', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(
+      ['events', 'proj', '42'],
+      [
+        makeEvent(1, 'agent.investigation-complete', {
+          investigate: {
+            findings: '',
+            keyFiles: [],
+            confidence: 'medium',
+            openQuestions: [],
+            decisionSummaries: [],
+          },
+        }),
+      ],
+    );
+    queryClient.setQueryData(['issue-diff', 'proj', '42'], { diff: null, runId: null });
+    queryClient.setQueryData(['issue-costs', 'proj', '42'], {
+      rows: [],
+      totalUsd: 0,
+      hasEstimated: false,
+    });
+    queryClient.setQueryData(['triage', 'proj', '42'], TRIAGE_RESULT);
+    queryClient.setQueryData(['persona-names'], []);
+
+    const html = renderToStaticMarkup(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(
+          MemoryRouter,
+          { initialEntries: ['/projects/proj/items/42'] },
+          createElement(
+            Routes,
+            null,
+            createElement(Route, {
+              path: '/projects/:slug/items/:id',
+              element: createElement(OverviewSection, { item: BASE_ITEM, projectSlug: 'proj' }),
+            }),
+          ),
+        ),
+      ),
+    );
+
+    expect(html).toContain('data-testid="overview-workflow-grid"');
+    expect(html).toContain('>Triage<');
+    expect(html).toContain('>Investigation<');
+    expect(html).toContain('>Grill<');
+    expect(html).toContain('>PRD<');
+    expect(html).toContain('>Review<');
+    expect(html).toContain('>Retro<');
+    expect(html).toContain('href="/projects/proj/items/42/repo"');
+    expect(html).toContain('href="/projects/proj/items/42/investigation"');
+    expect(html).toContain('href="/projects/proj/items/42/grill"');
+    expect(html).toContain('href="/projects/proj/items/42/prd"');
+    expect(html).toContain('href="/projects/proj/items/42/review"');
+    expect(html).toContain('href="/projects/proj/items/42/retrospective"');
   });
 });


### PR DESCRIPTION
## Summary

Workflow snapshot grid 2

## Work Packages

- ✓ **WP2**: In apps/web/src/components/detail/lib/costs.ts:12-90, extend IssueCostsBreakdown and EMPTY with bySkill: Map<string, Sta
- ✓ **WP3**: In apps/web/src/components/detail/components/TriageResultsSection.tsx:29-252, keep the existing canonical fetchTriageRes
- ✓ **WP4**: In apps/web/src/components/detail/lib/investigation.ts:16-119, reuse or add pure exported helpers for latest investigati
- ✓ **WP1**: In apps/web/src/components/detail/components/OverviewSection.tsx:1-152, add the OverviewWorkflowCard and BuildOverviewWo

Closes #980
