### PR TITLE
M19.XX: API bug

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -77,6 +77,18 @@ describe('POST /inbox', () => {
     expect(res.status).toBe(400);
     expect(mockCreateInboxItem).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for JSON null body', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid request body' });
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /inbox', () => {

--- a/apps/server/src/shared/middleware.test.ts
+++ b/apps/server/src/shared/middleware.test.ts
@@ -32,4 +32,22 @@ describe('parseBody', () => {
     });
     expect(result).toMatchObject({ ok: false });
   });
+
+  it('returns ok:false with 400 response for JSON null', async () => {
+    const app = new Hono();
+    let result: unknown;
+    app.post('/test', async (c) => {
+      result = await parseBody<{ name: string }>(c);
+      return c.json({});
+    });
+    await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(result).toMatchObject({ ok: false });
+    const parsed = result as { ok: false; error: Response };
+    expect(parsed.error.status).toBe(400);
+    await expect(parsed.error.json()).resolves.toEqual({ error: 'invalid request body' });
+  });
 });

--- a/apps/server/src/shared/middleware.test.ts
+++ b/apps/server/src/shared/middleware.test.ts
@@ -50,4 +50,22 @@ describe('parseBody', () => {
     expect(parsed.error.status).toBe(400);
     await expect(parsed.error.json()).resolves.toEqual({ error: 'invalid request body' });
   });
+
+  it('returns ok:false with 400 response for JSON arrays', async () => {
+    const app = new Hono();
+    let result: unknown;
+    app.post('/test', async (c) => {
+      result = await parseBody<{ name: string }>(c);
+      return c.json({});
+    });
+    await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ name: 'hello' }]),
+    });
+    expect(result).toMatchObject({ ok: false });
+    const parsed = result as { ok: false; error: Response };
+    expect(parsed.error.status).toBe(400);
+    await expect(parsed.error.json()).resolves.toEqual({ error: 'invalid request body' });
+  });
 });

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -8,6 +8,9 @@ export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response
 export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
   try {
     const data = (await c.req.json()) as T;
+    if (data === null) {
+      return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
+    }
     return { ok: true, data };
   } catch (err) {
     logger.warn('request body parse failed', { err: String(err) });

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -5,13 +5,17 @@ export type Result<T> = { ok: true; data: T } | { ok: false; error: string; stat
 
 export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response };
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
   try {
-    const data = (await c.req.json()) as T;
-    if (data === null) {
+    const data = await c.req.json();
+    if (!isPlainObject(data)) {
       return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
     }
-    return { ok: true, data };
+    return { ok: true, data: data as T };
   } catch (err) {
     logger.warn('request body parse failed', { err: String(err) });
     return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };


### PR DESCRIPTION
## Summary

API bug

## Work Packages

- ✓ **WP1**: In apps/server/src/shared/middleware.ts:8, keep parseBody<T>(c) as the shared contract but, after c.req.json() succeeds,

Closes #1037
