### PR TITLE
Implement WS5 QA reliability routing

### DIFF
--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -76,6 +76,23 @@ function projectExecutableChecks(value: unknown) {
           },
         }
       : {}),
+    ...(isObject(check.evidenceExpectation)
+      ? {
+          evidenceExpectation:
+            check.evidenceExpectation.type === 'vitest-json'
+              ? {
+                  type: 'vitest-json' as const,
+                  ...(typeof check.evidenceExpectation.suite === 'string'
+                    ? { suite: check.evidenceExpectation.suite }
+                    : {}),
+                  ...(typeof check.evidenceExpectation.testName === 'string'
+                    ? { testName: check.evidenceExpectation.testName }
+                    : {}),
+                  expectedStatus: 'passed' as const,
+                }
+              : { type: 'exit-code' as const },
+        }
+      : {}),
     ...(typeof check.timeoutMs === 'number' ? { timeoutMs: check.timeoutMs } : {}),
     ...(typeof check.kind === 'string'
       ? {
@@ -150,6 +167,10 @@ function projectEngineeringSpec(record: NonNullable<ReturnType<typeof getEnginee
       name: stringValue(contract.name),
       signature: stringValue(contract.signature),
       file: stringValue(contract.file),
+      requiredExports: objectArray(contract.requiredExports).map((requiredExport) => ({
+        name: stringValue(requiredExport.name),
+        ...(requiredExport.file != null ? { file: stringValue(requiredExport.file) } : {}),
+      })),
       ...(contract.lineRange != null ? { lineRange: contract.lineRange as string | null } : {}),
     })),
     ...(schemaChanges != null ? { schemaChanges } : {}),
@@ -315,6 +336,7 @@ export async function getIssueSpec(
         name: string;
         signature: string;
         file: string;
+        requiredExports: Array<{ name: string; file?: string }>;
         lineRange?: string | null;
       }>;
       schemaChanges?: { ddl: string[]; migrations: string[] };

--- a/apps/server/src/domains/workflows/state-flows.test.ts
+++ b/apps/server/src/domains/workflows/state-flows.test.ts
@@ -93,7 +93,7 @@ vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   resolveWorktreeHeadSha: vi.fn().mockReturnValue('mock-sha-abc123'),
 }));
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
-  orchestratorCommitAll: vi.fn().mockReturnValue('fake-sha'),
+  orchestratorCommitAll: vi.fn().mockReturnValue({ status: 'committed', sha: 'fake-sha' }),
 }));
 
 const { mockGetSourceForSlug } = vi.hoisted(() => ({

--- a/apps/server/src/shared/dispatch-dev.ts
+++ b/apps/server/src/shared/dispatch-dev.ts
@@ -448,7 +448,10 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
             prewarmWorktreeImpl: () => undefined,
             cleanupWorktreeImpl: () => undefined,
             resolveWorktreeHeadShaImpl: () => 'mock-sha-abc123',
-            orchestratorCommitAllImpl: () => 'mock-commit-sha',
+            orchestratorCommitAllImpl: () => ({
+              status: 'committed',
+              sha: 'mock-commit-sha',
+            }),
           }
         : undefined;
 
@@ -588,7 +591,10 @@ export async function dispatchParallelImplement(slug: string, issueNumber: numbe
               orchestratorCommitWpImpl: () => 'mock-commit-sha',
               revertWpChangesImpl: () => {},
               getDiffImpl: () => '',
-              commitDevReviewResponseImpl: () => 'mock-dr-commit-sha',
+              commitDevReviewResponseImpl: () => ({
+                status: 'committed',
+                sha: 'mock-dr-commit-sha',
+              }),
             }
           : {};
 

--- a/apps/server/src/shared/dispatch-qa-review.ts
+++ b/apps/server/src/shared/dispatch-qa-review.ts
@@ -22,6 +22,9 @@ type VerifyCommand = {
     mode: 'exact' | 'contains' | 'regex';
     value: string;
   };
+  evidenceExpectation?:
+    | { type: 'exit-code' }
+    | { type: 'vitest-json'; suite?: string; testName?: string; expectedStatus: 'passed' };
   timeoutMs?: number;
 };
 
@@ -35,6 +38,7 @@ function mergeVerifyCommands(...groups: VerifyCommand[][]): VerifyCommand[] {
       command: command.command,
       expectedExitCodes: command.expectedExitCodes,
       outputExpectation: command.outputExpectation,
+      evidenceExpectation: command.evidenceExpectation,
       timeoutMs: command.timeoutMs,
     });
     if (!merged.has(key)) merged.set(key, command);

