### PR TITLE
M19.XX: chat widget should reset to list view

### DIFF
--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: vi.fn(),
+  fetchToolManifest: vi.fn(),
+  listConversations: vi.fn(),
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+vi.mock('../lib/useChatEvents', () => ({
+  useChatEvents: () => [],
+}));
+
+import { fetchConversation, fetchToolManifest, listConversations } from '@/lib/api/chat';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(fetchToolManifest).mockResolvedValue([]);
+});
+
+const conversation = {
+  id: 'conv-1',
+  scope: 'project' as const,
+  projectId: 'goose-hub-self',
+  workItemId: null,
+  title: 'Project chat',
+  runtime: 'codex' as const,
+  createdAt: '2026-05-18T00:00:00Z',
+  updatedAt: '2026-05-18T00:00:00Z',
+};
+
+function renderDock() {
+  render(
+    <MemoryRouter>
+      <ChatDock />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatDock', () => {
+  it('reopens to the list view after a launcher-driven close while preserving the active conversation id', async () => {
+    vi.mocked(listConversations).mockResolvedValue([conversation]);
+    vi.mocked(fetchConversation).mockResolvedValue({
+      conversation,
+      messages: [],
+      invocations: [],
+    });
+
+    renderDock();
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('chat-conversation-select'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-input')).toBeTruthy();
+    });
+
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBe('conv-1');
+    expect(fetchConversation).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId('chat-input')).toBeNull();
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBe('conv-1');
+    expect(fetchConversation).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('chat-conversation-select'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-input')).toBeTruthy();
+    });
+
+    expect(fetchConversation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -17,6 +17,7 @@ export function ChatDock() {
       return false;
     }
   });
+  const [restoreActiveConversationOnOpen, setRestoreActiveConversationOnOpen] = useState(true);
 
   useEffect(() => {
     try {
@@ -26,8 +27,25 @@ export function ChatDock() {
 
   return (
     <>
-      <ChatPanel open={open} onClose={() => setOpen(false)} />
-      <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
+      <ChatPanel
+        open={open}
+        onClose={() => {
+          setRestoreActiveConversationOnOpen(true);
+          setOpen(false);
+        }}
+        restoreActiveConversationOnOpen={restoreActiveConversationOnOpen}
+      />
+      <ChatLauncher
+        open={open}
+        onToggle={() => {
+          if (open) {
+            setRestoreActiveConversationOnOpen(false);
+            setOpen(false);
+            return;
+          }
+          setOpen(true);
+        }}
+      />
     </>
   );
 }

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -34,11 +34,16 @@ const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
+  restoreActiveConversationOnOpen?: boolean;
 }
 
 type View = 'thread' | 'list';
 
-export function ChatPanel({ open, onClose }: ChatPanelProps) {
+export function ChatPanel({
+  open,
+  onClose,
+  restoreActiveConversationOnOpen = true,
+}: ChatPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const resolved = useMemo(() => resolveScopeFromPath(location.pathname), [location.pathname]);
@@ -196,6 +201,13 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         const list = await listConversations({});
         if (cancelled || loadTokenRef.current !== openToken) return;
         setConversations(list);
+        if (!restoreActiveConversationOnOpen) {
+          setConversation(null);
+          setMessages([]);
+          setInvocations([]);
+          setView('list');
+          return;
+        }
         const previousId = readActiveId();
         const previous = list.find((c) => c.id === previousId);
         if (previous != null) {
@@ -220,7 +232,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     return () => {
       cancelled = true;
     };
-  }, [open, readActiveId, loadConversation]);
+  }, [open, readActiveId, loadConversation, restoreActiveConversationOnOpen]);
 
   const handleNewConversation = useCallback(async () => {
     setBusy(true);


### PR DESCRIPTION
## Summary

chat widget should reset to list view

## Work Packages

- ✓ **WP1**: In `ChatDock.tsx:11`, add local state or equivalent policy tracking that detects when the floating `ChatLauncher` closes

Closes #1074
