### PR TITLE
Route dogfood workflows from committed seed base

### DIFF
--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -1,5 +1,6 @@
 export const EVENT_KINDS = [
   'state.transitioned',
+  'dogfood.seed-applied',
   'milestone.activated',
   'agent.spawned',
   'agent.decision-summary',

--- a/core/workspaces/workflow-base.test.ts
+++ b/core/workspaces/workflow-base.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockReplay, mockResolveWorkflowBase } = vi.hoisted(() => ({
+  mockReplay: vi.fn(),
+  mockResolveWorkflowBase: vi.fn(),
+}));
+
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: {
+    replay: mockReplay,
+  },
+}));
+
+vi.mock('./worktree.js', () => ({
+  resolveWorkflowBase: (...args: unknown[]) => mockResolveWorkflowBase(...args),
+}));
+
+import { resolveWorkflowBaseForWorkItem } from './workflow-base.js';
+
+describe('resolveWorkflowBaseForWorkItem', () => {
+  beforeEach(() => {
+    mockReplay.mockReset();
+    mockResolveWorkflowBase.mockReset();
+    mockResolveWorkflowBase.mockReturnValue({
+      branch: 'main',
+      ref: 'origin/main',
+      source: 'configured-default',
+    });
+  });
+
+  it('prefers the latest dogfood seed base ref for the work item', () => {
+    mockReplay.mockReturnValue([
+      {
+        kind: 'dogfood.seed-applied',
+        payload: {
+          baseBranch: 'dogfood/run-1/logger-001-drop-meta',
+          baseRef: 'seed-commit-sha',
+        },
+      },
+    ]);
+
+    expect(
+      resolveWorkflowBaseForWorkItem('goose-hub-self', 'github:owner/repo#123', '/repo', 'main'),
+    ).toEqual({
+      branch: 'dogfood/run-1/logger-001-drop-meta',
+      ref: 'seed-commit-sha',
+      source: 'dogfood-seed',
+    });
+    expect(mockReplay).toHaveBeenCalledWith({
+      projectId: 'goose-hub-self',
+      workItemId: 'github:owner/repo#123',
+      kind: 'dogfood.seed-applied',
+      order: 'desc',
+      limit: 1,
+    });
+    expect(mockResolveWorkflowBase).not.toHaveBeenCalled();
+  });
+
+  it('falls back to normal workflow base resolution for non-dogfood issues', () => {
+    mockReplay.mockReturnValue([]);
+
+    expect(
+      resolveWorkflowBaseForWorkItem('proj', 'github:owner/repo#123', '/repo', 'develop'),
+    ).toEqual({
+      branch: 'main',
+      ref: 'origin/main',
+      source: 'configured-default',
+    });
+    expect(mockResolveWorkflowBase).toHaveBeenCalledWith('/repo', 'develop');
+  });
+});

--- a/core/workspaces/workflow-base.ts
+++ b/core/workspaces/workflow-base.ts
@@ -1,0 +1,47 @@
+import { eventStore } from '../event-stream/store.js';
+import { type WorkflowBase, resolveWorkflowBase } from './worktree.js';
+
+export type WorkflowBaseForWorkItemSource = WorkflowBase['source'] | 'dogfood-seed';
+
+export type WorkflowBaseForWorkItem = Omit<WorkflowBase, 'source'> & {
+  source: WorkflowBaseForWorkItemSource;
+};
+
+type DogfoodSeedAppliedPayload = {
+  baseBranch?: unknown;
+  baseRef?: unknown;
+};
+
+function payloadRecord(payload: unknown): DogfoodSeedAppliedPayload {
+  return payload != null && typeof payload === 'object'
+    ? (payload as DogfoodSeedAppliedPayload)
+    : {};
+}
+
+export function resolveWorkflowBaseForWorkItem(
+  projectId: string,
+  workItemId: string,
+  targetRepo: string,
+  defaultBranch?: string,
+): WorkflowBaseForWorkItem {
+  const seedEvent = eventStore
+    .replay({
+      projectId,
+      workItemId,
+      kind: 'dogfood.seed-applied',
+      order: 'desc',
+      limit: 1,
+    })
+    .at(0);
+
+  const payload = payloadRecord(seedEvent?.payload);
+  if (typeof payload.baseBranch === 'string' && typeof payload.baseRef === 'string') {
+    const branch = payload.baseBranch.trim();
+    const ref = payload.baseRef.trim();
+    if (branch.length > 0 && ref.length > 0) {
+      return { branch, ref, source: 'dogfood-seed' };
+    }
+  }
+
+  return resolveWorkflowBase(targetRepo, defaultBranch);
+}

--- a/slices/dogfood/README.md
+++ b/slices/dogfood/README.md
@@ -30,16 +30,17 @@ The agent's job is to investigate from the user-language issue, fix the bug, and
 
 ```
 pnpm dogfood run <seed-id> [--server-url=…] [--repo=…] [--project-slug=…] [--timeout-ms=…]
-                           [--no-restore] [--skip-verify-red]
+                           [--no-restore] [--skip-verify-red] [--skip-verify-green]
+                           [--delete-remote-branch-on-finish]
 ```
 
 What it does:
 
-1. Pre-flight: verifies `gh` is installed + authenticated.
-2. Applies the seed to your working tree and runs the truth-signal test locally; aborts if the test isn't red or unrelated tests are also failing.
-3. Calls `gh issue create` with the seed's user-language title + body + labels (including `factory:triaging`). Records a pending run row.
+1. Pre-flight: verifies `gh` is installed + authenticated and the operator worktree is clean.
+2. Creates `dogfood/<runId>/<seed-id>`, applies the seed there, runs the truth-signal test locally, commits the seed, and pushes the seed branch.
+3. Calls `gh issue create` with the seed's user-language title + body + labels (including `factory:triaging`). Records a pending run row plus a durable `dogfood.seed-applied` event carrying `baseBranch`, `baseRef`, `seedCommit`, and `truthSignal`.
 4. Opens an SSE connection to your local server and prints a workflow-specific checklist that ticks off as `state.transitioned` events arrive. Stops when the workflow reaches a terminal state or any agent run fails.
-5. Records the completion (reached-terminal / stalled / failed:<node>) and restores the seed locally. Prints the `pnpm dogfood record` invocation you should run once you've eyeballed truth-pass / qa-correct / hygiene-clean.
+5. Records the completion (reached-terminal / stalled / failed:<node>), checks the truth signal against the final PR branch when possible, restores the operator's original branch, and deletes the local dogfood branch.
 
 **Seed mechanics:**
 