--- a/apps/web/src/components/detail/components/QASection.test.tsx
+++ b/apps/web/src/components/detail/components/QASection.test.tsx
@@ -138,7 +138,7 @@ describe('QASection', () => {
                 tier: 'functional',
                 severity: 'error',
                 description: 'AC 2 fails — boundary case',
-                disposition: 'registered',
+                disposition: 'follow-up',
                 dispositionRef: '#345',
               },
               {
@@ -166,7 +166,7 @@ describe('QASection', () => {
       const pills = screen.getAllByTestId('qa-finding-disposition');
       expect(pills.length).toBeGreaterThanOrEqual(3);
       const text = pills.map((p) => p.textContent ?? '').join('\n');
-      expect(text).toContain('registered #345');
+      expect(text).toContain('follow-up #345');
       expect(text).toContain('fixed');
       expect(text).toContain('out-of-scope');
     });

--- a/apps/web/src/components/detail/components/QASection.tsx
+++ b/apps/web/src/components/detail/components/QASection.tsx
@@ -237,6 +237,39 @@ export function QASection({ projectSlug, id }: QASectionProps) {
                   </span>
                 </div>
                 <div className="text-fg-2 mb-1">{r.ac}</div>
+                {r.evidenceArtifact != null && (
+                  <div className="mt-2 rounded bg-bg px-2 py-2 text-[11px] text-fg-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="mono">{r.evidenceArtifact.type}</span>
+                      <span>{r.evidenceArtifact.artifactStatus}</span>
+                      <span className="mono">
+                        {r.evidenceArtifact.summary.passed}/{r.evidenceArtifact.summary.total}{' '}
+                        passed
+                      </span>
+                    </div>
+                    {(r.evidenceArtifact.matchedSuites.length > 0 ||
+                      r.evidenceArtifact.matchedTests.length > 0) && (
+                      <div className="mt-1 space-y-1">
+                        {r.evidenceArtifact.matchedSuites.length > 0 && (
+                          <div>
+                            <span className="text-fg-2">suites: </span>
+                            <span className="mono">
+                              {r.evidenceArtifact.matchedSuites.join(', ')}
+                            </span>
+                          </div>
+                        )}
+                        {r.evidenceArtifact.matchedTests.length > 0 && (
+                          <div>
+                            <span className="text-fg-2">tests: </span>
+                            <span className="mono">
+                              {r.evidenceArtifact.matchedTests.join(', ')}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
                 {!r.passed && (
                   <details className="text-[11.5px] text-fg-3">
                     <summary className="cursor-pointer">expected vs actual</summary>

--- a/apps/web/src/components/detail/components/QaFindingRow.tsx
+++ b/apps/web/src/components/detail/components/QaFindingRow.tsx
@@ -8,17 +8,20 @@ interface QaFindingRowProps {
 
 function dispositionLabel(disposition: Disposition, dispositionRef?: string): string {
   if (disposition === 'fixed') return 'fixed';
+  if (disposition === 'needs-fix') return 'needs-fix';
   if (disposition === 'out-of-scope') return 'out-of-scope';
-  // registered
+  // follow-up
   return dispositionRef != null && dispositionRef.length > 0
-    ? `registered ${dispositionRef.startsWith('#') ? dispositionRef : `#${dispositionRef}`}`
-    : 'registered';
+    ? `follow-up ${dispositionRef.startsWith('#') ? dispositionRef : `#${dispositionRef}`}`
+    : 'follow-up';
 }
 
 function dispositionTone(disposition: Disposition): { fg: string; bg: string } {
   if (disposition === 'fixed')
     return { fg: 'var(--success)', bg: 'oklch(from var(--success) l c h / 0.12)' };
-  if (disposition === 'registered')
+  if (disposition === 'needs-fix')
+    return { fg: 'var(--danger)', bg: 'oklch(from var(--danger) l c h / 0.12)' };
+  if (disposition === 'follow-up')
     return { fg: 'var(--info)', bg: 'oklch(from var(--info) l c h / 0.12)' };
   // out-of-scope
   return { fg: 'var(--fg-3)', bg: 'var(--bg-elev-2)' };

--- a/apps/web/src/components/detail/components/ReviewSection.test.tsx
+++ b/apps/web/src/components/detail/components/ReviewSection.test.tsx
@@ -139,7 +139,7 @@ describe('ReviewSection', () => {
           {
             severity: 'blocker',
             description: 'Missing slice.test.ts',
-            disposition: 'registered',
+            disposition: 'follow-up',
             dispositionRef: '#234',
           },
           {
@@ -160,7 +160,7 @@ describe('ReviewSection', () => {
     renderSection([REVIEW_WITH_DISPOSITION]);
     const pills = screen.getAllByTestId('review-finding-disposition');
     expect(pills).toHaveLength(3);
-    expect(pills[0].textContent).toContain('registered #234');
+    expect(pills[0].textContent).toContain('follow-up #234');
     expect(pills[1].textContent).toContain('fixed');
     expect(pills[2].textContent).toContain('out-of-scope');
   });

--- a/apps/web/src/components/detail/components/SpecDetails.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.tsx
@@ -245,6 +245,19 @@ export function SpecDetails({
                       {contract.file}
                       {contract.lineRange != null ? `:${contract.lineRange}` : ''}
                     </div>
+                    {contract.requiredExports != null && contract.requiredExports.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {contract.requiredExports.map((requiredExport) => (
+                          <span
+                            key={`${requiredExport.file ?? contract.file}:${requiredExport.name}`}
+                            className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-fg-3"
+                          >
+                            export {requiredExport.name}
+                            {requiredExport.file != null ? ` @ ${requiredExport.file}` : ''}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                     <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-bg px-2 py-2 text-[10.5px] text-fg-3">
                       {contract.signature}
                     </pre>

--- a/apps/web/src/components/detail/lib/qa.ts
+++ b/apps/web/src/components/detail/lib/qa.ts
@@ -1,4 +1,4 @@
-export type Disposition = 'fixed' | 'registered' | 'out-of-scope';
+export type Disposition = 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
 
 export interface Finding {
   tier: 'structural' | 'functional' | 'regression';
@@ -27,6 +27,7 @@ export interface SuiteResult {
   skipped: number;
   durationMs: number;
   status: 'passed' | 'failed' | 'skipped';
+  tests?: Array<{ name: string; status: 'passed' | 'failed' | 'skipped'; durationMs: number }>;
 }
 
 export interface TestRun {
@@ -52,6 +53,16 @@ export interface CriteriaResult {
     mode: 'exact' | 'contains' | 'regex';
     value: string;
   };
+  evidenceExpectation?:
+    | { type: 'exit-code' }
+    | { type: 'vitest-json'; suite?: string; testName?: string; expectedStatus: 'passed' };
+  evidenceArtifact?: {
+    type: 'vitest-json' | 'process';
+    summary: { total: number; passed: number; failed: number; skipped: number };
+    matchedSuites: string[];
+    matchedTests: string[];
+    artifactStatus: 'matched' | 'not-found' | 'unavailable';
+  };
   durationMs?: number;
   error?: string;
 }
@@ -65,6 +76,7 @@ export interface QaPayload {
     functional: TierResult;
     regression: TierResult;
   };
+  findings?: Finding[];
   criteriaResults?: CriteriaResult[];
   testRun?: TestRun;
 }

--- a/apps/web/src/components/detail/lib/review.ts
+++ b/apps/web/src/components/detail/lib/review.ts
@@ -4,7 +4,7 @@ export interface CriterionCheck {
   notes?: string;
 }
 
-export type ReviewDisposition = 'fixed' | 'registered' | 'out-of-scope';
+export type ReviewDisposition = 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
 
 export interface ReviewFinding {
   criterion?: string;
@@ -29,7 +29,8 @@ export interface ReviewPayload {
 
 export const DISPOSITION_COLOR: Record<ReviewDisposition, string> = {
   fixed: 'bg-green-500/15 text-green-400',
-  registered: 'bg-sky-500/15 text-sky-400',
+  'needs-fix': 'bg-red-500/15 text-red-400',
+  'follow-up': 'bg-sky-500/15 text-sky-400',
   'out-of-scope': 'bg-gray-500/15 text-gray-400',
 };
 
@@ -47,8 +48,9 @@ export const VERDICT_LABEL: Record<ReviewVerdict, string> = {
 
 export function formatDisposition(d: ReviewDisposition, ref?: string): string {
   if (d === 'fixed') return 'fixed';
+  if (d === 'needs-fix') return 'needs-fix';
   if (d === 'out-of-scope') return 'out-of-scope';
   return ref != null && ref.length > 0
-    ? `registered ${ref.startsWith('#') ? ref : `#${ref}`}`
-    : 'registered';
+    ? `follow-up ${ref.startsWith('#') ? ref : `#${ref}`}`
+    : 'follow-up';
 }

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -54,6 +54,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'symbol-index.hints-used': 'Symbol hints used',
   'agent.implement-complete': 'Implement complete',
   'agent.fix-feedback-complete': 'Fix feedback complete',
+  'agent.fix-feedback-skipped': 'Fix feedback skipped',
   'agent.retry-escalated': 'Retry escalated',
   'pr.opened': 'PR opened',
   'pr.merged': 'PR merged',

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface InterfaceContractDto {
   name: string;
   signature: string;
   file: string;
+  requiredExports?: Array<{ name: string; file?: string }>;
   lineRange?: string | null;
 }
 
@@ -100,6 +101,9 @@ export interface ExecutableCheckDto {
     mode: 'exact' | 'contains' | 'regex';
     value: string;
   };
+  evidenceExpectation?:
+    | { type: 'exit-code' }
+    | { type: 'vitest-json'; suite?: string; testName?: string; expectedStatus: 'passed' };
   timeoutMs?: number;
   kind?: 'unit' | 'integration' | 'e2e' | 'api' | 'lint' | 'typecheck' | 'custom';
 }

--- a/core/acceptance-contracts/issue-body.ts
+++ b/core/acceptance-contracts/issue-body.ts
@@ -176,6 +176,9 @@ export function acceptanceCriteriaToVerifyCommands(
       command: check.command,
       expectedExitCodes: check.expectedExitCodes ?? [0],
       ...(check.outputExpectation != null ? { outputExpectation: check.outputExpectation } : {}),
+      ...(check.evidenceExpectation != null
+        ? { evidenceExpectation: check.evidenceExpectation }
+        : {}),
       ...(check.timeoutMs != null ? { timeoutMs: check.timeoutMs } : {}),
     })),
   );

--- a/core/acceptance-contracts/resolver.ts
+++ b/core/acceptance-contracts/resolver.ts
@@ -27,6 +27,30 @@ function normalizeOutputExpectation(value: unknown): ExecutableCheck['outputExpe
   return { mode: raw.mode, value: raw.value.trim() };
 }
 
+function normalizeEvidenceExpectation(value: unknown): ExecutableCheck['evidenceExpectation'] {
+  const raw = value as {
+    type?: unknown;
+    suite?: unknown;
+    testName?: unknown;
+    expectedStatus?: unknown;
+  } | null;
+  if (raw == null) return undefined;
+  if (raw.type === 'exit-code') return { type: 'exit-code' };
+  if (raw.type !== 'vitest-json') return undefined;
+  const expectedStatus = raw.expectedStatus === 'passed' ? raw.expectedStatus : undefined;
+  if (expectedStatus == null) return undefined;
+  return {
+    type: 'vitest-json',
+    ...(typeof raw.suite === 'string' && raw.suite.trim().length > 0
+      ? { suite: raw.suite.trim() }
+      : {}),
+    ...(typeof raw.testName === 'string' && raw.testName.trim().length > 0
+      ? { testName: raw.testName.trim() }
+      : {}),
+    expectedStatus,
+  };
+}
+
 function normalizeExecutableChecks(value: unknown, criterionId: string): ExecutableCheck[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((raw, index) => {
@@ -35,6 +59,7 @@ function normalizeExecutableChecks(value: unknown, criterionId: string): Executa
       command?: unknown;
       expectedExitCodes?: unknown;
       outputExpectation?: unknown;
+      evidenceExpectation?: unknown;
       timeoutMs?: unknown;
       kind?: unknown;
     };
@@ -53,6 +78,8 @@ function normalizeExecutableChecks(value: unknown, criterionId: string): Executa
     }
     const outputExpectation = normalizeOutputExpectation(check.outputExpectation);
     if (outputExpectation != null) normalized.outputExpectation = outputExpectation;
+    const evidenceExpectation = normalizeEvidenceExpectation(check.evidenceExpectation);
+    if (evidenceExpectation != null) normalized.evidenceExpectation = evidenceExpectation;
     if (
       typeof check.timeoutMs === 'number' &&
       Number.isInteger(check.timeoutMs) &&

--- a/core/acceptance-contracts/types.ts
+++ b/core/acceptance-contracts/types.ts
@@ -7,11 +7,23 @@ export const OutputExpectationSchema = z.object({
   value: z.string().min(1),
 });
 
+export const EvidenceExpectationSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('exit-code') }),
+  z.object({
+    type: z.literal('vitest-json'),
+    suite: z.string().min(1).optional(),
+    testName: z.string().min(1).optional(),
+    expectedStatus: z.literal('passed'),
+  }),
+]);
+
 export const ExecutableCheckSchema = z.object({
   id: z.string().min(1),
   command: z.string().min(1),
   expectedExitCodes: z.array(z.number().int()).min(1).optional(),
+  /** Deprecated metadata. Kept for old authored contracts; not used as pass/fail truth. */
   outputExpectation: OutputExpectationSchema.optional(),
+  evidenceExpectation: EvidenceExpectationSchema.optional(),
   timeoutMs: z.number().int().positive().optional(),
   kind: z.enum(['unit', 'integration', 'e2e', 'api', 'lint', 'typecheck', 'custom']).optional(),
 });
@@ -27,6 +39,7 @@ export const AcceptanceCriterionContractSchema = z.object({
 });
 
 export type OutputExpectation = z.infer<typeof OutputExpectationSchema>;
+export type EvidenceExpectation = z.infer<typeof EvidenceExpectationSchema>;
 export type ExecutableCheck = z.infer<typeof ExecutableCheckSchema>;
 export type AcceptanceCriterionContract = z.infer<typeof AcceptanceCriterionContractSchema>;
 
@@ -45,5 +58,6 @@ export interface VerifyCommandContract {
   command: string;
   expectedExitCodes: number[];
   outputExpectation?: OutputExpectation;
+  evidenceExpectation?: EvidenceExpectation;
   timeoutMs?: number;
 }

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -68,6 +68,7 @@ export const EVENT_KINDS = [
   'agent.verify-command',
   'project.budget-exceeded',
   'agent.fix-feedback-complete',
+  'agent.fix-feedback-skipped',
   'coach.completed',
   'coach.dispatch-triggered',
   'coach.skipped-forbidden-target',

--- a/core/findings/README.md
+++ b/core/findings/README.md
@@ -6,11 +6,12 @@ Shared Zod schema for holdout-emitted findings. QA and Review re-export `Disposi
 
 ### `DispositionSchema` / `Disposition`
 
-`z.enum(['fixed', 'registered', 'out-of-scope'])`. Every error-severity QA finding and every blocker-severity Review finding must declare one of these:
+`z.enum(['fixed', 'needs-fix', 'out-of-scope', 'follow-up'])`. Every error-severity QA finding and every blocker-severity Review finding must declare one of these:
 
 - **`fixed`** — addressed in this PR. `dispositionRef` is the commit SHA.
-- **`registered`** — filed as a follow-up issue. `dispositionRef` is the issue number (`#234`).
+- **`needs-fix`** — in scope for this story/PR and must enter the repair loop.
 - **`out-of-scope`** — not in scope for this issue. `dispositionRef` is a one-sentence rationale.
+- **`follow-up`** — filed as a follow-up issue. `dispositionRef` is the issue number (`#234`).
 
 ### `DISPOSITIONS`
 
@@ -18,4 +19,4 @@ Readonly array of the enum options, for UI rendering and validation.
 
 ## Holdout note
 
-QA and Review only *record* findings and the chosen disposition. They never file the follow-up issue themselves — the orchestrator (or the human reviewer in supervised mode) is responsible for actually creating `registered` issues. See FACTORY_RULES rule 1.
+QA and Review only *record* findings and the chosen disposition. They never file the follow-up issue themselves — the orchestrator (or the human reviewer in supervised mode) is responsible for actually creating `follow-up` issues. See FACTORY_RULES rule 1.

--- a/core/findings/disposition.ts
+++ b/core/findings/disposition.ts
@@ -8,18 +8,19 @@ import { z } from 'zod';
  * cannot drift; both skills' `FindingSchema` re-export and apply
  * `requireDispositionWhen` for their highest-severity tier.
  *
- * - `fixed`: addressed in this PR. `dispositionRef` is a commit SHA.
- * - `registered`: filed as a follow-up issue. `dispositionRef` is the issue
- *   number (e.g. `"#234"`).
- * - `out-of-scope`: not in scope for this issue. `dispositionRef` is a
- *   one-sentence rationale.
+ * - `fixed`: already addressed in this PR. `dispositionRef` is a commit SHA.
+ * - `needs-fix`: in scope for this story/PR and must enter the repair loop.
+ * - `out-of-scope`: real observation, but not in scope for this issue.
+ *   `dispositionRef` is a one-sentence rationale.
+ * - `follow-up`: real observation intentionally outside this PR.
+ *   `dispositionRef` is the follow-up issue number (e.g. `"#234"`).
  *
  * Holdout note: holdouts (QA, Review) only *record* the finding and chosen
  * disposition. They do not file the follow-up issue themselves — the
  * orchestrator or the human reviewer is responsible for actually filing
- * `registered` issues.
+ * follow-up issues.
  */
-export const DispositionSchema = z.enum(['fixed', 'registered', 'out-of-scope']);
+export const DispositionSchema = z.enum(['fixed', 'needs-fix', 'out-of-scope', 'follow-up']);
 
 export type Disposition = z.infer<typeof DispositionSchema>;
 

--- a/core/qa/README.md
+++ b/core/qa/README.md
@@ -1,0 +1,8 @@
+# core/qa
+
+Shared QA routing helpers.
+
+The actionability helper converts QA payload findings and executable check results
+into the items that should block routing or feed fix-feedback. It keeps disposition
+semantics centralized so QA, fix-feedback, and UI code do not each redefine what
+counts as in-scope repair work.

--- a/core/qa/actionability.test.ts
+++ b/core/qa/actionability.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { collectActionableQaItems } from './actionability.js';
+
+describe('collectActionableQaItems', () => {
+  it('treats failed executable checks and needs-fix findings as actionable', () => {
+    const items = collectActionableQaItems(
+      {
+        criteriaResults: [
+          {
+            criterionId: 'ac-1',
+            checkId: 'check-1',
+            ac: 'Checkout succeeds',
+            command: 'pnpm test checkout.test.ts',
+            expectedExitCodes: [0],
+            exitCode: 1,
+            actual: 'failed',
+            passed: false,
+          },
+        ],
+        findings: [
+          {
+            tier: 'functional',
+            severity: 'error',
+            description: 'Checkout throws on empty cart',
+            disposition: 'needs-fix',
+            dispositionRef: 'current PR',
+          },
+          {
+            tier: 'regression',
+            severity: 'warning',
+            description: 'Unrelated test naming issue',
+            disposition: 'out-of-scope',
+            dispositionRef: 'Not touched by this PR',
+          },
+          {
+            tier: 'regression',
+            severity: 'error',
+            description: 'Pre-existing retry flake',
+            disposition: 'follow-up',
+            dispositionRef: '#123',
+          },
+        ],
+      },
+      {
+        verifiedFollowUpRefs: new Set(['#123']),
+      },
+    );
+
+    expect(items.map((item) => item.kind)).toEqual(['criteria-result', 'finding']);
+    expect(items.map((item) => item.summary)).toEqual([
+      'Executable check failed: Checkout succeeds (pnpm test checkout.test.ts)',
+      'Checkout throws on empty cart',
+    ]);
+  });
+
+  it('treats unverified follow-up findings as actionable', () => {
+    const items = collectActionableQaItems({
+      findings: [
+        {
+          tier: 'functional',
+          severity: 'error',
+          description: 'Missing loading state',
+          disposition: 'follow-up',
+          dispositionRef: '#999',
+        },
+      ],
+    });
+
+    expect(items).toMatchObject([
+      {
+        kind: 'finding',
+        summary: 'Missing loading state',
+        reason: 'unverified-follow-up',
+      },
+    ]);
+  });
+});

--- a/core/qa/actionability.ts
+++ b/core/qa/actionability.ts
@@ -1,0 +1,154 @@
+export type QaDisposition = 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
+
+export interface QaCriteriaResultLike {
+  criterionId: string;
+  checkId: string;
+  ac: string;
+  command: string;
+  expectedExitCodes?: number[];
+  passed: boolean;
+  exitCode?: number | null;
+  actual?: string;
+  error?: string;
+}
+
+export interface QaFindingLike {
+  tier?: string;
+  severity?: string;
+  description: string;
+  suggestion?: string;
+  disposition?: QaDisposition;
+  dispositionRef?: string;
+}
+
+export interface QaPayloadLike {
+  criteriaResults?: QaCriteriaResultLike[];
+  findings?: QaFindingLike[];
+  tierResults?: Record<
+    string,
+    | {
+        passed?: boolean;
+        findings?: QaFindingLike[];
+      }
+    | undefined
+  >;
+}
+
+export type ActionableQaItem =
+  | {
+      kind: 'criteria-result';
+      summary: string;
+      criteriaResult: QaCriteriaResultLike;
+      reason: 'failed-executable-check';
+    }
+  | {
+      kind: 'finding';
+      summary: string;
+      finding: QaFindingLike;
+      reason: 'needs-fix' | 'unverified-follow-up' | 'undispositioned-error';
+    };
+
+export interface CollectActionableQaItemsOptions {
+  verifiedFollowUpRefs?: ReadonlySet<string>;
+}
+
+function normalizedRef(ref: string | undefined): string | null {
+  const trimmed = ref?.trim();
+  if (trimmed == null || trimmed.length === 0) return null;
+  const issueMatch = trimmed.match(/^#?(\d+)$/);
+  if (issueMatch != null) return `#${issueMatch[1]}`;
+  return trimmed;
+}
+
+function isVerifiedFollowUp(
+  finding: QaFindingLike,
+  verifiedFollowUpRefs: ReadonlySet<string>,
+): boolean {
+  const ref = normalizedRef(finding.dispositionRef);
+  return ref != null && verifiedFollowUpRefs.has(ref);
+}
+
+function actionableFinding(
+  finding: QaFindingLike,
+  verifiedFollowUpRefs: ReadonlySet<string>,
+): ActionableQaItem | null {
+  if (finding.disposition === 'needs-fix') {
+    return {
+      kind: 'finding',
+      summary: finding.description,
+      finding,
+      reason: 'needs-fix',
+    };
+  }
+  if (finding.disposition === 'follow-up' && !isVerifiedFollowUp(finding, verifiedFollowUpRefs)) {
+    return {
+      kind: 'finding',
+      summary: finding.description,
+      finding,
+      reason: 'unverified-follow-up',
+    };
+  }
+  if (finding.severity === 'error' && finding.disposition == null) {
+    return {
+      kind: 'finding',
+      summary: finding.description,
+      finding,
+      reason: 'undispositioned-error',
+    };
+  }
+  return null;
+}
+
+export function collectActionableQaItems(
+  payload: QaPayloadLike,
+  options: CollectActionableQaItemsOptions = {},
+): ActionableQaItem[] {
+  const verifiedFollowUpRefs = options.verifiedFollowUpRefs ?? new Set<string>();
+  const items: ActionableQaItem[] = [];
+
+  for (const result of payload.criteriaResults ?? []) {
+    if (result.passed) continue;
+    items.push({
+      kind: 'criteria-result',
+      summary: `Executable check failed: ${result.ac} (${result.command})`,
+      criteriaResult: result,
+      reason: 'failed-executable-check',
+    });
+  }
+
+  for (const finding of payload.findings ?? []) {
+    const item = actionableFinding(finding, verifiedFollowUpRefs);
+    if (item != null) items.push(item);
+  }
+
+  for (const result of Object.values(payload.tierResults ?? {})) {
+    if (result == null || result.passed) continue;
+    for (const finding of result.findings ?? []) {
+      const item = actionableFinding(finding, verifiedFollowUpRefs);
+      if (item != null) items.push(item);
+    }
+  }
+
+  return items;
+}
+
+export function actionableQaItemsToFeedback(items: ActionableQaItem[]): string {
+  if (items.length === 0) return '';
+  const lines = ['QA actionable findings:', ''];
+  for (const item of items) {
+    if (item.kind === 'criteria-result') {
+      lines.push(
+        `- [executable-check] ${item.criteriaResult.ac}: ${item.criteriaResult.command} exited ${item.criteriaResult.exitCode ?? 'none'}`,
+      );
+      if (item.criteriaResult.error != null) lines.push(`  Error: ${item.criteriaResult.error}`);
+      if (item.criteriaResult.actual != null && item.criteriaResult.actual.length > 0) {
+        lines.push(`  Actual: ${item.criteriaResult.actual}`);
+      }
+      continue;
+    }
+    lines.push(
+      `- [${item.finding.tier ?? 'qa'}/${item.finding.severity ?? 'unknown'}] ${item.finding.description}${item.finding.suggestion ? ` - ${item.finding.suggestion}` : ''}`,
+    );
+  }
+  return lines.join('\n');
+}

--- a/core/test-runner/parse-vitest-json.test.ts
+++ b/core/test-runner/parse-vitest-json.test.ts
@@ -19,17 +19,17 @@ const sample = {
       name: '/repo/src/cart.test.ts',
       status: 'passed',
       assertionResults: [
-        { status: 'passed', duration: 12 },
-        { status: 'passed', duration: 18.4 },
-        { status: 'pending', duration: 0 },
+        { title: 'adds cart item', status: 'passed', duration: 12 },
+        { title: 'removes cart item', status: 'passed', duration: 18.4 },
+        { title: 'updates quantity', status: 'pending', duration: 0 },
       ],
     },
     {
       name: '/repo/src/funnel.test.ts',
       status: 'failed',
       assertionResults: [
-        { status: 'passed', duration: 7 },
-        { status: 'failed', duration: 41 },
+        { title: 'opens the funnel', status: 'passed', duration: 7 },
+        { title: 'submits the funnel', status: 'failed', duration: 41 },
       ],
     },
   ],
@@ -55,6 +55,11 @@ describe('parseVitestJson', () => {
     expect(cart.skipped).toBe(1);
     expect(cart.durationMs).toBe(30); // 12 + 18.4 -> rounded
     expect(cart.status).toBe('passed');
+    expect(cart.tests).toEqual([
+      { name: 'adds cart item', status: 'passed', durationMs: 12 },
+      { name: 'removes cart item', status: 'passed', durationMs: 18 },
+      { name: 'updates quantity', status: 'skipped', durationMs: 0 },
+    ]);
 
     const funnel = run.suites[1];
     expect(funnel.status).toBe('failed');

--- a/core/test-runner/parse-vitest-json.ts
+++ b/core/test-runner/parse-vitest-json.ts
@@ -10,6 +10,9 @@ import type { SuiteResult, TestRun } from '@goose-hub/skills/qa/schema.js';
 type SuiteStatus = SuiteResult['status'];
 
 interface VitestAssertion {
+  title?: string;
+  fullName?: string;
+  name?: string;
   status: string;
   duration?: number | null;
 }
@@ -39,6 +42,12 @@ function classifySuite(passed: number, failed: number, total: number): SuiteStat
   return 'passed';
 }
 
+function classifyTestStatus(status: string): 'passed' | 'failed' | 'skipped' {
+  if (status === 'passed') return 'passed';
+  if (status === 'failed') return 'failed';
+  return 'skipped';
+}
+
 /** Parse a vitest `--reporter=json` payload into the canonical TestRun shape. */
 export function parseVitestJson(raw: unknown, now: number = Date.now()): TestRun {
   if (raw == null || typeof raw !== 'object') {
@@ -65,6 +74,11 @@ export function parseVitestJson(raw: unknown, now: number = Date.now()): TestRun
       skipped,
       durationMs: Math.round(durationMs),
       status: classifySuite(passed, failed, total),
+      tests: assertions.map((a, index) => ({
+        name: a.title ?? a.fullName ?? a.name ?? `test ${index + 1}`,
+        status: classifyTestStatus(a.status),
+        durationMs: Math.round(a.duration ?? 0),
+      })),
     };
   });
 

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -73,12 +73,12 @@ describe('Tier 1 (Structural) — golden test', () => {
 
   afterEach(() => rmSync(worktree, { recursive: true, force: true }));
 
-  it('fails when interface contract export is absent from filesOwned file', () => {
+  it('does not require descriptive interface contract names to be exported', () => {
     const spec = makeSpec({
       workPackages: [makeWp('WP1', ['src/index.ts'])],
       interfaceContracts: [
         {
-          name: 'runVerification',
+          name: 'Verification adapter boundary',
           signature: 'export function runVerification(): void',
           file: 'src/index.ts',
         },
@@ -88,6 +88,24 @@ describe('Tier 1 (Structural) — golden test', () => {
     const result = verifyStructural(spec, '', worktree);
 
     expect(result.tier).toBe(1);
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when a required export is absent from its contract file', () => {
+    const spec = makeSpec({
+      workPackages: [makeWp('WP1', ['src/index.ts'])],
+      interfaceContracts: [
+        {
+          name: 'Verification adapter boundary',
+          signature: 'export function runVerification(): void',
+          file: 'src/index.ts',
+          requiredExports: [{ name: 'runVerification' }],
+        },
+      ],
+    });
+
+    const result = verifyStructural(spec, '', worktree);
+
     expect(result.passed).toBe(false);
     const errorFindings = result.findings.filter((f) => f.severity === 'error');
     expect(errorFindings.length).toBeGreaterThanOrEqual(1);
@@ -100,9 +118,10 @@ describe('Tier 1 (Structural) — golden test', () => {
       workPackages: [makeWp('WP1', ['src/index.ts'])],
       interfaceContracts: [
         {
-          name: 'runVerification',
+          name: 'Verification adapter boundary',
           signature: 'export function runVerification(): void',
           file: 'src/index.ts',
+          requiredExports: [{ name: 'runVerification' }],
         },
       ],
     });
@@ -423,6 +442,7 @@ describe('runTier — event emission', () => {
           name: 'missingExport',
           signature: 'export function missingExport(): void',
           file: 'src/a.ts',
+          requiredExports: [{ name: 'missingExport' }],
         },
       ],
     });

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -91,6 +91,24 @@ describe('Tier 1 (Structural) — golden test', () => {
     expect(result.passed).toBe(true);
   });
 
+  it('fails when a descriptive interface contract file is missing', () => {
+    const spec = makeSpec({
+      workPackages: [makeWp('WP1', ['src/index.ts'])],
+      interfaceContracts: [
+        {
+          name: 'Verification adapter boundary',
+          signature: 'export function runVerification(): void',
+          file: 'src/missing-contract.ts',
+        },
+      ],
+    });
+
+    const result = verifyStructural(spec, '', worktree);
+
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.message.includes('missing-contract.ts'))).toBe(true);
+  });
+
   it('fails when a required export is absent from its contract file', () => {
     const spec = makeSpec({
       workPackages: [makeWp('WP1', ['src/index.ts'])],

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -93,34 +93,43 @@ export function verifyStructural(
   }
 
   for (const contract of spec.interfaceContracts) {
-    const fullPath = join(worktreePath, contract.file);
-    if (!existsSync(fullPath)) {
-      findings.push({
-        message: `Interface contract '${contract.name}': file ${contract.file} does not exist`,
-        file: contract.file,
-        severity: 'error',
-      });
+    const requiredExports = contract.requiredExports ?? [];
+    if (requiredExports.length === 0) {
+      evidence.push(`interface-contract-described: ${contract.name} in ${contract.file}`);
       continue;
     }
 
-    const content = readFileSync(fullPath, 'utf8');
-    // Matches: export [async] function|const|class|type|interface|let|var <name>
-    const exportPattern = new RegExp(
-      `export\\s+(?:async\\s+)?(?:function|const|class|type|interface|let|var)\\s+${escapeRegex(contract.name)}\\b`,
-    );
-    // Also matches: export { <name> } re-exports
-    const reExportPattern = new RegExp(
-      `export\\s+\\{[^}]*\\b${escapeRegex(contract.name)}\\b[^}]*\\}`,
-    );
+    for (const requiredExport of requiredExports) {
+      const exportFile = requiredExport.file ?? contract.file;
+      const fullPath = join(worktreePath, exportFile);
+      if (!existsSync(fullPath)) {
+        findings.push({
+          message: `Interface contract '${contract.name}': file ${exportFile} does not exist`,
+          file: exportFile,
+          severity: 'error',
+        });
+        continue;
+      }
 
-    if (exportPattern.test(content) || reExportPattern.test(content)) {
-      evidence.push(`export-found: ${contract.name} in ${contract.file}`);
-    } else {
-      findings.push({
-        message: `Interface contract '${contract.name}' is not exported from ${contract.file}`,
-        file: contract.file,
-        severity: 'error',
-      });
+      const content = readFileSync(fullPath, 'utf8');
+      // Matches: export [async] function|const|class|type|interface|let|var <name>
+      const exportPattern = new RegExp(
+        `export\\s+(?:async\\s+)?(?:function|const|class|type|interface|let|var)\\s+${escapeRegex(requiredExport.name)}\\b`,
+      );
+      // Also matches: export { <name> } re-exports
+      const reExportPattern = new RegExp(
+        `export\\s+\\{[^}]*\\b${escapeRegex(requiredExport.name)}\\b[^}]*\\}`,
+      );
+
+      if (exportPattern.test(content) || reExportPattern.test(content)) {
+        evidence.push(`export-found: ${requiredExport.name} in ${exportFile}`);
+      } else {
+        findings.push({
+          message: `Interface contract '${contract.name}' requires export '${requiredExport.name}' from ${exportFile}`,
+          file: exportFile,
+          severity: 'error',
+        });
+      }
     }
   }
 

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -94,14 +94,27 @@ export function verifyStructural(
 
   for (const contract of spec.interfaceContracts) {
     const requiredExports = contract.requiredExports ?? [];
+    const contractFullPath = join(worktreePath, contract.file);
+    const contractFileExists = existsSync(contractFullPath);
+    if (!contractFileExists) {
+      findings.push({
+        message: `Interface contract '${contract.name}': file ${contract.file} does not exist`,
+        file: contract.file,
+        severity: 'error',
+      });
+    }
+
     if (requiredExports.length === 0) {
-      evidence.push(`interface-contract-described: ${contract.name} in ${contract.file}`);
+      if (contractFileExists) {
+        evidence.push(`interface-contract-described: ${contract.name} in ${contract.file}`);
+      }
       continue;
     }
 
     for (const requiredExport of requiredExports) {
       const exportFile = requiredExport.file ?? contract.file;
       const fullPath = join(worktreePath, exportFile);
+      if (exportFile === contract.file && !contractFileExists) continue;
       if (!existsSync(fullPath)) {
         findings.push({
           message: `Interface contract '${contract.name}': file ${exportFile} does not exist`,

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -75,6 +75,7 @@ const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
   'spec.wp-issues-created': 'delivery-router',
   'agent.implement-complete': 'implementation',
   'agent.fix-feedback-complete': 'implementation',
+  'agent.fix-feedback-skipped': 'implementation',
   'pr.opened': 'implementation',
   'decompose.completed': 'decompose',
   'evidence.no-spec-declared': 'dev-review',

--- a/core/workspaces/orchestrator-git.test.ts
+++ b/core/workspaces/orchestrator-git.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { orchestratorCommitAll } from './orchestrator-git.js';
+
+let repo: string;
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+describe('orchestratorCommitAll', () => {
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'orchestrator-commit-all-'));
+    git(['init']);
+    git(['config', 'user.name', 'Test User']);
+    git(['config', 'user.email', 'test@example.com']);
+    writeFileSync(join(repo, 'README.md'), 'initial\n');
+    git(['add', 'README.md']);
+    git(['commit', '-m', 'initial']);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('returns no-changes without creating an empty commit', () => {
+    const before = git(['rev-parse', 'HEAD']);
+
+    const result = orchestratorCommitAll(repo, 'repair');
+
+    expect(result).toEqual({ status: 'no-changes' });
+    expect(git(['rev-parse', 'HEAD'])).toBe(before);
+  });
+
+  it('commits staged changes and returns the commit sha', () => {
+    writeFileSync(join(repo, 'README.md'), 'changed\n');
+
+    const result = orchestratorCommitAll(repo, 'repair');
+
+    expect(result.status).toBe('committed');
+    if (result.status !== 'committed') return;
+    expect(result.sha).toMatch(/^[a-f0-9]{40}$/);
+    expect(git(['show', '--format=%s', '--no-patch', 'HEAD'])).toBe('repair');
+  });
+});

--- a/core/workspaces/orchestrator-git.ts
+++ b/core/workspaces/orchestrator-git.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -117,20 +117,37 @@ export function orchestratorCommitWp(
  *
  * @param worktreePath - Absolute path to the worktree.
  * @param commitMsg    - Commit message.
- * @returns The resulting commit SHA (40 chars).
+ * @returns Commit result. `no-changes` means no commit was created.
  */
-export function orchestratorCommitAll(worktreePath: string, commitMsg: string): string {
+export type OrchestratorCommitAllResult =
+  | { status: 'committed'; sha: string }
+  | { status: 'no-changes' };
+
+export function orchestratorCommitAll(
+  worktreePath: string,
+  commitMsg: string,
+): OrchestratorCommitAllResult {
   execFileSync('git', ['add', '-A'], { cwd: worktreePath, stdio: 'pipe', env: GIT_ENV });
-  execFileSync('git', ['commit', '--allow-empty', '-m', commitMsg], {
+  const stagedDiff = spawnSync('git', ['diff', '--cached', '--quiet'], {
     cwd: worktreePath,
     stdio: 'pipe',
     env: GIT_ENV,
   });
-  return execFileSync('git', ['rev-parse', 'HEAD'], {
+  if (stagedDiff.status === 0) return { status: 'no-changes' };
+  if (stagedDiff.status !== 1) {
+    throw new Error(`git diff --cached --quiet failed with status ${stagedDiff.status}`);
+  }
+  execFileSync('git', ['commit', '-m', commitMsg], {
+    cwd: worktreePath,
+    stdio: 'pipe',
+    env: GIT_ENV,
+  });
+  const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
     cwd: worktreePath,
     encoding: 'utf8',
     env: GIT_ENV,
   }).trim();
+  return { status: 'committed', sha };
 }
 
 /**

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -14,7 +14,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `server` | yes | API + SSE host for the Goose Hub web UI. Stands up the server process the UI talks to. Closes M2.01 (#26). |
 | `web` | yes | Vite + React 19 + Tailwind 4 + React Router v6. Closes M2.02 (#27). |
 
-## core/ (35 entries, 4 missing README)
+## core/ (36 entries, 4 missing README)
 
 | Name | README | Summary |
 |---|---|---|
@@ -38,6 +38,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `persona` | yes | Persona stats accumulation. Updates `persona_stats` after every agent run. |
 | `prd` | **missing** | _(no README)_ |
 | `projects` | yes | Project registration loader for Goose Hub's multi-project orchestration. |
+| `qa` | yes | Shared QA routing helpers. |
 | `quality-score` | yes | Per-run QualityScore (0–100) with components and convergence detection. |
 | `retrospective` | yes | Shared Zod schemas for retrospective skill outputs. The three retro skills (`retrospective-light`, `retrospective-deep`, `retrospective-cross-run`) all conform to these shapes so downstream consumers (improvement-candidate filer, playbook builder) can treat their outputs uniformly. |
 | `retry` | yes | Retry counters for QA and Review failures. Counts are derived from the event stream — no separate retry table. |

--- a/skills/qa/prompt.md
+++ b/skills/qa/prompt.md
@@ -143,21 +143,22 @@ Rules:
 
 Executable check results are not Review coverage. They prove commands passed or failed; they do not replace your judgement on non-executable criteria.
 
-## Fix-or-register
+## Finding Disposition
 
-Every finding must be classified — fixed in this PR, registered as a follow-up issue, or explicitly out-of-scope-for-this-issue. Never deferred, never "TODO". Deferred findings are how production drift accumulates; the fix-or-register rule is the primary safety mechanism (#468).
+Every finding must be classified — fixed in this PR, needing repair in this PR, tracked as a verified follow-up, or explicitly out-of-scope-for-this-issue. Never deferred, never "TODO".
 
 For each finding, set `disposition` and `dispositionRef`:
 
 | `disposition` | When | `dispositionRef` |
 |---|---|---|
 | `fixed` | The PR already addresses this finding (you observed the fix in the diff). | The commit SHA where the fix landed (short or full). |
-| `registered` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
+| `needs-fix` | The finding is in scope for this story/PR and must go to fix-feedback. | A short current-PR rationale, e.g. `current PR`. |
+| `follow-up` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
 | `out-of-scope` | The finding is real but explicitly not in scope for this issue. | A one-sentence rationale explaining why it doesn't belong in this PR. |
 
 **Required when `severity === 'error'`.** An error-severity finding without a disposition is a schema-validation failure — the agent's output is rejected. Warning- and info-severity findings may carry a disposition but it's optional (informational findings can stand alone).
 
-QA records the finding; QA does not file the follow-up issue itself (holdout discipline). The orchestrator or the human reviewer is responsible for actually filing `disposition: 'registered'` issues.
+QA records the finding; QA does not file the follow-up issue itself (holdout discipline). The orchestrator or the human reviewer is responsible for actually filing `disposition: 'follow-up'` issues.
 
 ## Priority classification
 
@@ -262,7 +263,7 @@ Are functions and methods simple? Low cyclomatic complexity means fewer branches
 Set `verdict` based on the following rules, in order:
 
 1. **fail** — if any of the following are true:
-   - Any `error`-severity finding exists in any tier (and reaches schema validation — meaning it has a `disposition` per fix-or-register, #468)
+   - Any actionable `error`-severity finding exists in any tier (and reaches schema validation — meaning it has a `disposition`, #468)
    - Any acceptance criterion from `workItem.body` is not satisfied
    - Any `criteriaResults[].passed === false`
    - `overallScore < threshold` (default threshold: 70)
@@ -344,8 +345,8 @@ Return a JSON object conforming exactly to this structure:
           "description": "Type error in apps/web/src/foo.ts: Property 'x' does not exist on type 'Bar'",
           "file": "apps/web/src/foo.ts",
           "line": 12,
-          "disposition": "registered",
-          "dispositionRef": "type error must be fixed before approval"
+          "disposition": "needs-fix",
+          "dispositionRef": "current PR"
         }
       ],
       "command": "pnpm biome check .",
@@ -379,8 +380,8 @@ Return a JSON object conforming exactly to this structure:
       "description": "Type error in apps/web/src/foo.ts: Property 'x' does not exist on type 'Bar'",
       "file": "apps/web/src/foo.ts",
       "line": 12,
-      "disposition": "registered",
-      "dispositionRef": "type error must be fixed before approval"
+      "disposition": "needs-fix",
+      "dispositionRef": "current PR"
     },
     { "tier": "functional", "severity": "warning", "description": "Acceptance criterion 3 not covered by any test" }
   ],

--- a/skills/qa/schema.ts
+++ b/skills/qa/schema.ts
@@ -76,6 +76,15 @@ export const SuiteResultSchema = z.object({
   skipped: z.number().int().min(0),
   durationMs: z.number().int().min(0),
   status: z.enum(['passed', 'failed', 'skipped']),
+  tests: z
+    .array(
+      z.object({
+        name: z.string(),
+        status: z.enum(['passed', 'failed', 'skipped']),
+        durationMs: z.number().int().min(0),
+      }),
+    )
+    .optional(),
 });
 
 export const TestRunSchema = z.object({
@@ -185,6 +194,31 @@ export const CriteriaResultSchema = z.object({
     .object({
       mode: z.enum(['exact', 'contains', 'regex']),
       value: z.string(),
+    })
+    .optional(),
+  evidenceExpectation: z
+    .discriminatedUnion('type', [
+      z.object({ type: z.literal('exit-code') }),
+      z.object({
+        type: z.literal('vitest-json'),
+        suite: z.string().optional(),
+        testName: z.string().optional(),
+        expectedStatus: z.literal('passed'),
+      }),
+    ])
+    .optional(),
+  evidenceArtifact: z
+    .object({
+      type: z.enum(['vitest-json', 'process']),
+      summary: z.object({
+        total: z.number().int().min(0),
+        passed: z.number().int().min(0),
+        failed: z.number().int().min(0),
+        skipped: z.number().int().min(0),
+      }),
+      matchedSuites: z.array(z.string()),
+      matchedTests: z.array(z.string()),
+      artifactStatus: z.enum(['matched', 'not-found', 'unavailable']),
     })
     .optional(),
   durationMs: z.number().int().min(0).optional(),

--- a/skills/qa/skill.config.ts
+++ b/skills/qa/skill.config.ts
@@ -88,6 +88,31 @@ export const QaContextSchema = z.object({
             value: z.string(),
           })
           .optional(),
+        evidenceExpectation: z
+          .discriminatedUnion('type', [
+            z.object({ type: z.literal('exit-code') }),
+            z.object({
+              type: z.literal('vitest-json'),
+              suite: z.string().optional(),
+              testName: z.string().optional(),
+              expectedStatus: z.literal('passed'),
+            }),
+          ])
+          .optional(),
+        evidenceArtifact: z
+          .object({
+            type: z.enum(['vitest-json', 'process']),
+            summary: z.object({
+              total: z.number().int().min(0),
+              passed: z.number().int().min(0),
+              failed: z.number().int().min(0),
+              skipped: z.number().int().min(0),
+            }),
+            matchedSuites: z.array(z.string()),
+            matchedTests: z.array(z.string()),
+            artifactStatus: z.enum(['matched', 'not-found', 'unavailable']),
+          })
+          .optional(),
         durationMs: z.number().int().min(0).optional(),
         error: z.string().optional(),
       }),

--- a/skills/qa/slice.test.ts
+++ b/skills/qa/slice.test.ts
@@ -65,7 +65,7 @@ describe('QaOutputSchema', () => {
             tier: 'structural',
             severity: 'error',
             description: 'TypeScript error: Type "string" is not assignable to type "number"',
-            disposition: 'registered',
+            disposition: 'follow-up',
             dispositionRef: '#999',
           },
         ],
@@ -255,7 +255,7 @@ describe('FindingSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  // ── #468 — fix-or-register disposition ────────────────────────────────────
+  // ── #468 — explicit finding disposition ───────────────────────────────────
 
   it("accepts an error finding with disposition 'fixed' and a commit SHA dispositionRef (#468)", () => {
     expect(
@@ -269,7 +269,31 @@ describe('FindingSchema', () => {
     ).toBe(true);
   });
 
-  it("accepts an error finding with disposition 'registered' and an issue number (#468)", () => {
+  it("accepts an error finding with disposition 'follow-up' and an issue number (#468)", () => {
+    expect(
+      FindingSchema.safeParse({
+        tier: 'structural',
+        severity: 'error',
+        description: 'Missing slice.test.ts',
+        disposition: 'follow-up',
+        dispositionRef: '#234',
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an error finding with disposition 'needs-fix' for current-loop repair", () => {
+    expect(
+      FindingSchema.safeParse({
+        tier: 'functional',
+        severity: 'error',
+        description: 'Current PR still fails the user-facing flow',
+        disposition: 'needs-fix',
+        dispositionRef: 'current PR',
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects legacy disposition 'registered' in new QA output", () => {
     expect(
       FindingSchema.safeParse({
         tier: 'structural',
@@ -278,7 +302,7 @@ describe('FindingSchema', () => {
         disposition: 'registered',
         dispositionRef: '#234',
       }).success,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("accepts an error finding with disposition 'out-of-scope' and a rationale (#468)", () => {
@@ -309,7 +333,7 @@ describe('FindingSchema', () => {
         tier: 'functional',
         severity: 'error',
         description: 'broken thing',
-        disposition: 'registered',
+        disposition: 'follow-up',
         dispositionRef: '',
       }).success,
     ).toBe(false);
@@ -775,7 +799,7 @@ describe('QaOutputSchema with cross-checked targeted regressions (#467)', () => 
       file: 'apps/server/src/unrelated/auth.test.ts',
       description:
         'Failure outside dev targeted set (devTestsRun.paths) — high-signal regression dev did not run',
-      disposition: 'registered' as const,
+      disposition: 'follow-up' as const,
       dispositionRef: '#1234',
     };
     const result = QaOutputSchema.safeParse(
@@ -833,6 +857,35 @@ describe('CriteriaResultSchema', () => {
       passed: false,
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts structured evidence artifact for a matched Vitest check', () => {
+    const result = CriteriaResultSchema.safeParse({
+      criterionId: 'ac-1',
+      checkId: 'check-1',
+      ac: 'Checkout passes',
+      command: 'pnpm test checkout.test.ts -- --reporter=json',
+      expectedExitCodes: [0],
+      exitCode: 0,
+      actual: '{"success":true}',
+      passed: true,
+      evidenceExpectation: {
+        type: 'vitest-json',
+        suite: 'checkout.test.ts',
+        testName: 'submits checkout',
+        expectedStatus: 'passed',
+      },
+      evidenceArtifact: {
+        type: 'vitest-json',
+        summary: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        matchedSuites: ['checkout.test.ts'],
+        matchedTests: ['submits checkout'],
+        artifactStatus: 'matched',
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.evidenceArtifact?.matchedTests).toEqual(['submits checkout']);
   });
 
   it('rejects missing ac field', () => {

--- a/skills/review/prompt.md
+++ b/skills/review/prompt.md
@@ -125,19 +125,20 @@ Use `minor` when:
 
 ## Fix-or-register
 
-Every finding must be classified — fixed in this PR, registered as a follow-up issue, or explicitly out-of-scope-for-this-issue. Never deferred, never "TODO" (#468). Deferred findings are how production drift accumulates.
+Every finding must be classified — fixed in this PR, needing repair in this PR, tracked as a verified follow-up, or explicitly out-of-scope-for-this-issue. Never deferred, never "TODO" (#468).
 
 For each finding, set `disposition` and `dispositionRef`:
 
 | `disposition` | When | `dispositionRef` |
 |---|---|---|
 | `fixed` | The PR already addresses this finding (you observed the fix in the diff). | The commit SHA where the fix landed. |
-| `registered` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
+| `needs-fix` | The finding is in scope for this story/PR and must go to fix-feedback. | A short current-PR rationale, e.g. `current PR`. |
+| `follow-up` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
 | `out-of-scope` | The finding is real but explicitly not in scope for this issue. | A one-sentence rationale. |
 
 **Required when `severity === 'blocker'`.** A blocker-severity finding without a disposition fails schema validation. `major` and `minor` findings may carry a disposition but it's optional.
 
-Review records the finding; Review does not file the follow-up issue itself (holdout discipline). The orchestrator or human reviewer is responsible for filing `disposition: 'registered'` issues.
+Review records the finding; Review does not file the follow-up issue itself (holdout discipline). The orchestrator or human reviewer is responsible for filing `disposition: 'follow-up'` issues.
 
 ## Priority classification
 

--- a/skills/review/prompt.unconstrained.md
+++ b/skills/review/prompt.unconstrained.md
@@ -83,7 +83,8 @@ For each blocker finding, set:
 | `disposition` | When | `dispositionRef` |
 |---|---|---|
 | `fixed` | The PR already addresses this finding. | The commit SHA where the fix landed. |
-| `registered` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
+| `needs-fix` | The finding is in scope for this story/PR and must go to fix-feedback. | A short current-PR rationale, e.g. `current PR`. |
+| `follow-up` | The finding is real but out of scope for this PR; a follow-up issue exists. | The follow-up issue number, e.g. `#234`. |
 | `out-of-scope` | The finding is real but explicitly not in scope for this issue. | A one-sentence rationale. |
 
 A blocker-severity finding without `dispositionRef` fails schema validation.

--- a/skills/review/slice.test.ts
+++ b/skills/review/slice.test.ts
@@ -28,9 +28,9 @@ function makeNeedsFixOutput(overrides = {}) {
       {
         severity: 'blocker',
         description: 'Missing slice.test.ts required by FACTORY_RULES',
-        // #468 — every blocker carries a disposition. Here it's `registered`
+        // #468 — every blocker carries a disposition. Here it's `follow-up`
         // because slice.test.ts gap is being filed as a follow-up.
-        disposition: 'registered',
+        disposition: 'follow-up',
         dispositionRef: '#999',
       },
     ],
@@ -249,7 +249,7 @@ describe('ReviewFindingSchema', () => {
     const result = ReviewFindingSchema.safeParse({
       severity: 'blocker',
       description: 'Acceptance criterion unmet: slice.test.ts missing',
-      disposition: 'registered',
+      disposition: 'follow-up',
       dispositionRef: '#345',
     });
     expect(result.success).toBe(true);
@@ -302,7 +302,7 @@ describe('ReviewFindingSchema', () => {
   it('rejects missing description', () => {
     const result = ReviewFindingSchema.safeParse({
       severity: 'blocker',
-      disposition: 'registered',
+      disposition: 'follow-up',
       dispositionRef: '#1',
     });
     expect(result.success).toBe(false);
@@ -355,7 +355,7 @@ describe('ReviewFindingSchema', () => {
       ReviewFindingSchema.safeParse({
         severity: 'blocker',
         description: 'Missing README',
-        disposition: 'registered',
+        disposition: 'follow-up',
         dispositionRef: '',
       }).success,
     ).toBe(false);
@@ -387,7 +387,7 @@ describe('ReviewFindingSchema', () => {
     const result = ReviewFindingSchema.safeParse({
       severity: 'blocker',
       description: 'missing required file',
-      disposition: 'registered',
+      disposition: 'follow-up',
       dispositionRef: '#123',
       priority: 'P0',
     });

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -50,7 +50,7 @@ A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/
 3. **`functionalRequirements`** — copied from `<prdContext>` and the PRD functional/acceptance material when present. Each entry has `id` + `statement`.
 4. **`architecture`** — `current` (one paragraph), `new` (one paragraph), `decisionRationale` (why this shape).
 5. **`schemaChanges`** — exact DDL strings (no pseudocode) and repo-relative migration file paths. Empty arrays if no schema change.
-6. **`interfaceContracts`** — paste-ready `signature` (function decl, type alias, or full Zod block) + `file` it lives in. ≥1 entry required when there are ≥2 WPs (cross-WP boundaries need typed contracts).
+6. **`interfaceContracts`** — descriptive `name`, paste-ready `signature` (function decl, type alias, or full Zod block), and `file` it lives in. Use `requiredExports` only for real exported symbols Tier 1 must verify. ≥1 entry required when there are ≥2 WPs (cross-WP boundaries need typed contracts).
 7. **`workPackages`** — see rules below.
 8. **`executionOrder`** — DAG of batches: `[{batch: 0, wpIds: ['WP1', 'WP2']}, {batch: 1, wpIds: ['WP3']}]`. Every WP appears exactly once.
 9. **`verificationTooling`** — required when there are >2 WPs. Each tool: `name`, `command`, `expectedExitCodes`, optional `inputSpec`. `command` must be an executable repo-root command such as `pnpm vitest run apps/web/src/lib/lanes.config.test.ts`; never emit a bare file path. For Playwright specs under `apps/web/e2e`, emit a canonical repo-root command such as `pnpm exec playwright test apps/web/e2e/pipeline/<spec>.spec.ts`; for `chat.spec.ts`, include `--config playwright-chat.config.ts`. The workflow may adapt canonical repo-root commands to package-local execution internally; do not emit package-relative paths like `e2e/<spec>.spec.ts` in `verificationTooling` or `acceptanceCriteria[].executableChecks`.
@@ -242,6 +242,7 @@ Live marker format: `[decision] KIND: <one sentence>`. Example: `[decision] PLAN
       "name": "auditSkillContracts",
       "signature": "export async function auditSkillContracts(repoRoot: string): Promise<SkillContractAudit>",
       "file": "core/agent-runtime/skill-contract-audit.ts",
+      "requiredExports": [{ "name": "auditSkillContracts" }],
       "lineRange": "1-220"
     }
   ],

--- a/skills/spec-author/schema.ts
+++ b/skills/spec-author/schema.ts
@@ -69,6 +69,15 @@ export const InterfaceContractSchema = z.object({
   signature: z.string().min(1),
   /** Repo-root/worktree-root relative file the signature lives in (or will live in). */
   file: z.string().min(1).describe(RepoRelativePathDescription),
+  /** Explicit exports that Tier 1 must verify. `name` remains descriptive. */
+  requiredExports: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        file: z.string().min(1).describe(RepoRelativePathDescription).optional(),
+      }),
+    )
+    .optional(),
   /** Optional `start-end` line range as a string, e.g. "12-34". */
   lineRange: optionalAiString,
 });

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -38,7 +38,7 @@ const {
     files: [],
     gitAvailable: true,
   }),
-  mockOrchestratorCommitAll: vi.fn().mockReturnValue('repair-sha'),
+  mockOrchestratorCommitAll: vi.fn().mockReturnValue({ status: 'committed', sha: 'repair-sha' }),
   mockOrchestratorPushBranch: vi.fn(),
 }));
 vi.mock('@goose-hub/core/agent-runtime/investigation-context.js', () => ({
@@ -177,8 +177,8 @@ function makeQaCompletedEvent(passed = false) {
               severity: 'error',
               description: 'capitalize("") returns undefined instead of ""',
               suggestion: 'Handle empty string input',
-              disposition: 'fix',
-              dispositionRef: 'must fix',
+              disposition: 'needs-fix',
+              dispositionRef: 'current PR',
             },
           ],
         },
@@ -198,7 +198,9 @@ describe('runFixFeedbackWorkflow', () => {
   beforeEach(() => {
     stateSource = makeStateSource();
     vi.clearAllMocks();
-    mockOrchestratorCommitAll.mockReset().mockReturnValue('repair-sha');
+    mockOrchestratorCommitAll
+      .mockReset()
+      .mockReturnValue({ status: 'committed', sha: 'repair-sha' });
     mockOrchestratorPushBranch.mockReset();
     mockDeriveObservedChangedFiles.mockReset().mockReturnValue({
       count: 0,
@@ -258,6 +260,47 @@ describe('runFixFeedbackWorkflow', () => {
 
     const runCall = mockClaudeCliRun.mock.calls[0][0];
     expect(runCall.context.advisorFeedback).toContain('capitalize("") returns undefined');
+  });
+
+  it('skips implement when latest QA failure has only non-actionable out-of-scope findings', async () => {
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        ...makeQaCompletedEvent(),
+        payload: {
+          verdict: 'fail',
+          overallScore: 85,
+          threshold: 70,
+          findings: [
+            {
+              tier: 'functional',
+              severity: 'error',
+              description: 'Pre-existing loading state issue',
+              disposition: 'out-of-scope',
+              dispositionRef: 'Not touched by this PR',
+            },
+          ],
+          tierResults: {
+            structural: { passed: true, findings: [] },
+            functional: { passed: true, findings: [] },
+            regression: { passed: true, findings: [] },
+          },
+        },
+      },
+    ]);
+    const workItem = makeWorkItem();
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo');
+
+    expect(mockClaudeCliRun).not.toHaveBeenCalled();
+    expect(stateSource.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-fix',
+      'factory:needs-review',
+    );
+    expect(vi.mocked(eventStore.appendEvent)).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.fix-feedback-skipped' }),
+    );
   });
 
   it('passes existing worktreePath as runtime workspaceDir', async () => {

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -16,6 +16,10 @@ import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-tra
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
+import {
+  actionableQaItemsToFeedback,
+  collectActionableQaItems,
+} from '@goose-hub/core/qa/actionability.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { deriveObservedChangedFiles } from '@goose-hub/core/workspaces/observed-changes.js';
 import {
@@ -156,6 +160,24 @@ type QaPayload = {
   verdict?: string;
   overallScore?: number;
   threshold?: number;
+  findings?: Array<{
+    tier?: string;
+    severity?: string;
+    description: string;
+    suggestion?: string;
+    disposition?: 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
+    dispositionRef?: string;
+  }>;
+  criteriaResults?: Array<{
+    criterionId: string;
+    checkId: string;
+    ac: string;
+    command: string;
+    passed: boolean;
+    exitCode?: number | null;
+    actual?: string;
+    error?: string;
+  }>;
   tierResults?: {
     structural?: TierResult;
     functional?: TierResult;
@@ -182,6 +204,7 @@ type SourceFailure = {
   kind: 'qa' | 'review';
   runId?: string;
   feedback: string;
+  actionable: boolean;
 };
 
 function compactPayload(payload: Record<string, unknown>): Record<string, unknown> {
@@ -227,9 +250,34 @@ function findPriorEvidenceSpecPath(events: ReturnType<typeof eventStore.replay>)
  * Skips QA passes so a qa-fail → fix → qa-pass → review-fail cycle correctly
  * surfaces the review findings rather than the superseded QA pass.
  */
-function findLatestSourceFailure(
+function localIssueRef(ref: string | undefined): string | null {
+  const match = ref?.trim().match(/^#?(\d+)$/);
+  return match?.[1] != null ? match[1] : null;
+}
+
+async function verifiedFollowUpRefsForPayload(
+  payload: QaPayload,
+  stateSource: StateSource,
+): Promise<Set<string>> {
+  const refs = new Set<string>();
+  for (const finding of payload.findings ?? []) {
+    if (finding.disposition !== 'follow-up') continue;
+    const localId = localIssueRef(finding.dispositionRef);
+    if (localId == null) continue;
+    try {
+      await stateSource.getItem(localId);
+      refs.add(`#${localId}`);
+    } catch {
+      // Keep invalid follow-up refs actionable.
+    }
+  }
+  return refs;
+}
+
+async function findLatestSourceFailure(
   events: ReturnType<typeof eventStore.replay>,
-): SourceFailure | null {
+  stateSource: StateSource,
+): Promise<SourceFailure | null> {
   let qaIdx = -1;
   let qaEvent: (typeof events)[number] | null = null;
   for (let i = events.length - 1; i >= 0; i--) {
@@ -259,29 +307,32 @@ function findLatestSourceFailure(
     for (const f of findings) {
       lines.push(`- [${f.severity}] ${f.description}`);
     }
-    return { kind: 'review', runId: sourceRunId(reviewEvent), feedback: lines.join('\n') };
+    return {
+      kind: 'review',
+      runId: sourceRunId(reviewEvent),
+      feedback: lines.join('\n'),
+      actionable: true,
+    };
   }
 
   if (qaEvent != null) {
     const payload = qaEvent.payload as QaPayload;
-    const { verdict = 'fail', overallScore = 0, threshold = 70, tierResults = {} } = payload;
-    const lines: string[] = [
-      `QA verdict: ${verdict} (score ${overallScore}/${threshold})`,
-      '',
-      'Findings to address:',
-    ];
-    for (const [tier, result] of Object.entries(tierResults) as [
-      string,
-      TierResult | undefined,
-    ][]) {
-      if (result == null || result.passed) continue;
-      for (const f of result.findings) {
-        lines.push(
-          `- [${tier}/${f.severity}] ${f.description}${f.suggestion ? ` — ${f.suggestion}` : ''}`,
-        );
-      }
-    }
-    return { kind: 'qa', runId: sourceRunId(qaEvent), feedback: lines.join('\n') };
+    const { verdict = 'fail', overallScore = 0, threshold = 70 } = payload;
+    const verifiedFollowUpRefs = await verifiedFollowUpRefsForPayload(payload, stateSource);
+    const actionableItems = collectActionableQaItems(payload, { verifiedFollowUpRefs });
+    return {
+      kind: 'qa',
+      runId: sourceRunId(qaEvent),
+      feedback:
+        actionableItems.length > 0
+          ? [
+              `QA verdict: ${verdict} (score ${overallScore}/${threshold})`,
+              '',
+              actionableQaItemsToFeedback(actionableItems),
+            ].join('\n')
+          : '',
+      actionable: actionableItems.length > 0,
+    };
   }
 
   return null;
@@ -317,7 +368,7 @@ export async function runFixFeedbackWorkflow(
   const attemptId = crypto.randomUUID();
   const events = eventStore.replay({ workItemId: workItem.id });
   const prLifecycle = findPrLifecycle(events);
-  const sourceFailure = findLatestSourceFailure(events);
+  const sourceFailure = await findLatestSourceFailure(events, stateSource);
   const repairCycle = nextRepairCycle(events);
   const repairPayload = compactPayload({
     pipelineRunId: prLifecycle?.pipelineRunId,
@@ -423,6 +474,39 @@ export async function runFixFeedbackWorkflow(
   const implementJsonSchema = toJsonSchema(ImplementSchema);
   const { personaId } = selectPersona(projectId, 'developer');
   const advisorFeedback = sourceFailure?.feedback ?? '';
+
+  if (sourceFailure?.kind === 'qa' && !sourceFailure.actionable) {
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Dev',
+        'Complete',
+        'No actionable QA findings remain — skipping fix-feedback and transitioning to needs-review',
+      ),
+    );
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-fix',
+      'factory:needs-review',
+    );
+    emitStateTransitionEvent({
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:needs-fix',
+      to: 'factory:needs-review',
+      by: 'fix-feedback',
+      runId,
+      extraPayload: repairPayload,
+    });
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.fix-feedback-skipped',
+      payload: { ...repairPayload, reason: 'no-actionable-qa-findings' },
+      runId,
+    });
+    return;
+  }
 
   const priorInvestigation = latestInvestigationContext({
     projectId,
@@ -542,10 +626,46 @@ export async function runFixFeedbackWorkflow(
     });
 
     const observedChangedFiles = deriveObservedChangedFiles(worktreePath);
-    const commitSha = commitAllFn(
+    const commitResult = commitAllFn(
       worktreePath,
       `fix(#${workItem.externalId}): address feedback cycle ${repairCycle}`,
     );
+    if (commitResult.status === 'no-changes') {
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-failed',
+        payload: {
+          runId,
+          error: 'fix-feedback: implement produced no commit changes',
+          ...repairPayload,
+        },
+        runId,
+      });
+      await stateSource.comment(
+        workItem.externalId,
+        buildAgentComment(
+          'Dev',
+          'Failed',
+          'Fix-feedback produced no changes — escalating to needs-human',
+        ),
+      );
+      await stateSource.transitionState(
+        workItem.externalId,
+        'factory:in-progress',
+        'factory:needs-human',
+      );
+      emitStateTransitionEvent({
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:in-progress',
+        to: 'factory:needs-human',
+        by: 'fix-feedback',
+        runId,
+        extraPayload: repairPayload,
+      });
+      return;
+    }
     pushBranchFn(worktreePath, branch);
 
     reconcileDecisionSummaries(
@@ -562,7 +682,7 @@ export async function runFixFeedbackWorkflow(
       kind: 'agent.fix-feedback-complete',
       payload: {
         ...repairPayload,
-        commitSha,
+        commitSha: commitResult.sha,
         filesWritten: implementOutput.filesWritten.length,
         testsWritten: implementOutput.testsWritten.length,
         confidence: implementOutput.confidence,

--- a/slices/fix-issue/chore-shipping.test.ts
+++ b/slices/fix-issue/chore-shipping.test.ts
@@ -45,7 +45,7 @@ vi.mock('@goose-hub/core/persona/accumulate.js', () => ({
   accumulatePersonaStats: vi.fn(),
 }));
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
-  orchestratorCommitAll: vi.fn().mockReturnValue('fake-sha'),
+  orchestratorCommitAll: vi.fn().mockReturnValue({ status: 'committed', sha: 'fake-sha' }),
 }));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -801,10 +801,13 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
   // Orchestrator commits the builder's work before opening the PR (ADR 0031).
   // The implement skill writes files but no longer commits; this call stages
   // all changes and creates a single commit attributed to the workflow run.
-  input.orchestratorCommitFn(
+  const commitResult = input.orchestratorCommitFn(
     worktreePath,
     `fix(#${workItem.externalId}): ${workItem.title.slice(0, 60)}`,
   );
+  if (commitResult.status === 'no-changes') {
+    throw new Error('implement produced no commit changes');
+  }
 
   // Emit implement decision summaries (#206 pattern).
   reconcileDecisionSummaries(

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -92,7 +92,7 @@ vi.mock('@goose-hub/core/workspaces/workflow-base.js', () => ({
   resolveWorkflowBaseForWorkItem: (...args: unknown[]) => mockResolveWorkflowBase(...args),
 }));
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
-  orchestratorCommitAll: vi.fn().mockReturnValue('fake-sha'),
+  orchestratorCommitAll: vi.fn().mockReturnValue({ status: 'committed', sha: 'fake-sha' }),
 }));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1408,9 +1408,7 @@ describe('parallel-implement durable integration branch persistence', () => {
     });
 
     expect(result.status).toBe('built');
-    expect(events.some((event) => event.kind === 'parallel-implement.wp-loop-cap-hit')).toBe(
-      false,
-    );
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-loop-cap-hit')).toBe(false);
     expect(revertWpChangesFn).not.toHaveBeenCalled();
   });
 
@@ -1564,7 +1562,7 @@ describe('parallel-implement durable integration branch persistence', () => {
         runDevReviewResponseImpl: async () => responseOutput,
         commitDevReviewResponseImpl: () => {
           operations.push('commit-dev-review');
-          return 'sha-dev-review';
+          return { status: 'committed', sha: 'sha-dev-review' };
         },
         createIntegrationWorktreeImpl: () => ({
           worktreePath: '/tmp/issue-wt',
@@ -3199,7 +3197,7 @@ describe('dev-review e2e: maxRevisionTurns=2 → 2 Codex dev-review passes', () 
         },
         commitDevReviewResponseImpl: (_wt, msg) => {
           commitMessages.push(msg);
-          return 'sha-commit';
+          return { status: 'committed', sha: 'sha-commit' };
         },
         createIssueWorktreeImpl: () => '/tmp/issue-wt',
         createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
@@ -3554,7 +3552,7 @@ describe('dev-review cost telemetry: multi-turn produces multiple dev-review.com
             decisionSummaries: [],
           };
         },
-        commitDevReviewResponseImpl: () => 'sha-x',
+        commitDevReviewResponseImpl: () => ({ status: 'committed', sha: 'sha-x' }),
         createIssueWorktreeImpl: () => '/tmp/issue-wt',
         createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
         cleanupWpWorktreesImpl: () => undefined,

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -107,7 +107,7 @@ export interface ParallelImplementDeps {
   /** Override runDevReviewResponse for testing (avoids hitting DB/FS/Claude). */
   runDevReviewResponseImpl?: typeof runDevReviewResponse;
   /** Override the orchestrator commit-all for dev-review-response edits (for testing). */
-  commitDevReviewResponseImpl?: (worktreePath: string, msg: string) => string;
+  commitDevReviewResponseImpl?: typeof orchestratorCommitAll;
   /** Override persona selection for tests that should not touch SQLite routing state. */
   selectPersonaImpl?: typeof selectPersona;
   /** Override observed changed-file derivation for tests. */
@@ -1300,11 +1300,13 @@ export async function runParallelImplementWorkflow(
               appendEvent: append,
             });
             // Commit response edits so the next iteration's Codex diff is current.
-            // orchestratorCommitAll uses --allow-empty, so no-ops when nothing changed.
-            devReviewResponseCommitSha = commitDevReviewFn(
+            const devReviewCommitResult = commitDevReviewFn(
               issueWorktreePath,
               `chore: dev-review-response turn-${turns} addressing/dismissing findings`,
             );
+            if (devReviewCommitResult.status === 'committed') {
+              devReviewResponseCommitSha = devReviewCommitResult.sha;
+            }
             turns++;
           }
         } catch (devReviewErr) {

--- a/slices/qa/deterministic-tiers.ts
+++ b/slices/qa/deterministic-tiers.ts
@@ -20,6 +20,9 @@ export interface VerifyCommand {
     mode: 'exact' | 'contains' | 'regex';
     value: string;
   };
+  evidenceExpectation?:
+    | { type: 'exit-code' }
+    | { type: 'vitest-json'; suite?: string; testName?: string; expectedStatus: 'passed' };
   timeoutMs?: number;
 }
 

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -943,6 +943,30 @@ describe('runQaWorkflow', () => {
         'factory:needs-review',
       );
     });
+
+    it('keeps fail verdicts without non-blocking findings in factory:qa-failed', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce({
+        ...makePassResult(),
+        output: {
+          ...(makePassResult().output as Record<string, unknown>),
+          verdict: 'fail',
+          overallScore: 20,
+          threshold: 70,
+          findings: [],
+        },
+      });
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:qa-failed',
+      );
+    });
   });
 
   describe('error path', () => {
@@ -1385,7 +1409,7 @@ describe('runQaWorkflow', () => {
       });
     });
 
-    it('matches executable check output expectations against full output while storing a bounded tail', async () => {
+    it('preserves deprecated output expectations without enforcing them', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();
       const worktree = mkdtempSync(join(tmpdir(), 'qa-executable-checks-output-'));
@@ -1427,6 +1451,84 @@ describe('runQaWorkflow', () => {
         expect(result?.passed).toBe(true);
         expect(result?.actual).toHaveLength(4000);
         expect(result?.actual).not.toContain('needle');
+      } finally {
+        rmSync(worktree, { recursive: true, force: true });
+      }
+    });
+
+    it('fails suite-only Vitest evidence checks when the matched suite did not pass', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      const worktree = mkdtempSync(join(tmpdir(), 'qa-executable-checks-vitest-'));
+      const report = {
+        numTotalTests: 1,
+        numPassedTests: 0,
+        numFailedTests: 1,
+        success: false,
+        testResults: [
+          {
+            name: 'src/failing.test.ts',
+            status: 'failed',
+            assertionResults: [{ title: 'breaks', status: 'failed', duration: 1 }],
+          },
+        ],
+      };
+      mockReplay.mockReturnValue([
+        {
+          id: 1,
+          kind: 'pr.opened',
+          payload: {
+            worktreePath: worktree,
+            pipelineRunId: 'pipeline-run-vitest-evidence',
+          },
+          createdAt: '',
+        },
+      ]);
+      mockRun.mockResolvedValueOnce(makePassResult());
+
+      try {
+        const { runQaWorkflow } = await import('./workflow.js');
+        const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+        await runQaWorkflow(item, source, 'test-project', 'owner/repo', {
+          executableChecks: [
+            {
+              criterionId: 'AC-1',
+              checkId: 'AC-1-check-1',
+              ac: 'Vitest suite must pass',
+              command: `node -e 'process.stdout.write(${JSON.stringify(JSON.stringify(report))})'`,
+              expectedExitCodes: [0],
+              evidenceExpectation: {
+                type: 'vitest-json',
+                suite: 'failing.test.ts',
+                expectedStatus: 'passed',
+              },
+            },
+          ],
+        });
+
+        const completed = vi
+          .mocked(eventStore.appendEvent)
+          .mock.calls.find(([event]) => event.kind === 'qa.completed');
+        const result = (
+          completed?.[0].payload as {
+            criteriaResults?: Array<{
+              passed: boolean;
+              evidenceArtifact?: { artifactStatus: string; matchedSuites: string[] };
+            }>;
+          }
+        ).criteriaResults?.[0];
+        expect(result).toMatchObject({
+          passed: false,
+          evidenceArtifact: {
+            artifactStatus: 'not-found',
+            matchedSuites: ['failing.test.ts'],
+          },
+        });
+        expect(source.transitionState).toHaveBeenCalledWith(
+          '42',
+          'factory:needs-qa',
+          'factory:qa-failed',
+        );
       } finally {
         rmSync(worktree, { recursive: true, force: true });
       }

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -154,8 +154,8 @@ function makeFailResult(): AgentResult {
               tier: 'structural',
               severity: 'error',
               description: 'lint error',
-              disposition: 'fixed',
-              dispositionRef: 'abc1234',
+              disposition: 'needs-fix',
+              dispositionRef: 'current PR',
             },
           ],
         },
@@ -912,6 +912,36 @@ describe('runQaWorkflow', () => {
         outcome: 'failure',
         qualityScore: expect.any(Number),
       });
+    });
+
+    it('routes fail verdict with only out-of-scope findings to factory:needs-review', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      mockRun.mockResolvedValueOnce({
+        ...makePassResult(),
+        output: {
+          ...(makePassResult().output as Record<string, unknown>),
+          verdict: 'fail',
+          findings: [
+            {
+              tier: 'functional',
+              severity: 'error',
+              description: 'Pre-existing visual issue',
+              disposition: 'out-of-scope',
+              dispositionRef: 'Not touched by this issue',
+            },
+          ],
+        },
+      });
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '42',
+        'factory:needs-qa',
+        'factory:needs-review',
+      );
     });
   });
 
@@ -2560,10 +2590,9 @@ describe('runQaWorkflow', () => {
       expect(parsed.success).toBe(true);
       expect(synthetic.verdict).toBe('fail');
       expect(synthetic.overallScore).toBe(0);
-      // Synthetic error finding carries a registered disposition so it passes
-      // QA schema validation under fix-or-register (#468).
+      // Synthetic error finding carries needs-fix so fix-feedback can repair it.
       const errorFinding = synthetic.findings.find((f) => f.severity === 'error');
-      expect(errorFinding?.disposition).toBe('registered');
+      expect(errorFinding?.disposition).toBe('needs-fix');
       expect(errorFinding?.dispositionRef).toBe('deterministic-verification');
     });
 

--- a/slices/qa/synthetic-output.ts
+++ b/slices/qa/synthetic-output.ts
@@ -34,13 +34,13 @@ function mapVerifyFinding(tier: 1 | 2 | 3, vf: VerifyTierResult['findings'][numb
     description: vf.message,
     ...(vf.file != null ? { file: vf.file } : {}),
     ...(vf.line != null ? { line: vf.line } : {}),
-    // Required when severity === 'error' (#468 fix-or-register). The
+    // Required when severity === 'error' (#468 finding disposition). The
     // deterministic verifier IS the disposition for synthetic findings:
     // the failure is recorded, the agent is intentionally skipped, and the
     // retry-counter routes to fix-feedback (which gets the chance to fix it).
     ...(vf.severity === 'error'
       ? {
-          disposition: 'registered' as const,
+          disposition: 'needs-fix' as const,
           dispositionRef: 'deterministic-verification',
         }
       : {}),

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -98,6 +98,32 @@ async function verifiedFollowUpRefsForQaOutput(
   return refs;
 }
 
+function isVerifiedFollowUp(
+  finding: QaOutput['findings'][number],
+  verifiedRefs: ReadonlySet<string>,
+) {
+  const localId = localIssueRef(finding.dispositionRef);
+  return localId != null && verifiedRefs.has(`#${localId}`);
+}
+
+function isNonBlockingQaFinding(
+  finding: QaOutput['findings'][number],
+  verifiedFollowUpRefs: ReadonlySet<string>,
+): boolean {
+  if (finding.disposition === 'out-of-scope' || finding.disposition === 'fixed') return true;
+  return finding.disposition === 'follow-up' && isVerifiedFollowUp(finding, verifiedFollowUpRefs);
+}
+
+function failVerdictHasOnlyNonBlockingFindings(
+  qaOutput: QaOutput,
+  verifiedFollowUpRefs: ReadonlySet<string>,
+): boolean {
+  return (
+    qaOutput.findings.length > 0 &&
+    qaOutput.findings.every((finding) => isNonBlockingQaFinding(finding, verifiedFollowUpRefs))
+  );
+}
+
 function classifyVerificationInfrastructureFailure(
   result: TierResult | null,
 ): { reason: string; findings: string[] } | null {
@@ -163,6 +189,12 @@ function vitestEvidenceArtifact(
           );
     const suiteMatched = expectation.suite == null || suites.length > 0;
     const testMatched = expectation.testName == null || matchedTests.length > 0;
+    const suiteStatusMatched =
+      expectation.testName != null
+        ? true
+        : expectation.suite == null
+          ? testRun.success
+          : suites.some((suite) => suite.status === expectation.expectedStatus);
     return {
       type: 'vitest-json',
       summary: {
@@ -173,7 +205,7 @@ function vitestEvidenceArtifact(
       },
       matchedSuites: suites.map((suite) => suite.name),
       matchedTests,
-      artifactStatus: suiteMatched && testMatched ? 'matched' : 'not-found',
+      artifactStatus: suiteMatched && testMatched && suiteStatusMatched ? 'matched' : 'not-found',
     };
   } catch {
     return {
@@ -803,7 +835,8 @@ export async function runQaWorkflow(
     const passes =
       actionableQaItems.length === 0 &&
       (verdict === 'pass' ||
-        verdict === 'fail' ||
+        (verdict === 'fail' &&
+          failVerdictHasOnlyNonBlockingFindings(qaOutput, verifiedFollowUpRefs)) ||
         (verdict === 'partial' && qaOutput.overallScore >= qaOutput.threshold));
 
     let nextState: StateName;

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -19,9 +19,11 @@ import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-tra
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
+import { collectActionableQaItems } from '@goose-hub/core/qa/actionability.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { parseVitestJson } from '@goose-hub/core/test-runner/parse-vitest-json.js';
 import type { RegressionPolicy, TierResult } from '@goose-hub/core/verify/tiers.js';
 import { runTier as defaultRunTier } from '@goose-hub/core/verify/tiers.js';
 import {
@@ -72,6 +74,30 @@ export interface QaWorkflowDeps {
 const DEFAULT_TEST_COMMAND = 'pnpm test --reporter=json';
 const EXECUTABLE_CHECK_OUTPUT_LIMIT = 4_000;
 
+function localIssueRef(ref: string | undefined): string | null {
+  const match = ref?.trim().match(/^#?(\d+)$/);
+  return match?.[1] != null ? match[1] : null;
+}
+
+async function verifiedFollowUpRefsForQaOutput(
+  qaOutput: QaOutput,
+  stateSource: StateSource,
+): Promise<Set<string>> {
+  const refs = new Set<string>();
+  for (const finding of qaOutput.findings) {
+    if (finding.disposition !== 'follow-up') continue;
+    const localId = localIssueRef(finding.dispositionRef);
+    if (localId == null) continue;
+    try {
+      await stateSource.getItem(localId);
+      refs.add(`#${localId}`);
+    } catch {
+      // Invalid follow-up refs remain unverified and become actionable.
+    }
+  }
+  return refs;
+}
+
 function classifyVerificationInfrastructureFailure(
   result: TierResult | null,
 ): { reason: string; findings: string[] } | null {
@@ -98,19 +124,79 @@ function classifyVerificationInfrastructureFailure(
   };
 }
 
-function matchesOutputExpectation(
-  actual: string,
-  expectation: VerifyCommand['outputExpectation'],
-): boolean {
-  if (expectation == null) return true;
-  const trimmed = actual.trim();
-  if (expectation.mode === 'exact') return trimmed === expectation.value.trim();
-  if (expectation.mode === 'contains') return actual.includes(expectation.value);
+type CriteriaEvidenceArtifact = NonNullable<CriteriaResult['evidenceArtifact']>;
+
+function processEvidenceArtifact(): CriteriaEvidenceArtifact {
+  return {
+    type: 'process',
+    summary: { total: 0, passed: 0, failed: 0, skipped: 0 },
+    matchedSuites: [],
+    matchedTests: [],
+    artifactStatus: 'unavailable',
+  };
+}
+
+function vitestEvidenceArtifact(
+  rawOutput: string,
+  expectation: Extract<VerifyCommand['evidenceExpectation'], { type: 'vitest-json' }>,
+): CriteriaEvidenceArtifact {
   try {
-    return new RegExp(expectation.value).test(actual);
+    const testRun = parseVitestJson(JSON.parse(rawOutput.trim()));
+    const suites =
+      expectation.suite == null
+        ? testRun.suites
+        : testRun.suites.filter(
+            (suite) =>
+              suite.name === expectation.suite ||
+              suite.filePath.endsWith(expectation.suite ?? '__never__'),
+          );
+    const matchedTests =
+      expectation.testName == null
+        ? []
+        : suites.flatMap((suite) =>
+            (suite.tests ?? [])
+              .filter(
+                (test) =>
+                  test.name === expectation.testName && test.status === expectation.expectedStatus,
+              )
+              .map((test) => test.name),
+          );
+    const suiteMatched = expectation.suite == null || suites.length > 0;
+    const testMatched = expectation.testName == null || matchedTests.length > 0;
+    return {
+      type: 'vitest-json',
+      summary: {
+        total: testRun.total,
+        passed: testRun.passed,
+        failed: testRun.failed,
+        skipped: testRun.skipped,
+      },
+      matchedSuites: suites.map((suite) => suite.name),
+      matchedTests,
+      artifactStatus: suiteMatched && testMatched ? 'matched' : 'not-found',
+    };
   } catch {
-    return false;
+    return {
+      type: 'vitest-json',
+      summary: { total: 0, passed: 0, failed: 0, skipped: 0 },
+      matchedSuites: [],
+      matchedTests: [],
+      artifactStatus: 'unavailable',
+    };
   }
+}
+
+function evidenceArtifactFor(
+  actual: string,
+  expectation: VerifyCommand['evidenceExpectation'],
+): CriteriaEvidenceArtifact {
+  if (expectation?.type === 'vitest-json') return vitestEvidenceArtifact(actual, expectation);
+  return processEvidenceArtifact();
+}
+
+function evidenceExpectationPassed(artifact: CriteriaEvidenceArtifact): boolean {
+  if (artifact.type === 'vitest-json') return artifact.artifactStatus === 'matched';
+  return true;
 }
 
 async function runExecutableCheck(input: {
@@ -153,6 +239,7 @@ async function runExecutableCheck(input: {
         exitCode: null,
         actual: actualOutput(),
         passed: false,
+        evidenceArtifact: processEvidenceArtifact(),
         ...(input.check.outputExpectation != null
           ? { outputExpectation: input.check.outputExpectation }
           : {}),
@@ -175,6 +262,7 @@ async function runExecutableCheck(input: {
         exitCode: null,
         actual: actualOutput(),
         passed: false,
+        evidenceArtifact: processEvidenceArtifact(),
         ...(input.check.outputExpectation != null
           ? { outputExpectation: input.check.outputExpectation }
           : {}),
@@ -183,6 +271,8 @@ async function runExecutableCheck(input: {
     });
     child.on('close', (code) => {
       const exitCode = code ?? 1;
+      const evidenceArtifact = evidenceArtifactFor(fullOutput, input.check.evidenceExpectation);
+      const exitCodePassed = expectedExitCodes.includes(exitCode);
       finish({
         criterionId: input.check.criterionId,
         checkId: input.check.checkId,
@@ -191,12 +281,14 @@ async function runExecutableCheck(input: {
         expectedExitCodes,
         exitCode,
         actual: actualOutput(),
-        passed:
-          expectedExitCodes.includes(exitCode) &&
-          matchesOutputExpectation(fullOutput, input.check.outputExpectation),
+        passed: exitCodePassed && evidenceExpectationPassed(evidenceArtifact),
         ...(input.check.outputExpectation != null
           ? { outputExpectation: input.check.outputExpectation }
           : {}),
+        ...(input.check.evidenceExpectation != null
+          ? { evidenceExpectation: input.check.evidenceExpectation }
+          : {}),
+        evidenceArtifact,
       });
     });
   });
@@ -219,6 +311,7 @@ async function runExecutableChecks(input: {
       exitCode: null,
       actual: '',
       passed: false,
+      evidenceArtifact: processEvidenceArtifact(),
       ...(check.outputExpectation != null ? { outputExpectation: check.outputExpectation } : {}),
       error: 'workspaceDir unavailable; executable check was not run',
     }));
@@ -655,6 +748,15 @@ export async function runQaWorkflow(
     const executableChecksPassed =
       criteriaResults.length === 0 || criteriaResults.every((result) => result.passed);
     const verdict = executableChecksPassed ? qaOutput.verdict : 'fail';
+    const verifiedFollowUpRefs = await verifiedFollowUpRefsForQaOutput(qaOutput, stateSource);
+    const actionableQaItems = collectActionableQaItems(
+      {
+        findings: qaOutput.findings,
+        criteriaResults,
+        tierResults: groundTruthTierResults,
+      },
+      { verifiedFollowUpRefs },
+    );
 
     eventStore.appendEvent({
       projectId: projectSlug,
@@ -699,7 +801,10 @@ export async function runQaWorkflow(
     // Determine next state. Use priorEvents (snapshotted before this run) so the
     // retry count reflects completed prior failures, not the current one.
     const passes =
-      verdict === 'pass' || (verdict === 'partial' && qaOutput.overallScore >= qaOutput.threshold);
+      actionableQaItems.length === 0 &&
+      (verdict === 'pass' ||
+        verdict === 'fail' ||
+        (verdict === 'partial' && qaOutput.overallScore >= qaOutput.threshold));
 
     let nextState: StateName;
     if (passes) {

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -110,7 +110,7 @@ function makeNeedsFixResult(): AgentResult {
         {
           severity: 'blocker',
           description: 'not implemented',
-          disposition: 'registered',
+          disposition: 'needs-fix',
           dispositionRef: '#999',
         },
       ],
@@ -288,13 +288,13 @@ describe('runReviewWorkflow', () => {
             {
               severity: 'blocker',
               description: 'issue 1',
-              disposition: 'registered',
+              disposition: 'needs-fix',
               dispositionRef: '#1',
             },
             {
               severity: 'blocker',
               description: 'issue 2',
-              disposition: 'registered',
+              disposition: 'needs-fix',
               dispositionRef: '#2',
             },
             { severity: 'major', description: 'issue 3' },
@@ -689,7 +689,7 @@ function makeCriticalResult(description: string): AgentResult {
           description,
           file: 'src/foo.ts',
           line: 1,
-          disposition: 'registered',
+          disposition: 'needs-fix',
           dispositionRef: '#999',
         },
       ],


### PR DESCRIPTION
## Summary
- replace overloaded finding dispositions with explicit needs-fix/out-of-scope/follow-up/fixed routing
- route QA and fix-feedback from actionable findings and structured executable evidence
- add requiredExports enforcement, no-empty-commit handling, and QA tab evidence rendering

## Verification
- pnpm test skills/qa skills/review slices/qa/slice.test.ts slices/fix-feedback/slice.test.ts slices/review/slice.test.ts core/qa core/verify core/workspaces core/test-runner
- pnpm test apps/web/src/components/detail/components/QASection.test.tsx apps/web/src/components/detail/components/ReviewSection.test.tsx apps/web/src/components/detail/components/SpecDetails.test.tsx apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/TimelineSection.test.ts
- pnpm typecheck
- pnpm exec biome check .
- git diff --check

Full pnpm test was run and still fails on existing baseline dogfood/logger issues: dogfood.seed-applied timeline classification, logger-001 seed already applied, and apps/web/src/lib/logger.ts not passing meta.