### PR TITLE
M20.08: Add line-precise handoff context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -321,6 +321,8 @@ No other code in `core/` may call `insertEvent` directly. Lint rule enforces. On
 
 **Scout Digest Handoff.** Wave-2 scouts and the final investigate synthesis receive `scoutDigest` (`ScoutReportDigestBundle`) instead of raw `scoutReports`. Raw scout reports remain persisted in `core/scout-reports/`; consumers fetch them on demand through `repo_intel.query` with `intent: 'prior-investigation'` when the digest is insufficient for a specific finding.
 
+**Line-Precise Handoff Context.** Investigation outputs may attach `line`, `symbol`, and short `snippet` fields to `keyFiles`, plus an optional `fixHint`. Before `implement` runs, `slices/fix-issue/workflow.ts` builds a bounded `codeContext` bundle from those line-marked key files (`core/agent-runtime/code-context.ts`) and injects it through the explicit implement allowlist. QA and Review receive `prDiffWithContext`, a diff-derived changed-file/hunk summary from `core/agent-runtime/pr-diff-context.ts`; it preserves holdout boundaries because it contains only PR diff metadata, not developer or investigation reasoning.
+
 **Two guards, different paths:**
 - `contextAllowlist: ContextKey[]` — the *manifest*. Filters which keys from `AgentSpec.context` render into the user-prompt XML. Guards against wrong keys at spec construction time. Now required (not optional) on `SkillConfig`.
 - `freshContext: boolean` — the *closure assertion*. When `true`, no other injection channel adds anything. Guards against runtime infrastructure adding ambient state the AgentSpec author doesn't control.

