### PR TITLE
M19.XX: test: add integration test exercising G1+G2+G3 cas

### DIFF
--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -463,7 +463,7 @@ describe('CodexCliRuntime timeout handling', () => {
     );
   });
 
-  it('audits a failed MCP resource read without killing the Codex run', async () => {
+  it('records resources/read failed as a non-fatal advisory event', async () => {
     const child = makeHangingChild();
     mockSpawn.mockReturnValue(child);
 
@@ -485,12 +485,11 @@ describe('CodexCliRuntime timeout handling', () => {
     await expect(run).resolves.toMatchObject({ output: { ok: true } });
     expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: 'agent.tool-call',
+        kind: 'agent.runtime-advisory',
         payload: expect.objectContaining({
-          tool_name: 'resources/read',
-          blocked: true,
-          block_reason: 'blocked-runtime-surface: resources/read failed',
-          status: 'failed',
+          surface: 'resources/read failed',
+          stderr: 'resources/read failed: file://memory',
+          toolName: 'resources/read',
         }),
         personaId: 'test-project/developer/0',
       }),

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -80,7 +80,17 @@ const BLOCKED_RUNTIME_SURFACE_PATTERNS: Array<{
   toolName: string;
   re: RegExp;
 }> = [
-  { surface: 'resources/read failed', toolName: 'resources/read', re: /resources\/read\s+failed/i },
+];
+const ADVISORY_RUNTIME_SURFACE_PATTERNS: Array<{
+  surface: string;
+  toolName: string;
+  re: RegExp;
+}> = [
+  {
+    surface: 'resources/read failed',
+    toolName: 'resources/read',
+    re: /resources\/read(?:\?path=[^\s]+)?(?:\s+failed|[^\n]*transient stderr)/i,
+  },
 ];
 
 function isPathUnderRoot(path: string, root: string): boolean {
@@ -182,6 +192,61 @@ function detectBlockedRuntimeSurface(line: string): {
     }
   }
   return null;
+}
+
+function parseRequestedPath(line: string): string | undefined {
+  const match = line.match(/resources\/read\?path=([^\s&]+)/i);
+  if (match == null) return undefined;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function detectRuntimeAdvisorySurface(line: string): {
+  surface: string;
+  toolName: string;
+  requestedPath?: string;
+} | null {
+  for (const pattern of ADVISORY_RUNTIME_SURFACE_PATTERNS) {
+    if (pattern.re.test(line)) {
+      return {
+        surface: pattern.surface,
+        toolName: pattern.toolName,
+        requestedPath: parseRequestedPath(line),
+      };
+    }
+  }
+  return null;
+}
+
+export function appendRuntimeAdvisoryEvent(input: {
+  line: string;
+  projectId: string;
+  workItemId: string | null;
+  runId: string;
+  personaId?: string;
+  skill: string;
+}): boolean {
+  const advisory = detectRuntimeAdvisorySurface(input.line);
+  if (advisory == null) return false;
+  eventStore.appendEvent({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    kind: 'agent.runtime-advisory',
+    payload: {
+      runId: input.runId,
+      skill: input.skill,
+      surface: advisory.surface,
+      stderr: input.line.slice(0, 4000),
+      toolName: advisory.toolName,
+      requestedPath: advisory.requestedPath,
+    },
+    runId: input.runId,
+    personaId: input.personaId,
+  });
+  return true;
 }
 
 function outputSchemaPathForRun(workspaceDir: string, runId: string): string {
@@ -620,10 +685,14 @@ export class CodexCliRuntime implements AgentRuntime {
             failForbiddenRuntimeSurface(violation);
             return;
           }
-          const blocked = detectBlockedRuntimeSurface(line);
-          if (blocked != null) {
-            emitForbiddenRuntimeSurfaceBlocked(blocked);
-          }
+          appendRuntimeAdvisoryEvent({
+            line,
+            projectId,
+            workItemId,
+            runId,
+            personaId,
+            skill: spec.skill,
+          });
         }
       });
 
@@ -710,10 +779,14 @@ export class CodexCliRuntime implements AgentRuntime {
             reject(new Error(violation.blockReason));
             return;
           }
-          const blocked = detectBlockedRuntimeSurface(stderrLineBuffer);
-          if (blocked != null) {
-            emitForbiddenRuntimeSurfaceBlocked(blocked);
-          }
+          appendRuntimeAdvisoryEvent({
+            line: stderrLineBuffer,
+            projectId,
+            workItemId,
+            runId,
+            personaId,
+            skill: spec.skill,
+          });
         }
 
         const envelope = parseCodexEnvelope(stdout);

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -75,12 +75,6 @@ const FORBIDDEN_RUNTIME_SURFACE_PATTERNS: Array<{
     re: /(?:full[- ]history.*(?:fork|spawn)|(?:fork|spawn).*full[- ]history).*(?:failed|error)/i,
   },
 ];
