### PR TITLE
Implement WS6 dev-review gates and workflow health

### DIFF
--- a/apps/web/src/components/detail/components/timeline/AgentLifecycleEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/AgentLifecycleEvents.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import type { AgentEventDto } from '@/lib/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderTimelineItem } from '../TimelineEvents';
+
+afterEach(cleanup);
+
+function makeEvent(kind: string, payload: unknown): AgentEventDto {
+  return {
+    id: 1,
+    kind,
+    payload,
+    runId: 'run-1',
+    createdAt: '2026-05-14T04:46:39Z',
+    workItemId: 'github:shaunnez/goose-hub#783',
+    projectId: 'goose-hub-self',
+  } as AgentEventDto;
+}
+
+describe('agent lifecycle timeline events', () => {
+  it('renders runDisposition badges on agent run failures', () => {
+    const event = makeEvent('agent.run-failed', {
+      skill: 'parallel-implement',
+      error: 'Dev review blocked PR open',
+      runDisposition: 'blocked-gate',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText(/Agent run failed: parallel-implement/)).toBeTruthy();
+    expect(screen.getByText('Blocked Gate')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/timeline/AgentLifecycleEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/AgentLifecycleEvents.tsx
@@ -2,6 +2,14 @@ import type { AgentEventDto } from '@/lib/types';
 import { Bot, CheckCircle, Circle, XCircle } from 'lucide-react';
 import { EVENT_KIND_LABEL } from '../../lib/timeline';
 
+function formatDisposition(disposition: string | undefined): string | null {
+  if (disposition == null || disposition.length === 0) return null;
+  return disposition
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
 export function AgentSpawnedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as { skill?: string } | null;
   const skill = p?.skill ?? '';
@@ -51,8 +59,14 @@ export function AgentTerminatedEvent({ event }: { event: AgentEventDto }) {
 export function AgentRunStatusEvent({ event }: { event: AgentEventDto }) {
   const isCompleted = event.kind === 'agent.run-completed';
   const isFailed = event.kind === 'agent.run-failed';
-  const p = event.payload as { runId?: string; error?: string; skill?: string } | null;
+  const p = event.payload as {
+    runId?: string;
+    error?: string;
+    skill?: string;
+    runDisposition?: string;
+  } | null;
   const skillSuffix = p?.skill != null ? `: ${p.skill}` : '';
+  const disposition = formatDisposition(p?.runDisposition);
   return (
     <li
       data-event-kind={event.kind}
@@ -71,6 +85,11 @@ export function AgentRunStatusEvent({ event }: { event: AgentEventDto }) {
           {skillSuffix}
           {isFailed && p?.error != null ? ` — ${p.error}` : ''}
         </span>
+        {disposition != null && (
+          <span className="rounded border border-fg-5/20 bg-fg-5/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-fg-3">
+            {disposition}
+          </span>
+        )}
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
       </div>

--- a/apps/web/src/components/detail/components/timeline/GateEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/GateEvents.test.tsx
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+import type { AgentEventDto } from '@/lib/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderTimelineItem } from '../TimelineEvents';
+
+afterEach(cleanup);
+
+function makeEvent(kind: string, payload: unknown): AgentEventDto {
+  return {
+    id: 1,
+    kind,
+    payload,
+    runId: 'run-1',
+    createdAt: '2026-05-14T04:46:39Z',
+    workItemId: 'github:shaunnez/goose-hub#783',
+    projectId: 'goose-hub-self',
+  } as AgentEventDto;
+}
+
+describe('gate timeline events', () => {
+  it('renders awaiting-human gate reason for blocked dev-review', () => {
+    const event = makeEvent('gate.awaiting-human', {
+      gate: 'dev-review',
+      reason: 'P1 dev-review finding(s) were dismissed; human review required before PR open.',
+      runDisposition: 'blocked-gate',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Gate — awaiting human')).toBeTruthy();
+    expect(screen.getByText('dev-review')).toBeTruthy();
+    expect(screen.getByText(/P1 dev-review/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/timeline/GateEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/GateEvents.tsx
@@ -2,6 +2,7 @@ import type { AgentEventDto } from '@/lib/types';
 import { AlertCircle, CheckCircle, XCircle } from 'lucide-react';
 
 export function GateAwaitingHumanEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as { gate?: string; reason?: string; runDisposition?: string } | null;
   return (
     <li
       data-event-kind={event.kind}
@@ -10,9 +11,15 @@ export function GateAwaitingHumanEvent({ event }: { event: AgentEventDto }) {
       <div className="flex items-center gap-2 text-[11px] text-fg-3">
         <AlertCircle size={13} className="shrink-0 text-[color:var(--warning)]" />
         <span className="font-mono uppercase tracking-wider">Gate — awaiting human</span>
+        {p?.gate != null && (
+          <span className="rounded border border-yellow-500/20 bg-yellow-500/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-yellow-400">
+            {p.gate}
+          </span>
+        )}
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
       </div>
+      {p?.reason != null && <p className="mt-1.5 text-[12px] text-fg-2">{p.reason}</p>}
     </li>
   );
 }

--- a/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
@@ -57,12 +57,14 @@ describe('QA timeline events', () => {
       tier: 3,
       evidence: ['carry-forward-ok-wps: WP1'],
       findingCount: 1,
+      failureCategory: 'regression-unrelated',
       runId: '0eca3ecb-034d-4467-8573-7c691ec8b6e2',
     });
 
     render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
 
     expect(screen.getByText('QA Regression failed')).toBeTruthy();
+    expect(screen.getByText('Regression Unrelated')).toBeTruthy();
     expect(screen.getByText('1 finding')).toBeTruthy();
     expect(screen.getByText('carry-forward-ok-wps: WP1')).toBeTruthy();
     expect(document.body.textContent).not.toContain('"tier"');
@@ -164,5 +166,33 @@ describe('QA timeline events', () => {
     expect(screen.getByText('Max retries 2')).toBeTruthy();
     expect(screen.getByText('run 7684da8c')).toBeTruthy();
     expect(document.body.textContent).not.toContain('"maxRetries"');
+  });
+
+  it('renders qa.completed failure category badges', () => {
+    const event = makeEvent('qa.completed', {
+      verdict: 'fail',
+      overallScore: 40,
+      threshold: 70,
+      failureCategory: 'product',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('QA completed')).toBeTruthy();
+    expect(screen.getByText('Product')).toBeTruthy();
+  });
+
+  it('renders verification-blocked failure category badges', () => {
+    const event = makeEvent('qa.verification-blocked', {
+      failedTier: 2,
+      reason: 'malformed-verification-command',
+      agentSkipped: true,
+      failureCategory: 'orchestration',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('QA verification blocked')).toBeTruthy();
+    expect(screen.getByText('Orchestration')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/detail/components/timeline/QaEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.tsx
@@ -14,6 +14,7 @@ type TierPayload = {
   evidence?: string[];
   findingCount?: number;
   findings?: { tier?: string; severity?: string; description?: string }[];
+  failureCategory?: string;
   runId?: string;
 };
 
@@ -90,6 +91,24 @@ function statusTone(status: VerificationStatus | undefined): string {
   return 'border-yellow-500/20 bg-yellow-500/10 text-yellow-400';
 }
 
+function formatFailureCategory(category: string | undefined): string | null {
+  if (category == null || category.length === 0) return null;
+  return category
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function FailureCategoryBadge({ category }: { category?: string }) {
+  const label = formatFailureCategory(category);
+  if (label == null) return null;
+  return (
+    <span className="rounded border border-yellow-500/20 bg-yellow-500/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-yellow-400">
+      {label}
+    </span>
+  );
+}
+
 function StatusRow({
   label,
   status,
@@ -146,6 +165,7 @@ export function QaFailedEvent({ event }: { event: AgentEventDto }) {
       <div className="flex items-center gap-2 mb-2 text-[11px] text-fg-3">
         <XCircle size={13} className="shrink-0 text-[color:var(--danger)]" />
         <span className="font-mono uppercase tracking-wider">QA {tierLabel} failed</span>
+        <FailureCategoryBadge category={p?.failureCategory} />
         <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
         <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
       </div>
@@ -228,6 +248,7 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
     verdict?: string;
     overallScore?: number;
     threshold?: number;
+    failureCategory?: string;
     tierResults?: {
       structural?: TierResult;
       functional?: TierResult;
@@ -278,6 +299,7 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
             Agent skipped
           </span>
         )}
+        <FailureCategoryBadge category={p?.failureCategory} />
         {score != null && (
           <span className="text-[11.5px] text-fg-3 font-mono">
             <span className={score >= threshold ? 'text-green-400' : 'text-[color:var(--danger)]'}>
@@ -322,6 +344,7 @@ export function QaVerificationBlockedEvent({ event }: { event: AgentEventDto }) 
     findings?: string[];
     reason?: string;
     agentSkipped?: boolean;
+    failureCategory?: string;
   } | null;
   const findings = p?.findings ?? [];
   return (
@@ -351,6 +374,7 @@ export function QaVerificationBlockedEvent({ event }: { event: AgentEventDto }) 
             Agent skipped
           </span>
         )}
+        <FailureCategoryBadge category={p?.failureCategory} />
       </div>
       {findings.length > 0 && (
         <ul className="flex flex-col gap-1.5">

--- a/core/event-stream/run-disposition.ts
+++ b/core/event-stream/run-disposition.ts
@@ -1,0 +1,12 @@
+export const RUN_DISPOSITIONS = [
+  'completed',
+  'budget-killed',
+  'persistence-failed',
+  'blocked-gate',
+] as const;
+
+export type RunDisposition = (typeof RUN_DISPOSITIONS)[number];
+
+export function isRunDisposition(value: unknown): value is RunDisposition {
+  return typeof value === 'string' && RUN_DISPOSITIONS.includes(value as RunDisposition);
+}

--- a/core/qa/failure-category.ts
+++ b/core/qa/failure-category.ts
@@ -1,0 +1,31 @@
+export const QA_FAILURE_CATEGORIES = [
+  'spec-contract',
+  'product',
+  'regression-unrelated',
+  'orchestration',
+] as const;
+
+export type QaFailureCategory = (typeof QA_FAILURE_CATEGORIES)[number];
+
+export type QaTierName = 'structural' | 'functional' | 'regression';
+
+export function classifyQaFailure(input: {
+  failedTier?: 1 | 2 | 3 | QaTierName;
+  hasActionableFinding?: boolean;
+  hasFailedExecutableCheck?: boolean;
+  orchestration?: boolean;
+}): QaFailureCategory {
+  if (input.orchestration === true) return 'orchestration';
+  if (input.failedTier === 3 || input.failedTier === 'regression') return 'regression-unrelated';
+  if (
+    input.failedTier === 1 ||
+    input.failedTier === 2 ||
+    input.failedTier === 'structural' ||
+    input.failedTier === 'functional' ||
+    input.hasFailedExecutableCheck === true
+  ) {
+    return 'spec-contract';
+  }
+  if (input.hasActionableFinding === true) return 'product';
+  return 'orchestration';
+}

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -481,6 +481,7 @@ describe('runTier — event emission', () => {
       evidence: expect.any(Array),
       findingCount: 1,
       runId: 'r1',
+      failureCategory: 'spec-contract',
     });
     expect(result.tier).toBe(1);
   });

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { db } from '@goose-hub/core/db/db.js';
 import { wpIterations } from '@goose-hub/core/db/schema.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
+import { classifyQaFailure } from '@goose-hub/core/qa/failure-category.js';
 import { type EngineeringSpec, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import { and, desc, eq } from 'drizzle-orm';
 
@@ -468,6 +469,7 @@ export async function runTier(
         evidence: result.evidence,
         findingCount: result.findings.length,
         runId: runArtifacts.runId,
+        ...(!result.passed ? { failureCategory: classifyQaFailure({ failedTier: tier }) } : {}),
       },
       runId: runArtifacts.runId,
     });

--- a/slices/parallel-implement/dev-review-gate.ts
+++ b/slices/parallel-implement/dev-review-gate.ts
@@ -1,0 +1,90 @@
+import type { DevReviewResponseOutput } from '@goose-hub/skills/dev-review-response/schema.js';
+import type { DevReviewFinding, DevReviewOutput } from '@goose-hub/skills/dev-review/schema.js';
+
+type DevReviewResponseCommit =
+  | { status: 'committed'; sha: string }
+  | { status: 'no-changes' }
+  | null;
+
+export type DevReviewGateInput = {
+  latestVerdict: DevReviewOutput | null;
+  latestResponse: DevReviewResponseOutput | null;
+  latestResponseCommit: DevReviewResponseCommit;
+  failureReason?: string;
+};
+
+export type DevReviewGateResult =
+  | { status: 'clear' }
+  | { status: 'blocked'; reason: string; blockerCount: number };
+
+function findingRef(finding: DevReviewFinding): string {
+  return `${finding.file}:${finding.line}`;
+}
+
+function isHighSeverity(severity: string): boolean {
+  return severity === 'P0' || severity === 'P1';
+}
+
+export function evaluateDevReviewGate(input: DevReviewGateInput): DevReviewGateResult {
+  if (input.failureReason != null) {
+    return { status: 'blocked', reason: input.failureReason, blockerCount: 1 };
+  }
+
+  const verdict = input.latestVerdict;
+  if (verdict == null || verdict.verdict === 'no-blockers') return { status: 'clear' };
+
+  if (verdict.verdict === 'inconclusive') {
+    return {
+      status: 'blocked',
+      reason: 'Dev review ended inconclusive; human review required before PR open.',
+      blockerCount: Math.max(1, verdict.findings.length),
+    };
+  }
+
+  const response = input.latestResponse;
+  if (response == null) {
+    return {
+      status: 'blocked',
+      reason: 'Dev review found blockers but no response was recorded.',
+      blockerCount: verdict.findings.length,
+    };
+  }
+
+  const dispositionsByRef = new Map(response.findingDispositions.map((d) => [d.findingRef, d]));
+  const missingResponse = verdict.findings.filter(
+    (finding) => !dispositionsByRef.has(findingRef(finding)),
+  );
+  if (missingResponse.length > 0) {
+    return {
+      status: 'blocked',
+      reason: `Dev review response did not cover ${missingResponse.length} finding(s).`,
+      blockerCount: missingResponse.length,
+    };
+  }
+
+  const dismissedHighSeverity = verdict.findings.filter((finding) => {
+    const disposition = dispositionsByRef.get(findingRef(finding));
+    return isHighSeverity(finding.severity) && disposition?.disposition === 'dismissed';
+  });
+  if (dismissedHighSeverity.length > 0) {
+    const severities = [...new Set(dismissedHighSeverity.map((finding) => finding.severity))].join(
+      '/',
+    );
+    return {
+      status: 'blocked',
+      reason: `${severities} dev-review finding(s) were dismissed; human review required before PR open.`,
+      blockerCount: dismissedHighSeverity.length,
+    };
+  }
+
+  const addressed = response.findingDispositions.filter((d) => d.disposition === 'addressed');
+  if (addressed.length > 0 && input.latestResponseCommit?.status !== 'committed') {
+    return {
+      status: 'blocked',
+      reason: 'Dev review response addressed findings but produced no response commit.',
+      blockerCount: addressed.length,
+    };
+  }
+
+  return { status: 'clear' };
+}

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -3083,6 +3083,94 @@ describe('dev-review e2e: dismissed finding captures DEV_REVIEW_DISMISSED', () =
     expect((responseCompleted?.payload as { dismissed?: number }).dismissed).toBe(1);
     expect((responseCompleted?.payload as { addressed?: number }).addressed).toBe(0);
   });
+
+  it('blocks PR opening when a P1 blocker is dismissed', async () => {
+    const wp1 = makeWp('WP1', ['core/b.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const openPRImpl = vi.fn();
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem({ priority: 'high' }),
+      spec,
+      'pipeline-run-dev-review-p1-dismissed',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        devReviewConfigOverride: {
+          enabled: true,
+          triggerOn: 'all',
+          maxRevisionTurns: 1,
+          perCycleMaxUsd: 2.0,
+          timeoutMs: 180_000,
+        },
+        runDevReviewImpl: async () => ({
+          verdict: 'blockers-found',
+          findings: [
+            {
+              severity: 'P1',
+              category: 'correctness',
+              file: 'core/b.ts',
+              line: 10,
+              summary: 'Drops failed writes',
+              suggestion: 'Persist the write before opening the PR',
+            },
+          ],
+          decisionSummaries: [{ kind: 'VERDICT', summary: 'blockers-found: 1 P1 finding' }],
+        }),
+        runDevReviewResponseImpl: async () => ({
+          findingDispositions: [
+            {
+              findingRef: 'core/b.ts:10',
+              severity: 'P1',
+              disposition: 'dismissed',
+              reason: 'Not reproducible',
+            },
+          ],
+          decisionSummaries: [
+            {
+              kind: 'DEV_REVIEW_DISMISSED',
+              summary: 'Dismissed P1 at core/b.ts:10',
+              evidence: 'core/b.ts:10',
+            },
+          ],
+        }),
+        commitDevReviewResponseImpl: () => ({ status: 'committed', sha: 'sha-dev-review' }),
+        createIssueWorktreeImpl: () => '/tmp/issue-wt',
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha2',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: () => undefined,
+        getLastStatusImpl: (_runId, wpId) => {
+          const seen = events.some(
+            (e) =>
+              (e.kind as string).includes('wp-committed') &&
+              (e.payload as { wpId?: string }).wpId === wpId,
+          );
+          return seen ? 'ok' : null;
+        },
+        openPRImpl,
+        getDiffImpl: () => 'diff --git a/core/b.ts b/core/b.ts\n',
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('failed');
+    expect(openPRImpl).not.toHaveBeenCalled();
+    expect(events.find((event) => event.kind === 'gate.awaiting-human')?.payload).toMatchObject({
+      gate: 'dev-review',
+      reason: expect.stringContaining('P1'),
+    });
+    expect(events.find((event) => event.kind === 'agent.run-failed')?.payload).toMatchObject({
+      skill: 'parallel-implement',
+      runDisposition: 'blocked-gate',
+    });
+    expect(events.find((event) => event.kind === 'pr.opened')).toBeUndefined();
+  });
 });
 
 // ─── E2E spec 3: budget zero → dev-review.budget-skipped → workflow continues ─

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -25,6 +25,7 @@ import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { readProjectSettings } from '@goose-hub/core/db/repositories/project-settings.js';
+import type { RunDisposition } from '@goose-hub/core/event-stream/run-disposition.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
@@ -51,10 +52,13 @@ import {
   reattachIntegrationWorktreeAtRemoteTip,
   resolveWorkflowBase,
 } from '@goose-hub/core/workspaces/worktree.js';
+import type { DevReviewResponseOutput } from '@goose-hub/skills/dev-review-response/schema.js';
+import type { DevReviewOutput } from '@goose-hub/skills/dev-review/schema.js';
 import { ImplementWpSchema } from '@goose-hub/skills/implement-wp/schema.js';
 import { type EngineeringSpec, fileOwnedPath } from '@goose-hub/skills/spec-author/schema.js';
 import { normalizeEngineeringSpecPaths } from '../spec-author/path-normalization.js';
 import { buildPrdPlanningContext } from '../spec-author/prd-planning-context.js';
+import { type DevReviewGateInput, evaluateDevReviewGate } from './dev-review-gate.js';
 import {
   type WpDispatchResult,
   buildParallelPrBody,
@@ -300,6 +304,15 @@ export class PersistenceFailureError extends Error {
     this.name = 'PersistenceFailureError';
     this.reason = reason;
     this.causeValue = causeValue;
+  }
+}
+
+class BlockedGateError extends Error {
+  readonly gate = 'dev-review';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'BlockedGateError';
   }
 }
 
@@ -1245,6 +1258,7 @@ export async function runParallelImplementWorkflow(
     // Runs after all WPs are committed, before the PR is opened.
     // Budget guard: skip if perCycleMaxUsd <= 0.
     let devReviewResponseCommitSha: string | undefined;
+    let latestDevReviewGate: DevReviewGateInput | null = null;
     if (
       devReviewCfg.enabled &&
       shouldRunDevReview(devReviewCfg.triggerOn, workItem.priority) &&
@@ -1262,26 +1276,46 @@ export async function runParallelImplementWorkflow(
         try {
           const maxTurns = Math.max(1, Math.min(5, devReviewCfg.maxRevisionTurns));
           let turns = 0;
+          let latestDevReviewOutput: DevReviewOutput | null = null;
+          let latestDevReviewResponse: DevReviewResponseOutput | null = null;
+          let latestDevReviewResponseCommit: DevReviewGateInput['latestResponseCommit'] = null;
+          let devReviewFailureReason: string | undefined;
           while (turns < maxTurns) {
             // Each iteration = one Codex dev-review call.
             // Use turn-scoped runId so multi-turn events are distinguishable.
             const turnRunId = turns === 0 ? runId : `${runId}:turn-${turns}`;
-            const devReviewOutput = await devReviewFn({
-              runId: turnRunId,
-              projectId,
-              workItemId: workItem.id,
-              workItem: {
-                title: workItem.title,
-                body: workItem.body,
-                number: Number(workItem.externalId),
-                priority: workItem.priority,
-              },
-              worktreePath: issueWorktreePath,
-              baseBranch: workflowBase.branch,
-              stack,
-              runtime: deps.devReviewRuntime,
-              appendEvent: append,
-            });
+            let devReviewOutput: DevReviewOutput;
+            try {
+              devReviewOutput = await devReviewFn({
+                runId: turnRunId,
+                projectId,
+                workItemId: workItem.id,
+                workItem: {
+                  title: workItem.title,
+                  body: workItem.body,
+                  number: Number(workItem.externalId),
+                  priority: workItem.priority,
+                },
+                worktreePath: issueWorktreePath,
+                baseBranch: workflowBase.branch,
+                stack,
+                runtime: deps.devReviewRuntime,
+                appendEvent: append,
+              });
+            } catch (devReviewErr) {
+              const msg = errorMessage(devReviewErr);
+              append({
+                projectId,
+                workItemId: workItem.id,
+                kind: 'dev-review.error',
+                payload: { runId: turnRunId, error: msg },
+                runId: turnRunId,
+              });
+              devReviewFailureReason = `Dev review failed: ${msg}`;
+              break;
+            }
+
+            latestDevReviewOutput = devReviewOutput;
 
             if (devReviewOutput.verdict === 'no-blockers') break;
             // On the last turn, inconclusive = no more passes available; skip response.
@@ -1289,43 +1323,85 @@ export async function runParallelImplementWorkflow(
 
             // Re-fetch diff after any previous response commits so Codex sees current state.
             const currentDiff = getDiffFn(issueWorktreePath, workflowBase.branch);
-            await devReviewResponseFn({
-              runId: turnRunId,
-              projectId,
-              workItemId: workItem.id,
-              workItem: {
-                title: workItem.title,
-                body: workItem.body,
-                number: Number(workItem.externalId),
-                priority: workItem.priority,
-              },
-              prDiff: currentDiff,
-              devReviewFindings: devReviewOutput.findings,
-              worktreePath: issueWorktreePath,
-              stack,
-              runtime: deps.devReviewResponseRuntime,
-              appendEvent: append,
-            });
+            try {
+              latestDevReviewResponse = await devReviewResponseFn({
+                runId: turnRunId,
+                projectId,
+                workItemId: workItem.id,
+                workItem: {
+                  title: workItem.title,
+                  body: workItem.body,
+                  number: Number(workItem.externalId),
+                  priority: workItem.priority,
+                },
+                prDiff: currentDiff,
+                devReviewFindings: devReviewOutput.findings,
+                worktreePath: issueWorktreePath,
+                stack,
+                runtime: deps.devReviewResponseRuntime,
+                appendEvent: append,
+              });
+            } catch (responseErr) {
+              const msg = errorMessage(responseErr);
+              append({
+                projectId,
+                workItemId: workItem.id,
+                kind: 'dev-review.response-failed',
+                payload: { runId: `${turnRunId}:dev-review-response`, error: msg },
+                runId: `${turnRunId}:dev-review-response`,
+              });
+              devReviewFailureReason = `Dev review response failed: ${msg}`;
+              break;
+            }
             // Commit response edits so the next iteration's Codex diff is current.
-            const devReviewCommitResult = commitDevReviewFn(
-              issueWorktreePath,
-              `chore: dev-review-response turn-${turns} addressing/dismissing findings`,
-            );
+            let devReviewCommitResult: DevReviewGateInput['latestResponseCommit'];
+            try {
+              devReviewCommitResult = commitDevReviewFn(
+                issueWorktreePath,
+                `chore: dev-review-response turn-${turns} addressing/dismissing findings`,
+              );
+            } catch (commitErr) {
+              const msg = errorMessage(commitErr);
+              devReviewFailureReason = `Dev review response commit failed: ${msg}`;
+              break;
+            }
+            latestDevReviewResponseCommit = devReviewCommitResult;
             if (devReviewCommitResult.status === 'committed') {
               devReviewResponseCommitSha = devReviewCommitResult.sha;
             }
             turns++;
           }
+          latestDevReviewGate = {
+            latestVerdict: latestDevReviewOutput,
+            latestResponse: latestDevReviewResponse,
+            latestResponseCommit: latestDevReviewResponseCommit,
+            ...(devReviewFailureReason != null ? { failureReason: devReviewFailureReason } : {}),
+          };
         } catch (devReviewErr) {
-          // Dev-review failures are non-fatal. Log and continue to PR.
-          const msg = devReviewErr instanceof Error ? devReviewErr.message : String(devReviewErr);
-          append({
-            projectId,
-            workItemId: workItem.id,
-            kind: 'dev-review.error',
-            payload: { runId, error: msg },
-            runId,
-          });
+          latestDevReviewGate = {
+            latestVerdict: null,
+            latestResponse: null,
+            latestResponseCommit: null,
+            failureReason: `Dev review failed: ${errorMessage(devReviewErr)}`,
+          };
+        }
+        if (latestDevReviewGate != null) {
+          const gateResult = evaluateDevReviewGate(latestDevReviewGate);
+          if (gateResult.status === 'blocked') {
+            append({
+              projectId,
+              workItemId: workItem.id,
+              kind: 'gate.awaiting-human',
+              payload: {
+                gate: 'dev-review',
+                reason: gateResult.reason,
+                blockerCount: gateResult.blockerCount,
+                runDisposition: 'blocked-gate',
+              },
+              runId,
+            });
+            throw new BlockedGateError(gateResult.reason);
+          }
         }
       }
     }
@@ -1437,6 +1513,10 @@ export async function runParallelImplementWorkflow(
       error instanceof PersistenceFailureError
         ? { runDisposition: 'persistence-failed', persistenceFailureReason: error.reason }
         : undefined;
+    const blockedGate =
+      error instanceof BlockedGateError
+        ? ({ runDisposition: 'blocked-gate' satisfies RunDisposition, gate: error.gate } as const)
+        : undefined;
     append({
       projectId,
       workItemId: workItem.id,
@@ -1446,6 +1526,7 @@ export async function runParallelImplementWorkflow(
         skill: 'parallel-implement',
         error: error.message,
         ...(persistenceFailure ?? {}),
+        ...(blockedGate ?? {}),
       },
       runId,
     });

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -828,6 +828,39 @@ describe('runQaWorkflow', () => {
       expect(payload.qualityScores).toBeDefined();
     });
 
+    it('classifies actionable QA findings as product failures on qa.completed', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource();
+      const productFailure = makePassResult();
+      productFailure.output = {
+        ...(productFailure.output as Record<string, unknown>),
+        verdict: 'fail',
+        overallScore: 60,
+        findings: [
+          {
+            tier: 'functional',
+            severity: 'error',
+            description: 'User cannot save the form',
+            disposition: 'needs-fix',
+            dispositionRef: 'current PR',
+          },
+        ],
+      };
+      mockRun.mockResolvedValueOnce(productFailure);
+
+      const { runQaWorkflow } = await import('./workflow.js');
+      const { eventStore } = await import('@goose-hub/core/event-stream/store.js');
+      await runQaWorkflow(item, source, 'test-project', 'owner/repo');
+
+      const completed = vi
+        .mocked(eventStore.appendEvent)
+        .mock.calls.find(([e]) => e.kind === 'qa.completed');
+      expect(completed?.[0].payload).toMatchObject({
+        verdict: 'fail',
+        failureCategory: 'product',
+      });
+    });
+
     it('emits agent.decision-summary per decisionSummary entry', async () => {
       const item = makeWorkItem();
       const source = makeMockSource();
@@ -2213,6 +2246,7 @@ describe('runQaWorkflow', () => {
       expect(payload.overallScore).toBe(0);
       expect(payload.agentSkipped).toBe(true);
       expect(payload.deterministic).toBe(true);
+      expect(payload.failureCategory).toBe('spec-contract');
 
       expect(source.transitionState).toHaveBeenCalledWith(
         '42',
@@ -2313,6 +2347,7 @@ describe('runQaWorkflow', () => {
         failedTier: 2,
         reason: 'malformed-verification-command',
         agentSkipped: true,
+        failureCategory: 'orchestration',
       });
     });
 

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -20,6 +20,7 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { collectActionableQaItems } from '@goose-hub/core/qa/actionability.js';
+import { classifyQaFailure } from '@goose-hub/core/qa/failure-category.js';
 import { DEFAULT_MAX_RETRIES, shouldEscalateQa } from '@goose-hub/core/retry/retry-counter.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -475,6 +476,7 @@ export async function runQaWorkflow(
             findings: infrastructureFailure.findings,
             deterministic: true,
             agentSkipped: true,
+            failureCategory: classifyQaFailure({ orchestration: true }),
             ...(prHints.pipelineRunId != null ? { pipelineRunId: prHints.pipelineRunId } : {}),
           },
           runId,
@@ -534,6 +536,7 @@ export async function runQaWorkflow(
           findings: synthetic.findings,
           deterministic: true,
           agentSkipped: true,
+          failureCategory: classifyQaFailure({ failedTier }),
           ...(prHints.pipelineRunId != null ? { pipelineRunId: prHints.pipelineRunId } : {}),
         },
         runId,
@@ -767,7 +770,11 @@ export async function runQaWorkflow(
           projectId: projectSlug,
           workItemId: workItem.id,
           kind,
-          payload: { tier, findings: groundTruthTierResults[tier].findings },
+          payload: {
+            tier,
+            findings: groundTruthTierResults[tier].findings,
+            failureCategory: classifyQaFailure({ failedTier: tier }),
+          },
           runId,
         });
       }
@@ -789,6 +796,18 @@ export async function runQaWorkflow(
       },
       { verifiedFollowUpRefs },
     );
+    const failedTier = (['structural', 'functional', 'regression'] as const).find(
+      (tier) => !groundTruthTierResults[tier].passed,
+    );
+    const hasFailedExecutableCheck = criteriaResults.some((result) => !result.passed);
+    const qaFailureCategory =
+      verdict === 'pass' && actionableQaItems.length === 0 && !hasFailedExecutableCheck
+        ? undefined
+        : classifyQaFailure({
+            failedTier,
+            hasActionableFinding: actionableQaItems.length > 0,
+            hasFailedExecutableCheck,
+          });
 
     eventStore.appendEvent({
       projectId: projectSlug,
@@ -801,6 +820,7 @@ export async function runQaWorkflow(
         tierResults: groundTruthTierResults,
         qualityScores: qaOutput.qualityScores,
         findings: qaOutput.findings,
+        ...(qaFailureCategory != null ? { failureCategory: qaFailureCategory } : {}),
         ...(criteriaResults.length > 0 ? { criteriaResults } : {}),
         ...(testRun ? { testRun } : {}),
         ...(deterministic != null ? { deterministic: true } : {}),
@@ -888,7 +908,11 @@ export async function runQaWorkflow(
       projectId: projectSlug,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
-      payload: { runId, error: error.message },
+      payload: {
+        runId,
+        error: error.message,
+        failureCategory: classifyQaFailure({ orchestration: true }),
+      },
       runId,
     });
     await stateSource.comment(


### PR DESCRIPTION
## Summary
- add WS6 runDisposition and QA failureCategory contracts
- block unresolved dev-review gates before PR open and route blocked-gate failures to needs-human via existing dispatcher
- surface runDisposition and QA failureCategory badges in the timeline

## Tests
- pnpm test slices/parallel-implement/slice.test.ts -t "dev-review"
- pnpm test apps/server/src/shared/dispatch.test.ts -t "parallel-implement"
- pnpm test slices/qa/slice.test.ts -t "deterministic|qa.completed|verification-blocked"
- pnpm test core/workflows/timeline-sections.test.ts apps/web/src/components/detail/lib/timeline.test.ts
- pnpm test apps/web/src/components/detail/components/timeline/DevReviewEvents.test.tsx apps/web/src/components/detail/components/timeline/QaEvents.test.tsx apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx apps/web/src/components/detail/components/timeline/AgentLifecycleEvents.test.tsx apps/web/src/components/detail/components/timeline/GateEvents.test.tsx
- pnpm test core/verify/tiers.test.ts -t "structural-failed"
- pnpm typecheck
- pnpm lint
- pnpm manifest --check
- git diff --check