--- a/core/agent-runtime/code-context.test.ts
+++ b/core/agent-runtime/code-context.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildCodeContextBundle } from './code-context.js';
+
+describe('buildCodeContextBundle', () => {
+  it('builds bounded line hunks for key files with precise lines', () => {
+    const root = mkdtempSync(join(tmpdir(), 'goose-hub-code-context-'));
+    try {
+      writeFileSync(
+        join(root, 'target.ts'),
+        Array.from({ length: 80 }, (_, index) => `line ${index + 1}`).join('\n'),
+      );
+
+      const bundle = buildCodeContextBundle({
+        worktreePath: root,
+        keyFiles: [{ path: 'target.ts', line: 40, reason: 'root cause' }],
+        radius: 3,
+      });
+
+      expect(bundle).toEqual([
+        {
+          path: 'target.ts',
+          startLine: 37,
+          endLine: 43,
+          snippet: [
+            '37: line 37',
+            '38: line 38',
+            '39: line 39',
+            '40: line 40',
+            '41: line 41',
+            '42: line 42',
+            '43: line 43',
+          ].join('\n'),
+        },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips missing paths and files without a line', () => {
+    const root = mkdtempSync(join(tmpdir(), 'goose-hub-code-context-'));
+    try {
+      writeFileSync(join(root, 'target.ts'), 'line 1\nline 2\n');
+
+      expect(
+        buildCodeContextBundle({
+          worktreePath: root,
+          keyFiles: [
+            { path: 'target.ts', reason: 'no line' },
+            { path: 'missing.ts', line: 1, reason: 'missing' },
+          ],
+        }),
+      ).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/core/agent-runtime/code-context.test.ts
+++ b/core/agent-runtime/code-context.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -54,6 +54,52 @@ describe('buildCodeContextBundle', () => {
           ],
         }),
       ).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips symlinked files that resolve outside the worktree', () => {
+    const root = mkdtempSync(join(tmpdir(), 'goose-hub-code-context-'));
+    const outside = mkdtempSync(join(tmpdir(), 'goose-hub-code-context-outside-'));
+    try {
+      writeFileSync(join(outside, 'secret.txt'), 'secret\n');
+      symlinkSync(join(outside, 'secret.txt'), join(root, 'linked-secret.txt'));
+
+      expect(
+        buildCodeContextBundle({
+          worktreePath: root,
+          keyFiles: [{ path: 'linked-secret.txt', line: 1, reason: 'symlink' }],
+        }),
+      ).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('recomputes line range metadata when snippet output is truncated', () => {
+    const root = mkdtempSync(join(tmpdir(), 'goose-hub-code-context-'));
+    try {
+      mkdirSync(join(root, 'src'));
+      writeFileSync(
+        join(root, 'src', 'long.ts'),
+        ['before '.repeat(80), 'target line', 'after '.repeat(80)].join('\n'),
+      );
+
+      const [entry] = buildCodeContextBundle({
+        worktreePath: root,
+        keyFiles: [{ path: 'src/long.ts', line: 2, reason: 'target' }],
+        radius: 1,
+        maxSnippetChars: 40,
+      });
+
+      expect(entry).toMatchObject({
+        path: 'src/long.ts',
+        startLine: 2,
+        endLine: 2,
+        snippet: '2: target line',
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/core/agent-runtime/code-context.ts
+++ b/core/agent-runtime/code-context.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+export interface CodeContextKeyFile {
+  path: string;
+  line?: number;
+  reason?: string;
+}
+
+export interface CodeContextEntry {
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+}
+
+export function buildCodeContextBundle(input: {
+  worktreePath: string;
+  keyFiles: CodeContextKeyFile[];
+  radius?: number;
+  maxEntries?: number;
+  maxSnippetChars?: number;
+}): CodeContextEntry[] {
+  const radius = input.radius ?? 30;
+  const maxEntries = input.maxEntries ?? 8;
+  const maxSnippetChars = input.maxSnippetChars ?? 12_000;
+  const root = resolve(input.worktreePath);
+  const entries: CodeContextEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const keyFile of input.keyFiles) {
+    if (entries.length >= maxEntries) break;
+    if (
+      typeof keyFile.path !== 'string' ||
+      keyFile.path.length === 0 ||
+      isAbsolute(keyFile.path) ||
+      !Number.isInteger(keyFile.line) ||
+      keyFile.line == null ||
+      keyFile.line < 1
+    ) {
+      continue;
+    }
+    const absolutePath = resolve(root, keyFile.path);
+    const relativePath = relative(root, absolutePath);
+    if (relativePath.startsWith('..') || isAbsolute(relativePath)) continue;
+    const cacheKey = `${keyFile.path}:${keyFile.line}`;
+    if (seen.has(cacheKey)) continue;
+    seen.add(cacheKey);
+    if (!existsSync(absolutePath)) continue;
+    const stat = statSync(absolutePath);
+    if (!stat.isFile()) continue;
+
+    const lines = readFileSync(absolutePath, 'utf8').split(/\r?\n/);
+    if (keyFile.line > lines.length) continue;
+    const targetLine = keyFile.line;
+    const startLine = Math.max(1, targetLine - radius);
+    const endLine = Math.min(lines.length, targetLine + radius);
+    const snippet = lines
+      .slice(startLine - 1, endLine)
+      .map((line, index) => `${startLine + index}: ${line}`)
+      .join('\n')
+      .slice(0, maxSnippetChars);
+
+    entries.push({
+      path: keyFile.path,
+      startLine,
+      endLine,
+      snippet,
+    });
+  }
+
+  return entries;
+}

--- a/core/agent-runtime/code-context.ts
+++ b/core/agent-runtime/code-context.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { isAbsolute, relative, resolve } from 'node:path';
 
 export interface CodeContextKeyFile {
@@ -25,6 +25,7 @@ export function buildCodeContextBundle(input: {
   const maxEntries = input.maxEntries ?? 8;
   const maxSnippetChars = input.maxSnippetChars ?? 12_000;
   const root = resolve(input.worktreePath);
+  const realRoot = safeRealpath(root) ?? root;
   const entries: CodeContextEntry[] = [];
   const seen = new Set<string>();
 
@@ -47,27 +48,81 @@ export function buildCodeContextBundle(input: {
     if (seen.has(cacheKey)) continue;
     seen.add(cacheKey);
     if (!existsSync(absolutePath)) continue;
-    const stat = statSync(absolutePath);
-    if (!stat.isFile()) continue;
+    const realPath = safeRealpath(absolutePath);
+    if (realPath == null || !isWithinRoot(realRoot, realPath)) continue;
 
-    const lines = readFileSync(absolutePath, 'utf8').split(/\r?\n/);
+    let stat: ReturnType<typeof statSync>;
+    let contents: string;
+    try {
+      stat = statSync(realPath);
+      if (!stat.isFile()) continue;
+      contents = readFileSync(realPath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    const lines = contents.split(/\r?\n/);
     if (keyFile.line > lines.length) continue;
     const targetLine = keyFile.line;
     const startLine = Math.max(1, targetLine - radius);
     const endLine = Math.min(lines.length, targetLine + radius);
-    const snippet = lines
-      .slice(startLine - 1, endLine)
-      .map((line, index) => `${startLine + index}: ${line}`)
-      .join('\n')
-      .slice(0, maxSnippetChars);
+    const snippet = buildSnippet({ lines, startLine, endLine, targetLine, maxSnippetChars });
 
     entries.push({
       path: keyFile.path,
-      startLine,
-      endLine,
-      snippet,
+      startLine: snippet.startLine,
+      endLine: snippet.endLine,
+      snippet: snippet.text,
     });
   }
 
   return entries;
+}
+
+function safeRealpath(path: string): string | null {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+function buildSnippet(input: {
+  lines: string[];
+  startLine: number;
+  endLine: number;
+  targetLine: number;
+  maxSnippetChars: number;
+}): { startLine: number; endLine: number; text: string } {
+  let startLine = input.startLine;
+  let endLine = input.endLine;
+  let text = renderSnippet(input.lines, startLine, endLine);
+
+  while (text.length > input.maxSnippetChars && startLine < input.targetLine) {
+    startLine += 1;
+    text = renderSnippet(input.lines, startLine, endLine);
+  }
+  while (text.length > input.maxSnippetChars && endLine > input.targetLine) {
+    endLine -= 1;
+    text = renderSnippet(input.lines, startLine, endLine);
+  }
+  if (text.length > input.maxSnippetChars) {
+    startLine = input.targetLine;
+    endLine = input.targetLine;
+    text = renderSnippet(input.lines, startLine, endLine).slice(0, input.maxSnippetChars);
+  }
+
+  return { startLine, endLine, text };
+}
+
+function renderSnippet(lines: string[], startLine: number, endLine: number): string {
+  return lines
+    .slice(startLine - 1, endLine)
+    .map((line, index) => `${startLine + index}: ${line}`)
+    .join('\n');
 }

--- a/core/agent-runtime/investigation-context.ts
+++ b/core/agent-runtime/investigation-context.ts
@@ -7,12 +7,26 @@ import {
 
 export interface InvestigationContext {
   findings?: string;
-  keyFiles: Array<{ path: string; reason?: string }>;
+  keyFiles: Array<{
+    path: string;
+    reason?: string;
+    line?: number;
+    symbol?: string;
+    snippet?: string;
+  }>;
   openQuestions: string[];
+  fixHint?: {
+    file: string;
+    line: number;
+    currentCode: string;
+    suggestedApproach: string;
+  };
   investigationRunId?: string;
 }
 
-function normalizeKeyFile(raw: unknown): { path: string; reason?: string } | null {
+function normalizeKeyFile(
+  raw: unknown,
+): { path: string; reason?: string; line?: number; symbol?: string; snippet?: string } | null {
   if (typeof raw === 'string' && raw.trim().length > 0) {
     return { path: raw.trim() };
   }
@@ -22,6 +36,41 @@ function normalizeKeyFile(raw: unknown): { path: string; reason?: string } | nul
   return {
     path: record.path.trim(),
     reason: typeof record.reason === 'string' ? record.reason : undefined,
+    line:
+      typeof record.line === 'number' && Number.isInteger(record.line) && record.line >= 1
+        ? record.line
+        : undefined,
+    symbol: typeof record.symbol === 'string' ? record.symbol : undefined,
+    snippet: typeof record.snippet === 'string' ? record.snippet.slice(0, 800) : undefined,
+  };
+}
+
+function normalizeFixHint(raw: unknown):
+  | {
+      file: string;
+      line: number;
+      currentCode: string;
+      suggestedApproach: string;
+    }
+  | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.file !== 'string' ||
+    record.file.trim().length === 0 ||
+    typeof record.line !== 'number' ||
+    !Number.isInteger(record.line) ||
+    record.line < 1 ||
+    typeof record.currentCode !== 'string' ||
+    typeof record.suggestedApproach !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    file: record.file.trim(),
+    line: record.line,
+    currentCode: record.currentCode.slice(0, 1200),
+    suggestedApproach: record.suggestedApproach,
   };
 }
 
@@ -45,6 +94,7 @@ export function latestInvestigationContext(input: {
           findings?: unknown;
           keyFiles?: unknown;
           openQuestions?: unknown;
+          fixHint?: unknown;
         };
         investigationRunId?: unknown;
       }
@@ -73,11 +123,13 @@ export function latestInvestigationContext(input: {
     ? investigation.openQuestions.filter((q): q is string => typeof q === 'string')
     : [];
   const findings = typeof investigation.findings === 'string' ? investigation.findings : undefined;
+  const fixHint = normalizeFixHint(investigation.fixHint);
 
   if (
     (findings == null || findings.length === 0) &&
     keyFiles.length === 0 &&
-    openQuestions.length === 0
+    openQuestions.length === 0 &&
+    fixHint == null
   ) {
     return undefined;
   }
@@ -86,6 +138,18 @@ export function latestInvestigationContext(input: {
     findings,
     keyFiles,
     openQuestions,
+    fixHint:
+      fixHint == null || worktreePath == null
+        ? fixHint
+        : {
+            ...fixHint,
+            file: normalizeRepoRelativePath({
+              rawPath: fixHint.file,
+              worktreePath,
+              packageRoots,
+              referencePaths: [...rawKeyFiles.map((f) => f.path), fixHint.file],
+            }).path,
+          },
     investigationRunId:
       typeof payload?.investigationRunId === 'string'
         ? payload.investigationRunId

--- a/core/agent-runtime/pr-diff-context.test.ts
+++ b/core/agent-runtime/pr-diff-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildPrDiffWithContext } from './pr-diff-context.js';
+
+describe('buildPrDiffWithContext', () => {
+  it('extracts changed files and hunk line ranges from a PR diff', () => {
+    const context = buildPrDiffWithContext(
+      [
+        'diff --git a/src/foo.ts b/src/foo.ts',
+        '@@ -10,2 +10,3 @@ function foo()',
+        '-old',
+        '+new',
+        'diff --git a/src/bar.ts b/src/bar.ts',
+        '@@ -1 +1 @@',
+        '+export const bar = true;',
+      ].join('\n'),
+    );
+
+    expect(context.changedFiles).toEqual(['src/foo.ts', 'src/bar.ts']);
+    expect(context.hunks).toEqual([
+      {
+        file: 'src/foo.ts',
+        oldStart: 10,
+        oldLines: 2,
+        newStart: 10,
+        newLines: 3,
+        heading: 'function foo()',
+      },
+      {
+        file: 'src/bar.ts',
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+      },
+    ]);
+  });
+});

--- a/core/agent-runtime/pr-diff-context.test.ts
+++ b/core/agent-runtime/pr-diff-context.test.ts
@@ -34,4 +34,20 @@ describe('buildPrDiffWithContext', () => {
       },
     ]);
   });
+
+  it('parses quoted diff headers and unescapes unusual path characters', () => {
+    const context = buildPrDiffWithContext(
+      [
+        'diff --git "a/src/foo b/bar\\tfile.ts" "b/src/foo b/bar\\tfile.ts"',
+        '@@ -5 +5 @@ function quoted()',
+        '-old',
+        '+new',
+      ].join('\n'),
+    );
+
+    expect(context.changedFiles).toEqual(['src/foo b/bar\tfile.ts']);
+    expect(context.hunks).toMatchObject([
+      { file: 'src/foo b/bar\tfile.ts', oldStart: 5, newStart: 5 },
+    ]);
+  });
 });

--- a/core/agent-runtime/pr-diff-context.ts
+++ b/core/agent-runtime/pr-diff-context.ts
@@ -25,9 +25,9 @@ export function buildPrDiffWithContext(
   let currentFile: string | undefined;
 
   for (const line of prDiff.split('\n')) {
-    const fileMatch = /^diff --git a\/.+ b\/(.+)$/.exec(line);
-    if (fileMatch != null) {
-      currentFile = fileMatch[1];
+    const filePath = parseDiffGitNewPath(line);
+    if (filePath != null) {
+      currentFile = filePath;
       if (!seenFiles.has(currentFile)) {
         seenFiles.add(currentFile);
         changedFiles.push(currentFile);
@@ -53,4 +53,63 @@ export function buildPrDiffWithContext(
     hunks,
     diffCharCount: prDiff.length,
   };
+}
+
+function parseDiffGitNewPath(line: string): string | null {
+  if (!line.startsWith('diff --git ')) return null;
+  const tokens = parseDiffGitTokens(line.slice('diff --git '.length));
+  const newPath = tokens[1];
+  if (newPath == null || !newPath.startsWith('b/')) return null;
+  return newPath.slice(2);
+}
+
+function parseDiffGitTokens(input: string): string[] {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < input.length && tokens.length < 2) {
+    while (input[index] === ' ') index += 1;
+    if (index >= input.length) break;
+    if (input[index] === '"') {
+      const parsed = readQuotedToken(input, index + 1);
+      if (parsed == null) return tokens;
+      tokens.push(parsed.value);
+      index = parsed.nextIndex;
+    } else {
+      const nextSpace = input.indexOf(' ', index);
+      if (nextSpace === -1) {
+        tokens.push(input.slice(index));
+        break;
+      }
+      tokens.push(input.slice(index, nextSpace));
+      index = nextSpace + 1;
+    }
+  }
+  return tokens;
+}
+
+function readQuotedToken(
+  input: string,
+  startIndex: number,
+): { value: string; nextIndex: number } | null {
+  let value = '';
+  for (let index = startIndex; index < input.length; index += 1) {
+    const char = input[index];
+    if (char === '"') return { value, nextIndex: index + 1 };
+    if (char === '\\') {
+      const next = input[index + 1];
+      if (next == null) return null;
+      value += unescapeGitPathChar(next);
+      index += 1;
+    } else {
+      value += char;
+    }
+  }
+  return null;
+}
+
+function unescapeGitPathChar(char: string): string {
+  if (char === 't') return '\t';
+  if (char === 'n') return '\n';
+  if (char === 'r') return '\r';
+  return char;
 }

--- a/core/agent-runtime/pr-diff-context.ts
+++ b/core/agent-runtime/pr-diff-context.ts
@@ -1,0 +1,56 @@
+export interface PrDiffHunkContext {
+  file: string;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  heading?: string;
+}
+
+export interface PrDiffWithContext {
+  changedFiles: string[];
+  hunkCount: number;
+  hunks: PrDiffHunkContext[];
+  diffCharCount: number;
+}
+
+export function buildPrDiffWithContext(
+  prDiff: string,
+  options: { maxHunks?: number } = {},
+): PrDiffWithContext {
+  const maxHunks = options.maxHunks ?? 120;
+  const changedFiles: string[] = [];
+  const hunks: PrDiffHunkContext[] = [];
+  const seenFiles = new Set<string>();
+  let currentFile: string | undefined;
+
+  for (const line of prDiff.split('\n')) {
+    const fileMatch = /^diff --git a\/.+ b\/(.+)$/.exec(line);
+    if (fileMatch != null) {
+      currentFile = fileMatch[1];
+      if (!seenFiles.has(currentFile)) {
+        seenFiles.add(currentFile);
+        changedFiles.push(currentFile);
+      }
+      continue;
+    }
+    if (currentFile == null || hunks.length >= maxHunks) continue;
+    const hunkMatch = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@\s?(.*)$/.exec(line);
+    if (hunkMatch == null) continue;
+    hunks.push({
+      file: currentFile,
+      oldStart: Number(hunkMatch[1]),
+      oldLines: Number(hunkMatch[2] ?? 1),
+      newStart: Number(hunkMatch[3]),
+      newLines: Number(hunkMatch[4] ?? 1),
+      ...(hunkMatch[5].trim().length > 0 ? { heading: hunkMatch[5].trim() } : {}),
+    });
+  }
+
+  return {
+    changedFiles,
+    hunkCount: hunks.length,
+    hunks,
+    diffCharCount: prDiff.length,
+  };
+}

--- a/docs/cost-performance-improvements/handoff.md
+++ b/docs/cost-performance-improvements/handoff.md
@@ -239,3 +239,46 @@
   - Cross-validation contradictions are represented through digest report fields and the new digest-applied event; there is no separate raw contradictions JSON in synthesis context anymore.
   - Raw scout reports remain persisted unchanged, but any agent wanting full text now needs to request it through #997 `repo_intel.query`.
 - Next branch to create: `cost-perf/993-handoff-precision` from `cost-perf/1000-scout-digest`
+
+## Issue #993 - Handoff precision and codeContext
+
+- Branch name: `cost-perf/993-handoff-precision`
+- PR number/url: #1009 - https://github.com/shaunnez/goose-hub/pull/1009
+- Parent branch: `cost-perf/1000-scout-digest`
+- Files changed:
+  - `CONTEXT.md`
+  - `core/agent-runtime/code-context.ts`
+  - `core/agent-runtime/code-context.test.ts`
+  - `core/agent-runtime/investigation-context.ts`
+  - `core/agent-runtime/pr-diff-context.ts`
+  - `core/agent-runtime/pr-diff-context.test.ts`
+  - `docs/cost-performance-improvements/handoff.md`
+  - `skills/implement/prompt.md`
+  - `skills/implement/skill.config.ts`
+  - `skills/investigate/prompt.md`
+  - `skills/investigate/schema.ts`
+  - `skills/investigate/slice.test.ts`
+  - `skills/qa/prompt.md`
+  - `skills/qa/skill.config.ts`
+  - `skills/qa/slice.test.ts`
+  - `skills/review/prompt.md`
+  - `skills/review/skill.config.ts`
+  - `skills/review/slice.test.ts`
+  - `slices/fix-issue/implement-phase.ts`
+  - `slices/fix-issue/slice.test.ts`
+  - `slices/fix-issue/workflow.ts`
+  - `slices/qa/slice.test.ts`
+  - `slices/qa/workflow.ts`
+  - `slices/review/review-spec.ts`
+  - `slices/review/slice.test.ts`
+- Tests run:
+  - `pnpm vitest run core/agent-runtime/code-context.test.ts core/agent-runtime/pr-diff-context.test.ts skills/investigate/slice.test.ts slices/fix-issue/slice.test.ts skills/implement/slice.test.ts skills/qa/slice.test.ts skills/review/slice.test.ts slices/qa/slice.test.ts slices/review/slice.test.ts`
+  - `pnpm exec tsc --noEmit --pretty false`
+  - `pnpm skill-contract:audit`
+  - `pnpm audit-docs`
+  - `pnpm manifest --check`
+  - `pnpm exec biome check core/agent-runtime/code-context.ts core/agent-runtime/code-context.test.ts core/agent-runtime/pr-diff-context.ts core/agent-runtime/pr-diff-context.test.ts core/agent-runtime/investigation-context.ts skills/investigate/schema.ts skills/investigate/slice.test.ts skills/investigate/prompt.md skills/implement/skill.config.ts skills/implement/prompt.md slices/fix-issue/workflow.ts slices/fix-issue/implement-phase.ts slices/fix-issue/slice.test.ts skills/qa/skill.config.ts skills/qa/slice.test.ts skills/qa/prompt.md skills/review/skill.config.ts skills/review/slice.test.ts skills/review/prompt.md slices/qa/workflow.ts slices/qa/slice.test.ts slices/review/review-spec.ts slices/review/slice.test.ts`
+- Remaining risks:
+  - `codeContext` is best-effort and skips missing files or key files without line numbers; implement still receives the original investigation and related-surface handoff.
+  - `prDiffWithContext` is deliberately diff-derived only, so QA/Review holdout agents may still need read-only tools when a diff hunk needs broader file context.
+- Next branch to create: `cost-perf/999-ast-route-index` from `cost-perf/993-handoff-precision`

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -41,6 +41,7 @@ The context contains a `<task>` block with:
 - `<workItem>` — JSON payload for the issue, with `title`, `body`, `number`, and `priority`
 - `<wp>` — JSON payload with `id`, `filesOwned`, `changes`, and `dependsOn`
 - `<codeSnippets>` (optional) — JSON array of relevant code excerpts pre-loaded by the scout wave
+- `<codeContext>` (optional) — exact pre-read hunks for line-precise investigation key files owned by this WP
 - `<verificationCommands>` (optional) — executable checks relevant to this WP, projected from canonical acceptance criteria and verification tooling
 - `<investigation>` (optional) — original bug-investigation findings, key files, and open questions
 - `<acceptanceContract>` (optional) — resolved acceptance criteria relevant to this implementation path
@@ -62,6 +63,7 @@ Path contract: all output paths must be repo-root/worktree-root relative POSIX p
 - If `<acceptanceContract>` is present, use `criteria[]` as the behavioral contract for tests and implementation. Satisfy all cross-cutting criteria and any criteria that obviously apply to your filesOwned.
 - Treat `executableChecks` and `<verificationCommands>` as targeted verification guidance. Run applicable executable checks before broad stack commands. Do not rediscover test commands when executable checks are present.
 - If `<parentPrdContext>` is present, use it to avoid drifting beyond the approved PRD and to understand the parent journey, slice, implementation, and testing decisions.
+- If `<codeContext>` is present, treat those snippets as the starting source context. Use them before broad reads, and call `read_file` only when the snippet is insufficient, stale, or contradicted by surrounding code.
 - Read the files in `<wp>.filesOwned` to understand the current state.
 - Use `mcp__factory-tools__read_file` and `mcp__factory-tools__search_text` to load test files for the surfaces you will touch FIRST.
 - Emit: `[decision] READ: Loaded WP <id> context and N relevant files`

--- a/skills/implement-wp/skill.config.ts
+++ b/skills/implement-wp/skill.config.ts
@@ -13,7 +13,7 @@ import { ImplementWpSchema } from './schema.js';
  * the ACs it must satisfy, parent PRD summary, and the stack commands to run tests and lint.
  *
  * Full-repo context is intentionally excluded — the builder sees only its slice
- * of the problem plus the code snippets pre-loaded by the spec-author scout wave.
+ * of the problem plus owned-file previews and line-precise investigation hunks.
  */
 export const ImplementWpContextSchema = z.object({
   workItem: z.object({
@@ -39,6 +39,17 @@ export const ImplementWpContextSchema = z.object({
       }),
     )
     .optional(),
+  /** Exact pre-read hunks for line-precise investigation key files owned by this WP. */
+  codeContext: z
+    .array(
+      z.object({
+        path: z.string(),
+        startLine: z.number().int().min(1),
+        endLine: z.number().int().min(1),
+        snippet: z.string(),
+      }),
+    )
+    .optional(),
   verificationCommands: z.array(ExecutableCheckSchema).optional(),
   investigation: z
     .object({
@@ -48,6 +59,9 @@ export const ImplementWpContextSchema = z.object({
           z.object({
             path: z.string(),
             reason: z.string().optional(),
+            line: z.number().int().min(1).optional(),
+            symbol: z.string().optional(),
+            snippet: z.string().optional(),
           }),
         )
         .optional(),
@@ -108,6 +122,7 @@ const config: SkillConfig = {
     'wp.changes',
     'wp.dependsOn',
     'codeSnippets',
+    'codeContext',
     'verificationCommands',
     'investigation',
     'acceptanceContract',

--- a/skills/implement-wp/slice.test.ts
+++ b/skills/implement-wp/slice.test.ts
@@ -90,6 +90,7 @@ describe('implement-wp skill.config', () => {
     expect(allowlist).toContain('wp.id');
     expect(allowlist).toContain('wp.filesOwned');
     expect(allowlist).toContain('wp.changes');
+    expect(allowlist).toContain('codeContext');
     expect(allowlist).toContain('parentPrdContext');
     expect(allowlist).not.toContain('worktreePath');
   });
@@ -117,6 +118,28 @@ describe('implement-wp skill.config', () => {
         filesOwned: ['core/foo/bar.ts'],
         changes: 'Add helper',
         dependsOn: [],
+      },
+      codeContext: [
+        {
+          path: 'core/foo/bar.ts',
+          startLine: 10,
+          endLine: 16,
+          snippet: '10: export function bar() {',
+        },
+      ],
+      investigation: {
+        findings: 'bar needs a guard',
+        keyFiles: [
+          {
+            path: 'core/foo/bar.ts',
+            reason: 'guard lives here',
+            line: 10,
+            symbol: 'bar',
+            snippet: 'export function bar() {}',
+          },
+        ],
+        openQuestions: [],
+        investigationRunId: 'investigation-run-1',
       },
       parentPrdContext: {
         source: 'event',
@@ -147,5 +170,10 @@ describe('implement-wp prompt live decisions', () => {
     expect(prompt).toContain('mcp__factory-tools__record_decision');
     expect(prompt).toContain('The tool call is the primary live timeline signal');
     expect(prompt).toContain('do not rely on text markers alone');
+  });
+
+  it('documents line-precise code context', () => {
+    expect(prompt).toContain('<codeContext>');
+    expect(prompt).toContain('exact pre-read hunks');
   });
 });

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -16,6 +16,7 @@ The `<task>` block can include:
 - `<stack>` — `testCommand`, optional `lintCommand`, optional `typecheckCommand`.
 - `<advisorFeedback>` — revision guidance, if this is a respawn.
 - `<investigation>` — prior findings, `keyFiles`, open questions, and run id.
+- `<codeContext>` — exact pre-read hunks for line-precise investigation key files.
 - `<acceptanceContract>` — resolved acceptance criteria that must be satisfied before QA/Review.
 - `<relatedSurface>` — deterministic execution lane from the workflow.
 - `<revisionPass>` — `0` or `1`.
@@ -48,6 +49,7 @@ If the handoff is stale, emit a `PLAN` decision summary with concrete evidence b
 
 - Read `<workItem>`, `<advisorFeedback>`, and `<investigation>` if present.
 - If `<acceptanceContract>` is present, treat its criteria as the behavioral contract for the implementation and tests.
+- If `<codeContext>` is present, treat those snippets as the starting source context. Use them before broad reads, and call `read_file` only when the snippet is insufficient, stale, or contradicted by surrounding code.
 - If `<relatedSurface>` exists, read `readFirst` first. Prefer `existingTests` and `primaryTestPath`; otherwise use `testCandidates[0]` when `testMode` is `create-candidate`.
 - If an investigation has key files and no open questions, treat it as the implementation contract. Patch that surface unless the files are missing or contradict the finding.
 - Emit `[decision] READ: Loaded #<number> and <N> relevant files`.

--- a/skills/implement/skill.config.ts
+++ b/skills/implement/skill.config.ts
@@ -10,6 +10,7 @@ import { ImplementSchema } from './schema.js';
  *     <workItem>{"title":"...","body":"...","number":123,"priority":"medium"}</workItem>
  *     <stack>{"testCommand":"pnpm test","lintCommand":"pnpm lint","typecheckCommand":"pnpm typecheck"}</stack>
  *     <advisorFeedback>...</advisorFeedback>               <!-- optional, when revising -->
+ *     <codeContext>[{"path":"...","startLine":1,"endLine":20,"snippet":"..."}]</codeContext>
  *     <revisionPass>0 | 1</revisionPass>                   <!-- optional, default 0 -->
  *   </task>
  */
@@ -46,12 +47,33 @@ const config: SkillConfig = {
             z.object({
               path: z.string(),
               reason: z.string().optional(),
+              line: z.number().int().min(1).optional(),
+              symbol: z.string().optional(),
+              snippet: z.string().optional(),
             }),
           )
           .optional(),
         openQuestions: z.array(z.string()).optional(),
+        fixHint: z
+          .object({
+            file: z.string(),
+            line: z.number().int().min(1),
+            currentCode: z.string(),
+            suggestedApproach: z.string(),
+          })
+          .optional(),
         investigationRunId: z.string().optional(),
       })
+      .optional(),
+    codeContext: z
+      .array(
+        z.object({
+          path: z.string(),
+          startLine: z.number().int().min(1),
+          endLine: z.number().int().min(1),
+          snippet: z.string(),
+        }),
+      )
       .optional(),
     relatedSurface: z
       .object({
@@ -79,6 +101,7 @@ const config: SkillConfig = {
     'stack.lintCommand',
     'stack.typecheckCommand',
     'investigation',
+    'codeContext',
     'relatedSurface',
     'advisorFeedback',
     'revisionPass',

--- a/skills/investigate/prompt.md
+++ b/skills/investigate/prompt.md
@@ -136,6 +136,8 @@ Return a JSON object with this exact structure:
 `decisionSummaries` must have at least one entry. Include one entry per major investigation step.
 
 `keyFiles` must list the files an implementer most likely needs to change or verify. Include materially relevant implementation files and existing test/spec files when you find them; exclude files you only skimmed or searched without finding actionable implementation signal.
+For medium or high confidence findings, add `line`, `symbol`, and a short `snippet` when the cited location is known. Keep `snippet` under 800 characters and copy only the smallest code fragment needed to anchor the fix.
+When the fix shape is clear, include `fixHint` with the most likely file, line, current code, and suggested approach. This is an implementation hint, not a substitute for tests.
 
 `confidence` reflects how certain you are about your root cause hypothesis:
 - `low` — symptom identified but root cause unclear; many unknowns remain

--- a/skills/investigate/schema.ts
+++ b/skills/investigate/schema.ts
@@ -9,6 +9,9 @@ const RepoRelativePathDescription =
 export const KeyFileSchema = z.object({
   path: z.string().describe(RepoRelativePathDescription),
   reason: z.string(),
+  line: z.number().int().min(1).optional(),
+  symbol: z.string().optional(),
+  snippet: z.string().max(800).optional(),
 });
 
 export const InvestigateSchema = z.object({
@@ -22,6 +25,14 @@ export const InvestigateSchema = z.object({
       'True if the bug manifests in the browser UI and can be reproduced via Playwright. False for pure server-side/API bugs where a browser repro is meaningless.',
     ),
   decisionSummaries: z.array(DecisionSummarySchema).min(1),
+  fixHint: z
+    .object({
+      file: z.string().describe(RepoRelativePathDescription),
+      line: z.number().int().min(1),
+      currentCode: z.string().max(1200),
+      suggestedApproach: z.string(),
+    })
+    .optional(),
 });
 
 export type KeyFile = z.infer<typeof KeyFileSchema>;

--- a/skills/investigate/slice.test.ts
+++ b/skills/investigate/slice.test.ts
@@ -58,6 +58,32 @@ describe('investigate schema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts line-precise key files and fix hints', () => {
+    const result = InvestigateSchema.safeParse({
+      findings: 'Root cause is clear: divide-by-zero in calculateRatio().',
+      keyFiles: [
+        {
+          path: 'core/math/ratio.ts',
+          reason: 'Divide-by-zero bug',
+          line: 42,
+          symbol: 'calculateRatio',
+          snippet: 'return numerator / denominator;',
+        },
+      ],
+      fixHint: {
+        file: 'core/math/ratio.ts',
+        line: 42,
+        currentCode: 'return numerator / denominator;',
+        suggestedApproach: 'Return null or throw before dividing when denominator is zero.',
+      },
+      confidence: 'high',
+      openQuestions: [],
+      requiresBrowserRepro: false,
+      decisionSummaries: [{ kind: 'INSIGHT', summary: 'Divide-by-zero in calculateRatio()' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('accepts evidence as optional on DecisionSummary', () => {
     const result = InvestigateSchema.safeParse({
       findings: 'Investigation complete.',

--- a/skills/qa/prompt.md
+++ b/skills/qa/prompt.md
@@ -33,6 +33,7 @@ The context contains a `<task>` block with:
 
 - `<workItem>` — JSON payload for the original GitHub issue, with `title`, `body`, and `number`
 - `<prDiff>` — complete git diff of the PR being reviewed
+- `<prDiffWithContext>` — diff-derived changed-file and hunk metadata. Use it to orient before reading `prDiff`; it contains no developer reasoning.
 - `<verificationSummary>` — compact workflow-owned verification packet:
   - `changedFiles` — changed paths, count, diff character count, and diff stat
   - `pr` — PR number, base branch, and head SHA when available

--- a/skills/qa/skill.config.ts
+++ b/skills/qa/skill.config.ts
@@ -17,6 +17,7 @@ import { QaOutputSchema, TestRunSchema, VerificationSummarySchema } from './sche
  *   <task>
  *     <workItem>{"title":"...","body":"...","number":123}</workItem>
  *     <prDiff>...</prDiff>
+ *     <prDiffWithContext>{"changedFiles":["..."],"hunks":[...]}</prDiffWithContext>
  *     <projectCommands>{"testCommand":"...","lintCommand":"...","e2eCommand":"..."}</projectCommands>
  *     <verificationSummary>{"changedFiles":...,"commands":...,"testRun":...}</verificationSummary>
  *     <sliceTests>["path/to/test.ts"]</sliceTests>
@@ -31,6 +32,24 @@ export const QaContextSchema = z.object({
   }),
   /** The git diff of the PR being reviewed — what was actually changed */
   prDiff: z.string(),
+  /** Diff-derived changed-file and hunk metadata. Contains no developer or investigation reasoning. */
+  prDiffWithContext: z
+    .object({
+      changedFiles: z.array(z.string()),
+      hunkCount: z.number().int().min(0),
+      hunks: z.array(
+        z.object({
+          file: z.string(),
+          oldStart: z.number().int().min(0),
+          oldLines: z.number().int().min(0),
+          newStart: z.number().int().min(0),
+          newLines: z.number().int().min(0),
+          heading: z.string().optional(),
+        }),
+      ),
+      diffCharCount: z.number().int().min(0),
+    })
+    .optional(),
   /** Shell commands to run verification — project-specific */
   projectCommands: z.object({
     testCommand: z.string(),
@@ -136,6 +155,7 @@ const config: SkillConfig = {
   contextAllowlist: [
     'workItem',
     'prDiff',
+    'prDiffWithContext',
     'projectCommands',
     'e2eDecision',
     'sliceTests',

--- a/skills/qa/slice.test.ts
+++ b/skills/qa/slice.test.ts
@@ -563,6 +563,10 @@ describe('qa skill config', () => {
     expect(config.contextAllowlist).toContain('prDiff');
   });
 
+  it('contextAllowlist contains prDiffWithContext', () => {
+    expect(config.contextAllowlist).toContain('prDiffWithContext');
+  });
+
   it('contextAllowlist contains projectCommands', () => {
     expect(config.contextAllowlist).toContain('projectCommands');
   });
@@ -579,6 +583,12 @@ describe('qa skill config', () => {
     const valid = QaContextSchema.safeParse({
       workItem: { title: 'Fix auth bug', body: 'Auth breaks on login.', number: 42 },
       prDiff: 'diff --git a/src/foo.ts b/src/foo.ts\n...',
+      prDiffWithContext: {
+        changedFiles: ['src/foo.ts'],
+        hunkCount: 1,
+        hunks: [{ file: 'src/foo.ts', oldStart: 1, oldLines: 1, newStart: 1, newLines: 2 }],
+        diffCharCount: 42,
+      },
       projectCommands: { testCommand: 'pnpm test ', lintCommand: 'pnpm biome check .' },
     });
     expect(valid.success).toBe(true);

--- a/skills/review/prompt.md
+++ b/skills/review/prompt.md
@@ -25,6 +25,7 @@ The context contains a `<task>` block with:
 
 - `<workItem>` — JSON payload for the original GitHub issue, with `title`, `body`, and `number`
 - `<prDiff>` — complete git diff of the PR being reviewed
+- `<prDiffWithContext>` — diff-derived changed-file and hunk metadata. Use it to orient before reading `prDiff`; it contains no developer reasoning.
 - `<qaVerdict>` (optional) — JSON payload for the prior QA holdout run, with `verdict` and `overallScore`
 - `<acceptanceContract>` (optional) — resolved acceptance criteria from a normalized contract, engineering spec, PRD, or issue body
 

--- a/skills/review/skill.config.ts
+++ b/skills/review/skill.config.ts
@@ -17,6 +17,7 @@ import { ReviewOutputSchema } from './schema.js';
  *   <task>
  *     <workItem>{"title":"...","body":"...","number":123}</workItem>
  *     <prDiff>...</prDiff>
+ *     <prDiffWithContext>{"changedFiles":["..."],"hunks":[...]}</prDiffWithContext>
  *     <qaVerdict>{"verdict":"pass","overallScore":82}</qaVerdict>
  *   </task>
  */
@@ -29,6 +30,24 @@ export const ReviewContextSchema = z.object({
   }),
   /** The git diff of the PR being reviewed — what was actually changed */
   prDiff: z.string(),
+  /** Diff-derived changed-file and hunk metadata. Contains no developer or investigation reasoning. */
+  prDiffWithContext: z
+    .object({
+      changedFiles: z.array(z.string()),
+      hunkCount: z.number().int().min(0),
+      hunks: z.array(
+        z.object({
+          file: z.string(),
+          oldStart: z.number().int().min(0),
+          oldLines: z.number().int().min(0),
+          newStart: z.number().int().min(0),
+          newLines: z.number().int().min(0),
+          heading: z.string().optional(),
+        }),
+      ),
+      diffCharCount: z.number().int().min(0),
+    })
+    .optional(),
   /**
    * QA verdict from the prior QA holdout run — used as signal, not directive.
    * The reviewer forms its own independent judgement. QA verdict is context only.
@@ -74,7 +93,7 @@ const config: SkillConfig = {
    * Explicitly EXCLUDED: devDecisionSummaries, investigationFindings.
    * The Review agent must independently verify criteria, not rubber-stamp developer reasoning.
    */
-  contextAllowlist: ['workItem', 'prDiff', 'qaVerdict', 'acceptanceContract'],
+  contextAllowlist: ['workItem', 'prDiff', 'prDiffWithContext', 'qaVerdict', 'acceptanceContract'],
 };
 
 export default config;

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -476,6 +476,10 @@ describe('review skill config', () => {
     expect(config.contextAllowlist).toContain('prDiff');
   });
 
+  it('contextAllowlist contains prDiffWithContext', () => {
+    expect(config.contextAllowlist).toContain('prDiffWithContext');
+  });
+
   it('contextAllowlist contains qaVerdict', () => {
     expect(config.contextAllowlist).toContain('qaVerdict');
   });
@@ -496,6 +500,20 @@ describe('review skill config', () => {
         number: 240,
       },
       prDiff: 'diff --git a/skills/review/schema.ts b/skills/review/schema.ts\n...',
+      prDiffWithContext: {
+        changedFiles: ['skills/review/schema.ts'],
+        hunkCount: 1,
+        hunks: [
+          {
+            file: 'skills/review/schema.ts',
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 2,
+          },
+        ],
+        diffCharCount: 64,
+      },
     });
     expect(valid.success).toBe(true);
   });

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { isAbsolute, relative, resolve } from 'node:path';
 import type { AcceptanceContract } from '@goose-hub/core/acceptance-contracts/types.js';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
+import type { CodeContextEntry } from '@goose-hub/core/agent-runtime/code-context.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import {
   type InvestigationContext,
@@ -55,6 +56,7 @@ export interface RunImplementInput {
   personaId: string;
   advisorFeedback?: string;
   investigation?: InvestigationContext;
+  codeContext?: CodeContextEntry[];
   relatedSurface?: RelatedSurfaceManifest;
   surfaceGuardInvestigation?: InvestigationContext;
   symbolIndexKeyFiles?: SymbolKeyFileHint[];
@@ -591,6 +593,7 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
         investigationRunId: input.investigation.investigationRunId ?? null,
         keyFiles: input.investigation.keyFiles.map((f) => f.path),
         keyFileCount: input.investigation.keyFiles.length,
+        codeContextCount: input.codeContext?.length ?? 0,
         findingsChars: input.investigation.findings?.length ?? 0,
         openQuestionCount: input.investigation.openQuestions.length,
       },
@@ -625,6 +628,7 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
         },
         stack: input.stack,
         investigation: input.investigation,
+        codeContext: input.codeContext,
         relatedSurface: input.relatedSurface,
         acceptanceContract: input.acceptanceContract,
         advisorFeedback: input.advisorFeedback,
@@ -640,6 +644,7 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
         'stack.lintCommand',
         'stack.typecheckCommand',
         'investigation',
+        'codeContext',
         'relatedSurface',
         'acceptanceContract',
         'advisorFeedback',

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { AgentResult, AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
@@ -530,7 +530,23 @@ describe('runFixIssueWorkflow (#183)', () => {
   it('injects latest investigation findings into implement context and emits an audit event', async () => {
     const item = makeWorkItem({ priority: 'medium', type: 'bug' });
     const source = makeStateSource();
-    vi.mocked(eventStore.replay).mockReturnValue([makeInvestigationEvent(item)]);
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makeInvestigationEvent(item, {
+        keyFiles: [
+          {
+            path: 'apps/server/src/domains/workflows/triage-batch.ts',
+            reason: 'owns failed triage state transitions',
+            line: 1,
+            symbol: 'transitionFailedTriage',
+            snippet: 'function transitionFailedTriage() {}',
+          },
+          {
+            path: 'core/agent-runtime/fallback.ts',
+            reason: 'owns maxAttempts handling',
+          },
+        ],
+      }),
+    ]);
 
     const runtime: AgentRuntime = {
       run: vi.fn().mockResolvedValueOnce({
@@ -558,6 +574,7 @@ describe('runFixIssueWorkflow (#183)', () => {
       } satisfies AgentResult),
     };
 
+    const worktreePath = makeTempWorktree(['apps/server/src/domains/workflows/triage-batch.ts']);
     const { runFixIssueWorkflow } = await import('./workflow.js');
     await runFixIssueWorkflow(item, source, 'proj', '/repo', {
       runtime,
@@ -568,8 +585,8 @@ describe('runFixIssueWorkflow (#183)', () => {
         base: 'main',
       }),
       adviseOnPlanImpl: vi.fn(),
-      createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
-      cleanupWorktreeImpl: vi.fn(),
+      createWorktreeImpl: vi.fn().mockReturnValue(worktreePath),
+      cleanupWorktreeImpl: vi.fn(() => rmSync(worktreePath, { recursive: true, force: true })),
       resolveWorktreeHeadShaImpl: vi
         .fn()
         .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
@@ -578,6 +595,12 @@ describe('runFixIssueWorkflow (#183)', () => {
     const implementSpec = vi.mocked(runtime.run).mock.calls[0][0] as {
       context: {
         investigation?: { findings?: string; keyFiles?: Array<{ path: string }> };
+        codeContext?: Array<{
+          path: string;
+          startLine: number;
+          endLine: number;
+          snippet: string;
+        }>;
         relatedSurface?: {
           keyFiles?: Array<{ path: string }>;
           testCandidates?: string[];
@@ -591,13 +614,20 @@ describe('runFixIssueWorkflow (#183)', () => {
       workspaceDir?: string;
       contextAllowlist: string[];
     };
-    expect(implementSpec.workspaceDir).toBe('/work/wt');
+    expect(implementSpec.workspaceDir).toBe(worktreePath);
     expect((implementSpec.context as { worktreePath?: string }).worktreePath).toBeUndefined();
     expect(implementSpec.context.investigation?.findings).toContain('triage-batch');
     expect(implementSpec.context.investigation?.keyFiles?.map((f) => f.path)).toContain(
       'apps/server/src/domains/workflows/triage-batch.ts',
     );
+    expect(implementSpec.context.codeContext?.[0]).toMatchObject({
+      path: 'apps/server/src/domains/workflows/triage-batch.ts',
+      startLine: 1,
+      endLine: expect.any(Number),
+    });
+    expect(implementSpec.context.codeContext?.[0]?.snippet).toContain('# mock skill prompt');
     expect(implementSpec.contextAllowlist).toContain('investigation');
+    expect(implementSpec.contextAllowlist).toContain('codeContext');
     expect(implementSpec.contextAllowlist).toContain('relatedSurface');
     expect(implementSpec.context.relatedSurface?.keyFiles?.map((f) => f.path)).toContain(
       'apps/server/src/domains/workflows/triage-batch.ts',

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -156,10 +156,6 @@ export async function runFixIssueWorkflow(
     investigation: implementInvestigation,
     evidencePostEnabled,
   });
-  const codeContext = buildCodeContextBundle({
-    worktreePath,
-    keyFiles: implementInvestigation?.keyFiles ?? [],
-  });
   if (relatedSurface != null) {
     eventStore.appendEvent({
       projectId,
@@ -203,6 +199,11 @@ export async function runFixIssueWorkflow(
     // Pre-warm: install dependencies before spawning the agent so it doesn't
     // waste its first turn running pnpm install.
     prewarmWtFn(worktreePath);
+
+    const codeContext = buildCodeContextBundle({
+      worktreePath,
+      keyFiles: implementInvestigation?.keyFiles ?? [],
+    });
 
     // Step 3: optional advisor on plan (priority:high/critical only).
     let advisorFeedback: string | undefined;

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -1,6 +1,7 @@
 import { resolveAcceptanceContract } from '@goose-hub/core/acceptance-contracts/resolver.js';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { adviseOnPlan } from '@goose-hub/core/agent-runtime/advisor.js';
+import { buildCodeContextBundle } from '@goose-hub/core/agent-runtime/code-context.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { buildRelatedSurfaceManifest } from '@goose-hub/core/agent-runtime/related-surface.js';
@@ -155,6 +156,10 @@ export async function runFixIssueWorkflow(
     investigation: implementInvestigation,
     evidencePostEnabled,
   });
+  const codeContext = buildCodeContextBundle({
+    worktreePath,
+    keyFiles: implementInvestigation?.keyFiles ?? [],
+  });
   if (relatedSurface != null) {
     eventStore.appendEvent({
       projectId,
@@ -220,6 +225,7 @@ export async function runFixIssueWorkflow(
         outputJsonSchema: implementJsonSchema,
         personaId: implementPersonaId,
         investigation: implementInvestigation,
+        codeContext,
         acceptanceContract,
         relatedSurface,
         surfaceGuardInvestigation: investigation,
@@ -314,6 +320,7 @@ export async function runFixIssueWorkflow(
       outputJsonSchema: implementJsonSchema,
       personaId: implementPersonaId,
       investigation: implementInvestigation,
+      codeContext,
       acceptanceContract,
       relatedSurface,
       surfaceGuardInvestigation: investigation,

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -100,6 +100,7 @@ function makeInvestigationEvent(workItem: WorkItem) {
           {
             path: 'apps/server/src/domains/workflows/triage-batch.ts',
             reason: 'owns failed triage state transitions',
+            line: 3,
           },
         ],
         openQuestions: ['Should repo-match fail immediately?'],
@@ -1110,6 +1111,20 @@ describe('parallel-implement investigation context', () => {
     const { fn: appendEvent, events } = makeAppendEvent();
     const specs: AgentSpec[] = [];
     const iterations: Array<{ wpId: string; status: string }> = [];
+    const scratch = mkdtempSync(join(tmpdir(), 'goose-hub-wp-code-context-'));
+    const investigatedFile = join(scratch, 'apps/server/src/domains/workflows/triage-batch.ts');
+    mkdirSync(dirname(investigatedFile), { recursive: true });
+    writeFileSync(
+      investigatedFile,
+      [
+        'export function transition(state: string) {',
+        "  if (state === 'failed') {",
+        "    return 'triage_failed';",
+        '  }',
+        "  return 'ok';",
+        '}',
+      ].join('\n'),
+    );
     const replaySpy = vi
       .spyOn(eventStore, 'replay')
       .mockReturnValue([makeInvestigationEvent(workItem)]);
@@ -1130,7 +1145,7 @@ describe('parallel-implement investigation context', () => {
             },
           },
           createIssueWorktreeImpl: () => '/tmp/issue-wt',
-          createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+          createWpWorktreeImpl: () => scratch,
           cleanupWpWorktreesImpl: () => undefined,
           cleanupIssueWorktreeImpl: () => undefined,
           orchestratorCommitWpImpl: () => 'abc123',
@@ -1159,7 +1174,17 @@ describe('parallel-implement investigation context', () => {
           investigationRunId: 'investigation-run-1',
         },
       });
+      expect(specs[0]?.context).toMatchObject({
+        codeContext: [
+          expect.objectContaining({
+            path: 'apps/server/src/domains/workflows/triage-batch.ts',
+            startLine: 1,
+            snippet: expect.stringContaining("3:     return 'triage_failed';"),
+          }),
+        ],
+      });
       expect(specs[0]?.contextAllowlist).toContain('investigation');
+      expect(specs[0]?.contextAllowlist).toContain('codeContext');
       const injected = events.find((e) => e.kind === 'agent.investigation-context-injected');
       expect(injected?.payload).toMatchObject({
         skill: 'implement-wp',

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -8,6 +8,7 @@ import type {
   AgentRuntime,
   AgentSpec,
 } from '@goose-hub/core/agent-runtime/interface.js';
+import { buildCodeContextBundle } from '@goose-hub/core/agent-runtime/code-context.js';
 import type { InvestigationContext } from '@goose-hub/core/agent-runtime/investigation-context.js';
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
@@ -306,6 +307,13 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     worktreePath: opts.scratchWorktreePath,
     filesOwned: wp.filesOwned,
   });
+  const codeContext =
+    opts.investigation == null
+      ? []
+      : buildCodeContextBundle({
+          worktreePath: opts.scratchWorktreePath,
+          keyFiles: opts.investigation.keyFiles.filter((file) => wp.filesOwned.includes(file.path)),
+        });
   const verificationCommands = wpRelevantExecutableChecks({
     acceptanceContract: opts.acceptanceContract,
     verificationCommands: opts.verificationCommands,
@@ -333,6 +341,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
         dependsOn: wp.dependsOn,
       },
       ...(codeSnippets.length > 0 ? { codeSnippets } : {}),
+      ...(codeContext.length > 0 ? { codeContext } : {}),
       ...(verificationCommands.length > 0 ? { verificationCommands } : {}),
       investigation: opts.investigation,
       acceptanceContract: opts.acceptanceContract,
@@ -370,6 +379,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       'wp.changes',
       'wp.dependsOn',
       'codeSnippets',
+      'codeContext',
       'verificationCommands',
       'investigation',
       'acceptanceContract',

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -976,7 +976,7 @@ describe('runQaWorkflow', () => {
       expect(specUsed.freshContext).toBe(true);
     });
 
-    it('contextAllowlist contains "workItem" and "prDiff" but NOT "devDecisionSummaries"', async () => {
+    it('contextAllowlist contains diff context but NOT developer reasoning', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();
       mockRun.mockResolvedValueOnce(makePassResult());
@@ -984,9 +984,19 @@ describe('runQaWorkflow', () => {
       const { runQaWorkflow } = await import('./workflow.js');
       await runQaWorkflow(item, source, 'test-project', 'owner/repo');
 
-      const specUsed = mockRun.mock.calls[0][0] as { contextAllowlist: string[] };
+      const specUsed = mockRun.mock.calls[0][0] as {
+        context: { prDiffWithContext?: { changedFiles: string[] } };
+        contextAllowlist: string[];
+      };
       expect(specUsed.contextAllowlist).toContain('workItem');
       expect(specUsed.contextAllowlist).toContain('prDiff');
+      expect(specUsed.contextAllowlist).toContain('prDiffWithContext');
+      expect(specUsed.context.prDiffWithContext).toEqual({
+        changedFiles: [],
+        hunkCount: 0,
+        hunks: [],
+        diffCharCount: 0,
+      });
       expect(specUsed.contextAllowlist).not.toContain('devDecisionSummaries');
     });
 

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -6,6 +6,7 @@ import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { findFreePort } from '@goose-hub/core/agent-runtime/find-free-port.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
+import { buildPrDiffWithContext } from '@goose-hub/core/agent-runtime/pr-diff-context.js';
 import { killProcessGroupOrChild } from '@goose-hub/core/agent-runtime/process-kill.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
@@ -544,6 +545,7 @@ export async function runQaWorkflow(
     const deterministicTierResults = deterministic
       ? toAgentTierResults(deterministic.tierResults)
       : undefined;
+    const prDiffWithContext = buildPrDiffWithContext(prDiff);
 
     const qaResult = await runtime.run({
       runId,
@@ -558,6 +560,7 @@ export async function runQaWorkflow(
           number: Number(workItem.externalId),
         },
         prDiff,
+        prDiffWithContext,
         projectCommands: {
           testCommand,
           lintCommand,
@@ -575,6 +578,7 @@ export async function runQaWorkflow(
       contextAllowlist: [
         'workItem',
         'prDiff',
+        'prDiffWithContext',
         'projectCommands',
         'verificationSummary',
         'e2eDecision',

--- a/slices/review/review-spec.ts
+++ b/slices/review/review-spec.ts
@@ -1,5 +1,6 @@
 import type { AcceptanceContract } from '@goose-hub/core/acceptance-contracts/types.js';
 import type { AgentRuntime, AgentSpec } from '@goose-hub/core/agent-runtime/interface.js';
+import { buildPrDiffWithContext } from '@goose-hub/core/agent-runtime/pr-diff-context.js';
 // slices/review/review-spec.ts
 import type { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import type { ReviewerSlot } from '@goose-hub/core/db/repositories/project-review-settings.js';
@@ -138,10 +139,17 @@ export function buildReviewSpec(params: {
         number: Number(params.workItem.externalId),
       },
       prDiff: params.prDiff,
+      prDiffWithContext: buildPrDiffWithContext(params.prDiff),
       qaVerdict: params.qaResult,
       acceptanceContract: params.acceptanceContract ?? undefined,
     },
-    contextAllowlist: ['workItem', 'prDiff', 'qaVerdict', 'acceptanceContract'],
+    contextAllowlist: [
+      'workItem',
+      'prDiff',
+      'prDiffWithContext',
+      'qaVerdict',
+      'acceptanceContract',
+    ],
     freshContext: true,
     toolBundles: ['read', 'validate'],
     toolExtras: [],

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -207,6 +207,10 @@ describe('runReviewWorkflow', () => {
       expect(getPrDiff).toHaveBeenCalledWith('42');
       const spec = mockRun.mock.calls[0][0] as { context: Record<string, unknown> };
       expect(spec.context.prDiff).toBe('diff --git a/foo.ts b/foo.ts\n+added line');
+      expect(spec.context.prDiffWithContext).toMatchObject({
+        changedFiles: ['foo.ts'],
+        diffCharCount: 40,
+      });
     });
 
     it('passes empty prDiff when stateSource returns empty string', async () => {


### PR DESCRIPTION
Stacked on #1008 (cost-perf/1000-scout-digest).

Adds line/symbol/snippet precision to investigation handoffs, builds bounded codeContext for implement, and gives QA/Review a diff-derived prDiffWithContext while preserving holdout boundaries.

Closes #993