### PR TITLE
M19.XX: chat widget should reset to list view

### DIFF
--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -26,7 +26,7 @@ export function ChatDock() {
 
   return (
     <>
-      <ChatPanel open={open} onClose={() => setOpen(false)} />
+      <ChatPanel open={open} onClose={() => setOpen(false)} restoreLastConversationOnOpen={false} />
       <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
     </>
   );

--- a/apps/web/src/components/chat/components/ChatLauncher.test.tsx
+++ b/apps/web/src/components/chat/components/ChatLauncher.test.tsx
@@ -1,24 +1,114 @@
 /** @vitest-environment jsdom */
-import { cleanup, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
 import { ChatLauncher } from './ChatLauncher';
 
-afterEach(cleanup);
+vi.mock('./ChatPanel', () => ({
+  ChatPanel: ({
+    open,
+    onClose,
+    restoreLastConversationOnOpen,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    restoreLastConversationOnOpen?: boolean;
+  }) => (
+    <div
+      data-open={String(open)}
+      data-restore-last-conversation-on-open={String(restoreLastConversationOnOpen)}
+      data-testid="chat-panel"
+    >
+      <button data-testid="chat-panel-close" onClick={onClose} type="button">
+        Close panel
+      </button>
+    </div>
+  ),
+}));
+
+function renderIntoBody(element: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  flushSync(() => {
+    root.render(element);
+  });
+
+  return {
+    container,
+    rerender(next: ReactNode) {
+      flushSync(() => {
+        root.render(next);
+      });
+    },
+    unmount() {
+      flushSync(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function click(element: Element | null) {
+  expect(element).not.toBeNull();
+  if (element == null) {
+    throw new Error('Expected clickable element');
+  }
+  element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+const mountedRoots: Array<{ unmount: () => void }> = [];
+
+afterEach(() => {
+  for (const mounted of mountedRoots.splice(0)) {
+    mounted.unmount();
+  }
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
 
 describe('ChatLauncher', () => {
   it('renders with aria-pressed reflecting open state', () => {
-    const { rerender } = render(<ChatLauncher open={false} onToggle={() => {}} />);
-    expect(screen.getByTestId('chat-launcher').getAttribute('aria-pressed')).toBe('false');
-    rerender(<ChatLauncher open onToggle={() => {}} />);
-    expect(screen.getByTestId('chat-launcher').getAttribute('aria-pressed')).toBe('true');
+    const mounted = renderIntoBody(<ChatLauncher open={false} onToggle={() => {}} />);
+    mountedRoots.push(mounted);
+
+    const launcher = document.querySelector('[data-testid="chat-launcher"]');
+    expect(launcher?.getAttribute('aria-pressed')).toBe('false');
+
+    mounted.rerender(<ChatLauncher open onToggle={() => {}} />);
+    expect(launcher?.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('fires onToggle when clicked', async () => {
-    const user = userEvent.setup();
+  it('fires onToggle when clicked', () => {
     const onToggle = vi.fn();
-    render(<ChatLauncher open={false} onToggle={onToggle} />);
-    await user.click(screen.getByTestId('chat-launcher'));
+    const mounted = renderIntoBody(<ChatLauncher open={false} onToggle={onToggle} />);
+    mountedRoots.push(mounted);
+
+    click(document.querySelector('[data-testid="chat-launcher"]'));
     expect(onToggle).toHaveBeenCalledOnce();
+  });
+});
+
+describe('ChatDock', () => {
+  it('reopens from the launcher without restoring the last conversation', () => {
+    const mounted = renderIntoBody(<ChatDock />);
+    mountedRoots.push(mounted);
+
+    const panel = () => document.querySelector('[data-testid="chat-panel"]');
+    expect(panel()?.getAttribute('data-open')).toBe('false');
+    expect(panel()?.getAttribute('data-restore-last-conversation-on-open')).toBe('false');
+
+    click(document.querySelector('[data-testid="chat-launcher"]'));
+    expect(panel()?.getAttribute('data-open')).toBe('true');
+
+    click(document.querySelector('[data-testid="chat-panel-close"]'));
+    expect(panel()?.getAttribute('data-open')).toBe('false');
+
+    click(document.querySelector('[data-testid="chat-launcher"]'));
+    expect(panel()?.getAttribute('data-open')).toBe('true');
+    expect(panel()?.getAttribute('data-restore-last-conversation-on-open')).toBe('false');
   });
 });

--- a/apps/web/src/components/chat/components/ChatLauncher.test.tsx
+++ b/apps/web/src/components/chat/components/ChatLauncher.test.tsx
@@ -57,7 +57,9 @@ function click(element: Element | null) {
   if (element == null) {
     throw new Error('Expected clickable element');
   }
-  element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  flushSync(() => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
 }
 
 const mountedRoots: Array<{ unmount: () => void }> = [];

--- a/apps/web/src/components/chat/components/ChatPanel.test.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.test.tsx
@@ -1,15 +1,8 @@
 /** @vitest-environment jsdom */
-vi.mock('react', async () => {
-  const actual = await vi.importActual<typeof import('react')>('react');
-  return {
-    ...actual,
-    act: actual.act ?? (async (callback: () => unknown) => await callback()),
-  };
-});
-
 import type { ChatConversationDto, ChatMessageDto } from '@/lib/types';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChatPanel } from './ChatPanel';
@@ -28,13 +21,54 @@ vi.mock('../lib/useChatEvents', () => ({
   useChatEvents: vi.fn(() => []),
 }));
 
-afterEach(() => {
-  cleanup();
-  localStorage.clear();
-  vi.clearAllMocks();
-});
+vi.mock('./ConversationList', () => ({
+  ConversationList: ({
+    conversations,
+    onSelect,
+  }: {
+    conversations: ChatConversationDto[];
+    onSelect: (id: string) => void;
+  }) => (
+    <div data-testid="chat-conversation-list">
+      {conversations.map((conversation) => (
+        <button
+          key={conversation.id}
+          data-testid="chat-conversation-select"
+          onClick={() => onSelect(conversation.id)}
+          type="button"
+        >
+          {conversation.title}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./ChatThread', () => ({
+  ChatThread: ({ messages }: { messages: ChatMessageDto[] }) => (
+    <div data-testid="chat-thread">
+      {messages.map((message) => (
+        <div key={message.id}>{message.content}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./ChatInput', () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}));
 
 const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
+const mountedRoots: Array<{ unmount: () => void }> = [];
+
+afterEach(() => {
+  for (const mounted of mountedRoots.splice(0)) {
+    mounted.unmount();
+  }
+  localStorage.clear();
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
 
 function makeConversation(overrides: Partial<ChatConversationDto> = {}): ChatConversationDto {
   return {
@@ -63,8 +97,31 @@ function makeMessage(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
   };
 }
 
+function renderIntoBody(element: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  flushSync(() => {
+    root.render(element);
+  });
+
+  return {
+    rerender(next: ReactNode) {
+      flushSync(() => {
+        root.render(next);
+      });
+    },
+    unmount() {
+      flushSync(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
 function renderPanel(open: boolean, restoreLastConversationOnOpen?: boolean) {
-  render(
+  return renderIntoBody(
     <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
       <ChatPanel
         open={open}
@@ -73,6 +130,47 @@ function renderPanel(open: boolean, restoreLastConversationOnOpen?: boolean) {
       />
     </MemoryRouter>,
   );
+}
+
+function click(element: Element | null) {
+  expect(element).not.toBeNull();
+  if (element == null) {
+    throw new Error('Expected clickable element');
+  }
+  flushSync(() => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+function queryByText(text: string) {
+  return Array.from(document.body.querySelectorAll('*')).find((node) =>
+    node.textContent?.includes(text),
+  );
+}
+
+async function waitFor(assertion: () => void, timeoutMs = 1000) {
+  const start = Date.now();
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - start >= timeoutMs) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+}
+
+function deferredPromise<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe('ChatPanel', () => {
@@ -90,14 +188,14 @@ describe('ChatPanel', () => {
     });
     localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, conversation.id);
 
-    renderPanel(true);
+    const mounted = renderPanel(true);
+    mountedRoots.push(mounted);
 
-    expect(await screen.findByText('Restored thread content')).toBeTruthy();
+    await waitFor(() => expect(queryByText('Restored thread content')).toBeTruthy());
     expect(fetchConversation).toHaveBeenCalledWith(conversation.id);
   });
 
   it('resets to the list view on reopen when restoreLastConversationOnOpen is false', async () => {
-    const user = userEvent.setup();
     const { fetchConversation, fetchToolManifest, listConversations } = await import(
       '@/lib/api/chat'
     );
@@ -111,38 +209,89 @@ describe('ChatPanel', () => {
       invocations: [],
     });
 
-    const { rerender } = render(
-      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
-        <ChatPanel open={false} onClose={() => {}} restoreLastConversationOnOpen={false} />
-      </MemoryRouter>,
-    );
+    const mounted = renderPanel(false, false);
+    mountedRoots.push(mounted);
 
-    rerender(
+    mounted.rerender(
       <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
         <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
       </MemoryRouter>,
     );
 
-    await screen.findByTestId('chat-conversation-list');
-    await user.click(await screen.findByTestId('chat-conversation-select'));
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="chat-conversation-select"]')).toBeTruthy(),
+    );
+    click(document.querySelector('[data-testid="chat-conversation-select"]'));
 
-    expect(await screen.findByText('Conversation-only content')).toBeTruthy();
+    await waitFor(() => expect(queryByText('Conversation-only content')).toBeTruthy());
     expect(fetchConversation).toHaveBeenCalledTimes(1);
 
-    rerender(
+    mounted.rerender(
       <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
         <ChatPanel open={false} onClose={() => {}} restoreLastConversationOnOpen={false} />
       </MemoryRouter>,
     );
 
-    rerender(
+    mounted.rerender(
       <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
         <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(screen.getByTestId('chat-conversation-list')).toBeTruthy());
-    expect(screen.queryByText('Conversation-only content')).toBeNull();
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="chat-conversation-select"]')).toBeTruthy(),
+    );
+    expect(queryByText('Conversation-only content')).toBeUndefined();
     expect(fetchConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the previous thread before conversations finish loading when reopen does not restore', async () => {
+    const { fetchConversation, fetchToolManifest, listConversations } = await import(
+      '@/lib/api/chat'
+    );
+    const conversation = makeConversation();
+    const threadMessage = makeMessage({ content: 'Thread should clear immediately' });
+    const reopenList = deferredPromise<ChatConversationDto[]>();
+    vi.mocked(fetchToolManifest).mockResolvedValue([]);
+    vi.mocked(listConversations)
+      .mockResolvedValueOnce([conversation])
+      .mockReturnValueOnce(reopenList.promise);
+    vi.mocked(fetchConversation).mockResolvedValue({
+      conversation,
+      messages: [threadMessage],
+      invocations: [],
+    });
+
+    const mounted = renderPanel(false, false);
+    mountedRoots.push(mounted);
+
+    mounted.rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="chat-conversation-list"]')).toBeTruthy(),
+    );
+    click(document.querySelector('[data-testid="chat-conversation-select"]'));
+    await waitFor(() => expect(queryByText('Thread should clear immediately')).toBeTruthy());
+
+    mounted.rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open={false} onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+    mounted.rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    expect(document.querySelector('[data-testid="chat-conversation-list"]')).toBeTruthy();
+    expect(queryByText('Thread should clear immediately')).toBeUndefined();
+
+    reopenList.resolve([conversation]);
+    await waitFor(() => expect(listConversations).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/web/src/components/chat/components/ChatPanel.test.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.test.tsx
@@ -1,0 +1,148 @@
+/** @vitest-environment jsdom */
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    act: actual.act ?? (async (callback: () => unknown) => await callback()),
+  };
+});
+
+import type { ChatConversationDto, ChatMessageDto } from '@/lib/types';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatPanel } from './ChatPanel';
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: vi.fn(),
+  fetchToolManifest: vi.fn(),
+  listConversations: vi.fn(),
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+vi.mock('../lib/useChatEvents', () => ({
+  useChatEvents: vi.fn(() => []),
+}));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
+
+function makeConversation(overrides: Partial<ChatConversationDto> = {}): ChatConversationDto {
+  return {
+    id: 'conv-1',
+    scope: 'project',
+    projectId: 'goose-hub-self',
+    workItemId: null,
+    title: 'Alpha thread',
+    runtime: 'codex',
+    createdAt: '2026-05-18T00:00:00Z',
+    updatedAt: '2026-05-18T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
+  return {
+    id: 1,
+    conversationId: 'conv-1',
+    role: 'agent',
+    content: 'Restored thread content',
+    runId: null,
+    meta: null,
+    createdAt: '2026-05-18T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderPanel(open: boolean, restoreLastConversationOnOpen?: boolean) {
+  render(
+    <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+      <ChatPanel
+        open={open}
+        onClose={() => {}}
+        restoreLastConversationOnOpen={restoreLastConversationOnOpen}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatPanel', () => {
+  it('restores the persisted conversation by default when reopening', async () => {
+    const { fetchConversation, fetchToolManifest, listConversations } = await import(
+      '@/lib/api/chat'
+    );
+    const conversation = makeConversation();
+    vi.mocked(fetchToolManifest).mockResolvedValue([]);
+    vi.mocked(listConversations).mockResolvedValue([conversation]);
+    vi.mocked(fetchConversation).mockResolvedValue({
+      conversation,
+      messages: [makeMessage()],
+      invocations: [],
+    });
+    localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, conversation.id);
+
+    renderPanel(true);
+
+    expect(await screen.findByText('Restored thread content')).toBeTruthy();
+    expect(fetchConversation).toHaveBeenCalledWith(conversation.id);
+  });
+
+  it('resets to the list view on reopen when restoreLastConversationOnOpen is false', async () => {
+    const user = userEvent.setup();
+    const { fetchConversation, fetchToolManifest, listConversations } = await import(
+      '@/lib/api/chat'
+    );
+    const conversation = makeConversation();
+    const threadMessage = makeMessage({ content: 'Conversation-only content' });
+    vi.mocked(fetchToolManifest).mockResolvedValue([]);
+    vi.mocked(listConversations).mockResolvedValue([conversation]);
+    vi.mocked(fetchConversation).mockResolvedValue({
+      conversation,
+      messages: [threadMessage],
+      invocations: [],
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open={false} onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    await screen.findByTestId('chat-conversation-list');
+    await user.click(await screen.findByTestId('chat-conversation-select'));
+
+    expect(await screen.findByText('Conversation-only content')).toBeTruthy();
+    expect(fetchConversation).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open={false} onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={['/projects/goose-hub-self']}>
+        <ChatPanel open onClose={() => {}} restoreLastConversationOnOpen={false} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('chat-conversation-list')).toBeTruthy());
+    expect(screen.queryByText('Conversation-only content')).toBeNull();
+    expect(fetchConversation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/chat/components/ChatPanel.test.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.test.tsx
@@ -272,7 +272,7 @@ describe('ChatPanel', () => {
     );
 
     await waitFor(() =>
-      expect(document.querySelector('[data-testid="chat-conversation-list"]')).toBeTruthy(),
+      expect(document.querySelector('[data-testid="chat-conversation-select"]')).toBeTruthy(),
     );
     click(document.querySelector('[data-testid="chat-conversation-select"]'));
     await waitFor(() => expect(queryByText('Thread should clear immediately')).toBeTruthy());
@@ -290,6 +290,7 @@ describe('ChatPanel', () => {
 
     expect(document.querySelector('[data-testid="chat-conversation-list"]')).toBeTruthy();
     expect(queryByText('Thread should clear immediately')).toBeUndefined();
+    expect(localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY)).toBeNull();
 
     reopenList.resolve([conversation]);
     await waitFor(() => expect(listConversations).toHaveBeenCalledTimes(2));

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -34,11 +34,12 @@ const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
+  restoreLastConversationOnOpen?: boolean;
 }
 
 type View = 'thread' | 'list';
 
-export function ChatPanel({ open, onClose }: ChatPanelProps) {
+export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true }: ChatPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const resolved = useMemo(() => resolveScopeFromPath(location.pathname), [location.pathname]);
@@ -196,6 +197,13 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         const list = await listConversations({});
         if (cancelled || loadTokenRef.current !== openToken) return;
         setConversations(list);
+        if (!restoreLastConversationOnOpen) {
+          setConversation(null);
+          setMessages([]);
+          setInvocations([]);
+          setView('list');
+          return;
+        }
         const previousId = readActiveId();
         const previous = list.find((c) => c.id === previousId);
         if (previous != null) {
@@ -220,7 +228,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     return () => {
       cancelled = true;
     };
-  }, [open, readActiveId, loadConversation]);
+  }, [open, readActiveId, loadConversation, restoreLastConversationOnOpen]);
 
   const handleNewConversation = useCallback(async () => {
     setBusy(true);

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -64,6 +64,7 @@ export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true 
   //  * the open-panel roster effect clobbering a thread the user just clicked
   //    "New" to create while the list was still in flight.
   const loadTokenRef = useRef(0);
+  const previousOpenRef = useRef(open);
   const activeConversationIdRef = useRef<string | null>(null);
   const inFlightRunByConversationRef = useRef<Map<string, string>>(new Map());
 
@@ -137,6 +138,22 @@ export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true 
     }
   }, []);
 
+  const resetToListView = useCallback(() => {
+    setConversation(null);
+    setMessages([]);
+    setInvocations([]);
+    setView('list');
+  }, []);
+
+  useEffect(() => {
+    const openChanged = previousOpenRef.current !== open;
+    previousOpenRef.current = open;
+    if (restoreLastConversationOnOpen) return;
+    if (!openChanged && !open) return;
+    loadTokenRef.current += 1;
+    resetToListView();
+  }, [open, restoreLastConversationOnOpen, resetToListView]);
+
   useEffect(() => {
     if (!open || toolManifest.length > 0) return;
     let cancelled = false;
@@ -198,10 +215,7 @@ export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true 
         if (cancelled || loadTokenRef.current !== openToken) return;
         setConversations(list);
         if (!restoreLastConversationOnOpen) {
-          setConversation(null);
-          setMessages([]);
-          setInvocations([]);
-          setView('list');
+          resetToListView();
           return;
         }
         const previousId = readActiveId();
@@ -228,7 +242,7 @@ export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true 
     return () => {
       cancelled = true;
     };
-  }, [open, readActiveId, loadConversation, restoreLastConversationOnOpen]);
+  }, [open, readActiveId, loadConversation, resetToListView, restoreLastConversationOnOpen]);
 
   const handleNewConversation = useCallback(async () => {
     setBusy(true);

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -151,8 +151,9 @@ export function ChatPanel({ open, onClose, restoreLastConversationOnOpen = true 
     if (restoreLastConversationOnOpen) return;
     if (!openChanged && !open) return;
     loadTokenRef.current += 1;
+    writeActiveId(null);
     resetToListView();
-  }, [open, restoreLastConversationOnOpen, resetToListView]);
+  }, [open, restoreLastConversationOnOpen, resetToListView, writeActiveId]);
 
   useEffect(() => {
     if (!open || toolManifest.length > 0) return;


### PR DESCRIPTION
## Summary

chat widget should reset to list view

## Work Packages

- ✓ **WP1**: In ChatPanel, add restoreLastConversationOnOpen?: boolean to the props contract with a default that preserves existing r
- ✗ **WP2**: Update ChatDock's ChatPanel invocation near the existing <ChatPanel open={open} onClose={() => setOpen(false)} /> call t
- ✓ **WP2**: Update ChatDock's ChatPanel invocation near the existing <ChatPanel open={open} onClose={() => setOpen(false)} /> call t

Closes #1069
