### PR TITLE
M19.XX: chat bug

### DIFF
--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+const chatApi = vi.hoisted(() => ({
+  listConversations: vi.fn(),
+  fetchConversation: vi.fn(),
+  fetchToolManifest: vi.fn(),
+}));
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: chatApi.fetchConversation,
+  fetchToolManifest: chatApi.fetchToolManifest,
+  listConversations: chatApi.listConversations,
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  chatApi.fetchToolManifest.mockResolvedValue([]);
+});
+
+afterEach(cleanup);
+
+describe('ChatDock', () => {
+  it('restores the persisted open state on mount', async () => {
+    localStorage.setItem('hub-chat-open', 'true');
+    chatApi.listConversations.mockResolvedValueOnce([]);
+
+    renderDock();
+
+    await waitFor(() => {
+      expect(chatApi.listConversations).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId('chat-launcher').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByTestId('chat-panel').className).toContain('translate-x-0');
+  });
+
+  it('reopens on the conversations list instead of restoring the last thread', async () => {
+    const user = userEvent.setup();
+    chatApi.listConversations.mockResolvedValue([
+      { ...conversation, updatedAt: '2026-05-18T00:00:00Z' },
+    ]);
+    chatApi.fetchConversation.mockResolvedValue({
+      conversation,
+      messages: [message],
+      invocations: [],
+    });
+
+    renderDock();
+
+    await user.click(screen.getByTestId('chat-launcher'));
+    await screen.findByText(/Conversations · 1/);
+
+    await user.click(screen.getByTestId('chat-conversation-select'));
+    await screen.findByText('Agent reply');
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBe('conv-1');
+
+    await user.click(screen.getByTestId('chat-launcher'));
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBeNull();
+
+    await user.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => {
+      expect(chatApi.listConversations).toHaveBeenCalledTimes(2);
+    });
+    expect(chatApi.fetchConversation).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();
+    expect(screen.getByText(/Conversations · 1/)).toBeTruthy();
+    expect(screen.queryByText('Agent reply')).toBeNull();
+  });
+});
+
+function renderDock() {
+  return render(
+    <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+      <ChatDock />
+    </MemoryRouter>,
+  );
+}
+
+const conversation = {
+  id: 'conv-1',
+  scope: 'project',
+  projectId: 'goose-hub-self',
+  workItemId: null,
+  title: 'Project chat',
+  runtime: 'codex',
+  createdAt: '2026-05-18T00:00:00Z',
+  updatedAt: '2026-05-18T00:00:00Z',
+};
+
+const message = {
+  id: 1,
+  conversationId: 'conv-1',
+  role: 'agent',
+  content: 'Agent reply',
+  runId: 'run-1',
+  meta: null,
+  createdAt: '2026-05-18T00:00:01Z',
+};

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ChatLauncher } from './ChatLauncher';
 import { ChatPanel } from './ChatPanel';
 
@@ -17,6 +17,7 @@ export function ChatDock() {
       return false;
     }
   });
+  const [resetSignal, setResetSignal] = useState(0);
 
   useEffect(() => {
     try {
@@ -24,10 +25,19 @@ export function ChatDock() {
     } catch {}
   }, [open]);
 
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen((prevOpen) => {
+      if (prevOpen && !nextOpen) {
+        setResetSignal((prevSignal) => prevSignal + 1);
+      }
+      return nextOpen;
+    });
+  }, []);
+
   return (
     <>
-      <ChatPanel open={open} onClose={() => setOpen(false)} />
-      <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
+      <ChatPanel open={open} onClose={() => handleOpenChange(false)} resetSignal={resetSignal} />
+      <ChatLauncher open={open} onToggle={() => handleOpenChange(!open)} />
     </>
   );
 }

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -34,11 +34,12 @@ const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
+  resetSignal: number;
 }
 
 type View = 'thread' | 'list';
 
-export function ChatPanel({ open, onClose }: ChatPanelProps) {
+export function ChatPanel({ open, onClose, resetSignal }: ChatPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const resolved = useMemo(() => resolveScopeFromPath(location.pathname), [location.pathname]);
@@ -63,6 +64,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   //  * the open-panel roster effect clobbering a thread the user just clicked
   //    "New" to create while the list was still in flight.
   const loadTokenRef = useRef(0);
+  const lastResetSignalRef = useRef(resetSignal);
   const activeConversationIdRef = useRef<string | null>(null);
   const inFlightRunByConversationRef = useRef<Map<string, string>>(new Map());
 
@@ -135,6 +137,21 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       // localStorage unavailable — accept the loss; selection is best-effort.
     }
   }, []);
+
+  const resetVisibleState = useCallback(() => {
+    loadTokenRef.current += 1;
+    setConversation(null);
+    setMessages([]);
+    setInvocations([]);
+    writeActiveId(null);
+    setView('list');
+  }, [writeActiveId]);
+
+  useEffect(() => {
+    if (resetSignal === lastResetSignalRef.current) return;
+    lastResetSignalRef.current = resetSignal;
+    resetVisibleState();
+  }, [resetSignal, resetVisibleState]);
 
   useEffect(() => {
     if (!open || toolManifest.length > 0) return;


### PR DESCRIPTION
## Summary

chat bug

## Work Packages

- ✓ **WP1**: In `ChatDock.tsx:12`, replace direct `setOpen` call sites with one `handleOpenChange(nextOpen)` boundary. When transitio

Closes #1017
