### PR TITLE
Add timeline cards for WS observability events

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -54,6 +54,7 @@ import {
   CompactOperationalEvent,
   ContractDriftEvent,
   DiscoveryBudgetExceededEvent,
+  DogfoodSeedAppliedEvent,
   FallbackEvent,
   InvestigationContextInjectedEvent,
   InvestigationDigestAppliedEvent,
@@ -73,6 +74,7 @@ import {
   ParallelIterationStartedEvent,
   ParallelWpCommittedEvent,
   ParallelWpFailedEvent,
+  ParallelWpPersistedEvent,
   ParallelWpStartedEvent,
   ParallelWpTimeoutEvent,
   SpecCompletedEvent,
@@ -220,6 +222,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
   const { event } = item;
 
   switch (event.kind) {
+    case 'dogfood.seed-applied':
+      return <DogfoodSeedAppliedEvent key={event.id} event={event} />;
     case 'agent.model-selected':
       return <AgentModelSelectedEvent key={event.id} event={event} />;
     case 'agent.budget-exceeded':
@@ -417,6 +421,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <ParallelWpStartedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-committed':
       return <ParallelWpCommittedEvent key={event.id} event={event} />;
+    case 'parallel-implement.wp-persisted':
+      return <ParallelWpPersistedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-failed':
     case 'parallel-implement.wp-loop-cap-hit':
     case 'parallel-implement.wp-commit-failed':

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -27,6 +27,28 @@ function withRawProbe(payload: unknown): unknown {
 }
 
 describe('Misc timeline events', () => {
+  it('renders dogfood.seed-applied as base metadata instead of raw JSON', () => {
+    const event = makeEvent('dogfood.seed-applied', {
+      seedId: 'seed-issue-1061',
+      baseBranch: 'main',
+      seedCommit: 'df129a7113e7344f045166b5e5dc0b7214632c8d',
+      truthSignal: 'green',
+      rawProbeKey: 'raw-value',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Dogfood seed applied')).toBeTruthy();
+    const rendered = document.body.textContent ?? '';
+    expect(rendered).toContain('seed-issue-1061');
+    expect(rendered).toContain('main');
+    expect(rendered).toContain('df129a71');
+    expect(rendered).toContain('truth green');
+    expect(rendered).not.toContain('"seedCommit"');
+    expect(rendered).not.toContain('rawProbeKey');
+    expect(rendered).not.toContain('raw-value');
+  });
+
   it('renders agent.budget-exceeded as summary text instead of raw JSON', () => {
     const event = makeEvent('agent.budget-exceeded', {
       runId: 'e3bb94b3-4bf6-4c93-9407-9a2dc30c760d',

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -32,7 +32,10 @@ describe('Misc timeline events', () => {
       seedId: 'seed-issue-1061',
       baseBranch: 'main',
       seedCommit: 'df129a7113e7344f045166b5e5dc0b7214632c8d',
-      truthSignal: 'green',
+      truthSignal: {
+        testFile: 'apps/web/src/lib/logger.test.ts',
+        testName: 'drops metadata from browser logs',
+      },
       rawProbeKey: 'raw-value',
     });
 
@@ -43,8 +46,10 @@ describe('Misc timeline events', () => {
     expect(rendered).toContain('seed-issue-1061');
     expect(rendered).toContain('main');
     expect(rendered).toContain('df129a71');
-    expect(rendered).toContain('truth green');
+    expect(rendered).toContain('truth drops metadata from browser logs');
+    expect(rendered).toContain('apps/web/src/lib/logger.test.ts');
     expect(rendered).not.toContain('"seedCommit"');
+    expect(rendered).not.toContain('[object Object]');
     expect(rendered).not.toContain('rawProbeKey');
     expect(rendered).not.toContain('raw-value');
   });

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardCheck,
   Cpu,
   FileStack,
+  GitBranch,
   Info,
   Network,
   Route,
@@ -161,6 +162,13 @@ type AcceptanceContractPayload = {
   };
 };
 
+type DogfoodSeedAppliedPayload = {
+  seedId?: string;
+  baseBranch?: string;
+  seedCommit?: string;
+  truthSignal?: string | boolean | number;
+};
+
 function formatShortId(value: string | undefined): string | null {
   if (value == null || value.length === 0) return null;
   return value.length <= 12 ? value : value.slice(0, 8);
@@ -285,6 +293,31 @@ export function SystemNoteEvent({ event }: { event: AgentEventDto }) {
         <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
       </div>
       <div className="text-[12.5px] text-fg-2">{getPayloadStr(event.payload)}</div>
+    </li>
+  );
+}
+
+export function DogfoodSeedAppliedEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as DogfoodSeedAppliedPayload | null;
+  const shortSeedCommit = formatShortId(p?.seedCommit);
+
+  return (
+    <li
+      data-event-kind={event.kind}
+      className="rounded-md border border-line bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-1 text-[11px] text-fg-3">
+        <GitBranch size={13} className="shrink-0 text-[color:var(--accent)]" />
+        <span className="font-mono uppercase tracking-wider">Dogfood seed applied</span>
+        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12.5px] text-fg-2">
+        {p?.seedId != null && <span className="font-mono">{p.seedId}</span>}
+        {p?.baseBranch != null && <span>{p.baseBranch}</span>}
+        {shortSeedCommit != null && <span className="font-mono">{shortSeedCommit}</span>}
+        {p?.truthSignal != null && <span>truth {String(p.truthSignal)}</span>}
+      </div>
     </li>
   );
 }

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -166,7 +166,14 @@ type DogfoodSeedAppliedPayload = {
   seedId?: string;
   baseBranch?: string;
   seedCommit?: string;
-  truthSignal?: string | boolean | number;
+  truthSignal?:
+    | string
+    | boolean
+    | number
+    | {
+        testFile?: string;
+        testName?: string;
+      };
 };
 
 function formatShortId(value: string | undefined): string | null {
@@ -204,6 +211,17 @@ function payloadString(payload: CompactOperationalPayload | null, key: string): 
 function payloadNumber(payload: CompactOperationalPayload | null, key: string): number | null {
   const value = payload?.[key];
   return typeof value === 'number' ? value : null;
+}
+
+function formatTruthSignal(value: DogfoodSeedAppliedPayload['truthSignal']): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  const parts = [value.testName, value.testFile].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0,
+  );
+  return parts.length > 0 ? parts.join(' · ') : null;
 }
 
 function factoryResourceFromStderr(stderr: string | null): string | null {
@@ -300,6 +318,7 @@ export function SystemNoteEvent({ event }: { event: AgentEventDto }) {
 export function DogfoodSeedAppliedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as DogfoodSeedAppliedPayload | null;
   const shortSeedCommit = formatShortId(p?.seedCommit);
+  const truthSignal = formatTruthSignal(p?.truthSignal);
 
   return (
     <li
@@ -316,7 +335,7 @@ export function DogfoodSeedAppliedEvent({ event }: { event: AgentEventDto }) {
         {p?.seedId != null && <span className="font-mono">{p.seedId}</span>}
         {p?.baseBranch != null && <span>{p.baseBranch}</span>}
         {shortSeedCommit != null && <span className="font-mono">{shortSeedCommit}</span>}
-        {p?.truthSignal != null && <span>truth {String(p.truthSignal)}</span>}
+        {truthSignal != null && <span>truth {truthSignal}</span>}
       </div>
     </li>
   );

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
@@ -132,7 +132,7 @@ describe('ParallelImplementEvents', () => {
       wpId: 'WP2',
       pushedSha: 'f88f39a1080dc0ddc84c6e3bc9996ce1d9893368',
       integrationBranch: 'factory/run/805e37ae-2c79-40ef-b017-07b82dafbd09',
-      filesPersisted: 4,
+      filesPersisted: ['apps/web/src/Button.tsx', 'apps/web/src/Button.test.tsx'],
       persistMode: 'direct-integration-commit',
       pipelineRunId: '805e37ae-2c79-40ef-b017-07b82dafbd09',
       rawProbeKey: 'raw-value',
@@ -144,7 +144,7 @@ describe('ParallelImplementEvents', () => {
     const rendered = document.body.textContent ?? '';
     expect(rendered).toContain('f88f39a1');
     expect(rendered).toContain('factory/run/805e37ae-2c79-40ef-b017-07b82dafbd09');
-    expect(rendered).toContain('4 files persisted');
+    expect(rendered).toContain('2 files persisted');
     expect(rendered).toContain('direct-integration-commit');
     expect(rendered).not.toContain('"pushedSha"');
     expect(rendered).not.toContain('rawProbeKey');

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
@@ -2,6 +2,7 @@ import type { AgentEventDto } from '@/lib/types';
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { renderTimelineItem } from '../TimelineEvents';
 import {
   ParallelIterationStartedEvent,
   ParallelWpCommittedEvent,
@@ -124,5 +125,29 @@ describe('ParallelImplementEvents', () => {
     expect(screen.getByText('WP1 committed')).toBeTruthy();
     expect(screen.getByText('00bff479')).toBeTruthy();
     expect(document.body.textContent).not.toContain('"commitSha"');
+  });
+
+  it('renders wp-persisted with durability metadata instead of raw JSON', () => {
+    const event = makeEvent('parallel-implement.wp-persisted', {
+      wpId: 'WP2',
+      pushedSha: 'f88f39a1080dc0ddc84c6e3bc9996ce1d9893368',
+      integrationBranch: 'factory/run/805e37ae-2c79-40ef-b017-07b82dafbd09',
+      filesPersisted: 4,
+      persistMode: 'direct-integration-commit',
+      pipelineRunId: '805e37ae-2c79-40ef-b017-07b82dafbd09',
+      rawProbeKey: 'raw-value',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('WP2 persisted')).toBeTruthy();
+    const rendered = document.body.textContent ?? '';
+    expect(rendered).toContain('f88f39a1');
+    expect(rendered).toContain('factory/run/805e37ae-2c79-40ef-b017-07b82dafbd09');
+    expect(rendered).toContain('4 files persisted');
+    expect(rendered).toContain('direct-integration-commit');
+    expect(rendered).not.toContain('"pushedSha"');
+    expect(rendered).not.toContain('rawProbeKey');
+    expect(rendered).not.toContain('raw-value');
   });
 });

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
@@ -17,7 +17,7 @@ type ParallelPayload = {
   commitSha?: string;
   pushedSha?: string;
   integrationBranch?: string;
-  filesPersisted?: number;
+  filesPersisted?: string[] | number;
   persistMode?: string;
   pipelineRunId?: string;
   wpCount?: number;
@@ -53,6 +53,12 @@ function formatElapsed(ms: number | undefined): string | null {
   const seconds = Math.round(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function formatFilesPersisted(value: string[] | number | undefined): string | null {
+  const count = Array.isArray(value) ? value.length : value;
+  if (typeof count !== 'number') return null;
+  return `${count} file${count === 1 ? '' : 's'} persisted`;
 }
 
 function PipelineChip({ pipelineRunId }: { pipelineRunId?: string }) {
@@ -246,6 +252,7 @@ export function ParallelWpCommittedEvent({ event }: { event: AgentEventDto }) {
 export function ParallelWpPersistedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as ParallelPayload | null;
   const shortSha = formatShortId(p?.pushedSha);
+  const filesPersisted = formatFilesPersisted(p?.filesPersisted);
 
   return (
     <ParallelEventShell
@@ -257,11 +264,7 @@ export function ParallelWpPersistedEvent({ event }: { event: AgentEventDto }) {
       <div className="space-y-1">
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
           {shortSha != null && <span className="font-mono text-fg-2">{shortSha}</span>}
-          {typeof p?.filesPersisted === 'number' && (
-            <span>
-              {p.filesPersisted} file{p.filesPersisted === 1 ? '' : 's'} persisted
-            </span>
-          )}
+          {filesPersisted != null && <span>{filesPersisted}</span>}
           {p?.persistMode != null && <span>{p.persistMode}</span>}
           <PipelineChip pipelineRunId={p?.pipelineRunId} />
         </div>

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
@@ -15,6 +15,10 @@ type ParallelPayload = {
   wpRunId?: string;
   scratchPath?: string;
   commitSha?: string;
+  pushedSha?: string;
+  integrationBranch?: string;
+  filesPersisted?: number;
+  persistMode?: string;
   pipelineRunId?: string;
   wpCount?: number;
   wpIds?: string[];
@@ -234,6 +238,38 @@ export function ParallelWpCommittedEvent({ event }: { event: AgentEventDto }) {
           <span className="font-mono text-fg-4">run {formatShortId(p?.wpRunId)}</span>
         )}
         <PipelineChip pipelineRunId={p?.pipelineRunId} />
+      </div>
+    </ParallelEventShell>
+  );
+}
+
+export function ParallelWpPersistedEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as ParallelPayload | null;
+  const shortSha = formatShortId(p?.pushedSha);
+
+  return (
+    <ParallelEventShell
+      event={event}
+      icon={<PackageCheck size={13} className="shrink-0 text-green-400" />}
+      title={`${p?.wpId ?? 'Work package'} persisted`}
+      tone="success"
+    >
+      <div className="space-y-1">
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
+          {shortSha != null && <span className="font-mono text-fg-2">{shortSha}</span>}
+          {typeof p?.filesPersisted === 'number' && (
+            <span>
+              {p.filesPersisted} file{p.filesPersisted === 1 ? '' : 's'} persisted
+            </span>
+          )}
+          {p?.persistMode != null && <span>{p.persistMode}</span>}
+          <PipelineChip pipelineRunId={p?.pipelineRunId} />
+        </div>
+        {p?.integrationBranch != null && (
+          <DetailRow>
+            Integration branch: <span className="font-mono text-fg-2">{p.integrationBranch}</span>
+          </DetailRow>
+        )}
       </div>
     </ParallelEventShell>
   );

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -8,6 +8,7 @@
  */
 export const EVENT_KIND_LABEL: Record<string, string> = {
   'state.transitioned': 'State transitioned',
+  'dogfood.seed-applied': 'Dogfood seed applied',
   'milestone.activated': 'Milestone activated',
   'agent.spawned': 'Agent spawned',
   'agent.decision-summary': 'Decision summary',
@@ -125,6 +126,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'parallel-implement.iteration-started': 'Parallel iteration started',
   'parallel-implement.wp-started': 'Work package started',
   'parallel-implement.wp-committed': 'Work package committed',
+  'parallel-implement.wp-persisted': 'Work package persisted',
   'parallel-implement.wp-failed': 'Work package failed',
   'parallel-implement.wp-loop-cap-hit': 'Work package loop cap hit',
   'parallel-implement.wp-timeout': 'Work package timed out',

--- a/core/workflows/timeline-sections.test.ts
+++ b/core/workflows/timeline-sections.test.ts
@@ -110,6 +110,15 @@ describe('timeline sections', () => {
     expect(resolveTimelineSection({ kind: 'investigation.digest-applied' })).toBe('investigation');
   });
 
+  it('routes WS3 and dogfood observability events explicitly', () => {
+    expect(resolveTimelineSection({ kind: 'dogfood.seed-applied' })).toBe('system');
+    expect(resolveTimelineSection({ kind: 'parallel-implement.wp-persisted' })).toBe(
+      'implementation',
+    );
+    expect(TIMELINE_EVENT_CLASSIFICATION['dogfood.seed-applied']).toBe('direct');
+    expect(TIMELINE_EVENT_CLASSIFICATION['parallel-implement.wp-persisted']).toBe('direct');
+  });
+
   it('keeps historical run id parsing isolated as a compatibility fallback', () => {
     expect(
       resolveTimelineSection({ kind: 'agent.run-completed', runId: 'discover-1:write-prd' }),

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -56,6 +56,7 @@ const WORKFLOW_GROUP_TO_TIMELINE_SECTION: Record<WorkflowGroup, TimelineSectionI
 };
 
 const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
+  'dogfood.seed-applied': 'system',
   'agent.triage-complete': 'triage',
   'agent.repo-override': 'triage',
   'agent.investigation-complete': 'investigation',
@@ -76,6 +77,7 @@ const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
   'agent.implement-complete': 'implementation',
   'agent.fix-feedback-complete': 'implementation',
   'agent.fix-feedback-skipped': 'implementation',
+  'parallel-implement.wp-persisted': 'implementation',
   'pr.opened': 'implementation',
   'decompose.completed': 'decompose',
   'evidence.no-spec-declared': 'dev-review',


### PR DESCRIPTION
## Summary
- Add explicit labels and section routing for dogfood.seed-applied and parallel-implement.wp-persisted
- Render both events as compact timeline cards instead of raw JSON
- Cover both renderers and visible timeline classification with focused tests

## Verification
- pnpm test core/workflows/timeline-sections.test.ts
- pnpm test apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
- pnpm test apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx