### PR TITLE
Fix bug-enhance workflow map visibility

### DIFF
--- a/apps/server/src/domains/project-settings/router.test.ts
+++ b/apps/server/src/domains/project-settings/router.test.ts
@@ -268,6 +268,9 @@ describe('project settings router', () => {
     expect(body.skillMetadata['dev-review'].description).toContain('Codex pre-QA dev-review');
     expect(body.skillMetadata['dev-review'].dependencies).toContain('prDiff');
     expect(body.skillMetadata['dev-review'].callers).toContain('developer pre-QA advisor');
+    expect(body.skillMetadata['bug-enhance'].callers).toEqual(
+      expect.arrayContaining(['inbox promotion', 'lazy bug investigation grounding']),
+    );
   });
 
   it('returns implement-WP defaults, DB overrides, and resolved settings', async () => {

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -113,7 +113,7 @@ const RuntimeProfilerQuerySchema = z.object({
 const SKILL_CALLERS: Record<string, string[]> = {
   triage: ['triage-batch workflow', 'debug route'],
   'repo-match': ['triage-batch workflow'],
-  'bug-enhance': ['inbox promotion'],
+  'bug-enhance': ['inbox promotion', 'lazy bug investigation grounding'],
   'evidence-post': ['post-QA evidence workflow'],
   implement: ['standard implementation workflow', 'repair loop'],
   qa: ['post-implementation QA gate'],

--- a/apps/web/src/components/settings/components/WorkflowMapFlow.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapFlow.tsx
@@ -277,7 +277,9 @@ function BranchPanel({
   const status =
     branch.kind === 'retry' || branch.kind === 'failure'
       ? 'conditional'
-      : activationStatus(branch.activation, modes);
+      : branch.kind === 'conditional' && branch.activation == null
+        ? 'conditional'
+        : activationStatus(branch.activation, modes);
   const nodes = branch.nodes.map((nodeId) => nodesById.get(nodeId)).filter(isWorkflowNode);
   const icon =
     branch.kind === 'retry' ? (

--- a/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
@@ -149,6 +149,25 @@ vi.mock('@/lib/api', () => ({
             nodes: ['triaging', 'triage-skill', 'accepted'],
           },
           {
+            id: 'investigation',
+            title: 'Investigation',
+            group: 'investigation',
+            nodes: ['investigating', 'investigation-complete'],
+            branches: [
+              {
+                id: 'lazy-bug-grounding',
+                title: 'Lazy bug grounding',
+                kind: 'conditional',
+                activation: {
+                  setting: 'workItem.missingPromotionSeed',
+                  value: true,
+                  label: 'bug issue without promotion seed',
+                },
+                nodes: ['bug-enhance-skill'],
+              },
+            ],
+          },
+          {
             id: 'delivery',
             title: 'Delivery router',
             group: 'delivery',
@@ -196,6 +215,12 @@ vi.mock('@/lib/api', () => ({
         nodes: [
           { id: 'triaging', label: 'Triage', state: 'factory:triaging' },
           { id: 'accepted', label: 'Accepted', state: 'factory:accepted' },
+          { id: 'investigating', label: 'Investigating', state: 'factory:investigating' },
+          {
+            id: 'investigation-complete',
+            label: 'Investigation complete',
+            state: 'factory:investigation-complete',
+          },
           { id: 'needs-qa', label: 'QA', state: 'factory:needs-qa' },
           {
             id: 'triage-skill',
@@ -203,6 +228,18 @@ vi.mock('@/lib/api', () => ({
             skill: 'triage',
             role: 'triager',
             state: 'factory:triaging',
+          },
+          {
+            id: 'bug-enhance-skill',
+            label: 'bug-enhance',
+            skill: 'bug-enhance',
+            role: 'triager',
+            state: 'factory:investigating',
+            activation: {
+              setting: 'workItem.missingPromotionSeed',
+              value: true,
+              label: 'bug issue without promotion seed',
+            },
           },
           {
             id: 'qa-skill',
@@ -293,8 +330,11 @@ describe('WorkflowMapPanel', () => {
     expect(screen.getAllByText('triage').length).toBeGreaterThan(0);
     expect(screen.getAllByText('qa').length).toBeGreaterThan(0);
     expect(screen.getByText('Repair')).toBeTruthy();
+    expect(screen.getByTestId('workflow-branch-lazy-bug-grounding').textContent).toContain(
+      'conditional',
+    );
     expect(screen.getByTestId('workflow-vertical-flow')).toBeTruthy();
-    expect(screen.getAllByTestId('workflow-stage')).toHaveLength(3);
+    expect(screen.getAllByTestId('workflow-stage')).toHaveLength(4);
     expect(screen.getByTestId('workflow-variant-multi-agent-delivery').textContent).toContain(
       'active',
     );

--- a/apps/web/src/components/settings/lib/workflow-map.ts
+++ b/apps/web/src/components/settings/lib/workflow-map.ts
@@ -145,6 +145,7 @@ function activationValue(
       return modes.playwrightReproEnabled;
     case 'evidencePost.enabled':
       return modes.evidencePostEnabled;
+    case 'workItem.missingPromotionSeed':
     case 'workItem.simpleBug':
     case 'priority.highCritical':
       return null;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -766,6 +766,7 @@ export type WorkflowActivationSetting =
   | 'devReview.enabled'
   | 'review.convergent'
   | 'workItem.simpleBug'
+  | 'workItem.missingPromotionSeed'
   | 'priority.highCritical'
   | 'playwrightRepro.enabled'
   | 'evidencePost.enabled';

--- a/core/workflows/workflow-catalog.test.ts
+++ b/core/workflows/workflow-catalog.test.ts
@@ -27,6 +27,7 @@ const knownActivationSettings = new Set<WorkflowActivationSetting>([
   'devReview.enabled',
   'review.convergent',
   'workItem.simpleBug',
+  'workItem.missingPromotionSeed',
   'priority.highCritical',
   'playwrightRepro.enabled',
   'evidencePost.enabled',
@@ -152,6 +153,35 @@ describe('workflow catalog', () => {
         (edge) => edge.from === 'investigation-complete' && edge.to === 'acceptance-contract-skill',
       ),
     ).toBe(true);
+  });
+
+  it('shows lazy bug-enhance grounding as a runtime-conditional investigation branch', () => {
+    const bug = byKind('bug');
+    const investigation = bug.stages.find((stage) => stage.id === 'investigation');
+    const branch = investigation?.branches?.find(
+      (candidate) => candidate.id === 'lazy-bug-grounding',
+    );
+    const bugEnhanceNode = bug.nodes.find((node) => node.id === 'bug-enhance-skill');
+
+    expect(bugEnhanceNode).toMatchObject({
+      skill: 'bug-enhance',
+      state: 'factory:investigating',
+      mode: 'conditional',
+      activation: {
+        setting: 'workItem.missingPromotionSeed',
+        value: true,
+        label: 'bug issue without promotion seed',
+      },
+    });
+    expect(branch).toMatchObject({
+      kind: 'conditional',
+      nodes: ['bug-enhance-skill'],
+      activation: {
+        setting: 'workItem.missingPromotionSeed',
+        value: true,
+        label: 'bug issue without promotion seed',
+      },
+    });
   });
 
   it('represents Grill, PRD, Decompose, Delivery Router, Implementation, Conflict, and Dev Review as distinct stages', () => {

--- a/core/workflows/workflow-catalog.ts
+++ b/core/workflows/workflow-catalog.ts
@@ -35,6 +35,7 @@ export type WorkflowActivationSetting =
   | 'devReview.enabled'
   | 'review.convergent'
   | 'workItem.simpleBug'
+  | 'workItem.missingPromotionSeed'
   | 'priority.highCritical'
   | 'playwrightRepro.enabled'
   | 'evidencePost.enabled';
@@ -609,6 +610,11 @@ const bugEntry: WorkflowCatalogEntry = {
       {
         group: 'investigation',
         mode: 'conditional',
+        activation: activeWhen(
+          'workItem.missingPromotionSeed',
+          true,
+          'bug issue without promotion seed',
+        ),
         notes: 'Lazy UI/web bug grounding when no promotion seed exists.',
       },
     ),
@@ -819,6 +825,11 @@ const bugEntry: WorkflowCatalogEntry = {
           description: 'Runs bug-enhance inside investigation when no promotion seed exists.',
           kind: 'conditional',
           nodes: ['bug-enhance-skill'],
+          activation: activeWhen(
+            'workItem.missingPromotionSeed',
+            true,
+            'bug issue without promotion seed',
+          ),
         },
         {
           id: 'investigation-blocked',


### PR DESCRIPTION
## Summary
- mark lazy bug-enhance grounding as a runtime-conditional workflow-map branch
- render conditional workflow branches without project-resolvable activation as conditional instead of active
- include the lazy investigation caller in bug-enhance skill runtime metadata

## Verification
- pnpm vitest run core/workflows/workflow-catalog.test.ts apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx apps/server/src/domains/project-settings/router.test.ts
- pnpm exec biome check apps/server/src/domains/project-settings/router.test.ts apps/server/src/domains/project-settings/router.ts apps/web/src/components/settings/components/WorkflowMapFlow.tsx apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx apps/web/src/components/settings/lib/workflow-map.ts apps/web/src/lib/types.ts core/workflows/workflow-catalog.test.ts core/workflows/workflow-catalog.ts
- pnpm run typecheck