### PR TITLE
M20.02: add tool-intensity telemetry

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -505,6 +505,8 @@ All cost logic lives in `core/cost/`: `extract.ts` (parsers), `repository.ts` (w
 
 **`agent_run_costs`** has a unique index on `runId` — duplicate inserts (retries, webhook redeliveries) are silently ignored. Every run produces exactly one row, even at `costUsd = 0`, so dashboards reflect every run.
 
+**Tool-intensity telemetry** lives in `agent_run_tool_stats`, keyed one-to-one by `runId`. The agent runtime calls `recordToolStatsForRun(runId)` synchronously after `recordCost()`, aggregating `agent.tool-call` rows into read/search/write/edit counts, returned bytes, unique paths read, and redundant reads. The per-issue costs API joins these stats back onto cost rows, and a high-read outlier emits `agent.tool-intensity-anomaly` when a run exceeds 2x the same-skill p95 read baseline.
+
 **Stages:** `triage`, `investigate`, `dev`, `qa`, `review`, `retrospective`, `other`. Stage is UI-only metadata; never influences workflow logic. Unknown skills fall into `other` (soft fallback).
 
 **UI convention:** `~$0.04` for estimated, `$0.04` for exact. Enforced in frontend, not DB.

--- a/apps/server/src/domains/costs/repository.ts
+++ b/apps/server/src/domains/costs/repository.ts
@@ -1,15 +1,26 @@
 import {
   type CostRow,
+  type WorkItemToolStatsRow,
   listCostsForProjectSince as coreListCostsForProjectSince,
   listCostsForWorkItem as coreListCostsForWorkItem,
+  listToolStatsForWorkItem as coreListToolStatsForWorkItem,
   totalsByStageForProjectSince as coreTotalsByStage,
   totalsForProjectSince as coreTotalsForProject,
 } from '@goose-hub/core/cost/repository.js';
 
-export type { CostRow, ProjectTotals, StageTotal } from '@goose-hub/core/cost/repository.js';
+export type {
+  CostRow,
+  ProjectTotals,
+  StageTotal,
+  WorkItemToolStatsRow,
+} from '@goose-hub/core/cost/repository.js';
 
 export function listCostsForWorkItem(workItemId: string): CostRow[] {
   return coreListCostsForWorkItem(workItemId);
+}
+
+export function listToolStatsForWorkItem(workItemId: string): WorkItemToolStatsRow[] {
+  return coreListToolStatsForWorkItem(workItemId);
 }
 
 export function listCostsForProjectSince(projectId: string, sinceIso: string): CostRow[] {

--- a/apps/server/src/domains/costs/router.test.ts
+++ b/apps/server/src/domains/costs/router.test.ts
@@ -1,13 +1,19 @@
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetCostSummary, mockGetCostsForWorkItem, mockGetProject, mockResolveGlobalSettings } =
-  vi.hoisted(() => ({
-    mockGetCostSummary: vi.fn(),
-    mockGetCostsForWorkItem: vi.fn(),
-    mockGetProject: vi.fn(),
-    mockResolveGlobalSettings: vi.fn(),
-  }));
+const {
+  mockGetCostSummary,
+  mockGetCostsForWorkItem,
+  mockGetToolStatsForWorkItem,
+  mockGetProject,
+  mockResolveGlobalSettings,
+} = vi.hoisted(() => ({
+  mockGetCostSummary: vi.fn(),
+  mockGetCostsForWorkItem: vi.fn(),
+  mockGetToolStatsForWorkItem: vi.fn(),
+  mockGetProject: vi.fn(),
+  mockResolveGlobalSettings: vi.fn(),
+}));
 
 vi.mock('@goose-hub/core/agent-runtime/resolve-for-project.js', () => ({
   resolveGlobalSettingsForProject: mockResolveGlobalSettings,
@@ -16,6 +22,7 @@ vi.mock('@goose-hub/core/agent-runtime/resolve-for-project.js', () => ({
 vi.mock('./service.js', () => ({
   getCostSummary: mockGetCostSummary,
   getCostsForWorkItem: mockGetCostsForWorkItem,
+  getToolStatsForWorkItem: mockGetToolStatsForWorkItem,
 }));
 
 vi.mock('#shared/projects.js', () => ({
@@ -131,5 +138,23 @@ describe('GET /:slug/issues/:id/costs', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('bad input');
+  });
+});
+
+describe('GET /:slug/issues/:id/tool-stats', () => {
+  it('returns joined run tool stats for a work item', async () => {
+    mockGetProject.mockResolvedValue({ source: { kind: 'github', repo: 'shaunnez/goose-hub' } });
+    const data = {
+      workItemId: 'github:shaunnez/goose-hub#42',
+      rows: [{ runId: 'r1', skill: 'implement', readCount: 4, bytesRead: 2048 }],
+    };
+    mockGetToolStatsForWorkItem.mockResolvedValue({ ok: true, data });
+
+    const app = makeApp();
+    const res = await app.request('/goose-hub-self/issues/42/tool-stats');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(data);
+    expect(mockGetToolStatsForWorkItem).toHaveBeenCalledWith('github:shaunnez/goose-hub#42');
   });
 });

--- a/apps/server/src/domains/costs/router.ts
+++ b/apps/server/src/domains/costs/router.ts
@@ -1,7 +1,7 @@
 import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { Hono } from 'hono';
 import { getProject } from '#shared/projects.js';
-import { getCostSummary, getCostsForWorkItem } from './service.js';
+import { getCostSummary, getCostsForWorkItem, getToolStatsForWorkItem } from './service.js';
 
 const router = new Hono();
 
@@ -28,6 +28,19 @@ router.get('/:slug/issues/:id/costs', async (c) => {
   const repoRef = cfg.source.kind === 'github' ? cfg.source.repo : slug;
   const workItemId = `github:${repoRef}#${id}`;
   const result = await getCostsForWorkItem(workItemId);
+  return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 400);
+});
+
+/** Per-task tool-intensity breakdown: every stats row scoped to a single work item. */
+router.get('/:slug/issues/:id/tool-stats', async (c) => {
+  const slug = c.req.param('slug');
+  const id = c.req.param('id');
+  const cfg = await getProject(slug);
+  if (cfg == null) return c.json({ error: 'project not found' }, 404);
+
+  const repoRef = cfg.source.kind === 'github' ? cfg.source.repo : slug;
+  const workItemId = `github:${repoRef}#${id}`;
+  const result = await getToolStatsForWorkItem(workItemId);
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 400);
 });
 

--- a/apps/server/src/domains/costs/service.test.ts
+++ b/apps/server/src/domains/costs/service.test.ts
@@ -5,12 +5,14 @@ const {
   mockTotalsByStage,
   mockListCostsForWorkItem,
   mockListCostsForProjectSince,
+  mockListToolStatsForWorkItem,
   mockEventReplay,
 } = vi.hoisted(() => ({
   mockTotalsForProject: vi.fn(),
   mockTotalsByStage: vi.fn(),
   mockListCostsForWorkItem: vi.fn(),
   mockListCostsForProjectSince: vi.fn(),
+  mockListToolStatsForWorkItem: vi.fn(),
   mockEventReplay: vi.fn(),
 }));
 
@@ -23,14 +25,18 @@ vi.mock('./repository.js', () => ({
   totalsByStageForProjectSince: mockTotalsByStage,
   listCostsForWorkItem: mockListCostsForWorkItem,
   listCostsForProjectSince: mockListCostsForProjectSince,
+  listToolStatsForWorkItem: mockListToolStatsForWorkItem,
 }));
 
-const { getCostSummary, getCostsForWorkItem } = await import('./service.js');
+const { getCostSummary, getCostsForWorkItem, getToolStatsForWorkItem } = await import(
+  './service.js'
+);
 
 describe('getCostSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEventReplay.mockReturnValue([]);
+    mockListToolStatsForWorkItem.mockReturnValue([]);
   });
 
   it('rejects empty projectId', async () => {
@@ -239,11 +245,87 @@ describe('getCostsForWorkItem', () => {
         createdAt: '2026-05-01T00:00:00Z',
       },
     ]);
+    mockListToolStatsForWorkItem.mockReturnValue([
+      {
+        runId: 'r1',
+        workItemId: 'github:owner/repo#1',
+        stage: 'qa',
+        skill: 'qa',
+        modelId: 'claude-sonnet-4-6',
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 0.01,
+        costLabel: 'estimated',
+        personaId: null,
+        readCount: 3,
+        grepCount: 1,
+        writeCount: 0,
+        editCount: 0,
+        bytesRead: 4096,
+        uniquePathsRead: 2,
+        redundantReads: 1,
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-01T00:00:00Z',
+      },
+    ]);
     const r = await getCostsForWorkItem('github:owner/repo#1');
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.data.rows).toHaveLength(2);
     expect(r.data.totalUsd).toBeCloseTo(0.015);
     expect(r.data.hasEstimated).toBe(true);
+    expect(r.data.rows[0]).toMatchObject({
+      readCount: 3,
+      grepCount: 1,
+      bytesRead: 4096,
+      uniquePathsRead: 2,
+      redundantReads: 1,
+    });
+    expect(r.data.rows[1]).toMatchObject({
+      readCount: 0,
+      bytesRead: 0,
+      redundantReads: 0,
+    });
+  });
+});
+
+describe('getToolStatsForWorkItem', () => {
+  it('returns the joined tool-intensity rows for a work item', async () => {
+    mockListToolStatsForWorkItem.mockReturnValue([
+      {
+        runId: 'r1',
+        workItemId: 'github:owner/repo#1',
+        stage: 'dev',
+        skill: 'implement',
+        modelId: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 20,
+        costUsd: 0.1,
+        costLabel: 'estimated',
+        personaId: null,
+        readCount: 7,
+        grepCount: 2,
+        writeCount: 1,
+        editCount: 1,
+        bytesRead: 8192,
+        uniquePathsRead: 5,
+        redundantReads: 2,
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-01T00:00:00Z',
+      },
+    ]);
+
+    const r = await getToolStatsForWorkItem('github:owner/repo#1');
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.data.rows[0]).toMatchObject({
+      runId: 'r1',
+      skill: 'implement',
+      provider: 'codex',
+      readCount: 7,
+      bytesRead: 8192,
+      redundantReads: 2,
+    });
   });
 });

