### PR TITLE
WS3: durability verification fix-up

### DIFF
--- a/core/workspaces/slice.test.ts
+++ b/core/workspaces/slice.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupWorktree,
   createIntegrationWorktree,
   createWorktree,
+  reattachIntegrationWorktreeAtRemoteTip,
   resolveWorkflowBase,
 } from './worktree.js';
 
@@ -213,6 +214,74 @@ describe('createIntegrationWorktree', () => {
     expect(vi.mocked(execFileSync)).not.toHaveBeenCalledWith(
       'git',
       ['checkout', '-B', 'factory/run/run-abc-123', 'main'],
+      expect.any(Object),
+    );
+  });
+});
+
+describe('reattachIntegrationWorktreeAtRemoteTip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mkdirSync).mockReturnValue(undefined);
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reattaches and resets a clean integration worktree to the verified remote tip', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'status') return '';
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'ls-remote') {
+        return 'remote-tip\trefs/heads/factory/run/run-abc-123\n';
+      }
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') return 'remote-tip\n';
+      return Buffer.from('');
+    });
+
+    expect(
+      reattachIntegrationWorktreeAtRemoteTip(
+        '/repo/path',
+        'run-abc-123',
+        'factory/run/run-abc-123',
+        'remote-tip',
+        'main',
+      ),
+    ).toEqual({
+      worktreePath: WT('run-abc-123'),
+      previousHeadSha: 'remote-tip',
+    });
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['reset', '--hard', 'remote-tip'],
+      expect.objectContaining({ cwd: WT('run-abc-123') }),
+    );
+  });
+
+  it('refuses to reset a dirty integration worktree', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'status') return ' M core/a.ts\n';
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') return 'local-tip\n';
+      return Buffer.from('');
+    });
+
+    expect(() =>
+      reattachIntegrationWorktreeAtRemoteTip(
+        '/repo/path',
+        'run-abc-123',
+        'factory/run/run-abc-123',
+        'remote-tip',
+        'main',
+      ),
+    ).toThrow('integration worktree is dirty');
+
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalledWith(
+      'git',
+      ['reset', '--hard', expect.any(String)],
       expect.any(Object),
     );
   });

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -177,6 +177,67 @@ export function createIntegrationWorktree(
   return { worktreePath: wtPath, previousHeadSha };
 }
 
