### PR TITLE
Refresh PRD approval state from transitions

### DIFF
--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -14,6 +14,7 @@ import {
   applyLatestEventState,
   backfillIssueTimelineEvents,
   mergeIssueEvents,
+  patchIssueStateFromLatestTransition,
 } from '../lib/live-events';
 import { SECTIONS } from '../lib/sections';
 import { computeIsLive } from '../lib/timeline';
@@ -68,10 +69,12 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
     queryKey: ['events', slug, id],
     queryFn: async ({ signal }) => {
       const { events } = await fetchEventsPage(slug, id, { limit: TIMELINE_PAGE_SIZE }, signal);
-      return mergeIssueEvents(
+      const merged = mergeIssueEvents(
         queryClient.getQueryData<AgentEventDto[]>(['events', slug, id]),
         events,
       );
+      patchIssueStateFromLatestTransition(queryClient, slug, id, merged);
+      return merged;
     },
     enabled: id.length > 0,
   });

--- a/apps/web/src/components/detail/components/PRDSection.test.tsx
+++ b/apps/web/src/components/detail/components/PRDSection.test.tsx
@@ -87,13 +87,24 @@ function makePRDReadModel(advisor?: string): PrdReadModelDto {
   };
 }
 
+function makeTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
 function render_(jsx: React.ReactNode) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}>{jsx}</QueryClientProvider>);
+  return renderWithClient(jsx, makeTestClient());
+}
+
+function renderWithClient(jsx: React.ReactNode, client = makeTestClient()) {
+  return {
+    client,
+    ...render(<QueryClientProvider client={client}>{jsx}</QueryClientProvider>),
+  };
 }
 
 describe('PRDSection', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(fetchEvents).mockResolvedValue([]);
   });
 
@@ -146,20 +157,34 @@ describe('PRDSection', () => {
       expect(screen.getByTestId('prd-request-changes-btn')).toBeTruthy();
       expect(screen.getByTestId('prd-decline-btn')).toBeTruthy();
     });
+    expect(screen.getByTestId('prd-approval-controls').textContent).toContain(
+      'Approve to route into delivery.',
+    );
+    expect(screen.getByTestId('prd-approval-controls').textContent).not.toContain(
+      'decomposing into vertical slices',
+    );
     unmount();
 
     render_(<PRDSection projectSlug="proj" id="42" state="factory:decomposing" />);
     await waitFor(() => {
       expect(screen.getByTestId('prd-section')).toBeTruthy();
     });
+    expect(screen.getByTestId('prd-approved-banner').textContent).toContain(
+      'decomposing into vertical slices',
+    );
     expect(screen.queryByTestId('prd-approve-btn')).toBeNull();
     expect(screen.queryByTestId('prd-request-changes-btn')).toBeNull();
   });
 
