### PR TITLE
M20.10: fix codex resources/read converter + demote blocking pattern

### DIFF
--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -463,7 +463,7 @@ describe('CodexCliRuntime timeout handling', () => {
     );
   });
 
-  it('audits a failed MCP resource read without killing the Codex run', async () => {
+  it('records resources/read failed as a non-fatal advisory event', async () => {
     const child = makeHangingChild();
     mockSpawn.mockReturnValue(child);
 
@@ -483,18 +483,31 @@ describe('CodexCliRuntime timeout handling', () => {
     child.emit('close', 0);
 
     await expect(run).resolves.toMatchObject({ output: { ok: true } });
-    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: 'agent.tool-call',
-        payload: expect.objectContaining({
-          tool_name: 'resources/read',
-          blocked: true,
-          block_reason: 'blocked-runtime-surface: resources/read failed',
-          status: 'failed',
-        }),
-        personaId: 'test-project/developer/0',
-      }),
+
+    const calls: Parameters<typeof mockEventStore.appendEvent>[0][] =
+      mockEventStore.appendEvent.mock.calls.map((c: unknown[]) => c[0]);
+
+    const advisory = calls.find(
+      (e) =>
+        e.kind === 'agent.runtime-advisory' &&
+        (e.payload as { surface: string }).surface === 'resources/read failed',
     );
+    expect(advisory).toBeDefined();
+    expect((advisory?.payload as { blocked?: unknown }).blocked).toBeUndefined();
+
+    // No agent.run-blocked event for this surface.
+    expect(calls.some((e) => e.kind === 'agent.run-blocked')).toBe(false);
+
+    // No blocked tool-call for resources/read.
+    expect(
+      calls.some(
+        (e) =>
+          e.kind === 'agent.tool-call' &&
+          (e.payload as { tool_name?: string; blocked?: boolean }).tool_name === 'resources/read' &&
+          (e.payload as { blocked?: boolean }).blocked === true,
+      ),
+    ).toBe(false);
+
     expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -79,8 +79,10 @@ const BLOCKED_RUNTIME_SURFACE_PATTERNS: Array<{
   surface: string;
   toolName: string;
   re: RegExp;
-}> = [
-  { surface: 'resources/read failed', toolName: 'resources/read', re: /resources\/read\s+failed/i },
+}> = [];
+
+const ADVISORY_RUNTIME_SURFACE_PATTERNS: Array<{ surface: string; re: RegExp }> = [
+  { surface: 'resources/read failed', re: /resources\/read\s+failed/i },
 ];
 
 function isPathUnderRoot(path: string, root: string): boolean {
@@ -180,6 +182,13 @@ function detectBlockedRuntimeSurface(line: string): {
         blockReason: `blocked-runtime-surface: ${pattern.surface}`,
       };
     }
+  }
+  return null;
+}
+
+function detectAdvisoryRuntimeSurface(line: string): { surface: string } | null {
+  for (const pattern of ADVISORY_RUNTIME_SURFACE_PATTERNS) {
+    if (pattern.re.test(line)) return { surface: pattern.surface };
   }
   return null;
 }
@@ -624,6 +633,17 @@ export class CodexCliRuntime implements AgentRuntime {
           if (blocked != null) {
             emitForbiddenRuntimeSurfaceBlocked(blocked);
           }
+          const advisory = detectAdvisoryRuntimeSurface(line);
+          if (advisory != null) {
+            eventStore.appendEvent({
+              projectId,
+              workItemId,
+              runId,
+              personaId: personaId ?? null,
+              kind: 'agent.runtime-advisory',
+              payload: { surface: advisory.surface, source: 'codex-cli-stderr' },
+            });
+          }
         }
       });
 
