### PR TITLE
M20.04: add duplicate-call advisory nudge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -597,6 +597,8 @@ Every tool call emits `agent.tool-call`. The audit payload is normalized via `co
 
 Read-side MCP tools use a process-local per-`FACTORY_RUN_ID` cache in `core/tool-layer/mcp/run-cache.ts`. Only `read_file`, `read_many_files`, `list_dir`, `list_files`, and `search_text` are cached; cache keys are built from canonical tool paths plus the arguments that affect output. Cached hits still emit `agent.tool-call` with `cached: true`. `write_file`, `edit_file`, `apply_patch`, `move_file`, and `delete_file` invalidate overlapping read/list/search entries, and `agent.run-completed` / `agent.run-failed` evict the whole run cache. This never crosses separate scout or synthesis runs.
 
+Duplicate-call nudges are advisory only. `core/tool-layer/mcp/run-cache.ts` tracks identical cache-key calls per run and marks `agent.tool-call` with `duplicateCount` from the second call onward; at the configured threshold (`FACTORY_DUPLICATE_NUDGE_THRESHOLD`, default 3) the PostToolUse hook forwards a one-line `additionalContext` reminder. The hook never blocks, denies, aborts, or fails duplicate calls.
+
 `core/tool-layer/tools/{read,write,bash,test}.ts` and their tests have been deleted (Phase 7 cleanup complete). `core/tool-layer/tools/record-decision.ts` is the surviving helper, wrapped by `mcp/tools/context.ts`.
 
 ## Flagged ambiguities

--- a/core/tool-layer/mcp/audit.ts
+++ b/core/tool-layer/mcp/audit.ts
@@ -16,6 +16,7 @@ export interface ToolCallAudit {
   truncated?: boolean;
   bytesRead?: number;
   cached?: boolean;
+  duplicateCount?: number;
   status?: 'ok' | 'failed' | 'timed_out';
   exitCode?: number | null;
   noMatches?: boolean;

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -19,7 +19,19 @@ export interface CachedResult<T> {
   paths: string[];
 }
 
+export interface DuplicateToolCallRecord {
+  duplicateCount: number;
+  duplicateNudge?: string;
+}
+
+export const DUPLICATE_NUDGE_REMINDER =
+  '[harness] You have invoked this tool with identical args {count} times this run. The cached result was returned. If you need different information, change your query.';
+
 const runCaches = new Map<string, Map<string, CachedResult<unknown>>>();
+const duplicateCounters = new Map<
+  string,
+  Map<string, { count: number; nudged: boolean; paths: string[] }>
+>();
 
 eventStore.subscribe((event) => {
   if (
@@ -114,22 +126,62 @@ export function setCachedRunResult<T>(runId: string, key: NormalizedRunCacheKey,
 
 export function invalidateRunCacheForPaths(runId: string, rawPaths: string[]): void {
   const cache = runCaches.get(runId);
-  if (cache == null || rawPaths.length === 0) return;
+  const duplicateMap = duplicateCounters.get(runId);
+  if ((cache == null && duplicateMap == null) || rawPaths.length === 0) return;
   const changedPaths = rawPaths.map(normalizePathForOverlap);
-  for (const [key, entry] of cache) {
+  for (const [key, entry] of cache ?? []) {
     if (
       entry.paths.some((entryPath) =>
         changedPaths.some((changedPath) => pathsOverlap(entryPath, changedPath)),
       )
     ) {
-      cache.delete(key);
+      cache?.delete(key);
     }
   }
-  if (cache.size === 0) runCaches.delete(runId);
+  if (cache?.size === 0) runCaches.delete(runId);
+  for (const [key, entry] of duplicateMap ?? []) {
+    if (
+      entry.paths.some((entryPath) =>
+        changedPaths.some((changedPath) => pathsOverlap(entryPath, changedPath)),
+      )
+    ) {
+      duplicateMap?.delete(key);
+    }
+  }
+  if (duplicateMap?.size === 0) duplicateCounters.delete(runId);
 }
 
 export function clearRunCache(runId: string): void {
   runCaches.delete(runId);
+  duplicateCounters.delete(runId);
+}
+
+export function recordDuplicateToolCall(
+  runId: string,
+  key: NormalizedRunCacheKey,
+  env: NodeJS.ProcessEnv = process.env,
+): DuplicateToolCallRecord {
+  let runMap = duplicateCounters.get(runId);
+  if (runMap == null) {
+    runMap = new Map();
+    duplicateCounters.set(runId, runMap);
+  }
+  const existing = runMap.get(key.key) ?? { count: 0, nudged: false, paths: key.paths };
+  existing.count += 1;
+  existing.paths = key.paths;
+  let duplicateNudge: string | undefined;
+  const threshold = duplicateNudgeThreshold(env);
+  if (!existing.nudged && existing.count === threshold) {
+    existing.nudged = true;
+    duplicateNudge = DUPLICATE_NUDGE_REMINDER.replace('{count}', String(existing.count));
+  }
+  runMap.set(key.key, existing);
+  return { duplicateCount: existing.count, duplicateNudge };
+}
+
+export function duplicateNudgeThreshold(env: NodeJS.ProcessEnv = process.env): number {
+  const value = Number.parseInt(env.FACTORY_DUPLICATE_NUDGE_THRESHOLD ?? '', 10);
+  return Number.isFinite(value) && value > 1 ? value : 3;
 }
 
 function key(

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -23,12 +23,17 @@ import {
 import { writeFileTool } from './tools/write.js';
 
 let workspace: string;
+let duplicateNudgeThresholdEnv: string | undefined;
 
 beforeEach(() => {
   workspace = mkdtempSync(join(tmpdir(), 'factory-mcp-'));
+  duplicateNudgeThresholdEnv = process.env.FACTORY_DUPLICATE_NUDGE_THRESHOLD;
+  process.env.FACTORY_DUPLICATE_NUDGE_THRESHOLD = undefined;
 });
 
 afterEach(() => {
+  if (duplicateNudgeThresholdEnv == null) process.env.FACTORY_DUPLICATE_NUDGE_THRESHOLD = undefined;
+  else process.env.FACTORY_DUPLICATE_NUDGE_THRESHOLD = duplicateNudgeThresholdEnv;
   rmSync(workspace, { recursive: true, force: true });
 });
 
@@ -254,6 +259,44 @@ describe('per-run read cache', () => {
     expect(first.content).toHaveLength(200 * 1024);
     expect(second).toEqual({ ...first, cached: true });
     expect(elapsedMs).toBeLessThan(10);
+  });
+
+  it('nudges once after the third identical cached tool call and emits duplicate telemetry', async () => {
+    const ctx = makeCtx();
+    writeFileSync(join(workspace, 'README.md'), '# Demo\n');
+
+    const first = await readFileTool(ctx, { path: 'README.md' });
+    const second = await readFileTool(ctx, { path: 'README.md' });
+    const third = await readFileTool(ctx, { path: 'README.md' });
+    const fourth = await readFileTool(ctx, { path: 'README.md' });
+
+    expect(first).not.toHaveProperty('duplicateNudge');
+    expect(second).not.toHaveProperty('duplicateNudge');
+    expect(third.duplicateNudge).toBe(
+      '[harness] You have invoked this tool with identical args 3 times this run. The cached result was returned. If you need different information, change your query.',
+    );
+    expect(fourth).not.toHaveProperty('duplicateNudge');
+    const readEvents = eventStore
+      .replay({ runId: ctx.runId, kind: 'agent.tool-call' })
+      .filter((event) => (event.payload as { tool_name?: string }).tool_name === 'read_file');
+    expect(
+      readEvents.map((event) => (event.payload as { duplicateCount?: number }).duplicateCount),
+    ).toEqual([undefined, 2, 3, 4]);
+  });
+
+  it('honours FACTORY_DUPLICATE_NUDGE_THRESHOLD without blocking duplicate calls', async () => {
+    process.env.FACTORY_DUPLICATE_NUDGE_THRESHOLD = '2';
+    const ctx = makeCtx();
+    writeFileSync(join(workspace, 'README.md'), '# Demo\n');
+
+    const first = await readFileTool(ctx, { path: 'README.md' });
+    const second = await readFileTool(ctx, { path: 'README.md' });
+    const third = await readFileTool(ctx, { path: 'README.md' });
+
+    expect(first).not.toHaveProperty('duplicateNudge');
+    expect(second.duplicateNudge).toContain('identical args 2 times this run');
+    expect(third.content).toBe('# Demo\n');
+    expect(third).not.toHaveProperty('duplicateNudge');
   });
 });
 

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -13,7 +13,12 @@ import {
 } from '../command-policy.js';
 import type { FactoryContext } from '../context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from '../path-policy.js';
-import { getCachedRunResult, normalizeRunCacheKey, setCachedRunResult } from '../run-cache.js';
+import {
+  getCachedRunResult,
+  normalizeRunCacheKey,
+  recordDuplicateToolCall,
+  setCachedRunResult,
+} from '../run-cache.js';
 import type {
   FileExistsInput,
   FileInfoInput,
@@ -53,12 +58,14 @@ export interface ReadFileResult {
   endLine: number;
   totalLines: number;
   cached?: true;
+  duplicateNudge?: string;
 }
 
 export interface ReadManyFilesResult {
   files: Array<{ path: RepoRelativePath; content: string; truncated: boolean }>;
   errors: Array<{ path: string; reason: string }>;
   cached?: true;
+  duplicateNudge?: string;
 }
 
 export interface ListDirEntry {
@@ -71,12 +78,14 @@ export interface ListDirResult {
   entries: ListDirEntry[];
   truncated: boolean;
   cached?: true;
+  duplicateNudge?: string;
 }
 
 export interface ListFilesResult {
   files: RepoRelativePath[];
   truncated: boolean;
   cached?: true;
+  duplicateNudge?: string;
 }
 
 export interface SearchMatch {
@@ -89,6 +98,7 @@ export interface SearchTextResult {
   matches: SearchMatch[];
   truncated: boolean;
   cached?: true;
+  duplicateNudge?: string;
 }
 
 export interface FileInfoResult {
@@ -125,6 +135,20 @@ function handleBlocked(
     message: err.message,
   });
   throw err;
+}
+
+function duplicateAuditFields(duplicate: ReturnType<typeof recordDuplicateToolCall> | null): {
+  duplicateCount?: number;
+} {
+  return duplicate != null && duplicate.duplicateCount >= 2
+    ? { duplicateCount: duplicate.duplicateCount }
+    : {};
+}
+
+function duplicateNudgeFields(duplicate: ReturnType<typeof recordDuplicateToolCall> | null): {
+  duplicateNudge?: string;
+} {
+  return duplicate?.duplicateNudge != null ? { duplicateNudge: duplicate.duplicateNudge } : {};
 }
 
 function rawPathToCanonical(rawPath: string, workspaceRoot: string): RepoRelativePath {
@@ -284,10 +308,11 @@ export async function readFileTool(
     args: input,
     workspaceRoot: ctx.workspaceRoot,
   });
+  const duplicate = cacheKey == null ? null : recordDuplicateToolCall(ctx.runId, cacheKey);
   const cached =
     cacheKey == null ? null : getCachedRunResult<ReadFileResult>(ctx.runId, cacheKey.key);
   if (cached != null) {
-    const result = { ...cached, cached: true as const };
+    const result = { ...cached, cached: true as const, ...duplicateNudgeFields(duplicate) };
     emitToolCall(ctx, {
       tool: 'read_file',
       input: { path: input.path },
@@ -295,6 +320,7 @@ export async function readFileTool(
       truncated: result.truncated,
       bytesRead: Buffer.byteLength(result.content, 'utf8'),
       cached: true,
+      ...duplicateAuditFields(duplicate),
     });
     return result;
   }
@@ -329,6 +355,7 @@ export async function readFileTool(
     status: 'ok',
     truncated,
     bytesRead: Buffer.byteLength(result.content, 'utf8'),
+    ...duplicateAuditFields(duplicate),
   });
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
   return result;
@@ -348,6 +375,7 @@ export async function readManyFilesTool(
     args: input,
     workspaceRoot: ctx.workspaceRoot,
   });
+  const duplicate = cacheKey == null ? null : recordDuplicateToolCall(ctx.runId, cacheKey);
   const cached =
     cacheKey == null ? null : getCachedRunResult<ReadManyFilesResult>(ctx.runId, cacheKey.key);
   if (cached != null) {
@@ -356,8 +384,9 @@ export async function readManyFilesTool(
       input: { count: input.paths.length },
       status: 'ok',
       cached: true,
+      ...duplicateAuditFields(duplicate),
     });
-    return { ...cached, cached: true as const };
+    return { ...cached, cached: true as const, ...duplicateNudgeFields(duplicate) };
   }
 
   const files: ReadManyFilesResult['files'] = [];
@@ -377,6 +406,7 @@ export async function readManyFilesTool(
     tool: 'read_many_files',
     input: { count: input.paths.length },
     status: 'ok',
+    ...duplicateAuditFields(duplicate),
   });
   const result = { files, errors };
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
@@ -406,6 +436,7 @@ export async function listDirTool(
     args: { ...input, depth },
     workspaceRoot: ctx.workspaceRoot,
   });
+  const duplicate = cacheKey == null ? null : recordDuplicateToolCall(ctx.runId, cacheKey);
   const cached =
     cacheKey == null ? null : getCachedRunResult<ListDirResult>(ctx.runId, cacheKey.key);
   if (cached != null) {
@@ -415,8 +446,9 @@ export async function listDirTool(
       status: 'ok',
       truncated: cached.truncated,
       cached: true,
+      ...duplicateAuditFields(duplicate),
     });
-    return { ...cached, cached: true as const };
+    return { ...cached, cached: true as const, ...duplicateNudgeFields(duplicate) };
   }
 
   const entries: ListDirEntry[] = [];
@@ -461,6 +493,7 @@ export async function listDirTool(
     input: { path: input.path, depth },
     status: 'ok',
     truncated,
+    ...duplicateAuditFields(duplicate),
   });
   const result = { path: resolved.canonical, entries, truncated };
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
@@ -495,6 +528,7 @@ export async function listFilesTool(
     args: { ...input, limit },
     workspaceRoot: ctx.workspaceRoot,
   });
+  const duplicate = cacheKey == null ? null : recordDuplicateToolCall(ctx.runId, cacheKey);
   const cached =
     cacheKey == null ? null : getCachedRunResult<ListFilesResult>(ctx.runId, cacheKey.key);
   if (cached != null) {
@@ -505,8 +539,9 @@ export async function listFilesTool(
       truncated: cached.truncated,
       noMatches: cached.files.length === 0,
       cached: true,
+      ...duplicateAuditFields(duplicate),
     });
-    return { ...cached, cached: true as const };
+    return { ...cached, cached: true as const, ...duplicateNudgeFields(duplicate) };
   }
 
   const result = await runCommand({
@@ -547,6 +582,7 @@ export async function listFilesTool(
     durationMs: result.durationMs,
     truncated,
     noMatches: files.length === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
+    ...duplicateAuditFields(duplicate),
   });
   const output = { files, truncated };
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, output);
@@ -594,6 +630,7 @@ export async function searchTextTool(
     args: { ...input, maxMatches: limit },
     workspaceRoot: ctx.workspaceRoot,
   });
+  const duplicate = cacheKey == null ? null : recordDuplicateToolCall(ctx.runId, cacheKey);
   const cached =
     cacheKey == null ? null : getCachedRunResult<SearchTextResult>(ctx.runId, cacheKey.key);
   if (cached != null) {
@@ -604,8 +641,9 @@ export async function searchTextTool(
       truncated: cached.truncated,
       noMatches: cached.matches.length === 0,
       cached: true,
+      ...duplicateAuditFields(duplicate),
     });
-    return { ...cached, cached: true as const };
+    return { ...cached, cached: true as const, ...duplicateNudgeFields(duplicate) };
   }
 
   const result = await runCommand({
@@ -659,6 +697,7 @@ export async function searchTextTool(
     durationMs: result.durationMs,
     truncated,
     noMatches: matches.length === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
+    ...duplicateAuditFields(duplicate),
   });
   const output = { matches, truncated };
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, output);

--- a/core/tool-layer/post-tool-use-hook.test.ts
+++ b/core/tool-layer/post-tool-use-hook.test.ts
@@ -193,4 +193,20 @@ describe('deployPostHook', () => {
     const script = vi.mocked(writeFileSync).mock.calls[0][1] as string;
     expect(script).toContain('.length > 0');
   });
+
+  it('hook script forwards duplicate-call nudges as PostToolUse additionalContext', () => {
+    deployPostHook();
+    const script = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    expect(script).toContain('duplicateNudge');
+    expect(script).toContain("hookEventName: 'PostToolUse'");
+    expect(script).toContain('additionalContext: duplicateNudge');
+  });
+
+  it('hook script does not block or fail when emitting duplicate-call advice', () => {
+    deployPostHook();
+    const script = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    expect(script).toContain('process.stdout.write');
+    expect(script).not.toContain("decision: 'block'");
+    expect(script).not.toContain('process.exit(2)');
+  });
 });

--- a/core/tool-layer/post-tool-use-hook.ts
+++ b/core/tool-layer/post-tool-use-hook.ts
@@ -103,6 +103,22 @@ async function main() {
     } catch { /* best-effort */ }
   }
 
+  const duplicateNudge =
+    call?.tool_response != null &&
+    typeof call.tool_response === 'object' &&
+    typeof call.tool_response?.duplicateNudge === 'string'
+      ? call.tool_response.duplicateNudge
+      : '';
+
+  if (duplicateNudge.length > 0) {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: duplicateNudge,
+      },
+    }));
+  }
+
   if (markers.length === 0) process.exit(0);
 
   for (const { kind, summary } of markers) {

--- a/docs/cost-performance-improvements/handoff.md
+++ b/docs/cost-performance-improvements/handoff.md
@@ -102,3 +102,28 @@
 - Notes:
   - While verifying #995, `pnpm exec tsc --noEmit --pretty false` exposed a missing #994 server repository re-export. PR #1003 was amended and force-pushed with that parent-stack fix before #995 was rebased.
 - Next branch to create: `cost-perf/998-duplicate-call-nudge` from `cost-perf/995-run-cache`
+
+## Issue #998 - Duplicate-call advisory nudge
+
+- Branch name: `cost-perf/998-duplicate-call-nudge`
+- PR number/url: #1005 - https://github.com/shaunnez/goose-hub/pull/1005
+- Parent branch: `cost-perf/995-run-cache`
+- Files changed:
+  - `CONTEXT.md`
+  - `core/tool-layer/mcp/audit.ts`
+  - `core/tool-layer/mcp/run-cache.ts`
+  - `core/tool-layer/mcp/slice.test.ts`
+  - `core/tool-layer/mcp/tools/read.ts`
+  - `core/tool-layer/post-tool-use-hook.test.ts`
+  - `core/tool-layer/post-tool-use-hook.ts`
+- Tests run:
+  - `pnpm vitest run core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/tools/read.test.ts core/tool-layer/post-tool-use-hook.test.ts core/tool-layer/mcp/tools/write.test.ts core/cost/repository.test.ts`
+  - `pnpm exec tsc --noEmit --pretty false`
+  - `pnpm exec biome check core/tool-layer/mcp/run-cache.ts core/tool-layer/mcp/audit.ts core/tool-layer/mcp/tools/read.ts core/tool-layer/mcp/slice.test.ts core/tool-layer/post-tool-use-hook.ts core/tool-layer/post-tool-use-hook.test.ts CONTEXT.md`
+  - `pnpm audit-docs`
+  - `pnpm manifest --check`
+- Remaining risks:
+  - The deployed PostToolUse hook is a short-lived command, so durable per-run duplicate counting cannot live inside that script's memory. The counter lives beside #995's process-local MCP run cache, and the hook forwards the generated nudge as non-blocking `additionalContext`.
+  - The advisory currently covers cacheable MCP read/list/search calls that share #995 cache-key semantics; non-cacheable tools are not nudged.
+  - The reminder is returned in the structured MCP result and forwarded by PostToolUse context; downstream clients that ignore PostToolUse `additionalContext` will still see `duplicateNudge` in the tool payload.
+- Next branch to create: `cost-perf/996-investigation-seed` from `cost-perf/998-duplicate-call-nudge`


### PR DESCRIPTION
Stacked on: #1004 / cost-perf/995-run-cache

Adds per-run duplicate-call counting on the shared cache-key semantics, cached-call duplicate telemetry, a one-time advisory nudge at the configured threshold, and PostToolUse forwarding as non-blocking context.

Closes #998