### PR TITLE
M20.11: ground spec-author with existing-file manifest + per-file check

### DIFF
--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -37,6 +37,20 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
+function fileOwnedArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string') {
+      out.push(entry);
+    } else if (entry != null && typeof entry === 'object' && 'path' in entry) {
+      const path = (entry as { path: unknown }).path;
+      if (typeof path === 'string') out.push(path);
+    }
+  }
+  return out;
+}
+
 function numberArray(value: unknown): number[] {
   return Array.isArray(value)
     ? value.filter((item): item is number => typeof item === 'number')
@@ -115,7 +129,7 @@ function projectEngineeringSpec(record: NonNullable<ReturnType<typeof getEnginee
     ...(architecture != null ? { architecture } : {}),
     workPackages: objectArray(s.workPackages).map((wp, index) => ({
       id: stringValue(wp.id, `WP${index + 1}`),
-      filesOwned: stringArray(wp.filesOwned),
+      filesOwned: fileOwnedArray(wp.filesOwned),
       changes: stringValue(wp.changes),
       dependsOn: stringArray(wp.dependsOn),
       builderTier: stringValue(wp.builderTier),

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import { db } from '@goose-hub/core/db/db.js';
 import { wpIterations } from '@goose-hub/core/db/schema.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
-import type { EngineeringSpec } from '@goose-hub/skills/spec-author/schema.js';
+import { type EngineeringSpec, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import { and, desc, eq } from 'drizzle-orm';
 
 export type RegressionPolicy = 'escalate' | 'ignore';
@@ -77,7 +77,8 @@ export function verifyStructural(
   const findings: VerifyFinding[] = [];
 
   for (const wp of spec.workPackages) {
-    for (const filePath of wp.filesOwned) {
+    for (const entry of wp.filesOwned) {
+      const filePath = fileOwnedPath(entry);
       const fullPath = join(worktreePath, filePath);
       if (existsSync(fullPath)) {
         evidence.push(`file-exists: ${filePath} (WP ${wp.id})`);

--- a/skills/spec-author/manifest.test.ts
+++ b/skills/spec-author/manifest.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { collectScopeManifest } from './manifest.js';
+
+function scratchRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'manifest-'));
+  mkdirSync(join(root, 'apps/web/src/components/detail'), { recursive: true });
+  writeFileSync(join(root, 'apps/web/src/components/detail/TaskHeader.tsx'), '');
+  writeFileSync(join(root, 'apps/web/src/components/detail/api.ts.bak'), '');
+  return root;
+}
+
+describe('collectScopeManifest', () => {
+  it('returns file + dir entries under each scopeRoot, capped at 800', () => {
+    const root = scratchRepo();
+    const out = collectScopeManifest(root, ['apps/web/src/components/detail']);
+    expect(out.find((e) => e.path === 'apps/web/src/components/detail/TaskHeader.tsx' && e.kind === 'file')).toBeDefined();
+    expect(out.find((e) => e.path === 'apps/web/src/components/detail' && e.kind === 'dir')).toBeDefined();
+    expect(out.length).toBeLessThanOrEqual(800);
+  });
+
+  it('returns [] for non-existent scopeRoots without throwing', () => {
+    const root = scratchRepo();
+    expect(collectScopeManifest(root, ['does/not/exist'])).toEqual([]);
+  });
+
+  it('skips node_modules, .git, dist, .factory', () => {
+    const root = scratchRepo();
+    mkdirSync(join(root, 'apps/web/src/components/detail/node_modules/foo'), { recursive: true });
+    writeFileSync(join(root, 'apps/web/src/components/detail/node_modules/foo/index.ts'), '');
+    const out = collectScopeManifest(root, ['apps/web/src/components/detail']);
+    expect(out.every((e) => !e.path.includes('node_modules'))).toBe(true);
+  });
+});

--- a/skills/spec-author/manifest.test.ts
+++ b/skills/spec-author/manifest.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import { collectScopeManifest } from './manifest.js';
 
 function scratchRepo(): string {
@@ -16,8 +16,14 @@ describe('collectScopeManifest', () => {
   it('returns file + dir entries under each scopeRoot, capped at 800', () => {
     const root = scratchRepo();
     const out = collectScopeManifest(root, ['apps/web/src/components/detail']);
-    expect(out.find((e) => e.path === 'apps/web/src/components/detail/TaskHeader.tsx' && e.kind === 'file')).toBeDefined();
-    expect(out.find((e) => e.path === 'apps/web/src/components/detail' && e.kind === 'dir')).toBeDefined();
+    expect(
+      out.find(
+        (e) => e.path === 'apps/web/src/components/detail/TaskHeader.tsx' && e.kind === 'file',
+      ),
+    ).toBeDefined();
+    expect(
+      out.find((e) => e.path === 'apps/web/src/components/detail' && e.kind === 'dir'),
+    ).toBeDefined();
     expect(out.length).toBeLessThanOrEqual(800);
   });
 

--- a/skills/spec-author/manifest.test.ts
+++ b/skills/spec-author/manifest.test.ts
@@ -39,4 +39,24 @@ describe('collectScopeManifest', () => {
     const out = collectScopeManifest(root, ['apps/web/src/components/detail']);
     expect(out.every((e) => !e.path.includes('node_modules'))).toBe(true);
   });
+
+  it('rejects absolute scopeRoot paths (security: path traversal)', () => {
+    const root = scratchRepo();
+    // /etc is an absolute path outside repoRoot — must yield no entries
+    const out = collectScopeManifest(root, ['/etc']);
+    expect(out).toEqual([]);
+  });
+
+  it('rejects traversal scopeRoot paths that resolve outside repoRoot', () => {
+    const root = scratchRepo();
+    // ../../etc resolves above repoRoot — must yield no entries
+    const out = collectScopeManifest(root, ['../../etc']);
+    expect(out).toEqual([]);
+  });
+
+  it('accepts an innocuous relative scopeRoot inside repoRoot', () => {
+    const root = scratchRepo();
+    const out = collectScopeManifest(root, ['apps/web/src/components/detail']);
+    expect(out.some((e) => e.kind === 'file')).toBe(true);
+  });
 });

--- a/skills/spec-author/manifest.ts
+++ b/skills/spec-author/manifest.ts
@@ -1,6 +1,14 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, posix } from 'node:path';
 
+function isDirSync(abs: string): boolean {
+  try {
+    return statSync(abs).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 const SKIP_DIRS = new Set(['.git', 'node_modules', '.factory', 'dist', 'build', '.pnpm']);
 const MANIFEST_CAP = 800;
 
@@ -17,7 +25,7 @@ export function collectScopeManifest(
   for (const scope of scopeRoots) {
     if (out.length >= MANIFEST_CAP) break;
     const abs = join(repoRoot, scope);
-    if (!existsSync(abs)) continue;
+    if (!existsSync(abs) || !isDirSync(abs)) continue;
     walk(abs, scope, out);
   }
   return out.slice(0, MANIFEST_CAP);

--- a/skills/spec-author/manifest.ts
+++ b/skills/spec-author/manifest.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join, posix } from 'node:path';
+import { join, posix, resolve, sep } from 'node:path';
 
 function isDirSync(abs: string): boolean {
   try {
@@ -21,12 +21,17 @@ export function collectScopeManifest(
   repoRoot: string,
   scopeRoots: ReadonlyArray<string>,
 ): ManifestEntry[] {
+  const resolvedRoot = resolve(repoRoot);
   const out: ManifestEntry[] = [];
   for (const scope of scopeRoots) {
     if (out.length >= MANIFEST_CAP) break;
-    const abs = join(repoRoot, scope);
+    // Reject absolute paths and traversals outside repoRoot.
+    const abs = resolve(repoRoot, scope);
+    if (abs !== resolvedRoot && !abs.startsWith(resolvedRoot + sep)) continue;
     if (!existsSync(abs) || !isDirSync(abs)) continue;
-    walk(abs, scope, out);
+    // Derive POSIX-relative path from the resolved root for consistent output.
+    const rel = abs === resolvedRoot ? '.' : abs.slice(resolvedRoot.length + sep.length);
+    walk(abs, rel, out);
   }
   return out.slice(0, MANIFEST_CAP);
 }

--- a/skills/spec-author/manifest.ts
+++ b/skills/spec-author/manifest.ts
@@ -1,0 +1,46 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, posix } from 'node:path';
+
+const SKIP_DIRS = new Set(['.git', 'node_modules', '.factory', 'dist', 'build', '.pnpm']);
+const MANIFEST_CAP = 800;
+
+export interface ManifestEntry {
+  path: string; // repo-root relative POSIX
+  kind: 'file' | 'dir';
+}
+
+export function collectScopeManifest(
+  repoRoot: string,
+  scopeRoots: ReadonlyArray<string>,
+): ManifestEntry[] {
+  const out: ManifestEntry[] = [];
+  for (const scope of scopeRoots) {
+    if (out.length >= MANIFEST_CAP) break;
+    const abs = join(repoRoot, scope);
+    if (!existsSync(abs)) continue;
+    walk(abs, scope, out);
+  }
+  return out.slice(0, MANIFEST_CAP);
+}
+
+function walk(absDir: string, relDir: string, out: ManifestEntry[]): void {
+  if (out.length >= MANIFEST_CAP) return;
+  out.push({ path: relDir, kind: 'dir' });
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (out.length >= MANIFEST_CAP) return;
+    if (entry.isDirectory() && SKIP_DIRS.has(entry.name)) continue;
+    const rel = posix.join(relDir, entry.name);
+    const abs = join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      walk(abs, rel, out);
+    } else if (entry.isFile()) {
+      out.push({ path: rel, kind: 'file' });
+    }
+  }
+}

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -16,6 +16,7 @@ The `<task>` block contains:
 - `<scoutReports>` (optional) — JSON-stringified Wave-1 scout report digest metadata (M19.01). This is `scout-report-digest-v1`, not the raw scout report JSON. It includes top findings, high-confidence facts, files referenced, risks, contradictions, and artifact keys for full reports when they were offloaded.
 - `<wave2Reports>` (optional) — JSON-stringified Wave-2 deep-agent report digest metadata (interface-designer artefacts, risk-analyst register). This is also digest-first and may include artifact keys for full reports.
 - `<repairFeedback>` (optional) — validator errors from a prior attempt. When present, return a complete corrected JSON object and address every listed error.
+- `<existingFileManifest>` (optional) — JSON array `[{path, kind: 'file' | 'dir'}]` listing files and directories that already exist under the spec scopeRoots. Every WP `filesOwned[].path` that points to a non-test, non-`*.config.ts` production file under `apps/`, `core/`, `slices/`, or `skills/` MUST either appear in this manifest OR be annotated as `{ "path": "…", "status": "new" }`. The validator hard-rejects unannotated missing paths.
 
 **Fallback rule.** If `<scoutReports>` is absent (the swarm is not yet wired or not dispatched for this run), fall back to manual investigation: read the rooted workspace directly via the read bundle. The spec format does not require the swarm to be implementable.
 
@@ -58,6 +59,15 @@ A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/
 12. **`riskRegister`** — at least one risk when the spec touches `auth | session | crypto | secret` paths.
 
 ### Hard rules
+
+#### Grounded `filesOwned`
+
+Each WP `filesOwned` entry is one of:
+
+- A bare string path: `"apps/web/src/components/detail/TaskHeader.tsx"` — must exist in `<existingFileManifest>`.
+- An object `{ "path": "apps/web/src/components/detail/NewSection.tsx", "status": "new" }` — declares a file to be created. Validator skips the existence check.
+
+Do not invent paths. If `<existingFileManifest>` is absent, fall back to the manual investigation path and read the directory with `list_dir` before authoring `filesOwned`.
 
 #### File ownership (full-stop, not per-batch)
 

--- a/skills/spec-author/schema.ts
+++ b/skills/spec-author/schema.ts
@@ -73,10 +73,33 @@ export const InterfaceContractSchema = z.object({
   lineRange: optionalAiString,
 });
 
+export const FileOwnedEntrySchema = z.union([
+  z.string().min(1).describe(RepoRelativePathDescription),
+  z.object({
+    path: z.string().min(1).describe(RepoRelativePathDescription),
+    status: z.enum(['existing', 'new']).optional(),
+  }),
+]);
+
+/**
+ * Extract the file path from a FileOwnedEntry (bare string or annotated object).
+ */
+export function fileOwnedPath(entry: z.infer<typeof FileOwnedEntrySchema>): string {
+  return typeof entry === 'string' ? entry : entry.path;
+}
+
+/**
+ * Extract the status from a FileOwnedEntry. Bare strings are treated as 'existing'.
+ */
+export function fileOwnedStatus(entry: z.infer<typeof FileOwnedEntrySchema>): 'existing' | 'new' {
+  if (typeof entry === 'string') return 'existing';
+  return entry.status ?? 'existing';
+}
+
 export const WorkPackageSchema = z.object({
   id: z.string().min(1),
   /** Paths this WP owns. No path may appear in two WPs (full-stop, not per-batch). */
-  filesOwned: z.array(z.string().min(1).describe(RepoRelativePathDescription)).min(1),
+  filesOwned: z.array(FileOwnedEntrySchema).min(1),
   /** Description of changes — file:line citations encouraged. */
   changes: z.string().min(1),
   /** WP ids this WP depends on; must reference real WPs in the spec. */

--- a/skills/spec-author/skill.config.ts
+++ b/skills/spec-author/skill.config.ts
@@ -67,6 +67,11 @@ export const SpecAuthorContextSchema = z.object({
   investigationSynthesis: z.string().optional(),
   /** One-shot validation feedback when the workflow retries a mechanically invalid spec. */
   repairFeedback: z.string().optional(),
+  /** Capped list of files+dirs under the spec scopeRoots. Use to ground WP filesOwned. */
+  existingFileManifest: z
+    .array(z.object({ path: z.string(), kind: z.enum(['file', 'dir']) }))
+    .optional()
+    .describe('Capped list of files+dirs under the spec scopeRoots. Use to ground WP filesOwned.'),
 });
 
 const config: SkillConfig = {
@@ -83,6 +88,7 @@ const config: SkillConfig = {
     'wave2Reports',
     'investigationSynthesis',
     'repairFeedback',
+    'existingFileManifest',
   ],
   /**
    * Read bundle: spec-author authors a JSON artefact in its terminal

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -862,3 +862,87 @@ describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () =
     expect(testFileErrors).toHaveLength(0);
   });
 });
+
+// ─── Per-file self-check-grounded-in-code ────────────────────────────────────
+
+describe('self-check-grounded-in-code (per-file)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'spec-author-validate-'));
+  mkdirSync(join(tmp, 'apps/web/src/components/detail'), { recursive: true });
+  writeFileSync(join(tmp, 'apps/web/src/components/detail/TaskHeader.tsx'), '');
+
+  it('errors when a WP filesOwned entry is a missing production .tsx without status:new', () => {
+    const result = validateEngineeringSpec(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: [
+              'apps/web/src/components/detail/TaskHeader.tsx', // exists
+              'apps/web/src/components/detail/OverviewSection.tsx', // missing
+            ],
+            changes: 'Add TaskHeader and OverviewSection components.',
+            dependsOn: [],
+            builderTier: 'haiku',
+          },
+        ],
+        executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+        interfaceContracts: [],
+      }),
+      { repoRoot: tmp },
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      (result as { ok: false; errors: Array<{ rule: string; message: string }> }).errors.some(
+        (e) =>
+          e.rule === 'self-check-grounded-in-code' && e.message.includes('OverviewSection.tsx'),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts missing files when annotated as status:new', () => {
+    const result = validateEngineeringSpec(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: [
+              { path: 'apps/web/src/components/detail/OverviewSection.tsx', status: 'new' },
+              // test file also new — exempt from grounding check
+              'apps/web/src/components/detail/OverviewSection.test.tsx',
+            ],
+            changes: 'Add OverviewSection component and test.',
+            dependsOn: [],
+            builderTier: 'haiku',
+          },
+        ],
+        executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+        interfaceContracts: [],
+      }),
+      { repoRoot: tmp },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips existence check for *.test.ts, *.spec.ts, *.config.ts, *.d.ts (still allowed to plan new)', () => {
+    const result = validateEngineeringSpec(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: [
+              'apps/web/src/components/detail/TaskHeader.test.tsx', // missing test file — ok
+              'apps/web/src/components/detail/TaskHeader.tsx', // existing prod file
+            ],
+            changes: 'Add TaskHeader component and test.',
+            dependsOn: [],
+            builderTier: 'haiku',
+          },
+        ],
+        executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+        interfaceContracts: [],
+      }),
+      { repoRoot: tmp },
+    );
+    expect(result.ok).toBe(true);
+  });
+});

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -945,4 +945,35 @@ describe('self-check-grounded-in-code (per-file)', () => {
     );
     expect(result.ok).toBe(true);
   });
+
+  it('errors when a sensitive missing path triggers grounding error (no sensitive skip)', () => {
+    // Sensitive paths (auth/secret/crypto/session) must also be grounded in the worktree.
+    // Previously these were skipped via sensitivePattern.test(path) — that skip is removed.
+    const result = validateEngineeringSpec(
+      baseSpec({
+        workPackages: [
+          {
+            id: 'WP1',
+            filesOwned: [
+              // Missing sensitive file — should trigger grounding error, not be silently skipped.
+              'apps/web/src/auth/SecretHandler.tsx',
+            ],
+            changes: 'Add secret handler.',
+            dependsOn: [],
+            builderTier: 'haiku',
+          },
+        ],
+        executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+        interfaceContracts: [],
+        riskRegister: [{ id: 'R1', description: 'Secret exposure', mitigation: 'Encrypt at rest' }],
+      }),
+      { repoRoot: tmp },
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      (result as { ok: false; errors: Array<{ rule: string; message: string }> }).errors.some(
+        (e) => e.rule === 'self-check-grounded-in-code' && e.message.includes('SecretHandler.tsx'),
+      ),
+    ).toBe(true);
+  });
 });

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -4,7 +4,12 @@ import {
   discoverPackageRoots,
   normalizeRepoRelativePath,
 } from '@goose-hub/core/workspaces/path-normalization.js';
-import { CONSTRAINT_SOURCE_PATTERN, type EngineeringSpec } from './schema.js';
+import {
+  CONSTRAINT_SOURCE_PATTERN,
+  type EngineeringSpec,
+  fileOwnedPath,
+  fileOwnedStatus,
+} from './schema.js';
 
 /**
  * Engineering Spec validators (M19.02, issue #559).
@@ -100,7 +105,8 @@ export function validateEngineeringSpec(
   // ── File ownership: same path may not appear in two WPs (full-stop). ──
   const ownerByPath = new Map<string, string>();
   for (const wp of spec.workPackages) {
-    for (const path of wp.filesOwned) {
+    for (const entry of wp.filesOwned) {
+      const path = fileOwnedPath(entry);
       const prior = ownerByPath.get(path);
       if (prior != null && prior !== wp.id) {
         errors.push({
@@ -145,7 +151,7 @@ export function validateEngineeringSpec(
   }
 
   // ── Sensitive-path risk-register requirement. ──
-  const allFilesOwned = spec.workPackages.flatMap((wp) => wp.filesOwned);
+  const allFilesOwned = spec.workPackages.flatMap((wp) => wp.filesOwned.map(fileOwnedPath));
   const sensitiveTouches = allFilesOwned.filter((p) => sensitivePattern.test(p));
   if (sensitiveTouches.length > 0 && spec.riskRegister.length === 0) {
     errors.push({
@@ -305,8 +311,9 @@ export function validateEngineeringSpec(
     (f.endsWith('.ts') || f.endsWith('.tsx')) && !EXEMPT_SUFFIX.test(f);
   const isTestFile = (f: string) => /\.(test|spec)\.(ts|tsx)$/.test(f);
   for (const wp of spec.workPackages) {
-    const hasProductionTs = wp.filesOwned.some(isProductionTs);
-    const hasTestFile = wp.filesOwned.some(isTestFile);
+    const paths = wp.filesOwned.map(fileOwnedPath);
+    const hasProductionTs = paths.some(isProductionTs);
+    const hasTestFile = paths.some(isTestFile);
     if (hasProductionTs && !hasTestFile) {
       errors.push({
         rule: 'wp-missing-test-file',
@@ -362,33 +369,28 @@ export function validateEngineeringSpec(
     });
   }
 
-  // 2. Grounded in code — when repoRoot is provided, verify each WP file
-  //    actually exists in the worktree. (Constraint source check above is
-  //    a strict subset of this; this catches WP filesOwned that don't yet
-  //    exist either.) Soft check: only fire on files that *should* already
-  //    exist (not on files the WP plans to create). Since the spec doesn't
-  //    distinguish create vs modify, we only emit a warning-level error
-  //    when none of the WP's files exist. That suggests a typo, not a
-  //    plan to create a new module.
+  // 2. Grounded in code — per-file existence check. Production files under
+  //    apps/, core/, slices/, skills/ must exist in the worktree OR be
+  //    annotated { status: 'new' }. Test, config, and .d.ts files are exempt.
+  const GROUNDABLE_SCOPE_RE = /^(apps|core|slices|skills)\//;
+  const EXEMPT_SUFFIX_FOR_GROUNDING = /\.(test|spec)\.(ts|tsx)$|\.(config|d)\.ts$/;
+
   if (options.repoRoot != null) {
     const repoRoot = options.repoRoot;
     for (const wp of spec.workPackages) {
-      const anyExists = wp.filesOwned.some((p) => existsSync(join(repoRoot, p)));
-      // Skip when WP touches sensitive paths (likely brand-new modules).
-      if (!anyExists && !wp.filesOwned.some((p) => sensitivePattern.test(p))) {
-        // Soft signal — emit only if filesOwned ALL look like they should
-        // exist (e.g. paths under existing directories) but none do.
-        const allLookExisting = wp.filesOwned.every((p) => {
-          const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
-          return existsSync(join(repoRoot, dir));
+      for (const entry of wp.filesOwned) {
+        const path = fileOwnedPath(entry);
+        const status = fileOwnedStatus(entry);
+        if (status === 'new') continue;
+        if (!GROUNDABLE_SCOPE_RE.test(path)) continue;
+        if (EXEMPT_SUFFIX_FOR_GROUNDING.test(path)) continue;
+        if (sensitivePattern.test(path)) continue;
+        if (existsSync(join(repoRoot, path))) continue;
+        errors.push({
+          rule: 'self-check-grounded-in-code',
+          message: `WP '${wp.id}' filesOwned path '${path}' does not exist in worktree and is not annotated status:'new'. Either fix the path or declare it as a new file.`,
+          ref: wp.id,
         });
-        if (allLookExisting) {
-          errors.push({
-            rule: 'self-check-grounded-in-code',
-            message: `WP '${wp.id}' files do not exist in worktree but their parent dirs do — possible typo`,
-            ref: wp.id,
-          });
-        }
       }
     }
   }

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -384,7 +384,6 @@ export function validateEngineeringSpec(
         if (status === 'new') continue;
         if (!GROUNDABLE_SCOPE_RE.test(path)) continue;
         if (EXEMPT_SUFFIX_FOR_GROUNDING.test(path)) continue;
-        if (sensitivePattern.test(path)) continue;
         if (existsSync(join(repoRoot, path))) continue;
         errors.push({
           rule: 'self-check-grounded-in-code',

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -45,7 +45,7 @@ import {
   resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
 import { ImplementWpSchema } from '@goose-hub/skills/implement-wp/schema.js';
-import type { EngineeringSpec } from '@goose-hub/skills/spec-author/schema.js';
+import { type EngineeringSpec, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import { normalizeEngineeringSpecPaths } from '../spec-author/path-normalization.js';
 import { buildPrdPlanningContext } from '../spec-author/prd-planning-context.js';
 import {
@@ -359,7 +359,9 @@ export async function runParallelImplementWorkflow(
   let issueWorktreePath: string | undefined;
 
   try {
-    const plannedWpFiles = specForRun.workPackages.flatMap((wp) => wp.filesOwned);
+    const plannedWpFiles = specForRun.workPackages.flatMap((wp) =>
+      wp.filesOwned.map(fileOwnedPath),
+    );
     if (!pathsTouchInvestigationSurface(plannedWpFiles, investigation)) {
       append({
         projectId,
@@ -534,9 +536,10 @@ export async function runParallelImplementWorkflow(
               observedPaths: changedPaths,
             });
 
+            const wpOwnedPaths = wp.filesOwned.map(fileOwnedPath);
             const outsideOwned = observedOutsideOwned({
               observedPaths: changedPaths,
-              filesOwned: wp.filesOwned,
+              filesOwned: wpOwnedPaths,
             });
             if (outsideOwned.length > 0) {
               const reason = `observed changes outside filesOwned: ${outsideOwned.join(', ')}`;
@@ -550,7 +553,7 @@ export async function runParallelImplementWorkflow(
                   wpId: wp.id,
                   gate: 'implement-wp-observed-changes',
                   reason: 'observed-changes-outside-files-owned',
-                  filesOwned: compactPaths(wp.filesOwned),
+                  filesOwned: compactPaths(wpOwnedPaths),
                   observedChangedFiles: compactPaths(changedPaths),
                   outsideOwned: compactPaths(outsideOwned),
                 },
@@ -599,7 +602,7 @@ export async function runParallelImplementWorkflow(
               payload: { wpId: wp.id, wpRunId, errorReason: reason },
               runId: wpRunId,
             });
-            revertFn(scratchWorktreePath, wp.filesOwned);
+            revertFn(scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
             recordFn(runId, wp.id, iteration, 'failed', `commit-failed: ${reason}`);
             allWpResults.push({
               wpId: wp.id,

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -24,7 +24,7 @@ import {
 } from '@goose-hub/core/workspaces/path-normalization.js';
 import { ImplementWpSchema } from '@goose-hub/skills/implement-wp/schema.js';
 import type { ImplementWpOutput } from '@goose-hub/skills/implement-wp/schema.js';
-import type { WorkPackage } from '@goose-hub/skills/spec-author/schema.js';
+import { type WorkPackage, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import type { PrdPlanningContext } from '../spec-author/prd-planning-context.js';
 import type { recordWpIteration } from './parallel-helpers.js';
 
@@ -88,12 +88,14 @@ function normalizeWpFilesOwned(input: {
 }): { wp: WorkPackage; fields: NormalizedPathField[]; ambiguousFields: NormalizedPathField[] } {
   const packageRoots = discoverPackageRoots(input.worktreePath);
   const fields: NormalizedPathField[] = [];
-  const filesOwned = input.wp.filesOwned.map((rawPath, index) => {
+  const rawPaths = input.wp.filesOwned.map(fileOwnedPath);
+  const filesOwned = input.wp.filesOwned.map((entry, index) => {
+    const rawPath = fileOwnedPath(entry);
     const result = normalizeRepoRelativePath({
       rawPath,
       worktreePath: input.worktreePath,
       packageRoots,
-      referencePaths: input.wp.filesOwned,
+      referencePaths: rawPaths,
     });
     if (result.path !== rawPath || result.ambiguous != null) {
       fields.push({
@@ -104,7 +106,8 @@ function normalizeWpFilesOwned(input: {
         ...(result.ambiguous != null && { ambiguous: result.ambiguous }),
       });
     }
-    return result.path;
+    if (typeof entry === 'string') return result.path;
+    return { ...entry, path: result.path };
   });
   return {
     wp: { ...input.wp, filesOwned },
@@ -126,7 +129,7 @@ function normalizeImplementWpOutputPaths(input: {
 } {
   const packageRoots = discoverPackageRoots(input.worktreePath);
   const referencePaths = [
-    ...input.wp.filesOwned,
+    ...input.wp.filesOwned.map(fileOwnedPath),
     ...input.output.filesWritten.map((file) => file.path),
     ...input.output.testsWritten.map((test) => test.path),
     ...input.output.testsRun.paths,
@@ -303,21 +306,22 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       runId: wpRunId,
     });
   }
+  const wpFilePaths = wp.filesOwned.map(fileOwnedPath);
   const codeSnippets = buildCodeSnippets({
     worktreePath: opts.scratchWorktreePath,
-    filesOwned: wp.filesOwned,
+    filesOwned: wpFilePaths,
   });
   const codeContext =
     opts.investigation == null
       ? []
       : buildCodeContextBundle({
           worktreePath: opts.scratchWorktreePath,
-          keyFiles: opts.investigation.keyFiles.filter((file) => wp.filesOwned.includes(file.path)),
+          keyFiles: opts.investigation.keyFiles.filter((file) => wpFilePaths.includes(file.path)),
         });
   const verificationCommands = wpRelevantExecutableChecks({
     acceptanceContract: opts.acceptanceContract,
     verificationCommands: opts.verificationCommands,
-    filesOwned: wp.filesOwned,
+    filesOwned: wpFilePaths,
   });
 
   const spawnSpec: AgentSpec = {
@@ -336,7 +340,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       },
       wp: {
         id: wp.id,
-        filesOwned: wp.filesOwned,
+        filesOwned: wpFilePaths,
         changes: wp.changes,
         dependsOn: wp.dependsOn,
       },
@@ -405,7 +409,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
 
   // Write WP sandbox fresh for each spawn attempt (covers retries and preserves
   // decision-capture hook when experimental.recordDecisionTool is enabled).
-  writeWpBuilderSandbox(opts.scratchWorktreePath, wp.filesOwned, wp.id, {
+  writeWpBuilderSandbox(opts.scratchWorktreePath, wpFilePaths, wp.id, {
     role: 'developer',
     recordDecisionTool: getRecordDecisionTool(projectId),
   });
@@ -438,7 +442,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       payload: { wpId: wp.id, wpRunId, elapsedMs: Date.now() - start },
       runId: wpRunId,
     });
-    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned);
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
     opts.recordIterationFn(runId, wp.id, iteration, 'failed', 'timeout');
     return { status: 'timeout', wpId: wp.id, errorReason: 'timeout', runId: wpRunId };
   }
@@ -451,7 +455,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       payload: { wpId: wp.id, wpRunId, errorReason: errorReason ?? 'unknown' },
       runId: wpRunId,
     });
-    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned);
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
     opts.recordIterationFn(runId, wp.id, iteration, 'failed', errorReason ?? 'unknown');
     return { status: 'failed', wpId: wp.id, errorReason: errorReason ?? 'unknown', runId: wpRunId };
   }
@@ -468,7 +472,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       payload: { wpId: wp.id, wpRunId, errorReason: reason },
       runId: wpRunId,
     });
-    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned);
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
     opts.recordIterationFn(runId, wp.id, iteration, 'failed', reason);
     return { status: 'failed', wpId: wp.id, errorReason: reason, runId: wpRunId };
   }
@@ -503,7 +507,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       payload: { wpId: wp.id, wpRunId, errorReason: reason },
       runId: wpRunId,
     });
-    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned);
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
     opts.recordIterationFn(runId, wp.id, iteration, 'failed', reason);
     return { status: 'failed', wpId: wp.id, errorReason: reason, runId: wpRunId };
   }

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -402,7 +402,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     appendSystemPrompt: opts.implementWpPrompt,
     sandboxMode: 'preconfigured', // writeWpBuilderSandbox already ran in workflow.ts before spawn
     env: {
-      FACTORY_WP_FILESOWNED: wp.filesOwned.join(':'),
+      FACTORY_WP_FILESOWNED: wpFilePaths.join(':'),
       FACTORY_WP_ID: wp.id,
     },
   };

--- a/slices/spec-author/path-normalization.ts
+++ b/slices/spec-author/path-normalization.ts
@@ -3,7 +3,7 @@ import {
   discoverPackageRoots,
   normalizeRepoRelativePath,
 } from '@goose-hub/core/workspaces/path-normalization.js';
-import type { EngineeringSpec } from '@goose-hub/skills/spec-author/schema.js';
+import { type EngineeringSpec, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 
 export type SpecPathNormalizationField = {
   field: string;
@@ -25,7 +25,7 @@ export function normalizeEngineeringSpecPaths(input: {
   const packageRoots = discoverPackageRoots(input.worktreePath);
   const fields: SpecPathNormalizationField[] = [];
   const referencePaths = [
-    ...input.spec.workPackages.flatMap((wp) => wp.filesOwned),
+    ...input.spec.workPackages.flatMap((wp) => wp.filesOwned.map(fileOwnedPath)),
     ...input.spec.interfaceContracts.map((contract) => contract.file),
     ...input.spec.schemaChanges.migrations,
     ...(input.referencePaths ?? []),
@@ -64,9 +64,15 @@ export function normalizeEngineeringSpecPaths(input: {
     })),
     workPackages: input.spec.workPackages.map((wp, wpIndex) => ({
       ...wp,
-      filesOwned: wp.filesOwned.map((path, pathIndex) =>
-        normalizeField(`workPackages[${wpIndex}].filesOwned[${pathIndex}]`, path),
-      ),
+      filesOwned: wp.filesOwned.map((entry, pathIndex) => {
+        const rawPath = fileOwnedPath(entry);
+        const normalized = normalizeField(
+          `workPackages[${wpIndex}].filesOwned[${pathIndex}]`,
+          rawPath,
+        );
+        if (typeof entry === 'string') return normalized;
+        return { ...entry, path: normalized };
+      }),
     })),
   };
 

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -1028,6 +1028,95 @@ describe('runSpecAuthorWorkflow', () => {
       );
     });
 
+    it('derives scopeRoots from investigationSynthesis.keyFiles only (PRD slices have no .path field)', async () => {
+      const { collectScopeManifest } = await import('@goose-hub/skills/spec-author/manifest.js');
+
+      vi.mocked(eventStore.replay).mockImplementation((query?: { kind?: string }) => {
+        if (query?.kind === 'agent.investigation-complete') {
+          return [
+            {
+              id: 1,
+              projectId: 'goose-hub-self',
+              workItemId: 'github:shaunnez/goose-hub#55',
+              kind: 'agent.investigation-complete',
+              payload: {
+                investigationRunId: null,
+                investigate: {
+                  findings: 'Core service needs update.',
+                  keyFiles: [{ path: 'core/service/index.ts' }],
+                  confidence: 'high',
+                  openQuestions: [],
+                },
+              },
+              runId: 'inv-run',
+              createdAt: '2026-05-14T00:00:00Z',
+            },
+          ] as never;
+        }
+        if (query?.kind === 'prd.drafted') {
+          return [
+            {
+              id: 10,
+              projectId: 'goose-hub-self',
+              workItemId: 'github:shaunnez/goose-hub#55',
+              kind: 'prd.drafted',
+              payload: {
+                prd: {
+                  title: 'Some PRD',
+                  problem: 'Problem.',
+                  proposedSolution: 'Solution.',
+                  successCriteria: [],
+                  acceptanceCriteria: [],
+                  journeys: [],
+                  functionalSpec: null,
+                  // verticalSlices have no .path field — title/goal/estimatedSize/journeyRefs only
+                  verticalSlices: [
+                    { title: 'Slice A', goal: 'Do A', estimatedSize: 'S', journeyRefs: [] },
+                  ],
+                  implementationDecisions: [],
+                  testingDecisions: null,
+                },
+              },
+              runId: 'prd-run',
+              personaId: null,
+              createdAt: '2026-05-22T00:00:00.000Z',
+            },
+          ] as never;
+        }
+        return [];
+      });
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(
+        makeWorkItem({ type: 'feature' }),
+        makeMockSource(),
+        'goose-hub-self',
+        '/repo',
+      );
+
+      // scopeRoots should be derived from investigationSynthesis.keyFiles only
+      expect(collectScopeManifest).toHaveBeenCalledWith(
+        '/tmp/test-spec-worktree',
+        expect.arrayContaining(['core/service']),
+      );
+      // Should NOT contain anything from PRD verticalSlices (they have no .path)
+      const call = vi.mocked(collectScopeManifest).mock.calls[0];
+      const roots = call?.[1] ?? [];
+      expect(roots).not.toContain('Slice A');
+    });
+
+    it('omits existingFileManifest from context when collectScopeManifest returns []', async () => {
+      // collectScopeManifest is mocked to return [] by default
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(mockInvokeSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.not.objectContaining({ existingFileManifest: expect.anything() }),
+        }),
+      );
+    });
+
     it('blocks ambiguous package-relative filesOwned before persistence', async () => {
       touchSpecWorktree('apps/web/src/index.ts');
       touchSpecWorktree('apps/server/src/index.ts');

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -23,6 +23,10 @@ vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
   invokeSkill: (...args: unknown[]) => mockInvokeSkill(...args),
 }));
 
+vi.mock('@goose-hub/skills/spec-author/manifest.js', () => ({
+  collectScopeManifest: vi.fn().mockReturnValue([]),
+}));
+
 vi.mock('@goose-hub/skills/spec-author/validate.js', () => ({
   validateEngineeringSpec: (...args: unknown[]) => mockValidateEngineeringSpec(...args),
 }));
@@ -976,6 +980,52 @@ describe('runSpecAuthorWorkflow', () => {
         phase: 'wave1',
         artifactKeys: ['scout-report:abc'],
       });
+    });
+
+    it('injects existingFileManifest derived from investigationSynthesis keyFiles into context', async () => {
+      const { collectScopeManifest } = await import('@goose-hub/skills/spec-author/manifest.js');
+      vi.mocked(collectScopeManifest).mockReturnValueOnce([
+        { path: 'apps/web/src/components/detail', kind: 'dir' },
+        { path: 'apps/web/src/components/detail/TaskHeader.tsx', kind: 'file' },
+      ]);
+
+      vi.mocked(eventStore.replay).mockReturnValue([
+        {
+          id: 1,
+          projectId: 'goose-hub-self',
+          workItemId: 'github:shaunnez/goose-hub#55',
+          kind: 'agent.investigation-complete',
+          payload: {
+            investigationRunId: null,
+            investigate: {
+              findings: 'The component renders incorrectly.',
+              keyFiles: [{ path: 'apps/web/src/components/detail/TaskHeader.tsx' }],
+              confidence: 'high',
+              openQuestions: [],
+            },
+          },
+          runId: 'investigation-run',
+          createdAt: '2026-05-14T00:00:00Z',
+        },
+      ] as never);
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(collectScopeManifest).toHaveBeenCalledWith(
+        '/tmp/test-spec-worktree',
+        expect.arrayContaining(['apps/web/src/components/detail']),
+      );
+      expect(mockInvokeSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({
+            existingFileManifest: [
+              { path: 'apps/web/src/components/detail', kind: 'dir' },
+              { path: 'apps/web/src/components/detail/TaskHeader.tsx', kind: 'file' },
+            ],
+          }),
+        }),
+      );
     });
 
     it('blocks ambiguous package-relative filesOwned before persistence', async () => {

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -252,12 +252,8 @@ function deriveSpecScopeRoots(input: {
     }
   }
 
-  for (const s of input.prdContext?.verticalSlices ?? []) {
-    if (s != null && typeof s === 'object') {
-      const path = (s as { path?: unknown }).path;
-      if (typeof path === 'string' && path.length > 0) roots.add(path);
-    }
-  }
+  // PRD vertical slices have fields title/goal/estimatedSize/journeyRefs — no .path field.
+  // Scope roots are derived solely from investigationSynthesis.keyFiles above.
 
   return Array.from(roots);
 }
@@ -405,7 +401,8 @@ export async function runSpecAuthorWorkflow(
       scoutReports,
       wave2Reports,
       investigationSynthesis,
-      existingFileManifest,
+      // Omit when empty so the prompt's fallback behaviour (keyed on field absence) fires correctly.
+      ...(existingFileManifest.length > 0 && { existingFileManifest }),
     };
 
     if (prdContext != null) {

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -21,6 +21,7 @@ import {
   type ValidationResult,
   validateEngineeringSpec,
 } from '@goose-hub/skills/spec-author/validate.js';
+import { collectScopeManifest } from '@goose-hub/skills/spec-author/manifest.js';
 import { normalizeEngineeringSpecPaths } from './path-normalization.js';
 import { type PrdPlanningContext, buildPrdPlanningContext } from './prd-planning-context.js';
 import { createWpIssueProjections } from './wp-issue-projection.js';
@@ -65,6 +66,7 @@ type SpecAuthorContext = {
   scoutReports?: string;
   wave2Reports?: string;
   investigationSynthesis?: string;
+  existingFileManifest?: Array<{ path: string; kind: 'file' | 'dir' }>;
 };
 
 type SpecAttempt = {
@@ -216,6 +218,48 @@ function investigationKeyFilePaths(event: { payload: unknown } | undefined): str
   });
 }
 
+function dirOf(p: string): string {
+  const slash = p.lastIndexOf('/');
+  return slash === -1 ? '' : p.slice(0, slash);
+}
+
+function deriveSpecScopeRoots(input: {
+  prdContext?: { verticalSlices?: Array<unknown> };
+  investigationSynthesis?: string;
+}): string[] {
+  const roots = new Set<string>();
+
+  if (input.investigationSynthesis != null) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input.investigationSynthesis);
+    } catch {
+      parsed = null;
+    }
+    const keyFiles = (parsed as { keyFiles?: unknown } | null)?.keyFiles;
+    if (Array.isArray(keyFiles)) {
+      for (const file of keyFiles) {
+        if (file != null && typeof file === 'object') {
+          const path = (file as { path?: unknown }).path;
+          if (typeof path === 'string' && path.length > 0) {
+            const d = dirOf(path);
+            if (d.length > 0) roots.add(d);
+          }
+        }
+      }
+    }
+  }
+
+  for (const s of input.prdContext?.verticalSlices ?? []) {
+    if (s != null && typeof s === 'object') {
+      const path = (s as { path?: unknown }).path;
+      if (typeof path === 'string' && path.length > 0) roots.add(path);
+    }
+  }
+
+  return Array.from(roots);
+}
+
 function stringifyScoutDigestForContext(
   reports: ReturnType<typeof buildScoutReportDigestBundle>['reports'],
 ): string {
@@ -346,6 +390,9 @@ export async function runSpecAuthorWorkflow(
       }
     }
 
+    const scopeRoots = deriveSpecScopeRoots({ prdContext, investigationSynthesis });
+    const existingFileManifest = collectScopeManifest(worktreePath, scopeRoots);
+
     const baseContext: SpecAuthorContext = {
       workItem: workItemCtx,
       issueType: workItem.type === 'bug' ? 'bug' : 'feature',
@@ -356,6 +403,7 @@ export async function runSpecAuthorWorkflow(
       scoutReports,
       wave2Reports,
       investigationSynthesis,
+      existingFileManifest,
     };
 
     if (prdContext != null) {

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -13,6 +13,7 @@ import {
   createWorktree,
   resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
+import { collectScopeManifest } from '@goose-hub/skills/spec-author/manifest.js';
 import {
   type EngineeringSpec,
   EngineeringSpecSchema,
@@ -21,7 +22,6 @@ import {
   type ValidationResult,
   validateEngineeringSpec,
 } from '@goose-hub/skills/spec-author/validate.js';
-import { collectScopeManifest } from '@goose-hub/skills/spec-author/manifest.js';
 import { normalizeEngineeringSpecPaths } from './path-normalization.js';
 import { type PrdPlanningContext, buildPrdPlanningContext } from './prd-planning-context.js';
 import { createWpIssueProjections } from './wp-issue-projection.js';

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -17,6 +17,7 @@ import { collectScopeManifest } from '@goose-hub/skills/spec-author/manifest.js'
 import {
   type EngineeringSpec,
   EngineeringSpecSchema,
+  fileOwnedPath,
 } from '@goose-hub/skills/spec-author/schema.js';
 import {
   type ValidationResult,
@@ -162,7 +163,8 @@ function emitSpecContractGateBlocked(input: {
 function duplicateFilesOwned(spec: EngineeringSpec): DuplicateOwnedPath[] {
   const ownersByPath = new Map<string, Set<string>>();
   for (const wp of spec.workPackages) {
-    for (const path of wp.filesOwned) {
+    for (const entry of wp.filesOwned) {
+      const path = fileOwnedPath(entry);
       const owners = ownersByPath.get(path) ?? new Set<string>();
       owners.add(wp.id);
       ownersByPath.set(path, owners);

--- a/slices/spec-author/wp-issue-projection.ts
+++ b/slices/spec-author/wp-issue-projection.ts
@@ -1,5 +1,9 @@
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
-import type { EngineeringSpec, WorkPackage } from '@goose-hub/skills/spec-author/schema.js';
+import {
+  type EngineeringSpec,
+  type WorkPackage,
+  fileOwnedPath,
+} from '@goose-hub/skills/spec-author/schema.js';
 
 type WpProjection = {
   wp: WorkPackage;
@@ -56,7 +60,7 @@ function buildProjectionBody(input: {
     `Dependency batch: ${input.batch ?? 'unbatched'}`,
     '',
     '### Owned files',
-    bulletList(input.wp.filesOwned.map((path) => `\`${path}\``)),
+    bulletList(input.wp.filesOwned.map((entry) => `\`${fileOwnedPath(entry)}\``)),
     '',
     '### Changes',
     input.wp.changes,


### PR DESCRIPTION
## Summary

G2 of the 1021–1023 failure-cascade plan.

- **Task 4**: add `collectScopeManifest(repoRoot, scopeRoots)` helper in `skills/spec-author/manifest.ts`. Walks scopeRoots returning capped (800) `{path, kind: 'file' | 'dir'}` entries.
- **Task 5**: inject `existingFileManifest` into `SpecAuthorContextSchema` + wire into `slices/spec-author/workflow.ts`. Derives scopeRoots from `investigationSynthesis.keyFiles` + `prdContext.verticalSlices`.
- **Task 6**: promote `self-check-grounded-in-code` to per-file rule. `FileOwnedEntry` is now `string | {path, status: 'existing'|'new'}`. Production files under `apps/|core/|slices/|skills/` must exist OR be annotated `status:'new'`. Test, config, `.d.ts` files exempt.

Plus follow-up fix commits handling FileOwnedEntry propagation through downstream consumers (wp-issue-projection, server API, wp-builder env var) and guarding non-directory scopeRoots.

## Eval

| Metric | Pre | Target |
|---|---|---|
| spec-author runs with `self-check-grounded-in-code` failures | 5+ per failed spec | 0 unless agent genuinely typo'd; survivors caught at retry with explicit error |

## Test plan

- [x] `pnpm vitest run skills/spec-author slices/spec-author` — green
- [x] `pnpm test` — 4840 passed | 3 skipped
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm audit-docs` — clean

Depends on: #1028 (G1) — merged.
Related: #1021, #1022, #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)