### PR TITLE
Render runtime advisory timeline cards

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -243,6 +243,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
     case 'coach.dispatch-failed':
     case 'workflow.smoke-failed':
     case 'agent.cancelled':
+    case 'agent.runtime-advisory':
     case 'spec.wp-issues-created':
     case 'merge-decision.completed':
     case 'audit.completed':

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -290,6 +290,30 @@ describe('Misc timeline events', () => {
     expect(rendered).not.toContain('raw-value');
   });
 
+  it('renders agent.runtime-advisory as a compact warning instead of raw JSON', () => {
+    const event = makeEvent('agent.runtime-advisory', {
+      runId: '706dcce3-efc7-409e-9f85-6b892b27f092',
+      skill: 'bug-enhance',
+      surface: 'resources/read failed',
+      stderr:
+        "2026-05-24T23:17:27.555260Z ERROR codex_core::tools::router: error=resources/read failed: resources/read failed for `factory-tools` (factory://core/agent-runtime/logger.ts): Mcp error: -32603: ENOENT: no such file or directory, open '/Users/shaunnesbitt/.factory/workspaces/388033da-91c0-4b27-bf19-83c02f667308/core/agent-runtime/logger.ts'",
+      toolName: 'resources/read',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Runtime advisory')).toBeTruthy();
+    const rendered = document.body.textContent ?? '';
+    expect(rendered).toContain('bug-enhance');
+    expect(rendered).toContain('resources/read');
+    expect(rendered).toContain('resources/read failed');
+    expect(rendered).toContain('factory://core/agent-runtime/logger.ts');
+    expect(rendered).toContain('706dcce3-efc7-409e-9f85-6b892b27f092');
+    expect(rendered).toContain('Runtime surfaced a tool access warning');
+    expect(rendered).not.toContain('"stderr"');
+    expect(rendered).not.toContain('codex_core::tools::router');
+  });
+
   it('renders agent.investigation-context-injected as summary text instead of raw JSON', () => {
     const event = makeEvent('agent.investigation-context-injected', {
       skill: 'implement-wp',

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -198,6 +198,10 @@ function payloadNumber(payload: CompactOperationalPayload | null, key: string): 
   return typeof value === 'number' ? value : null;
 }
 
+function factoryResourceFromStderr(stderr: string | null): string | null {
+  return stderr?.match(/factory:\/\/[^\s)]+/)?.[0] ?? null;
+}
+
 export function ManualActionEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as { action?: string } | null;
   const action = p?.action ?? getPayloadStr(event.payload);
@@ -739,6 +743,19 @@ function compactOperationalEventDetails(event: AgentEventDto): {
       push(payloadString(p, 'reason'));
       if (payloadNumber(p, 'elapsedMs') != null) facts.push(`${payloadNumber(p, 'elapsedMs')} ms`);
       break;
+    case 'agent.runtime-advisory': {
+      tone = 'warning';
+      icon = 'warning';
+      push(payloadString(p, 'skill'));
+      push(payloadString(p, 'toolName'));
+      push(payloadString(p, 'surface'));
+      push(
+        payloadString(p, 'requestedPath') ?? factoryResourceFromStderr(payloadString(p, 'stderr')),
+      );
+      push(payloadString(p, 'runId') ?? formatShortId(event.runId ?? undefined));
+      detail = 'Runtime surfaced a tool access warning; the agent run may still continue.';
+      break;
+    }
     case 'spec.wp-issues-created':
       tone = 'success';
       push(payloadString(p, 'pipelineRunId') ?? formatShortId(event.runId ?? undefined));

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -21,6 +21,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.run-started': 'Agent run started',
   'agent.run-completed': 'Agent run completed',
   'agent.run-failed': 'Agent run failed',
+  'agent.runtime-advisory': 'Runtime advisory',
   'agent.budget-exceeded': 'Agent budget exceeded',
   'agent.tool-call': 'Tool call',
   'agent.tool-intensity-anomaly': 'Tool intensity anomaly',


### PR DESCRIPTION
## Summary
- Route agent.runtime-advisory timeline rows through the compact operational JSX card
- Show skill, tool, surface, resource URI, and run ID without dumping raw stderr
- Add a focused timeline regression test for the resources/read advisory payload

## Verification
- env TMPDIR=/private/tmp pnpm test apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
- pnpm exec biome check apps/web/src/components/detail/components/TimelineEvents.tsx apps/web/src/components/detail/components/timeline/MiscEvents.tsx apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx apps/web/src/components/detail/lib/timeline/labels.ts