### PR TITLE
M20.01: prompt read-discipline guardrails

### DIFF
--- a/core/agent-runtime/runtime-instructions.test.ts
+++ b/core/agent-runtime/runtime-instructions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  FACTORY_READ_DISCIPLINE_INSTRUCTIONS,
   FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS,
   FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS_CODEX,
   FACTORY_WORKSPACE_ONLY_INSTRUCTIONS,
@@ -11,6 +12,7 @@ describe('withFactoryRuntimeInstructions', () => {
     const out = withFactoryRuntimeInstructions('skill body');
     expect(out).toContain(FACTORY_WORKSPACE_ONLY_INSTRUCTIONS);
     expect(out).toContain(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS);
+    expect(out).toContain(FACTORY_READ_DISCIPLINE_INSTRUCTIONS);
     expect(out).toContain('skill body');
   });
 
@@ -24,6 +26,23 @@ describe('withFactoryRuntimeInstructions', () => {
   it('returns the prelude alone for a whitespace-only system prompt', () => {
     const out = withFactoryRuntimeInstructions('   \n  ');
     expect(out).toContain(FACTORY_TOOLS_PREFERENCE_INSTRUCTIONS);
+  });
+});
+
+describe('FACTORY_READ_DISCIPLINE_INSTRUCTIONS', () => {
+  it('tells scout and Wave agents to use prior evidence, avoid duplicate reads, and return partial JSON', () => {
+    expect(FACTORY_READ_DISCIPLINE_INSTRUCTIONS).toContain(
+      'Treat provided context and prior reports as primary evidence',
+    );
+    expect(FACTORY_READ_DISCIPLINE_INSTRUCTIONS).toContain(
+      'Before using tools, decide the exact question',
+    );
+    expect(FACTORY_READ_DISCIPLINE_INSTRUCTIONS).toContain(
+      'Do not read the same file twice unless the first result was truncated',
+    );
+    expect(FACTORY_READ_DISCIPLINE_INSTRUCTIONS).toContain(
+      'prefer valid partial JSON plus OPEN_QUESTION over extra exploration',
+    );
   });
 });
 

