### PR TITLE
M20.03: add per-run MCP read cache

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -595,6 +595,8 @@ Every path-bearing tool response returns the structured `RepoRelativePath` shape
 
 Every tool call emits `agent.tool-call`. The audit payload is normalized via `core/tool-layer/tool-call-audit.ts` (`normalizeToolCallAuditPayload`) so every path-bearing event carries `raw_path` + `canonical_path`. Every blocked call emits `agent.tool-call` with `blocked: true` and a reason code. Workflow-owned mutations (commit, open PR, transition, publish evidence) are not exposed to normal bundles; the orchestrator drives them.
 
+Read-side MCP tools use a process-local per-`FACTORY_RUN_ID` cache in `core/tool-layer/mcp/run-cache.ts`. Only `read_file`, `read_many_files`, `list_dir`, `list_files`, and `search_text` are cached; cache keys are built from canonical tool paths plus the arguments that affect output. Cached hits still emit `agent.tool-call` with `cached: true`. `write_file`, `edit_file`, `apply_patch`, `move_file`, and `delete_file` invalidate overlapping read/list/search entries, and `agent.run-completed` / `agent.run-failed` evict the whole run cache. This never crosses separate scout or synthesis runs.
+
 `core/tool-layer/tools/{read,write,bash,test}.ts` and their tests have been deleted (Phase 7 cleanup complete). `core/tool-layer/tools/record-decision.ts` is the surviving helper, wrapped by `mcp/tools/context.ts`.
 
 ## Flagged ambiguities

