### PR TITLE
M19.WS3: durable parallel implement persistence

### DIFF
--- a/core/connectors/github/open-pr.ts
+++ b/core/connectors/github/open-pr.ts
@@ -33,6 +33,8 @@ export interface OpenPrInput {
   fetchImpl?: typeof fetch;
   /** Optional override of the git invocation — used by tests. */
   gitExec?: (args: string[], cwd: string) => string;
+  /** Skip the git push when the caller already pushed and verified the branch. */
+  skipPush?: boolean;
 }
 
 export interface OpenPrResult {
@@ -75,6 +77,7 @@ export async function openPR(input: OpenPrInput): Promise<OpenPrResult> {
     token,
     fetchImpl = fetch,
     gitExec = defaultGitExec,
+    skipPush = false,
   } = input;
 
   if (title.length === 0 || title.length > 70) {
@@ -86,7 +89,12 @@ export async function openPR(input: OpenPrInput): Promise<OpenPrResult> {
   // `--force-with-lease` is intentional: replays of the same workflow run
   // (after retry) push the same logical change to the same branch. Forcing
   // without lease would clobber upstream commits — refused by callers.
-  gitExec(['push', '--force-with-lease', 'origin', `HEAD:refs/heads/${branchName}`], worktreePath);
+  if (!skipPush) {
+    gitExec(
+      ['push', '--force-with-lease', 'origin', `HEAD:refs/heads/${branchName}`],
+      worktreePath,
+    );
+  }
 
   // 2. Open the PR via REST.
   const url = `https://api.github.com/repos/${repo}/pulls`;

--- a/core/connectors/github/slice.test.ts
+++ b/core/connectors/github/slice.test.ts
@@ -80,6 +80,24 @@ describe('openPR (#184)', () => {
     expect(sent.base).toBe('develop');
   });
 
+  it('can open a PR without pushing when the branch was already verified', async () => {
+    const gitExec = vi.fn().mockReturnValue('');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ number: 2, html_url: 'https://example/2' }), { status: 201 }),
+      ) as unknown as typeof fetch;
+
+    await openPR({ ...baseInput, skipPush: true, gitExec, fetchImpl });
+
+    expect(gitExec).not.toHaveBeenCalled();
+    const sent = JSON.parse(
+      ((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit)
+        .body as string,
+    ) as Record<string, unknown>;
+    expect(sent.head).toBe('factory/run-abc');
+  });
+
   it('rejects empty title', async () => {
     await expect(openPR({ ...baseInput, title: '', gitExec: () => '' })).rejects.toThrow(
       /title must be 1–70 chars/,

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -96,6 +96,7 @@ export const EVENT_KINDS = [
   'parallel-implement.iteration-started',
   'parallel-implement.wp-started',
   'parallel-implement.wp-committed',
+  'parallel-implement.wp-persisted',
   'parallel-implement.wp-failed',
   'parallel-implement.wp-timeout',
   'parallel-implement.wp-commit-failed',

--- a/core/workspaces/orchestrator-git.ts
+++ b/core/workspaces/orchestrator-git.ts
@@ -151,6 +151,22 @@ export function orchestratorPushBranch(worktreePath: string, branchName: string)
   });
 }
 
+export function resolveRemoteBranchHead(worktreePath: string, branchName: string): string {
+  if (branchName.trim().length === 0) {
+    throw new Error('branchName is required to verify remote branch head');
+  }
+  const output = execFileSync('git', ['ls-remote', 'origin', `refs/heads/${branchName}`], {
+    cwd: worktreePath,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim();
+  const [sha] = output.split(/\s+/);
+  if (sha == null || sha.length === 0) {
+    throw new Error(`remote branch not found after push: ${branchName}`);
+  }
+  return sha;
+}
+
 /**
  * Reverts a WP builder's file changes in the scratch worktree.
  *

--- a/core/workspaces/slice.test.ts
+++ b/core/workspaces/slice.test.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanupWorktree, createWorktree, resolveWorkflowBase } from './worktree.js';
+import {
+  cleanupWorktree,
+  createIntegrationWorktree,
+  createWorktree,
+  resolveWorkflowBase,
+} from './worktree.js';
 
 const WT = (runId: string) => join('/mock-home', '.factory', 'workspaces', runId);
 const WORKSPACES_DIR = join('/mock-home', '.factory', 'workspaces');
@@ -124,6 +129,92 @@ describe('resolveWorkflowBase', () => {
       ref: 'origin/main',
       source: 'fallback-main',
     });
+  });
+});
+
+describe('createIntegrationWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mkdirSync).mockReturnValue(undefined);
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reattaches an existing local branch without resetting it to the base ref', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') {
+        return 'branch-tip\n';
+      }
+      return Buffer.from('');
+    });
+
+    expect(
+      createIntegrationWorktree('/repo/path', 'run-abc-123', 'factory/run/run-abc-123', 'main'),
+    ).toEqual({
+      worktreePath: WT('run-abc-123'),
+      previousHeadSha: 'branch-tip',
+    });
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['show-ref', '--verify', 'refs/heads/factory/run/run-abc-123'],
+      expect.objectContaining({ cwd: WT('run-abc-123') }),
+    );
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['checkout', 'factory/run/run-abc-123'],
+      expect.objectContaining({ cwd: WT('run-abc-123') }),
+    );
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalledWith(
+      'git',
+      ['checkout', '-B', 'factory/run/run-abc-123', 'main'],
+      expect.any(Object),
+    );
+  });
+
+  it('creates the integration branch from the base ref only when no local branch exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'show-ref') {
+        throw new Error('missing branch');
+      }
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') {
+        return 'base-tip\n';
+      }
+      return Buffer.from('');
+    });
+
+    createIntegrationWorktree('/repo/path', 'run-abc-123', 'factory/run/run-abc-123', 'main');
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['checkout', '-B', 'factory/run/run-abc-123', 'main'],
+      expect.objectContaining({ cwd: WT('run-abc-123') }),
+    );
+  });
+
+  it('does not reset an existing integration branch when checkout fails', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'checkout') {
+        throw new Error('checkout conflicts');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() =>
+      createIntegrationWorktree('/repo/path', 'run-abc-123', 'factory/run/run-abc-123', 'main'),
+    ).toThrow('checkout conflicts');
+
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalledWith(
+      'git',
+      ['checkout', '-B', 'factory/run/run-abc-123', 'main'],
+      expect.any(Object),
+    );
   });
 });
 

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -16,6 +16,11 @@ export type WorkflowBase = {
   source: WorkflowBaseSource;
 };
 
+export type IntegrationWorktree = {
+  worktreePath: string;
+  previousHeadSha: string;
+};
+
 /**
  * Resolves the worktree path for a given runId.
  * Pattern: ~/.factory/workspaces/<runId>/
@@ -102,6 +107,61 @@ export function createWorktree(repo: string, runId: string, baseRef?: string): s
   });
 
   return wtPath;
+}
+
+/**
+ * Creates or reattaches the durable per-pipeline integration worktree.
+ *
+ * The parent repo checkout is used only as the `git worktree add` source. Branch
+ * checkout/reset happens inside the integration worktree so the operator's
+ * current checkout is not mutated.
+ */
+export function createIntegrationWorktree(
+  repo: string,
+  pipelineRunId: string,
+  branchName: string,
+  baseRef?: string,
+): IntegrationWorktree {
+  const wtPath = worktreePath(pipelineRunId);
+  mkdirSync(WORKSPACES_DIR, { recursive: true });
+
+  if (!existsSync(wtPath)) {
+    const args = ['worktree', 'add', '--detach', wtPath];
+    if (baseRef != null && baseRef.length > 0) {
+      args.push(baseRef);
+    }
+    execFileSync('git', args, {
+      cwd: repo,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+  }
+
+  try {
+    execFileSync('git', ['checkout', branchName], {
+      cwd: wtPath,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+  } catch {
+    const args = ['checkout', '-B', branchName];
+    if (baseRef != null && baseRef.length > 0) {
+      args.push(baseRef);
+    }
+    execFileSync('git', args, {
+      cwd: wtPath,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+  }
+
+  const previousHeadSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: wtPath,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim();
+
+  return { worktreePath: wtPath, previousHeadSha };
 }
 
 /**

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -109,6 +109,19 @@ export function createWorktree(repo: string, runId: string, baseRef?: string): s
   return wtPath;
 }
 
+function localBranchExists(worktreePath: string, branchName: string): boolean {
+  try {
+    execFileSync('git', ['show-ref', '--verify', `refs/heads/${branchName}`], {
+      cwd: worktreePath,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Creates or reattaches the durable per-pipeline integration worktree.
  *
@@ -137,13 +150,13 @@ export function createIntegrationWorktree(
     });
   }
 
-  try {
+  if (localBranchExists(wtPath, branchName)) {
     execFileSync('git', ['checkout', branchName], {
       cwd: wtPath,
       stdio: 'pipe',
       env: GIT_ENV,
     });
-  } catch {
+  } else {
     const args = ['checkout', '-B', branchName];
     if (baseRef != null && baseRef.length > 0) {
       args.push(baseRef);

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1143,6 +1143,105 @@ describe('parallel-implement durable integration branch persistence', () => {
     });
   });
 
+  it('pushes dev-review response commits before opening the PR without repush', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent } = makeAppendEvent();
+    const operations: string[] = [];
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const remoteHeads = ['sha-wp1', 'sha-dev-review'];
+
+    const devReviewOutput: DevReviewOutput = {
+      verdict: 'blockers-found',
+      findings: [
+        {
+          severity: 'P1',
+          category: 'correctness',
+          file: 'core/a.ts',
+          line: 12,
+          summary: 'Missing durable push',
+          suggestion: 'Push after committing the response',
+        },
+      ],
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Found one blocker' }],
+    };
+    const responseOutput: DevReviewResponseOutput = {
+      findingDispositions: [
+        {
+          findingRef: 'core/a.ts:12',
+          severity: 'P1',
+          disposition: 'addressed',
+          reason: 'Added the missing push',
+        },
+      ],
+      decisionSummaries: [{ kind: 'DEV_REVIEW_ADDRESSED', summary: 'Pushed response commit' }],
+    };
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'high' }),
+      spec,
+      'pipeline-run-dev-review-push',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'all',
+          maxRevisionTurns: 1,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async () => devReviewOutput,
+        runDevReviewResponseImpl: async () => responseOutput,
+        commitDevReviewResponseImpl: () => {
+          operations.push('commit-dev-review');
+          return 'sha-dev-review';
+        },
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp1',
+        pushBranchImpl: (_worktreePath, branchName) => {
+          operations.push(`push:${branchName}`);
+        },
+        resolveRemoteBranchHeadImpl: () => remoteHeads.shift() ?? 'unexpected-sha',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: async (input) => {
+          operations.push(`open-pr:skipPush=${String(input.skipPush)}`);
+          return {
+            prNumber: 12,
+            prUrl: 'https://gh/pr/12',
+            branch: input.branchName,
+            base: input.baseBranch ?? 'main',
+          };
+        },
+        getDiffImpl: () => 'diff --git a/core/a.ts b/core/a.ts\n+durable push',
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(operations).toEqual([
+      'push:factory/run/pipeline-run-dev-review-push',
+      'commit-dev-review',
+      'push:factory/run/pipeline-run-dev-review-push',
+      'open-pr:skipPush=true',
+    ]);
+  });
+
   it('skips already persisted WPs on resume and continues with the first unpersisted WP', async () => {
     const wp1 = makeWp('WP1', ['core/a.ts']);
     const wp2 = makeWp('WP2', ['core/b.ts']);

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -691,6 +691,7 @@ describe('parallel-implement repo-relative path normalization', () => {
     const spec = makeSpec([makeWp('WP1', ['apps/web/src/foo.ts'])]);
     const { fn: appendEvent, events } = makeAppendEvent();
     const replaySpy = vi.spyOn(eventStore, 'replay').mockReturnValue([]);
+    let runtimeCalls = 0;
 
     try {
       const result = await runParallelImplementWorkflow(
@@ -703,6 +704,7 @@ describe('parallel-implement repo-relative path normalization', () => {
         {
           runtime: makeRuntime({
             WP1: async () => {
+              runtimeCalls++;
               const output = makeOkResult('WP1').output as ImplementWpOutput;
               return {
                 output: {
@@ -738,6 +740,7 @@ describe('parallel-implement repo-relative path normalization', () => {
       );
 
       expect(result.status).toBe('failed');
+      expect(runtimeCalls).toBe(1);
       const mismatch = events.find((event) => event.kind === 'agent.output-fact-mismatch');
       expect(mismatch?.payload).toMatchObject({
         skill: 'implement-wp',
@@ -1061,6 +1064,374 @@ describe('parallel-implement concurrency: 3 fake builders on disjoint files', ()
 
     // No failures
     expect(iterations.some((i) => i.status === 'failed')).toBe(false);
+  });
+});
+
+describe('parallel-implement durable integration branch persistence', () => {
+  it('pushes and verifies each WP commit before emitting wp-persisted and opening PR without repush', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const pushes: Array<{ worktreePath: string; branchName: string }> = [];
+    const openPrCalls: Array<{ branchName: string; skipPush?: boolean }> = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-123',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp1',
+        pushBranchImpl: (worktreePath, branchName) => {
+          pushes.push({ worktreePath, branchName });
+        },
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: async (input) => {
+          openPrCalls.push({ branchName: input.branchName, skipPush: input.skipPush });
+          return {
+            prNumber: 1,
+            prUrl: 'https://gh/pr/1',
+            branch: input.branchName,
+            base: input.baseBranch ?? 'main',
+          };
+        },
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(pushes).toEqual([
+      { worktreePath: '/tmp/issue-wt', branchName: 'factory/run/pipeline-run-123' },
+    ]);
+    expect(openPrCalls).toEqual([{ branchName: 'factory/run/pipeline-run-123', skipPush: true }]);
+
+    const persisted = events.find((event) => event.kind === 'parallel-implement.wp-persisted');
+    expect(persisted?.payload).toMatchObject({
+      schemaVersion: 1,
+      pipelineRunId: 'pipeline-run-123',
+      wpId: 'WP1',
+      integrationBranch: 'factory/run/pipeline-run-123',
+      baseBranch: 'main',
+      previousHeadSha: 'base-sha',
+      wpCommitSha: 'sha-wp1',
+      pushedSha: 'sha-wp1',
+      filesPersisted: [],
+      persistMode: 'direct-integration-commit',
+    });
+    expect(events.find((event) => event.kind === 'agent.run-completed')?.payload).toMatchObject({
+      skill: 'parallel-implement',
+      runDisposition: 'completed',
+    });
+  });
+
+  it('skips already persisted WPs on resume and continues with the first unpersisted WP', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const wp2 = makeWp('WP2', ['core/b.ts']);
+    const spec = makeSpec([wp1, wp2]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const startedWpIds: string[] = [];
+    const iterations: Array<{ wpId: string; status: string }> = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-resume',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({
+          WP2: async () => makeOkResult('WP2'),
+        }),
+        replayEventsImpl: () => [
+          {
+            id: 1,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId: 'pipeline-run-resume',
+              devRunId: 'old-dev-run',
+              wpId: 'WP1',
+              wpRunId: 'old-dev-run:wp:WP1:iter:1',
+              iteration: 1,
+              integrationBranch: 'factory/run/pipeline-run-resume',
+              baseBranch: 'main',
+              previousHeadSha: 'base-sha',
+              wpCommitSha: 'sha-wp1',
+              pushedSha: 'sha-wp1',
+              filesPersisted: ['core/a.ts'],
+              persistMode: 'direct-integration-commit',
+            },
+            runId: 'old-dev-run:wp:WP1:iter:1',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+        ],
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'sha-wp1',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => {
+          startedWpIds.push(wpId);
+          return `/tmp/wp-${wpId}`;
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp2',
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp2',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: async (input) => ({
+          prNumber: 2,
+          prUrl: 'https://gh/pr/2',
+          branch: input.branchName,
+          base: input.baseBranch ?? 'main',
+        }),
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(startedWpIds).toEqual(['WP2']);
+    expect(
+      events.find((event) => event.kind === 'parallel-implement.wp-started')?.payload,
+    ).toMatchObject({
+      wpId: 'WP2',
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.kind === 'parallel-implement.wp-started' &&
+          (event.payload as { wpId?: string }).wpId === 'WP1',
+      ),
+    ).toBe(false);
+  });
+
+  it('creates dependent WP scratch worktrees from the latest persisted integration tip', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const wp2 = { ...makeWp('WP2', ['core/b.ts']), dependsOn: ['WP1'] };
+    const spec = {
+      ...makeSpec([wp1, wp2]),
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+    };
+    const { fn: appendEvent } = makeAppendEvent();
+    const scratchBases: Array<{ wpId: string; baseRef?: string }> = [];
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const commitShas = ['sha-wp1', 'sha-wp2'];
+    const remoteHeads = ['sha-wp1', 'sha-wp2'];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-deps',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({
+          WP1: async () => makeOkResult('WP1'),
+          WP2: async () => makeOkResult('WP2'),
+        }),
+        resolveWorkflowBaseImpl: () => ({
+          branch: 'main',
+          ref: 'origin/main',
+          source: 'configured-default',
+        }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId, baseRef) => {
+          scratchBases.push({ wpId, baseRef });
+          return `/tmp/wp-${wpId}`;
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => commitShas.shift() ?? 'unexpected-sha',
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => remoteHeads.shift() ?? 'unexpected-sha',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: async (input) => ({
+          prNumber: 3,
+          prUrl: 'https://gh/pr/3',
+          branch: input.branchName,
+          base: input.baseBranch ?? 'main',
+        }),
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(scratchBases).toEqual([
+      { wpId: 'WP1', baseRef: 'base-sha' },
+      { wpId: 'WP2', baseRef: 'sha-wp1' },
+    ]);
+  });
+
+  it('hard-stops with persistence-failed when remote branch verification mismatches', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-mismatch',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-local',
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-remote',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(openPRImpl).not.toHaveBeenCalled();
+    const runFailed = events.find((event) => event.kind === 'agent.run-failed');
+    expect(runFailed?.payload).toMatchObject({
+      skill: 'parallel-implement',
+      runDisposition: 'persistence-failed',
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-persisted')).toBe(false);
+  });
+
+  it('does not duplicate an existing PR when resume finds all WPs persisted', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent } = makeAppendEvent();
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-existing-pr',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({}),
+        replayEventsImpl: () => [
+          {
+            id: 1,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId: 'pipeline-run-existing-pr',
+              devRunId: 'old-dev-run',
+              wpId: 'WP1',
+              wpRunId: 'old-dev-run:wp:WP1:iter:1',
+              iteration: 1,
+              integrationBranch: 'factory/run/pipeline-run-existing-pr',
+              baseBranch: 'main',
+              previousHeadSha: 'base-sha',
+              wpCommitSha: 'sha-wp1',
+              pushedSha: 'sha-wp1',
+              filesPersisted: ['core/a.ts'],
+              persistMode: 'direct-integration-commit',
+            },
+            runId: 'old-dev-run:wp:WP1:iter:1',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+          {
+            id: 2,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'pr.opened',
+            payload: {
+              pipelineRunId: 'pipeline-run-existing-pr',
+              prNumber: 44,
+              prUrl: 'https://gh/pr/44',
+              branch: 'factory/run/pipeline-run-existing-pr',
+              baseBranch: 'main',
+              worktreePath: '/tmp/issue-wt',
+              devRunId: 'old-dev-run',
+            },
+            runId: 'old-dev-run',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+        ],
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'sha-wp1',
+        }),
+        createWpWorktreeImpl: () => {
+          throw new Error('no WP scratch worktrees should be created');
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'success',
+      prNumber: 44,
+      prUrl: 'https://gh/pr/44',
+      worktreePath: '/tmp/issue-wt',
+    });
+    expect(openPRImpl).not.toHaveBeenCalled();
   });
 });
 

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -36,10 +36,13 @@ import {
   createWpScratchWorktree,
   orchestratorCommitAll,
   orchestratorCommitWp,
+  orchestratorPushBranch,
+  resolveRemoteBranchHead,
   revertWpChanges,
 } from '@goose-hub/core/workspaces/orchestrator-git.js';
 import {
   type cleanupWorktree,
+  createIntegrationWorktree,
   createWorktree,
   prewarmWorktree,
   resolveWorkflowBase,
@@ -77,9 +80,12 @@ export interface ParallelImplementDeps {
   /** Override dependency prewarm for tests or alternate package managers. */
   prewarmWorktreeImpl?: typeof prewarmWorktree;
   resolveWorkflowBaseImpl?: typeof resolveWorkflowBase;
+  createIntegrationWorktreeImpl?: typeof createIntegrationWorktree;
   cleanupWpWorktreesImpl?: typeof cleanupAllWpWorktrees;
   cleanupIssueWorktreeImpl?: typeof cleanupWorktree;
   orchestratorCommitWpImpl?: typeof orchestratorCommitWp;
+  pushBranchImpl?: typeof orchestratorPushBranch;
+  resolveRemoteBranchHeadImpl?: typeof resolveRemoteBranchHead;
   revertWpChangesImpl?: typeof revertWpChanges;
   recordIterationImpl?: typeof recordWpIteration;
   getLastStatusImpl?: typeof getLastWpStatus;
@@ -98,6 +104,8 @@ export interface ParallelImplementDeps {
   selectPersonaImpl?: typeof selectPersona;
   /** Override observed changed-file derivation for tests. */
   deriveObservedChangedFilesImpl?: typeof deriveObservedChangedFiles;
+  /** Override event replay for resume tests. */
+  replayEventsImpl?: typeof eventStore.replay;
 }
 
 function uniqueSorted(paths: string[]): string[] {
@@ -222,6 +230,93 @@ function applyObservedFileToIssueWorktree(input: {
   copyFileSync(sourcePath, destPath);
 }
 
+type PersistedWpCheckpoint = {
+  wpId: string;
+  wpRunId: string;
+  iteration: number;
+  integrationBranch: string;
+  wpCommitSha: string;
+  pushedSha: string;
+  filesPersisted: string[];
+};
+
+type ExistingPipelinePr = {
+  prNumber: number;
+  prUrl: string;
+  branch: string;
+  base: string;
+  worktreePath?: string;
+};
+
+function persistedWpCheckpoints(input: {
+  events: AgentEvent[];
+  pipelineRunId: string;
+  integrationBranch: string;
+}): Map<string, PersistedWpCheckpoint> {
+  const checkpoints = new Map<string, PersistedWpCheckpoint>();
+  for (const event of input.events) {
+    if (event.kind !== 'parallel-implement.wp-persisted') continue;
+    const payload = event.payload as Partial<PersistedWpCheckpoint> & {
+      pipelineRunId?: string;
+      persistMode?: string;
+    };
+    if (payload.pipelineRunId !== input.pipelineRunId) continue;
+    if (payload.integrationBranch !== input.integrationBranch) continue;
+    if (
+      typeof payload.wpId !== 'string' ||
+      typeof payload.wpRunId !== 'string' ||
+      typeof payload.iteration !== 'number' ||
+      typeof payload.wpCommitSha !== 'string' ||
+      typeof payload.pushedSha !== 'string'
+    ) {
+      continue;
+    }
+    checkpoints.set(payload.wpId, {
+      wpId: payload.wpId,
+      wpRunId: payload.wpRunId,
+      iteration: payload.iteration,
+      integrationBranch: payload.integrationBranch,
+      wpCommitSha: payload.wpCommitSha,
+      pushedSha: payload.pushedSha,
+      filesPersisted: Array.isArray(payload.filesPersisted)
+        ? payload.filesPersisted.filter((file): file is string => typeof file === 'string')
+        : [],
+    });
+  }
+  return checkpoints;
+}
+
+function latestPipelinePr(input: {
+  events: AgentEvent[];
+  pipelineRunId: string;
+  integrationBranch: string;
+}): ExistingPipelinePr | null {
+  for (const event of [...input.events].reverse()) {
+    if (event.kind !== 'pr.opened') continue;
+    const payload = event.payload as Partial<ExistingPipelinePr> & {
+      pipelineRunId?: string;
+      baseBranch?: string;
+    };
+    if (payload.pipelineRunId !== input.pipelineRunId) continue;
+    if (payload.branch !== input.integrationBranch) continue;
+    if (
+      typeof payload.prNumber !== 'number' ||
+      typeof payload.prUrl !== 'string' ||
+      typeof payload.branch !== 'string'
+    ) {
+      continue;
+    }
+    return {
+      prNumber: payload.prNumber,
+      prUrl: payload.prUrl,
+      branch: payload.branch,
+      base: typeof payload.base === 'string' ? payload.base : (payload.baseBranch ?? 'main'),
+      worktreePath: typeof payload.worktreePath === 'string' ? payload.worktreePath : undefined,
+    };
+  }
+  return null;
+}
+
 // ─── Main workflow ─────────────────────────────────────────────────────────────
 
 export async function runParallelImplementWorkflow(
@@ -245,6 +340,17 @@ export async function runParallelImplementWorkflow(
   const openPRFn = deps.openPRImpl ?? openPR;
   const createWpFn = deps.createWpWorktreeImpl ?? createWpScratchWorktree;
   const createIssueFn = deps.createIssueWorktreeImpl ?? createWorktree;
+  const createIntegrationFn =
+    deps.createIntegrationWorktreeImpl ??
+    ((repo: string, pipelineId: string, _branchName: string, baseRef?: string) => {
+      if (deps.createIssueWorktreeImpl != null) {
+        return {
+          worktreePath: createIssueFn(repo, pipelineId, baseRef),
+          previousHeadSha: null,
+        };
+      }
+      return createIntegrationWorktree(repo, pipelineId, _branchName, baseRef);
+    });
   const prewarmWtFn =
     deps.prewarmWorktreeImpl ??
     (deps.createIssueWorktreeImpl == null && deps.createWpWorktreeImpl == null
@@ -255,11 +361,20 @@ export async function runParallelImplementWorkflow(
   // cleanupIssueWorktreeImpl is available for test injection but unused in production:
   // the integration worktree persists until PR merge so QA can reuse the same environment.
   const commitWpFn = deps.orchestratorCommitWpImpl ?? orchestratorCommitWp;
+  const pushBranchFn =
+    deps.pushBranchImpl ??
+    (deps.createIssueWorktreeImpl == null ? orchestratorPushBranch : () => undefined);
+  const resolveRemoteBranchHeadFn =
+    deps.resolveRemoteBranchHeadImpl ??
+    (deps.createIssueWorktreeImpl == null
+      ? resolveRemoteBranchHead
+      : (_worktreePath: string, _branchName: string) => undefined);
   const revertFn = deps.revertWpChangesImpl ?? revertWpChanges;
   const recordFn = deps.recordIterationImpl ?? recordWpIteration;
   const getStatusFn = deps.getLastStatusImpl ?? getLastWpStatus;
   const deriveObservedChangedFilesFn =
     deps.deriveObservedChangedFilesImpl ?? deriveObservedChangedFiles;
+  const replayEventsFn = deps.replayEventsImpl ?? ((filter) => eventStore.replay(filter));
 
   const projectConfig = await getProjectBySlug(projectId);
   const workflowBase = resolveWorkflowBaseFn(targetRepo, projectConfig?.targetRepo?.defaultBranch);
@@ -356,6 +471,22 @@ export async function runParallelImplementWorkflow(
   const allWpIds = specForRun.workPackages.map((wp) => wp.id);
   const scratchWorktrees = new Map<string, string>(); // wpId → path
   let issueWorktreePath: string | undefined;
+  const integrationBranch = `factory/run/${pipelineRunId}`;
+  const resumeEvents = replayEventsFn({
+    projectId,
+    workItemId: workItem.id,
+  });
+  const persistedByWp = persistedWpCheckpoints({
+    events: resumeEvents,
+    pipelineRunId,
+    integrationBranch,
+  });
+  const existingPr = latestPipelinePr({
+    events: resumeEvents,
+    pipelineRunId,
+    integrationBranch,
+  });
+  let integrationHeadSha: string | null = null;
 
   try {
     const plannedWpFiles = specForRun.workPackages.flatMap((wp) =>
@@ -390,22 +521,28 @@ export async function runParallelImplementWorkflow(
     }
 
     // Create the integration worktree (all WP commits land here).
-    issueWorktreePath = createIssueFn(targetRepo, runId, workflowBase.ref);
+    const integrationWorktree = createIntegrationFn(
+      targetRepo,
+      pipelineRunId,
+      integrationBranch,
+      workflowBase.ref,
+    );
+    issueWorktreePath = integrationWorktree.worktreePath;
+    const latestPersisted = [...persistedByWp.values()].at(-1);
+    integrationHeadSha = latestPersisted?.pushedSha ?? integrationWorktree.previousHeadSha;
     prewarmWtFn(issueWorktreePath);
 
-    // Create per-WP scratch worktrees. Sandbox is written in runOneWpBuilder
-    // (per-spawn, so retries always get a fresh sandbox with correct opts).
-    for (const wp of specForRun.workPackages) {
-      const wtPath = createWpFn(targetRepo, runId, wp.id, workflowBase.ref);
-      prewarmWtFn(wtPath);
-      scratchWorktrees.set(wp.id, wtPath);
-    }
-
-    const allWpResults: WpDispatchResult[] = [];
+    const allWpResults: WpDispatchResult[] = [...persistedByWp.values()].map((checkpoint) => ({
+      wpId: checkpoint.wpId,
+      status: 'ok',
+      commitSha: checkpoint.wpCommitSha,
+      runId: checkpoint.wpRunId,
+    }));
 
     for (let iteration = 1; iteration <= maxRetries + 1; iteration++) {
       // Carry-forward: skip WPs that are already ok.
       const wpsToRun = specForRun.workPackages.filter((wp) => {
+        if (persistedByWp.has(wp.id)) return false;
         const lastStatus = getStatusFn(runId, wp.id);
         return lastStatus !== 'ok';
       });
@@ -427,6 +564,14 @@ export async function runParallelImplementWorkflow(
       for (const batch of specForRun.executionOrder) {
         const batchWps = wpsToRun.filter((wp) => batch.wpIds.includes(wp.id));
         if (batchWps.length === 0) continue;
+
+        const scratchBaseRef = integrationHeadSha ?? workflowBase.ref;
+        for (const wp of batchWps) {
+          if (scratchWorktrees.has(wp.id)) continue;
+          const wtPath = createWpFn(targetRepo, runId, wp.id, scratchBaseRef);
+          prewarmWtFn(wtPath);
+          scratchWorktrees.set(wp.id, wtPath);
+        }
 
         // Phase 1 — concurrent build (no git writes to integration worktree).
         const buildPhaseResults = await runWithConcurrencyCap(batchWps, maxParallel, (wp) =>
@@ -522,7 +667,17 @@ export async function runParallelImplementWorkflow(
                 errorReason: reason,
                 runId: wpRunId,
               });
-              continue;
+              await stateSource.comment(
+                workItem.externalId,
+                buildAgentComment('Dev', 'Failed', 'Parallel implement stopped on no-op WP', [
+                  `${wp.id}: ${reason}`,
+                ]),
+              );
+              return {
+                status: 'failed',
+                devRunId: runId,
+                errorReason: reason,
+              };
             }
 
             emitWpObservedMismatch({
@@ -619,12 +774,48 @@ export async function runParallelImplementWorkflow(
             payload: { wpId: wp.id, wpRunId, commitSha },
             runId: wpRunId,
           });
+
+          const previousHeadSha = integrationHeadSha;
+          pushBranchFn(issueWt, integrationBranch);
+          const pushedSha = resolveRemoteBranchHeadFn(issueWt, integrationBranch) ?? commitSha;
+          if (pushedSha !== commitSha) {
+            throw new Error(
+              `persistence verification failed for ${wp.id}: remote ${pushedSha} != commit ${commitSha}`,
+            );
+          }
+          append({
+            projectId,
+            workItemId: workItem.id,
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId,
+              devRunId: runId,
+              wpId: wp.id,
+              wpRunId,
+              iteration,
+              integrationBranch,
+              baseBranch: workflowBase.branch,
+              previousHeadSha,
+              wpCommitSha: commitSha,
+              pushedSha,
+              filesPersisted:
+                observedChangedFiles.gitAvailable && changedPaths.length > 0
+                  ? changedPaths
+                  : modelDeclaredPaths,
+              persistMode: 'direct-integration-commit',
+            },
+            runId: wpRunId,
+          });
+          integrationHeadSha = pushedSha;
           recordFn(runId, wp.id, iteration, 'ok');
           allWpResults.push({ wpId: wp.id, status: 'ok', commitSha, runId: wpRunId });
         }
       }
 
-      const stillFailed = allWpIds.filter((id) => getStatusFn(runId, id) !== 'ok');
+      const stillFailed = allWpIds.filter(
+        (id) => !persistedByWp.has(id) && getStatusFn(runId, id) !== 'ok',
+      );
 
       if (stillFailed.length === 0) break;
 
@@ -652,6 +843,30 @@ export async function runParallelImplementWorkflow(
           errorReason: `Parallel implement exhausted ${maxRetries + 1} iterations`,
         };
       }
+    }
+
+    if (persistedByWp.size === allWpIds.length && existingPr != null) {
+      append({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-completed',
+        payload: {
+          runId,
+          skill: 'parallel-implement',
+          runDisposition: 'completed',
+          prNumber: existingPr.prNumber,
+          branch: existingPr.branch,
+          baseBranch: existingPr.base,
+        },
+        runId,
+      });
+      return {
+        status: 'success',
+        devRunId: runId,
+        worktreePath: existingPr.worktreePath ?? issueWorktreePath ?? '',
+        prNumber: existingPr.prNumber,
+        prUrl: existingPr.prUrl,
+      };
     }
 
     // ── Dev-review advisor step with maxRevisionTurns loop (M19.25) ─────────
@@ -746,7 +961,7 @@ export async function runParallelImplementWorkflow(
       throw new Error('GITHUB_TOKEN env var is required to open PR');
     }
 
-    const branchName = `factory/${runId}`;
+    const branchName = integrationBranch;
     const title = `M19.XX: ${workItem.title.slice(0, 50)}`;
     const body = buildParallelPrBody({ workItem, spec: specForRun, wpResults: allWpResults });
 
@@ -759,6 +974,7 @@ export async function runParallelImplementWorkflow(
       branchName,
       baseBranch: workflowBase.branch,
       token,
+      skipPush: true,
     });
 
     append({
@@ -772,6 +988,21 @@ export async function runParallelImplementWorkflow(
         baseBranch: prResult.base,
         worktreePath: issueWorktreePath ?? '',
         devRunId: runId,
+      },
+      runId,
+    });
+
+    append({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.run-completed',
+      payload: {
+        runId,
+        skill: 'parallel-implement',
+        runDisposition: 'completed',
+        prNumber: prResult.prNumber,
+        branch: prResult.branch,
+        baseBranch: prResult.base,
       },
       runId,
     });
@@ -795,11 +1026,19 @@ export async function runParallelImplementWorkflow(
     };
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
+    const runDisposition = error.message.includes('persistence verification failed')
+      ? 'persistence-failed'
+      : undefined;
     append({
       projectId,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
-      payload: { runId, error: error.message },
+      payload: {
+        runId,
+        skill: 'parallel-implement',
+        error: error.message,
+        ...(runDisposition != null ? { runDisposition } : {}),
+      },
       runId,
     });
     await stateSource.comment(

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -872,6 +872,7 @@ export async function runParallelImplementWorkflow(
     // ── Dev-review advisor step with maxRevisionTurns loop (M19.25) ─────────
     // Runs after all WPs are committed, before the PR is opened.
     // Budget guard: skip if perCycleMaxUsd <= 0.
+    let devReviewResponseCommitSha: string | undefined;
     if (
       devReviewCfg.enabled &&
       shouldRunDevReview(devReviewCfg.triggerOn, workItem.priority) &&
@@ -935,7 +936,7 @@ export async function runParallelImplementWorkflow(
             });
             // Commit response edits so the next iteration's Codex diff is current.
             // orchestratorCommitAll uses --allow-empty, so no-ops when nothing changed.
-            commitDevReviewFn(
+            devReviewResponseCommitSha = commitDevReviewFn(
               issueWorktreePath,
               `chore: dev-review-response turn-${turns} addressing/dismissing findings`,
             );
@@ -953,6 +954,19 @@ export async function runParallelImplementWorkflow(
           });
         }
       }
+    }
+
+    if (devReviewResponseCommitSha != null && issueWorktreePath != null) {
+      pushBranchFn(issueWorktreePath, integrationBranch);
+      const pushedSha =
+        resolveRemoteBranchHeadFn(issueWorktreePath, integrationBranch) ??
+        devReviewResponseCommitSha;
+      if (pushedSha !== devReviewResponseCommitSha) {
+        throw new Error(
+          `persistence verification failed for dev-review response: remote ${pushedSha} != commit ${devReviewResponseCommitSha}`,
+        );
+      }
+      integrationHeadSha = pushedSha;
     }
 
     // All WPs committed — open PR.


### PR DESCRIPTION
## Summary
- Persist parallel-implement WP commits on factory/run/<pipelineRunId> integration branches.
- Push and verify each WP checkpoint before emitting parallel-implement.wp-persisted.
- Resume from persisted WPs, avoid duplicate PR creation, and materialize dependent WPs from the latest integration tip.
- Add openPR skip-push support for already-verified branches.

## Verification
- pnpm test slices/parallel-implement/slice.test.ts
- pnpm test core/connectors/github/slice.test.ts core/workspaces/slice.test.ts core/workspaces/workflow-base.test.ts
- pnpm test apps/server/src/shared/dispatch.test.ts
- pnpm typecheck
- pnpm lint (passes with pre-existing warnings in apps/web/src/lib/logger.ts and slices/grill-and-prd/slice.test.ts)

Plan: docs/superpowers/plans/2026-05-25-goose-hub-agent-reliability.md#ws3--durable-persistence--resume--wp-dependency-materialization-f4--f1--f5

No Closes line: I could not find a matching open WS3 issue to close.