@@ -61,7 +62,7 @@ pnpm dogfood runs [--limit=N]              # List recent dogfood runs (default 2
 pnpm dogfood runs:summary                  # Aggregate stats across all recorded runs
 ```
 
-The outcome row lives in `~/.factory/dogfood/runs.jsonl` (one JSON line per run). Each row carries `seedId`, `workflow`, `startedAt`, `issue` (number + URL), `completion`, and the four outcome signals:
+The outcome row lives in `~/.factory/dogfood/runs.jsonl` (one JSON line per run). Each row carries `seedId`, `workflow`, `startedAt`, `issue` (number + URL), `baseBranch`, `baseRef`, `seedCommit`, `completion`, and the four outcome signals:
 
 - `truthPass` — did the truth-signal test go red → green on the PR head?
 - `qaCorrect` — did the QA agent's verdict match `truthPass`? (Measures QA accuracy.)
@@ -74,50 +75,33 @@ Completion is one of: `pending | reached-terminal | stalled | aborted-by-human |
 
 The harness handles seed mechanics, issue-command generation, and outcome recording. Kicking the workflow itself is still manual — needs a running server with the project's mode set to `supervised`.
 
-1. **Apply the seed locally on `main`:**
+1. **Run the orchestrator from a clean checkout:**
    ```bash
-   pnpm dogfood apply logger-001-drop-meta
-   pnpm dogfood verify-red logger-001-drop-meta   # Confirm the truth-signal test is red
-   git add -A && git commit -m "seed: logger-001 drop-meta"
-   git push origin main
+   pnpm dogfood run logger-001-drop-meta
    ```
 
-2. **Generate the file-issue command and record a pending run:**
-   ```bash
-   pnpm dogfood file-issue logger-001-drop-meta
-   # Prints the `gh issue create` command + creates a pending row in ~/.factory/dogfood/runs.jsonl
-   # Run the printed command yourself (or paste into the GitHub UI if no gh)
-   pnpm dogfood record <run-id> --issue-url=<url-from-gh-output>
-   ```
-
-3. **Let the workflow run.** With the local server running and the project on supervised mode, dispatch picks up `factory:triaging` and routes through:
+2. **Let the workflow run.** With the local server running and the project on supervised mode, dispatch picks up `factory:triaging` and routes through:
    `triage → investigate → dev-ready → fix-issue → needs-qa → needs-review → approved → merged`
 
-4. **Watch the event stream:**
+3. **Watch the event stream:**
    ```bash
-   curl -N "http://localhost:3001/events?projectId=goose-hub-self&workItemId=<n>"
+   curl -N "http://localhost:3001/events?projectId=goose-hub-self&workItemId=github:shaunnez/goose-hub#<n>"
    ```
 
