### PR TITLE
M20.12: forward priorEvidenceSpecPath through fix-feedback

### DIFF
--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -21,6 +21,7 @@ The `<task>` block can include:
 - `<relatedSurface>` — deterministic execution lane from the workflow.
 - `<revisionPass>` — `0` or `1`.
 - `<evidencePostEnabled>` — whether frontend evidence specs should be produced.
+- `<priorEvidenceSpecPath>` — path to the evidence spec authored or reused by the prior dev/fix-feedback cycle on this work item, when present.
 
 `<relatedSurface>` is prescriptive unless stale:
 

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -100,6 +100,7 @@ report files that were only read.
 - Implement the smallest slice that satisfies the tests and every criterion in `<acceptanceContract>` when present.
 - Re-run targeted tests only after a real write has occurred, then iterate until green or blocked.
 - For frontend changes with evidence enabled, create/update `apps/web/e2e/issue-<number>.spec.ts` or the provided `relatedSurface.evidenceSpecPath`. Use bounded discovery; if blocked, return `evidenceSpecPath: null` with `TOOL_FAILURE` or `UNCERTAINTY`.
+- If `priorEvidenceSpecPath` is provided and your changes still touch `apps/web/`, reuse it as `evidenceSpecPath` unless the prior spec is now stale for the changed surface. If you cannot reuse it and cannot author a new one, return `evidenceSpecPath: null` with a `SKIP_GATE` decision summary explaining why (e.g., "evidence skipped: type-only handler export, no UI surface changed").
 - If evidence is disabled, return `evidenceSpecPath: null` with a `SKIP_GATE` summary.
 - Emit `[decision] GREEN: Targeted tests pass`.
 

--- a/skills/implement/skill.config.ts
+++ b/skills/implement/skill.config.ts
@@ -90,6 +90,13 @@ const config: SkillConfig = {
         doNotSearchFor: z.array(z.string()),
       })
       .optional(),