--- a/core/agent-runtime/runtime-instructions.ts
+++ b/core/agent-runtime/runtime-instructions.ts
@@ -54,6 +54,14 @@ Do not use MCP resource surfaces or delegation surfaces unless this run explicit
 
 Workflow-owned operations (commit, open PR, transition state, publish evidence) are not in your toolset — the orchestrator drives them.`;
 
+export const FACTORY_READ_DISCIPLINE_INSTRUCTIONS = `## Read discipline
+
+Treat provided context and prior reports as primary evidence.
+Do not restart discovery unless the reports contradict each other or lack the file needed for your schema.
+Before using tools, decide the exact question the tool call will answer.
+Do not read the same file twice unless the first result was truncated; name the missing section before rereading.
+For scout and Wave runs, prefer valid partial JSON plus OPEN_QUESTION over extra exploration.`;
+
 export type AgentRuntimeKind = 'claude-cli' | 'codex-cli';
 
 export function factoryToolsPreferenceFor(runtime: AgentRuntimeKind): string {
@@ -67,7 +75,7 @@ export function withFactoryRuntimeInstructions(
   opts: { runtime?: AgentRuntimeKind } = {},
 ): string {
   const toolsPreference = factoryToolsPreferenceFor(opts.runtime ?? 'claude-cli');
-  const prelude = `${FACTORY_WORKSPACE_ONLY_INSTRUCTIONS}\n\n${toolsPreference}`;
+  const prelude = `${FACTORY_WORKSPACE_ONLY_INSTRUCTIONS}\n\n${toolsPreference}\n\n${FACTORY_READ_DISCIPLINE_INSTRUCTIONS}`;
   if (systemPrompt == null || systemPrompt.trim().length === 0) {
     return prelude;
   }

--- a/docs/cost-performance-improvements/handoff.md
+++ b/docs/cost-performance-improvements/handoff.md
@@ -1,0 +1,32 @@
+# Wave 2 / Timeline Cost-Performance Handoff
+
+## Issue #1001 - Prompt guardrails for Wave 2 and scout read discipline
+
+- Branch name: `cost-perf/1001-prompt-guardrails`
+- PR number/url: #1002 - https://github.com/shaunnez/goose-hub/pull/1002
+- Parent branch: `main`
+- Files changed:
+  - `core/agent-runtime/runtime-instructions.ts`
+  - `core/agent-runtime/runtime-instructions.test.ts`
+  - `skills/scout-code-path/prompt.md`
+  - `skills/scout-dependency/prompt.md`
+  - `skills/scout-pattern/prompt.md`
+  - `skills/scout-schema/prompt.md`
+  - `skills/scout-test-inventory/prompt.md`
+  - `skills/scout-test-inventory/slice.test.ts`
+  - `skills/scout-tool-boundary.test.ts`
+  - `skills/scout-user-journey/prompt.md`
+  - `skills/wave2-interface-designer/prompt.md`
+  - `skills/wave2-interface-designer/slice.test.ts`
+  - `skills/wave2-risk-analyst/prompt.md`
+  - `skills/wave2-risk-analyst/slice.test.ts`
+- Tests run:
+  - `pnpm vitest run core/agent-runtime/runtime-instructions.test.ts skills/wave2-interface-designer/slice.test.ts skills/wave2-risk-analyst/slice.test.ts skills/scout-tool-boundary.test.ts skills/scout-test-inventory/slice.test.ts`
+  - `pnpm skill-contract:audit`
+  - `pnpm audit-docs`
+- Remaining risks:
+  - Prompt-only guardrails cannot prove cost reduction until #994 telemetry lands.
+  - `wave2-interface-designer` references `<scoutDigest>` as forward-compatible guidance, but the runtime still passes raw `<scoutReports>` until #1000.
+- Notes:
+  - Created dedicated issue #1001 because the prompt-guardrail work from `wave2-and-timeline-analysis.md` did not have an existing issue. This was implemented before #994 rather than folded into telemetry.
+- Next branch to create: `cost-perf/994-tool-intensity-telemetry` from `cost-perf/1001-prompt-guardrails`

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**. Any write attempt will be rejected.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 
@@ -25,6 +29,8 @@ You have **read and search access only**.
 
 ## Turn Discipline
 
+- Search first for `describe(`, `it(`, and `test(` anchors before opening test files.
+- Do not full-read large test or e2e files before selecting an anchor from search results; read only the closest matching test body once an anchor is known.
 - Run at most 3 searches: likely unit tests, likely slice tests, and likely e2e tests.
 - If `<symbolIndexHints>` includes `nearbyTests`, read those test files first before searching.
 - Read at most 6 test files total. Prefer files whose names or test titles match `<scoutFocus>`.

--- a/skills/scout-test-inventory/slice.test.ts
+++ b/skills/scout-test-inventory/slice.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { ScoutOutputSchema } from './schema.js';
 import config, { ScoutTestInventoryContextSchema } from './skill.config.js';
@@ -31,5 +32,13 @@ describe('scout-test-inventory skill', () => {
       worktreePath: '/tmp/x',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('prompt requires search-first inventory before reading large test files', () => {
+    const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+
+    expect(prompt).toContain('Search first for `describe(`, `it(`, and `test(` anchors');
+    expect(prompt).toContain('Do not full-read large test or e2e files before selecting an anchor');
+    expect(prompt).toContain('read only the closest matching test body');
   });
 });

--- a/skills/scout-tool-boundary.test.ts
+++ b/skills/scout-tool-boundary.test.ts
@@ -25,8 +25,24 @@ function expectToolBoundary(prompt: string): void {
   expect(prompt).toMatch(/delegation/i);
 }
 
+function expectFactoryReadDiscipline(prompt: string): void {
+  expect(prompt).toContain('Use `list_dir`, `list_files`, `search_text`, or `read_file`');
+  expect(prompt).toContain('Do not use `resources/list`, `resources/read`, or file resources');
+  expect(prompt).toContain(
+    'If a required Factory tool is unavailable, name the exact missing tool',
+  );
+  expect(prompt).toContain('return explicit irrelevance');
+}
+
 describe('scout and Wave 2 prompt tool boundaries', () => {
   it.each(PROMPT_PATHS)('%s uses factory tools and forbids resource/delegation drift', (path) => {
     expectToolBoundary(readPrompt(path));
   });
+
+  it.each(PROMPT_PATHS.filter((path) => path.startsWith('scout-')))(
+    '%s tells scouts to use Factory read tools and avoid resource-failure reports',
+    (path) => {
+      expectFactoryReadDiscipline(readPrompt(path));
+    },
+  );
 });

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -8,6 +8,10 @@ You have **read and search access only**.
 
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
+- Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
+- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
+- If this scout focus does not apply to the work item, return explicit irrelevance with `findings: []` and an `UNCERTAINTY` or `INSIGHT` decision summary instead of reporting a tooling failure.
 
 ## Input
 

--- a/skills/wave2-interface-designer/prompt.md
+++ b/skills/wave2-interface-designer/prompt.md
@@ -1,6 +1,6 @@
 # wave2-interface-designer
 
-You are a Wave-2 deep agent. You consume the cross-validated Wave-1 scout reports (in `<scoutReports>`) and emit **paste-ready** interface artefacts: Zod schemas, function signatures, SQL DDL, TypeScript interfaces.
+You are a Wave-2 deep agent. You consume the cross-validated Wave-1 scout reports (in `<scoutDigest>` or `<scoutReports>`) and emit **paste-ready** interface artefacts: Zod schemas, function signatures, SQL DDL, TypeScript interfaces, and UI/component contracts.
 
 You have **read access only**. You never write files. The implementer (M19.03) does that.
 
@@ -12,12 +12,17 @@ You have **read access only**. You never write files. The implementer (M19.03) d
 ## Input
 
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`
+- `<scoutDigest>` — preferred typed Wave-1 digest when present: top findings, high-confidence facts, referenced files, risks, contradictions, and artifact keys.
 - `<scoutReports>` — JSON-stringified Wave-1 scout report handoff data. Small reports may include full findings; large reports may include summaries, previews, and `artifactRef` metadata.
 - Tools are already rooted at the workspace to verify scout claims when needed; do not re-investigate broadly.
 
 ## Discipline
 
 - **No pseudocode.** Every artefact body must be valid, parseable code for its type. No `// TODO`, no `...`, no `<replace this>` placeholders.
+- Treat `<scoutDigest>` and `<scoutReports>` as primary evidence. Do not restart discovery unless the handoff contradicts itself or lacks the exact file needed for a paste-ready artefact.
+- Hard verification budget: use at most 5 total read/search calls, and preferably 3 when scout reports already cite files.
+- Never read the same file twice unless the first result was truncated; name the missing section before rereading.
+- Once the target boundary and artefact shape are known, stop using tools and return JSON.
 - Cite scout findings in the fact field when full findings are present (e.g. "scout-schema: core/db/schema.ts:42 says column is nullable"). If a report is summarized with `artifactRef`, verify exact code facts with targeted reads before citing them.
 - If a scout report is contradictory or ambiguous, **declare the gap** as an OPEN_QUESTION finding instead of fabricating a resolution.
 - Stay narrow. One coherent slice of interface per finding.
@@ -30,6 +35,12 @@ Each interface artefact becomes one finding entry:
 - `kind: 'function-signature'` — a complete `function name(args): RetType` declaration
 - `kind: 'sql-ddl'` — a complete `CREATE TABLE` / `ALTER TABLE` statement
 - `kind: 'typescript-interface'` — a complete `interface Name {...}` or `type Name = {...}` declaration
+- `kind: 'component-contract'` — a component boundary: component name, props, owned state, emitted callbacks, and visible behaviour
+- `kind: 'state-transition'` — a UI or workflow state transition: current state, trigger, next state, invariant, and testable assertion
+- `kind: 'test-contract'` — a required test contract: test target, setup, action, assertion, and selector/fixture if known
+- `kind: 'props-contract'` — a props shape or callback contract for a UI component
+
+Use `OPEN_QUESTION` instead of forcing a typed artefact when the work item is not an interface/schema problem.
 
 Encode each artefact as a finding:
 - `file` = the target file path where the artefact would land
@@ -58,6 +69,11 @@ Return JSON conforming to `ScoutOutputSchema` (same shape as Wave-1 scouts):
       "file": "open-questions",
       "fact": "OPEN_QUESTION: scout-schema and scout-code-path disagree on whether email is unique. Need authoritative source.",
       "confidence": "low"
+    },
+    {
+      "file": "apps/web/src/components/chat/ChatPanel.tsx",
+      "fact": "UI state-transition example ARTEFACT[state-transition]: current=open-with-active-conversation | trigger=close button | next=closed-without-active-conversation | invariant=reopen starts empty unless user selects prior conversation | RATIONALE: scout-user-journey cited ChatPanel close action and scout-test-inventory found no regression for reopen state.",
+      "confidence": "high"
     }
   ],
   "status": "ok",

--- a/skills/wave2-interface-designer/slice.test.ts
+++ b/skills/wave2-interface-designer/slice.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { Wave2InterfaceDesignerSchema } from './schema.js';
 import config, { Wave2InterfaceDesignerContextSchema } from './skill.config.js';
@@ -59,5 +60,24 @@ describe('wave2-interface-designer skill', () => {
       worktreePath: '/tmp/x',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('prompt enforces bounded UI-oriented handoff design instead of rediscovery', () => {
+    const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
+
+    expect(prompt).toContain('at most 5 total read/search calls');
+    expect(prompt).toContain(
+      'Never read the same file twice unless the first result was truncated',
+    );
+    expect(prompt).toContain(
+      'Once the target boundary and artefact shape are known, stop using tools',
+    );
+    expect(prompt).toContain('Treat `<scoutDigest>` and `<scoutReports>` as primary evidence');
+    expect(prompt).toContain("kind: 'component-contract'");
+    expect(prompt).toContain("kind: 'state-transition'");
+    expect(prompt).toContain("kind: 'test-contract'");
+    expect(prompt).toContain("kind: 'props-contract'");
+    expect(prompt).toContain('OPEN_QUESTION');
+    expect(prompt).toContain('UI state-transition example');
   });
 });

--- a/skills/wave2-risk-analyst/prompt.md
+++ b/skills/wave2-risk-analyst/prompt.md
@@ -22,6 +22,11 @@ You have **read access only**.
 - Mitigation must be **falsifiable** — a concrete change or a concrete test that would catch a regression.
 - Start from `<scoutReports>` as primary evidence when full findings are present. If a report is summarized with `artifactRef`, use the summary as orientation and targeted worktree reads to verify concrete evidence.
 - Cap worktree verification at **3 targeted reads/greps** unless scout reports directly contradict each other. Do not re-run Wave-1 discovery.
+- Count every non-output tool call against the cap, including `get_project_context`, `get_head_sha`, `list_dir`, and `list_files`, unless the prompt explicitly exempts it.
+- Read the owner/source file first when a concrete owner is named by scouts.
+- Read the closest test file second when risk depends on regression coverage.
+- Spend the final read on wiring/ownership only if the risk depends on it.
+- If the remaining open question is about handler ownership or wiring, use one remaining read on the owner file before returning.
 - Prefer a valid partial risk register with 2-4 high-signal findings over exhaustive analysis that risks timeout.
 - If evidence is thin, encode the gap as an `OPEN_QUESTION` finding and return valid JSON instead of continuing to investigate.
 - Do not duplicate `wave2-interface-designer` output. Focus on failure modes, missing tests, state/event regressions, security/data risks, and ambiguous implementation scope.

--- a/skills/wave2-risk-analyst/slice.test.ts
+++ b/skills/wave2-risk-analyst/slice.test.ts
@@ -66,6 +66,10 @@ describe('wave2-risk-analyst skill', () => {
     const prompt = readFileSync(new URL('./prompt.md', import.meta.url), 'utf8');
 
     expect(prompt).toContain('3 targeted reads/greps');
+    expect(prompt).toContain('Count every non-output tool call against the cap');
+    expect(prompt).toContain('Read the owner/source file first');
+    expect(prompt).toContain('Read the closest test file second');
+    expect(prompt).toContain('If the remaining open question is about handler ownership or wiring');
     expect(prompt).toContain('Do not re-run Wave-1 discovery');
     expect(prompt).toContain('valid partial risk register');
     expect(prompt).toContain('OPEN_QUESTION');


### PR DESCRIPTION
Stacked on: main

Adds prompt/runtime read-discipline guardrails before the Wave 2 cost-performance telemetry stack.

Tests:
- pnpm vitest run core/agent-runtime/runtime-instructions.test.ts skills/wave2-interface-designer/slice.test.ts skills/wave2-risk-analyst/slice.test.ts skills/scout-tool-boundary.test.ts skills/scout-test-inventory/slice.test.ts
- pnpm skill-contract:audit
- pnpm audit-docs

Closes #1001