@@ -713,6 +733,17 @@ export class CodexCliRuntime implements AgentRuntime {
           const blocked = detectBlockedRuntimeSurface(stderrLineBuffer);
           if (blocked != null) {
             emitForbiddenRuntimeSurfaceBlocked(blocked);
+          }
+          const advisory = detectAdvisoryRuntimeSurface(stderrLineBuffer);
+          if (advisory != null) {
+            eventStore.appendEvent({
+              projectId,
+              workItemId,
+              runId,
+              personaId: personaId ?? null,
+              kind: 'agent.runtime-advisory',
+              payload: { surface: advisory.surface, source: 'codex-cli-stderr' },
+            });
           }
         }
 

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -137,6 +137,7 @@ export const EVENT_KINDS = [
   'agent.bug-enhance-hallucinated',
   'agent.bug-enhance-workspace-empty',
   'agent.run-aborted',
+  'agent.runtime-advisory',
 ] as const;
 
 export type EventKind = (typeof EVENT_KINDS)[number];

--- a/core/tool-layer/mcp/resources.test.ts
+++ b/core/tool-layer/mcp/resources.test.ts
@@ -75,6 +75,23 @@ describe('uriToWorkspaceRelative', () => {
     });
   });
 
+  it('does not throw on malformed percent sequences — returns raw capture as fallback', () => {
+    // %GG is not a valid percent-encoded sequence; must not throw
+    expect(() => uriToWorkspaceRelative('read_file?path=foo%GGbar.ts')).not.toThrow();
+    const result = uriToWorkspaceRelative('read_file?path=foo%GGbar.ts');
+    expect(result.op).toBe('read');
+    // fallback: raw encoded string is returned unchanged
+    expect(result.path).toBe('foo%GGbar.ts');
+  });
+
+  it('captures only up to & in tool-shaped URIs (greedy-match guard)', () => {
+    // extra query params must not bleed into path
+    expect(uriToWorkspaceRelative('read_file?path=foo.ts&encoding=utf8')).toEqual({
+      op: 'read',
+      path: 'foo.ts',
+    });
+  });
+
   it('keeps bare path / factory:// / file:// forms as read', () => {
     expect(uriToWorkspaceRelative('factory://core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
     expect(uriToWorkspaceRelative('file:///core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
@@ -184,7 +201,7 @@ describe('resources/read', () => {
   it('routes file_exists?path=… via fileExistsTool and serializes { exists: bool }', async () => {
     const result = await readWorkspaceResource(ctx, 'file_exists?path=README.md');
     expect(result.contents[0].mimeType).toBe('application/json');
-    expect(JSON.parse(result.contents[0].text as string)).toEqual({
+    expect(JSON.parse(asText(result.contents[0]).text)).toEqual({
       exists: true,
       path: 'README.md',
     });
@@ -192,7 +209,7 @@ describe('resources/read', () => {
 
   it('routes file_exists for a missing path and reports exists:false (no throw)', async () => {
     const result = await readWorkspaceResource(ctx, 'file_exists?path=does-not-exist.ts');
-    expect(JSON.parse(result.contents[0].text as string)).toMatchObject({ exists: false });
+    expect(JSON.parse(asText(result.contents[0]).text)).toMatchObject({ exists: false });
   });
 
   it('shares run-cache with read_file for the same canonical path', async () => {
@@ -201,8 +218,9 @@ describe('resources/read', () => {
     const result = await readWorkspaceResource(ctx, 'read_file?path=README.md');
     // The audit event should be marked cached:true on the second read.
     const events = eventStore.replay({ workItemId: ctx.workItemId });
-    const last = events.findLast((e) => (e.payload as any).tool_name === 'resources/read');
-    expect((last?.payload as any).cached).toBe(true);
-    expect(result.contents[0].text).toBeDefined();
+    type ToolCallPayload = { tool_name?: string; cached?: boolean };
+    const last = [...events].reverse().find((e) => (e.payload as ToolCallPayload).tool_name === 'resources/read');
+    expect((last?.payload as ToolCallPayload).cached).toBe(true);
+    expect(asText(result.contents[0]).text).toBeDefined();
   });
 });

--- a/core/tool-layer/mcp/resources.test.ts
+++ b/core/tool-layer/mcp/resources.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { eventStore } from '../../event-stream/store.js';
 import type { FactoryContext } from './context.js';
+import { buildFactoryMcpServer } from './server.js';
 import {
   buildWorkspaceResourceTemplate,
   readWorkspaceResource,
@@ -222,5 +223,23 @@ describe('resources/read', () => {
     const last = [...events].reverse().find((e) => (e.payload as ToolCallPayload).tool_name === 'resources/read');
     expect((last?.payload as ToolCallPayload).cached).toBe(true);
     expect(asText(result.contents[0]).text).toBeDefined();
+  });
+
+  it('does not throw "Invalid URL" when called with read_file?path=… via the server transport', async () => {
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'test-pkg' }, null, 2));
+    const server = buildFactoryMcpServer(ctx);
+    // Access the low-level Server's _requestHandlers map to call the handler directly
+    type HandlerMap = Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+    const handlers = (server.server as unknown as { _requestHandlers: HandlerMap })['_requestHandlers'];
+    const handler = handlers.get('resources/read');
+    expect(handler).toBeDefined();
+    const response = await handler!(
+      {
+        method: 'resources/read',
+        params: { uri: 'read_file?path=package.json' },
+      },
+      {},
+    );
+    expect((response as { contents: Array<{ text: string }> }).contents[0].text).toContain('"name"');
   });
 });

--- a/core/tool-layer/mcp/resources.test.ts
+++ b/core/tool-layer/mcp/resources.test.ts
@@ -40,15 +40,24 @@ afterEach(() => {
 
 describe('uriToWorkspaceRelative', () => {
   it('strips factory:// prefix', () => {
-    expect(uriToWorkspaceRelative('factory://src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
+    expect(uriToWorkspaceRelative('factory://src/index.ts')).toEqual({
+      op: 'read',
+      path: 'src/index.ts',
+    });
   });
 
   it('strips file:/// prefix', () => {
-    expect(uriToWorkspaceRelative('file:///src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
+    expect(uriToWorkspaceRelative('file:///src/index.ts')).toEqual({
+      op: 'read',
+      path: 'src/index.ts',
+    });
   });
 
   it('strips file:// prefix (two slashes)', () => {
-    expect(uriToWorkspaceRelative('file://src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
+    expect(uriToWorkspaceRelative('file://src/index.ts')).toEqual({
+      op: 'read',
+      path: 'src/index.ts',
+    });
   });
 
   it('passes bare path through unchanged', () => {
@@ -63,7 +72,11 @@ describe('uriToWorkspaceRelative', () => {
   });
 
   it('handles codex file_exists?path=… URI form', () => {
-    expect(uriToWorkspaceRelative('file_exists?path=apps/web/src/components/chat/components/ChatDock.tsx')).toEqual({
+    expect(
+      uriToWorkspaceRelative(
+        'file_exists?path=apps/web/src/components/chat/components/ChatDock.tsx',
+      ),
+    ).toEqual({
       op: 'exists',
       path: 'apps/web/src/components/chat/components/ChatDock.tsx',
     });
@@ -94,8 +107,14 @@ describe('uriToWorkspaceRelative', () => {
   });
 
   it('keeps bare path / factory:// / file:// forms as read', () => {
-    expect(uriToWorkspaceRelative('factory://core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
-    expect(uriToWorkspaceRelative('file:///core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
+    expect(uriToWorkspaceRelative('factory://core/types.ts')).toEqual({
+      op: 'read',
+      path: 'core/types.ts',
+    });
+    expect(uriToWorkspaceRelative('file:///core/types.ts')).toEqual({
+      op: 'read',
+      path: 'core/types.ts',
+    });
     expect(uriToWorkspaceRelative('core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
   });
 });
@@ -220,7 +239,9 @@ describe('resources/read', () => {
     // The audit event should be marked cached:true on the second read.
     const events = eventStore.replay({ workItemId: ctx.workItemId });
     type ToolCallPayload = { tool_name?: string; cached?: boolean };
-    const last = [...events].reverse().find((e) => (e.payload as ToolCallPayload).tool_name === 'resources/read');
+    const last = [...events]
+      .reverse()
+      .find((e) => (e.payload as ToolCallPayload).tool_name === 'resources/read');
     expect((last?.payload as ToolCallPayload).cached).toBe(true);
     expect(asText(result.contents[0]).text).toBeDefined();
   });
@@ -230,16 +251,19 @@ describe('resources/read', () => {
     const server = buildFactoryMcpServer(ctx);
     // Access the low-level Server's _requestHandlers map to call the handler directly
     type HandlerMap = Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
-    const handlers = (server.server as unknown as { _requestHandlers: HandlerMap })['_requestHandlers'];
+    const handlers = (server.server as unknown as { _requestHandlers: HandlerMap })
+      ._requestHandlers;
     const handler = handlers.get('resources/read');
     expect(handler).toBeDefined();
-    const response = await handler!(
+    const response = await handler?.(
       {
         method: 'resources/read',
         params: { uri: 'read_file?path=package.json' },
       },
       {},
     );
-    expect((response as { contents: Array<{ text: string }> }).contents[0].text).toContain('"name"');
+    expect((response as { contents: Array<{ text: string }> }).contents[0].text).toContain(
+      '"name"',
+    );
   });
 });

--- a/core/tool-layer/mcp/resources.test.ts
+++ b/core/tool-layer/mcp/resources.test.ts
@@ -39,19 +39,46 @@ afterEach(() => {
 
 describe('uriToWorkspaceRelative', () => {
   it('strips factory:// prefix', () => {
-    expect(uriToWorkspaceRelative('factory://src/index.ts')).toBe('src/index.ts');
+    expect(uriToWorkspaceRelative('factory://src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
   });
 
   it('strips file:/// prefix', () => {
-    expect(uriToWorkspaceRelative('file:///src/index.ts')).toBe('src/index.ts');
+    expect(uriToWorkspaceRelative('file:///src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
   });
 
   it('strips file:// prefix (two slashes)', () => {
-    expect(uriToWorkspaceRelative('file://src/index.ts')).toBe('src/index.ts');
+    expect(uriToWorkspaceRelative('file://src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
   });
 
   it('passes bare path through unchanged', () => {
-    expect(uriToWorkspaceRelative('src/index.ts')).toBe('src/index.ts');
+    expect(uriToWorkspaceRelative('src/index.ts')).toEqual({ op: 'read', path: 'src/index.ts' });
+  });
+
+  it('handles codex read_file?path=… URI form', () => {
+    expect(uriToWorkspaceRelative('read_file?path=package.json')).toEqual({
+      op: 'read',
+      path: 'package.json',
+    });
+  });
+
+  it('handles codex file_exists?path=… URI form', () => {
+    expect(uriToWorkspaceRelative('file_exists?path=apps/web/src/components/chat/components/ChatDock.tsx')).toEqual({
+      op: 'exists',
+      path: 'apps/web/src/components/chat/components/ChatDock.tsx',
+    });
+  });
+
+  it('url-decodes percent-encoded paths in tool-shaped URIs', () => {
+    expect(uriToWorkspaceRelative('read_file?path=apps%2Fweb%2Fsrc%2Findex.ts')).toEqual({
+      op: 'read',
+      path: 'apps/web/src/index.ts',
+    });
+  });
+
+  it('keeps bare path / factory:// / file:// forms as read', () => {
+    expect(uriToWorkspaceRelative('factory://core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
+    expect(uriToWorkspaceRelative('file:///core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
+    expect(uriToWorkspaceRelative('core/types.ts')).toEqual({ op: 'read', path: 'core/types.ts' });
   });
 });
 
@@ -152,5 +179,30 @@ describe('resources/read', () => {
     );
     // The underlying readFileTool is called; it may return cached result
     expect(resourceReadCall).toBeDefined();
+  });
+
+  it('routes file_exists?path=… via fileExistsTool and serializes { exists: bool }', async () => {
+    const result = await readWorkspaceResource(ctx, 'file_exists?path=README.md');
+    expect(result.contents[0].mimeType).toBe('application/json');
+    expect(JSON.parse(result.contents[0].text as string)).toEqual({
+      exists: true,
+      path: 'README.md',
+    });
+  });
+
+  it('routes file_exists for a missing path and reports exists:false (no throw)', async () => {
+    const result = await readWorkspaceResource(ctx, 'file_exists?path=does-not-exist.ts');
+    expect(JSON.parse(result.contents[0].text as string)).toMatchObject({ exists: false });
+  });
+
+  it('shares run-cache with read_file for the same canonical path', async () => {
+    const { readFileTool } = await import('./tools/read.js');
+    await readFileTool(ctx, { path: 'README.md' });
+    const result = await readWorkspaceResource(ctx, 'read_file?path=README.md');
+    // The audit event should be marked cached:true on the second read.
+    const events = eventStore.replay({ workItemId: ctx.workItemId });
+    const last = events.findLast((e) => (e.payload as any).tool_name === 'resources/read');
+    expect((last?.payload as any).cached).toBe(true);
+    expect(result.contents[0].text).toBeDefined();
   });
 });

--- a/core/tool-layer/mcp/server.ts
+++ b/core/tool-layer/mcp/server.ts
@@ -1,5 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import { type FactoryContext, FactoryContextError, loadFactoryContext } from './context.js';
 import {
   ApplyPatchInput,
@@ -81,7 +85,10 @@ import {
   searchTextTool,
 } from './tools/read.js';
 import { repoIntelQueryTool } from './tools/repo-intel.js';
-import { buildWorkspaceResourceTemplate, readWorkspaceResource } from './tools/resources.js';
+import {
+  listWorkspaceResources,
+  readWorkspaceResource,
+} from './tools/resources.js';
 import {
   runLintTool,
   runPackageScriptTool,
@@ -132,13 +139,16 @@ function errorResult(err: unknown): { content: JsonContent[]; isError: true } {
  */
 export function buildFactoryMcpServer(ctx: FactoryContext): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
-  // Register resources/list + resources/read so codex-cli (which probes resources/* on startup)
-  // gets real workspace file enumeration instead of -32603 errors.
-  server.resource(
-    'workspace-files',
-    buildWorkspaceResourceTemplate(ctx),
-    { description: 'Files in the agent workspace, filtered by path policy.' },
-    async (uri) => readWorkspaceResource(ctx, uri),
+  // Register resources/list + resources/read via low-level setRequestHandler so we own URI
+  // parsing before the SDK's `new URL()` validation fires. This allows codex's bare and
+  // tool-shaped URIs (read_file?path=…, file_exists?path=…) to reach our converter instead
+  // of failing in the SDK URL constructor.
+  server.server.registerCapabilities({ resources: { listChanged: true } });
+  server.server.setRequestHandler(ListResourcesRequestSchema, () =>
+    Promise.resolve(listWorkspaceResources(ctx)),
+  );
+  server.server.setRequestHandler(ReadResourceRequestSchema, (req) =>
+    readWorkspaceResource(ctx, req.params.uri),
   );
 
   server.registerTool(

--- a/core/tool-layer/mcp/server.ts
+++ b/core/tool-layer/mcp/server.ts
@@ -85,10 +85,7 @@ import {
   searchTextTool,
 } from './tools/read.js';
 import { repoIntelQueryTool } from './tools/repo-intel.js';
-import {
-  listWorkspaceResources,
-  readWorkspaceResource,
-} from './tools/resources.js';
+import { listWorkspaceResources, readWorkspaceResource } from './tools/resources.js';
 import {
   runLintTool,
   runPackageScriptTool,

--- a/core/tool-layer/mcp/server.ts
+++ b/core/tool-layer/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
+  ListResourceTemplatesRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -146,6 +147,18 @@ export function buildFactoryMcpServer(ctx: FactoryContext): McpServer {
   );
   server.server.setRequestHandler(ReadResourceRequestSchema, (req) =>
     readWorkspaceResource(ctx, req.params.uri),
+  );
+  server.server.setRequestHandler(ListResourceTemplatesRequestSchema, () =>
+    Promise.resolve({
+      resourceTemplates: [
+        {
+          uriTemplate: 'factory://{+path}',
+          name: 'workspace-files',
+          description: 'Workspace files relative to the agent run worktree.',
+          mimeType: 'text/plain',
+        },
+      ],
+    }),
   );
 
   server.registerTool(

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -147,12 +147,23 @@ describe('server resources', () => {
     // the handlers are registered directly on server.server._requestHandlers instead.
     expect(internals.server?._requestHandlers?.has('resources/list')).toBe(true);
     expect(internals.server?._requestHandlers?.has('resources/read')).toBe(true);
+    expect(internals.server?._requestHandlers?.has('resources/templates/list')).toBe(true);
 
     const listResult = await internals.server?._requestHandlers?.get('resources/list')?.(
       { method: 'resources/list', params: {} },
       {},
     );
     expect((listResult as { resources: unknown[] }).resources).toEqual([]);
+
+    const templatesResult = await internals.server?._requestHandlers?.get(
+      'resources/templates/list',
+    )?.({ method: 'resources/templates/list', params: {} }, {});
+    expect(
+      (templatesResult as { resourceTemplates: Array<{ name: string; uriTemplate: string }> })
+        .resourceTemplates,
+    ).toEqual([
+      expect.objectContaining({ name: 'workspace-files', uriTemplate: 'factory://{+path}' }),
+    ]);
   });
 });
 

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -142,9 +142,11 @@ describe('server resources', () => {
       };
     };
 
-    expect(internals._resourceHandlersInitialized).toBe(true);
-    expect(Object.keys(internals._registeredResources ?? {})).toEqual([]);
-    expect(Object.keys(internals._registeredResourceTemplates ?? {})).toContain('workspace-files');
+    // With low-level setRequestHandler registration, the SDK's high-level resource bookkeeping
+    // (_resourceHandlersInitialized, _registeredResourceTemplates) is not used. Verify that
+    // the handlers are registered directly on server.server._requestHandlers instead.
+    expect(internals.server?._requestHandlers?.has('resources/list')).toBe(true);
+    expect(internals.server?._requestHandlers?.has('resources/read')).toBe(true);
 
     const listResult = await internals.server?._requestHandlers?.get('resources/list')?.(
       { method: 'resources/list', params: {} },

--- a/core/tool-layer/mcp/tools/resources.ts
+++ b/core/tool-layer/mcp/tools/resources.ts
@@ -110,6 +110,14 @@ export function buildWorkspaceResourceTemplate(ctx: FactoryContext): ResourceTem
 }
 
 /**
+ * Return the flat list of workspace resources for resources/list.
+ * Used by the low-level setRequestHandler registration in server.ts.
+ */
+export function listWorkspaceResources(ctx: FactoryContext): { resources: WorkspaceResource[] } {
+  return { resources: collectWorkspaceResources(ctx) };
+}
+
+/**
  * Read a workspace file by URI, routing through the read_file or file_exists pipeline
  * (same per-run cache key, secret redaction, path policy, redundancy check).
  */

--- a/core/tool-layer/mcp/tools/resources.ts
+++ b/core/tool-layer/mcp/tools/resources.ts
@@ -142,11 +142,13 @@ export async function readWorkspaceResource(
         payload: { ...auditBase, status: 'ok' },
       });
       return {
-        contents: [{
-          uri: workspaceRelativeToUri(result.path.path),
-          mimeType: 'application/json',
-          text: JSON.stringify({ exists: result.exists, path: result.path.path }),
-        }],
+        contents: [
+          {
+            uri: workspaceRelativeToUri(result.path.path),
+            mimeType: 'application/json',
+            text: JSON.stringify({ exists: result.exists, path: result.path.path }),
+          },
+        ],
       } satisfies ReadResourceResult;
     }
     const result = await readFileTool(ctx, { path: parsed.path });

--- a/core/tool-layer/mcp/tools/resources.ts
+++ b/core/tool-layer/mcp/tools/resources.ts
@@ -5,25 +5,39 @@ import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { eventStore } from '../../../event-stream/store.js';
 import type { FactoryContext } from '../context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from '../path-policy.js';
-import { readFileTool } from './read.js';
+import { fileExistsTool, readFileTool } from './read.js';
 
 export { ResourceTemplate };
 
 const FACTORY_URI_PREFIX = 'factory://';
+const TOOL_URI_RE = /^(read_file|file_exists)\?path=(.+)$/;
+
+export type ResourceOp = { op: 'read'; path: string } | { op: 'exists'; path: string };
 
 /**
- * Normalise an incoming URI/path to a workspace-relative path string.
+ * Normalise an incoming URI/path to a workspace-relative path with operation tag.
  * Accepts:
- *   factory://<worktree-relative>   → strip prefix
- *   file:///<path>                  → strip file:// prefix
- *   bare path                       → use as-is
+ *   read_file?path=<path>           → {op: 'read', path}
+ *   file_exists?path=<path>         → {op: 'exists', path}
+ *   factory://<worktree-relative>   → {op: 'read', path}
+ *   file:///<path>                  → {op: 'read', path}
+ *   bare path                       → {op: 'read', path}
  */
-export function uriToWorkspaceRelative(uri: string): string {
-  if (uri.startsWith(FACTORY_URI_PREFIX)) return uri.slice(FACTORY_URI_PREFIX.length);
+export function uriToWorkspaceRelative(uri: string): ResourceOp {
+  const toolMatch = TOOL_URI_RE.exec(uri);
+  if (toolMatch != null) {
+    const op = toolMatch[1] === 'file_exists' ? 'exists' : 'read';
+    return { op, path: decodeURIComponent(toolMatch[2]) };
+  }
+  if (uri.startsWith(FACTORY_URI_PREFIX)) {
+    return { op: 'read', path: uri.slice(FACTORY_URI_PREFIX.length) };
+  }
   // file:// forms: strip the scheme but keep the path
   const fileMatch = /^file:\/\/\/?(.*)$/.exec(uri);
-  if (fileMatch) return fileMatch[1];
-  return uri;
+  if (fileMatch) {
+    return { op: 'read', path: fileMatch[1] };
+  }
+  return { op: 'read', path: uri };
 }
 
 export function workspaceRelativeToUri(relativePath: string): string {
@@ -89,7 +103,7 @@ export function buildWorkspaceResourceTemplate(ctx: FactoryContext): ResourceTem
 }
 
 /**
- * Read a workspace file by URI, routing through the read_file pipeline
+ * Read a workspace file by URI, routing through the read_file or file_exists pipeline
  * (same per-run cache key, secret redaction, path policy, redundancy check).
  */
 export async function readWorkspaceResource(
@@ -97,11 +111,29 @@ export async function readWorkspaceResource(
   uri: URL | string,
 ): Promise<ReadResourceResult> {
   const uriStr = typeof uri === 'string' ? uri : uri.toString();
-  const relativePath = uriToWorkspaceRelative(uriStr);
-  const auditBase = { tool_name: 'resources/read', uri: uriStr, relativePath };
+  const parsed = uriToWorkspaceRelative(uriStr);
+  const auditBase = { tool_name: 'resources/read', uri: uriStr, relativePath: parsed.path, op: parsed.op };
 
   try {
-    const result = await readFileTool(ctx, { path: relativePath });
+    if (parsed.op === 'exists') {
+      const result = await fileExistsTool(ctx, { path: parsed.path });
+      eventStore.appendEvent({
+        projectId: ctx.projectId,
+        workItemId: ctx.workItemId,
+        runId: ctx.runId,
+        personaId: ctx.personaId ?? null,
+        kind: 'agent.tool-call',
+        payload: { ...auditBase, status: 'ok' },
+      });
+      return {
+        contents: [{
+          uri: workspaceRelativeToUri(result.path.path),
+          mimeType: 'application/json',
+          text: JSON.stringify({ exists: result.exists, path: result.path.path }),
+        }],
+      } satisfies ReadResourceResult;
+    }
+    const result = await readFileTool(ctx, { path: parsed.path });
     eventStore.appendEvent({
       projectId: ctx.projectId,
       workItemId: ctx.workItemId,
@@ -114,7 +146,7 @@ export async function readWorkspaceResource(
         cached: (result as { cached?: boolean }).cached ?? false,
       },
     });
-    const canonicalUri = workspaceRelativeToUri(result.path?.path ?? relativePath);
+    const canonicalUri = workspaceRelativeToUri(result.path?.path ?? parsed.path);
     return {
       contents: [{ uri: canonicalUri, mimeType: 'text/plain', text: result.content }],
     } satisfies ReadResourceResult;

--- a/core/tool-layer/mcp/tools/resources.ts
+++ b/core/tool-layer/mcp/tools/resources.ts
@@ -10,7 +10,7 @@ import { fileExistsTool, readFileTool } from './read.js';
 export { ResourceTemplate };
 
 const FACTORY_URI_PREFIX = 'factory://';
-const TOOL_URI_RE = /^(read_file|file_exists)\?path=(.+)$/;
+const TOOL_URI_RE = /^(read_file|file_exists)\?path=([^&]+)/;
 
 export type ResourceOp = { op: 'read'; path: string } | { op: 'exists'; path: string };
 
@@ -27,7 +27,14 @@ export function uriToWorkspaceRelative(uri: string): ResourceOp {
   const toolMatch = TOOL_URI_RE.exec(uri);
   if (toolMatch != null) {
     const op = toolMatch[1] === 'file_exists' ? 'exists' : 'read';
-    return { op, path: decodeURIComponent(toolMatch[2]) };
+    let path: string;
+    try {
+      path = decodeURIComponent(toolMatch[2]);
+    } catch {
+      // Malformed percent sequence — fall back to raw capture
+      path = toolMatch[2];
+    }
+    return { op, path };
   }
   if (uri.startsWith(FACTORY_URI_PREFIX)) {
     return { op: 'read', path: uri.slice(FACTORY_URI_PREFIX.length) };
@@ -111,10 +118,11 @@ export async function readWorkspaceResource(
   uri: URL | string,
 ): Promise<ReadResourceResult> {
   const uriStr = typeof uri === 'string' ? uri : uri.toString();
-  const parsed = uriToWorkspaceRelative(uriStr);
-  const auditBase = { tool_name: 'resources/read', uri: uriStr, relativePath: parsed.path, op: parsed.op };
+  const auditBase = { tool_name: 'resources/read', uri: uriStr };
 
   try {
+    const parsed = uriToWorkspaceRelative(uriStr);
+    Object.assign(auditBase, { relativePath: parsed.path, op: parsed.op });
     if (parsed.op === 'exists') {
       const result = await fileExistsTool(ctx, { path: parsed.path });
       eventStore.appendEvent({
@@ -143,7 +151,7 @@ export async function readWorkspaceResource(
       payload: {
         ...auditBase,
         status: 'ok',
-        cached: (result as { cached?: boolean }).cached ?? false,
+        cached: result.cached ?? false,
       },
     });
     const canonicalUri = workspaceRelativeToUri(result.path?.path ?? parsed.path);

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -134,6 +134,7 @@ export const RUNTIME_INHERIT_TIMELINE_EVENT_KINDS = new Set<string>([
   'agent.verify-command',
   'agent.cancelled',
   'agent.run-aborted',
+  'agent.runtime-advisory',
   'tool.violation',
   'symbol-index.lookup',
   'symbol-index.hints-used',


### PR DESCRIPTION
## Summary

G1 of the 1021–1023 failure-cascade plan (`docs/cost-performance-improvements/1021-1023-failure-cascade-plan.md`).

- **Task 1**: widen `uriToWorkspaceRelative` to return a tagged `{op: 'read'|'exists', path}` and handle codex tool-shaped URIs (`read_file?path=…`, `file_exists?path=…`); dispatch `readWorkspaceResource` on op.
- **Task 2**: switch `core/tool-layer/mcp/server.ts` from high-level `server.resource(...)` to low-level `server.server.setRequestHandler(...)` so codex's bare/tool-shaped URIs reach our converter before SDK URL validation fires.
- **Task 3**: remove `resources/read failed` from `BLOCKED_RUNTIME_SURFACE_PATTERNS`; emit `agent.runtime-advisory` instead so transient stderr lines no longer abort the run.

## Eval

| Metric | Pre | Target |
|---|---|---|
| `agent.tool-call` `tool_name:"resources/read"` `status:"failed"` with `Invalid URL` | 3+ per fix-feedback run | 0 |
| `agent.run-blocked` `block_reason:"blocked-runtime-surface: resources/read failed"` | every fix-feedback codex run | 0 |
| `agent.runtime-advisory` `surface:"resources/read failed"` | 0 (didn't exist) | non-zero, advisory only |

## Test plan

- [x] `pnpm vitest run core/tool-layer/mcp` — 230/230 green
- [x] `pnpm vitest run core/agent-runtime` — green incl. new advisory test
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm audit-docs` — clean
- [x] `pnpm test` — 4843 passed | 3 skipped (1 timeline classification updated for new event kind)

Related: #1021, #1022, #1023 (failure modes observed on these issues that this PR resolves at infrastructure layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)