### PR TITLE
M19.XX: API bug

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -77,6 +77,18 @@ describe('POST /inbox', () => {
     expect(res.status).toBe(400);
     expect(mockCreateInboxItem).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for JSON null body', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid request body' });
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /inbox', () => {

--- a/apps/server/src/shared/middleware.test.ts
+++ b/apps/server/src/shared/middleware.test.ts
@@ -32,4 +32,19 @@ describe('parseBody', () => {
     });
     expect(result).toMatchObject({ ok: false });
   });
+
+  it('returns ok:false for JSON null', async () => {
+    const app = new Hono();
+    let result: unknown;
+    app.post('/test', async (c) => {
+      result = await parseBody<{ name: string }>(c);
+      return c.json({});
+    });
+    await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(result).toMatchObject({ ok: false });
+  });
 });

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -7,8 +7,14 @@ export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response
 
 export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
   try {
-    const data = (await c.req.json()) as T;
-    return { ok: true, data };
+    const data = await c.req.json();
+
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+      logger.warn('request body parse failed', { err: 'request body must be a JSON object' });
+      return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
+    }
+
+    return { ok: true, data: data as T };
   } catch (err) {
     logger.warn('request body parse failed', { err: String(err) });
     return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -5,11 +5,15 @@ export type Result<T> = { ok: true; data: T } | { ok: false; error: string; stat
 
 export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response };
 
+function isJsonObjectBody(data: unknown): data is Record<string, unknown> {
+  return data !== null && typeof data === 'object' && !Array.isArray(data);
+}
+
 export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
   try {
     const data = await c.req.json();
 
-    if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    if (!isJsonObjectBody(data)) {
       logger.warn('request body parse failed', { err: 'request body must be a JSON object' });
       return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
     }

--- a/core/tool-layer/mcp/tools/resources.ts
+++ b/core/tool-layer/mcp/tools/resources.ts
@@ -80,7 +80,7 @@ function collectWorkspaceResources(ctx: FactoryContext): WorkspaceResource[] {
  * telemetry, path policy, and the run-cache all apply.
  */
 export function buildWorkspaceResourceTemplate(ctx: FactoryContext): ResourceTemplate {
-  return new ResourceTemplate(`${FACTORY_URI_PREFIX}{path}`, {
+  return new ResourceTemplate(`${FACTORY_URI_PREFIX}{+path}`, {
     list: () => {
       const resources = collectWorkspaceResources(ctx);
       return Promise.resolve({ resources });


### PR DESCRIPTION
## Summary

API bug

## Work Packages

- ✓ **WP1**: In `apps/server/src/shared/middleware.ts:8`, keep the `parseBody<T>(c: Context): Promise<ParsedBody<T>>` signature but a

Closes #1024