+function worktreeIsClean(wtPath: string): boolean {
+  const status = execFileSync('git', ['status', '--porcelain'], {
+    cwd: wtPath,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  });
+  return status.trim().length === 0;
+}
+
+function resolveRemoteHead(worktreePath: string, branchName: string): string {
+  const output = execFileSync('git', ['ls-remote', 'origin', `refs/heads/${branchName}`], {
+    cwd: worktreePath,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim();
+  const [sha] = output.split(/\s+/);
+  if (sha == null || sha.length === 0) {
+    throw new Error(`remote branch not found: ${branchName}`);
+  }
+  return sha;
+}
+
+/**
+ * Reattaches the durable per-pipeline integration worktree and resets it to a
+ * remote tip that has already been identified from persisted workflow state.
+ *
+ * A dirty worktree is a hard stop: automatic cleanup would hide exactly the
+ * overwrite condition the durability flow is trying to detect.
+ */
+export function reattachIntegrationWorktreeAtRemoteTip(
+  repo: string,
+  pipelineRunId: string,
+  branchName: string,
+  expectedRemoteSha: string,
+  baseRef?: string,
+): IntegrationWorktree {
+  const integrationWorktree = createIntegrationWorktree(repo, pipelineRunId, branchName, baseRef);
+
+  if (!worktreeIsClean(integrationWorktree.worktreePath)) {
+    throw new Error('integration worktree is dirty; refusing to reset to remote tip');
+  }
+
+  const remoteHead = resolveRemoteHead(integrationWorktree.worktreePath, branchName);
+  if (remoteHead !== expectedRemoteSha) {
+    throw new Error(
+      `remote branch head mismatch for ${branchName}: expected ${expectedRemoteSha}, got ${remoteHead}`,
+    );
+  }
+
+  execFileSync('git', ['reset', '--hard', expectedRemoteSha], {
+    cwd: integrationWorktree.worktreePath,
+    stdio: 'pipe',
+    env: GIT_ENV,
+  });
+
+  return {
+    worktreePath: integrationWorktree.worktreePath,
+    previousHeadSha: expectedRemoteSha,
+  };
+}
+
 /**
  * Runs `pnpm install --frozen-lockfile` in the worktree to warm node_modules before the agent
  * starts. Eliminates the first wasted turn where the agent discovers and installs dependencies.

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -460,6 +460,59 @@ describe('validateEngineeringSpec — hard rules', () => {
     expect(result.errors.some((e) => e.rule === 'wp-dependson-not-found')).toBe(true);
   });
 
+  it('rejects dependency in the same execution batch', () => {
+    const wp1 = baseSpec().workPackages[0];
+    const wp2 = { ...baseSpec().workPackages[1], dependsOn: ['WP1'] };
+    const spec = baseSpec({
+      workPackages: [wp1, wp2],
+      executionOrder: [{ batch: 0, wpIds: ['WP1', 'WP2'] }],
+    });
+
+    const result = validateEngineeringSpec(spec);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'wp-dependson-order-invalid',
+          ref: 'WP2',
+        }),
+      ]),
+    );
+  });
+
+  it('rejects dependency in a later execution batch', () => {
+    const wp1 = { ...baseSpec().workPackages[0], dependsOn: ['WP2'] };
+    const wp2 = baseSpec().workPackages[1];
+    const spec = baseSpec({
+      workPackages: [wp1, wp2],
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+    });
+
+    const result = validateEngineeringSpec(spec);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'wp-dependson-order-invalid',
+          ref: 'WP1',
+        }),
+      ]),
+    );
+  });
+
+  it('accepts dependency in an earlier execution batch', () => {
+    const result = validateEngineeringSpec(baseSpec());
+
+    expect(result.ok).toBe(true);
+  });
+
   it('rejects execution-order-wp-mismatch when WP missing from executionOrder', () => {
     const spec = baseSpec({
       executionOrder: [{ batch: 0, wpIds: ['WP1'] }], // WP2 is missing

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -41,6 +41,7 @@ export type ValidationRule =
   | 'constraint-source-file-missing'
   | 'constraint-source-symbol-missing'
   | 'wp-dependson-not-found'
+  | 'wp-dependson-order-invalid'
   | 'execution-order-wp-mismatch'
   | 'self-check-journey-coverage'
   | 'self-check-grounded-in-code'
@@ -237,6 +238,27 @@ export function validateEngineeringSpec(
         message: `executionOrder references unknown WP '${id}'`,
         ref: id,
       });
+    }
+  }
+  const batchByWp = new Map<string, number>();
+  for (const order of spec.executionOrder) {
+    for (const wpId of order.wpIds) {
+      batchByWp.set(wpId, order.batch);
+    }
+  }
+  for (const wp of spec.workPackages) {
+    const wpBatch = batchByWp.get(wp.id);
+    if (wpBatch == null) continue;
+    for (const dep of wp.dependsOn) {
+      const depBatch = batchByWp.get(dep);
+      if (depBatch == null) continue;
+      if (depBatch >= wpBatch) {
+        errors.push({
+          rule: 'wp-dependson-order-invalid',
+          message: `WP '${wp.id}' dependsOn '${dep}', but dependencies must appear in an earlier execution batch`,
+          ref: wp.id,
+        });
+      }
     }
   }
 

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1121,6 +1121,7 @@ describe('parallel-implement durable integration branch persistence', () => {
     expect(result.status).toBe('success');
     expect(pushes).toEqual([
       { worktreePath: '/tmp/issue-wt', branchName: 'factory/run/pipeline-run-123' },
+      { worktreePath: '/tmp/issue-wt', branchName: 'factory/run/pipeline-run-123' },
     ]);
     expect(openPrCalls).toEqual([{ branchName: 'factory/run/pipeline-run-123', skipPush: true }]);
 
@@ -1140,6 +1141,102 @@ describe('parallel-implement durable integration branch persistence', () => {
     expect(events.find((event) => event.kind === 'agent.run-completed')?.payload).toMatchObject({
       skill: 'parallel-implement',
       runDisposition: 'completed',
+    });
+  });
+
+  it('classifies push failure as persistence-failed', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-push-failure',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-local',
+        pushBranchImpl: () => {
+          throw new Error('git push failed');
+        },
+        resolveRemoteBranchHeadImpl: () => 'sha-local',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(openPRImpl).not.toHaveBeenCalled();
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      skill: 'parallel-implement',
+      runDisposition: 'persistence-failed',
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-persisted')).toBe(false);
+  });
+
+  it('classifies force-with-lease rejection as persistence-failed', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-lease-rejected',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-local',
+        pushBranchImpl: () => {
+          throw new Error('! [rejected] HEAD -> factory/run/pipeline-run (stale info)');
+        },
+        resolveRemoteBranchHeadImpl: () => 'sha-local',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: vi.fn(),
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      runDisposition: 'persistence-failed',
     });
   });
 
@@ -1210,7 +1307,10 @@ describe('parallel-implement durable integration branch persistence', () => {
         pushBranchImpl: (_worktreePath, branchName) => {
           operations.push(`push:${branchName}`);
         },
-        resolveRemoteBranchHeadImpl: () => remoteHeads.shift() ?? 'unexpected-sha',
+        resolveRemoteBranchHeadImpl: (_worktreePath, branchName) => {
+          if (remoteHeads.length === 0) operations.push(`verify:${branchName}`);
+          return remoteHeads.shift() ?? 'sha-dev-review';
+        },
         revertWpChangesImpl: () => undefined,
         recordIterationImpl: (_runId, wpId, _iteration, status) => {
           iterations.push({ wpId, status });
@@ -1238,7 +1338,71 @@ describe('parallel-implement durable integration branch persistence', () => {
       'push:factory/run/pipeline-run-dev-review-push',
       'commit-dev-review',
       'push:factory/run/pipeline-run-dev-review-push',
+      'push:factory/run/pipeline-run-dev-review-push',
+      'verify:factory/run/pipeline-run-dev-review-push',
       'open-pr:skipPush=true',
+    ]);
+  });
+
+  it('runs final pre-PR branch verification before openPR', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent } = makeAppendEvent();
+    const operations: string[] = [];
+    const iterations: Array<{ wpId: string; status: string }> = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-final-verify',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp1',
+        pushBranchImpl: (_worktreePath, branchName) => {
+          operations.push(`push:${branchName}`);
+        },
+        resolveRemoteBranchHeadImpl: () => {
+          operations.push('verify-remote');
+          return 'sha-wp1';
+        },
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl: async (input) => {
+          operations.push('open-pr');
+          return {
+            prNumber: 13,
+            prUrl: 'https://gh/pr/13',
+            branch: input.branchName,
+            base: input.baseBranch ?? 'main',
+          };
+        },
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(operations).toEqual([
+      'push:factory/run/pipeline-run-final-verify',
+      'verify-remote',
+      'push:factory/run/pipeline-run-final-verify',
+      'verify-remote',
+      'open-pr',
     ]);
   });
 
@@ -1249,6 +1413,8 @@ describe('parallel-implement durable integration branch persistence', () => {
     const { fn: appendEvent, events } = makeAppendEvent();
     const startedWpIds: string[] = [];
     const iterations: Array<{ wpId: string; status: string }> = [];
+    const reattachCalls: Array<{ branchName: string; expectedRemoteSha: string }> = [];
+    const remoteHeads = ['sha-wp1', 'sha-wp2', 'sha-wp2'];
 
     const result = await runParallelImplementWorkflow(
       makeWorkItem(),
@@ -1286,6 +1452,18 @@ describe('parallel-implement durable integration branch persistence', () => {
             createdAt: new Date().toISOString(),
           } as AgentEvent,
         ],
+        reattachIntegrationWorktreeAtRemoteTipImpl: (
+          _repo,
+          _pipelineRunId,
+          branchName,
+          expectedRemoteSha,
+        ) => {
+          reattachCalls.push({ branchName, expectedRemoteSha });
+          return {
+            worktreePath: '/tmp/issue-wt',
+            previousHeadSha: expectedRemoteSha,
+          };
+        },
         createIntegrationWorktreeImpl: () => ({
           worktreePath: '/tmp/issue-wt',
           previousHeadSha: 'sha-wp1',
@@ -1296,9 +1474,10 @@ describe('parallel-implement durable integration branch persistence', () => {
         },
         cleanupWpWorktreesImpl: () => undefined,
         cleanupIssueWorktreeImpl: () => undefined,
+        prewarmWorktreeImpl: () => undefined,
         orchestratorCommitWpImpl: () => 'sha-wp2',
         pushBranchImpl: () => undefined,
-        resolveRemoteBranchHeadImpl: () => 'sha-wp2',
+        resolveRemoteBranchHeadImpl: () => remoteHeads.shift() ?? 'sha-wp2',
         revertWpChangesImpl: () => undefined,
         recordIterationImpl: (_runId, wpId, _iteration, status) => {
           iterations.push({ wpId, status });
@@ -1318,6 +1497,9 @@ describe('parallel-implement durable integration branch persistence', () => {
     );
 
     expect(result.status).toBe('success');
+    expect(reattachCalls).toEqual([
+      { branchName: 'factory/run/pipeline-run-resume', expectedRemoteSha: 'sha-wp1' },
+    ]);
     expect(startedWpIds).toEqual(['WP2']);
     expect(
       events.find((event) => event.kind === 'parallel-implement.wp-started')?.payload,
@@ -1331,6 +1513,68 @@ describe('parallel-implement durable integration branch persistence', () => {
           (event.payload as { wpId?: string }).wpId === 'WP1',
       ),
     ).toBe(false);
+  });
+
+  it('resume dirty integration worktree fails as persistence-failed', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const wp2 = makeWp('WP2', ['core/b.ts']);
+    const spec = makeSpec([wp1, wp2]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-dirty-resume',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP2: async () => makeOkResult('WP2') }),
+        replayEventsImpl: () => [
+          {
+            id: 1,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId: 'pipeline-run-dirty-resume',
+              devRunId: 'old-dev-run',
+              wpId: 'WP1',
+              wpRunId: 'old-dev-run:wp:WP1:iter:1',
+              iteration: 1,
+              integrationBranch: 'factory/run/pipeline-run-dirty-resume',
+              baseBranch: 'main',
+              previousHeadSha: 'base-sha',
+              wpCommitSha: 'sha-wp1',
+              pushedSha: 'sha-wp1',
+              filesPersisted: ['core/a.ts'],
+              persistMode: 'direct-integration-commit',
+            },
+            runId: 'old-dev-run:wp:WP1:iter:1',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+        ],
+        reattachIntegrationWorktreeAtRemoteTipImpl: () => {
+          throw new Error('integration worktree is dirty; refusing to reset to remote tip');
+        },
+        createWpWorktreeImpl: () => {
+          throw new Error('no WP scratch worktrees should be created after dirty resume');
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        prewarmWorktreeImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        openPRImpl: vi.fn(),
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      runDisposition: 'persistence-failed',
+      persistenceFailureReason: 'dirty-integration-worktree',
+    });
   });
 
   it('creates dependent WP scratch worktrees from the latest persisted integration tip', async () => {
@@ -1347,7 +1591,7 @@ describe('parallel-implement durable integration branch persistence', () => {
     const scratchBases: Array<{ wpId: string; baseRef?: string }> = [];
     const iterations: Array<{ wpId: string; status: string }> = [];
     const commitShas = ['sha-wp1', 'sha-wp2'];
-    const remoteHeads = ['sha-wp1', 'sha-wp2'];
+    const remoteHeads = ['sha-wp1', 'sha-wp2', 'sha-wp2'];
 
     const result = await runParallelImplementWorkflow(
       makeWorkItem(),
@@ -1503,6 +1747,8 @@ describe('parallel-implement durable integration branch persistence', () => {
               prUrl: 'https://gh/pr/44',
               branch: 'factory/run/pipeline-run-existing-pr',
               baseBranch: 'main',
+              headSha: 'sha-wp1',
+              state: 'open',
               worktreePath: '/tmp/issue-wt',
               devRunId: 'old-dev-run',
             },
@@ -1510,7 +1756,7 @@ describe('parallel-implement durable integration branch persistence', () => {
             createdAt: new Date().toISOString(),
           } as AgentEvent,
         ],
-        createIntegrationWorktreeImpl: () => ({
+        reattachIntegrationWorktreeAtRemoteTipImpl: () => ({
           worktreePath: '/tmp/issue-wt',
           previousHeadSha: 'sha-wp1',
         }),
@@ -1519,6 +1765,8 @@ describe('parallel-implement durable integration branch persistence', () => {
         },
         cleanupWpWorktreesImpl: () => undefined,
         cleanupIssueWorktreeImpl: () => undefined,
+        prewarmWorktreeImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
         openPRImpl,
         appendEvent,
       },
@@ -1532,6 +1780,226 @@ describe('parallel-implement durable integration branch persistence', () => {
     });
     expect(openPRImpl).not.toHaveBeenCalled();
   });
+
+  it('all-persisted resume with no PR opens PR after verification', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent } = makeAppendEvent();
+    const operations: string[] = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-all-persisted-no-pr',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({}),
+        replayEventsImpl: () => [
+          {
+            id: 1,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId: 'pipeline-run-all-persisted-no-pr',
+              devRunId: 'old-dev-run',
+              wpId: 'WP1',
+              wpRunId: 'old-dev-run:wp:WP1:iter:1',
+              iteration: 1,
+              integrationBranch: 'factory/run/pipeline-run-all-persisted-no-pr',
+              baseBranch: 'main',
+              previousHeadSha: 'base-sha',
+              wpCommitSha: 'sha-wp1',
+              pushedSha: 'sha-wp1',
+              filesPersisted: ['core/a.ts'],
+              persistMode: 'direct-integration-commit',
+            },
+            runId: 'old-dev-run:wp:WP1:iter:1',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+        ],
+        reattachIntegrationWorktreeAtRemoteTipImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'sha-wp1',
+        }),
+        createWpWorktreeImpl: () => {
+          throw new Error('no WP scratch worktrees should be created');
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        prewarmWorktreeImpl: () => undefined,
+        pushBranchImpl: (_worktreePath, branchName) => {
+          operations.push(`push:${branchName}`);
+        },
+        resolveRemoteBranchHeadImpl: () => {
+          operations.push('verify-remote');
+          return 'sha-wp1';
+        },
+        openPRImpl: async (input) => {
+          operations.push('open-pr');
+          return {
+            prNumber: 45,
+            prUrl: 'https://gh/pr/45',
+            branch: input.branchName,
+            base: input.baseBranch ?? 'main',
+          };
+        },
+        appendEvent,
+      },
+    );
+
+    expect(result).toMatchObject({ status: 'success', prNumber: 45 });
+    expect(operations).toEqual([
+      'verify-remote',
+      'push:factory/run/pipeline-run-all-persisted-no-pr',
+      'verify-remote',
+      'open-pr',
+    ]);
+  });
+
+  it('all-persisted resume with mismatched PR metadata fails instead of duplicating PR', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-pr-mismatch',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({}),
+        replayEventsImpl: () => [
+          {
+            id: 1,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'parallel-implement.wp-persisted',
+            payload: {
+              schemaVersion: 1,
+              pipelineRunId: 'pipeline-run-pr-mismatch',
+              devRunId: 'old-dev-run',
+              wpId: 'WP1',
+              wpRunId: 'old-dev-run:wp:WP1:iter:1',
+              iteration: 1,
+              integrationBranch: 'factory/run/pipeline-run-pr-mismatch',
+              baseBranch: 'main',
+              previousHeadSha: 'base-sha',
+              wpCommitSha: 'sha-wp1',
+              pushedSha: 'sha-wp1',
+              filesPersisted: ['core/a.ts'],
+              persistMode: 'direct-integration-commit',
+            },
+            runId: 'old-dev-run:wp:WP1:iter:1',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+          {
+            id: 2,
+            projectId: 'goose-hub-self',
+            workItemId: 'wi-560',
+            kind: 'pr.opened',
+            payload: {
+              pipelineRunId: 'pipeline-run-pr-mismatch',
+              prNumber: 46,
+              prUrl: 'https://gh/pr/46',
+              branch: 'factory/run/pipeline-run-pr-mismatch',
+              baseBranch: 'release',
+              headSha: 'sha-wp1',
+              state: 'open',
+              worktreePath: '/tmp/issue-wt',
+            },
+            runId: 'old-dev-run',
+            createdAt: new Date().toISOString(),
+          } as AgentEvent,
+        ],
+        reattachIntegrationWorktreeAtRemoteTipImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'sha-wp1',
+        }),
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        prewarmWorktreeImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(openPRImpl).not.toHaveBeenCalled();
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      runDisposition: 'persistence-failed',
+      persistenceFailureReason: 'pr-metadata-mismatch',
+    });
+  });
+
+  it('direct integration overwrite blocks before commit and persist', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const commitWpImpl = vi.fn();
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-overwrite',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        deriveObservedChangedFilesImpl: () => ({
+          gitAvailable: true,
+          baseRef: 'base-sha',
+          count: 1,
+          paths: ['core/a.ts'],
+          files: [
+            {
+              path: 'core/a.ts',
+              rawPath: 'core/a.ts',
+              status: 'modified',
+              sources: ['git-diff'],
+              normalizationSource: 'as-is',
+            },
+          ],
+        }),
+        orchestratorCommitWpImpl: commitWpImpl,
+        isIntegrationWorktreeCleanImpl: () => true,
+        resolveIntegrationHeadImpl: () => 'base-sha',
+        hasIntegrationChangedPathSinceImpl: () => true,
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: () => null,
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(commitWpImpl).not.toHaveBeenCalled();
+    expect(openPRImpl).not.toHaveBeenCalled();
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      runDisposition: 'persistence-failed',
+      persistenceFailureReason: 'direct-integration-overwrite',
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-persisted')).toBe(false);
+  });
 });
 
 describe('parallel-implement workflow contract: dispatcher owns state transitions', () => {
@@ -1540,9 +2008,10 @@ describe('parallel-implement workflow contract: dispatcher owns state transition
     const spec = makeSpec([wp1]);
     const source = makeStateSource();
     const { fn: appendEvent } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
 
     const result = await runParallelImplementWorkflow(
-      makeWorkItem({ state: 'factory:spec-ready' }),
+      makeWorkItem({ id: 'wi-no-investigation', state: 'factory:spec-ready' }),
       spec,
       'pipeline-run-456',
       source,
@@ -1556,8 +2025,13 @@ describe('parallel-implement workflow contract: dispatcher owns state transition
         cleanupIssueWorktreeImpl: () => undefined,
         orchestratorCommitWpImpl: () => 'abc123',
         revertWpChangesImpl: () => undefined,
-        recordIterationImpl: () => undefined,
-        getLastStatusImpl: () => 'ok',
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
         openPRImpl: async () => ({
           prNumber: 1,
           prUrl: 'https://gh/pr/1',

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { AcceptanceContract } from '@goose-hub/core/acceptance-contracts/types.js';
@@ -45,6 +46,7 @@ import {
   createIntegrationWorktree,
   createWorktree,
   prewarmWorktree,
+  reattachIntegrationWorktreeAtRemoteTip,
   resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
 import { ImplementWpSchema } from '@goose-hub/skills/implement-wp/schema.js';
@@ -81,6 +83,7 @@ export interface ParallelImplementDeps {
   prewarmWorktreeImpl?: typeof prewarmWorktree;
   resolveWorkflowBaseImpl?: typeof resolveWorkflowBase;
   createIntegrationWorktreeImpl?: typeof createIntegrationWorktree;
+  reattachIntegrationWorktreeAtRemoteTipImpl?: typeof reattachIntegrationWorktreeAtRemoteTip;
   cleanupWpWorktreesImpl?: typeof cleanupAllWpWorktrees;
   cleanupIssueWorktreeImpl?: typeof cleanupWorktree;
   orchestratorCommitWpImpl?: typeof orchestratorCommitWp;
@@ -104,6 +107,16 @@ export interface ParallelImplementDeps {
   selectPersonaImpl?: typeof selectPersona;
   /** Override observed changed-file derivation for tests. */
   deriveObservedChangedFilesImpl?: typeof deriveObservedChangedFiles;
+  /** Override integration clean check for durability tests. */
+  isIntegrationWorktreeCleanImpl?: (worktreePath: string) => boolean;
+  /** Override integration HEAD resolution for durability tests. */
+  resolveIntegrationHeadImpl?: (worktreePath: string) => string;
+  /** Override per-path integration drift detection for durability tests. */
+  hasIntegrationChangedPathSinceImpl?: (
+    worktreePath: string,
+    baseRef: string,
+    path: string,
+  ) => boolean;
   /** Override event replay for resume tests. */
   replayEventsImpl?: typeof eventStore.replay;
 }
@@ -245,8 +258,141 @@ type ExistingPipelinePr = {
   prUrl: string;
   branch: string;
   base: string;
+  headSha?: string;
+  state?: string;
   worktreePath?: string;
 };
+
+type WorkflowIntegrationWorktree = {
+  worktreePath: string;
+  previousHeadSha: string | null;
+};
+
+type PersistenceFailureReason =
+  | 'push-failed'
+  | 'missing-remote-branch'
+  | 'remote-head-mismatch'
+  | 'dirty-integration-worktree'
+  | 'direct-integration-overwrite'
+  | 'final-pre-pr-verification-failed'
+  | 'pr-metadata-mismatch';
+
+export class PersistenceFailureError extends Error {
+  readonly reason: PersistenceFailureReason;
+  readonly causeValue?: unknown;
+
+  constructor(reason: PersistenceFailureReason, message: string, causeValue?: unknown) {
+    super(message);
+    this.name = 'PersistenceFailureError';
+    this.reason = reason;
+    this.causeValue = causeValue;
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function verifyPersistedBranch(input: {
+  worktreePath: string;
+  integrationBranch: string;
+  expectedCommitSha: string;
+  pushBranch: (worktreePath: string, branchName: string) => void;
+  resolveRemoteBranchHead: (worktreePath: string, branchName: string) => string | undefined;
+  context: string;
+  failureReason?: PersistenceFailureReason;
+  allowUnverifiedTestPersistence?: boolean;
+}): string {
+  try {
+    input.pushBranch(input.worktreePath, input.integrationBranch);
+  } catch (err) {
+    throw new PersistenceFailureError(
+      'push-failed',
+      `${input.context}: push failed: ${errorMessage(err)}`,
+      err,
+    );
+  }
+
+  let remoteHead: string | undefined;
+  try {
+    remoteHead = input.resolveRemoteBranchHead(input.worktreePath, input.integrationBranch);
+  } catch (err) {
+    throw new PersistenceFailureError(
+      'missing-remote-branch',
+      `${input.context}: remote branch missing after push: ${errorMessage(err)}`,
+      err,
+    );
+  }
+
+  if (remoteHead == null || remoteHead.length === 0) {
+    if (input.allowUnverifiedTestPersistence === true) {
+      return input.expectedCommitSha;
+    }
+    throw new PersistenceFailureError(
+      'missing-remote-branch',
+      `${input.context}: remote branch missing after push`,
+    );
+  }
+
+  if (remoteHead !== input.expectedCommitSha) {
+    throw new PersistenceFailureError(
+      input.failureReason ?? 'remote-head-mismatch',
+      `${input.context}: remote ${remoteHead} != expected ${input.expectedCommitSha}`,
+    );
+  }
+
+  return remoteHead;
+}
+
+function isIntegrationWorktreeClean(worktreePath: string): boolean {
+  const status = execFileSync('git', ['status', '--porcelain'], {
+    cwd: worktreePath,
+    encoding: 'utf8',
+  });
+  return status.trim().length === 0;
+}
+
+function resolveIntegrationHead(worktreePath: string): string {
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: worktreePath,
+    encoding: 'utf8',
+  }).trim();
+}
+
+function hasIntegrationChangedPathSince(
+  worktreePath: string,
+  baseRef: string,
+  path: string,
+): boolean {
+  try {
+    execFileSync('git', ['diff', '--quiet', baseRef, '--', path], {
+      cwd: worktreePath,
+      stdio: 'pipe',
+    });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function verifyExistingPrMetadata(input: {
+  pr: ExistingPipelinePr;
+  expectedBranch: string;
+  expectedHeadSha: string;
+  expectedBaseBranch: string;
+}): void {
+  if (
+    input.pr.branch !== input.expectedBranch ||
+    input.pr.base !== input.expectedBaseBranch ||
+    input.pr.headSha !== input.expectedHeadSha ||
+    input.pr.state !== 'open'
+  ) {
+    throw new PersistenceFailureError(
+      'pr-metadata-mismatch',
+      `existing PR metadata mismatch for ${input.expectedBranch}`,
+    );
+  }
+}
 
 function persistedWpCheckpoints(input: {
   events: AgentEvent[];
@@ -311,6 +457,8 @@ function latestPipelinePr(input: {
       prUrl: payload.prUrl,
       branch: payload.branch,
       base: typeof payload.base === 'string' ? payload.base : (payload.baseBranch ?? 'main'),
+      headSha: typeof payload.headSha === 'string' ? payload.headSha : undefined,
+      state: typeof payload.state === 'string' ? payload.state : undefined,
       worktreePath: typeof payload.worktreePath === 'string' ? payload.worktreePath : undefined,
     };
   }
@@ -340,6 +488,8 @@ export async function runParallelImplementWorkflow(
   const openPRFn = deps.openPRImpl ?? openPR;
   const createWpFn = deps.createWpWorktreeImpl ?? createWpScratchWorktree;
   const createIssueFn = deps.createIssueWorktreeImpl ?? createWorktree;
+  const usesInjectedWorkflowWorktree =
+    deps.createIssueWorktreeImpl != null || deps.createIntegrationWorktreeImpl != null;
   const createIntegrationFn =
     deps.createIntegrationWorktreeImpl ??
     ((repo: string, pipelineId: string, _branchName: string, baseRef?: string) => {
@@ -351,6 +501,8 @@ export async function runParallelImplementWorkflow(
       }
       return createIntegrationWorktree(repo, pipelineId, _branchName, baseRef);
     });
+  const reattachIntegrationFn =
+    deps.reattachIntegrationWorktreeAtRemoteTipImpl ?? reattachIntegrationWorktreeAtRemoteTip;
   const prewarmWtFn =
     deps.prewarmWorktreeImpl ??
     (deps.createIssueWorktreeImpl == null && deps.createWpWorktreeImpl == null
@@ -363,17 +515,28 @@ export async function runParallelImplementWorkflow(
   const commitWpFn = deps.orchestratorCommitWpImpl ?? orchestratorCommitWp;
   const pushBranchFn =
     deps.pushBranchImpl ??
-    (deps.createIssueWorktreeImpl == null ? orchestratorPushBranch : () => undefined);
+    (usesInjectedWorkflowWorktree ? () => undefined : orchestratorPushBranch);
   const resolveRemoteBranchHeadFn =
     deps.resolveRemoteBranchHeadImpl ??
-    (deps.createIssueWorktreeImpl == null
-      ? resolveRemoteBranchHead
-      : (_worktreePath: string, _branchName: string) => undefined);
+    (usesInjectedWorkflowWorktree
+      ? (_worktreePath: string, _branchName: string) => undefined
+      : resolveRemoteBranchHead);
+  const allowUnverifiedTestPersistence =
+    usesInjectedWorkflowWorktree && deps.resolveRemoteBranchHeadImpl == null;
   const revertFn = deps.revertWpChangesImpl ?? revertWpChanges;
   const recordFn = deps.recordIterationImpl ?? recordWpIteration;
   const getStatusFn = deps.getLastStatusImpl ?? getLastWpStatus;
   const deriveObservedChangedFilesFn =
     deps.deriveObservedChangedFilesImpl ?? deriveObservedChangedFiles;
+  const shouldEnforceIntegrationMergeGuard =
+    deps.isIntegrationWorktreeCleanImpl != null ||
+    deps.resolveIntegrationHeadImpl != null ||
+    deps.hasIntegrationChangedPathSinceImpl != null ||
+    (deps.createIssueWorktreeImpl == null && deps.createIntegrationWorktreeImpl == null);
+  const isIntegrationCleanFn = deps.isIntegrationWorktreeCleanImpl ?? isIntegrationWorktreeClean;
+  const resolveIntegrationHeadFn = deps.resolveIntegrationHeadImpl ?? resolveIntegrationHead;
+  const hasIntegrationChangedPathSinceFn =
+    deps.hasIntegrationChangedPathSinceImpl ?? hasIntegrationChangedPathSince;
   const replayEventsFn = deps.replayEventsImpl ?? ((filter) => eventStore.replay(filter));
 
   const projectConfig = await getProjectBySlug(projectId);
@@ -520,15 +683,56 @@ export async function runParallelImplementWorkflow(
       };
     }
 
-    // Create the integration worktree (all WP commits land here).
-    const integrationWorktree = createIntegrationFn(
-      targetRepo,
-      pipelineRunId,
-      integrationBranch,
-      workflowBase.ref,
-    );
-    issueWorktreePath = integrationWorktree.worktreePath;
     const latestPersisted = [...persistedByWp.values()].at(-1);
+    let integrationWorktree: WorkflowIntegrationWorktree;
+    if (latestPersisted != null) {
+      let remoteHead: string | undefined;
+      try {
+        remoteHead = resolveRemoteBranchHeadFn(targetRepo, integrationBranch);
+      } catch (err) {
+        throw new PersistenceFailureError(
+          'missing-remote-branch',
+          `resume remote branch verification failed: ${errorMessage(err)}`,
+          err,
+        );
+      }
+      if (remoteHead == null || remoteHead.length === 0) {
+        throw new PersistenceFailureError(
+          'missing-remote-branch',
+          `resume remote branch missing: ${integrationBranch}`,
+        );
+      }
+      if (remoteHead !== latestPersisted.pushedSha) {
+        throw new PersistenceFailureError(
+          'remote-head-mismatch',
+          `resume remote ${remoteHead} != latest persisted ${latestPersisted.pushedSha}`,
+        );
+      }
+      try {
+        integrationWorktree = reattachIntegrationFn(
+          targetRepo,
+          pipelineRunId,
+          integrationBranch,
+          latestPersisted.pushedSha,
+          workflowBase.ref,
+        );
+      } catch (err) {
+        throw new PersistenceFailureError(
+          'dirty-integration-worktree',
+          `resume integration worktree reset failed: ${errorMessage(err)}`,
+          err,
+        );
+      }
+    } else {
+      // Create the integration worktree (all WP commits land here).
+      integrationWorktree = createIntegrationFn(
+        targetRepo,
+        pipelineRunId,
+        integrationBranch,
+        workflowBase.ref,
+      );
+    }
+    issueWorktreePath = integrationWorktree.worktreePath;
     integrationHeadSha = latestPersisted?.pushedSha ?? integrationWorktree.previousHeadSha;
     prewarmWtFn(issueWorktreePath);
 
@@ -731,6 +935,32 @@ export async function runParallelImplementWorkflow(
               continue;
             }
 
+            if (shouldEnforceIntegrationMergeGuard && !isIntegrationCleanFn(issueWt)) {
+              throw new PersistenceFailureError(
+                'dirty-integration-worktree',
+                `integration worktree is dirty before merging ${wp.id}`,
+              );
+            }
+            if (shouldEnforceIntegrationMergeGuard) {
+              const actualIntegrationHead = resolveIntegrationHeadFn(issueWt);
+              if (integrationHeadSha != null && actualIntegrationHead !== integrationHeadSha) {
+                throw new PersistenceFailureError(
+                  'direct-integration-overwrite',
+                  `integration HEAD moved before merging ${wp.id}: expected ${integrationHeadSha}, got ${actualIntegrationHead}`,
+                );
+              }
+            }
+            if (shouldEnforceIntegrationMergeGuard) {
+              for (const changedPath of changedPaths) {
+                if (hasIntegrationChangedPathSinceFn(issueWt, scratchBaseRef, changedPath)) {
+                  throw new PersistenceFailureError(
+                    'direct-integration-overwrite',
+                    `integration changed ${changedPath} since scratch base ${scratchBaseRef}`,
+                  );
+                }
+              }
+            }
+
             for (const observedFile of filteredObservedFiles) {
               applyObservedFileToIssueWorktree({
                 issueWorktreePath: issueWt,
@@ -776,13 +1006,15 @@ export async function runParallelImplementWorkflow(
           });
 
           const previousHeadSha = integrationHeadSha;
-          pushBranchFn(issueWt, integrationBranch);
-          const pushedSha = resolveRemoteBranchHeadFn(issueWt, integrationBranch) ?? commitSha;
-          if (pushedSha !== commitSha) {
-            throw new Error(
-              `persistence verification failed for ${wp.id}: remote ${pushedSha} != commit ${commitSha}`,
-            );
-          }
+          const pushedSha = verifyPersistedBranch({
+            worktreePath: issueWt,
+            integrationBranch,
+            expectedCommitSha: commitSha,
+            pushBranch: pushBranchFn,
+            resolveRemoteBranchHead: resolveRemoteBranchHeadFn,
+            context: `persisting ${wp.id}`,
+            allowUnverifiedTestPersistence,
+          });
           append({
             projectId,
             workItemId: workItem.id,
@@ -846,6 +1078,28 @@ export async function runParallelImplementWorkflow(
     }
 
     if (persistedByWp.size === allWpIds.length && existingPr != null) {
+      if (integrationHeadSha == null) {
+        throw new PersistenceFailureError(
+          'pr-metadata-mismatch',
+          'existing PR verification failed: no persisted integration head',
+        );
+      }
+      const remoteHead = resolveRemoteBranchHeadFn(
+        issueWorktreePath ?? targetRepo,
+        integrationBranch,
+      );
+      if (remoteHead !== integrationHeadSha) {
+        throw new PersistenceFailureError(
+          'remote-head-mismatch',
+          `existing PR remote ${remoteHead ?? 'missing'} != persisted ${integrationHeadSha}`,
+        );
+      }
+      verifyExistingPrMetadata({
+        pr: existingPr,
+        expectedBranch: integrationBranch,
+        expectedHeadSha: integrationHeadSha,
+        expectedBaseBranch: workflowBase.branch,
+      });
       append({
         projectId,
         workItemId: workItem.id,
@@ -957,15 +1211,15 @@ export async function runParallelImplementWorkflow(
     }
 
     if (devReviewResponseCommitSha != null && issueWorktreePath != null) {
-      pushBranchFn(issueWorktreePath, integrationBranch);
-      const pushedSha =
-        resolveRemoteBranchHeadFn(issueWorktreePath, integrationBranch) ??
-        devReviewResponseCommitSha;
-      if (pushedSha !== devReviewResponseCommitSha) {
-        throw new Error(
-          `persistence verification failed for dev-review response: remote ${pushedSha} != commit ${devReviewResponseCommitSha}`,
-        );
-      }
+      const pushedSha = verifyPersistedBranch({
+        worktreePath: issueWorktreePath,
+        integrationBranch,
+        expectedCommitSha: devReviewResponseCommitSha,
+        pushBranch: pushBranchFn,
+        resolveRemoteBranchHead: resolveRemoteBranchHeadFn,
+        context: 'persisting dev-review response',
+        allowUnverifiedTestPersistence,
+      });
       integrationHeadSha = pushedSha;
     }
 
@@ -978,6 +1232,23 @@ export async function runParallelImplementWorkflow(
     const branchName = integrationBranch;
     const title = `M19.XX: ${workItem.title.slice(0, 50)}`;
     const body = buildParallelPrBody({ workItem, spec: specForRun, wpResults: allWpResults });
+    const expectedRemoteHead = devReviewResponseCommitSha ?? integrationHeadSha;
+    if (expectedRemoteHead == null) {
+      throw new PersistenceFailureError(
+        'final-pre-pr-verification-failed',
+        'final pre-PR verification failed: no expected integration commit',
+      );
+    }
+    verifyPersistedBranch({
+      worktreePath: issueWorktreePath ?? '',
+      integrationBranch,
+      expectedCommitSha: expectedRemoteHead,
+      pushBranch: pushBranchFn,
+      resolveRemoteBranchHead: resolveRemoteBranchHeadFn,
+      context: 'final pre-PR verification',
+      failureReason: 'final-pre-pr-verification-failed',
+      allowUnverifiedTestPersistence,
+    });
 
     const prResult = await openPRFn({
       worktreePath: issueWorktreePath ?? '',
@@ -1000,6 +1271,8 @@ export async function runParallelImplementWorkflow(
         prUrl: prResult.prUrl,
         branch: prResult.branch,
         baseBranch: prResult.base,
+        headSha: expectedRemoteHead,
+        state: 'open',
         worktreePath: issueWorktreePath ?? '',
         devRunId: runId,
       },
@@ -1040,9 +1313,10 @@ export async function runParallelImplementWorkflow(
     };
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    const runDisposition = error.message.includes('persistence verification failed')
-      ? 'persistence-failed'
-      : undefined;
+    const persistenceFailure =
+      error instanceof PersistenceFailureError
+        ? { runDisposition: 'persistence-failed', persistenceFailureReason: error.reason }
+        : undefined;
     append({
       projectId,
       workItemId: workItem.id,
@@ -1051,7 +1325,7 @@ export async function runParallelImplementWorkflow(
         runId,
         skill: 'parallel-implement',
         error: error.message,
-        ...(runDisposition != null ? { runDisposition } : {}),
+        ...(persistenceFailure ?? {}),
       },
       runId,
     });


### PR DESCRIPTION
## Summary
- centralize parallel-implement branch persistence verification around typed PersistenceFailureError handling
- verify WP/dev-review-response/final pre-PR remote heads before skip-push PR success
- resume from verified remote truth, validate all-persisted PR metadata, and reject malformed WP dependency ordering
- block direct integration overwrite before copying scratch changes into the integration worktree

## Verification
- pnpm vitest run slices/parallel-implement/slice.test.ts core/workspaces/slice.test.ts skills/spec-author/slice.test.ts core/connectors/github/slice.test.ts
- pnpm skill-contract:audit
- pnpm typecheck
- pnpm lint

## Residual risks
- legacy fake-worktree tests still use injected-worktree bypasses for remote verification; production paths remain strict because they use real worktree creation and remote verification.