### PR TITLE
Fix unconstrained review disposition guidance

### DIFF
--- a/skills/review/prompt.unconstrained.md
+++ b/skills/review/prompt.unconstrained.md
@@ -76,7 +76,17 @@ Beyond the stated criteria, identify any concerns. For each, record a `ReviewFin
 - **major** — design decisions that will cause meaningful pain; ambiguous public APIs; missing edge-case tests
 - **minor** — style inconsistencies, misleading comments, cosmetic issues
 
-All blocker findings require a `disposition` (fixed / registered / out-of-scope).
+All blocker findings require both `disposition` and `dispositionRef`.
+
+For each blocker finding, set:
+
+| `disposition` | When | `dispositionRef` |
+|---|---|---|
+| `fixed` | The PR already addresses this finding. | The commit SHA where the fix landed. |
+| `registered` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
+| `out-of-scope` | The finding is real but explicitly not in scope for this issue. | A one-sentence rationale. |
+
+A blocker-severity finding without `dispositionRef` fails schema validation.
 
 Emit:
 ```

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -457,6 +457,17 @@ describe('prompt.md — criteriaChecks population requirement', () => {
   });
 });
 
+// ─── prompt.unconstrained.md — blocker disposition contract ──────────────────
+
+describe('prompt.unconstrained.md — blocker disposition contract', () => {
+  const promptMd = readFileSync(join(import.meta.dirname, 'prompt.unconstrained.md'), 'utf-8');
+
+  it('requires blocker findings to include dispositionRef', () => {
+    expect(promptMd).toMatch(/blocker[\s\S]+dispositionRef/);
+    expect(promptMd).toMatch(/without `dispositionRef` fails schema validation/);
+  });
+});
+
 // ─── Review skill config ──────────────────────────────────────────────────────
 
 describe('review skill config', () => {


### PR DESCRIPTION
## Summary
- require unconstrained review blocker findings to include both disposition and dispositionRef
- add a prompt regression test for the unconstrained review variant

## Verification
- pnpm test skills/review/slice.test.ts
- pnpm skill-contract:audit
- pnpm audit-docs

Related to #1041