### PR TITLE
WS2 Task 1: repo_intel not-found audit status

### DIFF
--- a/core/tool-layer/mcp/tools/repo-intel.test.ts
+++ b/core/tool-layer/mcp/tools/repo-intel.test.ts
@@ -379,6 +379,40 @@ describe('repoIntelQueryTool', () => {
     });
   });
 
+  it('audits not-found as ok with noMatches while invalid-args remains failed', async () => {
+    const notFoundCtx = makeCtx({ runId: 'repo-intel-audit-not-found' });
+    await repoIntelQueryTool(
+      notFoundCtx,
+      { intent: 'find-symbol', name: 'Missing' },
+      { lookupSymbol: vi.fn(() => []) },
+    );
+
+    const notFoundEvents = eventStore.replay({
+      runId: notFoundCtx.runId,
+      kind: 'agent.tool-call',
+    });
+    expect(notFoundEvents[0].payload).toMatchObject({
+      tool_name: 'repo_intel.query',
+      repo_intel_intent: 'find-symbol',
+      status: 'ok',
+      noMatches: true,
+    });
+
+    const invalidCtx = makeCtx({ runId: 'repo-intel-audit-invalid-still-failed' });
+    await repoIntelQueryTool(invalidCtx, { intent: 'find-symbol' } as unknown as RepoIntelQuery);
+
+    const invalidEvents = eventStore.replay({
+      runId: invalidCtx.runId,
+      kind: 'agent.tool-call',
+    });
+    expect(invalidEvents[0].payload).toMatchObject({
+      tool_name: 'repo_intel.query',
+      repo_intel_intent: 'find-symbol',
+      status: 'failed',
+      noMatches: false,
+    });
+  });
+
   it('audit event carries inputKeys including all provided fields', async () => {
     const ctx = makeCtx({ runId: 'repo-intel-audit-keys' });
     await repoIntelQueryTool(

--- a/core/tool-layer/mcp/tools/repo-intel.ts
+++ b/core/tool-layer/mcp/tools/repo-intel.ts
@@ -188,11 +188,12 @@ export async function repoIntelQueryTool(
   }
 
   const result = await dispatchRepoIntel(ctx, normalized, deps);
+  const isMiss = !result.ok && result.reason === 'not-found';
   emitToolCall(ctx, {
     tool: 'repo_intel.query',
     input: auditInput(input),
-    status: result.ok ? 'ok' : 'failed',
-    noMatches: !result.ok && result.reason === 'not-found',
+    status: result.ok || isMiss ? 'ok' : 'failed',
+    noMatches: isMiss,
     repo_intel_intent: input.intent,
     inputKeys,
     ...duplicateAuditFields(duplicate),


### PR DESCRIPTION
## Summary
- Relabel repo_intel not-found audit events as successful empty queries with noMatches=true.
- Keep invalid-args audit events marked as failed.

## Verification
- /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/tsx scripts/run-vitest-with-db.ts core/tool-layer/mcp/tools/repo-intel.test.ts -t "not-found"