### PR TITLE
M20.1045: tier-0 vagueness gate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,16 @@ type AdvisorVerdict =
 
 **Authorization:** deferred (single-user, v0). ADR when contributor support lands.
 
+## Triage Vagueness Gate
+
+**Purpose:** Triage classifies work-item vagueness deterministically before routing so vague intake is visible at zero model cost. `core/workflows/vagueness-gate.ts` is a pure helper: no LLM calls, no I/O, no event emission, and no state mutation.
+
+**Issue-label ownership:** Triage owns `vague:high` / `vague:low` and recomputes them on every triage pass. A triaged issue must have exactly one current `vague:*` label. Triage also owns `missing:repro` and `missing:criteria`, and those are the only persisted `missing:*` labels; other heuristics such as length, hedging, and missing file/component hints affect only the numeric score.
+
+**Routing contract:** `targetStateForTriage()` routes from classified type plus the current vagueness labels. Bugs continue to enter `factory:investigating`; high-vagueness bugs are enriched by the existing pre-investigation bug-enhance path when no grounded seed exists. Fresh features with `vague:low` keep the existing `factory:grilling` route. Fresh features with `vague:high` route to `factory:framing`, which is a holding state only until the follow-up feature-frame workflow lands. Chores route to `factory:dev-ready`; research routes to `factory:research-pending`.
+
+**PRD override:** `factory:from-prd` remains authoritative for `type:feature`: PRD-derived feature work routes directly to `factory:dev-ready` even when the deterministic gate scores it `vague:high`. The parent PRD path already performed framing, so triage must not send those children back through framing or grilling.
+
 ## Operator Intervention Control Plane
 
 **Purpose:** Durable operator interventions explain and resolve stuck work-item

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -473,6 +473,7 @@ describe('getIssueLegalTargets', () => {
       type: 'bug',
     });
     vi.mocked(legalTargets).mockReturnValueOnce([
+      'factory:framing',
       'factory:grilling',
       'factory:investigating',
       'factory:dev-ready',

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -167,7 +167,7 @@ function projectEngineeringSpec(record: NonNullable<ReturnType<typeof getEnginee
 }
 
 const TYPE_EXCLUDED_LEGAL_TARGETS: Readonly<Record<string, readonly StateName[]>> = {
-  bug: ['factory:grilling', 'factory:research-pending'],
+  bug: ['factory:framing', 'factory:grilling', 'factory:research-pending'],
   feature: ['factory:investigating', 'factory:research-pending'],
 };
 

--- a/apps/server/src/domains/workflows/triage-batch.test.ts
+++ b/apps/server/src/domains/workflows/triage-batch.test.ts
@@ -242,6 +242,84 @@ describe('runTriageBatch', () => {
     expect(source.setLabelInGroup).toHaveBeenCalledWith('42', 'priority', 'high');
   });
 
+  it('recomputes vagueness metadata labels and removes stale values on the issue', async () => {
+    const item = makeWorkItem({
+      type: 'bug',
+      title: 'Dashboard broken',
+      body: 'Something is weird. Maybe fix it.',
+    });
+    const source = makeMockSource([item]);
+    if (source.listLabels == null) throw new Error('mock source must define listLabels');
+    vi.mocked(source.listLabels).mockResolvedValue([
+      'factory:triaging',
+      'vague:low',
+      'missing:criteria',
+      'missing:repro',
+    ]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({
+        output: makeTriageOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult)
+      .mockResolvedValueOnce({
+        output: makeRepoMatchOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    expect(source.removeLabel).toHaveBeenCalledWith('42', 'vague:low');
+    expect(source.addLabels).toHaveBeenCalledWith('42', ['vague:high']);
+    expect(source.removeLabel).not.toHaveBeenCalledWith('42', 'missing:criteria');
+    expect(source.removeLabel).not.toHaveBeenCalledWith('42', 'missing:repro');
+  });
+
+  it('removes missing labels that no longer match the current gate result', async () => {
+    const item = makeWorkItem({
+      type: 'feature',
+      title: 'Show active milestone filter on board',
+      body: [
+        'Route: /projects/goose-hub-self/board',
+        'Component: BoardToolbar',
+        'Acceptance criteria:',
+        '- The board shows a milestone dropdown populated from /active-milestone.',
+        '- Selecting a milestone refetches issue cards for that milestone.',
+      ].join('\n'),
+    });
+    const source = makeMockSource([item]);
+    if (source.listLabels == null) throw new Error('mock source must define listLabels');
+    vi.mocked(source.listLabels).mockResolvedValue([
+      'factory:triaging',
+      'vague:high',
+      'missing:criteria',
+      'missing:repro',
+    ]);
+
+    mockRuntime.run
+      .mockResolvedValueOnce({
+        output: { ...makeTriageOutput(), type: 'feature' },
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult)
+      .mockResolvedValueOnce({
+        output: makeRepoMatchOutput(),
+        decisionSummaries: [],
+        events: [],
+      } satisfies AgentResult);
+
+    const { runTriageBatch } = await import('./triage-batch.js');
+    await runTriageBatch('goose-hub-self', source);
+
+    expect(source.removeLabel).toHaveBeenCalledWith('42', 'vague:high');
+    expect(source.removeLabel).toHaveBeenCalledWith('42', 'missing:criteria');
+    expect(source.removeLabel).toHaveBeenCalledWith('42', 'missing:repro');
+    expect(source.addLabels).toHaveBeenCalledWith('42', ['vague:low']);
+  });
+
   it('does not replace an existing type label', async () => {
     const item = makeWorkItem({ type: 'feature' });
     const source = makeMockSource([item]);
@@ -693,7 +771,18 @@ describe('runTriageBatch onward routing after accept', () => {
   });
 
   it('routes fresh type:feature (no factory:from-prd) to factory:grilling after accepting', async () => {
-    const source = makeMockSource([makeWorkItem()]);
+    const source = makeMockSource([
+      makeWorkItem({
+        title: 'Show active milestone filter on board',
+        body: [
+          'Route: /projects/goose-hub-self/board',
+          'Component: BoardToolbar',
+          'Acceptance criteria:',
+          '- The board shows a milestone dropdown populated from /active-milestone.',
+          '- Selecting a milestone refetches issue cards for that milestone.',
+        ].join('\n'),
+      }),
+    ]);
     // No factory:from-prd label — default mock returns []
     mockRuntime.run
       .mockResolvedValueOnce({

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -13,6 +13,7 @@ import { logger } from '@goose-hub/core/logger.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import { targetStateForTriage } from '@goose-hub/core/workflows/triage-routing.js';
+import { type VaguenessScore, scoreVagueness } from '@goose-hub/core/workflows/vagueness-gate.js';
 import { RepoMatchOutputSchema } from '@goose-hub/skills/repo-match/schema.js';
 import { TriageOutputSchema } from '@goose-hub/skills/triage/schema.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
@@ -50,6 +51,35 @@ function readReposContext(slug: string): string {
   } catch {
     return '';
   }
+}
+
+const VAGUENESS_LABELS = ['vague:high', 'vague:low'] as const;
+const MISSING_LABELS = ['missing:repro', 'missing:criteria'] as const;
+
+async function syncVaguenessLabels(input: {
+  source: StateSource;
+  itemId: string;
+  currentLabels: readonly string[];
+  vagueness: VaguenessScore;
+}): Promise<string[]> {
+  const desired = new Set<string>([
+    `vague:${input.vagueness.tier}`,
+    ...input.vagueness.missingDimensions.map((dimension) => `missing:${dimension}`),
+  ]);
+  const managedLabels = new Set<string>([...VAGUENESS_LABELS, ...MISSING_LABELS]);
+
+  for (const label of input.currentLabels) {
+    if (managedLabels.has(label) && !desired.has(label)) {
+      await input.source.removeLabel(input.itemId, label);
+    }
+  }
+
+  const labelsToAdd = [...desired].filter((label) => !input.currentLabels.includes(label));
+  if (labelsToAdd.length > 0) {
+    await input.source.addLabels(input.itemId, labelsToAdd);
+  }
+
+  return [...input.currentLabels.filter((label) => !managedLabels.has(label)), ...desired];
 }
 
 export async function runTriageBatch(slug: string, source?: StateSource): Promise<void> {
@@ -293,6 +323,13 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       'priority',
       mapPriority(triageOutput.priority),
     );
+    const vagueness = scoreVagueness({ ...item, type: triageOutput.type });
+    const routingLabels = await syncVaguenessLabels({
+      source: stateSource,
+      itemId: item.externalId,
+      currentLabels: itemLabels,
+      vagueness,
+    });
 
     // Post comment
     const comment = buildTriageComment(
@@ -322,7 +359,7 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
       runId,
     });
 
-    const finalState = targetStateForTriage(triageOutput.type, itemLabels);
+    const finalState = targetStateForTriage(triageOutput.type, routingLabels);
     await stateSource.transitionState(item.externalId, 'factory:accepted', finalState);
     emitStateTransitionEvent({
       projectId,

--- a/apps/web/src/lib/constants.test.ts
+++ b/apps/web/src/lib/constants.test.ts
@@ -12,6 +12,7 @@ const ALL_FACTORY_STATES = [
   'factory:triaging',
   'factory:accepted',
   'factory:rejected',
+  'factory:framing',
   'factory:grilling',
   'factory:prd-drafting',
   'factory:prd-review',

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -5,6 +5,7 @@ export const STATE_LABEL: Record<string, string> = {
   'factory:triaging': 'triaging',
   'factory:accepted': 'accepted',
   'factory:rejected': 'rejected',
+  'factory:framing': 'framing',
   'factory:grilling': 'grilling',
   'factory:prd-drafting': 'prd-drafting',
   'factory:prd-review': 'prd-review',

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -22,6 +22,7 @@ export const LANES: readonly LaneConfig[] = [
     key: 'discover',
     label: 'Discover',
     states: [
+      'factory:framing',
       'factory:grilling',
       'factory:prd-drafting',
       'factory:prd-review',

--- a/core/bootstrap/labels.ts
+++ b/core/bootstrap/labels.ts
@@ -16,6 +16,11 @@ export const FACTORY_LABELS: Label[] = [
   { name: 'factory:triaging', color: 'fbca04', description: 'Awaiting triage decision' },
   { name: 'factory:accepted', color: '0e8a16', description: 'Accepted by triage' },
   { name: 'factory:rejected', color: 'e6e6e6', description: 'Rejected by triage' },
+  {
+    name: 'factory:framing',
+    color: '8b5cf6',
+    description: 'Holding state for vague fresh features',
+  },
   { name: 'factory:grilling', color: '8b5cf6', description: 'Grill-me chat in progress' },
   { name: 'factory:prd-drafting', color: '8b5cf6', description: 'PRD being written' },
   { name: 'factory:prd-review', color: '8b5cf6', description: 'Awaiting human PRD approval' },
@@ -79,6 +84,16 @@ export const FACTORY_LABELS: Label[] = [
     name: 'factory:from-prd',
     color: 'c4b5fd',
     description: 'Child of a decomposed PRD; triage skips grilling',
+  },
+
+  // triage metadata
+  { name: 'vague:high', color: 'fbca04', description: 'Triage vagueness gate: high' },
+  { name: 'vague:low', color: 'd1d5db', description: 'Triage vagueness gate: low' },
+  { name: 'missing:repro', color: 'fbca04', description: 'Bug report lacks repro detail' },
+  {
+    name: 'missing:criteria',
+    color: 'fbca04',
+    description: 'Work item lacks acceptance criteria',
   },
 
   // type:*

--- a/core/state-machine/states.test.ts
+++ b/core/state-machine/states.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { STATES } from './states.js';
 
 describe('STATES', () => {
-  it('has exactly 26 canonical states', () => {
-    expect(STATES).toHaveLength(26);
+  it('has exactly 27 canonical states', () => {
+    expect(STATES).toHaveLength(27);
   });
 
   it('contains all canonical factory:* states in order', () => {
@@ -11,6 +11,7 @@ describe('STATES', () => {
       'factory:triaging',
       'factory:accepted',
       'factory:rejected',
+      'factory:framing',
       'factory:grilling',
       'factory:prd-drafting',
       'factory:prd-review',

--- a/core/state-machine/states.ts
+++ b/core/state-machine/states.ts
@@ -2,6 +2,7 @@ export const STATES = Object.freeze([
   'factory:triaging',
   'factory:accepted',
   'factory:rejected',
+  'factory:framing',
   'factory:grilling',
   'factory:prd-drafting',
   'factory:prd-review',

--- a/core/state-machine/transitions.test.ts
+++ b/core/state-machine/transitions.test.ts
@@ -13,6 +13,10 @@ describe('isLegalTransition — section 9.1 happy paths', () => {
   // feature path
   it('accepted → grilling', () =>
     expect(isLegalTransition('factory:accepted', 'factory:grilling')).toBe(true));
+  it('accepted → framing', () =>
+    expect(isLegalTransition('factory:accepted', 'factory:framing')).toBe(true));
+  it('framing has no concrete outbound workflow route yet', () =>
+    expect(legalTargets('factory:framing')).toStrictEqual(['factory:archived']));
   it('grilling → prd-drafting', () =>
     expect(isLegalTransition('factory:grilling', 'factory:prd-drafting')).toBe(true));
   it('prd-drafting → prd-review', () =>
@@ -163,8 +167,7 @@ describe('legalTargets', () => {
       'factory:archived',
     ]));
 
-  it('accepted yields five targets', () =>
-    expect(legalTargets('factory:accepted')).toHaveLength(5));
+  it('accepted yields six targets', () => expect(legalTargets('factory:accepted')).toHaveLength(6));
 
   it('dev-ready yields spec-ready, in-progress, needs-human, and archived', () =>
     expect(legalTargets('factory:dev-ready')).toStrictEqual([

--- a/core/state-machine/transitions.ts
+++ b/core/state-machine/transitions.ts
@@ -3,6 +3,7 @@ import type { StateName } from './states.js';
 const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
   'factory:triaging': ['factory:accepted', 'factory:rejected', 'factory:archived'],
   'factory:accepted': [
+    'factory:framing',
     'factory:grilling',
     'factory:investigating',
     'factory:dev-ready',
@@ -10,6 +11,7 @@ const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
     'factory:archived',
   ],
   'factory:rejected': ['factory:archived'],
+  'factory:framing': ['factory:archived'],
   'factory:grilling': ['factory:prd-drafting', 'factory:archived'],
   'factory:prd-drafting': ['factory:prd-review', 'factory:archived'],
   'factory:prd-review': ['factory:dev-ready', 'factory:decomposing', 'factory:archived'],

--- a/core/workflows/triage-routing.test.ts
+++ b/core/workflows/triage-routing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { targetStateForTriage } from './triage-routing.js';
+
+describe('targetStateForTriage', () => {
+  it.each([
+    {
+      name: 'vague bug still enters investigation where bug enrichment runs before scouts',
+      type: 'bug' as const,
+      labels: ['vague:high'],
+      expected: 'factory:investigating',
+    },
+    {
+      name: 'clean bug keeps the existing investigation route',
+      type: 'bug' as const,
+      labels: ['vague:low'],
+      expected: 'factory:investigating',
+    },
+    {
+      name: 'vague fresh feature routes to framing',
+      type: 'feature' as const,
+      labels: ['vague:high'],
+      expected: 'factory:framing',
+    },
+    {
+      name: 'clean fresh feature keeps grilling',
+      type: 'feature' as const,
+      labels: ['vague:low'],
+      expected: 'factory:grilling',
+    },
+  ])('$name', ({ type, labels, expected }) => {
+    expect(targetStateForTriage(type, labels)).toBe(expected);
+  });
+
+  it('keeps factory:from-prd as a feature override even when vagueness is high', () => {
+    expect(targetStateForTriage('feature', ['factory:from-prd', 'vague:high'])).toBe(
+      'factory:dev-ready',
+    );
+  });
+
+  it('continues routing non-feature non-bug items somewhere', () => {
+    expect(targetStateForTriage('chore', ['vague:high'])).toBe('factory:dev-ready');
+    expect(targetStateForTriage('research', ['vague:high'])).toBe('factory:research-pending');
+  });
+});

--- a/core/workflows/triage-routing.ts
+++ b/core/workflows/triage-routing.ts
@@ -3,8 +3,10 @@ import type { WorkItemType } from '../state-source/interface.js';
 
 export const TRIAGE_ROUTE_TARGETS = Object.freeze({
   bug: 'factory:investigating',
+  vagueBug: 'factory:investigating',
   research: 'factory:research-pending',
   freshFeature: 'factory:grilling',
+  vagueFeature: 'factory:framing',
   chore: 'factory:dev-ready',
   prdFeature: 'factory:dev-ready',
 } satisfies Record<string, StateName>);
@@ -13,10 +15,12 @@ export function targetStateForTriage(
   type: WorkItemType,
   labels: readonly string[] = [],
 ): StateName {
-  if (type === 'bug') return TRIAGE_ROUTE_TARGETS.bug;
+  const isVague = labels.includes('vague:high');
+  if (type === 'bug') return isVague ? TRIAGE_ROUTE_TARGETS.vagueBug : TRIAGE_ROUTE_TARGETS.bug;
   if (type === 'research') return TRIAGE_ROUTE_TARGETS.research;
-  if (type === 'feature' && !labels.includes('factory:from-prd')) {
-    return TRIAGE_ROUTE_TARGETS.freshFeature;
+  if (type === 'feature') {
+    if (labels.includes('factory:from-prd')) return TRIAGE_ROUTE_TARGETS.prdFeature;
+    return isVague ? TRIAGE_ROUTE_TARGETS.vagueFeature : TRIAGE_ROUTE_TARGETS.freshFeature;
   }
   return TRIAGE_ROUTE_TARGETS.chore;
 }

--- a/core/workflows/vagueness-gate.test.ts
+++ b/core/workflows/vagueness-gate.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkItem } from '../state-source/interface.js';
+import { scoreVagueness } from './vagueness-gate.js';
+
+function workItem(overrides: Pick<WorkItem, 'title' | 'body' | 'type'>): WorkItem {
+  return {
+    id: 'github:shaunnez/goose-hub#1',
+    externalId: '1',
+    repoRef: 'shaunnez/goose-hub',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:triaging',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date('2026-05-25T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('scoreVagueness', () => {
+  it.each([
+    {
+      name: 'vague bug missing repro and criteria',
+      item: workItem({
+        type: 'bug',
+        title: 'Dashboard broken',
+        body: 'Something is weird on the dashboard. Maybe fix it.',
+      }),
+      expected: { score: 100, tier: 'high', missingDimensions: ['repro', 'criteria'] },
+    },
+    {
+      name: 'clear bug with repro and expected behaviour',
+      item: workItem({
+        type: 'bug',
+        title: 'Settings save returns 500',
+        body: [
+          'Route: /settings',
+          'File: apps/server/src/domains/settings/service.ts',
+          'Steps to reproduce:',
+          '1. Open settings.',
+          '2. Change the display name.',
+          '3. Click Save.',
+          'Expected: the new display name is persisted and the form shows Saved.',
+          'Actual: the request returns HTTP 500.',
+          'Acceptance criteria: saving a valid display name returns 200 and updates the profile.',
+        ].join('\n'),
+      }),
+      expected: { score: 0, tier: 'low', missingDimensions: [] },
+    },
+    {
+      name: 'vague feature missing criteria',
+      item: workItem({
+        type: 'feature',
+        title: 'Better project dashboard',
+        body: 'Make the dashboard better and easier to use somehow.',
+      }),
+      expected: { score: 85, tier: 'high', missingDimensions: ['criteria'] },
+    },
+    {
+      name: 'clean feature with concrete acceptance criteria',
+      item: workItem({
+        type: 'feature',
+        title: 'Show active milestone filter on board',
+        body: [
+          'Route: /projects/goose-hub-self/board',
+          'Component: BoardToolbar',
+          'Acceptance criteria:',
+          '- The board shows a milestone dropdown populated from /active-milestone.',
+          '- Selecting a milestone refetches issue cards for that milestone.',
+          '- Clearing the filter restores the current milestone view.',
+        ].join('\n'),
+      }),
+      expected: { score: 0, tier: 'low', missingDimensions: [] },
+    },
+  ])('$name', ({ item, expected }) => {
+    expect(scoreVagueness(item)).toStrictEqual(expected);
+  });
+
+  it('is deterministic for the same work item input', () => {
+    const item = workItem({
+      type: 'feature',
+      title: 'Add export',
+      body: 'Need export support. Not sure what format yet.',
+    });
+
+    expect(scoreVagueness(item)).toStrictEqual(scoreVagueness(item));
+  });
+});

--- a/core/workflows/vagueness-gate.ts
+++ b/core/workflows/vagueness-gate.ts
@@ -1,0 +1,53 @@
+import type { WorkItem } from '../state-source/interface.js';
+
+export type VaguenessTier = 'high' | 'low';
+export type MissingVaguenessDimension = 'repro' | 'criteria';
+
+export interface VaguenessScore {
+  score: number;
+  missingDimensions: MissingVaguenessDimension[];
+  tier: VaguenessTier;
+}
+
+const HIGH_VAGUENESS_CUTOFF = 50;
+
+const HEDGING_RE =
+  /\b(something|somehow|maybe|unclear|not sure|weird|broken|better|stuff|thing|things|sort of|kind of|probably)\b/i;
+const REPRO_RE =
+  /\b(steps? to reproduce|repro(?:duce|duction)?|given|when|then|actual|observed|error|exception|crash|screenshot|recording)\b/i;
+const CRITERIA_RE =
+  /\b(acceptance criteria|success criteria|done when|expected|should|must|verify|test passes?|passes when)\b/i;
+const SURFACE_RE =
+  /\b(apps\/|core\/|slices\/|skills\/|components?[:\s]|routes?[:\s]|files?[:\s]|https?:\/\/|\/[a-z0-9][^\s]*)/i;
+
+export function scoreVagueness(
+  workItem: Pick<WorkItem, 'title' | 'body' | 'type'>,
+): VaguenessScore {
+  const text = `${workItem.title}\n${workItem.body}`.trim();
+  const body = workItem.body.trim();
+  const missingDimensions: MissingVaguenessDimension[] = [];
+  let score = 0;
+
+  if (body.length < 80) score += 30;
+  else if (body.length < 200) score += 15;
+
+  if (workItem.type === 'bug' && !REPRO_RE.test(text)) {
+    missingDimensions.push('repro');
+    score += 25;
+  }
+
+  if (workItem.type !== 'research' && !CRITERIA_RE.test(text)) {
+    missingDimensions.push('criteria');
+    score += 25;
+  }
+
+  if (HEDGING_RE.test(text)) score += 20;
+  if (!SURFACE_RE.test(text)) score += 10;
+
+  const cappedScore = Math.min(score, 100);
+  return {
+    score: cappedScore,
+    missingDimensions,
+    tier: cappedScore >= HIGH_VAGUENESS_CUTOFF ? 'high' : 'low',
+  };
+}

--- a/core/workflows/workflow-catalog.test.ts
+++ b/core/workflows/workflow-catalog.test.ts
@@ -59,11 +59,15 @@ describe('workflow catalog', () => {
     expect(targetStateForTriage('bug')).toBe('factory:investigating');
     expect(targetStateForTriage('research')).toBe('factory:research-pending');
     expect(targetStateForTriage('feature')).toBe('factory:grilling');
+    expect(targetStateForTriage('feature', ['vague:high'])).toBe('factory:framing');
     expect(targetStateForTriage('chore')).toBe('factory:dev-ready');
 
     expect(hasEdge(byKind('bug'), 'accepted', targetStateForTriage('bug'))).toBe(true);
     expect(hasEdge(byKind('research'), 'accepted', targetStateForTriage('research'))).toBe(true);
     expect(hasEdge(byKind('feature'), 'accepted', targetStateForTriage('feature'))).toBe(true);
+    expect(
+      hasEdge(byKind('feature'), 'accepted', targetStateForTriage('feature', ['vague:high'])),
+    ).toBe(true);
     expect(hasEdge(byKind('chore'), 'accepted', targetStateForTriage('chore'))).toBe(true);
     expect(targetStateForTriage('feature', ['factory:from-prd'])).toBe('factory:dev-ready');
   });

--- a/core/workflows/workflow-catalog.ts
+++ b/core/workflows/workflow-catalog.ts
@@ -844,6 +844,11 @@ const featureEntry: WorkflowCatalogEntry = {
     'Fresh feature work enters discovery, turns into an approved PRD, then the parent issue moves through spec-author, implementation, QA, review, and retro. Child issues are optional tracking projections after the Engineering Spec.',
   nodes: [
     ...triageNodes,
+    stateNode('framing', 'Framing', 'factory:framing', {
+      group: 'grill',
+      notes:
+        'Holding state for vague fresh features; outbound workflow is owned by the feature-frame issue.',
+    }),
     stateNode('grilling', 'Grilling', 'factory:grilling', { group: 'grill' }),
     stateNode('prd-drafting', 'PRD draft', 'factory:prd-drafting', { group: 'prd' }),
     stateNode('prd-review', 'PRD review', 'factory:prd-review', { group: 'prd' }),
@@ -879,6 +884,7 @@ const featureEntry: WorkflowCatalogEntry = {
     summary('triage-skill', 'repo-match-skill'),
     primary('triaging', 'accepted'),
     primary('accepted', 'grilling'),
+    optional('accepted', 'framing', 'Vague fresh feature'),
     primary('grilling', 'prd-drafting'),
     primary('prd-drafting', 'prd-review'),
     primary('prd-review', 'dev-ready'),
@@ -912,9 +918,10 @@ const featureEntry: WorkflowCatalogEntry = {
     {
       id: 'grill',
       title: 'Grill',
-      description: 'Fresh feature work is clarified through operator questions and answers.',
+      description:
+        'Clean fresh feature work enters grill-me; vague fresh feature work can pause in framing until the framing workflow is available.',
       group: 'grill',
-      nodes: ['grilling', 'grill-me-skill'],
+      nodes: ['framing', 'grilling', 'grill-me-skill'],
     },
     {
       id: 'prd',


### PR DESCRIPTION
## Summary
- Add pure deterministic vagueness scoring and issue-label convergence for vague/missing metadata during triage.
- Route fresh vague features to factory:framing while preserving clean feature and factory:from-prd routes.
- Register factory:framing as a holding state and document the gate-to-route contract.

Closes #1045

## Tests
- pnpm vitest run core/workflows/vagueness-gate.test.ts core/workflows/triage-routing.test.ts core/state-machine/states.test.ts core/state-machine/transitions.test.ts core/workflows/workflow-catalog.test.ts apps/server/src/domains/workflows/triage-batch.test.ts apps/server/src/domains/issues/service.test.ts apps/web/src/lib/constants.test.ts
- pnpm lint (passes with existing warnings in apps/web/src/lib/logger.ts and slices/grill-and-prd/slice.test.ts)
- pnpm typecheck
- pnpm audit-docs