### PR TITLE
fix-feedback: honor null evidence spec reset

### DIFF
--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -860,6 +860,37 @@ describe('runFixFeedbackWorkflow', () => {
       expect(runCall.context.priorEvidenceSpecPath).toBe('apps/web/e2e/new.spec.ts');
     });
 
+    it('treats null evidenceSpecPath on the most recent completion as authoritative', async () => {
+      vi.mocked(eventStore.replay).mockReturnValue([
+        makePrOpenedEvent(),
+        {
+          id: 4,
+          kind: 'agent.implement-complete' as EventKind,
+          payload: { runId: 'dev-1', evidenceSpecPath: 'apps/web/e2e/old.spec.ts' },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          runId: 'dev-1',
+        },
+        makeQaCompletedEvent(),
+        {
+          id: 6,
+          kind: 'agent.fix-feedback-complete' as EventKind,
+          payload: { repairCycle: 1, evidenceSpecPath: null },
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#42',
+          createdAt: new Date().toISOString(),
+          runId: 'fix-1',
+        },
+      ]);
+      mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+      await runFixFeedbackWorkflow(makeWorkItem(), stateSource, 'proj', 'owner/repo');
+
+      const runCall = mockClaudeCliRun.mock.calls[0][0];
+      expect(runCall.context.priorEvidenceSpecPath).toBeUndefined();
+    });
+
     it('omits priorEvidenceSpecPath when no relevant event exists', async () => {
       vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent(), makeQaCompletedEvent()]);
       mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -201,8 +201,9 @@ function nextRepairCycle(events: ReturnType<typeof eventStore.replay>): number {
 
 /**
  * Scans events backward for the most recent `agent.implement-complete` or
- * `agent.fix-feedback-complete` event that has a non-empty `evidenceSpecPath`,
- * and returns it so the repair run can reuse the prior cycle's spec.
+ * `agent.fix-feedback-complete` event. If that event has a non-empty
+ * `evidenceSpecPath`, returns it so the repair run can reuse the prior cycle's
+ * spec. Otherwise, treats the missing path as an authoritative reset.
  */
 function findPriorEvidenceSpecPath(events: ReturnType<typeof eventStore.replay>): string | null {
   for (let i = events.length - 1; i >= 0; i--) {
@@ -211,9 +212,9 @@ function findPriorEvidenceSpecPath(events: ReturnType<typeof eventStore.replay>)
       continue;
     }
     const payload = e.payload as { evidenceSpecPath?: unknown };
-    if (typeof payload.evidenceSpecPath === 'string' && payload.evidenceSpecPath.length > 0) {
-      return payload.evidenceSpecPath;
-    }
+    return typeof payload.evidenceSpecPath === 'string' && payload.evidenceSpecPath.length > 0
+      ? payload.evidenceSpecPath
+      : null;
   }
   return null;
 }


### PR DESCRIPTION
Closes #1031

Summary:
- Treat the latest implement/fix-feedback completion as authoritative for prior evidence spec lookup.
- Add regression coverage for an older spec path followed by a newer null evidenceSpecPath.

Verification:
- /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/vitest run slices/fix-feedback/slice.test.ts -t "null evidenceSpecPath"
- /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/vitest run slices/fix-feedback/slice.test.ts -t priorEvidenceSpecPath
- /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/vitest run slices/fix-feedback/slice.test.ts
- /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/biome check slices/fix-feedback/workflow.ts slices/fix-feedback/slice.test.ts