-5. **Once the PR merges**, the seed is naturally restored (the agent's fix returns the file to a passing state). Record the outcome:
+4. **Once the PR merges**, record any remaining manual outcome signals:
    ```bash
    pnpm dogfood record <run-id> \
      --completion=reached-terminal \
-     --truth-pass=true \
      --qa-correct=true \
      --hygiene-clean=true
    ```
 
-6. **If something stalls or fails**, record where:
+5. **If something stalls or fails**, record where:
    ```bash
    pnpm dogfood record <run-id> --completion=failed:qa:playwright-crashed --truth-pass=false
    ```
-   Then restore and reset:
-   ```bash
-   pnpm dogfood restore logger-001-drop-meta
-   git checkout main && git reset --hard HEAD~1 && git push --force-with-lease origin main
-   ```
 
-7. **See the trend:**
+6. **See the trend:**
    ```bash
    pnpm dogfood runs:summary
    # Total runs, pass rates, by-workflow + by-seed breakdowns

--- a/slices/dogfood/cli.ts
+++ b/slices/dogfood/cli.ts
@@ -30,7 +30,9 @@ End-to-end orchestrator:
   run <seed-id> [flags]         Apply seed → file issue → tail event stream → record outcome.
                                 Flags: --server-url=, --repo=, --project-slug=, --timeout-ms=,
                                 --no-restore (leave the seed applied on finish),
-                                --skip-verify-red (skip the local truth-signal check)
+                                --skip-verify-red (skip the local red check),
+                                --skip-verify-green (skip the final green check),
+                                --delete-remote-branch-on-finish
 
 Outcome tracking:
   file-issue <seed-id>          Print the gh-issue-create command and record a pending run
@@ -192,7 +194,9 @@ async function main(): Promise<void> {
         projectSlug: flags['project-slug'],
         timeoutMs: flags['timeout-ms'] ? Number(flags['timeout-ms']) : undefined,
         restoreOnFinish: flags['no-restore'] !== 'true',
+        deleteRemoteBranchOnFinish: flags['delete-remote-branch-on-finish'] === 'true',
         skipVerifyRed: flags['skip-verify-red'] === 'true',
+        skipVerifyGreen: flags['skip-verify-green'] === 'true',
       });
       return;
     }

--- a/slices/dogfood/outcome.ts
+++ b/slices/dogfood/outcome.ts
@@ -16,6 +16,9 @@ export interface DogfoodRun {
     number: number;
     url: string;
   };
+  baseBranch?: string;
+  baseRef?: string;
+  seedCommit?: string;
   completion: Completion;
   truthPass?: boolean;
   qaCorrect?: boolean;

--- a/slices/dogfood/run.ts
+++ b/slices/dogfood/run.ts
@@ -1,3 +1,4 @@
+import { type AppendEventInput, eventStore } from '@goose-hub/core/event-stream/store.js';
 import {
   type AgentEventDto,
   type ChecklistProgress,
@@ -10,7 +11,13 @@ import {
 import { tailEvents } from './event-tail.js';
 import { GhClient } from './gh-issue.js';
 import { type Completion, newRun } from './outcome.js';
-import { applySeed, restoreSeed, verifyRed } from './runner.js';
+import {
+  type DogfoodSeedGitOps,
+  applySeed,
+  defaultDogfoodSeedGitOps,
+  verifyGreen,
+  verifyRed,
+} from './runner.js';
 import { RunsStore } from './runs-store.js';
 import { getSeed } from './seeds/index.js';
 import type { Seed } from './seeds/types.js';
@@ -31,14 +38,22 @@ export interface RunOrchestratorOptions {
   timeoutMs?: number;
   /** Restore the seed when finished, regardless of outcome. */
   restoreOnFinish?: boolean;
+  /** Delete the pushed dogfood seed branch after the run completes. */
+  deleteRemoteBranchOnFinish?: boolean;
   /** Skip the local verify-red sanity check (use in CI dry-runs). */
   skipVerifyRed?: boolean;
+  /** Skip the final truth-signal green check. */
+  skipVerifyGreen?: boolean;
   /** Injected GhClient (for tests). */
   gh?: GhClient;
   /** Injected RunsStore (for tests). */
   store?: RunsStore;
   /** Injected event-tail (for tests). */
   tail?: typeof tailEvents;
+  /** Injected git operations (for tests). */
+  seedGit?: DogfoodSeedGitOps;
+  /** Injected durable event writer (for tests). */
+  appendEvent?: (input: AppendEventInput) => unknown;
   /** Console-like sink. */
   logger?: Pick<Console, 'log' | 'warn' | 'error'>;
 }
@@ -85,110 +100,192 @@ export async function runDogfood(opts: RunOrchestratorOptions): Promise<RunOrche
   const gh = opts.gh ?? new GhClient();
   const store = opts.store ?? new RunsStore();
   const tail = opts.tail ?? tailEvents;
+  const seedGit = opts.seedGit ?? defaultDogfoodSeedGitOps;
+  const appendEvent =
+    opts.appendEvent ?? ((event: AppendEventInput) => eventStore.appendEvent(event));
   const seed = getSeed(opts.seedId);
+  const run = newRun(seed.id, cfg.workflow);
+  const seedBranch = `dogfood/${run.runId}/${seed.id}`;
 
   log.log('[1/5] pre-flight — gh auth + seed');
   await gh.assertReady();
+  await seedGit.assertClean(opts.repoRoot);
+  const originalRef = await seedGit.currentRef(opts.repoRoot);
 
-  log.log(`[2/5] apply seed: ${seed.id}`);
-  await applySeed(seed.id, { repoRoot: opts.repoRoot });
-  if (!opts.skipVerifyRed) {
-    const result = await verifyRed(seed.id, { repoRoot: opts.repoRoot });
-    if (!result.truthSignalRed) {
-      throw new Error(
-        `verify-red failed: truth-signal "${seed.truthSignal.testName}" was NOT red after applying ${seed.id}. Seed likely needs an update.`,
-      );
-    }
-    if (result.unexpectedFailures.length > 0) {
-      throw new Error(
-        `verify-red failed: ${result.unexpectedFailures.length} unrelated tests failed in ${seed.truthSignal.testFile}. Fix those before running.`,
-      );
-    }
-    log.log(`      truth-signal red, ${result.passingTests.length} siblings green`);
-  }
-
-  log.log(`[3/5] file GitHub issue on ${cfg.repo}`);
-  let issue: { number: number; url: string };
+  log.log(`[2/5] create seed branch + apply seed: ${seed.id}`);
+  await seedGit.createBranch(opts.repoRoot, seedBranch);
+  let seedCommit: string | undefined;
+  let issue: { number: number; url: string } | undefined;
+  let completion: Completion = 'pending';
+  const progress = newProgress(cfg.workflow);
+  let tailReason: RunOrchestratorResult['reason'] = 'aborted';
+  let eventCount = 0;
   try {
+    await applySeed(seed.id, { repoRoot: opts.repoRoot });
+    if (!opts.skipVerifyRed) {
+      const result = await verifyRed(seed.id, { repoRoot: opts.repoRoot });
+      if (!result.truthSignalRed) {
+        throw new Error(
+          `verify-red failed: truth-signal "${seed.truthSignal.testName}" was NOT red after applying ${seed.id}. Seed likely needs an update.`,
+        );
+      }
+      if (result.unexpectedFailures.length > 0) {
+        throw new Error(
+          `verify-red failed: ${result.unexpectedFailures.length} unrelated tests failed in ${seed.truthSignal.testFile}. Fix those before running.`,
+        );
+      }
+      log.log(`      truth-signal red, ${result.passingTests.length} siblings green`);
+    }
+    seedCommit = await seedGit.commitAll(opts.repoRoot, `dogfood: seed ${seed.id}`);
+    await seedGit.pushBranch(opts.repoRoot, seedBranch);
+    log.log(`      baseBranch: ${seedBranch}`);
+    log.log(`      seedCommit: ${seedCommit}`);
+
+    log.log(`[3/5] file GitHub issue on ${cfg.repo}`);
     issue = await gh.createIssue({
       repo: cfg.repo,
       title: seed.issue.title,
       body: seed.issue.body,
       labels: seed.issue.labels,
     });
-  } catch (err) {
-    if (opts.restoreOnFinish !== false) {
-      await restoreSeed(seed.id, { repoRoot: opts.repoRoot }).catch(() => {});
-    }
-    throw err;
-  }
-  log.log(`      issue #${issue.number}: ${issue.url}`);
+    const workItemId = `github:${cfg.repo}#${issue.number}`;
+    log.log(`      issue #${issue.number}: ${issue.url}`);
+    log.log(`      workItemId: ${workItemId}`);
 
-  const run = newRun(seed.id, cfg.workflow);
-  run.issue = { repo: cfg.repo, number: issue.number, url: issue.url };
-  await store.append(run);
-  log.log(`      runId: ${run.runId}`);
-
-  log.log(`[4/5] tailing event stream (timeout ${cfg.timeoutMs}ms)`);
-  const progress = newProgress(cfg.workflow);
-  printChecklist(log, progress);
-
-  const tailResult = await tail(
-    {
-      serverUrl: cfg.serverUrl,
+    run.issue = { repo: cfg.repo, number: issue.number, url: issue.url };
+    run.baseBranch = seedBranch;
+    run.baseRef = seedCommit;
+    run.seedCommit = seedCommit;
+    await store.append(run);
+    appendEvent({
       projectId: cfg.projectSlug,
-      workItemId: issue.number,
-      timeoutMs: cfg.timeoutMs,
-    },
-    (event: AgentEventDto) => {
-      const advanced = observeEvent(progress, event);
-      if (advanced) {
-        log.log('');
-        printChecklist(log, progress);
-        if (progress.failedNode) log.log(`      [!] agent failure at node: ${progress.failedNode}`);
-      }
-      if (progress.terminalReached) return true;
-      if (progress.failedNode) return true;
-      return false;
-    },
-  );
-
-  log.log(`[5/5] tail ended (${tailResult.reason}); recording outcome`);
-  const completion = computeCompletion(progress, tailResult.reason);
-  await store.update(run.runId, {
-    completion,
-    endedAt: new Date().toISOString(),
-  });
-
-  if (opts.restoreOnFinish !== false) {
-    log.log('      restoring seed locally');
-    await restoreSeed(seed.id, { repoRoot: opts.repoRoot }).catch((err) => {
-      log.warn(`      restore failed: ${err instanceof Error ? err.message : String(err)}`);
+      workItemId,
+      kind: 'dogfood.seed-applied',
+      payload: {
+        seedId: seed.id,
+        baseBranch: seedBranch,
+        baseRef: seedCommit,
+        seedCommit,
+        truthSignal: seed.truthSignal,
+      },
+      runId: run.runId,
     });
+    log.log(`      runId: ${run.runId}`);
+
+    log.log(`[4/5] tailing event stream (timeout ${cfg.timeoutMs}ms)`);
+    printChecklist(log, progress);
+
+    const tailResult = await tail(
+      {
+        serverUrl: cfg.serverUrl,
+        projectId: cfg.projectSlug,
+        workItemId,
+        timeoutMs: cfg.timeoutMs,
+      },
+      (event: AgentEventDto) => {
+        const advanced = observeEvent(progress, event);
+        if (advanced) {
+          log.log('');
+          printChecklist(log, progress);
+          if (progress.failedNode)
+            log.log(`      [!] agent failure at node: ${progress.failedNode}`);
+        }
+        if (progress.terminalReached) return true;
+        if (progress.failedNode) return true;
+        return false;
+      },
+    );
+    tailReason = tailResult.reason;
+    eventCount = tailResult.events.length;
+
+    log.log(`[5/5] tail ended (${tailResult.reason}); recording outcome`);
+    completion = computeCompletion(progress, tailResult.reason);
+    const truthPass =
+      opts.skipVerifyGreen === true || !progress.terminalReached
+        ? undefined
+        : await verifyTruthSignalAgainstFinalCode({
+            repoRoot: opts.repoRoot,
+            seedId: seed.id,
+            seedGit,
+            events: tailResult.events,
+          });
+    await store.update(run.runId, {
+      completion,
+      endedAt: new Date().toISOString(),
+      ...(truthPass == null ? {} : { truthPass }),
+    });
+
+    if (truthPass != null) {
+      log.log(`      truth-pass: ${truthPass}`);
+    }
+  } finally {
+    if (opts.restoreOnFinish !== false) {
+      log.log('      restoring operator branch');
+      await seedGit.checkout(opts.repoRoot, originalRef).catch((err) => {
+        log.warn(
+          `      checkout restore failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+      await seedGit.deleteLocalBranch(opts.repoRoot, seedBranch).catch((err) => {
+        log.warn(
+          `      local branch cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+      if (opts.deleteRemoteBranchOnFinish === true && seedGit.deleteRemoteBranch != null) {
+        await seedGit.deleteRemoteBranch(opts.repoRoot, seedBranch).catch((err) => {
+          log.warn(
+            `      remote branch cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      }
+    }
   }
 
   log.log('');
   log.log('Summary:');
   log.log(`  runId:      ${run.runId}`);
-  log.log(`  issue:      ${issue.url}`);
+  log.log(`  issue:      ${issue?.url ?? '<not filed>'}`);
+  log.log(`  workItemId: ${issue == null ? '<not filed>' : `github:${cfg.repo}#${issue.number}`}`);
+  log.log(`  baseBranch: ${seedBranch}`);
+  log.log(`  seedCommit: ${seedCommit ?? '<not committed>'}`);
   log.log(
     `  completion: ${typeof completion === 'string' ? completion : `failed:${completion.failed.node}`}`,
   );
-  log.log(`  events:     ${tailResult.events.length}`);
+  log.log(`  events:     ${eventCount}`);
   log.log('');
   log.log('Once you know the real outcome, record the remaining signals:');
   log.log(
     `  pnpm dogfood record ${run.runId} --truth-pass=<true|false> --qa-correct=<true|false> --hygiene-clean=<true|false>`,
   );
 
+  if (issue == null) {
+    throw new Error('dogfood issue was not filed');
+  }
+
   return {
     runId: run.runId,
     seed,
-    issue: run.issue,
+    issue: { repo: cfg.repo, number: issue.number, url: issue.url },
     completion,
     progress,
-    reason: tailResult.reason,
+    reason: tailReason,
   };
+}
+
+async function verifyTruthSignalAgainstFinalCode(input: {
+  repoRoot: string;
+  seedId: string;
+  seedGit: DogfoodSeedGitOps;
+  events: AgentEventDto[];
+}): Promise<boolean> {
+  const prOpened = [...input.events].reverse().find((event) => event.kind === 'pr.opened');
+  const payload = prOpened?.payload as { branch?: unknown } | undefined;
+  const branch = typeof payload?.branch === 'string' ? payload.branch : undefined;
+  if (branch == null || branch.trim().length === 0) return false;
+
+  await input.seedGit.fetchBranch(input.repoRoot, branch);
+  await input.seedGit.checkout(input.repoRoot, `origin/${branch}`);
+  return verifyGreen(input.seedId, { repoRoot: input.repoRoot });
 }
 
 function printChecklist(

--- a/slices/dogfood/run.ts
+++ b/slices/dogfood/run.ts
@@ -15,6 +15,7 @@ import {
   type DogfoodSeedGitOps,
   applySeed,
   defaultDogfoodSeedGitOps,
+  restoreSeed,
   verifyGreen,
   verifyRed,
 } from './runner.js';
@@ -53,7 +54,7 @@ export interface RunOrchestratorOptions {
   /** Injected git operations (for tests). */
   seedGit?: DogfoodSeedGitOps;
   /** Injected durable event writer (for tests). */
-  appendEvent?: (input: AppendEventInput) => unknown;
+  appendEvent?: (input: AppendEventInput) => unknown | Promise<unknown>;
   /** Console-like sink. */
   logger?: Pick<Console, 'log' | 'warn' | 'error'>;
 }
@@ -120,8 +121,10 @@ export async function runDogfood(opts: RunOrchestratorOptions): Promise<RunOrche
   const progress = newProgress(cfg.workflow);
   let tailReason: RunOrchestratorResult['reason'] = 'aborted';
   let eventCount = 0;
+  let seedApplied = false;
   try {
     await applySeed(seed.id, { repoRoot: opts.repoRoot });
+    seedApplied = true;
     if (!opts.skipVerifyRed) {
       const result = await verifyRed(seed.id, { repoRoot: opts.repoRoot });
       if (!result.truthSignalRed) {
@@ -157,7 +160,7 @@ export async function runDogfood(opts: RunOrchestratorOptions): Promise<RunOrche
     run.baseRef = seedCommit;
     run.seedCommit = seedCommit;
     await store.append(run);
-    appendEvent({
+    await appendEvent({
       projectId: cfg.projectSlug,
       workItemId,
       kind: 'dogfood.seed-applied',
@@ -200,27 +203,42 @@ export async function runDogfood(opts: RunOrchestratorOptions): Promise<RunOrche
 
     log.log(`[5/5] tail ended (${tailResult.reason}); recording outcome`);
     completion = computeCompletion(progress, tailResult.reason);
-    const truthPass =
-      opts.skipVerifyGreen === true || !progress.terminalReached
-        ? undefined
-        : await verifyTruthSignalAgainstFinalCode({
-            repoRoot: opts.repoRoot,
-            seedId: seed.id,
-            seedGit,
-            events: tailResult.events,
-          });
     await store.update(run.runId, {
       completion,
       endedAt: new Date().toISOString(),
-      ...(truthPass == null ? {} : { truthPass }),
     });
 
-    if (truthPass != null) {
-      log.log(`      truth-pass: ${truthPass}`);
+    if (
+      opts.skipVerifyGreen !== true &&
+      opts.restoreOnFinish !== false &&
+      progress.terminalReached
+    ) {
+      const truthPass = await verifyTruthSignalAgainstFinalCode({
+        repoRoot: opts.repoRoot,
+        seedId: seed.id,
+        seedGit,
+        events: tailResult.events,
+      }).catch((err) => {
+        log.warn(
+          `      truth-pass check skipped: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return undefined;
+      });
+      if (truthPass != null) {
+        await store.update(run.runId, { truthPass });
+        log.log(`      truth-pass: ${truthPass}`);
+      }
     }
   } finally {
     if (opts.restoreOnFinish !== false) {
       log.log('      restoring operator branch');
+      if (seedApplied && seedCommit == null) {
+        await restoreSeed(seed.id, { repoRoot: opts.repoRoot }).catch((err) => {
+          log.warn(
+            `      uncommitted seed restore failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      }
       await seedGit.checkout(opts.repoRoot, originalRef).catch((err) => {
         log.warn(
           `      checkout restore failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -277,11 +295,11 @@ async function verifyTruthSignalAgainstFinalCode(input: {
   seedId: string;
   seedGit: DogfoodSeedGitOps;
   events: AgentEventDto[];
-}): Promise<boolean> {
+}): Promise<boolean | undefined> {
   const prOpened = [...input.events].reverse().find((event) => event.kind === 'pr.opened');
   const payload = prOpened?.payload as { branch?: unknown } | undefined;
   const branch = typeof payload?.branch === 'string' ? payload.branch : undefined;
-  if (branch == null || branch.trim().length === 0) return false;
+  if (branch == null || branch.trim().length === 0) return undefined;
 
   await input.seedGit.fetchBranch(input.repoRoot, branch);
   await input.seedGit.checkout(input.repoRoot, `origin/${branch}`);

--- a/slices/dogfood/runner.ts
+++ b/slices/dogfood/runner.ts
@@ -1,11 +1,26 @@
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promises as fs, accessSync } from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import { getSeed, listSeeds } from './seeds/index.js';
 import type { Seed, SeedState, VerifyResult } from './seeds/types.js';
 
+const execFileAsync = promisify(execFile);
+
 export interface RunnerOptions {
   repoRoot: string;
+}
+
+export interface DogfoodSeedGitOps {
+  assertClean(repoRoot: string): Promise<void>;
+  currentRef(repoRoot: string): Promise<string>;
+  createBranch(repoRoot: string, branch: string): Promise<void>;
+  commitAll(repoRoot: string, message: string): Promise<string>;
+  pushBranch(repoRoot: string, branch: string): Promise<void>;
+  fetchBranch(repoRoot: string, branch: string): Promise<void>;
+  checkout(repoRoot: string, ref: string): Promise<void>;
+  deleteLocalBranch(repoRoot: string, branch: string): Promise<void>;
+  deleteRemoteBranch?(repoRoot: string, branch: string): Promise<void>;
 }
 
 export interface SeedStatus {
@@ -152,6 +167,110 @@ export async function verifyRed(seedId: string, opts: RunnerOptions): Promise<Ve
     raw: json,
   };
 }
+
+export async function verifyGreen(seedId: string, opts: RunnerOptions): Promise<boolean> {
+  const seed = getSeed(seedId);
+  const vitest = findVitestBin(opts.repoRoot);
+  if (!vitest) {
+    throw new Error(
+      `vitest not found in node_modules. Run \`pnpm install\` first. Expected at: ${path.join(opts.repoRoot, 'node_modules', '.bin', 'vitest')}`,
+    );
+  }
+  const fullTestFile = path.join(opts.repoRoot, seed.truthSignal.testFile);
+  await fs.access(fullTestFile);
+
+  const json = await new Promise<VitestJsonResult>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const proc = spawn(
+      vitest,
+      ['run', '--reporter=json', seed.truthSignal.testFile, '-t', seed.truthSignal.testName],
+      {
+        cwd: opts.repoRoot,
+        env: process.env,
+      },
+    );
+    proc.stdout.on('data', (b) => {
+      stdout += b.toString();
+    });
+    proc.stderr.on('data', (b) => {
+      stderr += b.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', () => {
+      const trimmed = stdout.trim();
+      const start = trimmed.indexOf('{');
+      const end = trimmed.lastIndexOf('}');
+      if (start === -1 || end === -1) {
+        reject(new Error(`vitest produced no JSON. stderr:\n${stderr}\nstdout:\n${stdout}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(trimmed.slice(start, end + 1)) as VitestJsonResult);
+      } catch (err) {
+        reject(new Error(`failed to parse vitest JSON: ${(err as Error).message}`));
+      }
+    });
+  });
+
+  const { passing, failing } = namesFromVitestJson(json);
+  const normalize = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[›>\s]+/g, ' ')
+      .trim();
+  const needle = normalize(seed.truthSignal.testName);
+  return passing.some((n) => normalize(n).includes(needle)) && failing.length === 0;
+}
+
+async function git(repoRoot: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return stdout.trim();
+}
+
+export const defaultDogfoodSeedGitOps: DogfoodSeedGitOps = {
+  async assertClean(repoRoot) {
+    const status = await git(repoRoot, ['status', '--porcelain']);
+    if (status.length > 0) {
+      throw new Error(
+        `dogfood requires a clean worktree before applying a seed. Dirty paths:\n${status}`,
+      );
+    }
+  },
+  async currentRef(repoRoot) {
+    try {
+      return await git(repoRoot, ['symbolic-ref', '--short', 'HEAD']);
+    } catch {
+      return git(repoRoot, ['rev-parse', 'HEAD']);
+    }
+  },
+  async createBranch(repoRoot, branch) {
+    await git(repoRoot, ['checkout', '-b', branch]);
+  },
+  async commitAll(repoRoot, message) {
+    await git(repoRoot, ['add', '-A']);
+    await git(repoRoot, ['commit', '-m', message]);
+    return git(repoRoot, ['rev-parse', 'HEAD']);
+  },
+  async pushBranch(repoRoot, branch) {
+    await git(repoRoot, ['push', '--force-with-lease', 'origin', `HEAD:refs/heads/${branch}`]);
+  },
+  async fetchBranch(repoRoot, branch) {
+    await git(repoRoot, ['fetch', 'origin', `${branch}:refs/remotes/origin/${branch}`]);
+  },
+  async checkout(repoRoot, ref) {
+    await git(repoRoot, ['checkout', ref]);
+  },
+  async deleteLocalBranch(repoRoot, branch) {
+    await git(repoRoot, ['branch', '-D', branch]);
+  },
+  async deleteRemoteBranch(repoRoot, branch) {
+    await git(repoRoot, ['push', 'origin', '--delete', branch]);
+  },
+};
 
 export function renderIssueBody(seed: Seed): string {
   return seed.issue.body;

--- a/slices/dogfood/slice.test.ts
+++ b/slices/dogfood/slice.test.ts
@@ -637,6 +637,22 @@ describe('runDogfood orchestrator', () => {
     };
   }
 
+  function makeSeedGit() {
+    return {
+      assertClean: vi.fn().mockResolvedValue(undefined),
+      currentRef: vi.fn().mockResolvedValue('main'),
+      createBranch: vi.fn().mockResolvedValue(undefined),
+      commitAll: vi.fn().mockResolvedValue('seed-commit-sha'),
+      pushBranch: vi.fn().mockResolvedValue(undefined),
+      fetchBranch: vi.fn().mockResolvedValue(undefined),
+      checkout: vi.fn(async () => {
+        await restoreSeed('logger-001-drop-meta', { repoRoot: tmpRepoRoot }).catch(() => {});
+      }),
+      deleteLocalBranch: vi.fn().mockResolvedValue(undefined),
+      deleteRemoteBranch: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
   it('happy-path: applies seed, files issue, tails to terminal, records reached-terminal', async () => {
     const events: AgentEventDto[] = [
       { kind: 'state.transitioned', payload: { to: 'factory:investigating' } },
@@ -647,14 +663,17 @@ describe('runDogfood orchestrator', () => {
       { kind: 'state.transitioned', payload: { to: 'factory:done' } },
     ];
     const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    const seedGit = makeSeedGit();
     const result = await runDogfood({
       seedId: 'logger-001-drop-meta',
       repoRoot: tmpRepoRoot,
       gh: makeGh(),
       store,
       tail: makeTail(events),
+      seedGit,
       logger: silent,
       skipVerifyRed: true,
+      skipVerifyGreen: true,
     });
 
     expect(result.issue.number).toBe(4242);
@@ -665,7 +684,68 @@ describe('runDogfood orchestrator', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].completion).toBe('reached-terminal');
     expect(rows[0].issue?.number).toBe(4242);
+    expect(rows[0].baseBranch).toMatch(/^dogfood\/dogfood-/);
+    expect(rows[0].baseRef).toBe('seed-commit-sha');
+    expect(rows[0].seedCommit).toBe('seed-commit-sha');
     expect(rows[0].endedAt).toBeDefined();
+  });
+
+  it('tails the canonical repo-qualified GitHub work item id', async () => {
+    let tailedWorkItemId: unknown;
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repo: 'owner/repo',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: async (opts) => {
+        tailedWorkItemId = opts.workItemId;
+        return { events: [], reason: 'server-closed' as const };
+      },
+      seedGit: makeSeedGit(),
+      appendEvent: () => {},
+      logger: silent,
+      skipVerifyRed: true,
+      skipVerifyGreen: true,
+    });
+
+    expect(tailedWorkItemId).toBe('github:owner/repo#4242');
+  });
+
+  it('emits dogfood.seed-applied with base ref metadata', async () => {
+    const appendEvent = vi.fn();
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repo: 'owner/repo',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: makeTail([]),
+      seedGit: makeSeedGit(),
+      appendEvent,
+      logger: silent,
+      skipVerifyRed: true,
+      skipVerifyGreen: true,
+    });
+
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'goose-hub-self',
+        workItemId: 'github:owner/repo#4242',
+        kind: 'dogfood.seed-applied',
+        payload: expect.objectContaining({
+          seedId: 'logger-001-drop-meta',
+          baseBranch: expect.stringMatching(/^dogfood\/dogfood-/),
+          baseRef: 'seed-commit-sha',
+          seedCommit: 'seed-commit-sha',
+          truthSignal: expect.objectContaining({
+            testFile: 'apps/web/src/lib/logger.test.ts',
+          }),
+        }),
+      }),
+    );
   });
 
   it('failure path: records `failed:<node>` when an agent.run-failed arrives', async () => {
@@ -674,14 +754,17 @@ describe('runDogfood orchestrator', () => {
       { kind: 'agent.run-failed', payload: { skill: 'qa', reason: 'timeout' } },
     ];
     const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    const seedGit = makeSeedGit();
     const result = await runDogfood({
       seedId: 'logger-001-drop-meta',
       repoRoot: tmpRepoRoot,
       gh: makeGh(),
       store,
       tail: makeTail(events),
+      seedGit,
       logger: silent,
       skipVerifyRed: true,
+      skipVerifyGreen: true,
     });
     expect(typeof result.completion).toBe('object');
     if (typeof result.completion !== 'object') throw new Error('expected failed-object');
@@ -701,8 +784,10 @@ describe('runDogfood orchestrator', () => {
       gh: makeGh(),
       store,
       tail: makeTail(events),
+      seedGit: makeSeedGit(),
       logger: silent,
       skipVerifyRed: true,
+      skipVerifyGreen: true,
     });
     const after = await fs.readFile(targetPath, 'utf8');
     expect(after).toBe(before);

--- a/slices/dogfood/slice.test.ts
+++ b/slices/dogfood/slice.test.ts
@@ -748,6 +748,33 @@ describe('runDogfood orchestrator', () => {
     );
   });
 
+  it('awaits dogfood.seed-applied persistence before tailing events', async () => {
+    let seedEventPersisted = false;
+    let tailStartedAfterSeedEvent = false;
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: async () => {
+        tailStartedAfterSeedEvent = seedEventPersisted;
+        return { events: [], reason: 'server-closed' as const };
+      },
+      seedGit: makeSeedGit(),
+      appendEvent: async () => {
+        await Promise.resolve();
+        seedEventPersisted = true;
+      },
+      logger: silent,
+      skipVerifyRed: true,
+      skipVerifyGreen: true,
+    });
+
+    expect(tailStartedAfterSeedEvent).toBe(true);
+  });
+
   it('failure path: records `failed:<node>` when an agent.run-failed arrives', async () => {
     const events: AgentEventDto[] = [
       { kind: 'state.transitioned', payload: { to: 'factory:investigating' } },
@@ -791,6 +818,106 @@ describe('runDogfood orchestrator', () => {
     });
     const after = await fs.readFile(targetPath, 'utf8');
     expect(after).toBe(before);
+  });
+
+  it('restores uncommitted seed edits before returning to the operator branch when verify-red fails', async () => {
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    const targetPath = path.join(tmpRepoRoot, 'apps/web/src/lib/logger.ts');
+    const before = await fs.readFile(targetPath, 'utf8');
+    const seedGit = makeSeedGit();
+    seedGit.checkout.mockResolvedValue(undefined);
+
+    await expect(
+      runDogfood({
+        seedId: 'logger-001-drop-meta',
+        repoRoot: tmpRepoRoot,
+        gh: makeGh(),
+        store,
+        tail: makeTail([]),
+        seedGit,
+        logger: silent,
+      }),
+    ).rejects.toThrow(/vitest not found/);
+
+    const after = await fs.readFile(targetPath, 'utf8');
+    expect(after).toBe(before);
+    expect(seedGit.checkout).toHaveBeenCalledWith(tmpRepoRoot, 'main');
+    expect(seedGit.deleteLocalBranch).toHaveBeenCalled();
+  });
+
+  it('records completion even when final truth-signal verification cannot run', async () => {
+    const events: AgentEventDto[] = [
+      { kind: 'pr.opened', payload: { branch: 'factory/fix-4242' } },
+      { kind: 'state.transitioned', payload: { to: 'factory:done' } },
+    ];
+    const logger = { log: () => {}, warn: vi.fn(), error: () => {} } as unknown as Console;
+
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: makeTail(events),
+      seedGit: makeSeedGit(),
+      logger,
+      skipVerifyRed: true,
+    });
+
+    const rows = await store.list();
+    expect(rows[0].completion).toBe('reached-terminal');
+    expect(rows[0].truthPass).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('truth-pass check skipped'));
+  });
+
+  it('leaves truth-pass unknown when no PR branch is available in the tailed events', async () => {
+    const events: AgentEventDto[] = [
+      { kind: 'state.transitioned', payload: { to: 'factory:done' } },
+    ];
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    const seedGit = makeSeedGit();
+
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: makeTail(events),
+      seedGit,
+      logger: silent,
+      skipVerifyRed: true,
+    });
+
+    const rows = await store.list();
+    expect(rows[0].completion).toBe('reached-terminal');
+    expect(rows[0].truthPass).toBeUndefined();
+    expect(seedGit.fetchBranch).not.toHaveBeenCalled();
+  });
+
+  it('honors --no-restore by skipping final checkout-based green verification', async () => {
+    const events: AgentEventDto[] = [
+      { kind: 'pr.opened', payload: { branch: 'factory/fix-4242' } },
+      { kind: 'state.transitioned', payload: { to: 'factory:done' } },
+    ];
+    const silent = { log: () => {}, warn: () => {}, error: () => {} } as Console;
+    const seedGit = makeSeedGit();
+
+    await runDogfood({
+      seedId: 'logger-001-drop-meta',
+      repoRoot: tmpRepoRoot,
+      gh: makeGh(),
+      store,
+      tail: makeTail(events),
+      seedGit,
+      logger: silent,
+      skipVerifyRed: true,
+      restoreOnFinish: false,
+    });
+
+    const rows = await store.list();
+    expect(rows[0].completion).toBe('reached-terminal');
+    expect(rows[0].truthPass).toBeUndefined();
+    expect(seedGit.fetchBranch).not.toHaveBeenCalled();
+    expect(seedGit.checkout).not.toHaveBeenCalled();
   });
 
   it('computeCompletion translates timeout + no terminal into `stalled`', () => {

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -88,6 +88,9 @@ vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   prewarmWorktree: (...args: unknown[]) => mockPrewarmWorktree(...args),
   resolveWorkflowBase: (...args: unknown[]) => mockResolveWorkflowBase(...args),
 }));
+vi.mock('@goose-hub/core/workspaces/workflow-base.js', () => ({
+  resolveWorkflowBaseForWorkItem: (...args: unknown[]) => mockResolveWorkflowBase(...args),
+}));
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
   orchestratorCommitAll: vi.fn().mockReturnValue('fake-sha'),
 }));
@@ -275,6 +278,34 @@ describe('runFixIssueWorkflow — default deps (lines 68-73 ?? fallbacks)', () =
     expect(mockOpenPR).toHaveBeenCalled();
     // worktree persists until merge — NOT cleaned up after PR open
     expect(mockCleanupWorktree).not.toHaveBeenCalled();
+  });
+
+  it('creates the implementation worktree from a dogfood seed base ref when metadata exists', async () => {
+    mockResolveWorkflowBase.mockReturnValueOnce({
+      branch: 'dogfood/run/logger-001-drop-meta',
+      ref: 'seed-commit-sha',
+      source: 'dogfood-seed',
+    });
+    const item = makeWorkItem({
+      id: 'github:owner/repo#123',
+      externalId: '123',
+      priority: 'medium',
+    });
+    const source = makeStateSource();
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo');
+
+    expect(mockResolveWorkflowBase).toHaveBeenCalledWith(
+      'proj',
+      'github:owner/repo#123',
+      '/repo',
+      undefined,
+    );
+    expect(mockCreateWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'seed-commit-sha');
+    expect(mockOpenPR).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: 'dogfood/run/logger-001-drop-meta' }),
+    );
   });
 });
 

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -18,11 +18,11 @@ import {
   symbolHintsToKeyFiles,
 } from '@goose-hub/core/symbol-index/lookup.js';
 import { orchestratorCommitAll } from '@goose-hub/core/workspaces/orchestrator-git.js';
+import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import {
   cleanupWorktree,
   createWorktree,
   prewarmWorktree,
-  resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
 import { EvidencePostPlanSchema } from '@goose-hub/skills/evidence-post/schema.js';
 import { ImplementSchema } from '@goose-hub/skills/implement/schema.js';
@@ -60,7 +60,7 @@ export interface FixIssueDeps {
   /** Override resolveWorktreeHeadSha (used by tests to avoid real git subprocess). */
   resolveWorktreeHeadShaImpl?: typeof resolveWorktreeHeadSha;
   /** Override resolveWorkflowBase (used by tests to avoid real git subprocess). */
-  resolveWorkflowBaseImpl?: typeof resolveWorkflowBase;
+  resolveWorkflowBaseImpl?: typeof resolveWorkflowBaseForWorkItem;
   /**
    * Override orchestratorCommitAll (used by tests). Orchestrator commits the
    * implement skill's output before opening the PR (ADR 0031 — builder no-commit rule).
@@ -102,7 +102,7 @@ export async function runFixIssueWorkflow(
   const cleanupWtFn = deps.cleanupWorktreeImpl ?? cleanupWorktree;
   const prewarmWtFn = deps.prewarmWorktreeImpl ?? prewarmWorktree;
   const resolveHeadShaFn = deps.resolveWorktreeHeadShaImpl ?? resolveWorktreeHeadSha;
-  const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBase;
+  const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBaseForWorkItem;
   const orchestratorCommitFn = deps.orchestratorCommitAllImpl ?? orchestratorCommitAll;
 
   const implementPrompt = readPromptWithContext('implement', projectId);
@@ -117,6 +117,8 @@ export async function runFixIssueWorkflow(
     injectedRuntime: deps.runtime,
   });
   const workflowBase = resolveWorkflowBaseFn(
+    projectId,
+    workItem.id,
     targetRepo,
     implementExecution.projectConfig?.targetRepo?.defaultBranch,
   );

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -129,6 +129,14 @@ vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   }),
 }));
 
+vi.mock('@goose-hub/core/workspaces/workflow-base.js', () => ({
+  resolveWorkflowBaseForWorkItem: vi.fn().mockReturnValue({
+    branch: 'main',
+    ref: 'origin/main',
+    source: 'configured-default',
+  }),
+}));
+
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return { ...actual, readFileSync: vi.fn().mockReturnValue('# mock prompt') };
@@ -537,6 +545,30 @@ describe('runInvestigateWorkflow', () => {
 
       expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'origin/main');
       expect(cleanupWorktree).toHaveBeenCalledOnce();
+    });
+
+    it('creates the investigation worktree from a dogfood seed base ref when metadata exists', async () => {
+      const { createWorktree } = await import('@goose-hub/core/workspaces/worktree.js');
+      const { resolveWorkflowBaseForWorkItem } = await import(
+        '@goose-hub/core/workspaces/workflow-base.js'
+      );
+      vi.mocked(resolveWorkflowBaseForWorkItem).mockReturnValueOnce({
+        branch: 'dogfood/run/logger-001-drop-meta',
+        ref: 'seed-commit-sha',
+        source: 'dogfood-seed',
+      });
+
+      const item = makeWorkItem({ id: 'github:owner/repo#123', externalId: '123' });
+      const { runInvestigateWorkflow } = await import('./workflow.js');
+      await runInvestigateWorkflow(item, makeMockSource(), 'goose-hub-self', '/repo');
+
+      expect(resolveWorkflowBaseForWorkItem).toHaveBeenCalledWith(
+        'goose-hub-self',
+        'github:owner/repo#123',
+        '/repo',
+        expect.any(String),
+      );
+      expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'seed-commit-sha');
     });
 
     it('emits only one parent run-started event and suppresses the synthesis duplicate', async () => {

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -55,11 +55,11 @@ import {
   shapeSymbolIndexHintsForScout,
 } from '@goose-hub/core/symbol-index/lookup.js';
 import type { RuntimeEffort } from '@goose-hub/core/types.js';
+import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import {
   cleanupWorktree,
   createWorktree,
   prewarmWorktree,
-  resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
 import type { InvestigateSchema } from '@goose-hub/skills/investigate/schema.js';
 import {
@@ -170,7 +170,7 @@ function runtimeNameForModel(modelId: string): 'codex-cli' | 'claude-cli' {
 export interface InvestigateWorkflowDeps {
   createWorktreeImpl?: typeof createWorktree;
   prewarmWorktreeImpl?: typeof prewarmWorktree;
-  resolveWorkflowBaseImpl?: typeof resolveWorkflowBase;
+  resolveWorkflowBaseImpl?: typeof resolveWorkflowBaseForWorkItem;
   runtime?: AgentRuntime;
   playwrightEvidenceRunner?: typeof runPlaywrightReproPlan;
 }
@@ -212,7 +212,7 @@ export async function runInvestigateWorkflow(
 ): Promise<void> {
   const createWtFn = deps.createWorktreeImpl ?? createWorktree;
   const prewarmWtFn = deps.prewarmWorktreeImpl ?? prewarmWorktree;
-  const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBase;
+  const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBaseForWorkItem;
 
   const runId = crypto.randomUUID();
   const { personaId } = selectPersona(projectId, 'investigator');
@@ -245,7 +245,12 @@ export async function runInvestigateWorkflow(
       model: investigatorModelOverride,
       skillProvider: forcedRuntimeProvider ?? investigateBudget.provider,
     });
-  const workflowBase = resolveWorkflowBaseFn(targetRepo, projectConfig?.targetRepo?.defaultBranch);
+  const workflowBase = resolveWorkflowBaseFn(
+    projectId,
+    workItem.id,
+    targetRepo,
+    projectConfig?.targetRepo?.defaultBranch,
+  );
   const worktreePath = createWtFn(targetRepo, runId, workflowBase.ref);
 
   if (workItem.type === 'bug') {


### PR DESCRIPTION
## Summary
- commit dogfood seeds on dedicated pushed dogfood branches before filing issues
- persist dogfood.seed-applied metadata and tail canonical github:owner/repo#issue ids
- resolve investigate and fix-issue worktrees from dogfood seed base refs when present

## Verification
- pnpm test slices/dogfood/slice.test.ts core/workspaces/workflow-base.test.ts slices/investigate/slice.test.ts slices/fix-issue/slice.test.ts
- pnpm typecheck
- pnpm exec biome check slices/dogfood/run.ts slices/dogfood/runner.ts slices/dogfood/outcome.ts slices/dogfood/cli.ts slices/dogfood/slice.test.ts core/event-stream/kinds.ts core/workspaces/workflow-base.ts core/workspaces/workflow-base.test.ts slices/investigate/workflow.ts slices/investigate/slice.test.ts slices/fix-issue/workflow.ts slices/fix-issue/slice.test.ts
- git diff --check