### PR TITLE
M19.XX: Logger drops metadata when called with extra conte

### DIFF
--- a/apps/web/src/lib/logger.test.ts
+++ b/apps/web/src/lib/logger.test.ts
@@ -1,6 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logger } from './logger';
 
+const loggerCases = [
+  {
+    level: 'debug',
+    method: 'log',
+    message: 'debug msg',
+    invoke: (message: string, meta?: Record<string, unknown>) => logger.debug(message, meta),
+  },
+  {
+    level: 'info',
+    method: 'info',
+    message: 'hello',
+    invoke: (message: string, meta?: Record<string, unknown>) => logger.info(message, meta),
+  },
+  {
+    level: 'warn',
+    method: 'warn',
+    message: 'watch out',
+    invoke: (message: string, meta?: Record<string, unknown>) => logger.warn(message, meta),
+  },
+  {
+    level: 'error',
+    method: 'error',
+    message: 'something broke',
+    invoke: (message: string, meta?: Record<string, unknown>) => logger.error(message, meta),
+  },
+] as const;
+
 describe('logger', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
   let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -18,30 +45,33 @@ describe('logger', () => {
     vi.restoreAllMocks();
   });
 
-  it('logger.error calls console.error', () => {
-    logger.error('something broke');
-    expect(errorSpy).toHaveBeenCalledOnce();
-  });
+  const consoleSpies = {
+    debug: () => logSpy,
+    info: () => infoSpy,
+    warn: () => warnSpy,
+    error: () => errorSpy,
+  } as const;
 
-  it('logger.warn calls console.warn', () => {
-    logger.warn('watch out');
-    expect(warnSpy).toHaveBeenCalledOnce();
-  });
+  it.each(loggerCases)(
+    'calls console.$method with prefix and message for $level',
+    ({ level, message, invoke }) => {
+      invoke(message);
 
-  it('logger.info calls console.info', () => {
-    logger.info('hello');
-    expect(infoSpy).toHaveBeenCalledOnce();
-  });
+      expect(consoleSpies[level]()).toHaveBeenCalledOnce();
+      expect(consoleSpies[level]()).toHaveBeenCalledWith(`[goose-hub:${level}]`, message);
+    },
+  );
 
-  it('logger.debug calls console.log', () => {
-    logger.debug('debug msg');
-    expect(logSpy).toHaveBeenCalledOnce();
-  });
+  it.each(loggerCases)(
+    'preserves meta as the third console argument for $level',
+    ({ level, message, invoke }) => {
+      const meta = { code: 42, requestId: `${level}-request` };
 
-  it('includes meta when provided', () => {
-    logger.error('with meta', { code: 42 });
-    const call = errorSpy.mock.calls[0];
-    // meta object is passed as the third argument
-    expect(call[2]).toEqual({ code: 42 });
-  });
+      invoke(message, meta);
+
+      expect(consoleSpies[level]()).toHaveBeenCalledOnce();
+      expect(consoleSpies[level]()).toHaveBeenCalledWith(`[goose-hub:${level}]`, message, meta);
+      expect(consoleSpies[level]().mock.calls[0][2]).toBe(meta);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Logger drops metadata when called with extra context

## Work Packages

- ✓ **WP1**: Replace the one-off metadata assertion around `apps/web/src/lib/logger.test.ts:41` with a table-driven regression over `

Closes #1041
