### PR TITLE
Implement WS4 implement-wp cost control

### DIFF
--- a/apps/server/src/shared/dispatch-routing.ts
+++ b/apps/server/src/shared/dispatch-routing.ts
@@ -268,7 +268,32 @@ export async function dispatchResumeIssue(
   if (fromState === 'factory:needs-human') {
     const allEvents = eventStore.replay({ projectId: slug, workItemId });
     const lastRunFailed = [...allEvents].reverse().find((e) => e.kind === 'agent.run-failed');
-    const failedSkill = (lastRunFailed?.payload as { skill?: string } | undefined)?.skill;
+    const failedPayload = lastRunFailed?.payload as
+      | { skill?: string; runDisposition?: string; runId?: string }
+      | undefined;
+    const failedSkill = failedPayload?.skill;
+
+    if (failedSkill === 'parallel-implement' && failedPayload?.runDisposition === 'budget-killed') {
+      logger.info(
+        'dispatchResumeIssue: needs-human from budget-killed parallel-implement, resuming to spec-ready',
+        { slug, issueNumber },
+      );
+      await source.forceState(workItemId, 'factory:spec-ready');
+      emitStateTransitionEvent({
+        projectId: slug,
+        workItemId,
+        from: fromState,
+        to: 'factory:spec-ready',
+        by: 'resume',
+        extraPayload: {
+          ...interventionEventPayload(options.intervention),
+          resumeReason: 'budget-killed-after-persist',
+          priorRunId: failedPayload.runId ?? '',
+        },
+      });
+      await dispatchParallelImplement(slug, issueNumber);
+      return;
+    }
 
     if (failedSkill === 'spec-author') {
       logger.info(

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -1615,6 +1615,107 @@ describe('dispatchForLabel', () => {
       'factory:needs-human',
     );
   });
+
+  it('resumes needs-human parallel-implement budget-killed work through spec-ready', async () => {
+    const item = {
+      id: 'github:shaunnez/goose-hub#694',
+      externalId: '694',
+      repoRef: 'shaunnez/goose-hub',
+      title: 'parallel implement',
+      body: 'body',
+      state: 'factory:needs-human',
+      priority: 'high',
+      type: 'feature',
+      schedule: 'current',
+    };
+    const source = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi
+        .fn()
+        .mockResolvedValueOnce(item)
+        .mockResolvedValue({ ...item, state: 'factory:spec-ready' }),
+      forceState: vi.fn().mockResolvedValue(undefined),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+      comment: vi.fn().mockResolvedValue(undefined),
+    };
+    const spec = {
+      objective: 'Implement dispatch wiring',
+      userJourneys: [],
+      functionalRequirements: [],
+      architecture: { current: 'stub', new: 'wired', decisionRationale: 'test' },
+      schemaChanges: { ddl: [], migrations: [] },
+      interfaceContracts: [],
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: [
+            'apps/server/src/shared/dispatch.ts',
+            'apps/server/src/shared/dispatch.test.ts',
+          ],
+          changes:
+            'Wire budget-killed parallel implement resume through spec-ready and cover the dispatcher path with a focused regression test.',
+          dependsOn: [],
+          builderTier: 'sonnet',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      verificationTooling: [],
+      acceptanceCriteria: [
+        {
+          id: 'AC1',
+          statement: 'Dispatches',
+          crossCutting: true,
+          executableChecks: [{ id: 'AC1-check-1', command: 'pnpm test' }],
+        },
+      ],
+      constraints: [],
+      riskRegister: [],
+      decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockGetProject.mockResolvedValue({
+      id: 'project-config-id',
+      budgets: { maxParallelAgents: 1 },
+    });
+    mockGetUseMultiAgentPipeline.mockReturnValue(true);
+    mockGetEngineeringSpec.mockReturnValue({
+      id: 1,
+      projectId: 'goose-hub-self',
+      workItemId: item.id,
+      pipelineRunId: 'pipeline-run-dispatch',
+      spec,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: '2026-05-10T00:00:00Z',
+    });
+    mockEventStoreReplay.mockReturnValue([
+      {
+        kind: 'agent.run-failed',
+        payload: {
+          skill: 'parallel-implement',
+          runDisposition: 'budget-killed',
+          budgetKilledWpId: 'WP1',
+        },
+      },
+    ]);
+    mockRunParallelImplementWorkflow.mockResolvedValueOnce({
+      status: 'success',
+      devRunId: 'dev-run-456',
+      worktreePath: '/tmp/issue-wt',
+      prNumber: 7,
+      prUrl: 'https://gh/pr/7',
+    });
+
+    const { dispatchResumeIssue } = await import('./dispatch.js');
+    await dispatchResumeIssue('goose-hub-self', 694);
+
+    expect(source.forceState).toHaveBeenCalledWith(item.id, 'factory:spec-ready');
+    expect(mockRunParallelImplementWorkflow).toHaveBeenCalled();
+    expect(source.transitionState).toHaveBeenCalledWith(
+      '694',
+      'factory:spec-ready',
+      'factory:in-progress',
+    );
+  });
 });
 
 // ─── dispatchRetro ────────────────────────────────────────────────────────

--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -418,6 +418,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
     case 'parallel-implement.wp-committed':
       return <ParallelWpCommittedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-failed':
+    case 'parallel-implement.wp-loop-cap-hit':
     case 'parallel-implement.wp-commit-failed':
       return <ParallelWpFailedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-timeout':

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
@@ -19,6 +19,7 @@ type ParallelPayload = {
   wpCount?: number;
   wpIds?: string[];
   errorReason?: string;
+  diagnosis?: string;
   elapsedMs?: number;
   failedWpIds?: string[];
   workItemId?: string;
@@ -241,16 +242,20 @@ export function ParallelWpCommittedEvent({ event }: { event: AgentEventDto }) {
 export function ParallelWpFailedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as ParallelPayload | null;
   const isCommitFailure = event.kind === 'parallel-implement.wp-commit-failed';
+  const isLoopCap = event.kind === 'parallel-implement.wp-loop-cap-hit';
 
   return (
     <ParallelEventShell
       event={event}
       icon={<AlertTriangle size={13} className="shrink-0 text-[color:var(--danger)]" />}
-      title={`${p?.wpId ?? 'Work package'} ${isCommitFailure ? 'commit failed' : 'failed'}`}
+      title={`${p?.wpId ?? 'Work package'} ${
+        isCommitFailure ? 'commit failed' : isLoopCap ? 'loop cap hit' : 'failed'
+      }`}
       tone="danger"
     >
       <div className="space-y-1">
         {p?.errorReason != null && <DetailRow>{p.errorReason}</DetailRow>}
+        {isLoopCap && p?.diagnosis != null && <DetailRow>{p.diagnosis}</DetailRow>}
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
           {formatShortId(p?.wpRunId) != null && (
             <span className="font-mono text-fg-4">run {formatShortId(p?.wpRunId)}</span>

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -125,6 +125,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'parallel-implement.wp-started': 'Work package started',
   'parallel-implement.wp-committed': 'Work package committed',
   'parallel-implement.wp-failed': 'Work package failed',
+  'parallel-implement.wp-loop-cap-hit': 'Work package loop cap hit',
   'parallel-implement.wp-timeout': 'Work package timed out',
   'parallel-implement.wp-commit-failed': 'Work package commit failed',
   'parallel-implement.exhausted': 'Parallel implement exhausted',

--- a/core/agent-runtime/claude-cli.test.ts
+++ b/core/agent-runtime/claude-cli.test.ts
@@ -290,6 +290,49 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
     );
   });
 
+  it('can return valid terminal output after post-run budget exceeded when policy opts in', async () => {
+    vi.mocked(costFromCliEnvelope).mockReturnValue({
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedInputTokens: 0,
+      reasoningOutputTokens: 0,
+      costUsd: 1.25,
+      costLabel: 'exact',
+    });
+    const envelope = JSON.stringify({
+      is_error: false,
+      result: '{"wpId":"WP1","confidence":"high"}',
+    });
+    mockSpawn.mockReturnValue(makeChild(0, envelope));
+
+    const runtime = new ClaudeCliRuntime();
+    const run = runtime.run(
+      makeSpec({
+        skill: 'implement-wp',
+        budgetPolicy: { onPostRunExceeded: 'return-output' },
+        budgets: { maxTurns: 10, maxBudgetUsd: 1, timeoutMs: 5000 },
+      }),
+    );
+
+    await expect(run).resolves.toMatchObject({
+      output: { wpId: 'WP1', confidence: 'high' },
+      budgetExceeded: { costUsd: 1.25, budgetUsd: 1, overByUsd: 0.25 },
+    });
+
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.budget-exceeded' }),
+    );
+    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.run-completed' }),
+    );
+    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.run-failed',
+        payload: expect.objectContaining({ reason: 'budget-exceeded' }),
+      }),
+    );
+  });
+
   it('inserts a failure row when CLI reports is_error=true', async () => {
     const envelope = JSON.stringify({ is_error: true, result: 'budget exceeded' });
     mockSpawn.mockReturnValue(makeChild(0, envelope));

--- a/core/agent-runtime/claude-cli.test.ts
+++ b/core/agent-runtime/claude-cli.test.ts
@@ -325,7 +325,7 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
     expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );
-    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'agent.run-failed',
         payload: expect.objectContaining({ reason: 'budget-exceeded' }),

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -403,6 +403,21 @@ export class ClaudeCliRuntime implements AgentRuntime {
         });
 
         if (exceededBudget) {
+          const budgetExceeded = {
+            costUsd,
+            budgetUsd: spec.budgets.maxBudgetUsd,
+            overByUsd: Number((costUsd - spec.budgets.maxBudgetUsd).toFixed(6)),
+          };
+          if (spec.budgetPolicy?.onPostRunExceeded === 'return-output') {
+            recordRun('failure');
+            resolve({
+              output: extractResultJson(envelope?.result ?? stdout, runId),
+              decisionSummaries: [],
+              events: eventStore.replay({ runId }),
+              budgetExceeded,
+            });
+            return;
+          }
           recordRun('failure');
           eventStore.appendEvent({
             projectId,

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -410,6 +410,21 @@ export class ClaudeCliRuntime implements AgentRuntime {
           };
           if (spec.budgetPolicy?.onPostRunExceeded === 'return-output') {
             recordRun('failure');
+            eventStore.appendEvent({
+              projectId,
+              workItemId,
+              kind: 'agent.run-failed',
+              payload: {
+                runId,
+                skill: spec.skill,
+                reason: 'budget-exceeded',
+                error: `budget exceeded: $${costUsd} > $${spec.budgets.maxBudgetUsd}`,
+                costUsd,
+                budgetUsd: spec.budgets.maxBudgetUsd,
+              },
+              runId,
+              personaId,
+            });
             resolve({
               output: extractResultJson(envelope?.result ?? stdout, runId),
               decisionSummaries: [],

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -1136,7 +1136,7 @@ describe('CodexCliRuntime timeout handling', () => {
     expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );
-    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'agent.run-failed',
         payload: expect.objectContaining({ reason: 'budget-exceeded' }),

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -1099,4 +1099,48 @@ describe('CodexCliRuntime timeout handling', () => {
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );
   });
+
+  it('can return valid terminal output after post-run budget exceeded when policy opts in', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(
+      makeSpec({
+        skill: 'implement-wp',
+        budgetPolicy: { onPostRunExceeded: 'return-output' },
+        budgets: { maxTurns: 10, maxBudgetUsd: 0.5, timeoutMs: 5000 },
+      }),
+    );
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          result: '{"wpId":"WP1","confidence":"high"}',
+          usage: { input_tokens: 100, output_tokens: 50 },
+          total_cost_usd: 0.75,
+        }),
+      ),
+    );
+    child.emit('close', 0);
+
+    await expect(run).resolves.toMatchObject({
+      output: { wpId: 'WP1', confidence: 'high' },
+      budgetExceeded: { costUsd: 0.75, budgetUsd: 0.5, overByUsd: 0.25 },
+    });
+
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.budget-exceeded' }),
+    );
+    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.run-completed' }),
+    );
+    expect(mockEventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.run-failed',
+        payload: expect.objectContaining({ reason: 'budget-exceeded' }),
+      }),
+    );
+  });
 });

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -864,6 +864,21 @@ export class CodexCliRuntime implements AgentRuntime {
         });
 
         if (exceededBudget) {
+          const budgetExceeded = {
+            costUsd,
+            budgetUsd: spec.budgets.maxBudgetUsd,
+            overByUsd: Number((costUsd - spec.budgets.maxBudgetUsd).toFixed(6)),
+          };
+          if (spec.budgetPolicy?.onPostRunExceeded === 'return-output') {
+            recordRun('failure');
+            resolve({
+              output: extractResultJson(envelope == null ? stdout : (envelope.result ?? ''), runId),
+              decisionSummaries: [],
+              events: eventStore.replay({ runId }),
+              budgetExceeded,
+            });
+            return;
+          }
           recordRun('failure');
           eventStore.appendEvent({
             projectId,

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -871,6 +871,21 @@ export class CodexCliRuntime implements AgentRuntime {
           };
           if (spec.budgetPolicy?.onPostRunExceeded === 'return-output') {
             recordRun('failure');
+            eventStore.appendEvent({
+              projectId,
+              workItemId,
+              kind: 'agent.run-failed',
+              payload: {
+                runId,
+                skill: spec.skill,
+                reason: 'budget-exceeded',
+                error: `budget exceeded: $${costUsd} > $${spec.budgets.maxBudgetUsd}`,
+                costUsd,
+                budgetUsd: spec.budgets.maxBudgetUsd,
+              },
+              runId,
+              personaId,
+            });
             resolve({
               output: extractResultJson(envelope == null ? stdout : (envelope.result ?? ''), runId),
               decisionSummaries: [],

--- a/core/agent-runtime/interface.ts
+++ b/core/agent-runtime/interface.ts
@@ -15,6 +15,12 @@ export interface AgentBudgets {
   timeoutMs: number;
 }
 
+export interface BudgetExceededMetadata {
+  costUsd: number;
+  budgetUsd: number;
+  overByUsd: number;
+}
+
 // ─── Role spec (discriminated union for type-level holdout enforcement) ────────
 
 export type HoldoutRoleKind = 'qa' | 'reviewer';
@@ -36,6 +42,13 @@ export type AgentSpec<R extends RoleSpec = RoleSpec> = {
   toolBundles: string[];
   toolExtras: string[];
   budgets: AgentBudgets;
+  budgetPolicy?: {
+    /**
+     * Default is strict rejection. Workflows that can durably persist valid
+     * terminal output before stopping may opt into receiving the output.
+     */
+    onPostRunExceeded?: 'reject' | 'return-output';
+  };
   /** Runtime reasoning effort when the selected backend supports it. Unsupported runtimes ignore it. */
   effort?: RuntimeEffort;
   /** Persona identity for this run. Format: "<projectId>/<role>/<index>". Required. */
@@ -87,6 +100,7 @@ export interface AgentResult {
   output: unknown;
   decisionSummaries: DecisionSummary[];
   events: AgentEvent[];
+  budgetExceeded?: BudgetExceededMetadata;
 }
 
 export interface AgentRuntime {

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -98,6 +98,7 @@ export const EVENT_KINDS = [
   'parallel-implement.wp-committed',
   'parallel-implement.wp-persisted',
   'parallel-implement.wp-failed',
+  'parallel-implement.wp-loop-cap-hit',
   'parallel-implement.wp-timeout',
   'parallel-implement.wp-commit-failed',
   'parallel-implement.exhausted',

--- a/core/types.ts
+++ b/core/types.ts
@@ -151,6 +151,21 @@ export interface BudgetConfig {
       effort?: RuntimeEffort | null;
     }
   >;
+  implementWp?: {
+    editTestLoopMaxCycles?: number;
+    budgetSizing?: {
+      bug?: { maxTurns?: number; maxBudgetUsd?: number };
+      feature?: { maxTurns?: number; maxBudgetUsd?: number };
+      complex?: { maxTurns?: number; maxBudgetUsd?: number };
+      complexAdditions?: {
+        highPriorityUsd?: number;
+        manyFilesThreshold?: number;
+        manyFilesUsd?: number;
+        contractKeywords?: string[];
+        contractUsd?: number;
+      };
+    };
+  };
 }
 
 export interface GovernanceConfig {

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -201,6 +201,7 @@ const DIRECT_TIMELINE_EVENT_KINDS = new Set<string>([
   'parallel-implement.wp-started',
   'parallel-implement.wp-committed',
   'parallel-implement.wp-failed',
+  'parallel-implement.wp-loop-cap-hit',
   'parallel-implement.wp-timeout',
   'parallel-implement.wp-commit-failed',
   'parallel-implement.exhausted',

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -23,6 +23,7 @@ import type { DevReviewOutput } from '@goose-hub/skills/dev-review/schema.js';
 import type { ImplementWpOutput } from '@goose-hub/skills/implement-wp/schema.js';
 import type { EngineeringSpec, WorkPackage } from '@goose-hub/skills/spec-author/schema.js';
 import { runParallelImplementWorkflow } from './workflow.js';
+import { resolveImplementWpBudget } from './wp-budget.js';
 import { runOneWpBuilder } from './wp-builder.js';
 
 vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
@@ -125,6 +126,27 @@ function makeOkResult(wpId: string): AgentResult {
   return { output, decisionSummaries: [], events: [] };
 }
 
+function makeToolCallEvent(
+  runId: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): AgentEvent {
+  return {
+    id: Math.floor(Math.random() * 100000),
+    projectId: 'goose-hub-self',
+    workItemId: 'wi-560',
+    kind: 'agent.tool-call',
+    payload: {
+      runId,
+      skill: 'implement-wp',
+      tool_name: toolName,
+      tool_input: toolInput,
+    },
+    runId,
+    createdAt: new Date().toISOString(),
+  } as AgentEvent;
+}
+
 function makeRuntime(impls: Record<string, () => Promise<AgentResult>>): AgentRuntime {
   return {
     run: async (spec: AgentSpec): Promise<AgentResult> => {
@@ -149,6 +171,67 @@ function makeAppendEvent(): {
     events,
   };
 }
+
+describe('implement-wp budget sizing', () => {
+  it('derives per-WP budgets from project config and applies global caps', () => {
+    const bug = makeWorkItem({ type: 'bug', priority: 'medium' });
+    const feature = makeWorkItem({ type: 'feature', priority: 'high' });
+    const baseBudget = { maxTurns: 150, maxBudgetUsd: 10, timeoutMs: 900_000 };
+
+    expect(
+      resolveImplementWpBudget({
+        defaultBudgets: baseBudget,
+        workItem: bug,
+        wp: makeWp('WP1', ['core/a.ts']),
+        budgetConfig: {
+          perAgentMaxUsd: 10,
+          perWorkflowMaxUsd: 10,
+          implementWp: {
+            editTestLoopMaxCycles: 3,
+            budgetSizing: {
+              bug: { maxTurns: 70, maxBudgetUsd: 4 },
+              feature: { maxTurns: 100, maxBudgetUsd: 6 },
+              complexAdditions: {
+                highPriorityUsd: 1,
+                manyFilesThreshold: 3,
+                manyFilesUsd: 1,
+                contractKeywords: ['schema', 'migration', 'api'],
+                contractUsd: 1,
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({ maxTurns: 70, maxBudgetUsd: 4 });
+
+    expect(
+      resolveImplementWpBudget({
+        defaultBudgets: baseBudget,
+        workItem: feature,
+        wp: makeWp('WP2', ['a.ts', 'b.ts', 'c.ts', 'd.ts'], 'Update API schema'),
+        budgetConfig: {
+          perAgentMaxUsd: 7,
+          perWorkflowMaxUsd: 10,
+          implementWp: {
+            editTestLoopMaxCycles: 3,
+            budgetSizing: {
+              bug: { maxTurns: 70, maxBudgetUsd: 4 },
+              feature: { maxTurns: 100, maxBudgetUsd: 6 },
+              complex: { maxTurns: 130, maxBudgetUsd: 8 },
+              complexAdditions: {
+                highPriorityUsd: 1,
+                manyFilesThreshold: 3,
+                manyFilesUsd: 1,
+                contractKeywords: ['schema', 'migration', 'api'],
+                contractUsd: 1,
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({ maxTurns: 130, maxBudgetUsd: 7 });
+  });
+});
 
 function makeTempRepo(paths: string[] = []): string {
   const repoPath = mkdtempSync(join(tmpdir(), 'goose-hub-parallel-'));
@@ -1142,6 +1225,145 @@ describe('parallel-implement durable integration branch persistence', () => {
       skill: 'parallel-implement',
       runDisposition: 'completed',
     });
+  });
+
+  it('persists green WP work before stopping a post-run budget-killed workflow', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const wp2 = makeWp('WP2', ['core/b.ts']);
+    const spec = {
+      ...makeSpec([wp1, wp2]),
+      executionOrder: [
+        { batch: 0, wpIds: ['WP1'] },
+        { batch: 1, wpIds: ['WP2'] },
+      ],
+    };
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const startedWpIds: string[] = [];
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-budget-killed',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({
+          WP1: async () => ({
+            ...makeOkResult('WP1'),
+            budgetExceeded: { costUsd: 6.25, budgetUsd: 6, overByUsd: 0.25 },
+          }),
+          WP2: async () => makeOkResult('WP2'),
+        }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => {
+          startedWpIds.push(wpId);
+          return `/tmp/wp-${wpId}`;
+        },
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp1',
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: () => null,
+        openPRImpl,
+        appendEvent,
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      errorReason: expect.stringContaining('budget exceeded after persisted WP WP1'),
+    });
+    expect(startedWpIds).toEqual(['WP1']);
+    expect(events.find((event) => event.kind === 'parallel-implement.wp-persisted')).toMatchObject({
+      payload: expect.objectContaining({
+        wpId: 'WP1',
+        wpCommitSha: 'sha-wp1',
+        pushedSha: 'sha-wp1',
+      }),
+    });
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      skill: 'parallel-implement',
+      runDisposition: 'budget-killed',
+      budgetKilledWpId: 'WP1',
+    });
+    expect(openPRImpl).not.toHaveBeenCalled();
+  });
+
+  it('emits a loop-cap diagnosis event and does not persist unverified WP work', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const commitWpImpl = vi.fn();
+    const wpRunId = 'pipeline-run-loop-cap:wp:WP1:iter:1';
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem(),
+      spec,
+      'pipeline-run-loop-cap',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({
+          WP1: async () => ({
+            ...makeOkResult('WP1'),
+            events: [
+              makeToolCallEvent(wpRunId, 'Edit', { file_path: 'core/a.ts' }),
+              makeToolCallEvent(wpRunId, 'Bash', { command: 'pnpm test core/a.test.ts' }),
+              makeToolCallEvent(wpRunId, 'Edit', { file_path: 'core/a.ts' }),
+              makeToolCallEvent(wpRunId, 'Bash', { command: 'pnpm test core/a.test.ts' }),
+            ],
+          }),
+        }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: () => '/tmp/wp-WP1',
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: commitWpImpl,
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: () => null,
+        appendEvent,
+        implementWpControlOverride: {
+          editTestLoopMaxCycles: 1,
+        },
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(commitWpImpl).not.toHaveBeenCalled();
+    expect(
+      events.find((event) => event.kind === 'parallel-implement.wp-loop-cap-hit'),
+    ).toMatchObject({
+      payload: expect.objectContaining({
+        wpId: 'WP1',
+        pipelineRunId: 'pipeline-run-loop-cap',
+        wpRunId: expect.stringContaining(':wp:WP1:iter:1'),
+        cycleCount: 2,
+        maxCycles: 1,
+        diagnosis: 'edit-test-loop-cap-exceeded',
+      }),
+    });
+    expect(events.find((event) => event.kind === 'parallel-implement.wp-failed')).toMatchObject({
+      payload: expect.objectContaining({
+        wpId: 'WP1',
+        errorReason: 'edit-test-loop-cap-exceeded',
+      }),
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-persisted')).toBe(false);
   });
 
   it('classifies push failure as persistence-failed', async () => {

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1366,6 +1366,54 @@ describe('parallel-implement durable integration branch persistence', () => {
     expect(events.some((event) => event.kind === 'parallel-implement.wp-persisted')).toBe(false);
   });
 
+  it('does not count read-only shell inspection as edit-test cycles', async () => {
+    const wp = makeWp('WP1', ['core/a.ts']);
+    const scratchWorktree = makeTempRepo(['core/a.ts']);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const revertWpChangesFn = vi.fn();
+    const wpRunId = 'run-readonly-loop:wp:WP1:iter:1';
+
+    const result = await runOneWpBuilder({
+      wp,
+      iteration: 1,
+      runId: 'run-readonly-loop',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: {
+        run: async () => ({
+          ...makeOkResult('WP1'),
+          events: [
+            makeToolCallEvent(wpRunId, 'Bash', { command: 'cat core/a.ts' }),
+            makeToolCallEvent(wpRunId, 'Bash', { command: 'pnpm test core/a.test.ts' }),
+            makeToolCallEvent(wpRunId, 'Bash', { command: 'cat core/a.ts' }),
+            makeToolCallEvent(wpRunId, 'Bash', { command: 'pnpm test core/a.test.ts' }),
+          ],
+        }),
+      },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn,
+      recordIterationFn: () => undefined,
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+      implementWpControl: {
+        editTestLoopMaxCycles: 1,
+      },
+    });
+
+    expect(result.status).toBe('built');
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-loop-cap-hit')).toBe(
+      false,
+    );
+    expect(revertWpChangesFn).not.toHaveBeenCalled();
+  });
+
   it('classifies push failure as persistence-failed', async () => {
     const wp1 = makeWp('WP1', ['core/a.ts']);
     const spec = makeSpec([wp1]);

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -60,6 +60,11 @@ import {
   recordWpIteration,
   runWithConcurrencyCap,
 } from './parallel-helpers.js';
+import {
+  type ImplementWpControlConfig,
+  resolveImplementWpBudget,
+  resolveImplementWpControl,
+} from './wp-budget.js';
 import { runOneWpBuilder } from './wp-builder.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -125,6 +130,7 @@ export interface ParallelImplementDeps {
     pr: ExistingPipelinePr;
     token?: string;
   }) => Promise<ExistingPipelinePr>;
+  implementWpControlOverride?: ImplementWpControlConfig;
 }
 
 function uniqueSorted(paths: string[]): string[] {
@@ -601,6 +607,8 @@ export async function runParallelImplementWorkflow(
   const maxParallel = globalSettings.maxParallelAgents ?? 3;
   const maxRetries = globalSettings.maxRetries ?? 2;
   const wpTimeoutMs = 900_000;
+  const implementWpControl =
+    deps.implementWpControlOverride ?? resolveImplementWpControl(projectConfig?.budgets);
   const devReviewCfg =
     deps.devReviewConfigOverride ??
     resolveDevReviewConfig(projectId, projectConfig?.agentConfig?.devReview);
@@ -832,13 +840,19 @@ export async function runParallelImplementWorkflow(
             wp,
             iteration,
             runId,
+            pipelineRunId,
             projectId,
             workItemId: workItem.id,
             workItem,
             scratchWorktreePath: scratchWorktrees.get(wp.id) ?? '/tmp/missing-scratch',
             stack,
             runtime,
-            budgets: implementWpBudget.budgets,
+            budgets: resolveImplementWpBudget({
+              defaultBudgets: implementWpBudget.budgets,
+              workItem,
+              wp,
+              budgetConfig: projectConfig?.budgets,
+            }),
             modelOverride: implementWpBudget.modelOverride,
             personaId,
             wpTimeoutMs,
@@ -851,6 +865,7 @@ export async function runParallelImplementWorkflow(
             acceptanceContract,
             verificationCommands,
             parentPrdContext,
+            implementWpControl,
           }),
         );
 
@@ -1091,6 +1106,39 @@ export async function runParallelImplementWorkflow(
           integrationHeadSha = pushedSha;
           recordFn(runId, wp.id, iteration, 'ok');
           allWpResults.push({ wpId: wp.id, status: 'ok', commitSha, runId: wpRunId });
+          if (buildResult.budgetExceeded != null) {
+            append({
+              projectId,
+              workItemId: workItem.id,
+              kind: 'agent.run-failed',
+              payload: {
+                runId,
+                skill: 'parallel-implement',
+                runDisposition: 'budget-killed',
+                reason: 'budget-exceeded-after-wp-persisted',
+                budgetKilledWpId: wp.id,
+                wpRunId,
+                costUsd: buildResult.budgetExceeded.costUsd,
+                budgetUsd: buildResult.budgetExceeded.budgetUsd,
+                overByUsd: buildResult.budgetExceeded.overByUsd,
+                integrationBranch,
+                persistedSha: pushedSha,
+              },
+              runId,
+            });
+            await stateSource.comment(
+              workItem.externalId,
+              buildAgentComment('Dev', 'Failed', 'Parallel implement stopped by budget', [
+                `${wp.id}: green work persisted at ${pushedSha}`,
+                `Cost $${buildResult.budgetExceeded.costUsd} exceeded budget $${buildResult.budgetExceeded.budgetUsd}`,
+              ]),
+            );
+            return {
+              status: 'failed',
+              devRunId: runId,
+              errorReason: `budget exceeded after persisted WP ${wp.id}`,
+            };
+          }
         }
       }
 

--- a/slices/parallel-implement/wp-budget.ts
+++ b/slices/parallel-implement/wp-budget.ts
@@ -1,0 +1,93 @@
+import type { AgentBudgets } from '@goose-hub/core/agent-runtime/interface.js';
+import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import type { BudgetConfig } from '@goose-hub/core/types.js';
+import { type WorkPackage, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
+
+export interface ImplementWpControlConfig {
+  editTestLoopMaxCycles: number;
+}
+
+const DEFAULT_BUDGET_SIZING = {
+  bug: { maxTurns: 70, maxBudgetUsd: 4 },
+  feature: { maxTurns: 100, maxBudgetUsd: 6 },
+  complex: { maxTurns: 130, maxBudgetUsd: 8 },
+  complexAdditions: {
+    highPriorityUsd: 1,
+    manyFilesThreshold: 3,
+    manyFilesUsd: 1,
+    contractKeywords: ['schema', 'migration', 'api'],
+    contractUsd: 1,
+  },
+};
+
+export function resolveImplementWpControl(
+  budgetConfig?: Pick<BudgetConfig, 'implementWp'>,
+): ImplementWpControlConfig {
+  return {
+    editTestLoopMaxCycles: budgetConfig?.implementWp?.editTestLoopMaxCycles ?? 3,
+  };
+}
+
+export function resolveImplementWpBudget(input: {
+  defaultBudgets: AgentBudgets;
+  workItem: WorkItem;
+  wp: WorkPackage;
+  budgetConfig?: Pick<BudgetConfig, 'perAgentMaxUsd' | 'perWorkflowMaxUsd' | 'implementWp'>;
+}): AgentBudgets {
+  const sizing = {
+    bug: { ...DEFAULT_BUDGET_SIZING.bug, ...input.budgetConfig?.implementWp?.budgetSizing?.bug },
+    feature: {
+      ...DEFAULT_BUDGET_SIZING.feature,
+      ...input.budgetConfig?.implementWp?.budgetSizing?.feature,
+    },
+    complex: {
+      ...DEFAULT_BUDGET_SIZING.complex,
+      ...input.budgetConfig?.implementWp?.budgetSizing?.complex,
+    },
+    complexAdditions: {
+      ...DEFAULT_BUDGET_SIZING.complexAdditions,
+      ...input.budgetConfig?.implementWp?.budgetSizing?.complexAdditions,
+    },
+  };
+
+  const base = input.workItem.type === 'bug' ? sizing.bug : sizing.feature;
+  let maxBudgetUsd = base.maxBudgetUsd;
+  let maxTurns = base.maxTurns;
+  let complex = false;
+
+  if (input.workItem.priority === 'high' || input.workItem.priority === 'critical') {
+    maxBudgetUsd += sizing.complexAdditions.highPriorityUsd;
+    complex = true;
+  }
+
+  if (input.wp.filesOwned.map(fileOwnedPath).length > sizing.complexAdditions.manyFilesThreshold) {
+    maxBudgetUsd += sizing.complexAdditions.manyFilesUsd;
+    complex = true;
+  }
+
+  const searchable =
+    `${input.wp.changes} ${input.wp.filesOwned.map(fileOwnedPath).join(' ')}`.toLowerCase();
+  if (sizing.complexAdditions.contractKeywords.some((keyword) => searchable.includes(keyword))) {
+    maxBudgetUsd += sizing.complexAdditions.contractUsd;
+    complex = true;
+  }
+
+  if (complex) {
+    maxBudgetUsd = Math.min(maxBudgetUsd, sizing.complex.maxBudgetUsd);
+    maxTurns = Math.max(maxTurns, sizing.complex.maxTurns);
+  }
+
+  const workflowCap = input.budgetConfig?.perWorkflowMaxUsd;
+  if (workflowCap != null) maxBudgetUsd = Math.min(maxBudgetUsd, workflowCap);
+  const agentCap = input.budgetConfig?.perAgentMaxUsd;
+  if (agentCap != null) maxBudgetUsd = Math.min(maxBudgetUsd, agentCap);
+
+  maxBudgetUsd = Math.min(maxBudgetUsd, input.defaultBudgets.maxBudgetUsd);
+  maxTurns = Math.min(maxTurns, input.defaultBudgets.maxTurns);
+
+  return {
+    ...input.defaultBudgets,
+    maxTurns,
+    maxBudgetUsd,
+  };
+}

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -8,6 +8,7 @@ import type {
   AgentResult,
   AgentRuntime,
   AgentSpec,
+  BudgetExceededMetadata,
 } from '@goose-hub/core/agent-runtime/interface.js';
 import type { InvestigationContext } from '@goose-hub/core/agent-runtime/investigation-context.js';
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
@@ -27,6 +28,7 @@ import type { ImplementWpOutput } from '@goose-hub/skills/implement-wp/schema.js
 import { type WorkPackage, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import type { PrdPlanningContext } from '../spec-author/prd-planning-context.js';
 import type { recordWpIteration } from './parallel-helpers.js';
+import type { ImplementWpControlConfig } from './wp-budget.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -39,6 +41,7 @@ export type WpBuildPhaseResult =
       wpRunId: string;
       commitMsg: string;
       scratchWorktreePath: string;
+      budgetExceeded?: BudgetExceededMetadata;
     }
   | { status: 'failed' | 'timeout'; wpId: string; errorReason?: string; runId: string };
 
@@ -46,6 +49,7 @@ export interface RunOneWpBuilderOptions {
   wp: WorkPackage;
   iteration: number;
   runId: string;
+  pipelineRunId?: string;
   projectId: string;
   workItemId?: string;
   workItem: WorkItem;
@@ -65,6 +69,7 @@ export interface RunOneWpBuilderOptions {
   acceptanceContract?: AcceptanceContract;
   verificationCommands?: ExecutableCheck[];
   parentPrdContext?: PrdPlanningContext;
+  implementWpControl?: ImplementWpControlConfig;
 }
 
 type CodeSnippet = {
@@ -81,6 +86,74 @@ type NormalizedPathField = {
   source: RepoRelativePathNormalization['source'];
   ambiguous?: string[];
 };
+
+function toolCallName(event: AgentEvent): string | null {
+  if (event.kind !== 'agent.tool-call') return null;
+  const payload = event.payload as { tool_name?: unknown; toolName?: unknown };
+  const name = payload.tool_name ?? payload.toolName;
+  return typeof name === 'string' ? name : null;
+}
+
+function toolCallInput(event: AgentEvent): Record<string, unknown> {
+  const payload = event.payload as {
+    tool_input?: unknown;
+    toolInput?: unknown;
+  };
+  const input = payload.tool_input ?? payload.toolInput;
+  return input != null && typeof input === 'object' && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : {};
+}
+
+function isEditToolCall(event: AgentEvent): boolean {
+  const name = toolCallName(event)?.toLowerCase();
+  if (name == null) return false;
+  if (name.includes('edit') || name.includes('write')) return true;
+  const command = toolCallInput(event).command;
+  return typeof command === 'string' && /\b(apply_patch|cat|tee|sed -i)\b/.test(command);
+}
+
+function isVerificationToolCall(event: AgentEvent): boolean {
+  const name = toolCallName(event)?.toLowerCase();
+  if (name == null) return false;
+  if (name.includes('test') || name.includes('lint') || name.includes('typecheck')) return true;
+  const command = toolCallInput(event).command;
+  return (
+    typeof command === 'string' &&
+    /\b(test|vitest|lint|typecheck|tsc|biome|playwright)\b/.test(command)
+  );
+}
+
+function editTestLoopDiagnosis(input: {
+  events: AgentEvent[];
+  maxCycles: number;
+}): { cycleCount: number; recentToolCalls: Array<{ toolName: string; command?: string }> } | null {
+  let editedSinceVerification = false;
+  let cycleCount = 0;
+  const recentToolCalls: Array<{ toolName: string; command?: string }> = [];
+  for (const event of input.events) {
+    const toolName = toolCallName(event);
+    if (toolName == null) continue;
+    const command = toolCallInput(event).command;
+    recentToolCalls.push({
+      toolName,
+      ...(typeof command === 'string' ? { command: command.slice(0, 300) } : {}),
+    });
+    if (recentToolCalls.length > 8) recentToolCalls.shift();
+
+    if (isEditToolCall(event)) {
+      editedSinceVerification = true;
+      continue;
+    }
+    if (editedSinceVerification && isVerificationToolCall(event)) {
+      cycleCount += 1;
+      editedSinceVerification = false;
+    }
+  }
+
+  if (cycleCount <= input.maxCycles) return null;
+  return { cycleCount, recentToolCalls };
+}
 
 function normalizeWpFilesOwned(input: {
   wp: WorkPackage;
@@ -396,6 +469,7 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     toolBundles: ['dev-tools'],
     toolExtras: [],
     budgets: { ...opts.budgets, timeoutMs: opts.wpTimeoutMs },
+    budgetPolicy: { onPostRunExceeded: 'return-output' },
     modelOverride: opts.modelOverride,
     personaId: opts.personaId,
     outputJsonSchema: opts.implementWpJsonSchema,
@@ -458,6 +532,46 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
     opts.recordIterationFn(runId, wp.id, iteration, 'failed', errorReason ?? 'unknown');
     return { status: 'failed', wpId: wp.id, errorReason: errorReason ?? 'unknown', runId: wpRunId };
+  }
+
+  const loopDiagnosis = editTestLoopDiagnosis({
+    events: result.events,
+    maxCycles: opts.implementWpControl?.editTestLoopMaxCycles ?? 3,
+  });
+  if (loopDiagnosis != null) {
+    opts.appendEvent({
+      projectId,
+      workItemId: workItemId ?? null,
+      kind: 'parallel-implement.wp-loop-cap-hit',
+      payload: {
+        schemaVersion: 1,
+        pipelineRunId: opts.pipelineRunId ?? runId,
+        devRunId: runId,
+        wpId: wp.id,
+        wpRunId,
+        iteration,
+        cycleCount: loopDiagnosis.cycleCount,
+        maxCycles: opts.implementWpControl?.editTestLoopMaxCycles ?? 3,
+        recentToolCalls: loopDiagnosis.recentToolCalls,
+        diagnosis: 'edit-test-loop-cap-exceeded',
+      },
+      runId: wpRunId,
+    });
+    opts.appendEvent({
+      projectId,
+      workItemId: workItemId ?? null,
+      kind: 'parallel-implement.wp-failed',
+      payload: { wpId: wp.id, wpRunId, errorReason: 'edit-test-loop-cap-exceeded' },
+      runId: wpRunId,
+    });
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
+    opts.recordIterationFn(runId, wp.id, iteration, 'failed', 'edit-test-loop-cap-exceeded');
+    return {
+      status: 'failed',
+      wpId: wp.id,
+      errorReason: 'edit-test-loop-cap-exceeded',
+      runId: wpRunId,
+    };
   }
 
   const parsed = safeParseOutputForSchema(ImplementWpSchema, result.output);
@@ -529,5 +643,6 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     wpRunId,
     commitMsg,
     scratchWorktreePath: opts.scratchWorktreePath,
+    ...(result.budgetExceeded != null ? { budgetExceeded: result.budgetExceeded } : {}),
   };
 }

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -110,7 +110,13 @@ function isEditToolCall(event: AgentEvent): boolean {
   if (name == null) return false;
   if (name.includes('edit') || name.includes('write')) return true;
   const command = toolCallInput(event).command;
-  return typeof command === 'string' && /\b(apply_patch|cat|tee|sed -i)\b/.test(command);
+  return (
+    typeof command === 'string' &&
+    (/\bapply_patch\b/.test(command) ||
+      /\bsed\s+-[^;&|]*i/.test(command) ||
+      /\btee\s+(?:-[a-zA-Z]+\s+)*(?!\/dev\/null\b)\S+/.test(command) ||
+      /(^|[^<])>{1,2}\s*\S+/.test(command))
+  );
 }
 
 function isVerificationToolCall(event: AgentEvent): boolean {


### PR DESCRIPTION
## Summary
- Add an opt-in post-run budget policy for Codex and Claude runtimes so implement-wp can return valid terminal output after budget exceedance.
- Persist budget-exceeded green WP work through the WS3 integration branch before stopping parallel-implement with runDisposition=budget-killed.
- Add config-driven per-WP budget sizing, edit/test loop-cap diagnostics, and budget-killed resume back through spec-ready.

## Verification
- pnpm test core/agent-runtime/codex-cli-runtime.test.ts core/agent-runtime/claude-cli.test.ts slices/parallel-implement/slice.test.ts apps/server/src/shared/dispatch.test.ts
- pnpm typecheck
- pnpm lint (exits 0 with existing warnings in apps/web/src/lib/logger.ts and slices/grill-and-prd/slice.test.ts)

## Known pre-existing failures
Full pnpm test still fails on main and this branch for unrelated existing issues:
- core/workflows/timeline-sections.test.ts: dogfood.seed-applied classification missing
- apps/web/src/lib/logger.test.ts: logger meta is not passed
- slices/dogfood/slice.test.ts: logger-001 seed already applied
