### PR TITLE
Expand Engineering Spec artifact

### DIFF
--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -24,6 +24,9 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 vi.mock('@goose-hub/core/agent-artifacts/repository.js', () => ({
   getArtifact: vi.fn(),
 }));
+vi.mock('@goose-hub/core/engineering-specs/repository.js', () => ({
+  getEngineeringSpec: vi.fn(),
+}));
 vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   cleanupWorktree: vi.fn(),
 }));
@@ -71,6 +74,7 @@ vi.mock('../../shared/resolve-milestone.js', () => ({
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { getArtifact } from '@goose-hub/core/agent-artifacts/repository.js';
+import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { open } from '@goose-hub/core/interventions/reducer.js';
 import {
@@ -87,6 +91,7 @@ import {
   getIssue,
   getIssueArtifact,
   getIssueLegalTargets,
+  getIssueSpec,
   listIssues,
   overrideIssueRepo,
   setIssueLabel,
@@ -109,6 +114,185 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getSourceForSlug).mockResolvedValue(mockSource as never);
   vi.mocked(getArtifact).mockReturnValue(null);
+  vi.mocked(getEngineeringSpec).mockReturnValue(null);
+});
+
+describe('getIssueSpec', () => {
+  it('returns the expanded explicit Engineering Spec DTO', async () => {
+    vi.mocked(getEngineeringSpec).mockReturnValue({
+      id: 1,
+      projectId: 'test-proj',
+      workItemId: 'github:owner/repo#42',
+      pipelineRunId: 'pipe-123',
+      createdAt: '2026-05-22T09:00:00Z',
+      updatedAt: '2026-05-22T10:00:00Z',
+      spec: {
+        objective: 'Build the authentication flow with token refresh.',
+        architecture: {
+          current: 'Refresh logic lives in the route.',
+          new: 'Move refresh logic into middleware.',
+          decisionRationale: 'Centralized session enforcement is easier to verify.',
+        },
+        schemaChanges: {
+          ddl: ['ALTER TABLE sessions ADD COLUMN refreshed_at TEXT;'],
+          migrations: ['migrations/20260522100000_refresh_sessions.sql'],
+        },
+        interfaceContracts: [
+          {
+            name: 'validateRefreshToken',
+            signature: 'export function validateRefreshToken(token: string): Promise<AuthSession>;',
+            file: 'src/auth/token.ts',
+            lineRange: '12-20',
+          },
+        ],
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: ['src/auth/login.ts'],
+            changes: 'Update login refresh flow.',
+            dependsOn: [],
+            builderTier: 'sonnet',
+          },
+        ],
+        executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+        verificationTooling: [
+          {
+            name: 'Auth unit tests',
+            command: 'pnpm vitest run src/auth/login.test.ts',
+            expectedExitCodes: [0],
+            inputSpec: 'Run from repo root.',
+          },
+        ],
+        acceptanceCriteria: [
+          {
+            id: 'AC-1',
+            statement: 'Users can log in with a valid refresh token.',
+            executableChecks: [],
+          },
+          {
+            id: 'AC-2',
+            statement: 'Expired tokens are rejected.',
+            executableChecks: [
+              {
+                id: 'AC-2-check-1',
+                command: 'pnpm vitest run src/auth/token.test.ts',
+                expectedExitCodes: [0],
+                kind: 'unit',
+              },
+              {
+                id: 'AC-2-check-2',
+                command: 'pnpm vitest run src/auth/middleware.test.ts',
+                expectedExitCodes: [0, 1],
+                kind: 'integration',
+              },
+            ],
+          },
+        ],
+        constraints: [
+          {
+            kind: 'phase',
+            name: 'Investigation tab owns spec display',
+            source: 'apps/web/src/components/detail/components/InvestigationSection.tsx:277',
+          },
+        ],
+        riskRegister: [
+          {
+            risk: 'Refresh middleware could reject valid legacy sessions.',
+            mitigation: 'Keep legacy fallback covered by tests.',
+            severity: 'medium',
+          },
+        ],
+        decisionSummaries: [{ kind: 'PLAN', summary: 'Keep DTO projection explicit.' }],
+      },
+    });
+
+    const result = await getIssueSpec('test-proj', '42');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(getEngineeringSpec).toHaveBeenCalledWith('test-proj', 'github:owner/repo#42');
+    expect(result.data.spec).toMatchObject({
+      pipelineRunId: 'pipe-123',
+      updatedAt: '2026-05-22T10:00:00Z',
+      objective: 'Build the authentication flow with token refresh.',
+      architecture: {
+        current: 'Refresh logic lives in the route.',
+        new: 'Move refresh logic into middleware.',
+        decisionRationale: 'Centralized session enforcement is easier to verify.',
+      },
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: ['src/auth/login.ts'],
+          changes: 'Update login refresh flow.',
+          dependsOn: [],
+          builderTier: 'sonnet',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      verificationTooling: [
+        {
+          name: 'Auth unit tests',
+          command: 'pnpm vitest run src/auth/login.test.ts',
+          expectedExitCodes: [0],
+          inputSpec: 'Run from repo root.',
+        },
+      ],
+      interfaceContracts: [
+        {
+          name: 'validateRefreshToken',
+          signature: 'export function validateRefreshToken(token: string): Promise<AuthSession>;',
+          file: 'src/auth/token.ts',
+          lineRange: '12-20',
+        },
+      ],
+      schemaChanges: {
+        ddl: ['ALTER TABLE sessions ADD COLUMN refreshed_at TEXT;'],
+        migrations: ['migrations/20260522100000_refresh_sessions.sql'],
+      },
+      constraints: [
+        {
+          kind: 'phase',
+          name: 'Investigation tab owns spec display',
+          source: 'apps/web/src/components/detail/components/InvestigationSection.tsx:277',
+        },
+      ],
+      riskRegister: [
+        {
+          risk: 'Refresh middleware could reject valid legacy sessions.',
+          mitigation: 'Keep legacy fallback covered by tests.',
+          severity: 'medium',
+        },
+      ],
+    });
+    expect(result.data.spec?.acceptanceCriteria).toEqual([
+      {
+        id: 'AC-1',
+        statement: 'Users can log in with a valid refresh token.',
+        executableChecks: [],
+      },
+      {
+        id: 'AC-2',
+        statement: 'Expired tokens are rejected.',
+        executableChecks: [
+          {
+            id: 'AC-2-check-1',
+            command: 'pnpm vitest run src/auth/token.test.ts',
+            expectedExitCodes: [0],
+            kind: 'unit',
+          },
+          {
+            id: 'AC-2-check-2',
+            command: 'pnpm vitest run src/auth/middleware.test.ts',
+            expectedExitCodes: [0, 1],
+            kind: 'integration',
+          },
+        ],
+      },
+    ]);
+    expect(result.data.spec?.acceptanceCriteriaCount).toBe(2);
+    expect(result.data.spec).not.toHaveProperty('decisionSummaries');
+  });
 });
 
 describe('transitionIssue — validation', () => {

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -17,6 +17,141 @@ import { getSourceForSlug } from '#shared/source.js';
 import type { LegalTargetsDto } from '../interventions/dto.js';
 import { getLastPersonaIdsByWorkItem, getRepoRef } from './internal.js';
 
+type RawObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is RawObject {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function numberValue(value: unknown, fallback = 0): number {
+  return typeof value === 'number' ? value : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function numberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is number => typeof item === 'number')
+    : [];
+}
+
+function objectArray(value: unknown): RawObject[] {
+  return Array.isArray(value) ? value.filter(isObject) : [];
+}
+
+function projectExecutableChecks(value: unknown) {
+  return objectArray(value).map((check, index) => ({
+    id: stringValue(check.id, `check-${index + 1}`),
+    command: stringValue(check.command),
+    ...(Array.isArray(check.expectedExitCodes)
+      ? { expectedExitCodes: numberArray(check.expectedExitCodes) }
+      : {}),
+    ...(isObject(check.outputExpectation)
+      ? {
+          outputExpectation: {
+            mode: stringValue(check.outputExpectation.mode) as 'exact' | 'contains' | 'regex',
+            value: stringValue(check.outputExpectation.value),
+          },
+        }
+      : {}),
+    ...(typeof check.timeoutMs === 'number' ? { timeoutMs: check.timeoutMs } : {}),
+    ...(typeof check.kind === 'string'
+      ? {
+          kind: check.kind as
+            | 'unit'
+            | 'integration'
+            | 'e2e'
+            | 'api'
+            | 'lint'
+            | 'typecheck'
+            | 'custom',
+        }
+      : {}),
+  }));
+}
+
+function projectEngineeringSpec(record: NonNullable<ReturnType<typeof getEngineeringSpec>>) {
+  const s = isObject(record.spec) ? record.spec : {};
+  const acceptanceCriteria = objectArray(s.acceptanceCriteria).map((ac, index) => ({
+    id: stringValue(ac.id, `AC-${index + 1}`),
+    statement: stringValue(ac.statement),
+    ...(ac.executableChecks != null
+      ? { executableChecks: projectExecutableChecks(ac.executableChecks) }
+      : {}),
+    ...(ac.journeyRef != null ? { journeyRef: ac.journeyRef as string | null } : {}),
+    ...(ac.stepIdx != null ? { stepIdx: ac.stepIdx as number | null } : {}),
+    ...(ac.crossCutting != null ? { crossCutting: ac.crossCutting as boolean | null } : {}),
+    ...(typeof ac.sourceRef === 'string' ? { sourceRef: ac.sourceRef } : {}),
+    ...(typeof ac.source === 'string' ? { source: ac.source } : {}),
+  }));
+
+  const architecture = isObject(s.architecture)
+    ? {
+        current: stringValue(s.architecture.current),
+        new: stringValue(s.architecture.new),
+        decisionRationale: stringValue(s.architecture.decisionRationale),
+      }
+    : undefined;
+
+  const schemaChanges = isObject(s.schemaChanges)
+    ? {
+        ddl: stringArray(s.schemaChanges.ddl),
+        migrations: stringArray(s.schemaChanges.migrations),
+      }
+    : undefined;
+
+  return {
+    pipelineRunId: record.pipelineRunId,
+    updatedAt: record.updatedAt,
+    objective: stringValue(s.objective),
+    ...(architecture != null ? { architecture } : {}),
+    workPackages: objectArray(s.workPackages).map((wp, index) => ({
+      id: stringValue(wp.id, `WP${index + 1}`),
+      filesOwned: stringArray(wp.filesOwned),
+      changes: stringValue(wp.changes),
+      dependsOn: stringArray(wp.dependsOn),
+      builderTier: stringValue(wp.builderTier),
+    })),
+    executionOrder: objectArray(s.executionOrder).map((batch) => ({
+      batch: numberValue(batch.batch),
+      wpIds: stringArray(batch.wpIds),
+    })),
+    verificationTooling: objectArray(s.verificationTooling).map((tool) => ({
+      name: stringValue(tool.name),
+      command: stringValue(tool.command),
+      expectedExitCodes: numberArray(tool.expectedExitCodes),
+      ...(tool.inputSpec != null ? { inputSpec: tool.inputSpec as string | null } : {}),
+    })),
+    acceptanceCriteria,
+    acceptanceCriteriaCount: acceptanceCriteria.length,
+    interfaceContracts: objectArray(s.interfaceContracts).map((contract) => ({
+      name: stringValue(contract.name),
+      signature: stringValue(contract.signature),
+      file: stringValue(contract.file),
+      ...(contract.lineRange != null ? { lineRange: contract.lineRange as string | null } : {}),
+    })),
+    ...(schemaChanges != null ? { schemaChanges } : {}),
+    constraints: objectArray(s.constraints).map((constraint) => ({
+      kind: stringValue(constraint.kind),
+      name: stringValue(constraint.name),
+      source: stringValue(constraint.source),
+    })),
+    riskRegister: objectArray(s.riskRegister).map((risk) => ({
+      risk: stringValue(risk.risk),
+      mitigation: stringValue(risk.mitigation),
+      severity: stringValue(risk.severity),
+    })),
+  };
+}
+
 const TYPE_EXCLUDED_LEGAL_TARGETS: Readonly<Record<string, readonly StateName[]>> = {
   bug: ['factory:grilling', 'factory:research-pending'],
   feature: ['factory:investigating', 'factory:research-pending'],
@@ -124,8 +259,23 @@ export async function getIssueSpec(
   Result<{
     spec: {
       pipelineRunId: string;
+      updatedAt: string;
       objective: string;
-      workPackages: Array<{ id: string; filesOwned: string[]; builderTier: string }>;
+      architecture?: { current: string; new: string; decisionRationale: string };
+      workPackages: Array<{
+        id: string;
+        filesOwned: string[];
+        changes: string;
+        dependsOn: string[];
+        builderTier: string;
+      }>;
+      executionOrder: Array<{ batch: number; wpIds: string[] }>;
+      verificationTooling: Array<{
+        name: string;
+        command: string;
+        expectedExitCodes: number[];
+        inputSpec?: string | null;
+      }>;
       acceptanceCriteria: Array<{
         id: string;
         statement: string;
@@ -143,8 +293,19 @@ export async function getIssueSpec(
         journeyRef?: string | null;
         stepIdx?: number | null;
         crossCutting?: boolean | null;
+        sourceRef?: string;
+        source?: string;
       }>;
       acceptanceCriteriaCount: number;
+      interfaceContracts: Array<{
+        name: string;
+        signature: string;
+        file: string;
+        lineRange?: string | null;
+      }>;
+      schemaChanges?: { ddl: string[]; migrations: string[] };
+      constraints: Array<{ kind: string; name: string; source: string }>;
+      riskRegister: Array<{ risk: string; mitigation: string; severity: string }>;
     } | null;
   }>
 > {
@@ -154,49 +315,10 @@ export async function getIssueSpec(
   const workItemId = `github:${repoRef}#${id}`;
   const record = getEngineeringSpec(slug, workItemId);
   if (record == null) return { ok: true, data: { spec: null } };
-  const s = record.spec as {
-    objective: string;
-    workPackages: Array<{ id: string; filesOwned: string[]; builderTier: string }>;
-    acceptanceCriteria: unknown[];
-  };
-  const acceptanceCriteria = s.acceptanceCriteria.map((raw, index) => {
-    const ac = raw as {
-      id?: string;
-      statement?: string;
-      executableChecks?: Array<{
-        id: string;
-        command: string;
-        expectedExitCodes?: number[];
-        outputExpectation?: {
-          mode: 'exact' | 'contains' | 'regex';
-          value: string;
-        };
-        timeoutMs?: number;
-        kind?: 'unit' | 'integration' | 'e2e' | 'api' | 'lint' | 'typecheck' | 'custom';
-      }>;
-      journeyRef?: string | null;
-      stepIdx?: number | null;
-      crossCutting?: boolean | null;
-    };
-    return {
-      id: ac.id ?? `AC-${index + 1}`,
-      statement: ac.statement ?? '',
-      ...(ac.executableChecks != null ? { executableChecks: ac.executableChecks } : {}),
-      ...(ac.journeyRef != null ? { journeyRef: ac.journeyRef } : {}),
-      ...(ac.stepIdx != null ? { stepIdx: ac.stepIdx } : {}),
-      ...(ac.crossCutting != null ? { crossCutting: ac.crossCutting } : {}),
-    };
-  });
   return {
     ok: true,
     data: {
-      spec: {
-        pipelineRunId: record.pipelineRunId,
-        objective: s.objective,
-        workPackages: s.workPackages,
-        acceptanceCriteria,
-        acceptanceCriteriaCount: acceptanceCriteria.length,
-      },
+      spec: projectEngineeringSpec(record),
     },
   };
 }

--- a/apps/web/src/components/detail/components/InvestigationSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import type { AgentEventDto } from '@/lib/types';
+import type { AgentEventDto, EngineeringSpecDto } from '@/lib/types';
 import { ActiveProjectProvider } from '@/state/active-project';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
@@ -12,6 +12,8 @@ afterEach(cleanup);
 vi.mock('@/lib/api', () => ({
   fetchEvents: vi.fn().mockResolvedValue([]),
   fetchComments: vi.fn().mockResolvedValue([]),
+  fetchEngineeringSpec: vi.fn().mockResolvedValue(null),
+  fetchAcceptanceContract: vi.fn().mockResolvedValue(null),
   fetchPersonaNames: vi.fn().mockResolvedValue([]),
   fetchProjects: vi.fn().mockResolvedValue([
     {
@@ -52,6 +54,28 @@ const INVESTIGATION_EVENT: AgentEventDto = {
   createdAt: new Date().toISOString(),
 };
 
+const ENGINEERING_SPEC: EngineeringSpecDto = {
+  pipelineRunId: 'pipe-test-123',
+  updatedAt: '2026-05-22T10:00:00Z',
+  objective: 'Build the authentication flow with token refresh.',
+  workPackages: [
+    {
+      id: 'WP1',
+      filesOwned: ['src/auth/login.ts'],
+      changes: 'Update login refresh flow.',
+      dependsOn: [],
+      builderTier: 'sonnet',
+    },
+  ],
+  executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+  verificationTooling: [],
+  acceptanceCriteria: [{ id: 'AC-1', statement: 'Users can log in.' }],
+  acceptanceCriteriaCount: 1,
+  interfaceContracts: [],
+  constraints: [],
+  riskRegister: [],
+};
+
 function investigationEvent(partial: Partial<AgentEventDto> = {}): AgentEventDto {
   return {
     ...INVESTIGATION_EVENT,
@@ -77,9 +101,10 @@ function toolCallEvent(partial: Partial<AgentEventDto> = {}): AgentEventDto {
   };
 }
 
-function renderSection(events: AgentEventDto[] = []) {
+function renderSection(events: AgentEventDto[] = [], spec?: EngineeringSpecDto | null) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   qc.setQueryData(['events', 'test-proj', '42'], events);
+  if (spec !== undefined) qc.setQueryData(['spec', 'test-proj', '42'], spec);
   render(
     <QueryClientProvider client={qc}>
       <ActiveProjectProvider initialSlug="test-proj">
@@ -100,6 +125,12 @@ describe('InvestigationSection', () => {
     renderSection([INVESTIGATION_EVENT]);
     expect(screen.getByTestId('investigation-section')).toBeTruthy();
     expect(screen.getByTestId('findings-content')).toBeTruthy();
+  });
+
+  it('renders the Engineering Spec panel when a spec exists', () => {
+    renderSection([INVESTIGATION_EVENT], ENGINEERING_SPEC);
+    expect(screen.getByText('Engineering Spec')).toBeTruthy();
+    expect(screen.getByText('1 work package · 1 AC')).toBeTruthy();
   });
 
   it('displays the correct confidence badge for high confidence', () => {

--- a/apps/web/src/components/detail/components/SpecDetails.test.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.test.tsx
@@ -9,10 +9,40 @@ afterEach(cleanup);
 
 const SPEC: EngineeringSpecDto = {
   pipelineRunId: 'pipe-test-123',
+  updatedAt: '2026-05-22T10:00:00Z',
   objective: 'Build the authentication flow with token refresh.',
+  architecture: {
+    current: 'Auth requests refresh tokens in the route handler.',
+    new: 'Move refresh validation into session middleware.',
+    decisionRationale: 'Keeps route handlers thin and centralizes expiry handling.',
+  },
   workPackages: [
-    { id: 'WP1', filesOwned: ['src/auth/login.ts', 'src/auth/token.ts'], builderTier: 'sonnet' },
-    { id: 'WP2', filesOwned: ['src/auth/middleware.ts'], builderTier: 'haiku' },
+    {
+      id: 'WP1',
+      filesOwned: ['src/auth/login.ts', 'src/auth/token.ts'],
+      changes: 'Update login and token refresh flow.',
+      dependsOn: [],
+      builderTier: 'sonnet',
+    },
+    {
+      id: 'WP2',
+      filesOwned: ['src/auth/middleware.ts'],
+      changes: 'Add middleware enforcement for refreshed sessions.',
+      dependsOn: ['WP1'],
+      builderTier: 'haiku',
+    },
+  ],
+  executionOrder: [
+    { batch: 0, wpIds: ['WP1'] },
+    { batch: 1, wpIds: ['WP2'] },
+  ],
+  verificationTooling: [
+    {
+      name: 'Auth unit tests',
+      command: 'pnpm vitest run src/auth/login.test.ts src/auth/middleware.test.ts',
+      expectedExitCodes: [0],
+      inputSpec: 'Run from repo root.',
+    },
   ],
   acceptanceCriteria: [
     {
@@ -25,6 +55,12 @@ const SPEC: EngineeringSpecDto = {
           expectedExitCodes: [0],
           kind: 'unit',
         },
+        {
+          id: 'AC-1-check-2',
+          command: 'pnpm vitest run src/auth/token.test.ts',
+          expectedExitCodes: [0],
+          kind: 'unit',
+        },
       ],
     },
     { id: 'AC-2', statement: 'Expired tokens are rejected.' },
@@ -33,14 +69,40 @@ const SPEC: EngineeringSpecDto = {
     { id: 'AC-5', statement: 'No credentials are logged.' },
   ],
   acceptanceCriteriaCount: 5,
+  interfaceContracts: [
+    {
+      name: 'validateRefreshToken',
+      signature: 'export function validateRefreshToken(token: string): Promise<AuthSession>;',
+      file: 'src/auth/token.ts',
+      lineRange: '12-20',
+    },
+  ],
+  schemaChanges: {
+    ddl: ['ALTER TABLE sessions ADD COLUMN refreshed_at TEXT;'],
+    migrations: ['migrations/20260522100000_refresh_sessions.sql'],
+  },
+  constraints: [
+    {
+      kind: 'phase',
+      name: 'Investigation tab owns spec display',
+      source: 'apps/web/src/components/detail/components/InvestigationSection.tsx:277',
+    },
+  ],
+  riskRegister: [
+    {
+      severity: 'medium',
+      risk: 'Refresh middleware could reject valid legacy sessions.',
+      mitigation: 'Keep legacy fallback covered by integration tests.',
+    },
+  ],
 };
 
 describe('SpecDetails', () => {
-  it('renders nothing when itemState is before dev-ready', () => {
-    const { container } = render(
-      <SpecDetails spec={SPEC} itemState="factory:investigation-complete" />,
-    );
-    expect(container.firstChild).toBeNull();
+  it('renders collapsed header regardless of lifecycle state', () => {
+    render(<SpecDetails spec={SPEC} itemState="factory:investigation-complete" />);
+    expect(screen.getByText('Engineering Spec')).toBeTruthy();
+    expect(screen.getByText('2 work packages · 5 AC')).toBeTruthy();
+    expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
   });
 
   it('renders collapsed header when state is factory:dev-ready', () => {
@@ -50,26 +112,38 @@ describe('SpecDetails', () => {
     expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
   });
 
-  it('expands to show objective, work packages table, and AC count on click', async () => {
+  it('expands to show all populated engineering spec sections', async () => {
     render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
     await userEvent.click(screen.getByText('Engineering Spec'));
     expect(screen.getByText('Build the authentication flow with token refresh.')).toBeTruthy();
-    expect(screen.getByText('WP1')).toBeTruthy();
-    expect(screen.getByText('WP2')).toBeTruthy();
+    expect(screen.getByText('Move refresh validation into session middleware.')).toBeTruthy();
+    expect(screen.getAllByText('WP1').length).toBeGreaterThan(1);
+    expect(screen.getAllByText('WP2').length).toBeGreaterThan(1);
+    expect(screen.getByText('Update login and token refresh flow.')).toBeTruthy();
+    expect(screen.getByText('Batch 0')).toBeTruthy();
     expect(screen.getByText('sonnet')).toBeTruthy();
     expect(screen.getByText('haiku')).toBeTruthy();
     expect(screen.getByText('5 acceptance criteria')).toBeTruthy();
     expect(screen.getByText('Users can log in with a valid refresh token.')).toBeTruthy();
     expect(screen.getByText('pnpm vitest run src/auth/login.test.ts')).toBeTruthy();
+    expect(screen.getByText('pnpm vitest run src/auth/token.test.ts')).toBeTruthy();
+    expect(screen.getByText('Expired tokens are rejected.')).toBeTruthy();
+    expect(screen.getByText('Auth unit tests')).toBeTruthy();
+    expect(
+      screen.getByText('pnpm vitest run src/auth/login.test.ts src/auth/middleware.test.ts'),
+    ).toBeTruthy();
+    expect(screen.getByText('validateRefreshToken')).toBeTruthy();
+    expect(screen.getByText('ALTER TABLE sessions ADD COLUMN refreshed_at TEXT;')).toBeTruthy();
+    expect(screen.getByText('Investigation tab owns spec display')).toBeTruthy();
+    expect(screen.getByText('Refresh middleware could reject valid legacy sessions.')).toBeTruthy();
+    expect(screen.getByText('pipe-test-123')).toBeTruthy();
   });
 
-  it('renders when state is factory:in-progress', () => {
-    render(<SpecDetails spec={SPEC} itemState="factory:in-progress" />);
-    expect(screen.getByText('Engineering Spec')).toBeTruthy();
-  });
-
-  it('renders when state is factory:spec-ready', () => {
-    render(<SpecDetails spec={SPEC} itemState="factory:spec-ready" />);
-    expect(screen.getByText('Engineering Spec')).toBeTruthy();
+  it('does not render legacy verifyCommand text for canonical criteria without executable checks', async () => {
+    render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
+    await userEvent.click(screen.getByText('Engineering Spec'));
+    expect(screen.getByText('Expired tokens are rejected.')).toBeTruthy();
+    expect(screen.queryByText(/verifyCommand/i)).toBeNull();
+    expect(screen.queryByText(/missing/i)).toBeNull();
   });
 });

--- a/apps/web/src/components/detail/components/SpecDetails.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.tsx
@@ -1,33 +1,59 @@
 import type { EngineeringSpecDto } from '@/lib/types';
-import { ChevronDown, ChevronRight, ClipboardCheck, Package, Terminal } from 'lucide-react';
-import { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ClipboardCheck,
+  Database,
+  FileCode2,
+  GitBranch,
+  Package,
+  ShieldAlert,
+  Terminal,
+} from 'lucide-react';
+import { type ReactNode, useState } from 'react';
 
-const DEV_OR_LATER_STATES = new Set([
-  'factory:dev-ready',
-  'factory:spec-ready',
-  'factory:in-progress',
-  'factory:needs-qa',
-  'factory:qa-failed',
-  'factory:needs-review',
-  'factory:needs-fix',
-  'factory:approved',
-  'factory:merge-conflict',
-  'factory:retrospecting',
-  'factory:done',
-]);
+function hasText(value: string | null | undefined): value is string {
+  return value != null && value.trim().length > 0;
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-fg-3 mb-2">{title}</div>
+      {children}
+    </section>
+  );
+}
+
+function MonoList({ values }: { values: string[] }) {
+  if (values.length === 0) return <span className="text-fg-5">None</span>;
+  return (
+    <div className="flex flex-col gap-1">
+      {values.map((value) => (
+        <span key={value} className="font-mono text-[10.5px] text-fg-4 break-words">
+          {value}
+        </span>
+      ))}
+    </div>
+  );
+}
 
 export function SpecDetails({
   spec,
-  itemState,
 }: {
   spec: EngineeringSpecDto;
   itemState?: string;
 }) {
   const [open, setOpen] = useState(false);
-
-  if (!DEV_OR_LATER_STATES.has(itemState ?? '')) return null;
-
   const wpCount = spec.workPackages.length;
+  const hasArchitecture =
+    spec.architecture != null &&
+    (hasText(spec.architecture.current) ||
+      hasText(spec.architecture.new) ||
+      hasText(spec.architecture.decisionRationale));
+  const hasSchemaChanges =
+    spec.schemaChanges != null &&
+    (spec.schemaChanges.ddl.length > 0 || spec.schemaChanges.migrations.length > 0);
 
   return (
     <div className="rounded-lg border border-[color:var(--accent)]/20 bg-bg-elev overflow-hidden">
@@ -36,10 +62,12 @@ export function SpecDetails({
         onClick={() => setOpen(!open)}
         className="w-full flex items-center justify-between px-4 py-3 bg-bg-elev-2 text-left cursor-pointer"
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <Package size={12} className="shrink-0 text-[color:var(--accent)]" />
-          <span className="text-[10.5px] uppercase tracking-wider text-fg-2">Engineering Spec</span>
-          <span className="text-[11px] text-fg-4">
+          <span className="text-[10.5px] uppercase tracking-wider text-fg-2 shrink-0">
+            Engineering Spec
+          </span>
+          <span className="text-[11px] text-fg-4 truncate">
             {wpCount} work package{wpCount !== 1 ? 's' : ''} · {spec.acceptanceCriteriaCount} AC
           </span>
         </div>
@@ -50,44 +78,88 @@ export function SpecDetails({
 
       {open && (
         <div className="px-4 py-4 flex flex-col gap-4 border-t border-line">
-          <div>
-            <div className="text-[10px] uppercase tracking-wider text-fg-3 mb-1">Objective</div>
+          <Section title="Objective">
             <p className="text-[12.5px] text-fg-2 leading-relaxed">{spec.objective}</p>
-          </div>
+          </Section>
 
-          <div>
-            <div className="text-[10px] uppercase tracking-wider text-fg-3 mb-2">Work packages</div>
-            <div className="rounded border border-line overflow-hidden">
-              <table className="w-full text-[11.5px]">
-                <thead>
-                  <tr className="border-b border-line bg-bg-elev-2">
-                    <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">ID</th>
-                    <th className="px-3 py-2 text-left text-fg-3 font-medium">Files owned</th>
-                    <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">Tier</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {spec.workPackages.map((wp) => (
-                    <tr key={wp.id} className="border-b border-line last:border-0">
-                      <td className="px-3 py-2 font-mono text-fg-2 whitespace-nowrap">{wp.id}</td>
-                      <td className="px-3 py-2">
-                        {wp.filesOwned.map((f) => (
-                          <div key={f} className="font-mono text-[10.5px] text-fg-4 truncate">
-                            {f}
-                          </div>
-                        ))}
-                      </td>
-                      <td className="px-3 py-2 font-mono text-fg-4 whitespace-nowrap">
-                        {wp.builderTier}
-                      </td>
+          {hasArchitecture && spec.architecture != null && (
+            <Section title="Architecture">
+              <div className="grid gap-2 text-[12px] text-fg-2">
+                {hasText(spec.architecture.current) && (
+                  <div>
+                    <span className="text-fg-4">Current: </span>
+                    {spec.architecture.current}
+                  </div>
+                )}
+                {hasText(spec.architecture.new) && (
+                  <div>
+                    <span className="text-fg-4">New: </span>
+                    {spec.architecture.new}
+                  </div>
+                )}
+                {hasText(spec.architecture.decisionRationale) && (
+                  <div>
+                    <span className="text-fg-4">Rationale: </span>
+                    {spec.architecture.decisionRationale}
+                  </div>
+                )}
+              </div>
+            </Section>
+          )}
+
+          {spec.workPackages.length > 0 && (
+            <Section title="Work Packages">
+              <div className="rounded border border-line overflow-hidden">
+                <table className="w-full text-[11.5px]">
+                  <thead>
+                    <tr className="border-b border-line bg-bg-elev-2">
+                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">ID</th>
+                      <th className="px-3 py-2 text-left text-fg-3 font-medium">Changes</th>
+                      <th className="px-3 py-2 text-left text-fg-3 font-medium">Files</th>
+                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-28">Depends</th>
+                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">Tier</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
+                  </thead>
+                  <tbody>
+                    {spec.workPackages.map((wp) => (
+                      <tr key={wp.id} className="border-b border-line last:border-0 align-top">
+                        <td className="px-3 py-2 font-mono text-fg-2 whitespace-nowrap">{wp.id}</td>
+                        <td className="px-3 py-2 text-fg-2 leading-relaxed">{wp.changes}</td>
+                        <td className="px-3 py-2">
+                          <MonoList values={wp.filesOwned} />
+                        </td>
+                        <td className="px-3 py-2 font-mono text-[10.5px] text-fg-4">
+                          {wp.dependsOn.length > 0 ? wp.dependsOn.join(', ') : 'None'}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-fg-4 whitespace-nowrap">
+                          {wp.builderTier}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Section>
+          )}
 
-          <div>
+          {spec.executionOrder.length > 0 && (
+            <Section title="Execution Order">
+              <div className="flex flex-col gap-2">
+                {spec.executionOrder.map((batch) => (
+                  <div
+                    key={`${batch.batch}:${batch.wpIds.join(',')}`}
+                    className="flex items-center gap-2 text-[12px] text-fg-2"
+                  >
+                    <GitBranch size={12} className="shrink-0 text-fg-4" />
+                    <span className="font-mono text-fg-4">Batch {batch.batch}</span>
+                    <span>{batch.wpIds.join(', ')}</span>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          <Section title="Acceptance Criteria">
             <div className="flex items-center gap-2 text-[11.5px] text-fg-3 mb-2">
               <ClipboardCheck size={12} className="text-fg-4 shrink-0" />
               <span>{spec.acceptanceCriteriaCount} acceptance criteria</span>
@@ -128,7 +200,134 @@ export function SpecDetails({
                 ))}
               </ol>
             )}
-          </div>
+          </Section>
+
+          {spec.verificationTooling.length > 0 && (
+            <Section title="Verification">
+              <div className="flex flex-col gap-2">
+                {spec.verificationTooling.map((tool) => (
+                  <div
+                    key={tool.name}
+                    className="rounded border border-line bg-bg-elev-2 px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2 text-[12px] text-fg-2">
+                      <Terminal size={12} className="shrink-0 text-fg-4" />
+                      <span className="font-medium">{tool.name}</span>
+                      <span className="text-[10px] text-fg-5">
+                        exit {tool.expectedExitCodes.join(', ')}
+                      </span>
+                    </div>
+                    <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
+                      {tool.command}
+                    </div>
+                    {hasText(tool.inputSpec) && (
+                      <div className="mt-1 text-[11px] text-fg-4">{tool.inputSpec}</div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {spec.interfaceContracts.length > 0 && (
+            <Section title="Interfaces">
+              <div className="flex flex-col gap-2">
+                {spec.interfaceContracts.map((contract) => (
+                  <div
+                    key={`${contract.file}:${contract.name}`}
+                    className="rounded border border-line bg-bg-elev-2 px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2 text-[12px] text-fg-2">
+                      <FileCode2 size={12} className="shrink-0 text-fg-4" />
+                      <span className="font-medium">{contract.name}</span>
+                    </div>
+                    <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
+                      {contract.file}
+                      {contract.lineRange != null ? `:${contract.lineRange}` : ''}
+                    </div>
+                    <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-bg px-2 py-2 text-[10.5px] text-fg-3">
+                      {contract.signature}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {hasSchemaChanges && spec.schemaChanges != null && (
+            <Section title="Schema">
+              <div className="flex flex-col gap-2 text-[12px] text-fg-2">
+                {spec.schemaChanges.ddl.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-2 text-fg-4 mb-1">
+                      <Database size={12} />
+                      <span>DDL</span>
+                    </div>
+                    <MonoList values={spec.schemaChanges.ddl} />
+                  </div>
+                )}
+                {spec.schemaChanges.migrations.length > 0 && (
+                  <div>
+                    <div className="text-fg-4 mb-1">Migrations</div>
+                    <MonoList values={spec.schemaChanges.migrations} />
+                  </div>
+                )}
+              </div>
+            </Section>
+          )}
+
+          {spec.constraints.length > 0 && (
+            <Section title="Constraints">
+              <div className="flex flex-col gap-1">
+                {spec.constraints.map((constraint) => (
+                  <div
+                    key={`${constraint.kind}:${constraint.name}:${constraint.source}`}
+                    className="grid grid-cols-[5.5rem_1fr] gap-2 text-[12px]"
+                  >
+                    <span className="font-mono text-[10.5px] text-fg-4">{constraint.kind}</span>
+                    <span className="text-fg-2">
+                      {constraint.name}{' '}
+                      <span className="font-mono text-[10.5px] text-fg-4 break-words">
+                        {constraint.source}
+                      </span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {spec.riskRegister.length > 0 && (
+            <Section title="Risks">
+              <div className="flex flex-col gap-2">
+                {spec.riskRegister.map((risk) => (
+                  <div key={`${risk.severity}:${risk.risk}`} className="text-[12px] text-fg-2">
+                    <div className="flex items-center gap-2">
+                      <ShieldAlert size={12} className="shrink-0 text-fg-4" />
+                      <span className="font-mono text-[10.5px] uppercase text-fg-4">
+                        {risk.severity}
+                      </span>
+                      <span>{risk.risk}</span>
+                    </div>
+                    <div className="ml-5 mt-1 text-fg-4">{risk.mitigation}</div>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          <Section title="Metadata">
+            <div className="grid gap-1 text-[11px] text-fg-4">
+              <div>
+                <span className="text-fg-5">Pipeline: </span>
+                <span className="font-mono break-words">{spec.pipelineRunId}</span>
+              </div>
+              <div>
+                <span className="text-fg-5">Updated: </span>
+                <span className="font-mono">{spec.updatedAt}</span>
+              </div>
+            </div>
+          </Section>
         </div>
       )}
     </div>

--- a/apps/web/src/components/detail/lib/live-events.test.ts
+++ b/apps/web/src/components/detail/lib/live-events.test.ts
@@ -121,6 +121,18 @@ describe('applyIssueTimelineEvent', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['comments', 'p', '1'] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue-costs', 'p', '1'] });
   });
+
+  it('invalidates spec and acceptance contract when spec.completed arrives', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    applyIssueTimelineEvent(queryClient, 'p', '1', makeEvent(2, 'spec.completed'));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['spec', 'p', '1'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['acceptance-contract', 'p', '1'],
+    });
+  });
 });
 
 describe('backfillIssueTimelineEvents', () => {

--- a/apps/web/src/components/detail/lib/live-events.ts
+++ b/apps/web/src/components/detail/lib/live-events.ts
@@ -109,6 +109,13 @@ export function applyIssueTimelineEvent(
     void queryClient.invalidateQueries({ queryKey: ['comments', projectSlug, issueId] });
   }
 
+  if (event.kind === 'spec.completed') {
+    void queryClient.invalidateQueries({ queryKey: ['spec', projectSlug, issueId] });
+    void queryClient.invalidateQueries({
+      queryKey: ['acceptance-contract', projectSlug, issueId],
+    });
+  }
+
   if (
     event.kind === 'agent.run-completed' ||
     event.kind === 'agent.run-failed' ||

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -34,7 +34,51 @@ export interface WorkItemDto {
 export interface WorkPackageDto {
   id: string;
   filesOwned: string[];
+  changes: string;
+  dependsOn: string[];
   builderTier: string;
+}
+
+export interface EngineeringSpecArchitectureDto {
+  current: string;
+  new: string;
+  decisionRationale: string;
+}
+
+export interface ExecutionBatchDto {
+  batch: number;
+  wpIds: string[];
+}
+
+export interface VerificationToolDto {
+  name: string;
+  command: string;
+  expectedExitCodes: number[];
+  inputSpec?: string | null;
+}
+
+export interface InterfaceContractDto {
+  name: string;
+  signature: string;
+  file: string;
+  lineRange?: string | null;
+}
+
+export interface SchemaChangesDto {
+  ddl: string[];
+  migrations: string[];
+}
+
+export interface ConstraintDto {
+  kind: string;
+  name: string;
+  source: string;
+}
+
+export interface RiskEntryDto {
+  risk: string;
+  mitigation: string;
+  severity: string;
 }
 
 export interface AcceptanceCriterionDto {
@@ -44,6 +88,7 @@ export interface AcceptanceCriterionDto {
   stepIdx?: number | null;
   crossCutting?: boolean | null;
   sourceRef?: string;
+  source?: string;
   executableChecks?: ExecutableCheckDto[];
 }
 
@@ -69,10 +114,18 @@ export interface AcceptanceContractDto {
 
 export interface EngineeringSpecDto {
   pipelineRunId: string;
+  updatedAt: string;
   objective: string;
+  architecture?: EngineeringSpecArchitectureDto;
   workPackages: WorkPackageDto[];
+  executionOrder: ExecutionBatchDto[];
+  verificationTooling: VerificationToolDto[];
   acceptanceCriteria: AcceptanceCriterionDto[];
   acceptanceCriteriaCount: number;
+  interfaceContracts: InterfaceContractDto[];
+  schemaChanges?: SchemaChangesDto;
+  constraints: ConstraintDto[];
+  riskRegister: RiskEntryDto[];
 }
 
 export interface IssueCommentDto {


### PR DESCRIPTION
## Summary
- expand the issue spec DTO into an explicit first-class Engineering Spec projection
- render compact Engineering Spec sections in the Investigation tab
- refresh spec and acceptance-contract queries when spec.completed arrives

## Verification
- pnpm vitest run apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/components/SpecDetails.test.tsx apps/web/src/components/detail/components/InvestigationSection.test.tsx apps/web/src/components/detail/lib/live-events.test.ts
- pnpm --filter @goose-hub/web build
- pnpm typecheck
- pnpm exec biome check apps/server/src/domains/issues/service.ts apps/server/src/domains/issues/service.test.ts apps/web/src/lib/types.ts apps/web/src/components/detail/components/SpecDetails.tsx apps/web/src/components/detail/components/SpecDetails.test.tsx apps/web/src/components/detail/components/InvestigationSection.test.tsx apps/web/src/components/detail/lib/live-events.ts apps/web/src/components/detail/lib/live-events.test.ts