### PR TITLE
M19.XX: chat bug 1

### DIFF
--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -83,7 +83,7 @@ describe('ChatDock', () => {
     await waitFor(() => expect(screen.getByTestId('chat-input')).toBeTruthy());
     expect(fetchConversation).toHaveBeenCalledWith('conv-1');
 
-    fireEvent.click(screen.getByLabelText('Close chat'));
+    fireEvent.click(screen.getByTestId('chat-launcher'));
 
     await waitFor(() => {
       expect(screen.getByTestId('chat-panel').className).toContain('translate-x-full');

--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,98 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: vi.fn(),
+  fetchToolManifest: vi.fn(),
+  listConversations: vi.fn(),
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+vi.mock('../lib/useChatEvents', () => ({
+  useChatEvents: () => [],
+}));
+
+import { fetchConversation, fetchToolManifest, listConversations } from '@/lib/api/chat';
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.mocked(fetchToolManifest).mockResolvedValue([]);
+});
+
+describe('ChatDock', () => {
+  it('reopens on the conversation list after closing an active thread', async () => {
+    vi.mocked(listConversations).mockResolvedValue([
+      {
+        id: 'conv-1',
+        scope: 'project',
+        projectId: 'goose-hub-self',
+        workItemId: null,
+        title: 'Existing thread',
+        runtime: 'codex',
+        createdAt: '2026-05-18T00:00:00Z',
+        updatedAt: '2026-05-18T00:00:00Z',
+      },
+    ]);
+    vi.mocked(fetchConversation).mockResolvedValue({
+      conversation: {
+        id: 'conv-1',
+        scope: 'project',
+        projectId: 'goose-hub-self',
+        workItemId: null,
+        title: 'Existing thread',
+        runtime: 'codex',
+        createdAt: '2026-05-18T00:00:00Z',
+        updatedAt: '2026-05-18T00:00:00Z',
+      },
+      messages: [
+        {
+          id: 1,
+          conversationId: 'conv-1',
+          role: 'user',
+          content: 'Hello',
+          runId: null,
+          meta: null,
+          createdAt: '2026-05-18T00:00:00Z',
+        },
+      ],
+      invocations: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <ChatDock />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => expect(screen.getByTestId('chat-conversation-list')).toBeTruthy());
+    expect(screen.queryByTestId('chat-input')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('chat-conversation-select'));
+
+    await waitFor(() => expect(screen.getByTestId('chat-input')).toBeTruthy());
+    expect(fetchConversation).toHaveBeenCalledWith('conv-1');
+
+    fireEvent.click(screen.getByLabelText('Close chat'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-panel').className).toContain('translate-x-full');
+    });
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => expect(screen.getByTestId('chat-conversation-list')).toBeTruthy());
+    expect(screen.queryByTestId('chat-input')).toBeNull();
+    expect(fetchConversation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -65,6 +65,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
   const loadTokenRef = useRef(0);
   const activeConversationIdRef = useRef<string | null>(null);
   const inFlightRunByConversationRef = useRef<Map<string, string>>(new Map());
+  const previousOpenRef = useRef(open);
 
   useEffect(() => {
     activeConversationIdRef.current = conversation?.id ?? null;
@@ -135,6 +136,22 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
       // localStorage unavailable — accept the loss; selection is best-effort.
     }
   }, []);
+
+  const resetPanelState = useCallback(() => {
+    loadTokenRef.current += 1;
+    writeActiveId(null);
+    setConversation(null);
+    setMessages([]);
+    setInvocations([]);
+    setView('list');
+  }, [writeActiveId]);
+
+  useEffect(() => {
+    if (previousOpenRef.current && !open) {
+      resetPanelState();
+    }
+    previousOpenRef.current = open;
+  }, [open, resetPanelState]);
 
   useEffect(() => {
     if (!open || toolManifest.length > 0) return;
@@ -415,16 +432,6 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     [navigate, onClose],
   );
 
-  const handleClose = useCallback(() => {
-    loadTokenRef.current += 1;
-    writeActiveId(null);
-    setConversation(null);
-    setMessages([]);
-    setInvocations([]);
-    setView('list');
-    onClose();
-  }, [onClose, writeActiveId]);
-
   const toggleView = useCallback(() => {
     setView((v) => (v === 'thread' ? 'list' : conversation != null ? 'thread' : 'list'));
   }, [conversation]);
@@ -473,7 +480,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         </select>
         <button
           type="button"
-          onClick={handleClose}
+          onClick={onClose}
           aria-label="Close chat"
           className="p-1 text-fg-2 hover:text-fg rounded"
         >

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -415,6 +415,16 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
     [navigate, onClose],
   );
 
+  const handleClose = useCallback(() => {
+    loadTokenRef.current += 1;
+    writeActiveId(null);
+    setConversation(null);
+    setMessages([]);
+    setInvocations([]);
+    setView('list');
+    onClose();
+  }, [onClose, writeActiveId]);
+
   const toggleView = useCallback(() => {
     setView((v) => (v === 'thread' ? 'list' : conversation != null ? 'thread' : 'list'));
   }, [conversation]);
@@ -463,7 +473,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
         </select>
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           aria-label="Close chat"
           className="p-1 text-fg-2 hover:text-fg rounded"
         >


### PR DESCRIPTION
## Summary

chat bug 1

## Work Packages

- ✓ **WP1**: In `apps/web/src/components/chat/components/ChatPanel.tsx:29`, keep the `ChatPanelProps` close callback but route the cl

Closes #1073