--- a/core/tool-layer/mcp/audit.ts
+++ b/core/tool-layer/mcp/audit.ts
@@ -15,6 +15,7 @@ export interface ToolCallAudit {
   durationMs?: number;
   truncated?: boolean;
   bytesRead?: number;
+  cached?: boolean;
   status?: 'ok' | 'failed' | 'timed_out';
   exitCode?: number | null;
   noMatches?: boolean;

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -1,0 +1,172 @@
+import { eventStore } from '../../event-stream/store.js';
+import { canonicalizeFactoryToolPath } from '../path-contract.js';
+
+export type CacheableToolName =
+  | 'read_file'
+  | 'read_many_files'
+  | 'list_dir'
+  | 'list_files'
+  | 'search_text';
+
+export interface NormalizedRunCacheKey {
+  toolName: CacheableToolName;
+  key: string;
+  paths: string[];
+}
+
+export interface CachedResult<T> {
+  result: T;
+  paths: string[];
+}
+
+const runCaches = new Map<string, Map<string, CachedResult<unknown>>>();
+
+eventStore.subscribe((event) => {
+  if (
+    event.runId != null &&
+    (event.kind === 'agent.run-completed' || event.kind === 'agent.run-failed')
+  ) {
+    clearRunCache(event.runId);
+  }
+});
+
+export function normalizeRunCacheKey(input: {
+  toolName: string;
+  args: Record<string, unknown>;
+  workspaceRoot: string;
+}): NormalizedRunCacheKey | null {
+  const toolName = input.toolName as CacheableToolName;
+  switch (toolName) {
+    case 'read_file': {
+      const path = stringArg(input.args.path);
+      if (path == null) return null;
+      const canonicalPath = canonicalPathForKey(path, input.workspaceRoot);
+      return key(
+        toolName,
+        [canonicalPath, input.args.startLine ?? 0, input.args.lineCount ?? -1],
+        [canonicalPath],
+      );
+    }
+    case 'read_many_files': {
+      const paths = Array.isArray(input.args.paths)
+        ? input.args.paths.map((path) =>
+            typeof path === 'string' ? canonicalPathForKey(path, input.workspaceRoot) : '',
+          )
+        : [];
+      if (paths.some((path) => path.length === 0)) return null;
+      return key(toolName, paths, paths);
+    }
+    case 'list_dir': {
+      const path = stringArg(input.args.path);
+      if (path == null) return null;
+      const canonicalPath = canonicalPathForKey(path, input.workspaceRoot);
+      return key(toolName, [canonicalPath, input.args.depth ?? 1, ''], [canonicalPath]);
+    }
+    case 'list_files': {
+      const canonicalPath = canonicalPathForKey(
+        stringArg(input.args.path) ?? '.',
+        input.workspaceRoot,
+      );
+      return key(
+        toolName,
+        [canonicalPath, input.args.limit ?? 500, input.args.glob ?? ''],
+        [canonicalPath],
+      );
+    }
+    case 'search_text': {
+      const query = stringArg(input.args.query);
+      if (query == null) return null;
+      const canonicalPath = canonicalPathForKey(
+        stringArg(input.args.path) ?? '.',
+        input.workspaceRoot,
+      );
+      return key(
+        toolName,
+        [
+          query,
+          canonicalPath,
+          input.args.glob ?? '',
+          input.args.contextLines ?? 0,
+          input.args.maxMatches ?? 200,
+        ],
+        [canonicalPath],
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+export function getCachedRunResult<T>(runId: string, cacheKey: string): T | null {
+  const cached = runCaches.get(runId)?.get(cacheKey);
+  if (cached == null) return null;
+  return cloneResult(cached.result as T);
+}
+
+export function setCachedRunResult<T>(runId: string, key: NormalizedRunCacheKey, result: T): void {
+  let cache = runCaches.get(runId);
+  if (cache == null) {
+    cache = new Map();
+    runCaches.set(runId, cache);
+  }
+  cache.set(key.key, { result: cloneResult(result), paths: key.paths });
+}
+
+export function invalidateRunCacheForPaths(runId: string, rawPaths: string[]): void {
+  const cache = runCaches.get(runId);
+  if (cache == null || rawPaths.length === 0) return;
+  const changedPaths = rawPaths.map(normalizePathForOverlap);
+  for (const [key, entry] of cache) {
+    if (
+      entry.paths.some((entryPath) =>
+        changedPaths.some((changedPath) => pathsOverlap(entryPath, changedPath)),
+      )
+    ) {
+      cache.delete(key);
+    }
+  }
+  if (cache.size === 0) runCaches.delete(runId);
+}
+
+export function clearRunCache(runId: string): void {
+  runCaches.delete(runId);
+}
+
+function key(
+  toolName: CacheableToolName,
+  parts: unknown[],
+  paths: string[],
+): NormalizedRunCacheKey {
+  return {
+    toolName,
+    key: JSON.stringify([toolName, ...parts]),
+    paths: paths.map(normalizePathForOverlap),
+  };
+}
+
+function stringArg(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function canonicalPathForKey(rawPath: string, workspaceRoot: string): string {
+  if (rawPath === '.' || rawPath.trim() === '') return '.';
+  const result = canonicalizeFactoryToolPath({ rawPath, worktreePath: workspaceRoot });
+  return result.ok ? result.path.path : rawPath;
+}
+
+function normalizePathForOverlap(path: string): string {
+  const trimmed = path.trim();
+  if (trimmed === '' || trimmed === '.') return '.';
+  return trimmed.replace(/^\.\//, '').replace(/\/+$/, '') || '.';
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const a = normalizePathForOverlap(left);
+  const b = normalizePathForOverlap(right);
+  if (a === '.' || b === '.') return true;
+  return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function cloneResult<T>(result: T): T {
+  return structuredClone(result);
+}

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -1,16 +1,26 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eventStore } from '../../event-stream/store.js';
 import {
   DEFAULT_STDERR_LIMIT_BYTES,
   DEFAULT_STDOUT_LIMIT_BYTES,
   minimalEnv,
   runCommand,
 } from './command-policy.js';
+import type { FactoryContext } from './context.js';
 import { FactoryContextError, loadFactoryContext } from './context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from './path-policy.js';
 import { buildFactoryMcpServer } from './server.js';
+import {
+  listDirTool,
+  listFilesTool,
+  readFileTool,
+  readManyFilesTool,
+  searchTextTool,
+} from './tools/read.js';
+import { writeFileTool } from './tools/write.js';
 
 let workspace: string;
 
@@ -21,6 +31,17 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(workspace, { recursive: true, force: true });
 });
+
+function makeCtx(overrides: Partial<FactoryContext> = {}): FactoryContext {
+  return {
+    runId: `run-${Math.random().toString(36).slice(2, 12)}`,
+    projectId: 'demo',
+    workItemId: 'github:demo/repo#1',
+    workspaceRoot: workspace,
+    serverPort: 3001,
+    ...overrides,
+  };
+}
 
 describe('path-policy', () => {
   it('resolves a workspace-relative path to an absolute path under root', () => {
@@ -132,6 +153,107 @@ describe('server resources', () => {
         {},
       ),
     ).resolves.toEqual({ resourceTemplates: [] });
+  });
+});
+
+describe('per-run read cache', () => {
+  it('returns identical read_file bytes with cached=true on the second call', async () => {
+    const ctx = makeCtx();
+    writeFileSync(join(workspace, 'README.md'), '# Demo\n\nhello world\n');
+
+    const first = await readFileTool(ctx, { path: 'README.md' });
+    const second = await readFileTool(ctx, { path: './README.md' });
+
+    expect(second).toEqual({ ...first, cached: true });
+    const readEvents = eventStore
+      .replay({ runId: ctx.runId, kind: 'agent.tool-call' })
+      .filter((event) => (event.payload as { tool_name?: string }).tool_name === 'read_file');
+    expect(readEvents).toHaveLength(2);
+    expect(readEvents[0].payload).not.toMatchObject({ cached: true });
+    expect(readEvents[1].payload).toMatchObject({ cached: true });
+  });
+
+  it('caches read_many_files, list_dir, list_files, and search_text within one run', async () => {
+    const ctx = makeCtx();
+    mkdirSync(join(workspace, 'src'));
+    writeFileSync(join(workspace, 'README.md'), '# Demo\n');
+    writeFileSync(join(workspace, 'src', 'index.ts'), 'export const NEEDLE = 1;\n');
+
+    await readManyFilesTool(ctx, { paths: ['README.md', 'src/index.ts'] });
+    await listDirTool(ctx, { path: 'src' });
+    await listFilesTool(ctx, { path: 'src', glob: '*.ts' });
+    await searchTextTool(ctx, { query: 'NEEDLE', path: 'src' });
+
+    expect(
+      await readManyFilesTool(ctx, { paths: ['./README.md', './src/index.ts'] }),
+    ).toMatchObject({ cached: true });
+    expect(await listDirTool(ctx, { path: './src' })).toMatchObject({ cached: true });
+    expect(await listFilesTool(ctx, { path: './src', glob: '*.ts' })).toMatchObject({
+      cached: true,
+    });
+    expect(await searchTextTool(ctx, { query: 'NEEDLE', path: './src' })).toMatchObject({
+      cached: true,
+    });
+  });
+
+  it('invalidates overlapping entries after a write before re-reading', async () => {
+    const ctx = makeCtx();
+    writeFileSync(join(workspace, 'a.txt'), 'old\n');
+
+    await readFileTool(ctx, { path: 'a.txt' });
+    await writeFileTool(ctx, { path: 'a.txt', content: 'new\n' });
+    const reread = await readFileTool(ctx, { path: 'a.txt' });
+
+    expect(reread.content).toBe('new\n');
+    expect(reread).not.toHaveProperty('cached');
+    expect(readFileSync(join(workspace, 'a.txt'), 'utf8')).toBe('new\n');
+  });
+
+  it('does not share cached reads across different run ids', async () => {
+    writeFileSync(join(workspace, 'a.txt'), 'run one\n');
+    const firstRun = makeCtx({ runId: 'cache-run-one' });
+    const secondRun = makeCtx({ runId: 'cache-run-two' });
+
+    await readFileTool(firstRun, { path: 'a.txt' });
+    writeFileSync(join(workspace, 'a.txt'), 'run two\n');
+    const second = await readFileTool(secondRun, { path: 'a.txt' });
+
+    expect(second.content).toBe('run two\n');
+    expect(second).not.toHaveProperty('cached');
+  });
+
+  it('evicts a run cache when the run completes', async () => {
+    const ctx = makeCtx({ runId: 'cache-run-evict' });
+    writeFileSync(join(workspace, 'a.txt'), 'before\n');
+
+    await readFileTool(ctx, { path: 'a.txt' });
+    eventStore.appendEvent({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId,
+      runId: ctx.runId,
+      kind: 'agent.run-completed',
+      payload: {},
+    });
+    writeFileSync(join(workspace, 'a.txt'), 'after\n');
+    const reread = await readFileTool(ctx, { path: 'a.txt' });
+
+    expect(reread.content).toBe('after\n');
+    expect(reread).not.toHaveProperty('cached');
+  });
+
+  it('caches a 200KB read payload and serves the second hit from memory', async () => {
+    const ctx = makeCtx();
+    mkdirSync(join(workspace, 'large'));
+    writeFileSync(join(workspace, 'large', 'payload.txt'), 'x'.repeat(200 * 1024));
+
+    const first = await readFileTool(ctx, { path: 'large/payload.txt' });
+    const start = performance.now();
+    const second = await readFileTool(ctx, { path: 'large/payload.txt' });
+    const elapsedMs = performance.now() - start;
+
+    expect(first.content).toHaveLength(200 * 1024);
+    expect(second).toEqual({ ...first, cached: true });
+    expect(elapsedMs).toBeLessThan(10);
   });
 });
 

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -20,7 +20,7 @@ import {
   readManyFilesTool,
   searchTextTool,
 } from './tools/read.js';
-import { writeFileTool } from './tools/write.js';
+import { applyPatchTool, createDirectoryTool, writeFileTool } from './tools/write.js';
 
 let workspace: string;
 
@@ -207,6 +207,40 @@ describe('per-run read cache', () => {
     expect(reread.content).toBe('new\n');
     expect(reread).not.toHaveProperty('cached');
     expect(readFileSync(join(workspace, 'a.txt'), 'utf8')).toBe('new\n');
+  });
+
+  it('invalidates parent listing entries after creating a directory', async () => {
+    const ctx = makeCtx();
+    mkdirSync(join(workspace, 'src'));
+
+    await listDirTool(ctx, { path: 'src' });
+    await createDirectoryTool(ctx, { path: 'src/generated' });
+    const relisted = await listDirTool(ctx, { path: 'src' });
+
+    expect(relisted).not.toHaveProperty('cached');
+    expect(relisted.entries.map((entry) => entry.name.path)).toContain('src/generated');
+  });
+
+  it('invalidates patched files with tabs in their path names', async () => {
+    const ctx = makeCtx();
+    const weirdPath = 'weird\tname.txt';
+    writeFileSync(join(workspace, weirdPath), 'old\n');
+
+    await readFileTool(ctx, { path: weirdPath });
+    const patch = [
+      '--- "a/weird\\tname.txt"',
+      '+++ "b/weird\\tname.txt"',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '',
+    ].join('\n');
+    const result = await applyPatchTool(ctx, { path: weirdPath, patch });
+    const reread = await readFileTool(ctx, { path: weirdPath });
+
+    expect(result.filesChanged.map((path) => path.path)).toEqual([weirdPath]);
+    expect(reread.content).toBe('new\n');
+    expect(reread).not.toHaveProperty('cached');
   });
 
   it('does not share cached reads across different run ids', async () => {

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -13,6 +13,7 @@ import {
 } from '../command-policy.js';
 import type { FactoryContext } from '../context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from '../path-policy.js';
+import { getCachedRunResult, normalizeRunCacheKey, setCachedRunResult } from '../run-cache.js';
 import type {
   FileExistsInput,
   FileInfoInput,
@@ -51,11 +52,13 @@ export interface ReadFileResult {
   startLine: number;
   endLine: number;
   totalLines: number;
+  cached?: true;
 }
 
 export interface ReadManyFilesResult {
   files: Array<{ path: RepoRelativePath; content: string; truncated: boolean }>;
   errors: Array<{ path: string; reason: string }>;
+  cached?: true;
 }
 
 export interface ListDirEntry {
@@ -67,11 +70,13 @@ export interface ListDirResult {
   path: RepoRelativePath;
   entries: ListDirEntry[];
   truncated: boolean;
+  cached?: true;
 }
 
 export interface ListFilesResult {
   files: RepoRelativePath[];
   truncated: boolean;
+  cached?: true;
 }
 
 export interface SearchMatch {
@@ -83,6 +88,7 @@ export interface SearchMatch {
 export interface SearchTextResult {
   matches: SearchMatch[];
   truncated: boolean;
+  cached?: true;
 }
 
 export interface FileInfoResult {
@@ -273,6 +279,26 @@ export async function readFileTool(
     throw err;
   }
 
+  const cacheKey = normalizeRunCacheKey({
+    toolName: 'read_file',
+    args: input,
+    workspaceRoot: ctx.workspaceRoot,
+  });
+  const cached =
+    cacheKey == null ? null : getCachedRunResult<ReadFileResult>(ctx.runId, cacheKey.key);
+  if (cached != null) {
+    const result = { ...cached, cached: true as const };
+    emitToolCall(ctx, {
+      tool: 'read_file',
+      input: { path: input.path },
+      status: 'ok',
+      truncated: result.truncated,
+      bytesRead: Buffer.byteLength(result.content, 'utf8'),
+      cached: true,
+    });
+    return result;
+  }
+
   const buffer = await readFile(resolved.absolute);
   const totalBytes = buffer.byteLength;
   const truncatedByBytes = totalBytes > READ_FILE_CAP_BYTES;
@@ -304,6 +330,7 @@ export async function readFileTool(
     truncated,
     bytesRead: Buffer.byteLength(result.content, 'utf8'),
   });
+  if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
   return result;
 }
 
@@ -316,6 +343,23 @@ export async function readManyFilesTool(
   ctx: FactoryContext,
   input: z.infer<typeof ReadManyFilesInput>,
 ): Promise<ReadManyFilesResult> {
+  const cacheKey = normalizeRunCacheKey({
+    toolName: 'read_many_files',
+    args: input,
+    workspaceRoot: ctx.workspaceRoot,
+  });
+  const cached =
+    cacheKey == null ? null : getCachedRunResult<ReadManyFilesResult>(ctx.runId, cacheKey.key);
+  if (cached != null) {
+    emitToolCall(ctx, {
+      tool: 'read_many_files',
+      input: { count: input.paths.length },
+      status: 'ok',
+      cached: true,
+    });
+    return { ...cached, cached: true as const };
+  }
+
   const files: ReadManyFilesResult['files'] = [];
   const errors: ReadManyFilesResult['errors'] = [];
 
@@ -334,7 +378,9 @@ export async function readManyFilesTool(
     input: { count: input.paths.length },
     status: 'ok',
   });
-  return { files, errors };
+  const result = { files, errors };
+  if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
+  return result;
 }
 
 /**
@@ -355,6 +401,24 @@ export async function listDirTool(
   }
 
   const depth = input.depth ?? 1;
+  const cacheKey = normalizeRunCacheKey({
+    toolName: 'list_dir',
+    args: { ...input, depth },
+    workspaceRoot: ctx.workspaceRoot,
+  });
+  const cached =
+    cacheKey == null ? null : getCachedRunResult<ListDirResult>(ctx.runId, cacheKey.key);
+  if (cached != null) {
+    emitToolCall(ctx, {
+      tool: 'list_dir',
+      input: { path: input.path, depth },
+      status: 'ok',
+      truncated: cached.truncated,
+      cached: true,
+    });
+    return { ...cached, cached: true as const };
+  }
+
   const entries: ListDirEntry[] = [];
   let truncated = false;
   const dirWorkspacePath = resolved.canonical.path;
@@ -398,7 +462,9 @@ export async function listDirTool(
     status: 'ok',
     truncated,
   });
-  return { path: resolved.canonical, entries, truncated };
+  const result = { path: resolved.canonical, entries, truncated };
+  if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
+  return result;
 }
 
 /**
@@ -424,6 +490,24 @@ export async function listFilesTool(
   args.push(searchPath);
 
   const limit = Math.min(input.limit ?? LIST_FILES_CAP, LIST_FILES_CAP);
+  const cacheKey = normalizeRunCacheKey({
+    toolName: 'list_files',
+    args: { ...input, limit },
+    workspaceRoot: ctx.workspaceRoot,
+  });
+  const cached =
+    cacheKey == null ? null : getCachedRunResult<ListFilesResult>(ctx.runId, cacheKey.key);
+  if (cached != null) {
+    emitToolCall(ctx, {
+      tool: 'list_files',
+      input: { path: input.path ?? null, glob: input.glob ?? null },
+      status: 'ok',
+      truncated: cached.truncated,
+      noMatches: cached.files.length === 0,
+      cached: true,
+    });
+    return { ...cached, cached: true as const };
+  }
 
   const result = await runCommand({
     command: 'rg',
@@ -464,7 +548,9 @@ export async function listFilesTool(
     truncated,
     noMatches: files.length === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
   });
-  return { files, truncated };
+  const output = { files, truncated };
+  if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, output);
+  return output;
 }
 
 /**
@@ -502,6 +588,26 @@ export async function searchTextTool(
   }
   args.push('--', input.query, searchPath);
 
+  const limit = Math.min(input.maxMatches ?? SEARCH_MAX_MATCHES, SEARCH_MAX_MATCHES);
+  const cacheKey = normalizeRunCacheKey({
+    toolName: 'search_text',
+    args: { ...input, maxMatches: limit },
+    workspaceRoot: ctx.workspaceRoot,
+  });
+  const cached =
+    cacheKey == null ? null : getCachedRunResult<SearchTextResult>(ctx.runId, cacheKey.key);
+  if (cached != null) {
+    emitToolCall(ctx, {
+      tool: 'search_text',
+      input: { query: input.query, path: input.path ?? null, glob: input.glob ?? null },
+      status: 'ok',
+      truncated: cached.truncated,
+      noMatches: cached.matches.length === 0,
+      cached: true,
+    });
+    return { ...cached, cached: true as const };
+  }
+
   const result = await runCommand({
     command: 'rg',
     args,
@@ -511,7 +617,6 @@ export async function searchTextTool(
     env: minimalEnv(),
   });
 
-  const limit = Math.min(input.maxMatches ?? SEARCH_MAX_MATCHES, SEARCH_MAX_MATCHES);
   let matches: SearchMatch[];
   let truncated: boolean;
 
@@ -555,7 +660,9 @@ export async function searchTextTool(
     truncated,
     noMatches: matches.length === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
   });
-  return { matches, truncated };
+  const output = { matches, truncated };
+  if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, output);
+  return output;
 }
 
 /**

--- a/core/tool-layer/mcp/tools/write.ts
+++ b/core/tool-layer/mcp/tools/write.ts
@@ -10,6 +10,7 @@ import { emitBlockedToolCall, emitToolCall } from '../audit.js';
 import { minimalEnv, runCommand } from '../command-policy.js';
 import type { FactoryContext } from '../context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from '../path-policy.js';
+import { invalidateRunCacheForPaths } from '../run-cache.js';
 import type {
   ApplyPatchInput,
   CreateDirectoryInput,
@@ -107,6 +108,7 @@ export async function writeFileTool(
 
   await mkdir(dirname(resolved.absolute), { recursive: true });
   await writeFile(resolved.absolute, input.content, 'utf8');
+  invalidateRunCacheForPaths(ctx.runId, [resolved.canonical.path]);
 
   emitToolCall(ctx, {
     tool: 'write_file',
@@ -172,6 +174,7 @@ export async function editFileTool(
   }
 
   await writeFile(resolved.absolute, next, 'utf8');
+  invalidateRunCacheForPaths(ctx.runId, [resolved.canonical.path]);
 
   emitToolCall(ctx, {
     tool: 'edit_file',
@@ -274,6 +277,10 @@ export async function applyPatchTool(
     const filesChanged: RepoRelativePath[] = rawFiles.map((rawPath) =>
       rawPathToCanonical(rawPath, ctx.workspaceRoot),
     );
+    invalidateRunCacheForPaths(
+      ctx.runId,
+      filesChanged.map((path) => path.path),
+    );
 
     emitToolCall(ctx, {
       tool: 'apply_patch',
@@ -356,6 +363,7 @@ export async function moveFileTool(
 
   await mkdir(dirname(toResolved.absolute), { recursive: true });
   await rename(fromResolved.absolute, toResolved.absolute);
+  invalidateRunCacheForPaths(ctx.runId, [fromResolved.canonical.path, toResolved.canonical.path]);
 
   emitToolCall(ctx, {
     tool: 'move_file',
@@ -403,6 +411,7 @@ export async function deleteFileTool(
   }
 
   if (existed) await rm(resolved.absolute, { force: true });
+  invalidateRunCacheForPaths(ctx.runId, [resolved.canonical.path]);
 
   emitToolCall(ctx, {
     tool: 'delete_file',

--- a/core/tool-layer/mcp/tools/write.ts
+++ b/core/tool-layer/mcp/tools/write.ts
@@ -268,7 +268,7 @@ export async function applyPatchTool(
     // run it against the same patch file for a structured filesChanged list.
     const statResult = await runCommand({
       command: 'git',
-      args: ['apply', '--numstat', '--summary', patchFile],
+      args: ['apply', '--numstat', '-z', '--summary', patchFile],
       cwd: ctx.workspaceRoot,
       timeoutMs: APPLY_PATCH_TIMEOUT_MS,
       env: minimalEnv(),
@@ -296,14 +296,24 @@ export async function applyPatchTool(
 
 function parseNumstat(stdout: string): string[] {
   const out: string[] = [];
-  for (const line of stdout.split('\n')) {
-    // numstat lines: "<added>\t<removed>\t<path>"; summary lines start with " "
-    const cols = line.split('\t');
-    if (cols.length === 3 && cols[2].length > 0 && /^\d+|-$/.test(cols[0])) {
-      out.push(cols[2]);
+  const records = stdout.includes('\0') ? stdout.split('\0') : stdout.split('\n');
+  for (const record of records) {
+    // numstat records: "<added>\t<removed>\t<path>"; with -z, path may contain tabs.
+    const firstTab = record.indexOf('\t');
+    const secondTab = firstTab === -1 ? -1 : record.indexOf('\t', firstTab + 1);
+    if (firstTab === -1 || secondTab === -1) continue;
+    const added = record.slice(0, firstTab);
+    const removed = record.slice(firstTab + 1, secondTab);
+    const filePath = record.slice(secondTab + 1);
+    if (filePath.length > 0 && isNumstatCount(added) && isNumstatCount(removed)) {
+      out.push(filePath);
     }
   }
   return out;
+}
+
+function isNumstatCount(value: string): boolean {
+  return value === '-' || /^\d+$/.test(value);
 }
 
 export interface CreateDirectoryResult {
@@ -333,6 +343,7 @@ export async function createDirectoryTool(
   }
 
   await mkdir(resolved.absolute, { recursive: true });
+  invalidateRunCacheForPaths(ctx.runId, [resolved.canonical.path]);
 
   emitToolCall(ctx, {
     tool: 'create_directory',

--- a/docs/cost-performance-improvements/handoff.md
+++ b/docs/cost-performance-improvements/handoff.md
@@ -76,3 +76,29 @@
   - `read_many_files` can be counted in addition to its internal `read_file` audit events when both are emitted in the same run.
   - The anomaly threshold uses the available same-project/same-skill p95 history; early sparse baselines can be noisy.
 - Next branch to create: `cost-perf/995-run-cache` from `cost-perf/994-tool-intensity-telemetry`
+
+## Issue #995 - Per-run MCP read/search cache
+
+- Branch name: `cost-perf/995-run-cache`
+- PR number/url: #1004 - https://github.com/shaunnez/goose-hub/pull/1004
+- Parent branch: `cost-perf/994-tool-intensity-telemetry`
+- Files changed:
+  - `CONTEXT.md`
+  - `core/tool-layer/mcp/audit.ts`
+  - `core/tool-layer/mcp/run-cache.ts`
+  - `core/tool-layer/mcp/slice.test.ts`
+  - `core/tool-layer/mcp/tools/read.ts`
+  - `core/tool-layer/mcp/tools/write.ts`
+- Tests run:
+  - `pnpm vitest run core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/tools/read.test.ts core/tool-layer/mcp/tools/write.test.ts core/cost/repository.test.ts apps/server/src/domains/costs/service.test.ts apps/server/src/domains/costs/router.test.ts`
+  - `pnpm exec tsc --noEmit --pretty false`
+  - `pnpm exec biome check core/tool-layer/mcp/run-cache.ts core/tool-layer/mcp/audit.ts core/tool-layer/mcp/tools/read.ts core/tool-layer/mcp/tools/write.ts core/tool-layer/mcp/slice.test.ts apps/server/src/domains/costs/repository.ts`
+  - `pnpm audit-docs`
+  - `pnpm manifest --check`
+- Remaining risks:
+  - Cache state is process-local by design; restarting the MCP process drops all entries.
+  - `list_files` keys include the effective `limit` as a correctness extension beyond the issue wording, because limit changes the returned payload.
+  - This cache only removes repeated disk/process work inside a single run; separate scouts still need #996's shared InvestigationSeed.
+- Notes:
+  - While verifying #995, `pnpm exec tsc --noEmit --pretty false` exposed a missing #994 server repository re-export. PR #1003 was amended and force-pushed with that parent-stack fix before #995 was rebased.
+- Next branch to create: `cost-perf/998-duplicate-call-nudge` from `cost-perf/995-run-cache`


### PR DESCRIPTION
Stacked on: #1003 / cost-perf/994-tool-intensity-telemetry

Adds per-run read/list/search caching for Factory MCP tools, cached audit markers, write-side invalidation, run-completion eviction, and cache-key helper semantics for later duplicate-call nudges.

Closes #995