--- a/apps/server/src/domains/costs/service.ts
+++ b/apps/server/src/domains/costs/service.ts
@@ -8,8 +8,10 @@ import {
 import type { Result } from '#shared/middleware.js';
 import {
   type CostRow,
+  type WorkItemToolStatsRow,
   listCostsForProjectSince,
   listCostsForWorkItem,
+  listToolStatsForWorkItem,
   totalsByStageForProjectSince,
   totalsForProjectSince,
 } from './repository.js';
@@ -52,12 +54,24 @@ export interface CostRowDto {
   costLabel: CostLabel;
   personaId: string | null;
   createdAt: string;
+  readCount: number;
+  grepCount: number;
+  writeCount: number;
+  editCount: number;
+  bytesRead: number;
+  uniquePathsRead: number;
+  redundantReads: number;
 }
 
 export interface WorkItemCostsDto {
   workItemId: string;
   totalUsd: number;
   hasEstimated: boolean;
+  rows: CostRowDto[];
+}
+
+export interface WorkItemToolStatsDto {
+  workItemId: string;
   rows: CostRowDto[];
 }
 
@@ -144,6 +158,9 @@ export async function getCostsForWorkItem(workItemId: string): Promise<Result<Wo
     return { ok: false, error: 'workItemId is required', status: 400 };
   }
   const rows = listCostsForWorkItem(workItemId);
+  const toolStatsByRun = new Map(
+    listToolStatsForWorkItem(workItemId).map((row) => [row.runId, row]),
+  );
   const totalUsd = rows.reduce((s, r) => s + r.costUsd, 0);
   const hasEstimated = rows.some((r) => r.costLabel === 'estimated');
   return {
@@ -152,12 +169,27 @@ export async function getCostsForWorkItem(workItemId: string): Promise<Result<Wo
       workItemId,
       totalUsd,
       hasEstimated,
-      rows: rows.map(toRowDto),
+      rows: rows.map((row) => toRowDto(row, toolStatsByRun.get(row.runId))),
     },
   };
 }
 