-  it('Approve PRD button calls approvePRD API', async () => {
+  it('Approve PRD button calls approvePRD API and invalidates issue, event, PRD, and intervention queries', async () => {
     vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
     vi.mocked(approvePRD).mockResolvedValueOnce({ ok: true });
-    render_(<PRDSection projectSlug="proj" id="42" state="factory:prd-review" />);
+    const queryClient = makeTestClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    renderWithClient(
+      <PRDSection projectSlug="proj" id="42" state="factory:prd-review" />,
+      queryClient,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('prd-approve-btn')).toBeTruthy();
     });
@@ -167,6 +192,27 @@ describe('PRDSection', () => {
     await waitFor(() => {
       expect(approvePRD).toHaveBeenCalledWith('proj', '42');
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issue', 'proj', '42'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['issues', 'proj'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['prd', 'proj', '42'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['events', 'proj', '42'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['interventions', 'issue', 'proj', '42'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['intervention-timeline', 'proj', '42'],
+    });
+  });
+
+  it('shows approved/routed copy and hides approval controls for factory:dev-ready', async () => {
+    vi.mocked(fetchPRD).mockResolvedValue(makePRDReadModel());
+    render_(<PRDSection projectSlug="proj" id="42" state="factory:dev-ready" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prd-approved-banner').textContent).toContain('routed to delivery');
+    });
+    expect(screen.queryByTestId('prd-approval-controls')).toBeNull();
+    expect(screen.queryByTestId('prd-approve-btn')).toBeNull();
   });
 
   it('Request Changes opens the concern form and submits revisePRD', async () => {

--- a/apps/web/src/components/detail/components/PRDSection.tsx
+++ b/apps/web/src/components/detail/components/PRDSection.tsx
@@ -1,5 +1,6 @@
 import { approvePRD, declinePRD, fetchEvents, fetchPRD, revisePRD } from '@/lib/api';
 import { renderMarkdownToHtml } from '@/lib/markdown';
+import { interventionKeys } from '@/lib/query-keys';
 import type { AgentEventDto, PrdReadModelDto } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckCircle2, ChevronDown, ChevronRight, FileText, Loader2 } from 'lucide-react';
@@ -19,6 +20,21 @@ const COMPLEXITY_COLORS: Record<string, string> = {
   medium: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
   high: 'bg-red-500/15 text-red-300 border-red-500/30',
 };
+
+const PRD_ROUTED_TO_DELIVERY_STATES = new Set([
+  'factory:dev-ready',
+  'factory:spec-ready',
+  'factory:in-progress',
+  'factory:needs-qa',
+  'factory:qa-failed',
+  'factory:needs-review',
+  'factory:needs-fix',
+  'factory:approved',
+  'factory:merge-conflict',
+  'factory:retrospecting',
+  'factory:done',
+  'factory:archived',
+]);
 
 export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
   const queryClient = useQueryClient();
@@ -54,6 +70,8 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
     void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
     void queryClient.invalidateQueries({ queryKey: ['prd', projectSlug, id] });
     void queryClient.invalidateQueries({ queryKey: ['events', projectSlug, id] });
+    void queryClient.invalidateQueries({ queryKey: ['interventions', 'issue', projectSlug, id] });
+    void queryClient.invalidateQueries({ queryKey: interventionKeys.timeline(projectSlug, id) });
   };
 
   const approve = useMutation({
@@ -160,10 +178,12 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
   }
 
   const showApproveButtons = state === 'factory:prd-review';
+  const isDecomposing = state === 'factory:decomposing';
   const prdApproved =
-    state === 'factory:decomposing' ||
-    state === 'factory:issues-created' ||
-    state === 'factory:done';
+    state != null &&
+    (isDecomposing ||
+      state === 'factory:issues-created' ||
+      PRD_ROUTED_TO_DELIVERY_STATES.has(state));
   const isBusy = approve.isPending || requestChanges.isPending || decline.isPending;
 
   const onSubmitRequestChanges = (e: React.FormEvent) => {
@@ -234,9 +254,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
             <CheckCircle2 size={14} className="text-green-400 shrink-0" />
             <span className="text-[13px] text-green-300 font-medium">PRD approved</span>
             <span className="text-[12px] text-fg-3 ml-1">
-              {state === 'factory:decomposing'
-                ? '— decomposing into vertical slices'
-                : '— issues created'}
+              {isDecomposing ? '— decomposing into vertical slices' : '— routed to delivery'}
             </span>
           </div>
           {childIssueNumbers.length > 0 && (
@@ -263,9 +281,7 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
         >
           <div className="flex items-center justify-between">
             <div className="text-[13px] font-semibold">PRD review</div>
-            <div className="text-[12px] text-fg-3">
-              Approve to begin decomposing into vertical slices.
-            </div>
+            <div className="text-[12px] text-fg-3">Approve to route into delivery.</div>
           </div>
 
           {errorMsg != null && (

--- a/apps/web/src/components/detail/lib/live-events.test.ts
+++ b/apps/web/src/components/detail/lib/live-events.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyIssueTimelineEvent,
   backfillIssueTimelineEvents,
+  mergeIssueEvents,
+  patchIssueStateFromLatestTransition,
   upsertIssueEvent,
 } from './live-events';
 
@@ -132,6 +134,70 @@ describe('applyIssueTimelineEvent', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['acceptance-contract', 'p', '1'],
     });
+  });
+
+  it('does not let an older transition event regress a newer cached state', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      ['events', 'p', '1'],
+      [makeEvent(5, 'state.transitioned', { to: 'factory:spec-ready' })],
+    );
+    queryClient.setQueryData(['issue', 'p', '1'], {
+      externalId: '1',
+      state: 'factory:spec-ready',
+    } as WorkItemDto);
+    queryClient.setQueryData(
+      ['issues', 'p'],
+      [
+        {
+          externalId: '1',
+          state: 'factory:spec-ready',
+        } as WorkItemDto,
+      ],
+    );
+
+    applyIssueTimelineEvent(
+      queryClient,
+      'p',
+      '1',
+      makeEvent(3, 'state.transitioned', { to: 'factory:dev-ready' }),
+    );
+
+    expect(queryClient.getQueryData<WorkItemDto>(['issue', 'p', '1'])?.state).toBe(
+      'factory:spec-ready',
+    );
+    expect(queryClient.getQueryData<WorkItemDto[]>(['issues', 'p'])?.[0]?.state).toBe(
+      'factory:spec-ready',
+    );
+  });
+});
+
+describe('patchIssueStateFromLatestTransition', () => {
+  it('patches issue caches from merged fetched event pages', () => {
+    const queryClient = new QueryClient();
+    const issue = {
+      externalId: '1',
+      state: 'factory:prd-review',
+    } as WorkItemDto;
+    queryClient.setQueryData(
+      ['events', 'p', '1'],
+      [makeEvent(2, 'state.transitioned', { to: 'factory:prd-review' })],
+    );
+    queryClient.setQueryData(['issue', 'p', '1'], issue);
+    queryClient.setQueryData(['issues', 'p'], [issue]);
+
+    const merged = mergeIssueEvents(queryClient.getQueryData(['events', 'p', '1']), [
+      makeEvent(4, 'state.transitioned', { to: 'factory:dev-ready' }),
+    ]);
+
+    patchIssueStateFromLatestTransition(queryClient, 'p', '1', merged);
+
+    expect(queryClient.getQueryData<WorkItemDto>(['issue', 'p', '1'])?.state).toBe(
+      'factory:dev-ready',
+    );
+    expect(queryClient.getQueryData<WorkItemDto[]>(['issues', 'p'])?.[0]?.state).toBe(
+      'factory:dev-ready',
+    );
   });
 });
 