+    priorEvidenceSpecPath: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Path to the evidence spec authored or reused by the prior dev/fix-feedback cycle on this work item.',
+      ),
   }),
   outputSchema: ImplementSchema,
   contextAllowlist: [
@@ -107,6 +114,7 @@ const config: SkillConfig = {
     'revisionPass',
     'evidencePostEnabled',
     'acceptanceContract',
+    'priorEvidenceSpecPath',
   ],
   /**
    * `dev-tools` bundle — read, search, work-item-read, write, bash, test

--- a/skills/implement/skill.config.ts
+++ b/skills/implement/skill.config.ts
@@ -92,10 +92,9 @@ const config: SkillConfig = {
       .optional(),
     priorEvidenceSpecPath: z
       .string()
-      .nullable()
       .optional()
       .describe(
-        'Path to the evidence spec authored or reused by the prior dev/fix-feedback cycle on this work item.',
+        'Path to the evidence spec authored or reused by the prior dev/fix-feedback cycle on this work item. Omitted when no prior cycle exists; the call site coerces null → omission.',
       ),
   }),
   outputSchema: ImplementSchema,

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -618,4 +618,78 @@ describe('runFixFeedbackWorkflow', () => {
       expect(runCall.context.priorInvestigation).toBeUndefined();
     });
   });
+
+  describe('priorEvidenceSpecPath forwarding', () => {
+    it('forwards priorEvidenceSpecPath from the most recent implement-complete event', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([
+        makePrOpenedEvent(),
+        makeQaCompletedEvent(),
+        {
+          id: 5,
+          kind: 'agent.implement-complete' as EventKind,
+          payload: { runId: 'dev-1', evidenceSpecPath: 'apps/web/e2e/issue-123.spec.ts' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date().toISOString(),
+          runId: 'dev-1',
+        },
+      ]);
+      mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+      const workItem = makeWorkItem();
+
+      await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBe('apps/web/e2e/issue-123.spec.ts');
+      expect(runCall.contextAllowlist).toContain('priorEvidenceSpecPath');
+    });
+
+    it('forwards priorEvidenceSpecPath from the most recent fix-feedback-complete event', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([
+        makePrOpenedEvent(),
+        makeQaCompletedEvent(),
+        {
+          id: 5,
+          kind: 'agent.fix-feedback-complete' as EventKind,
+          payload: { repairCycle: 1, evidenceSpecPath: 'apps/web/e2e/issue-123.spec.ts' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date().toISOString(),
+          runId: 'fix-1',
+        },
+      ]);
+      mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBe('apps/web/e2e/issue-123.spec.ts');
+    });
+
+    it('omits priorEvidenceSpecPath when no relevant event exists', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent(), makeQaCompletedEvent()]);
+      mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBeUndefined();
+    });
+
+    it('includes evidenceSpecPath in agent.fix-feedback-complete payload', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent(), makeQaCompletedEvent()]);
+      mockClaudeCliRun.mockResolvedValue({
+        output: makeImplementOutput({ evidenceSpecPath: 'apps/web/e2e/issue-42.spec.ts' }),
+      });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const completeEvent = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([event]) => event.kind === 'agent.fix-feedback-complete')?.[0];
+      expect((completeEvent?.payload as { evidenceSpecPath?: unknown }).evidenceSpecPath).toBe(
+        'apps/web/e2e/issue-42.spec.ts',
+      );
+    });
+  });
 });

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -666,6 +666,37 @@ describe('runFixFeedbackWorkflow', () => {
       expect(runCall.context.priorEvidenceSpecPath).toBe('apps/web/e2e/issue-123.spec.ts');
     });
 
+    it('picks the most recent evidenceSpecPath when multiple events exist', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([
+        makePrOpenedEvent(),
+        {
+          id: 4,
+          kind: 'agent.implement-complete' as EventKind,
+          payload: { runId: 'dev-1', evidenceSpecPath: 'apps/web/e2e/old.spec.ts' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          runId: 'dev-1',
+        },
+        makeQaCompletedEvent(),
+        {
+          id: 6,
+          kind: 'agent.fix-feedback-complete' as EventKind,
+          payload: { repairCycle: 1, evidenceSpecPath: 'apps/web/e2e/new.spec.ts' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date().toISOString(),
+          runId: 'fix-1',
+        },
+      ]);
+      mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBe('apps/web/e2e/new.spec.ts');
+    });
+
     it('omits priorEvidenceSpecPath when no relevant event exists', async () => {
       vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent(), makeQaCompletedEvent()]);
       mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -186,6 +186,25 @@ function nextRepairCycle(events: ReturnType<typeof eventStore.replay>): number {
 }
 
 /**
+ * Scans events backward for the most recent `agent.implement-complete` or
+ * `agent.fix-feedback-complete` event that has a non-empty `evidenceSpecPath`,
+ * and returns it so the repair run can reuse the prior cycle's spec.
+ */
+function findPriorEvidenceSpecPath(events: ReturnType<typeof eventStore.replay>): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind !== 'agent.implement-complete' && e.kind !== 'agent.fix-feedback-complete') {
+      continue;
+    }
+    const payload = e.payload as { evidenceSpecPath?: unknown };
+    if (typeof payload.evidenceSpecPath === 'string' && payload.evidenceSpecPath.length > 0) {
+      return payload.evidenceSpecPath;
+    }
+  }
+  return null;
+}
+
+/**
  * Finds the most recent failure from either `qa.completed` (non-pass) or
  * `review.completed` (needs-fix), whichever is later in the event stream,
  * and formats it as advisor feedback for the implement skill.
@@ -398,6 +417,7 @@ export async function runFixFeedbackWorkflow(
   const priorInvestigationPayload = buildPriorInvestigationPayload(priorInvestigation);
   const priorDevDecisions = collectPriorDevDecisions(events, prLifecycle);
   const priorDevChangedFiles = collectPriorChangedFiles(worktreePath, prLifecycle?.baseBranch);
+  const priorEvidenceSpecPath = findPriorEvidenceSpecPath(events) ?? undefined;
 
   await stateSource.transitionState(
     workItem.externalId,
@@ -467,6 +487,7 @@ export async function runFixFeedbackWorkflow(
           priorInvestigation: priorInvestigationPayload,
           priorDevDecisions: priorDevDecisions.length > 0 ? priorDevDecisions : undefined,
           priorDevChangedFiles: priorDevChangedFiles.length > 0 ? priorDevChangedFiles : undefined,
+          priorEvidenceSpecPath,
         },
         contextAllowlist: [
           'workItem.title',
@@ -483,6 +504,7 @@ export async function runFixFeedbackWorkflow(
           'priorInvestigation.openQuestions',
           'priorDevDecisions',
           'priorDevChangedFiles',
+          'priorEvidenceSpecPath',
         ],
         freshContext: false,
         toolBundles: ['dev-tools'],
@@ -524,6 +546,7 @@ export async function runFixFeedbackWorkflow(
         testsWritten: implementOutput.testsWritten.length,
         confidence: implementOutput.confidence,
         testsRun: implementOutput.testsRun,
+        evidenceSpecPath: implementOutput.evidenceSpecPath,
         observedChangedFiles: {
           count: observedChangedFiles.count,
           paths: observedChangedFiles.paths,


### PR DESCRIPTION
## Summary

G3 of the 1021–1023 failure-cascade plan.

- **Task 7**: `slices/fix-feedback/workflow.ts` now scans events backward for the most recent `agent.implement-complete` or `agent.fix-feedback-complete` and forwards its `evidenceSpecPath` into the implement skill context as `priorEvidenceSpecPath`. `agent.fix-feedback-complete` payload now carries `evidenceSpecPath` so the next repair cycle can see it. Implement skill prompt + schema + allowlist updated.

Plus follow-up fix: backward-scan ordering test added; schema tightened to drop `.nullable()` (call site coerces null → omission); prompt Input section lists the new tag so skill-contract-audit passes.

## Eval

| Metric | Pre | Target |
|---|---|---|
| `agent.run-failed` `error: "contract gate blocked: evidenceSpecPath is required for apps/web changes"` on fix-feedback | observed on #1022 | 0 when prior dev cycle authored a spec |

## Test plan

- [x] `pnpm vitest run slices/fix-feedback skills/implement` — 91/91 green incl. new ordering test
- [x] `pnpm test` — 4848 passed | 3 skipped
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm audit-docs` — clean

Depends on: #1028 (G1) — merged. Pairs with #1029 (G2).
Related: #1021, #1022, #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)