-function toRowDto(r: CostRow): CostRowDto {
+export async function getToolStatsForWorkItem(
+  workItemId: string,
+): Promise<Result<WorkItemToolStatsDto>> {
+  if (!workItemId.trim()) {
+    return { ok: false, error: 'workItemId is required', status: 400 };
+  }
+  return {
+    ok: true,
+    data: {
+      workItemId,
+      rows: listToolStatsForWorkItem(workItemId).map((row) => toRowDto(row, row)),
+    },
+  };
+}
+
+function toRowDto(r: CostRow | WorkItemToolStatsRow, stats?: WorkItemToolStatsRow): CostRowDto {
   return {
     runId: r.runId,
     workItemId: r.workItemId,
@@ -171,5 +203,12 @@ function toRowDto(r: CostRow): CostRowDto {
     costLabel: r.costLabel,
     personaId: r.personaId,
     createdAt: r.createdAt,
+    readCount: stats?.readCount ?? 0,
+    grepCount: stats?.grepCount ?? 0,
+    writeCount: stats?.writeCount ?? 0,
+    editCount: stats?.editCount ?? 0,
+    bytesRead: stats?.bytesRead ?? 0,
+    uniquePathsRead: stats?.uniquePathsRead ?? 0,
+    redundantReads: stats?.redundantReads ?? 0,
   };
 }

--- a/apps/web/src/components/detail/components/CostsSection.test.tsx
+++ b/apps/web/src/components/detail/components/CostsSection.test.tsx
@@ -1,0 +1,67 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CostsSection } from './CostsSection';
+
+vi.mock('@/lib/api', () => ({
+  fetchIssueCosts: vi.fn().mockResolvedValue({
+    workItemId: 'github:owner/repo#42',
+    totalUsd: 0.25,
+    hasEstimated: false,
+    rows: [
+      {
+        runId: 'run-1',
+        workItemId: 'github:owner/repo#42',
+        stage: 'dev',
+        skill: 'implement',
+        modelId: 'gpt-5.4',
+        provider: 'codex',
+        inputTokens: 1000,
+        outputTokens: 500,
+        costUsd: 0.25,
+        costLabel: 'exact',
+        personaId: null,
+        createdAt: '2026-05-23T00:00:00Z',
+        readCount: 7,
+        grepCount: 2,
+        writeCount: 1,
+        editCount: 1,
+        bytesRead: 8192,
+        uniquePathsRead: 5,
+        redundantReads: 2,
+      },
+    ],
+  }),
+  fetchProjectConfigs: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/lib/usePersonaMap', () => ({
+  getPersonaInitials: () => null,
+  getPersonaLabel: () => null,
+  usePersonaMap: () => new Map(),
+}));
+
+afterEach(() => cleanup());
+
+describe('CostsSection', () => {
+  it('renders raw-run reads and bytes with redundant-read warning text', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <CostsSection projectSlug="goose-hub-self" id="42" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('costs-row-run-1')).toBeTruthy());
+
+    expect(screen.getByText('Reads')).toBeTruthy();
+    expect(screen.getByText('Bytes')).toBeTruthy();
+    expect(screen.getByText('7')).toBeTruthy();
+    expect(screen.getByText('8.0 KB')).toBeTruthy();
+    expect(screen.getByTitle('this run re-read 2 files it had already loaded.')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/CostsSection.tsx
+++ b/apps/web/src/components/detail/components/CostsSection.tsx
@@ -209,42 +209,69 @@ export function CostsSection({ projectSlug, id }: CostsSectionProps) {
 
         {/* Raw run table */}
         <div className="border border-line rounded-lg overflow-hidden min-w-0">
-          <div className="grid grid-cols-[100px_62px_1fr_80px_80px] px-4 py-2.5 border-b border-line bg-bg-elev/50 text-[10.5px] uppercase tracking-wider text-fg-2">
+          <div className="grid grid-cols-[82px_58px_1fr_64px_52px_70px_70px] px-4 py-2.5 border-b border-line bg-bg-elev/50 text-[10.5px] uppercase tracking-wider text-fg-2">
             <span className="pr-3">Stage</span>
             <span className="pr-3">Provider</span>
             <span className="pr-4">Skill</span>
             <span className="pr-4">Tokens</span>
+            <span className="pr-4">Reads</span>
+            <span className="pr-4">Bytes</span>
             <span>Cost</span>
           </div>
-          {data.rows.map((r) => (
-            <div
-              key={r.runId}
-              data-testid={`costs-row-${r.runId}`}
-              className="grid grid-cols-[100px_62px_1fr_80px_80px] px-4 py-2.5 border-t border-line items-center text-[12px]"
-            >
-              <span className="text-fg-2 pr-3">{STAGE_LABEL[r.stage]}</span>
-              <span className="pr-3">
+          {data.rows.map((r) => {
+            const redundantReads = r.redundantReads ?? 0;
+            const redundantTitle =
+              redundantReads > 0
+                ? `this run re-read ${redundantReads} files it had already loaded.`
+                : undefined;
+            return (
+              <div
+                key={r.runId}
+                data-testid={`costs-row-${r.runId}`}
+                className={`grid grid-cols-[82px_58px_1fr_64px_52px_70px_70px] px-4 py-2.5 border-t border-line items-center text-[12px] ${
+                  redundantReads > 0 ? 'bg-warning/5' : ''
+                }`}
+                title={redundantTitle}
+              >
+                <span className="text-fg-2 pr-3">{STAGE_LABEL[r.stage]}</span>
+                <span className="pr-3">
+                  <span
+                    className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                      r.provider === 'codex'
+                        ? 'bg-emerald-500/15 text-emerald-400'
+                        : 'bg-blue-500/15 text-blue-400'
+                    }`}
+                  >
+                    {r.provider === 'codex' ? 'Codex' : 'Claude'}
+                  </span>
+                </span>
+                <span className="font-mono text-fg-3 text-[11.5px] pr-4 truncate">{r.skill}</span>
+                <span className="font-mono text-fg-2 text-[11.5px] pr-4">
+                  {formatTokens(r.inputTokens + r.outputTokens)}
+                </span>
                 <span
-                  className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                    r.provider === 'codex'
-                      ? 'bg-emerald-500/15 text-emerald-400'
-                      : 'bg-blue-500/15 text-blue-400'
+                  className={`font-mono text-[11.5px] pr-4 ${
+                    redundantReads > 0 ? 'text-warning' : 'text-fg-2'
                   }`}
                 >
-                  {r.provider === 'codex' ? 'Codex' : 'Claude'}
+                  {r.readCount ?? 0}
                 </span>
-              </span>
-              <span className="font-mono text-fg-3 text-[11.5px] pr-4 truncate">{r.skill}</span>
-              <span className="font-mono text-fg-2 text-[11.5px] pr-4">
-                {formatTokens(r.inputTokens + r.outputTokens)}
-              </span>
-              <span className="font-mono text-fg-2 text-[11.5px]">
-                {formatCost(r.costUsd, r.costLabel)}
-              </span>
-            </div>
-          ))}
+                <span className="font-mono text-fg-2 text-[11.5px] pr-4">
+                  {formatByteCount(r.bytesRead ?? 0)}
+                </span>
+                <span className="font-mono text-fg-2 text-[11.5px]">
+                  {formatCost(r.costUsd, r.costLabel)}
+                </span>
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>
   );
+}
+
+function formatByteCount(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
 }

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -59,6 +59,7 @@ import {
   RelatedSurfaceManifestEvent,
   StateTransitionedEvent,
   SystemNoteEvent,
+  ToolIntensityAnomalyEvent,
   WrongSurfaceGuardEvent,
 } from './timeline/MiscEvents';
 import {
@@ -266,6 +267,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <AgentToolCallEvent key={event.id} event={event} />;
     case 'agent.tool-result':
       return <AgentToolResultEvent key={event.id} event={event} />;
+    case 'agent.tool-intensity-anomaly':
+      return <ToolIntensityAnomalyEvent key={event.id} event={event} />;
     case 'agent.verify-command':
       return <AgentVerifyCommandEvent key={event.id} event={event} />;
     case 'tool.stdout-truncated':

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -44,6 +44,31 @@ describe('Misc timeline events', () => {
     expect(document.body.textContent).not.toContain('"costUsd"');
   });
 
+  it('renders agent.tool-intensity-anomaly as a compact warning', () => {
+    const event = makeEvent('agent.tool-intensity-anomaly', {
+      runId: 'e3bb94b3-4bf6-4c93-9407-9a2dc30c760d',
+      skill: 'investigate',
+      readCount: 34,
+      p95ReadCount: 12,
+      thresholdReadCount: 24,
+      bytesRead: 8192,
+      redundantReads: 5,
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Tool intensity anomaly')).toBeTruthy();
+    const rendered = document.body.textContent ?? '';
+    expect(rendered).toContain('investigate');
+    expect(rendered).toContain('34 reads');
+    expect(rendered).toContain('p95 12 reads');
+    expect(rendered).toContain('threshold 24 reads');
+    expect(rendered).toContain('8.0 KB read');
+    expect(rendered).toContain('5 redundant reads');
+    expect(rendered).toContain('run e3bb94b3');
+    expect(rendered).not.toContain('"readCount"');
+  });
+
   it('renders agent.investigation-context-injected as summary text instead of raw JSON', () => {
     const event = makeEvent('agent.investigation-context-injected', {
       skill: 'implement-wp',

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -24,6 +24,16 @@ type BudgetExceededPayload = {
   overByUsd?: number;
 };
 
+type ToolIntensityAnomalyPayload = {
+  runId?: string;
+  skill?: string;
+  readCount?: number;
+  p95ReadCount?: number;
+  thresholdReadCount?: number;
+  bytesRead?: number;
+  redundantReads?: number;
+};
+
 type InvestigationContextInjectedPayload = {
   skill?: string;
   wpId?: string;
@@ -323,6 +333,39 @@ export function AgentBudgetExceededEvent({ event }: { event: AgentEventDto }) {
         {p?.skill != null && <span>{p.skill}</span>}
         {shortRunId != null && <span className="font-mono text-fg-4">run {shortRunId}</span>}
       </div>
+    </li>
+  );
+}
+
+export function ToolIntensityAnomalyEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as ToolIntensityAnomalyPayload | null;
+  const shortRunId = formatShortId(p?.runId ?? event.runId ?? undefined);
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-warning bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-2 text-[11px] text-fg-3">
+        <AlertTriangle size={13} className="shrink-0 text-amber-400" />
+        <span className="font-mono uppercase tracking-wider">Tool intensity anomaly</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[12px] text-fg-2">
+        {p?.skill != null && <span>{p.skill}</span>}
+        {typeof p?.readCount === 'number' && <span>{p.readCount} reads</span>}
+        {typeof p?.p95ReadCount === 'number' && <span>p95 {p.p95ReadCount} reads</span>}
+        {typeof p?.thresholdReadCount === 'number' && (
+          <span className="text-amber-300">threshold {p.thresholdReadCount} reads</span>
+        )}
+        {typeof p?.bytesRead === 'number' && <span>{formatByteCount(p.bytesRead)} read</span>}
+        {typeof p?.redundantReads === 'number' && p.redundantReads > 0 && (
+          <span>{p.redundantReads} redundant reads</span>
+        )}
+      </div>
+      {shortRunId != null && (
+        <div className="mt-1 text-[11px] font-mono text-fg-4">run {shortRunId}</div>
+      )}
     </li>
   );
 }

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -23,6 +23,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.run-failed': 'Agent run failed',
   'agent.budget-exceeded': 'Agent budget exceeded',
   'agent.tool-call': 'Tool call',
+  'agent.tool-intensity-anomaly': 'Tool intensity anomaly',
   'agent.tool-result': 'Tool result (error)',
   'tool.stdout-truncated': 'Stdout truncated',
   'tool.timeout': 'Timeout',

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
@@ -86,6 +86,8 @@ vi.mock('@/lib/api', () => ({
           p95OutputTokens: 700,
           medianCostUsd: 0.1,
           p95CostUsd: 0.3,
+          p95ReadCount: 12,
+          p95BytesRead: 8192,
           maxCostOutlier: { runId: 'r1', costUsd: 0.3 },
           timeoutRate: 0,
           budgetExceededRate: 0,
@@ -130,6 +132,8 @@ describe('ProjectBudgetPanel', () => {
     expect(screen.getByText(/from skill-default: holdout skill ignores/)).toBeTruthy();
     expect(screen.getByText(/from fallback: holdout skill ignores/)).toBeTruthy();
     expect(screen.getByText(/from db: project_skill_settings\.effort override/)).toBeTruthy();
+    expect(await screen.findByText('p95 reads 12')).toBeTruthy();
+    expect(await screen.findByText('p95 bytes 8.0 KB')).toBeTruthy();
     expect(await screen.findByText('This skill looks stable and inexpensive.')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -350,6 +350,8 @@ function RuntimeProfilerSection({
                       <span>p95 ${entry.metrics.p95CostUsd.toFixed(2)}</span>
                       <span>p95 in {entry.metrics.p95InputTokens.toLocaleString()} tok</span>
                       <span>p95 out {entry.metrics.p95OutputTokens.toLocaleString()} tok</span>
+                      <span>p95 reads {entry.metrics.p95ReadCount.toLocaleString()}</span>
+                      <span>p95 bytes {formatByteCount(entry.metrics.p95BytesRead)}</span>
                     </div>
                   </div>
                   <div className="min-w-0 text-right text-[11px] text-fg-3">
@@ -399,6 +401,11 @@ function ProfilerMetric({ label, value }: { label: string; value: number }) {
       {label} {Math.round(value * 100)}%
     </span>
   );
+}
+
+function formatByteCount(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
 export function ProjectBudgetPanel({ slug }: Props) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -371,6 +371,13 @@ export interface CostRowDto {
   costLabel: CostLabel;
   personaId: string | null;
   createdAt: string;
+  readCount?: number;
+  grepCount?: number;
+  writeCount?: number;
+  editCount?: number;
+  bytesRead?: number;
+  uniquePathsRead?: number;
+  redundantReads?: number;
 }
 
 export interface CostWindowTotals {
@@ -661,6 +668,8 @@ export interface RuntimeProfilerDto {
       p95OutputTokens: number;
       medianCostUsd: number;
       p95CostUsd: number;
+      p95ReadCount: number;
+      p95BytesRead: number;
       maxCostOutlier: { runId: string; costUsd: number } | null;
       timeoutRate: number;
       budgetExceededRate: number;

--- a/core/agent-runtime/claude-cli.test.ts
+++ b/core/agent-runtime/claude-cli.test.ts
@@ -1,20 +1,29 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbInsert, mockRecordCost, mockEventStore, mockExecFileSync, mockSpawn } = vi.hoisted(
-  () => ({
-    mockDbInsert: vi.fn().mockImplementation(() => ({
-      values: vi.fn().mockReturnValue({ run: vi.fn() }),
-    })),
-    mockRecordCost: vi.fn(),
-    mockEventStore: { appendEvent: vi.fn(), replay: vi.fn().mockReturnValue([]) },
-    mockExecFileSync: vi.fn().mockReturnValue('/usr/local/bin/claude\n'),
-    mockSpawn: vi.fn(),
-  }),
-);
+const {
+  mockDbInsert,
+  mockRecordCost,
+  mockRecordToolStatsForRun,
+  mockEventStore,
+  mockExecFileSync,
+  mockSpawn,
+} = vi.hoisted(() => ({
+  mockDbInsert: vi.fn().mockImplementation(() => ({
+    values: vi.fn().mockReturnValue({ run: vi.fn() }),
+  })),
+  mockRecordCost: vi.fn(),
+  mockRecordToolStatsForRun: vi.fn(),
+  mockEventStore: { appendEvent: vi.fn(), replay: vi.fn().mockReturnValue([]) },
+  mockExecFileSync: vi.fn().mockReturnValue('/usr/local/bin/claude\n'),
+  mockSpawn: vi.fn(),
+}));
 
 vi.mock('../db/db.js', () => ({ db: { insert: mockDbInsert } }));
-vi.mock('../cost/repository.js', () => ({ recordCost: mockRecordCost }));
+vi.mock('../cost/repository.js', () => ({
+  recordCost: mockRecordCost,
+  recordToolStatsForRun: mockRecordToolStatsForRun,
+}));
 vi.mock('../event-stream/store.js', () => ({ eventStore: mockEventStore }));
 vi.mock('../cost/extract.js', () => ({ costFromCliEnvelope: vi.fn().mockReturnValue(null) }));
 vi.mock('../cost/skill-stage.js', () => ({ stageForSkill: vi.fn().mockReturnValue('develop') }));
@@ -212,6 +221,7 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
         workItemId: 'github:owner/repo#1',
       }),
     );
+    expect(mockRecordToolStatsForRun).toHaveBeenCalledWith('run-abc');
   });
 
   it('emits model and runtime metadata when the run starts', async () => {
@@ -255,6 +265,7 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
         outputTokens: 50,
       }),
     );
+    expect(mockRecordToolStatsForRun).toHaveBeenCalledWith('run-abc');
 
     const calls = mockEventStore.appendEvent.mock.calls;
     const budgetIndex = calls.findIndex(([e]) => e.kind === 'agent.budget-exceeded');

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { costFromCliEnvelope } from '../cost/extract.js';
-import { recordCost } from '../cost/repository.js';
+import { recordCost, recordToolStatsForRun } from '../cost/repository.js';
 import { stageForSkill } from '../cost/skill-stage.js';
 import { db } from '../db/db.js';
 import { getRecordDecisionTool } from '../db/repositories/project-settings.js';
@@ -402,6 +402,7 @@ export class ClaudeCliRuntime implements AgentRuntime {
           costLabel: usage?.costLabel ?? 'estimated',
           personaId: personaId ?? null,
         });
+        recordToolStatsForRun(runId);
 
         const costUsd = usage?.costUsd ?? 0;
         const inputTokens = usage?.inputTokens ?? 0;

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -1,13 +1,17 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockEventStore, mockRecordCost, mockSpawn } = vi.hoisted(() => ({
+const { mockEventStore, mockRecordCost, mockRecordToolStatsForRun, mockSpawn } = vi.hoisted(() => ({
   mockEventStore: { appendEvent: vi.fn(), replay: vi.fn().mockReturnValue([]) },
   mockRecordCost: vi.fn(),
+  mockRecordToolStatsForRun: vi.fn(),
   mockSpawn: vi.fn(),
 }));
 
-vi.mock('../cost/repository.js', () => ({ recordCost: mockRecordCost }));
+vi.mock('../cost/repository.js', () => ({
+  recordCost: mockRecordCost,
+  recordToolStatsForRun: mockRecordToolStatsForRun,
+}));
 vi.mock('../event-stream/store.js', () => ({ eventStore: mockEventStore }));
 vi.mock('../cost/skill-stage.js', () => ({ stageForSkill: vi.fn().mockReturnValue('develop') }));
 vi.mock('../db/repositories/project-settings.js', () => ({
@@ -936,6 +940,7 @@ describe('CodexCliRuntime timeout handling', () => {
         outputTokens: 50,
       }),
     );
+    expect(mockRecordToolStatsForRun).toHaveBeenCalledWith('run-codex');
     const calls = mockEventStore.appendEvent.mock.calls;
     const recordCostOrder = mockRecordCost.mock.invocationCallOrder[0];
     const budgetCall = calls.find(([e]) => e.kind === 'agent.budget-exceeded');

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { recordCost } from '../cost/repository.js';
+import { recordCost, recordToolStatsForRun } from '../cost/repository.js';
 import { stageForSkill } from '../cost/skill-stage.js';
 import { getRecordDecisionTool } from '../db/repositories/project-settings.js';
 import { eventStore } from '../event-stream/store.js';
@@ -769,6 +769,7 @@ export class CodexCliRuntime implements AgentRuntime {
           costLabel,
           personaId: personaId ?? null,
         });
+        recordToolStatsForRun(runId);
 
         const exceededBudget = emitBudgetExceededIfNeeded({
           runId,

--- a/core/cost/repository.test.ts
+++ b/core/cost/repository.test.ts
@@ -233,6 +233,10 @@ describe('recordToolStatsForRun', () => {
       p95ReadCount: 2,
       thresholdReadCount: 4,
     });
+
+    recordToolStatsForRun(runId);
+
+    expect(eventStore.replay({ runId, kind: 'agent.tool-intensity-anomaly' })).toHaveLength(1);
   });
 });
 

--- a/core/cost/repository.test.ts
+++ b/core/cost/repository.test.ts
@@ -1,10 +1,13 @@
-import { sql } from 'drizzle-orm';
+import { like, sql } from 'drizzle-orm';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../db/db.js';
-import { agentRunCosts } from '../db/schema.js';
+import { agentRunCosts, agentRunToolStats, events } from '../db/schema.js';
+import { eventStore } from '../event-stream/store.js';
 import {
+  listToolStatsForWorkItem,
   listCostsForWorkItem,
   recordCost,
+  recordToolStatsForRun,
   totalSpendForSkill,
   totalsByStageForProjectSince,
   totalsForProjectSince,
@@ -31,14 +34,34 @@ beforeAll(() => {
   db.run(
     sql`CREATE UNIQUE INDEX IF NOT EXISTS agent_run_costs_run_id_uniq ON agent_run_costs (run_id)`,
   );
+  db.run(sql`CREATE TABLE IF NOT EXISTS agent_run_tool_stats (
+    run_id TEXT PRIMARY KEY,
+    read_count INTEGER NOT NULL DEFAULT 0,
+    grep_count INTEGER NOT NULL DEFAULT 0,
+    write_count INTEGER NOT NULL DEFAULT 0,
+    edit_count INTEGER NOT NULL DEFAULT 0,
+    bytes_read INTEGER NOT NULL DEFAULT 0,
+    unique_paths_read INTEGER NOT NULL DEFAULT 0,
+    redundant_reads INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
 });
 
 beforeEach(() => {
   db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+  db.delete(agentRunToolStats)
+    .where(like(agentRunToolStats.runId, `${PROJECT}:%`))
+    .run();
+  db.delete(events).where(sql`project_id = ${PROJECT}`).run();
 });
 
 afterAll(() => {
   db.delete(agentRunCosts).where(sql`project_id = ${PROJECT}`).run();
+  db.delete(agentRunToolStats)
+    .where(like(agentRunToolStats.runId, `${PROJECT}:%`))
+    .run();
+  db.delete(events).where(sql`project_id = ${PROJECT}`).run();
 });
 
 describe('recordCost', () => {
@@ -89,6 +112,127 @@ describe('recordCost', () => {
     const rows = listCostsForWorkItem('github:owner/repo#1');
     expect(rows).toHaveLength(1);
     expect(rows[0].costUsd).toBe(0.001);
+  });
+});
+
+describe('recordToolStatsForRun', () => {
+  it('aggregates read/search/write/edit calls and detects repeated read paths within one run', () => {
+    const runId = `${PROJECT}:tool-stats-run`;
+    recordCost({
+      runId,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#99',
+      stage: 'dev',
+      skill: 'implement',
+      modelId: 'claude-sonnet-4-6',
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.2,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    appendTool(runId, 'read_file', 'src/a.ts', { bytesRead: 120 });
+    appendTool(runId, 'search_text', null);
+    appendTool(runId, 'read_file', 'src/a.ts', { bytesRead: 120 });
+    appendTool(runId, 'read_file', 'src/b.ts', { bytesRead: 80 });
+    appendTool(runId, 'write_file', 'src/b.ts');
+    appendTool(runId, 'edit_file', 'src/c.ts');
+
+    const stats = recordToolStatsForRun(runId);
+
+    expect(stats).toMatchObject({
+      runId,
+      readCount: 3,
+      grepCount: 1,
+      writeCount: 1,
+      editCount: 1,
+      bytesRead: 320,
+      uniquePathsRead: 2,
+      redundantReads: 1,
+    });
+
+    const [joined] = listToolStatsForWorkItem('github:owner/repo#99');
+    expect(joined).toMatchObject({
+      runId,
+      skill: 'implement',
+      costUsd: 0.2,
+      readCount: 3,
+      bytesRead: 320,
+      redundantReads: 1,
+    });
+  });
+
+  it('keeps run stats idempotent when aggregation is called more than once', () => {
+    const runId = `${PROJECT}:tool-stats-idempotent`;
+    recordCost({
+      runId,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#100',
+      stage: 'qa',
+      skill: 'qa',
+      modelId: 'gpt-5.4',
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.2,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    appendTool(runId, 'Read', 'src/a.ts', { bytes_read: 12 });
+
+    recordToolStatsForRun(runId);
+    const stats = recordToolStatsForRun(runId);
+
+    expect(stats.readCount).toBe(1);
+    expect(listToolStatsForWorkItem('github:owner/repo#100')).toHaveLength(1);
+  });
+
+  it('emits a tool-intensity anomaly when read count exceeds twice the skill p95 baseline', () => {
+    const baselineRunId = `${PROJECT}:baseline`;
+    recordCost({
+      runId: baselineRunId,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#101',
+      stage: 'dev',
+      skill: 'implement',
+      modelId: 'gpt-5.4',
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.2,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    appendTool(baselineRunId, 'read_file', 'src/a.ts');
+    appendTool(baselineRunId, 'read_file', 'src/b.ts');
+    recordToolStatsForRun(baselineRunId);
+
+    const runId = `${PROJECT}:anomaly`;
+    recordCost({
+      runId,
+      projectId: PROJECT,
+      workItemId: 'github:owner/repo#102',
+      stage: 'dev',
+      skill: 'implement',
+      modelId: 'gpt-5.4',
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.2,
+      costLabel: 'estimated',
+      personaId: null,
+    });
+    for (let index = 0; index < 5; index += 1) {
+      appendTool(runId, 'read_file', `src/high-${index}.ts`);
+    }
+
+    recordToolStatsForRun(runId);
+
+    const [event] = eventStore.replay({ runId, kind: 'agent.tool-intensity-anomaly' });
+    expect(event?.payload).toMatchObject({
+      runId,
+      skill: 'implement',
+      readCount: 5,
+      p95ReadCount: 2,
+      thresholdReadCount: 4,
+    });
   });
 });
 
@@ -236,3 +380,23 @@ describe('totalsByStageForProjectSince', () => {
     expect(stages[1].totalUsd).toBeCloseTo(0.3);
   });
 });
+
+function appendTool(
+  runId: string,
+  toolName: string,
+  path: string | null,
+  extra: Record<string, unknown> = {},
+): void {
+  eventStore.appendEvent({
+    projectId: PROJECT,
+    workItemId: 'github:owner/repo#99',
+    runId,
+    kind: 'agent.tool-call',
+    payload: {
+      tool_name: toolName,
+      tool_input: path == null ? {} : { path },
+      ...(path == null ? {} : { canonical_path: { path } }),
+      ...extra,
+    },
+  });
+}

--- a/core/cost/repository.ts
+++ b/core/cost/repository.ts
@@ -349,6 +349,12 @@ function emitToolIntensityAnomalyIfNeeded(stats: AgentRunToolStatsRow): void {
   const p95ReadCount = percentile(baseline, 0.95);
   const thresholdReadCount = p95ReadCount * 2;
   if (p95ReadCount <= 0 || stats.readCount <= thresholdReadCount) return;
+  const [existing] = eventStore.replay({
+    runId: stats.runId,
+    kind: 'agent.tool-intensity-anomaly',
+    limit: 1,
+  });
+  if (existing != null) return;
 
   eventStore.appendEvent({
     projectId: run.projectId,

--- a/core/cost/repository.ts
+++ b/core/cost/repository.ts
@@ -1,11 +1,38 @@
-import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, ne, sql } from 'drizzle-orm';
 import { db } from '../db/db.js';
-import { agentRunCosts } from '../db/schema.js';
+import { agentRunCosts, agentRunToolStats } from '../db/schema.js';
+import { eventStore } from '../event-stream/store.js';
+import { canonicalPathStringFromAuditPayload } from '../tool-layer/tool-call-audit.js';
 import type { CostLabel, CostRecord, Stage } from './types.js';
 
 export interface CostRow extends CostRecord {
   id: number;
   createdAt: string;
+}
+
+export interface AgentRunToolStatsRow {
+  runId: string;
+  readCount: number;
+  grepCount: number;
+  writeCount: number;
+  editCount: number;
+  bytesRead: number;
+  uniquePathsRead: number;
+  redundantReads: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkItemToolStatsRow extends AgentRunToolStatsRow {
+  workItemId: string | null;
+  stage: Stage;
+  skill: string;
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costLabel: CostLabel;
+  personaId: string | null;
 }
 
 /**
@@ -39,6 +66,74 @@ export function listCostsForWorkItem(workItemId: string): CostRow[] {
     .orderBy(asc(agentRunCosts.createdAt))
     .all();
   return rows.map(toRow);
+}
+
+export function recordToolStatsForRun(runId: string): AgentRunToolStatsRow {
+  const stats = aggregateToolStatsForRun(runId);
+  const [row] = db
+    .insert(agentRunToolStats)
+    .values(stats)
+    .onConflictDoUpdate({
+      target: agentRunToolStats.runId,
+      set: {
+        readCount: stats.readCount,
+        grepCount: stats.grepCount,
+        writeCount: stats.writeCount,
+        editCount: stats.editCount,
+        bytesRead: stats.bytesRead,
+        uniquePathsRead: stats.uniquePathsRead,
+        redundantReads: stats.redundantReads,
+        updatedAt: sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+      },
+    })
+    .returning()
+    .all();
+  const saved = toToolStatsRow(row);
+  emitToolIntensityAnomalyIfNeeded(saved);
+  return saved;
+}
+
+export function listToolStatsForWorkItem(workItemId: string): WorkItemToolStatsRow[] {
+  const rows = db
+    .select({
+      runId: agentRunToolStats.runId,
+      readCount: agentRunToolStats.readCount,
+      grepCount: agentRunToolStats.grepCount,
+      writeCount: agentRunToolStats.writeCount,
+      editCount: agentRunToolStats.editCount,
+      bytesRead: agentRunToolStats.bytesRead,
+      uniquePathsRead: agentRunToolStats.uniquePathsRead,
+      redundantReads: agentRunToolStats.redundantReads,
+      createdAt: agentRunToolStats.createdAt,
+      updatedAt: agentRunToolStats.updatedAt,
+      workItemId: agentRunCosts.workItemId,
+      stage: agentRunCosts.stage,
+      skill: agentRunCosts.skill,
+      modelId: agentRunCosts.modelId,
+      inputTokens: agentRunCosts.inputTokens,
+      outputTokens: agentRunCosts.outputTokens,
+      costUsd: agentRunCosts.costUsd,
+      costLabel: agentRunCosts.costLabel,
+      personaId: agentRunCosts.personaId,
+    })
+    .from(agentRunToolStats)
+    .innerJoin(agentRunCosts, eq(agentRunToolStats.runId, agentRunCosts.runId))
+    .where(eq(agentRunCosts.workItemId, workItemId))
+    .orderBy(asc(agentRunCosts.createdAt))
+    .all();
+
+  return rows.map((row) => ({
+    ...toToolStatsRow(row),
+    workItemId: row.workItemId,
+    stage: row.stage as Stage,
+    skill: row.skill,
+    modelId: row.modelId,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    costUsd: row.costUsd,
+    costLabel: row.costLabel as CostLabel,
+    personaId: row.personaId,
+  }));
 }
 
 export function listCostsForProjectSince(projectId: string, sinceIso: string): CostRow[] {
@@ -131,4 +226,151 @@ function toRow(r: typeof agentRunCosts.$inferSelect): CostRow {
     personaId: r.personaId,
     createdAt: r.createdAt,
   };
+}
+
+function aggregateToolStatsForRun(
+  runId: string,
+): Omit<AgentRunToolStatsRow, 'createdAt' | 'updatedAt'> {
+  const readPaths = new Set<string>();
+  let readCount = 0;
+  let grepCount = 0;
+  let writeCount = 0;
+  let editCount = 0;
+  let bytesRead = 0;
+  let redundantReads = 0;
+
+  for (const event of eventStore.replay({ runId, kind: 'agent.tool-call' })) {
+    const payload = payloadRecord(event.payload);
+    const toolName = normalizeToolName(payload.tool_name ?? payload.toolName ?? payload.name);
+    if (isReadTool(toolName)) {
+      readCount += 1;
+      bytesRead += bytesReadFromPayload(payload);
+      const path = canonicalPathStringFromAuditPayload(payload) ?? pathFromPayload(payload);
+      if (path != null) {
+        if (readPaths.has(path)) redundantReads += 1;
+        readPaths.add(path);
+      }
+    } else if (isSearchTool(toolName)) {
+      grepCount += 1;
+    } else if (isWriteTool(toolName)) {
+      writeCount += 1;
+    } else if (isEditTool(toolName)) {
+      editCount += 1;
+    }
+  }
+
+  return {
+    runId,
+    readCount,
+    grepCount,
+    writeCount,
+    editCount,
+    bytesRead,
+    uniquePathsRead: readPaths.size,
+    redundantReads,
+  };
+}
+
+function toToolStatsRow(row: typeof agentRunToolStats.$inferSelect): AgentRunToolStatsRow {
+  return {
+    runId: row.runId,
+    readCount: row.readCount,
+    grepCount: row.grepCount,
+    writeCount: row.writeCount,
+    editCount: row.editCount,
+    bytesRead: row.bytesRead,
+    uniquePathsRead: row.uniquePathsRead,
+    redundantReads: row.redundantReads,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function normalizeToolName(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function isReadTool(name: string): boolean {
+  return name === 'read' || name === 'read_file' || name === 'read_many_files';
+}
+
+function isSearchTool(name: string): boolean {
+  return name === 'grep' || name === 'glob' || name === 'search_text';
+}
+
+function isWriteTool(name: string): boolean {
+  return name === 'write' || name === 'write_file';
+}
+
+function isEditTool(name: string): boolean {
+  return name === 'edit' || name === 'edit_file' || name === 'apply_patch';
+}
+
+function bytesReadFromPayload(payload: Record<string, unknown>): number {
+  const value = payload.bytesRead ?? payload.bytes_read ?? payload.bytes ?? payload.contentBytes;
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function pathFromPayload(payload: Record<string, unknown>): string | null {
+  const toolInput = payloadRecord(payload.tool_input ?? payload.toolInput);
+  const value = toolInput.path ?? toolInput.file_path ?? payload.path ?? payload.file_path;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function payloadRecord(value: unknown): Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function emitToolIntensityAnomalyIfNeeded(stats: AgentRunToolStatsRow): void {
+  const [run] = db
+    .select()
+    .from(agentRunCosts)
+    .where(eq(agentRunCosts.runId, stats.runId))
+    .limit(1)
+    .all();
+  if (run == null) return;
+
+  const baseline = db
+    .select({ readCount: agentRunToolStats.readCount })
+    .from(agentRunToolStats)
+    .innerJoin(agentRunCosts, eq(agentRunToolStats.runId, agentRunCosts.runId))
+    .where(
+      and(
+        eq(agentRunCosts.projectId, run.projectId),
+        eq(agentRunCosts.skill, run.skill),
+        ne(agentRunCosts.runId, stats.runId),
+      ),
+    )
+    .all()
+    .map((row) => row.readCount);
+
+  const p95ReadCount = percentile(baseline, 0.95);
+  const thresholdReadCount = p95ReadCount * 2;
+  if (p95ReadCount <= 0 || stats.readCount <= thresholdReadCount) return;
+
+  eventStore.appendEvent({
+    projectId: run.projectId,
+    workItemId: run.workItemId,
+    runId: stats.runId,
+    personaId: run.personaId,
+    kind: 'agent.tool-intensity-anomaly',
+    payload: {
+      runId: stats.runId,
+      skill: run.skill,
+      readCount: stats.readCount,
+      p95ReadCount,
+      thresholdReadCount,
+      bytesRead: stats.bytesRead,
+      redundantReads: stats.redundantReads,
+    },
+  });
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(p * sorted.length) - 1);
+  return sorted[index] ?? 0;
 }

--- a/core/db/migrations/0039_agent_run_tool_stats.sql
+++ b/core/db/migrations/0039_agent_run_tool_stats.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `agent_run_tool_stats` (
+  `run_id` text PRIMARY KEY NOT NULL,
+  `read_count` integer DEFAULT 0 NOT NULL,
+  `grep_count` integer DEFAULT 0 NOT NULL,
+  `write_count` integer DEFAULT 0 NOT NULL,
+  `edit_count` integer DEFAULT 0 NOT NULL,
+  `bytes_read` integer DEFAULT 0 NOT NULL,
+  `unique_paths_read` integer DEFAULT 0 NOT NULL,
+  `redundant_reads` integer DEFAULT 0 NOT NULL,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+);

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1779341266516,
       "tag": "0038_outgoing_zodiak",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1779400000000,
+      "tag": "0039_agent_run_tool_stats",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -409,6 +409,19 @@ export const agentRunCosts = sqliteTable(
   }),
 );
 
+export const agentRunToolStats = sqliteTable('agent_run_tool_stats', {
+  runId: text('run_id').primaryKey(),
+  readCount: integer('read_count').notNull().default(0),
+  grepCount: integer('grep_count').notNull().default(0),
+  writeCount: integer('write_count').notNull().default(0),
+  editCount: integer('edit_count').notNull().default(0),
+  bytesRead: integer('bytes_read').notNull().default(0),
+  uniquePathsRead: integer('unique_paths_read').notNull().default(0),
+  redundantReads: integer('redundant_reads').notNull().default(0),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+});
+
 // One row per agent run. runId is unique — the same run is never recorded twice.
 export const agentRuns = sqliteTable(
   'agent_runs',

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -10,6 +10,7 @@ export const EVENT_KINDS = [
   'system.note',
   'manual.action',
   'agent.tool-call',
+  'agent.tool-intensity-anomaly',
   'tool.stdout-truncated',
   'tool.timeout',
   'agent.run-started',

--- a/core/runtime-profiler/profile-runs.test.ts
+++ b/core/runtime-profiler/profile-runs.test.ts
@@ -16,7 +16,9 @@ describe('profileRuntimeRows', () => {
         tool('r1', 'Bash', 'pnpm test'),
         tool('r1', 'Bash', 'pnpm test'),
         tool('r2', 'Bash', 'pnpm test'),
-        tool('r2', 'Read'),
+        tool('r1', 'Read', undefined, { canonical_path: { path: 'src/a.ts' }, bytesRead: 100 }),
+        tool('r2', 'Read', undefined, { canonical_path: { path: 'src/b.ts' }, bytesRead: 300 }),
+        tool('r2', 'Read', undefined, { canonical_path: { path: 'src/c.ts' }, bytesRead: 200 }),
         { runId: 'r2', kind: 'tool.timeout', payload: {}, createdAt: '2026-05-19T00:00:00Z' },
       ],
     });
@@ -26,6 +28,8 @@ describe('profileRuntimeRows', () => {
     expect(qa?.metrics.runCount).toBe(3);
     expect(qa?.metrics.medianInputTokens).toBe(200);
     expect(qa?.metrics.p95CostUsd).toBe(0.4);
+    expect(qa?.metrics.p95ReadCount).toBe(2);
+    expect(qa?.metrics.p95BytesRead).toBe(500);
     expect(qa?.metrics.timeoutRate).toBeCloseTo(1 / 3);
     expect(qa?.metrics.repeatedBashCommands[0]).toEqual({ command: 'pnpm test', count: 3 });
     expect(qa?.recommendations.some((rec) => rec.kind === 'workflow-helper')).toBe(true);
@@ -63,11 +67,16 @@ function run(
   };
 }
 
-function tool(runId: string, toolName: string, command?: string) {
+function tool(
+  runId: string,
+  toolName: string,
+  command?: string,
+  extra: Record<string, unknown> = {},
+) {
   return {
     runId,
     kind: 'agent.tool-call',
-    payload: { tool_name: toolName, tool_input: command == null ? {} : { command } },
+    payload: { tool_name: toolName, tool_input: command == null ? {} : { command }, ...extra },
     createdAt: '2026-05-19T00:00:00Z',
   };
 }

--- a/core/runtime-profiler/profile-runs.ts
+++ b/core/runtime-profiler/profile-runs.ts
@@ -115,6 +115,8 @@ function buildMetrics(
   const toolCounts = new Map<string, number>();
   const bashCommands = new Map<string, number>();
   const sequencesByRun = new Map<string, string[]>();
+  const readCountsByRun = new Map<string, number>();
+  const bytesReadByRun = new Map<string, number>();
 
   for (const event of eventsForRuns) {
     if (event.runId == null) continue;
@@ -144,8 +146,17 @@ function buildMetrics(
         const command = normalizeCommand(commandFromToolPayload(payload));
         if (command !== '') bashCommands.set(command, (bashCommands.get(command) ?? 0) + 1);
       }
+      if (isReadTool(toolName)) {
+        readCountsByRun.set(event.runId, (readCountsByRun.get(event.runId) ?? 0) + 1);
+        bytesReadByRun.set(
+          event.runId,
+          (bytesReadByRun.get(event.runId) ?? 0) + bytesReadFromPayload(payload),
+        );
+      }
     }
   }
+  const readCounts = runs.map((run) => readCountsByRun.get(run.runId) ?? 0);
+  const bytesRead = runs.map((run) => bytesReadByRun.get(run.runId) ?? 0);
 
   return {
     runCount,
@@ -155,6 +166,8 @@ function buildMetrics(
     p95OutputTokens: percentile(outputTokens, 0.95),
     medianCostUsd: percentile(costs, 0.5),
     p95CostUsd: percentile(costs, 0.95),
+    p95ReadCount: percentile(readCounts, 0.95),
+    p95BytesRead: percentile(bytesRead, 0.95),
     maxCostOutlier: maxRun == null ? null : { runId: maxRun.runId, costUsd: maxRun.costUsd },
     timeoutRate: rate(timeoutRuns.size, runCount),
     budgetExceededRate: rate(budgetRuns.size, runCount),
@@ -199,6 +212,16 @@ function commonSequences(
     .filter((entry) => entry.count > 1)
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
+}
+
+function isReadTool(toolName: string): boolean {
+  const name = toolName.toLowerCase();
+  return name === 'read' || name === 'read_file' || name === 'read_many_files';
+}
+
+function bytesReadFromPayload(payload: Record<string, unknown>): number {
+  const value = payload.bytesRead ?? payload.bytes_read ?? payload.bytes ?? payload.contentBytes;
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
 
 function toolNameFromPayload(payload: Record<string, unknown>): string {

--- a/core/runtime-profiler/types.ts
+++ b/core/runtime-profiler/types.ts
@@ -29,6 +29,8 @@ export interface RuntimeProfilerMetrics {
   p95OutputTokens: number;
   medianCostUsd: number;
   p95CostUsd: number;
+  p95ReadCount: number;
+  p95BytesRead: number;
   maxCostOutlier: { runId: string; costUsd: number } | null;
   timeoutRate: number;
   budgetExceededRate: number;

--- a/core/tool-layer/mcp/audit.ts
+++ b/core/tool-layer/mcp/audit.ts
@@ -14,6 +14,7 @@ export interface ToolCallAudit {
   input: Record<string, unknown>;
   durationMs?: number;
   truncated?: boolean;
+  bytesRead?: number;
   status?: 'ok' | 'failed' | 'timed_out';
   exitCode?: number | null;
   noMatches?: boolean;

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -302,6 +302,7 @@ export async function readFileTool(
     input: { path: input.path },
     status: 'ok',
     truncated,
+    bytesRead: Buffer.byteLength(result.content, 'utf8'),
   });
   return result;
 }

--- a/docs/cost-performance-improvements/handoff.md
+++ b/docs/cost-performance-improvements/handoff.md
@@ -30,3 +30,49 @@
 - Notes:
   - Created dedicated issue #1001 because the prompt-guardrail work from `wave2-and-timeline-analysis.md` did not have an existing issue. This was implemented before #994 rather than folded into telemetry.
 - Next branch to create: `cost-perf/994-tool-intensity-telemetry` from `cost-perf/1001-prompt-guardrails`
+
+## Issue #994 - Tool-intensity telemetry
+
+- Branch name: `cost-perf/994-tool-intensity-telemetry`
+- PR number/url: #1003 - https://github.com/shaunnez/goose-hub/pull/1003
+- Parent branch: `cost-perf/1001-prompt-guardrails`
+- Files changed:
+  - `CONTEXT.md`
+  - `apps/server/src/domains/costs/router.test.ts`
+  - `apps/server/src/domains/costs/router.ts`
+  - `apps/server/src/domains/costs/service.test.ts`
+  - `apps/server/src/domains/costs/service.ts`
+  - `apps/web/src/components/detail/components/CostsSection.test.tsx`
+  - `apps/web/src/components/detail/components/CostsSection.tsx`
+  - `apps/web/src/components/detail/components/TimelineEvents.tsx`
+  - `apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx`
+  - `apps/web/src/components/detail/components/timeline/MiscEvents.tsx`
+  - `apps/web/src/components/detail/lib/timeline/labels.ts`
+  - `apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx`
+  - `apps/web/src/components/settings/components/ProjectBudgetPanel.tsx`
+  - `apps/web/src/lib/types.ts`
+  - `core/agent-runtime/claude-cli.test.ts`
+  - `core/agent-runtime/claude-cli.ts`
+  - `core/agent-runtime/codex-cli-runtime.test.ts`
+  - `core/agent-runtime/codex-cli.ts`
+  - `core/cost/repository.test.ts`
+  - `core/cost/repository.ts`
+  - `core/db/migrations/0039_agent_run_tool_stats.sql`
+  - `core/db/migrations/meta/_journal.json`
+  - `core/db/schema.ts`
+  - `core/event-stream/kinds.ts`
+  - `core/runtime-profiler/profile-runs.test.ts`
+  - `core/runtime-profiler/profile-runs.ts`
+  - `core/runtime-profiler/types.ts`
+  - `core/tool-layer/mcp/audit.ts`
+  - `core/tool-layer/mcp/tools/read.ts`
+- Tests run:
+  - `pnpm vitest run core/cost/repository.test.ts core/agent-runtime/claude-cli.test.ts core/agent-runtime/codex-cli-runtime.test.ts apps/server/src/domains/costs/service.test.ts apps/server/src/domains/costs/router.test.ts core/runtime-profiler/profile-runs.test.ts apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx apps/web/src/components/detail/components/CostsSection.test.tsx apps/web/src/components/detail/lib/costs.test.ts apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx`
+  - `pnpm --filter @goose-hub/web build`
+  - `pnpm manifest --check`
+  - `pnpm audit-docs`
+  - `DB_PATH=/private/tmp/goose-hub-tool-stats-migrate-2.db pnpm tsx core/db/migrate.ts` (sandbox `listen EPERM` first, then passed with escalation)
+- Remaining risks:
+  - `read_many_files` can be counted in addition to its internal `read_file` audit events when both are emitted in the same run.
+  - The anomaly threshold uses the available same-project/same-skill p95 history; early sparse baselines can be noisy.
+- Next branch to create: `cost-perf/995-run-cache` from `cost-perf/994-tool-intensity-telemetry`


### PR DESCRIPTION
Stacked on: #1002 / cost-perf/1001-prompt-guardrails

Adds per-run tool-intensity aggregation, API/UI surfacing, runtime profiler read/byte p95 metrics, and timeline anomaly rendering.

Closes #994