--- a/apps/web/src/components/detail/lib/live-events.ts
+++ b/apps/web/src/components/detail/lib/live-events.ts
@@ -7,6 +7,11 @@ type StateTransitionPayload = {
   to?: unknown;
 };
 
+type LatestTransitionState = {
+  eventId: number;
+  state: string;
+};
+
 type FetchEventsPage = (
   projectSlug: string,
   issueId: string,
@@ -36,9 +41,19 @@ export function upsertIssueEvent(
 }
 
 export function latestTransitionState(events: AgentEventDto[] | undefined): string | null {
-  const latest = (events ?? []).find((event) => event.kind === 'state.transitioned');
+  return latestStateTransition(events)?.state ?? null;
+}
+
+export function latestStateTransition(
+  events: AgentEventDto[] | undefined,
+): LatestTransitionState | null {
+  const latest = (events ?? [])
+    .filter((event) => event.kind === 'state.transitioned')
+    .sort((left, right) => right.id - left.id)[0];
   const payload = latest?.payload as StateTransitionPayload | null | undefined;
-  return typeof payload?.to === 'string' ? payload.to : null;
+  return latest != null && typeof payload?.to === 'string'
+    ? { eventId: latest.id, state: payload.to }
+    : null;
 }
 
 export function applyLatestEventState<T extends WorkItemDto>(
@@ -56,15 +71,32 @@ export function patchIssueStateFromTransition(
   event: AgentEventDto,
 ): void {
   if (event.kind !== 'state.transitioned') return;
-  const payload = event.payload as StateTransitionPayload | null | undefined;
-  if (typeof payload?.to !== 'string') return;
+  const events = mergeIssueEvents(
+    queryClient.getQueryData<AgentEventDto[]>(['events', projectSlug, issueId]),
+    [event],
+  );
+  patchIssueStateFromLatestTransition(queryClient, projectSlug, issueId, events);
+}
+
+export function patchIssueStateFromLatestTransition(
+  queryClient: QueryClient,
+  projectSlug: string,
+  issueId: string,
+  events: AgentEventDto[] | undefined,
+): void {
+  const latest = latestStateTransition(events);
+  if (latest == null) return;
 
   queryClient.setQueryData<WorkItemDto>(['issue', projectSlug, issueId], (existing) =>
-    existing == null ? existing : { ...existing, state: payload.to as string },
+    existing == null || existing.state === latest.state
+      ? existing
+      : { ...existing, state: latest.state },
   );
   queryClient.setQueryData<WorkItemDto[]>(['issues', projectSlug], (existing) =>
     existing?.map((item) =>
-      item.externalId === issueId ? { ...item, state: payload.to as string } : item,
+      item.externalId === issueId && item.state !== latest.state
+        ? { ...item, state: latest.state }
+        : item,
     ),
   );
 }
@@ -80,7 +112,12 @@ export function applyIssueTimelineEvent(
   upsertIssueEvent(queryClient, projectSlug, issueId, event);
 
   if (event.kind === 'state.transitioned') {
-    patchIssueStateFromTransition(queryClient, projectSlug, issueId, event);
+    patchIssueStateFromLatestTransition(
+      queryClient,
+      projectSlug,
+      issueId,
+      queryClient.getQueryData<AgentEventDto[]>(['events', projectSlug, issueId]),
+    );
     void queryClient.invalidateQueries({ queryKey: ['issue', projectSlug, issueId] });
     void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
     const payload = event.payload as {


### PR DESCRIPTION
## Summary
- patch detail issue caches from the newest merged state.transitioned event after event page fetches
- prevent older transition events from regressing newer cached issue state
- invalidate PRD-review intervention caches after approve-prd and update approved/routed PRD copy for delivery states

## Tests
- pnpm exec biome check apps/web/src/components/detail/components/DetailPage.tsx apps/web/src/components/detail/components/PRDSection.tsx apps/web/src/components/detail/components/PRDSection.test.tsx apps/web/src/components/detail/lib/live-events.ts apps/web/src/components/detail/lib/live-events.test.ts
- pnpm test apps/web/src/components/detail/lib/live-events.test.ts apps/web/src/components/detail/components/PRDSection.test.tsx
- pnpm --filter @goose-hub/web build