### PR TITLE
Address WS6 review feedback

### DIFF
--- a/core/qa/failure-category.test.ts
+++ b/core/qa/failure-category.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { classifyQaFailure } from './failure-category.js';
+
+describe('classifyQaFailure', () => {
+  it('prioritizes actionable product findings over structural or functional tier fallback', () => {
+    expect(
+      classifyQaFailure({
+        failedTier: 'functional',
+        hasActionableFinding: true,
+      }),
+    ).toBe('product');
+  });
+
+  it('keeps failed executable checks in the spec-contract category when no product finding exists', () => {
+    expect(classifyQaFailure({ hasFailedExecutableCheck: true })).toBe('spec-contract');
+  });
+});

--- a/core/qa/failure-category.ts
+++ b/core/qa/failure-category.ts
@@ -16,16 +16,16 @@ export function classifyQaFailure(input: {
   orchestration?: boolean;
 }): QaFailureCategory {
   if (input.orchestration === true) return 'orchestration';
+  if (input.hasFailedExecutableCheck === true) return 'spec-contract';
+  if (input.hasActionableFinding === true) return 'product';
   if (input.failedTier === 3 || input.failedTier === 'regression') return 'regression-unrelated';
   if (
     input.failedTier === 1 ||
     input.failedTier === 2 ||
     input.failedTier === 'structural' ||
-    input.failedTier === 'functional' ||
-    input.hasFailedExecutableCheck === true
+    input.failedTier === 'functional'
   ) {
     return 'spec-contract';
   }
-  if (input.hasActionableFinding === true) return 'product';
   return 'orchestration';
 }

--- a/slices/parallel-implement/dev-review-gate.test.ts
+++ b/slices/parallel-implement/dev-review-gate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateDevReviewGate } from './dev-review-gate.js';
+
+const baseFinding = {
+  severity: 'P1' as const,
+  category: 'correctness' as const,
+  file: 'core/a.ts',
+  line: 10,
+  summary: 'Drops writes',
+  suggestion: 'Persist before PR open',
+};
+
+describe('evaluateDevReviewGate', () => {
+  it('blocks blockers-found verdicts that have no findings to respond to', () => {
+    const result = evaluateDevReviewGate({
+      latestVerdict: {
+        verdict: 'blockers-found',
+        findings: [],
+        decisionSummaries: [],
+      },
+      latestResponse: {
+        findingDispositions: [],
+        decisionSummaries: [{ kind: 'DEV_REVIEW_ADDRESSED', summary: 'No findings' }],
+      },
+      latestResponseCommit: null,
+    });
+
+    expect(result).toMatchObject({
+      status: 'blocked',
+      blockerCount: 1,
+    });
+  });
+
+  it('does not let a lower-severity disposition hide a dismissed P1 on the same line', () => {
+    const result = evaluateDevReviewGate({
+      latestVerdict: {
+        verdict: 'blockers-found',
+        findings: [
+          baseFinding,
+          {
+            ...baseFinding,
+            severity: 'P3',
+            summary: 'Style nit on same line',
+            suggestion: 'Optional cleanup',
+          },
+        ],
+        decisionSummaries: [],
+      },
+      latestResponse: {
+        findingDispositions: [
+          {
+            findingRef: 'core/a.ts:10',
+            severity: 'P1',
+            disposition: 'dismissed',
+            reason: 'Not reproducible',
+          },
+          {
+            findingRef: 'core/a.ts:10',
+            severity: 'P3',
+            disposition: 'addressed',
+          },
+        ],
+        decisionSummaries: [{ kind: 'DEV_REVIEW_DISMISSED', summary: 'Dismissed P1' }],
+      },
+      latestResponseCommit: { status: 'committed', sha: 'sha-response' },
+    });
+
+    expect(result).toMatchObject({
+      status: 'blocked',
+      blockerCount: 1,
+    });
+  });
+});

--- a/slices/parallel-implement/dev-review-gate.ts
+++ b/slices/parallel-implement/dev-review-gate.ts
@@ -21,6 +21,15 @@ function findingRef(finding: DevReviewFinding): string {
   return `${finding.file}:${finding.line}`;
 }
 
+function dispositionMatchesFinding(
+  disposition: DevReviewResponseOutput['findingDispositions'][number],
+  finding: DevReviewFinding,
+): boolean {
+  return (
+    disposition.findingRef === findingRef(finding) && disposition.severity === finding.severity
+  );
+}
+
 function isHighSeverity(severity: string): boolean {
   return severity === 'P0' || severity === 'P1';
 }
@@ -41,6 +50,15 @@ export function evaluateDevReviewGate(input: DevReviewGateInput): DevReviewGateR
     };
   }
 
+  if (verdict.findings.length === 0) {
+    return {
+      status: 'blocked',
+      reason:
+        'Dev review reported blockers-found without findings; human review required before PR open.',
+      blockerCount: 1,
+    };
+  }
+
   const response = input.latestResponse;
   if (response == null) {
     return {
@@ -50,9 +68,8 @@ export function evaluateDevReviewGate(input: DevReviewGateInput): DevReviewGateR
     };
   }
 
-  const dispositionsByRef = new Map(response.findingDispositions.map((d) => [d.findingRef, d]));
   const missingResponse = verdict.findings.filter(
-    (finding) => !dispositionsByRef.has(findingRef(finding)),
+    (finding) => !response.findingDispositions.some((d) => dispositionMatchesFinding(d, finding)),
   );
   if (missingResponse.length > 0) {
     return {
@@ -63,8 +80,12 @@ export function evaluateDevReviewGate(input: DevReviewGateInput): DevReviewGateR
   }
 
   const dismissedHighSeverity = verdict.findings.filter((finding) => {
-    const disposition = dispositionsByRef.get(findingRef(finding));
-    return isHighSeverity(finding.severity) && disposition?.disposition === 'dismissed';
+    return (
+      isHighSeverity(finding.severity) &&
+      response.findingDispositions.some(
+        (d) => dispositionMatchesFinding(d, finding) && d.disposition === 'dismissed',
+      )
+    );
   });
   if (dismissedHighSeverity.length > 0) {
     const severities = [...new Set(dismissedHighSeverity.map((finding) => finding.severity))].join(


### PR DESCRIPTION
## Summary
- prioritize actionable QA product findings over structural/functional tier fallback in failureCategory classification
- make dev-review gate matching conservative by severity as well as findingRef
- block inconsistent blockers-found verdicts that contain no findings

## Tests
- pnpm test core/qa/failure-category.test.ts
- pnpm test slices/parallel-implement/dev-review-gate.test.ts
- pnpm test slices/parallel-implement/slice.test.ts -t "dev-review"
- pnpm test slices/qa/slice.test.ts -t "deterministic|qa.completed|verification-blocked"
- pnpm typecheck
- pnpm lint
- pnpm manifest --check
- git diff --check

Follow-up to review feedback on #1064.