-const BLOCKED_RUNTIME_SURFACE_PATTERNS: Array<{
-  surface: string;
-  toolName: string;
-  re: RegExp;
-}> = [
-];
 const ADVISORY_RUNTIME_SURFACE_PATTERNS: Array<{
   surface: string;
   toolName: string;
@@ -175,23 +169,6 @@ function handleForbiddenRuntimeSurface(line: string): {
   blockReason: string;
 } | null {
   return detectForbiddenRuntimeSurface(line);
-}
-
-function detectBlockedRuntimeSurface(line: string): {
-  surface: string;
-  toolName: string;
-  blockReason: string;
-} | null {
-  for (const pattern of BLOCKED_RUNTIME_SURFACE_PATTERNS) {
-    if (pattern.re.test(line)) {
-      return {
-        surface: pattern.surface,
-        toolName: pattern.toolName,
-        blockReason: `blocked-runtime-surface: ${pattern.surface}`,
-      };
-    }
-  }
-  return null;
 }
 
 function parseRequestedPath(line: string): string | undefined {

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -11,6 +11,7 @@ export const EVENT_KINDS = [
   'manual.action',
   'agent.tool-call',
   'agent.tool-intensity-anomaly',
+  'agent.runtime-advisory',
   'tool.stdout-truncated',
   'tool.timeout',
   'agent.run-started',

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -120,6 +120,7 @@ export const RUNTIME_INHERIT_TIMELINE_EVENT_KINDS = new Set<string>([
   'agent.tool-call',
   'agent.tool-intensity-anomaly',
   'agent.tool-result',
+  'agent.runtime-advisory',
   'agent.redundant-read',
   'tool.stdout-truncated',
   'tool.timeout',

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -20,6 +20,8 @@ The `<task>` block can include:
 - `<acceptanceContract>` — resolved acceptance criteria that must be satisfied before QA/Review.
 - `<relatedSurface>` — deterministic execution lane from the workflow.
 - `<revisionPass>` — `0` or `1`.
+- `<priorEvidenceSpecPath>` — the last evidence spec path seen on a prior implement/fix-feedback completion, if any.
+- `<existingFileManifest>` — the current manifest of existing files and directories for the investigated scope, when fix-feedback reuses an existing worktree.
 - `<evidencePostEnabled>` — whether frontend evidence specs should be produced.
 
 `<relatedSurface>` is prescriptive unless stale:

--- a/skills/implement/skill.config.ts
+++ b/skills/implement/skill.config.ts
@@ -28,6 +28,15 @@ export const ImplementContextSchema = z.object({
   }),
   advisorFeedback: z.string().optional(),
   revisionPass: z.union([z.literal(0), z.literal(1)]).optional(),
+  priorEvidenceSpecPath: z.string().nullable().optional(),
+  existingFileManifest: z
+    .array(
+      z.object({
+        path: z.string(),
+        kind: z.enum(['file', 'dir']),
+      }),
+    )
+    .optional(),
   evidencePostEnabled: z.boolean().optional(),
   acceptanceContract: z
     .object({
@@ -105,6 +114,8 @@ const config: SkillConfig = {
     'relatedSurface',
     'advisorFeedback',
     'revisionPass',
+    'priorEvidenceSpecPath',
+    'existingFileManifest',
     'evidencePostEnabled',
     'acceptanceContract',
   ],

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -644,13 +644,12 @@ describe('runFixFeedbackWorkflow', () => {
         },
       ];
       const { latestInvestigationContext: actualLatestInvestigationContext } =
-        await vi.importActual<typeof import('@goose-hub/core/agent-runtime/investigation-context.js')>(
-          '@goose-hub/core/agent-runtime/investigation-context.js',
-        );
-      const { appendRuntimeAdvisoryEvent } =
-        await vi.importActual<typeof import('@goose-hub/core/agent-runtime/codex-cli.js')>(
-          '@goose-hub/core/agent-runtime/codex-cli.js',
-        );
+        await vi.importActual<
+          typeof import('@goose-hub/core/agent-runtime/investigation-context.js')
+        >('@goose-hub/core/agent-runtime/investigation-context.js');
+      const { appendRuntimeAdvisoryEvent } = await vi.importActual<
+        typeof import('@goose-hub/core/agent-runtime/codex-cli.js')
+      >('@goose-hub/core/agent-runtime/codex-cli.js');
       mockLatestInvestigationContext.mockImplementation(actualLatestInvestigationContext);
       vi.mocked(eventStore.replay).mockImplementation((query) => {
         if (query?.kind === 'agent.investigation-complete') {

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -610,12 +610,28 @@ describe('runFixFeedbackWorkflow', () => {
 
     it('covers the G1 G2 G3 cascade together in a fix-feedback run', async () => {
       const evidenceSpecPath = 'apps/web/e2e/issue-X.spec.ts';
-      const existingFileManifest = [
-        { path: 'apps/web/src/components/detail/TaskHeader.tsx', kind: 'file' },
-        { path: 'apps/web/src/components/detail', kind: 'dir' },
-      ];
-      vi.mocked(eventStore.replay).mockReturnValue([
-        makePrOpenedEvent(),
+      const worktreePath = process.cwd();
+      const investigationEvent = {
+        id: 4,
+        kind: 'agent.investigation-complete' as EventKind,
+        payload: {
+          investigate: {
+            findings: 'Keep task detail view stable after repair',
+            keyFiles: [
+              { path: 'apps/web/src/components/detail/components/DetailPage.tsx' },
+              { path: 'apps/web/src/components/detail/components/CommentsSection.tsx' },
+            ],
+            openQuestions: ['Can the existing issue spec be reused?'],
+          },
+          investigationRunId: 'investigation-1',
+        },
+        projectId: 'proj',
+        workItemId: 'github:owner/repo#42',
+        createdAt: new Date().toISOString(),
+        runId: 'investigation-1',
+      };
+      const workflowEvents = [
+        makePrOpenedEvent(worktreePath),
         makeQaCompletedEvent(),
         {
           id: 3,
@@ -626,45 +642,53 @@ describe('runFixFeedbackWorkflow', () => {
           createdAt: new Date().toISOString(),
           runId: 'run-abc',
         },
-      ]);
-      mockGetChangedFilesSince.mockReturnValue([
-        'apps/web/src/components/detail/TaskHeader.tsx',
-        'apps/web/src/components/detail/TaskBody.tsx',
-      ]);
-      mockLatestInvestigationContext.mockReturnValue({
-        findings: 'Keep task detail view stable after repair',
-        keyFiles: existingFileManifest.map(({ path }) => ({ path })),
-        openQuestions: ['Can the existing issue spec be reused?'],
-        investigationRunId: 'investigation-1',
+      ];
+      const { latestInvestigationContext: actualLatestInvestigationContext } =
+        await vi.importActual<typeof import('@goose-hub/core/agent-runtime/investigation-context.js')>(
+          '@goose-hub/core/agent-runtime/investigation-context.js',
+        );
+      const { appendRuntimeAdvisoryEvent } =
+        await vi.importActual<typeof import('@goose-hub/core/agent-runtime/codex-cli.js')>(
+          '@goose-hub/core/agent-runtime/codex-cli.js',
+        );
+      mockLatestInvestigationContext.mockImplementation(actualLatestInvestigationContext);
+      vi.mocked(eventStore.replay).mockImplementation((query) => {
+        if (query?.kind === 'agent.investigation-complete') {
+          return [investigationEvent];
+        }
+        return workflowEvents;
       });
-      mockClaudeCliRun.mockImplementation(async ({ spec }) => {
-        vi.mocked(eventStore.appendEvent).mockReturnValue({ id: 1 } as ReturnType<
-          typeof eventStore.appendEvent
-        >);
-        eventStore.appendEvent({
+      mockGetChangedFilesSince.mockReturnValue([
+        'apps/web/src/components/detail/components/DetailPage.tsx',
+        'apps/web/src/components/detail/components/CommentsSection.tsx',
+      ]);
+      const customRun = vi.fn().mockImplementation(async (spec) => {
+        appendRuntimeAdvisoryEvent({
+          line: 'resources/read failed: resources/read?path=foo.ts transient stderr',
           projectId: 'proj',
           workItemId: 'github:owner/repo#42',
-          kind: 'agent.runtime-advisory' as EventKind,
-          payload: {
-            surface: 'resources/read failed',
-            stderr: 'resources/read?path=foo.ts transient stderr',
-            toolName: 'resources/read',
-            requestedPath: 'foo.ts',
-            runId: spec.runId,
-          },
           runId: spec.runId,
+          personaId: spec.personaId,
+          skill: spec.skill,
         });
-        return { output: makeImplementOutput({ evidenceSpecPath }) };
+        return {
+          output: makeImplementOutput({ evidenceSpecPath }),
+          decisionSummaries: [],
+          events: [],
+        };
+      });
+      const customRuntime: AgentRuntime = { run: customRun };
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo', {
+        runtime: customRuntime,
       });
 
-      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
-
-      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      const runCall = customRun.mock.calls[0][0];
       expect(runCall.context.priorEvidenceSpecPath).toBe(evidenceSpecPath);
       expect(runCall.context.existingFileManifest).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            path: expect.stringContaining('apps/web/src/'),
+            path: expect.stringContaining('apps/web/src/components/detail/components/'),
             kind: 'file',
           }),
         ]),

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -608,6 +608,90 @@ describe('runFixFeedbackWorkflow', () => {
       });
     });
 
+    it('covers the G1 G2 G3 cascade together in a fix-feedback run', async () => {
+      const evidenceSpecPath = 'apps/web/e2e/issue-X.spec.ts';
+      const existingFileManifest = [
+        { path: 'apps/web/src/components/detail/TaskHeader.tsx', kind: 'file' },
+        { path: 'apps/web/src/components/detail', kind: 'dir' },
+      ];
+      vi.mocked(eventStore.replay).mockReturnValue([
+        makePrOpenedEvent(),
+        makeQaCompletedEvent(),
+        {
+          id: 3,
+          kind: 'agent.implement-complete' as EventKind,
+          payload: { evidenceSpecPath },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date().toISOString(),
+          runId: 'run-abc',
+        },
+      ]);
+      mockGetChangedFilesSince.mockReturnValue([
+        'apps/web/src/components/detail/TaskHeader.tsx',
+        'apps/web/src/components/detail/TaskBody.tsx',
+      ]);
+      mockLatestInvestigationContext.mockReturnValue({
+        findings: 'Keep task detail view stable after repair',
+        keyFiles: existingFileManifest.map(({ path }) => ({ path })),
+        openQuestions: ['Can the existing issue spec be reused?'],
+        investigationRunId: 'investigation-1',
+      });
+      mockClaudeCliRun.mockImplementation(async ({ spec }) => {
+        vi.mocked(eventStore.appendEvent).mockReturnValue({ id: 1 } as ReturnType<
+          typeof eventStore.appendEvent
+        >);
+        eventStore.appendEvent({
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          kind: 'agent.runtime-advisory' as EventKind,
+          payload: {
+            surface: 'resources/read failed',
+            stderr: 'resources/read?path=foo.ts transient stderr',
+            toolName: 'resources/read',
+            requestedPath: 'foo.ts',
+            runId: spec.runId,
+          },
+          runId: spec.runId,
+        });
+        return { output: makeImplementOutput({ evidenceSpecPath }) };
+      });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBe(evidenceSpecPath);
+      expect(runCall.context.existingFileManifest).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining('apps/web/src/'),
+            kind: 'file',
+          }),
+        ]),
+      );
+      expect(runCall.context.existingFileManifest).not.toHaveLength(0);
+      expect(runCall.contextAllowlist).toEqual(
+        expect.arrayContaining(['priorEvidenceSpecPath', 'existingFileManifest']),
+      );
+
+      const appendedEvents = vi.mocked(eventStore.appendEvent).mock.calls.map(([event]) => event);
+      expect(appendedEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'agent.runtime-advisory',
+            payload: expect.objectContaining({
+              surface: 'resources/read failed',
+              stderr: expect.stringContaining('resources/read?path=foo.ts'),
+            }),
+          }),
+          expect.objectContaining({ kind: 'agent.fix-feedback-complete' }),
+        ]),
+      );
+      expect(appendedEvents).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: 'agent.run-blocked' })]),
+      );
+    });
+
     it('omits priorInvestigation when none recorded', async () => {
       vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent(), makeQaCompletedEvent()]);
       mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -1,3 +1,6 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { posix as pathPosix } from 'node:path';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { getChangedFilesSince } from '@goose-hub/core/agent-runtime/git-intel.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
