### PR TITLE
M20.1044: command output sandbox

### DIFF
--- a/core/tool-layer/mcp/command-policy.ts
+++ b/core/tool-layer/mcp/command-policy.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { type ShapeCommandOutputResult, shapeCommandOutput } from './output-sandbox.js';
 
 export type CommandStatus = 'ok' | 'failed' | 'timed_out';
 
@@ -7,6 +8,7 @@ export interface CommandSpec {
   args: ReadonlyArray<string>;
   cwd: string;
   env?: Readonly<Record<string, string>>;
+  runId?: string;
   timeoutMs: number;
   stdoutLimitBytes?: number;
   stderrLimitBytes?: number;
@@ -20,12 +22,21 @@ export interface CommandResult {
   stderr: string;
   durationMs: number;
   truncated: boolean;
+  displayTruncated: boolean;
+  fullOutputPath?: string;
 }
 
 export const DEFAULT_STDOUT_LIMIT_BYTES = 256 * 1024;
 export const DEFAULT_STDERR_LIMIT_BYTES = 64 * 1024;
 
 const FORCE_KILL_GRACE_MS = 2_000;
+const runInvocationCounters = new Map<string, number>();
+
+function nextInvocationForRun(runId: string): number {
+  const next = (runInvocationCounters.get(runId) ?? 0) + 1;
+  runInvocationCounters.set(runId, next);
+  return next;
+}
 
 /**
  * Sole execution path for MCP tools. `shell: false` is non-negotiable —
@@ -40,6 +51,7 @@ const FORCE_KILL_GRACE_MS = 2_000;
 export async function runCommand(spec: CommandSpec): Promise<CommandResult> {
   const stdoutLimit = spec.stdoutLimitBytes ?? DEFAULT_STDOUT_LIMIT_BYTES;
   const stderrLimit = spec.stderrLimitBytes ?? DEFAULT_STDERR_LIMIT_BYTES;
+  const invocation = spec.runId != null ? nextInvocationForRun(spec.runId) : null;
 
   return new Promise<CommandResult>((resolvePromise) => {
     const startedAt = Date.now();
@@ -57,6 +69,7 @@ export async function runCommand(spec: CommandSpec): Promise<CommandResult> {
     let truncated = false;
     let timedOut = false;
     let exited = false;
+    let settled = false;
     let forceKillTimer: NodeJS.Timeout | null = null;
 
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -102,36 +115,66 @@ export async function runCommand(spec: CommandSpec): Promise<CommandResult> {
       }, FORCE_KILL_GRACE_MS);
     }, spec.timeoutMs);
 
-    const finish = (exitCode: number | null, signal: NodeJS.Signals | null) => {
-      exited = true;
-      clearTimeout(timeoutHandle);
-      if (forceKillTimer) clearTimeout(forceKillTimer);
-      const status: CommandStatus = timedOut ? 'timed_out' : exitCode === 0 ? 'ok' : 'failed';
+    const resolveResult = async (
+      status: CommandStatus,
+      exitCode: number | null,
+      signal: NodeJS.Signals | null,
+    ) => {
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      let shaped: ShapeCommandOutputResult = {
+        stdout: stdout.toString('utf8'),
+        stderr: stderr.toString('utf8'),
+        displayTruncated: false,
+      };
+
+      if (spec.runId != null && invocation != null) {
+        try {
+          shaped = await shapeCommandOutput({
+            workspaceRoot: spec.cwd,
+            runId: spec.runId,
+            invocation,
+            stdout,
+            stderr,
+            byteCaptureTruncated: truncated,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          shaped.stderr = `${shaped.stderr}${shaped.stderr.length > 0 ? '\n' : ''}[factory] failed to write command output spill file: ${message}`;
+        }
+      }
+
       resolvePromise({
         status,
         exitCode,
         signal,
-        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
-        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+        stdout: shaped.stdout,
+        stderr: shaped.stderr,
         durationMs: Date.now() - startedAt,
         truncated,
+        displayTruncated: shaped.displayTruncated,
+        ...(shaped.fullOutputPath != null ? { fullOutputPath: shaped.fullOutputPath } : {}),
       });
     };
 
+    const finish = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) return;
+      settled = true;
+      exited = true;
+      clearTimeout(timeoutHandle);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      const status: CommandStatus = timedOut ? 'timed_out' : exitCode === 0 ? 'ok' : 'failed';
+      void resolveResult(status, exitCode, signal);
+    };
+
     child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
       exited = true;
       clearTimeout(timeoutHandle);
       if (forceKillTimer) clearTimeout(forceKillTimer);
       stderrChunks.push(Buffer.from(`${err.message}\n`, 'utf8'));
-      resolvePromise({
-        status: 'failed',
-        exitCode: null,
-        signal: null,
-        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
-        stderr: Buffer.concat(stderrChunks).toString('utf8'),
-        durationMs: Date.now() - startedAt,
-        truncated,
-      });
+      void resolveResult('failed', null, null);
     });
 
     child.on('close', finish);

--- a/core/tool-layer/mcp/command-policy.ts
+++ b/core/tool-layer/mcp/command-policy.ts
@@ -1,5 +1,9 @@
 import { spawn } from 'node:child_process';
-import { type ShapeCommandOutputResult, shapeCommandOutput } from './output-sandbox.js';
+import {
+  type ShapeCommandOutputResult,
+  shapeCommandOutput,
+  shapeCommandOutputInMemory,
+} from './output-sandbox.js';
 
 export type CommandStatus = 'ok' | 'failed' | 'timed_out';
 
@@ -9,6 +13,7 @@ export interface CommandSpec {
   cwd: string;
   env?: Readonly<Record<string, string>>;
   runId?: string;
+  displayOutput?: boolean;
   timeoutMs: number;
   stdoutLimitBytes?: number;
   stderrLimitBytes?: number;
@@ -36,6 +41,10 @@ function nextInvocationForRun(runId: string): number {
   const next = (runInvocationCounters.get(runId) ?? 0) + 1;
   runInvocationCounters.set(runId, next);
   return next;
+}
+
+export function clearRunCommandInvocationCounter(runId: string): void {
+  runInvocationCounters.delete(runId);
 }
 
 /**
@@ -128,7 +137,7 @@ export async function runCommand(spec: CommandSpec): Promise<CommandResult> {
         displayTruncated: false,
       };
 
-      if (spec.runId != null && invocation != null) {
+      if (spec.displayOutput === true && spec.runId != null && invocation != null) {
         try {
           shaped = await shapeCommandOutput({
             workspaceRoot: spec.cwd,
@@ -140,7 +149,17 @@ export async function runCommand(spec: CommandSpec): Promise<CommandResult> {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          shaped.stderr = `${shaped.stderr}${shaped.stderr.length > 0 ? '\n' : ''}[factory] failed to write command output spill file: ${message}`;
+          shaped = shapeCommandOutputInMemory(
+            {
+              workspaceRoot: spec.cwd,
+              runId: spec.runId,
+              invocation,
+              stdout,
+              stderr,
+              byteCaptureTruncated: truncated,
+            },
+            message,
+          );
         }
       }
 

--- a/core/tool-layer/mcp/output-sandbox.ts
+++ b/core/tool-layer/mcp/output-sandbox.ts
@@ -1,0 +1,105 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+
+export const DISPLAY_OUTPUT_LIMIT_BYTES = 4 * 1024;
+export const RUN_OUTPUT_DIR = '.factory/run-output';
+
+export interface ShapeCommandOutputInput {
+  workspaceRoot: string;
+  runId: string;
+  invocation: number;
+  stdout: Buffer;
+  stderr: Buffer;
+  byteCaptureTruncated: boolean;
+  displayLimitBytes?: number;
+}
+
+export interface ShapeCommandOutputResult {
+  stdout: string;
+  stderr: string;
+  displayTruncated: boolean;
+  fullOutputPath?: string;
+}
+
+function safeRunId(runId: string): string {
+  return runId.replace(/[^A-Za-z0-9._:-]/g, '_');
+}
+
+function assertInsideWorkspace(workspaceRoot: string, absolutePath: string): void {
+  const root = resolve(workspaceRoot);
+  const target = resolve(absolutePath);
+  if (target !== root && !target.startsWith(`${root}${sep}`)) {
+    throw new Error(`run output path escaped workspace: ${target}`);
+  }
+}
+
+function banner(stream: 'stdout' | 'stderr', input: ShapeCommandOutputInput, path: string): string {
+  const capNote = input.byteCaptureTruncated
+    ? '; spill contains captured output up to the command-policy byte limit'
+    : '';
+  return `[factory] ${stream} display truncated; full captured output: ${path}${capNote}`;
+}
+
+function shapeStream(
+  stream: 'stdout' | 'stderr',
+  input: ShapeCommandOutputInput,
+  path: string,
+): { text: string; truncated: boolean } {
+  const limit = input.displayLimitBytes ?? DISPLAY_OUTPUT_LIMIT_BYTES;
+  const value = input[stream];
+  if (value.byteLength <= limit) {
+    return { text: value.toString('utf8'), truncated: false };
+  }
+
+  const marker = Buffer.from(`\n${banner(stream, input, path)}\n`, 'utf8');
+  const remaining = Math.max(0, limit - marker.byteLength);
+  const headBytes = Math.floor(remaining / 2);
+  const tailBytes = remaining - headBytes;
+  const head = value.subarray(0, headBytes);
+  const tail = tailBytes > 0 ? value.subarray(value.byteLength - tailBytes) : Buffer.alloc(0);
+
+  return {
+    text: Buffer.concat([head, marker, tail]).toString('utf8'),
+    truncated: true,
+  };
+}
+
+function spillFileBytes(stdout: Buffer, stderr: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from('===== stdout =====\n', 'utf8'),
+    stdout,
+    Buffer.from('\n===== stderr =====\n', 'utf8'),
+    stderr,
+  ]);
+}
+
+export async function shapeCommandOutput(
+  input: ShapeCommandOutputInput,
+): Promise<ShapeCommandOutputResult> {
+  const limit = input.displayLimitBytes ?? DISPLAY_OUTPUT_LIMIT_BYTES;
+  const needsSpill = input.stdout.byteLength > limit || input.stderr.byteLength > limit;
+  if (!needsSpill) {
+    return {
+      stdout: input.stdout.toString('utf8'),
+      stderr: input.stderr.toString('utf8'),
+      displayTruncated: false,
+    };
+  }
+
+  const fullOutputPath = `${RUN_OUTPUT_DIR}/${safeRunId(input.runId)}-${input.invocation}.log`;
+  const outputDir = join(input.workspaceRoot, RUN_OUTPUT_DIR);
+  const absolutePath = join(input.workspaceRoot, fullOutputPath);
+  assertInsideWorkspace(input.workspaceRoot, absolutePath);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(absolutePath, spillFileBytes(input.stdout, input.stderr));
+
+  const stdout = shapeStream('stdout', input, fullOutputPath);
+  const stderr = shapeStream('stderr', input, fullOutputPath);
+
+  return {
+    stdout: stdout.text,
+    stderr: stderr.text,
+    displayTruncated: stdout.truncated || stderr.truncated,
+    fullOutputPath,
+  };
+}

--- a/core/tool-layer/mcp/output-sandbox.ts
+++ b/core/tool-layer/mcp/output-sandbox.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, open, realpath } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 
 export const DISPLAY_OUTPUT_LIMIT_BYTES = 4 * 1024;
@@ -22,28 +22,72 @@ export interface ShapeCommandOutputResult {
 }
 
 function safeRunId(runId: string): string {
-  return runId.replace(/[^A-Za-z0-9._:-]/g, '_');
+  return runId.replace(/[^A-Za-z0-9._-]/g, '_');
 }
 
-function assertInsideWorkspace(workspaceRoot: string, absolutePath: string): void {
-  const root = resolve(workspaceRoot);
-  const target = resolve(absolutePath);
-  if (target !== root && !target.startsWith(`${root}${sep}`)) {
+function isInside(root: string, target: string): boolean {
+  return target === root || target.startsWith(`${root}${sep}`);
+}
+
+function assertInsideWorkspace(root: string, target: string): void {
+  if (!isInside(root, target)) {
     throw new Error(`run output path escaped workspace: ${target}`);
   }
 }
 
-function banner(stream: 'stdout' | 'stderr', input: ShapeCommandOutputInput, path: string): string {
+async function assertNotSymlink(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`run output path must not be a symlink: ${path}`);
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`run output path is not a directory: ${path}`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+async function ensureRunOutputDir(workspaceRoot: string): Promise<string> {
+  const root = await realpath(workspaceRoot);
+  const factoryDir = join(root, '.factory');
+  const outputDir = join(root, RUN_OUTPUT_DIR);
+
+  await assertNotSymlink(factoryDir);
+  await mkdir(factoryDir, { recursive: true });
+  await assertNotSymlink(factoryDir);
+
+  await assertNotSymlink(outputDir);
+  await mkdir(outputDir, { recursive: true });
+  await assertNotSymlink(outputDir);
+
+  const outputReal = await realpath(outputDir);
+  assertInsideWorkspace(root, outputReal);
+  return outputDir;
+}
+
+function banner(
+  stream: 'stdout' | 'stderr',
+  input: ShapeCommandOutputInput,
+  path: string | null,
+  spillError?: string,
+): string {
   const capNote = input.byteCaptureTruncated
     ? '; spill contains captured output up to the command-policy byte limit'
     : '';
-  return `[factory] ${stream} display truncated; full captured output: ${path}${capNote}`;
+  const outputNote =
+    path == null
+      ? `spill file unavailable${spillError != null ? `: ${spillError}` : ''}`
+      : `full captured output: ${path}`;
+  return `[factory] ${stream} display truncated; ${outputNote}${capNote}`;
 }
 
 function shapeStream(
   stream: 'stdout' | 'stderr',
   input: ShapeCommandOutputInput,
-  path: string,
+  path: string | null,
+  spillError?: string,
 ): { text: string; truncated: boolean } {
   const limit = input.displayLimitBytes ?? DISPLAY_OUTPUT_LIMIT_BYTES;
   const value = input[stream];
@@ -51,7 +95,7 @@ function shapeStream(
     return { text: value.toString('utf8'), truncated: false };
   }
 
-  const marker = Buffer.from(`\n${banner(stream, input, path)}\n`, 'utf8');
+  const marker = Buffer.from(`\n${banner(stream, input, path, spillError)}\n`, 'utf8');
   const remaining = Math.max(0, limit - marker.byteLength);
   const headBytes = Math.floor(remaining / 2);
   const tailBytes = remaining - headBytes;
@@ -87,11 +131,16 @@ export async function shapeCommandOutput(
   }
 
   const fullOutputPath = `${RUN_OUTPUT_DIR}/${safeRunId(input.runId)}-${input.invocation}.log`;
-  const outputDir = join(input.workspaceRoot, RUN_OUTPUT_DIR);
-  const absolutePath = join(input.workspaceRoot, fullOutputPath);
-  assertInsideWorkspace(input.workspaceRoot, absolutePath);
-  await mkdir(outputDir, { recursive: true });
-  await writeFile(absolutePath, spillFileBytes(input.stdout, input.stderr));
+  const root = await realpath(input.workspaceRoot);
+  await ensureRunOutputDir(root);
+  const absolutePath = join(root, fullOutputPath);
+  assertInsideWorkspace(root, resolve(absolutePath));
+  const handle = await open(absolutePath, 'wx');
+  try {
+    await handle.writeFile(spillFileBytes(input.stdout, input.stderr));
+  } finally {
+    await handle.close();
+  }
 
   const stdout = shapeStream('stdout', input, fullOutputPath);
   const stderr = shapeStream('stderr', input, fullOutputPath);
@@ -101,5 +150,18 @@ export async function shapeCommandOutput(
     stderr: stderr.text,
     displayTruncated: stdout.truncated || stderr.truncated,
     fullOutputPath,
+  };
+}
+
+export function shapeCommandOutputInMemory(
+  input: ShapeCommandOutputInput,
+  spillError: string,
+): ShapeCommandOutputResult {
+  const stdout = shapeStream('stdout', input, null, spillError);
+  const stderr = shapeStream('stderr', input, null, spillError);
+  return {
+    stdout: stdout.text,
+    stderr: stderr.text,
+    displayTruncated: stdout.truncated || stderr.truncated,
   };
 }

--- a/core/tool-layer/mcp/path-policy.ts
+++ b/core/tool-layer/mcp/path-policy.ts
@@ -31,6 +31,10 @@ const DENIED_SEGMENTS: ReadonlyArray<{ segment: string; reason: PathPolicyReason
   { segment: '.factory', reason: 'factory_internals' },
 ];
 
+function isRunOutputPath(segments: ReadonlyArray<string>): boolean {
+  return segments[0] === '.factory' && segments[1] === 'run-output' && segments.length >= 3;
+}
+
 export interface ResolvedPath {
   absolute: string;
   canonical: RepoRelativePath;
@@ -80,7 +84,7 @@ export function resolveWorkspacePath(workspaceRoot: string, requested: string): 
   }
 
   for (const denied of DENIED_SEGMENTS) {
-    if (segments.includes(denied.segment)) {
+    if (segments.includes(denied.segment) && !isRunOutputPath(segments)) {
       throw new PathPolicyViolation(
         denied.reason,
         requested,
@@ -105,7 +109,7 @@ export function resolveWorkspacePath(workspaceRoot: string, requested: string): 
   // passed the raw-segment check above cannot smuggle a denied segment through.
   const canonicalSegments = result.path.path.split('/').filter((s) => s.length > 0);
   for (const denied of DENIED_SEGMENTS) {
-    if (canonicalSegments.includes(denied.segment)) {
+    if (canonicalSegments.includes(denied.segment) && !isRunOutputPath(canonicalSegments)) {
       throw new PathPolicyViolation(
         denied.reason,
         requested,

--- a/core/tool-layer/mcp/path-policy.ts
+++ b/core/tool-layer/mcp/path-policy.ts
@@ -31,6 +31,10 @@ const DENIED_SEGMENTS: ReadonlyArray<{ segment: string; reason: PathPolicyReason
   { segment: '.factory', reason: 'factory_internals' },
 ];
 
+export interface ResolveWorkspacePathOptions {
+  allowRunOutput?: boolean;
+}
+
 function isRunOutputPath(segments: ReadonlyArray<string>): boolean {
   return segments[0] === '.factory' && segments[1] === 'run-output' && segments.length >= 3;
 }
@@ -52,7 +56,11 @@ export interface ResolvedPath {
  * `path-contract.ts`, which normalizes package-relative and absolute-worktree
  * paths and returns the structured `RepoRelativePath` shape.
  */
-export function resolveWorkspacePath(workspaceRoot: string, requested: string): ResolvedPath {
+export function resolveWorkspacePath(
+  workspaceRoot: string,
+  requested: string,
+  options: ResolveWorkspacePathOptions = {},
+): ResolvedPath {
   if (typeof requested !== 'string' || requested.trim().length === 0) {
     throw new PathPolicyViolation('empty_path', requested, 'Path is empty.');
   }
@@ -84,7 +92,10 @@ export function resolveWorkspacePath(workspaceRoot: string, requested: string): 
   }
 
   for (const denied of DENIED_SEGMENTS) {
-    if (segments.includes(denied.segment) && !isRunOutputPath(segments)) {
+    if (
+      segments.includes(denied.segment) &&
+      !(options.allowRunOutput === true && isRunOutputPath(segments))
+    ) {
       throw new PathPolicyViolation(
         denied.reason,
         requested,
@@ -109,7 +120,10 @@ export function resolveWorkspacePath(workspaceRoot: string, requested: string): 
   // passed the raw-segment check above cannot smuggle a denied segment through.
   const canonicalSegments = result.path.path.split('/').filter((s) => s.length > 0);
   for (const denied of DENIED_SEGMENTS) {
-    if (canonicalSegments.includes(denied.segment) && !isRunOutputPath(canonicalSegments)) {
+    if (
+      canonicalSegments.includes(denied.segment) &&
+      !(options.allowRunOutput === true && isRunOutputPath(canonicalSegments))
+    ) {
       throw new PathPolicyViolation(
         denied.reason,
         requested,

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -1,5 +1,6 @@
 import { eventStore } from '../../event-stream/store.js';
 import { canonicalizeFactoryToolPath } from '../path-contract.js';
+import { clearRunCommandInvocationCounter } from './command-policy.js';
 
 export type CacheableToolName =
   | 'read_file'
@@ -305,6 +306,7 @@ export function clearRunCache(runId: string): void {
   testRetryCounters.delete(runId);
   redundantReadCounters.delete(runId);
   totalReadCounters.delete(runId);
+  clearRunCommandInvocationCounter(runId);
 }
 
 /**

--- a/core/tool-layer/mcp/schemas.ts
+++ b/core/tool-layer/mcp/schemas.ts
@@ -5,7 +5,7 @@ const WorkspacePath = z
   .string()
   .min(1)
   .describe(
-    'Workspace-relative path. Absolute paths, .., ~, .codex, .agents, .claude, .factory are rejected.',
+    'Workspace-relative path. Absolute paths, .., ~, .codex, .agents, .claude, and .factory are rejected except for readable .factory/run-output spill files.',
   );
 
 const WorkspacePaths = z.array(WorkspacePath).min(1).max(50);

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -12,6 +21,7 @@ import {
 import type { FactoryContext } from './context.js';
 import { FactoryContextError, loadFactoryContext } from './context.js';
 import { PathPolicyViolation, resolveWorkspacePath } from './path-policy.js';
+import { clearRunCache } from './run-cache.js';
 import { buildFactoryMcpServer } from './server.js';
 import {
   listDirTool,
@@ -105,8 +115,14 @@ describe('path-policy', () => {
     }
   });
 
-  it('allows only the .factory/run-output spill directory under Factory internals', () => {
-    const resolved = resolveWorkspacePath(workspace, '.factory/run-output/run-1-1.log');
+  it('allows .factory/run-output only when a read path opts into spill reads', () => {
+    expect(() => resolveWorkspacePath(workspace, '.factory/run-output/run-1-1.log')).toThrow(
+      PathPolicyViolation,
+    );
+
+    const resolved = resolveWorkspacePath(workspace, '.factory/run-output/run-1-1.log', {
+      allowRunOutput: true,
+    });
     expect(resolved.canonical.path).toBe('.factory/run-output/run-1-1.log');
     expect(resolved.absolute).toBe(join(workspace, '.factory/run-output/run-1-1.log'));
 
@@ -331,6 +347,7 @@ describe('command-policy', () => {
       args: ['-e', 'process.stdout.write("hello")'],
       cwd: workspace,
       runId: 'command-small',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -349,6 +366,7 @@ describe('command-policy', () => {
       args: ['-e', 'process.exit(2)'],
       cwd: workspace,
       runId: 'command-failed',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -362,6 +380,7 @@ describe('command-policy', () => {
       args: ['-e', 'process.stdout.write("a".repeat(50))'],
       cwd: workspace,
       runId: 'command-byte-cap',
+      displayOutput: true,
       timeoutMs: 5_000,
       stdoutLimitBytes: 10,
       env: minimalEnv(),
@@ -376,6 +395,7 @@ describe('command-policy', () => {
       args: ['-e', 'setInterval(() => {}, 1000)'],
       cwd: workspace,
       runId: 'command-timeout',
+      displayOutput: true,
       timeoutMs: 150,
       env: minimalEnv(),
     });
@@ -388,6 +408,7 @@ describe('command-policy', () => {
       args: [],
       cwd: workspace,
       runId: 'command-spawn-error',
+      displayOutput: true,
       timeoutMs: 1_000,
       env: minimalEnv(),
     });
@@ -407,6 +428,7 @@ describe('command-policy', () => {
       args: ['-e', 'process.stdout.write("warmup")'],
       cwd: workspace,
       runId: 'command-stdout-large',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -422,6 +444,7 @@ describe('command-policy', () => {
       ],
       cwd: workspace,
       runId: 'command-stdout-large',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -447,6 +470,23 @@ describe('command-policy', () => {
     expect(spill.content).toContain(stderr);
   });
 
+  it('does not display-shape machine-parsed command output unless explicitly requested', async () => {
+    const result = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("ROW" + "x".repeat(5000) + "END")'],
+      cwd: workspace,
+      runId: 'command-machine-output',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.displayTruncated).toBe(false);
+    expect(result.stdout).toContain('ROW');
+    expect(result.stdout).toContain('END');
+    expect(result.stdout).not.toContain('[factory] stdout display truncated');
+    expect(result.fullOutputPath).toBeUndefined();
+  });
+
   it('display-shapes stderr independently when stdout is under threshold', async () => {
     const stdout = 'tiny stdout';
     const result = await runCommand({
@@ -457,6 +497,7 @@ describe('command-policy', () => {
       ],
       cwd: workspace,
       runId: 'command-stderr-large',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -478,6 +519,7 @@ describe('command-policy', () => {
       ],
       cwd: workspace,
       runId: 'command-both-large',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -494,12 +536,40 @@ describe('command-policy', () => {
     expect(spill).toContain('ERR');
   });
 
+  it('clears per-run invocation counters with the run cache lifecycle', async () => {
+    const first = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("x".repeat(5000))'],
+      cwd: workspace,
+      runId: 'command-clear-counter',
+      displayOutput: true,
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+    expect(first.fullOutputPath).toBe('.factory/run-output/command-clear-counter-1.log');
+
+    clearRunCache('command-clear-counter');
+    rmSync(join(workspace, requireFullOutputPath(first)));
+
+    const second = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("y".repeat(5000))'],
+      cwd: workspace,
+      runId: 'command-clear-counter',
+      displayOutput: true,
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+    expect(second.fullOutputPath).toBe('.factory/run-output/command-clear-counter-1.log');
+  });
+
   it('keeps byte-capture truncation distinct from display truncation', async () => {
     const result = await runCommand({
       command: 'node',
       args: ['-e', 'process.stdout.write("x".repeat(10000))'],
       cwd: workspace,
       runId: 'command-capture-cap',
+      displayOutput: true,
       timeoutMs: 5_000,
       stdoutLimitBytes: 4500,
       env: minimalEnv(),
@@ -514,6 +584,64 @@ describe('command-policy', () => {
     expect(Buffer.byteLength(spill, 'utf8')).toBeLessThan(10000);
   });
 
+  it('sanitizes run ids for portable spill filenames', async () => {
+    const result = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("x".repeat(5000))'],
+      cwd: workspace,
+      runId: 'run:with:colon',
+      displayOutput: true,
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.fullOutputPath).toBe('.factory/run-output/run_with_colon-1.log');
+  });
+
+  it('keeps display output capped when spill persistence fails', async () => {
+    mkdirSync(join(workspace, '.factory'), { recursive: true });
+    writeFileSync(join(workspace, '.factory', 'run-output'), 'not a directory');
+
+    const result = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("x".repeat(5000))'],
+      cwd: workspace,
+      runId: 'command-spill-fails',
+      displayOutput: true,
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.displayTruncated).toBe(true);
+    expect(result.fullOutputPath).toBeUndefined();
+    expect(result.stdout).toContain('spill file unavailable');
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBeLessThanOrEqual(4096);
+  });
+
+  it('does not write spill output through a symlinked run-output directory', async () => {
+    const external = mkdtempSync(join(tmpdir(), 'factory-run-output-external-'));
+    mkdirSync(join(workspace, '.factory'), { recursive: true });
+    symlinkSync(external, join(workspace, '.factory', 'run-output'), 'dir');
+
+    try {
+      const result = await runCommand({
+        command: 'node',
+        args: ['-e', 'process.stdout.write("x".repeat(5000))'],
+        cwd: workspace,
+        runId: 'command-symlink-output',
+        displayOutput: true,
+        timeoutMs: 5_000,
+        env: minimalEnv(),
+      });
+
+      expect(result.displayTruncated).toBe(true);
+      expect(result.fullOutputPath).toBeUndefined();
+      expect(readdirSync(external)).toEqual([]);
+    } finally {
+      rmSync(external, { recursive: true, force: true });
+    }
+  });
+
   it('handles no-trailing-newline and binary-ish output without inventing tail content', async () => {
     const result = await runCommand({
       command: 'node',
@@ -523,6 +651,7 @@ describe('command-policy', () => {
       ],
       cwd: workspace,
       runId: 'command-binary-ish',
+      displayOutput: true,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });

--- a/core/tool-layer/mcp/slice.test.ts
+++ b/core/tool-layer/mcp/slice.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -46,6 +46,11 @@ function makeCtx(overrides: Partial<FactoryContext> = {}): FactoryContext {
     serverPort: 3001,
     ...overrides,
   };
+}
+
+function requireFullOutputPath(result: { fullOutputPath?: string }): string {
+  if (result.fullOutputPath == null) throw new Error('expected fullOutputPath');
+  return result.fullOutputPath;
 }
 
 describe('path-policy', () => {
@@ -98,6 +103,19 @@ describe('path-policy', () => {
     } catch (err) {
       expect((err as PathPolicyViolation).code).toBe(expected);
     }
+  });
+
+  it('allows only the .factory/run-output spill directory under Factory internals', () => {
+    const resolved = resolveWorkspacePath(workspace, '.factory/run-output/run-1-1.log');
+    expect(resolved.canonical.path).toBe('.factory/run-output/run-1-1.log');
+    expect(resolved.absolute).toBe(join(workspace, '.factory/run-output/run-1-1.log'));
+
+    expect(() => resolveWorkspacePath(workspace, '.factory/output-schemas/schema.json')).toThrow(
+      PathPolicyViolation,
+    );
+    expect(() => resolveWorkspacePath(workspace, '.factory/run-output/../secret.txt')).toThrow(
+      PathPolicyViolation,
+    );
   });
 
   it('rejects empty path', () => {
@@ -312,6 +330,7 @@ describe('command-policy', () => {
       command: 'node',
       args: ['-e', 'process.stdout.write("hello")'],
       cwd: workspace,
+      runId: 'command-small',
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -319,6 +338,9 @@ describe('command-policy', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('hello');
     expect(result.truncated).toBe(false);
+    expect(result.displayTruncated).toBe(false);
+    expect(result.fullOutputPath).toBeUndefined();
+    expect(existsSync(join(workspace, '.factory', 'run-output'))).toBe(false);
   });
 
   it('captures non-zero exit codes as failed without throwing', async () => {
@@ -326,6 +348,7 @@ describe('command-policy', () => {
       command: 'node',
       args: ['-e', 'process.exit(2)'],
       cwd: workspace,
+      runId: 'command-failed',
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -338,6 +361,7 @@ describe('command-policy', () => {
       command: 'node',
       args: ['-e', 'process.stdout.write("a".repeat(50))'],
       cwd: workspace,
+      runId: 'command-byte-cap',
       timeoutMs: 5_000,
       stdoutLimitBytes: 10,
       env: minimalEnv(),
@@ -351,6 +375,7 @@ describe('command-policy', () => {
       command: 'node',
       args: ['-e', 'setInterval(() => {}, 1000)'],
       cwd: workspace,
+      runId: 'command-timeout',
       timeoutMs: 150,
       env: minimalEnv(),
     });
@@ -362,6 +387,7 @@ describe('command-policy', () => {
       command: '/does/not/exist/factory-bin',
       args: [],
       cwd: workspace,
+      runId: 'command-spawn-error',
       timeoutMs: 1_000,
       env: minimalEnv(),
     });
@@ -373,6 +399,142 @@ describe('command-policy', () => {
     expect(DEFAULT_STDOUT_LIMIT_BYTES).toBeGreaterThan(0);
     expect(DEFAULT_STDERR_LIMIT_BYTES).toBeGreaterThan(0);
     expect(DEFAULT_STDOUT_LIMIT_BYTES).toBeGreaterThanOrEqual(DEFAULT_STDERR_LIMIT_BYTES);
+  });
+
+  it('display-shapes oversized stdout, preserves small stderr, and writes a readable spill file', async () => {
+    await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("warmup")'],
+      cwd: workspace,
+      runId: 'command-stdout-large',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    const stderr = 'small stderr';
+    const result = await runCommand({
+      command: 'node',
+      args: [
+        '-e',
+        `process.stdout.write("HEAD" + "a".repeat(5000) + "TAIL"); process.stderr.write(${JSON.stringify(
+          stderr,
+        )})`,
+      ],
+      cwd: workspace,
+      runId: 'command-stdout-large',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.displayTruncated).toBe(true);
+    expect(result.truncated).toBe(false);
+    expect(result.stderr).toBe(stderr);
+    expect(result.stdout).toContain('HEAD');
+    expect(result.stdout).toContain('TAIL');
+    expect(result.stdout).toContain('[factory] stdout display truncated');
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBeLessThanOrEqual(4096);
+    expect(result.fullOutputPath).toBe('.factory/run-output/command-stdout-large-2.log');
+
+    const fullOutputPath = requireFullOutputPath(result);
+    const spill = await readFileTool(makeCtx({ runId: 'reader' }), {
+      path: fullOutputPath,
+    });
+    expect(spill.content).toContain('===== stdout =====');
+    expect(spill.content).toContain('HEAD');
+    expect(spill.content).toContain('TAIL');
+    expect(spill.content).toContain('===== stderr =====');
+    expect(spill.content).toContain(stderr);
+  });
+
+  it('display-shapes stderr independently when stdout is under threshold', async () => {
+    const stdout = 'tiny stdout';
+    const result = await runCommand({
+      command: 'node',
+      args: [
+        '-e',
+        `process.stdout.write(${JSON.stringify(stdout)}); process.stderr.write("ERR" + "e".repeat(5000) + "TAIL")`,
+      ],
+      cwd: workspace,
+      runId: 'command-stderr-large',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.stdout).toBe(stdout);
+    expect(result.stderr).toContain('[factory] stderr display truncated');
+    expect(result.stderr).toContain('ERR');
+    expect(result.stderr).toContain('TAIL');
+    expect(result.displayTruncated).toBe(true);
+    expect(result.fullOutputPath).toBe('.factory/run-output/command-stderr-large-1.log');
+  });
+
+  it('display-shapes stdout and stderr independently into one labeled spill file', async () => {
+    const result = await runCommand({
+      command: 'node',
+      args: [
+        '-e',
+        'process.stdout.write("OUT" + "o".repeat(5000) + "END"); process.stderr.write("ERR" + "e".repeat(5000) + "END")',
+      ],
+      cwd: workspace,
+      runId: 'command-both-large',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.stdout).toContain('[factory] stdout display truncated');
+    expect(result.stderr).toContain('[factory] stderr display truncated');
+    expect(result.fullOutputPath).toBe('.factory/run-output/command-both-large-1.log');
+
+    const fullOutputPath = requireFullOutputPath(result);
+    const spill = readFileSync(join(workspace, fullOutputPath), 'utf8');
+    expect(spill).toContain('===== stdout =====');
+    expect(spill).toContain('OUT');
+    expect(spill).toContain('===== stderr =====');
+    expect(spill).toContain('ERR');
+  });
+
+  it('keeps byte-capture truncation distinct from display truncation', async () => {
+    const result = await runCommand({
+      command: 'node',
+      args: ['-e', 'process.stdout.write("x".repeat(10000))'],
+      cwd: workspace,
+      runId: 'command-capture-cap',
+      timeoutMs: 5_000,
+      stdoutLimitBytes: 4500,
+      env: minimalEnv(),
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.displayTruncated).toBe(true);
+    expect(result.stdout).toContain('captured output up to the command-policy byte limit');
+    const fullOutputPath = requireFullOutputPath(result);
+    const spill = readFileSync(join(workspace, fullOutputPath), 'utf8');
+    expect(spill).toContain('===== stdout =====');
+    expect(Buffer.byteLength(spill, 'utf8')).toBeLessThan(10000);
+  });
+
+  it('handles no-trailing-newline and binary-ish output without inventing tail content', async () => {
+    const result = await runCommand({
+      command: 'node',
+      args: [
+        '-e',
+        'process.stdout.write("START" + "n".repeat(5000) + "END"); process.stderr.write(Buffer.concat([Buffer.from([0, 1, 2, 3]), Buffer.from("b".repeat(5000)), Buffer.from([4, 5])]))',
+      ],
+      cwd: workspace,
+      runId: 'command-binary-ish',
+      timeoutMs: 5_000,
+      env: minimalEnv(),
+    });
+
+    expect(result.stdout.endsWith('END')).toBe(true);
+    expect(result.stderr).toContain('[factory] stderr display truncated');
+    expect(result.stderr.endsWith('\u0004\u0005')).toBe(true);
+    expect(result.displayTruncated).toBe(true);
+    const fullOutputPath = requireFullOutputPath(result);
+    const spill = readFileSync(join(workspace, fullOutputPath));
+    expect(spill.includes(Buffer.from([0, 1, 2, 3]))).toBe(true);
+    expect(spill.includes(Buffer.from([4, 5]))).toBe(true);
   });
 });
 

--- a/core/tool-layer/mcp/tools/evidence.ts
+++ b/core/tool-layer/mcp/tools/evidence.ts
@@ -191,6 +191,7 @@ export async function runPlaywrightSpecTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: PLAYWRIGHT_TIMEOUT_MS,
     stdoutLimitBytes: PLAYWRIGHT_STDOUT_LIMIT_BYTES,
     env: minimalEnv(extraEnv),

--- a/core/tool-layer/mcp/tools/evidence.ts
+++ b/core/tool-layer/mcp/tools/evidence.ts
@@ -190,6 +190,7 @@ export async function runPlaywrightSpecTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: PLAYWRIGHT_TIMEOUT_MS,
     stdoutLimitBytes: PLAYWRIGHT_STDOUT_LIMIT_BYTES,
     env: minimalEnv(extraEnv),
@@ -210,6 +211,8 @@ export async function runPlaywrightSpecTool(
     stderr: result.stderr,
     durationMs: result.durationMs,
     truncated: result.truncated,
+    displayTruncated: result.displayTruncated,
+    ...(result.fullOutputPath != null ? { fullOutputPath: result.fullOutputPath } : {}),
     command: argv,
   };
 }

--- a/core/tool-layer/mcp/tools/git.ts
+++ b/core/tool-layer/mcp/tools/git.ts
@@ -83,6 +83,7 @@ async function git(
     command: 'git',
     args,
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: GIT_TIMEOUT_MS,
     stdoutLimitBytes,
     env: minimalEnv(),

--- a/core/tool-layer/mcp/tools/qa.ts
+++ b/core/tool-layer/mcp/tools/qa.ts
@@ -108,6 +108,7 @@ export async function getPrDiffTool(
     args: ['diff', '--no-color', `${baseRef}...${resolvedRef}`],
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: PR_DIFF_TIMEOUT_MS,
     stdoutLimitBytes: PR_DIFF_STDOUT_LIMIT_BYTES,
     env: minimalEnv(),
@@ -213,6 +214,7 @@ export async function runIsolatedTestTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: 5 * 60 * 1000,
     env: minimalEnv(),
   });

--- a/core/tool-layer/mcp/tools/qa.ts
+++ b/core/tool-layer/mcp/tools/qa.ts
@@ -34,6 +34,8 @@ export interface GetPrDiffResult {
   prNumber: number;
   diff: string;
   truncated: boolean;
+  displayTruncated: boolean;
+  fullOutputPath?: string;
 }
 
 export interface RunFullSuiteIfNeededResult extends VerifyResult {
@@ -77,6 +79,7 @@ export async function getPrDiffTool(
       command: 'git',
       args: ['rev-parse', '--verify', ref],
       cwd: ctx.workspaceRoot,
+      runId: ctx.runId,
       timeoutMs: 5_000,
       env: minimalEnv(),
     });
@@ -104,6 +107,7 @@ export async function getPrDiffTool(
     command: 'git',
     args: ['diff', '--no-color', `${baseRef}...${resolvedRef}`],
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: PR_DIFF_TIMEOUT_MS,
     stdoutLimitBytes: PR_DIFF_STDOUT_LIMIT_BYTES,
     env: minimalEnv(),
@@ -124,7 +128,13 @@ export async function getPrDiffTool(
     durationMs: result.durationMs,
     truncated: result.truncated,
   });
-  return { prNumber: input.prNumber, diff: result.stdout, truncated: result.truncated };
+  return {
+    prNumber: input.prNumber,
+    diff: result.stdout,
+    truncated: result.truncated,
+    displayTruncated: result.displayTruncated,
+    ...(result.fullOutputPath != null ? { fullOutputPath: result.fullOutputPath } : {}),
+  };
 }
 
 /**
@@ -202,6 +212,7 @@ export async function runIsolatedTestTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: 5 * 60 * 1000,
     env: minimalEnv(),
   });
@@ -220,6 +231,8 @@ export async function runIsolatedTestTool(
     stderr: narrowed.stderr,
     durationMs: narrowed.durationMs,
     truncated: narrowed.truncated,
+    displayTruncated: narrowed.displayTruncated,
+    ...(narrowed.fullOutputPath != null ? { fullOutputPath: narrowed.fullOutputPath } : {}),
     command: argv,
   };
 }

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -300,7 +300,7 @@ export async function readFileTool(
 ): Promise<ReadFileResult> {
   let resolved: ReturnType<typeof resolveWorkspacePath>;
   try {
-    resolved = resolveWorkspacePath(ctx.workspaceRoot, input.path);
+    resolved = resolveWorkspacePath(ctx.workspaceRoot, input.path, { allowRunOutput: true });
   } catch (err) {
     if (err instanceof PathPolicyViolation) handleBlocked(ctx, 'read_file', err, { ...input });
     throw err;

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -579,6 +579,7 @@ export async function listFilesTool(
     command: 'rg',
     args,
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: LIST_FILES_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -681,6 +682,7 @@ export async function searchTextTool(
     command: 'rg',
     args,
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: SEARCH_TIMEOUT_MS,
     stdoutLimitBytes: DEFAULT_STDOUT_LIMIT_BYTES,
     env: minimalEnv(),

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -58,6 +58,8 @@ export interface VerifyResult {
   stderr: string;
   durationMs: number;
   truncated: boolean;
+  displayTruncated: boolean;
+  fullOutputPath?: string;
   command: ReadonlyArray<string>;
   rawPaths?: string[];
   paths?: RepoRelativePath[];
@@ -88,7 +90,9 @@ function toVerifyResult(
     stderr: r.stderr,
     durationMs: r.durationMs,
     truncated: r.truncated,
+    displayTruncated: r.displayTruncated ?? false,
     command: argv,
+    ...(r.fullOutputPath != null ? { fullOutputPath: r.fullOutputPath } : {}),
     ...(paths != null && paths.rawPaths.length > 0 ? { rawPaths: paths.rawPaths } : {}),
     ...(paths != null && paths.paths.length > 0 ? { paths: paths.paths } : {}),
   };
@@ -194,6 +198,7 @@ export async function runTestsTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: TEST_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -240,6 +245,7 @@ function buildRetryCapBlockedResult(
     stderr: `[harness] run_tests retry cap reached (${observed}/${cap} consecutive failures on ${pathLabel}). Edit the failing source or test before invoking run_tests again — read the prior failure output, classify the cause, then make a targeted change.`,
     durationMs: 0,
     truncated: false,
+    displayTruncated: false,
     command: argv,
   };
 }
@@ -269,6 +275,7 @@ export async function runLintTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: LINT_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -298,6 +305,7 @@ export async function runTypecheckTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: TYPECHECK_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -341,6 +349,7 @@ export async function runPackageScriptTool(
     command: argv[0],
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: PACKAGE_SCRIPT_TIMEOUT_MS,
     env: minimalEnv(),
   });

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -199,6 +199,7 @@ export async function runTestsTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: TEST_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -276,6 +277,7 @@ export async function runLintTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: LINT_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -306,6 +308,7 @@ export async function runTypecheckTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: TYPECHECK_TIMEOUT_MS,
     env: minimalEnv(),
   });
@@ -350,6 +353,7 @@ export async function runPackageScriptTool(
     args: argv.slice(1),
     cwd: ctx.workspaceRoot,
     runId: ctx.runId,
+    displayOutput: true,
     timeoutMs: PACKAGE_SCRIPT_TIMEOUT_MS,
     env: minimalEnv(),
   });

--- a/core/tool-layer/mcp/tools/workflow.ts
+++ b/core/tool-layer/mcp/tools/workflow.ts
@@ -63,6 +63,7 @@ async function git(ctx: FactoryContext, args: ReadonlyArray<string>): Promise<Co
     command: 'git',
     args,
     cwd: ctx.workspaceRoot,
+    runId: ctx.runId,
     timeoutMs: GIT_TIMEOUT_MS,
     env: minimalEnv(),
   });

--- a/core/tool-layer/mcp/tools/write.test.ts
+++ b/core/tool-layer/mcp/tools/write.test.ts
@@ -63,6 +63,12 @@ describe('writeFileTool', () => {
     expect(blocked).toBeTruthy();
     expect((blocked?.payload as { reason: string }).reason).toBe('assistant_home');
   });
+
+  it('does not allow agents to overwrite command-output spill files', async () => {
+    await expect(
+      writeFileTool(ctx, { path: '.factory/run-output/run-1-1.log', content: 'tamper' }),
+    ).rejects.toMatchObject({ code: 'factory_internals' });
+  });
 });
 
 describe('canonical RepoRelativePath contract', () => {

--- a/core/tool-layer/mcp/tools/write.ts
+++ b/core/tool-layer/mcp/tools/write.ts
@@ -252,6 +252,7 @@ export async function applyPatchTool(
       command: 'git',
       args: ['apply', '--whitespace=nowarn', patchFile],
       cwd: ctx.workspaceRoot,
+      runId: ctx.runId,
       timeoutMs: APPLY_PATCH_TIMEOUT_MS,
       env: minimalEnv(),
     });
@@ -270,6 +271,7 @@ export async function applyPatchTool(
       command: 'git',
       args: ['apply', '--numstat', '--summary', patchFile],
       cwd: ctx.workspaceRoot,
+      runId: ctx.runId,
       timeoutMs: APPLY_PATCH_TIMEOUT_MS,
       env: minimalEnv(),
     });


### PR DESCRIPTION
Closes #1044

Summary:
- Added post-capture command output display shaping with per-stream 4 KB head/banner/tail output.
- Persisted oversized captured stdout/stderr to .factory/run-output/<runId>-<n>.log with labeled sections and exposed displayTruncated/fullOutputPath.
- Added the narrow .factory/run-output path-policy exception and propagated runId through MCP command callers.

Tests:
- pnpm vitest run core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/tools/verify.test.ts core/tool-layer/mcp/tools/qa.test.ts core/tool-layer/mcp/tools/read.test.ts core/tool-layer/mcp/tools/git.test.ts core/tool-layer/mcp/tools/write.test.ts core/tool-layer/mcp/tools/evidence.test.ts core/tool-layer/mcp/tools/workflow.test.ts
- pnpm typecheck
- pnpm exec biome check core/tool-layer/mcp/command-policy.ts core/tool-layer/mcp/output-sandbox.ts core/tool-layer/mcp/path-policy.ts core/tool-layer/mcp/schemas.ts core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/tools/evidence.ts core/tool-layer/mcp/tools/git.ts core/tool-layer/mcp/tools/qa.ts core/tool-layer/mcp/tools/read.ts core/tool-layer/mcp/tools/verify.ts core/tool-layer/mcp/tools/workflow.ts core/tool-layer/mcp/tools/write.ts
- pnpm lint (exits 0; reports existing warnings in apps/web/src/lib/logger.ts and slices/grill-and-prd/slice.test.ts)