@@ -91,6 +94,69 @@ function buildPriorInvestigationPayload(investigation: InvestigationContext | un
     openQuestions: investigation.openQuestions,
     investigationRunId: investigation.investigationRunId,
   };
+}
+
+function findPriorEvidenceSpecPath(events: ReturnType<typeof eventStore.replay>): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.kind !== 'agent.implement-complete' && event.kind !== 'agent.fix-feedback-complete') {
+      continue;
+    }
+    const payload = event.payload as { evidenceSpecPath?: unknown } | null;
+    if (typeof payload?.evidenceSpecPath === 'string' && payload.evidenceSpecPath.length > 0) {
+      return payload.evidenceSpecPath;
+    }
+  }
+  return null;
+}
+
+function deriveScopeRootsFromInvestigation(
+  investigation: InvestigationContext | undefined,
+): string[] {
+  const roots = new Set<string>();
+  for (const keyFile of investigation?.keyFiles ?? []) {
+    if (keyFile.path.length === 0) continue;
+    const dir = pathPosix.dirname(keyFile.path);
+    if (dir.length > 0 && dir !== '.') roots.add(dir);
+  }
+  return [...roots];
+}
+
+function collectScopeManifest(
+  worktreePath: string,
+  scopeRoots: string[],
+): Array<{ path: string; kind: 'file' | 'dir' }> {
+  const manifest: Array<{ path: string; kind: 'file' | 'dir' }> = [];
+  const seen = new Set<string>();
+
+  const visit = (absolutePath: string, relativePath: string) => {
+    if (seen.has(relativePath)) return;
+    const entries = readdirSync(absolutePath, { withFileTypes: true });
+    manifest.push({ path: relativePath, kind: 'dir' });
+    seen.add(relativePath);
+    for (const entry of entries) {
+      const nextRelativePath = pathPosix.join(relativePath, entry.name);
+      if (seen.has(nextRelativePath)) continue;
+      if (entry.isDirectory()) {
+        visit(join(absolutePath, entry.name), nextRelativePath);
+        continue;
+      }
+      manifest.push({ path: nextRelativePath, kind: 'file' });
+      seen.add(nextRelativePath);
+    }
+  };
+
+  for (const scopeRoot of scopeRoots) {
+    const absoluteScopeRoot = join(worktreePath, scopeRoot);
+    if (!existsSync(absoluteScopeRoot)) continue;
+    try {
+      visit(absoluteScopeRoot, scopeRoot);
+    } catch {
+      continue;
+    }
+  }
+
+  return manifest;
 }
 
 export interface FixFeedbackDeps {
@@ -285,6 +351,7 @@ export async function runFixFeedbackWorkflow(
   const prLifecycle = findPrLifecycle(events);
   const sourceFailure = findLatestSourceFailure(events);
   const repairCycle = nextRepairCycle(events);
+  const priorEvidenceSpecPath = findPriorEvidenceSpecPath(events);
   const repairPayload = compactPayload({
     pipelineRunId: prLifecycle?.pipelineRunId,
     attemptId,
@@ -396,6 +463,10 @@ export async function runFixFeedbackWorkflow(
     worktreePath,
   });
   const priorInvestigationPayload = buildPriorInvestigationPayload(priorInvestigation);
+  const existingFileManifest = collectScopeManifest(
+    worktreePath,
+    deriveScopeRootsFromInvestigation(priorInvestigation),
+  );
   const priorDevDecisions = collectPriorDevDecisions(events, prLifecycle);
   const priorDevChangedFiles = collectPriorChangedFiles(worktreePath, prLifecycle?.baseBranch);
 
@@ -464,6 +535,8 @@ export async function runFixFeedbackWorkflow(
           },
           advisorFeedback: advisorFeedback || undefined,
           revisionPass: 1,
+          priorEvidenceSpecPath,
+          existingFileManifest: existingFileManifest.length > 0 ? existingFileManifest : undefined,
           priorInvestigation: priorInvestigationPayload,
           priorDevDecisions: priorDevDecisions.length > 0 ? priorDevDecisions : undefined,
           priorDevChangedFiles: priorDevChangedFiles.length > 0 ? priorDevChangedFiles : undefined,
@@ -478,6 +551,8 @@ export async function runFixFeedbackWorkflow(
           'stack.typecheckCommand',
           'advisorFeedback',
           'revisionPass',
+          'priorEvidenceSpecPath',
+          'existingFileManifest',
           'priorInvestigation.findings',
           'priorInvestigation.keyFiles',
           'priorInvestigation.openQuestions',
@@ -524,6 +599,7 @@ export async function runFixFeedbackWorkflow(
         testsWritten: implementOutput.testsWritten.length,
         confidence: implementOutput.confidence,
         testsRun: implementOutput.testsRun,
+        evidenceSpecPath: implementOutput.evidenceSpecPath,
         observedChangedFiles: {
           count: observedChangedFiles.count,
           paths: observedChangedFiles.paths,

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -152,7 +152,7 @@ function collectScopeManifest(
     try {
       visit(absoluteScopeRoot, scopeRoot);
     } catch {
-      continue;
+      // Ignore inaccessible scope roots and keep collecting the rest.
     }
   }
 


### PR DESCRIPTION
## Summary

test: add integration test exercising G1+G2+G3 cascade together in a fix-feedback run

## Work Packages

- ✗ **WP1**: Append a regression test near the existing prior context inheritance coverage in slices/fix-feedback/slice.test.ts. Reus
- ✓ **WP1**: Append a regression test near the existing prior context inheritance coverage in slices/fix-feedback/slice.test.ts. Reus

Closes #1032
