### PR TITLE
Make skill runtime settings configurable

### DIFF
--- a/apps/server/src/domains/project-settings/router.test.ts
+++ b/apps/server/src/domains/project-settings/router.test.ts
@@ -419,6 +419,65 @@ describe('project settings router', () => {
     );
   });
 
+  it('writes escalation patches to project_skill_settings', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings/skills/implement', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        escalationModelTier: 'opus',
+        escalationMaxBudgetUsd: 18,
+        escalationMaxTurns: 90,
+        escalationTimeoutMs: 420000,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteProjectSkillSetting).toHaveBeenCalledWith(
+      'goose-hub-self',
+      'implement',
+      {
+        escalationModelTier: 'opus',
+        escalationMaxBudgetUsd: 18,
+        escalationMaxTurns: 90,
+        escalationTimeoutMs: 420000,
+      },
+      'ui',
+    );
+  });
+
+  it('writes implement-WP contract keyword patches through global settings', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings/global', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ implementWpContractKeywords: ['schema', 'migration', 'auth'] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteProjectSettings).toHaveBeenCalledWith(
+      'goose-hub-self',
+      { implementWpContractKeywordsJson: JSON.stringify(['schema', 'migration', 'auth']) },
+      'ui',
+    );
+  });
+
+  it('clears implement-WP contract keyword overrides when the patch is empty', async () => {
+    const app = makeApp();
+    const res = await app.request('/projects/goose-hub-self/settings/global', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ implementWpContractKeywords: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteProjectSettings).toHaveBeenCalledWith(
+      'goose-hub-self',
+      { implementWpContractKeywordsJson: null },
+      'ui',
+    );
+  });
+
   it('resolves per-skill DB tier/provider above project config and skill defaults', async () => {
     mockGetProject.mockResolvedValue({
       ...project(),

--- a/apps/server/src/domains/project-settings/router.ts
+++ b/apps/server/src/domains/project-settings/router.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { SKILL_BUDGETS } from '@goose-hub/core/agent-runtime/budgets.js';
+import { SKILL_BUDGETS, resolveEscalatedBudgets } from '@goose-hub/core/agent-runtime/budgets.js';
 import { resolveImplementWpSettings } from '@goose-hub/core/agent-runtime/implement-wp-settings.js';
 import type { SkillConfig } from '@goose-hub/core/agent-runtime/interface.js';
 import { deriveSkillRuntimeResponse } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
@@ -59,6 +59,7 @@ const GlobalBudgetPatchSchema = z.object({
   implementWpHighPriorityUsd: z.number().min(0).max(100).nullable().optional(),
   implementWpManyFilesThreshold: z.number().int().min(0).max(100).nullable().optional(),
   implementWpManyFilesUsd: z.number().min(0).max(100).nullable().optional(),
+  implementWpContractKeywords: z.array(z.string().trim().min(1)).max(20).nullable().optional(),
   implementWpContractUsd: z.number().min(0).max(100).nullable().optional(),
   qaE2eMode: z.enum(['off', 'ui-changed', 'always']).nullable().optional(),
   playwrightReproEnabled: z.number().int().min(0).max(1).nullable().optional(),
@@ -72,6 +73,10 @@ const SkillBudgetPatchSchema = z.object({
   modelTier: z.enum(['haiku', 'sonnet', 'opus']).nullable().optional(),
   provider: z.enum(['claude', 'codex']).nullable().optional(),
   effort: z.enum(['low', 'medium', 'high', 'xhigh']).nullable().optional(),
+  escalationModelTier: z.enum(['haiku', 'sonnet', 'opus']).nullable().optional(),
+  escalationMaxBudgetUsd: z.number().min(0).max(100).nullable().optional(),
+  escalationMaxTurns: z.number().int().min(1).max(500).nullable().optional(),
+  escalationTimeoutMs: z.number().int().min(5_000).max(3_600_000).nullable().optional(),
 });
 
 const DevReviewPatchSchema = z.object({
@@ -86,7 +91,6 @@ const DevReviewPatchSchema = z.object({
 });
 
 const ReviewerSlotSchema = z.object({
-  model: z.enum(['claude', 'codex']),
   prompt: z.enum(['default', 'unconstrained']),
 });
 
@@ -159,8 +163,23 @@ function flattenImplementWpSettings(settings: ReturnType<typeof resolveImplement
     highPriorityUsd: settings.budgetSizing.complexAdditions.highPriorityUsd,
     manyFilesThreshold: settings.budgetSizing.complexAdditions.manyFilesThreshold,
     manyFilesUsd: settings.budgetSizing.complexAdditions.manyFilesUsd,
+    contractKeywords: settings.budgetSizing.complexAdditions.contractKeywords,
     contractUsd: settings.budgetSizing.complexAdditions.contractUsd,
   };
+}
+
+function parseKeywordsJson(value: string | null | undefined): string[] | null {
+  if (value == null) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  } catch {
+    return null;
+  }
 }
 
 function dbImplementWpOverrides(row: ReturnType<typeof readProjectSettings>) {
@@ -176,6 +195,7 @@ function dbImplementWpOverrides(row: ReturnType<typeof readProjectSettings>) {
     implementWpHighPriorityUsd: row.implementWpHighPriorityUsd,
     implementWpManyFilesThreshold: row.implementWpManyFilesThreshold,
     implementWpManyFilesUsd: row.implementWpManyFilesUsd,
+    implementWpContractKeywords: parseKeywordsJson(row.implementWpContractKeywordsJson),
     implementWpContractUsd: row.implementWpContractUsd,
   };
   if (!Object.values(values).some((value) => value != null)) return null;
@@ -317,6 +337,10 @@ router.get('/:slug/settings', async (c) => {
       modelTier: string | null;
       provider: string | null;
       effort: RuntimeEffort | null;
+      escalationModelTier: string | null;
+      escalationMaxBudgetUsd: number | null;
+      escalationMaxTurns: number | null;
+      escalationTimeoutMs: number | null;
       updatedAt: string | null;
     }
   > = {};
@@ -334,6 +358,10 @@ router.get('/:slug/settings', async (c) => {
         row.effort === 'xhigh'
           ? row.effort
           : null,
+      escalationModelTier: row.escalationModelTier ?? null,
+      escalationMaxBudgetUsd: row.escalationMaxBudgetUsd ?? null,
+      escalationMaxTurns: row.escalationMaxTurns ?? null,
+      escalationTimeoutMs: row.escalationTimeoutMs ?? null,
       updatedAt: row.updatedAt,
     };
   }
@@ -350,6 +378,12 @@ router.get('/:slug/settings', async (c) => {
       modelTier: string;
       modelProvider: string;
       effort: RuntimeEffort | null;
+      escalation: {
+        modelTier: string;
+        maxBudgetUsd: number;
+        maxTurns: number | null;
+        timeoutMs: number | null;
+      } | null;
     }
   > = {};
   const skillMetadata: Record<
@@ -369,6 +403,14 @@ router.get('/:slug/settings', async (c) => {
       modelTier: budget.modelTier,
       modelProvider: hint?.provider ?? budget.provider ?? 'claude',
       effort: budget.effort ?? null,
+      escalation: budget.escalation
+        ? {
+            modelTier: budget.escalation.modelTier,
+            maxBudgetUsd: budget.escalation.maxBudgetUsd,
+            maxTurns: budget.escalation.maxTurns ?? null,
+            timeoutMs: budget.escalation.timeoutMs ?? null,
+          }
+        : null,
     };
     skillMetadata[skill] = {
       description: hint?.description ?? null,
@@ -387,6 +429,7 @@ router.get('/:slug/settings', async (c) => {
       resolvedPrimary: unknown;
       resolvedFallback: unknown;
       resolvedAdvisor: unknown;
+      resolvedEscalation: unknown;
       selectionReason: string;
       resolutionTrace: unknown;
     }
@@ -405,6 +448,13 @@ router.get('/:slug/settings', async (c) => {
       fallbackTier: hint?.modelTier,
       fallbackProvider: hint?.provider,
     });
+    const escalation = resolveEscalatedBudgets(
+      skill,
+      project.budgets,
+      globalRow?.perWorkflowMaxUsd,
+      globalRow?.perAgentMaxUsd,
+      skillRows.get(skill),
+    );
     resolvedSkillRuntimes[skill] = {
       source: resolved.source,
       effectiveTier: resolved.tier,
@@ -413,6 +463,13 @@ router.get('/:slug/settings', async (c) => {
       resolvedPrimary: resolved.resolvedPrimary,
       resolvedFallback: resolved.resolvedFallback,
       resolvedAdvisor: resolved.resolvedAdvisor,
+      resolvedEscalation:
+        escalation != null
+          ? {
+              modelId: escalation.modelOverride,
+              budgets: escalation.budgets,
+            }
+          : null,
       selectionReason: resolved.selectionReason,
       resolutionTrace: resolved.runtimeTrace,
     };
@@ -504,7 +561,27 @@ router.patch('/:slug/settings/global', async (c) => {
     return c.json({ error: 'invalid body', details: parsed.error.issues }, 422);
   }
 
-  writeProjectSettings(project.id, parsed.data, 'ui');
+  const { implementWpContractKeywords, ...patch } = parsed.data;
+  writeProjectSettings(
+    project.id,
+    {
+      ...patch,
+      ...(implementWpContractKeywords !== undefined
+        ? {
+            implementWpContractKeywordsJson:
+              implementWpContractKeywords == null
+                ? null
+                : (() => {
+                    const keywords = [
+                      ...new Set(implementWpContractKeywords.map((keyword) => keyword.trim())),
+                    ].filter((keyword) => keyword.length > 0);
+                    return keywords.length > 0 ? JSON.stringify(keywords) : null;
+                  })(),
+          }
+        : {}),
+    },
+    'ui',
+  );
   return c.json({ ok: true });
 });
 

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectBudgetPanel } from './ProjectBudgetPanel';
 
 const mockPatchGlobalBudgetSettings = vi.hoisted(() => vi.fn());
+const mockPatchSkillBudgetSetting = vi.hoisted(() => vi.fn());
+const mockPatchDevReviewSettings = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
   deleteSkillBudgetSetting: vi.fn(),
@@ -12,6 +14,17 @@ vi.mock('@/lib/api', () => ({
     status: 'connected',
     authPath: '/Users/test/.codex/auth.json',
     loginCommand: 'codex login',
+  }),
+  fetchDevReviewSettings: vi.fn().mockResolvedValue({
+    projectId: 'goose-hub-self',
+    config: {
+      enabled: true,
+      triggerOn: 'priority:high+',
+      maxRevisionTurns: 1,
+      perCycleMaxUsd: 2,
+      timeoutMs: 180000,
+    },
+    dbOverride: null,
   }),
   fetchProjectSettings: vi.fn().mockResolvedValue({
     projectId: 'goose-hub-self',
@@ -29,6 +42,7 @@ vi.mock('@/lib/api', () => ({
       highPriorityUsd: 1,
       manyFilesThreshold: 3,
       manyFilesUsd: 1,
+      contractKeywords: ['schema', 'migration', 'api'],
       contractUsd: 1,
     },
     resolvedImplementWp: {
@@ -42,6 +56,7 @@ vi.mock('@/lib/api', () => ({
       highPriorityUsd: 1,
       manyFilesThreshold: 3,
       manyFilesUsd: 1,
+      contractKeywords: ['schema', 'migration', 'api'],
       contractUsd: 1,
     },
     dbImplementWpOverrides: {
@@ -55,6 +70,7 @@ vi.mock('@/lib/api', () => ({
       implementWpHighPriorityUsd: null,
       implementWpManyFilesThreshold: null,
       implementWpManyFilesUsd: null,
+      implementWpContractKeywords: null,
       implementWpContractUsd: null,
       updatedAt: '2026-05-20T00:00:00Z',
       updatedBy: 'ui',
@@ -67,10 +83,33 @@ vi.mock('@/lib/api', () => ({
         modelTier: null,
         provider: null,
         effort: 'high',
+        escalationModelTier: null,
+        escalationMaxBudgetUsd: null,
+        escalationMaxTurns: null,
+        escalationTimeoutMs: null,
+        devReviewMaxRevisionTurns: null,
+        devReviewPerCycleMaxUsd: null,
+        devReviewTimeoutMs: null,
+        updatedAt: '2026-05-20T00:00:00Z',
+      },
+      implement: {
+        maxTurns: null,
+        maxBudgetUsd: null,
+        timeoutMs: null,
+        modelTier: null,
+        provider: null,
+        effort: null,
+        escalationModelTier: 'opus',
+        escalationMaxBudgetUsd: 18,
+        escalationMaxTurns: null,
+        escalationTimeoutMs: null,
+        devReviewMaxRevisionTurns: null,
+        devReviewPerCycleMaxUsd: null,
+        devReviewTimeoutMs: null,
         updatedAt: '2026-05-20T00:00:00Z',
       },
     },
-    registeredSkills: ['qa'],
+    registeredSkills: ['qa', 'implement', 'dev-review'],
     skillMetadata: {
       qa: { description: 'Holdout QA check.', dependencies: ['prDiff'], callers: ['QA gate'] },
     },
@@ -82,6 +121,30 @@ vi.mock('@/lib/api', () => ({
         modelTier: 'sonnet',
         modelProvider: 'claude',
         effort: null,
+        escalation: null,
+      },
+      implement: {
+        maxTurns: 150,
+        maxBudgetUsd: 6,
+        timeoutMs: 900000,
+        modelTier: 'haiku',
+        modelProvider: 'claude',
+        effort: null,
+        escalation: {
+          modelTier: 'sonnet',
+          maxBudgetUsd: 15,
+          maxTurns: null,
+          timeoutMs: null,
+        },
+      },
+      'dev-review': {
+        maxTurns: 20,
+        maxBudgetUsd: 2,
+        timeoutMs: 180000,
+        modelTier: 'sonnet',
+        modelProvider: 'codex',
+        effort: null,
+        escalation: null,
       },
     },
     resolvedSkillRuntimes: {
@@ -107,6 +170,41 @@ vi.mock('@/lib/api', () => ({
               'holdout skill ignores DB/config provider overrides; using resolver fallback provider',
           },
           effort: { value: 'high', source: 'db', reason: 'project_skill_settings.effort override' },
+        },
+      },
+      implement: {
+        source: 'db',
+        effectiveTier: 'haiku',
+        effectiveProvider: 'claude',
+        effectiveEffort: null,
+        resolvedPrimary: { tier: 'haiku', provider: 'claude', modelId: 'claude-haiku' },
+        resolvedFallback: { tier: 'haiku', provider: 'claude', modelId: 'claude-haiku' },
+        resolvedAdvisor: { tier: 'sonnet', provider: 'claude', modelId: 'claude-sonnet' },
+        resolvedEscalation: {
+          tier: 'opus',
+          provider: 'claude',
+          modelId: 'claude-opus',
+          budgets: { maxTurns: 150, maxBudgetUsd: 18, timeoutMs: 900000 },
+        },
+        selectionReason: 'tier skill-default, provider fallback',
+        resolutionTrace: {
+          tier: { value: 'haiku', source: 'skill-default', reason: 'SKILL_BUDGETS default tier' },
+          provider: { value: 'claude', source: 'fallback', reason: 'resolver fallback provider' },
+        },
+      },
+      'dev-review': {
+        source: 'skill-default',
+        effectiveTier: 'sonnet',
+        effectiveProvider: 'codex',
+        effectiveEffort: null,
+        resolvedPrimary: { tier: 'sonnet', provider: 'codex', modelId: 'gpt-5.4' },
+        resolvedFallback: null,
+        resolvedAdvisor: null,
+        resolvedEscalation: null,
+        selectionReason: 'tier skill-default, provider skill-default',
+        resolutionTrace: {
+          tier: { value: 'sonnet', source: 'skill-default', reason: 'SKILL_BUDGETS default tier' },
+          provider: { value: 'codex', source: 'skill-default', reason: 'SKILL_BUDGETS provider' },
         },
       },
     },
@@ -152,12 +250,15 @@ vi.mock('@/lib/api', () => ({
     ],
   }),
   patchGlobalBudgetSettings: mockPatchGlobalBudgetSettings,
-  patchSkillBudgetSetting: vi.fn(),
+  patchDevReviewSettings: mockPatchDevReviewSettings,
+  patchSkillBudgetSetting: mockPatchSkillBudgetSetting,
   resetAllProjectBudgets: vi.fn(),
 }));
 
 beforeEach(() => {
   mockPatchGlobalBudgetSettings.mockClear();
+  mockPatchSkillBudgetSetting.mockClear();
+  mockPatchDevReviewSettings.mockClear();
 });
 
 afterEach(() => cleanup());
@@ -197,7 +298,10 @@ describe('ProjectBudgetPanel', () => {
 
     await waitFor(() => expect(screen.getByText('Implement-WP controls')).toBeTruthy());
     expect(screen.getByText('Edit-test loop cycles')).toBeTruthy();
-    expect(screen.getByDisplayValue('2')).toBeTruthy();
+    const editTestLoopInput = screen
+      .getAllByPlaceholderText('3')
+      .find((input) => (input as HTMLInputElement).value === '2') as HTMLInputElement;
+    expect(editTestLoopInput).toBeTruthy();
 
     const featureBudget = screen.getByPlaceholderText('6');
     fireEvent.change(featureBudget, { target: { value: '7.5' } });
@@ -206,6 +310,79 @@ describe('ProjectBudgetPanel', () => {
     await waitFor(() =>
       expect(mockPatchGlobalBudgetSettings).toHaveBeenCalledWith('goose-hub-self', {
         implementWpFeatureMaxBudgetUsd: 7.5,
+      }),
+    );
+  });
+
+  it('renders escalation and dev-review loop controls inside skill runtime settings', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ProjectBudgetPanel slug="goose-hub-self" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Skill runtime settings')).toBeTruthy());
+    expect(screen.getByText('Escalation tier')).toBeTruthy();
+    expect(screen.getByDisplayValue('opus')).toBeTruthy();
+    expect(screen.getByText('Dev-review loop controls')).toBeTruthy();
+
+    const escalationBudget = screen.getByDisplayValue('18');
+    fireEvent.change(escalationBudget, { target: { value: '19' } });
+    fireEvent.blur(escalationBudget);
+
+    await waitFor(() =>
+      expect(mockPatchSkillBudgetSetting).toHaveBeenCalledWith('goose-hub-self', 'implement', {
+        escalationMaxBudgetUsd: 19,
+      }),
+    );
+
+    const devReviewBudget = screen
+      .getAllByPlaceholderText('2.00')
+      .find((input) => (input as HTMLInputElement).value === '2') as HTMLInputElement;
+    expect(devReviewBudget).toBeTruthy();
+    fireEvent.change(devReviewBudget, { target: { value: '3' } });
+    fireEvent.blur(devReviewBudget);
+
+    await waitFor(() =>
+      expect(mockPatchDevReviewSettings).toHaveBeenCalledWith('goose-hub-self', {
+        perCycleMaxUsd: 3,
+      }),
+    );
+  });
+
+  it('renders and patches implement-WP contract keywords', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ProjectBudgetPanel slug="goose-hub-self" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Contract keywords')).toBeTruthy());
+
+    const input = screen.getByDisplayValue('schema, migration, api');
+    fireEvent.change(input, { target: { value: 'schema, auth' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(mockPatchGlobalBudgetSettings).toHaveBeenCalledWith('goose-hub-self', {
+        implementWpContractKeywords: ['schema', 'auth'],
+      }),
+    );
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(mockPatchGlobalBudgetSettings).toHaveBeenCalledWith('goose-hub-self', {
+        implementWpContractKeywords: null,
       }),
     );
   });

--- a/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
+++ b/apps/web/src/components/settings/components/ProjectBudgetPanel.tsx
@@ -1,14 +1,17 @@
 import {
   deleteSkillBudgetSetting,
   fetchCodexAuthStatus,
+  fetchDevReviewSettings,
   fetchProjectSettings,
   fetchRuntimeProfiler,
+  patchDevReviewSettings,
   patchGlobalBudgetSettings,
   patchSkillBudgetSetting,
   resetAllProjectBudgets,
 } from '@/lib/api';
 import type {
   CodexAuthStatusDto,
+  DevReviewSettingsDto,
   ModelProvider,
   ModelTier,
   ProjectSettingsDto,
@@ -205,6 +208,50 @@ function NumericInput({
   );
 }
 
+function TextInput({
+  value,
+  placeholder,
+  overridden,
+  subtitle,
+  onCommit,
+}: {
+  value: string;
+  placeholder: string;
+  overridden: boolean;
+  subtitle?: string | null;
+  onCommit: (val: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <div className="flex min-w-0 flex-wrap items-center gap-1">
+        <input
+          type="text"
+          value={draft}
+          placeholder={placeholder}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => onCommit(draft)}
+          className={[
+            'w-full max-w-72 min-w-0 rounded border px-2 py-0.5 text-[12px] font-mono bg-bg text-fg',
+            overridden ? 'border-accent' : 'border-line',
+          ].join(' ')}
+        />
+        {overridden && (
+          <span className="shrink-0 text-[10px] text-accent font-medium">override</span>
+        )}
+      </div>
+      {subtitle != null && subtitle !== '' && (
+        <span className="text-[10px] text-fg-3 font-mono break-words">{subtitle}</span>
+      )}
+    </div>
+  );
+}
+
 function RuntimeSelect({
   value,
   options,
@@ -263,6 +310,29 @@ function RuntimeModelCell({
       <span className="font-mono text-fg break-all leading-snug">{value.modelId}</span>
       <span className="text-[10px] text-fg-3 font-mono break-all">
         {value.provider}:{value.tier}
+      </span>
+    </div>
+  );
+}
+
+function RuntimeEscalationCell({
+  value,
+}: {
+  value:
+    | {
+        modelId: string;
+        budgets: { maxTurns: number; maxBudgetUsd: number; timeoutMs: number };
+      }
+    | null
+    | undefined;
+}) {
+  if (value == null) return <span className="text-fg-3">—</span>;
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <span className="font-mono text-fg break-all leading-snug">{value.modelId}</span>
+      <span className="text-[10px] text-fg-3 font-mono break-all">
+        {value.budgets.maxTurns} turns | ${value.budgets.maxBudgetUsd.toFixed(2)} |{' '}
+        {value.budgets.timeoutMs} ms
       </span>
     </div>
   );
@@ -483,9 +553,15 @@ export function ProjectBudgetPanel({ slug }: Props) {
     queryFn: ({ signal }) => fetchProjectSettings(slug, signal),
     staleTime: 10_000,
   });
+  const { data: devReviewSettings } = useQuery<DevReviewSettingsDto>({
+    queryKey: ['dev-review-settings', slug],
+    queryFn: ({ signal }) => fetchDevReviewSettings(slug, signal),
+    staleTime: 10_000,
+  });
 
   const patchGlobal = useMutation({
-    mutationFn: (patch: Record<string, number | null>) => patchGlobalBudgetSettings(slug, patch),
+    mutationFn: (patch: Record<string, number | string[] | null>) =>
+      patchGlobalBudgetSettings(slug, patch),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['project-settings', slug] }),
   });
 
@@ -503,6 +579,14 @@ export function ProjectBudgetPanel({ slug }: Props) {
   const deleteSkill = useMutation({
     mutationFn: (skill: string) => deleteSkillBudgetSetting(slug, skill),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['project-settings', slug] }),
+  });
+
+  const patchDevReview = useMutation({
+    mutationFn: (patch: Parameters<typeof patchDevReviewSettings>[1]) =>
+      patchDevReviewSettings(slug, patch),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['dev-review-settings', slug] });
+    },
   });
 
   const resetAll = useMutation({
@@ -609,6 +693,27 @@ export function ProjectBudgetPanel({ slug }: Props) {
               </Fragment>
             );
           })}
+          <span className="text-[12px] text-fg-2 flex items-center gap-1.5 pt-1">
+            Contract keywords
+          </span>
+          <TextInput
+            value={(
+              dbImplementWp?.implementWpContractKeywords ??
+              data.resolvedImplementWp.contractKeywords
+            ).join(', ')}
+            placeholder={data.implementWpDefaults.contractKeywords.join(', ')}
+            overridden={dbImplementWp?.implementWpContractKeywords != null}
+            subtitle={`default: ${data.implementWpDefaults.contractKeywords.join(', ')}`}
+            onCommit={(val) => {
+              const keywords = val
+                .split(',')
+                .map((keyword) => keyword.trim())
+                .filter((keyword) => keyword.length > 0);
+              patchGlobal.mutate({
+                implementWpContractKeywords: keywords.length > 0 ? keywords : null,
+              });
+            }}
+          />
         </div>
       </section>
 
@@ -628,6 +733,30 @@ export function ProjectBudgetPanel({ slug }: Props) {
             const defaults = skillDefaults[skill];
             const metadata = data.skillMetadata?.[skill];
             const resolved = data.resolvedSkillRuntimes?.[skill];
+            const showEscalation =
+              defaults?.escalation != null ||
+              resolved?.resolvedEscalation != null ||
+              row?.escalationModelTier != null ||
+              row?.escalationMaxBudgetUsd != null ||
+              row?.escalationMaxTurns != null ||
+              row?.escalationTimeoutMs != null;
+            const devReviewEffective =
+              skill === 'dev-review'
+                ? {
+                    maxRevisionTurns:
+                      devReviewSettings?.dbOverride?.maxRevisionTurns ??
+                      devReviewSettings?.config?.maxRevisionTurns ??
+                      1,
+                    perCycleMaxUsd:
+                      devReviewSettings?.dbOverride?.perCycleMaxUsd ??
+                      devReviewSettings?.config?.perCycleMaxUsd ??
+                      2,
+                    timeoutMs:
+                      devReviewSettings?.dbOverride?.timeoutMs ??
+                      devReviewSettings?.config?.timeoutMs ??
+                      180_000,
+                  }
+                : null;
             const hasAny =
               row != null &&
               (row.maxTurns != null ||
@@ -635,7 +764,11 @@ export function ProjectBudgetPanel({ slug }: Props) {
                 row.timeoutMs != null ||
                 row.modelTier != null ||
                 row.provider != null ||
-                row.effort != null);
+                row.effort != null ||
+                row.escalationModelTier != null ||
+                row.escalationMaxBudgetUsd != null ||
+                row.escalationMaxTurns != null ||
+                row.escalationTimeoutMs != null);
             return (
               <div
                 key={skill}
@@ -751,6 +884,133 @@ export function ProjectBudgetPanel({ slug }: Props) {
                       }
                     />
                   </SkillRuntimeField>
+                  {showEscalation && (
+                    <>
+                      <SkillRuntimeField label="Escalation tier">
+                        <RuntimeSelect
+                          value={row?.escalationModelTier ?? null}
+                          options={TIERS}
+                          defaultValue={defaults?.escalation?.modelTier}
+                          overridden={row?.escalationModelTier != null}
+                          subtitle={
+                            resolved?.resolvedEscalation != null
+                              ? `resolved: ${resolved.resolvedEscalation.modelId}`
+                              : undefined
+                          }
+                          onCommit={(val) =>
+                            patchSkill.mutate({
+                              skill,
+                              patch: { escalationModelTier: val as ModelTier | null },
+                            })
+                          }
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Escalation budget">
+                        <NumericInput
+                          value={row?.escalationMaxBudgetUsd ?? null}
+                          placeholder={
+                            defaults?.escalation != null
+                              ? defaults.escalation.maxBudgetUsd.toFixed(2)
+                              : 'default'
+                          }
+                          isFloat
+                          overridden={row?.escalationMaxBudgetUsd != null}
+                          subtitle={
+                            defaults?.escalation != null
+                              ? `default: $${defaults.escalation.maxBudgetUsd.toFixed(2)}`
+                              : null
+                          }
+                          onCommit={(val) =>
+                            patchSkill.mutate({ skill, patch: { escalationMaxBudgetUsd: val } })
+                          }
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Escalation turns">
+                        <NumericInput
+                          value={row?.escalationMaxTurns ?? null}
+                          placeholder={
+                            defaults?.escalation?.maxTurns != null
+                              ? String(defaults.escalation.maxTurns)
+                              : defaults != null
+                                ? String(defaults.maxTurns)
+                                : 'default'
+                          }
+                          overridden={row?.escalationMaxTurns != null}
+                          subtitle={
+                            defaults?.escalation?.maxTurns != null
+                              ? `default: ${defaults.escalation.maxTurns}`
+                              : defaults != null
+                                ? `inherits base: ${defaults.maxTurns}`
+                                : null
+                          }
+                          onCommit={(val) =>
+                            patchSkill.mutate({ skill, patch: { escalationMaxTurns: val } })
+                          }
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Escalation timeout">
+                        <NumericInput
+                          value={row?.escalationTimeoutMs ?? null}
+                          placeholder={
+                            defaults?.escalation?.timeoutMs != null
+                              ? String(defaults.escalation.timeoutMs)
+                              : defaults != null
+                                ? String(defaults.timeoutMs)
+                                : 'default'
+                          }
+                          overridden={row?.escalationTimeoutMs != null}
+                          subtitle={
+                            defaults?.escalation?.timeoutMs != null
+                              ? `default: ${defaults.escalation.timeoutMs} ms`
+                              : defaults != null
+                                ? `inherits base: ${defaults.timeoutMs} ms`
+                                : null
+                          }
+                          onCommit={(val) =>
+                            patchSkill.mutate({ skill, patch: { escalationTimeoutMs: val } })
+                          }
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Escalation" wide>
+                        <RuntimeEscalationCell value={resolved?.resolvedEscalation} />
+                      </SkillRuntimeField>
+                    </>
+                  )}
+                  {devReviewEffective != null && (
+                    <>
+                      <div className="basis-full text-[11px] font-semibold uppercase tracking-wider text-fg-2">
+                        Dev-review loop controls
+                      </div>
+                      <SkillRuntimeField label="Revision turns">
+                        <NumericInput
+                          value={devReviewEffective.maxRevisionTurns}
+                          placeholder="1"
+                          overridden={devReviewSettings?.dbOverride?.maxRevisionTurns != null}
+                          subtitle="1-5 developer response turns"
+                          onCommit={(val) => patchDevReview.mutate({ maxRevisionTurns: val })}
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Cycle budget">
+                        <NumericInput
+                          value={devReviewEffective.perCycleMaxUsd}
+                          placeholder="2.00"
+                          isFloat
+                          overridden={devReviewSettings?.dbOverride?.perCycleMaxUsd != null}
+                          subtitle="0 skips dev-review"
+                          onCommit={(val) => patchDevReview.mutate({ perCycleMaxUsd: val })}
+                        />
+                      </SkillRuntimeField>
+                      <SkillRuntimeField label="Loop timeout">
+                        <NumericInput
+                          value={devReviewEffective.timeoutMs}
+                          placeholder="180000"
+                          overridden={devReviewSettings?.dbOverride?.timeoutMs != null}
+                          subtitle="dev-review timeout ms"
+                          onCommit={(val) => patchDevReview.mutate({ timeoutMs: val })}
+                        />
+                      </SkillRuntimeField>
+                    </>
+                  )}
                   <SkillRuntimeField label="Primary" wide>
                     <RuntimeModelCell value={resolved?.resolvedPrimary} />
                   </SkillRuntimeField>

--- a/apps/web/src/components/settings/components/ReviewPanel.tsx
+++ b/apps/web/src/components/settings/components/ReviewPanel.tsx
@@ -6,13 +6,9 @@ interface Props {
   slug: string;
 }
 
-const SLOT_MODELS = ['claude', 'codex'] as const;
 const SLOT_PROMPTS = ['default', 'unconstrained'] as const;
 
-const DEFAULT_SLOTS: ReviewerSlot[] = [
-  { model: 'claude', prompt: 'default' },
-  { model: 'claude', prompt: 'unconstrained' },
-];
+const DEFAULT_SLOTS: ReviewerSlot[] = [{ prompt: 'default' }, { prompt: 'unconstrained' }];
 
 export function ReviewPanel({ slug }: Props) {
   const queryClient = useQueryClient();
@@ -48,10 +44,9 @@ export function ReviewPanel({ slug }: Props) {
           Convergent Reviewer Slots
         </h3>
         <p className="text-[11px] text-fg-3 mb-4">
-          Configure up to 2 reviewer slots for the convergent review workflow. Each slot chooses a
-          provider (claude or codex) and a prompt variant (default = scoped to acceptance criteria,
-          unconstrained = broader critique). Divergent verdicts (approved vs needs-fix) escalate to
-          needs-human.
+          Configure up to 2 reviewer prompt slots for the convergent review workflow. Provider and
+          model come from the Skill runtime row for <code>review</code>. Divergent verdicts
+          (approved vs needs-fix) escalate to needs-human.
         </p>
 
         <label className="flex items-center gap-2 text-[12px] mb-4">
@@ -75,26 +70,10 @@ export function ReviewPanel({ slug }: Props) {
           <div className="space-y-3">
             {currentSlots.map((slot, idx) => (
               <div
-                key={`${slot.model}-${slot.prompt}-${idx}`}
+                key={`${slot.prompt}-${idx}`}
                 className="flex items-center gap-3 border border-line rounded px-3 py-2"
               >
                 <span className="text-[11px] text-fg-3 w-12">Slot {idx + 1}</span>
-
-                <div className="flex items-center gap-1">
-                  <span className="text-[11px] text-fg-3">Provider</span>
-                  <select
-                    value={slot.model}
-                    onChange={(e) => updateSlot(idx, 'model', e.target.value)}
-                    disabled={patch.isPending}
-                    className="text-[12px] bg-bg border border-line rounded px-2 py-0.5"
-                  >
-                    {SLOT_MODELS.map((m) => (
-                      <option key={m} value={m}>
-                        {m}
-                      </option>
-                    ))}
-                  </select>
-                </div>
 
                 <div className="flex items-center gap-1">
                   <span className="text-[11px] text-fg-3">Prompt</span>

--- a/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
+++ b/apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx
@@ -127,10 +127,7 @@ vi.mock('@/lib/api', () => ({
   }),
   fetchReviewSettings: vi.fn().mockResolvedValue({
     projectId: 'goose-hub-self',
-    reviewerSlots: [
-      { model: 'claude', prompt: 'default' },
-      { model: 'codex', prompt: 'unconstrained' },
-    ],
+    reviewerSlots: [{ prompt: 'default' }, { prompt: 'unconstrained' }],
     updatedAt: null,
     updatedBy: null,
   }),

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -23,7 +23,7 @@ export async function fetchProjectSettings(
 
 export async function patchGlobalBudgetSettings(
   slug: string,
-  patch: Record<string, number | null>,
+  patch: Record<string, number | string[] | null>,
 ): Promise<void> {
   await patchJson(`/projects/${slug}/settings/global`, patch);
 }
@@ -38,6 +38,10 @@ export async function patchSkillBudgetSetting(
     modelTier: ModelTier | null;
     provider: ModelProvider | null;
     effort: RuntimeEffort | null;
+    escalationModelTier: ModelTier | null;
+    escalationMaxBudgetUsd: number | null;
+    escalationMaxTurns: number | null;
+    escalationTimeoutMs: number | null;
   }>,
 ): Promise<void> {
   await patchJson(`/projects/${slug}/settings/skills/${encodeURIComponent(skill)}`, patch);

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -606,6 +606,10 @@ export interface ProjectSettingsDto {
       modelTier: ModelTier | null;
       provider: ModelProvider | null;
       effort: RuntimeEffort | null;
+      escalationModelTier: ModelTier | null;
+      escalationMaxBudgetUsd: number | null;
+      escalationMaxTurns: number | null;
+      escalationTimeoutMs: number | null;
       updatedAt: string;
     }
   >;
@@ -628,6 +632,12 @@ export interface ProjectSettingsDto {
       modelTier: ModelTier;
       modelProvider: ModelProvider;
       effort: RuntimeEffort | null;
+      escalation: {
+        modelTier: ModelTier;
+        maxBudgetUsd: number;
+        maxTurns: number | null;
+        timeoutMs: number | null;
+      } | null;
     }
   >;
   resolvedSkillRuntimes?: Record<
@@ -641,6 +651,10 @@ export interface ProjectSettingsDto {
       resolvedPrimary: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedFallback: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
       resolvedAdvisor: { tier: ModelTier; provider: ModelProvider; modelId: string } | null;
+      resolvedEscalation: {
+        modelId: string;
+        budgets: { maxTurns: number; maxBudgetUsd: number; timeoutMs: number };
+      } | null;
       /** Human-readable summary of the per-axis runtime resolution. */
       selectionReason?: string;
       /**
@@ -664,6 +678,7 @@ export interface ImplementWpSettingsDto {
   highPriorityUsd: number;
   manyFilesThreshold: number;
   manyFilesUsd: number;
+  contractKeywords: string[];
   contractUsd: number;
 }
 
@@ -678,6 +693,7 @@ export type ImplementWpSettingsOverrideDto = {
   implementWpHighPriorityUsd: number | null;
   implementWpManyFilesThreshold: number | null;
   implementWpManyFilesUsd: number | null;
+  implementWpContractKeywords: string[] | null;
   implementWpContractUsd: number | null;
   updatedAt: string;
   updatedBy: string | null;
@@ -905,11 +921,9 @@ export interface LearningLoopSettingsDto {
   } | null;
 }
 
-export type ReviewerSlotModel = 'claude' | 'codex';
 export type ReviewerSlotPrompt = 'default' | 'unconstrained';
 
 export interface ReviewerSlot {
-  model: ReviewerSlotModel;
   prompt: ReviewerSlotPrompt;
 }
 

--- a/core/agent-runtime/budgets.test.ts
+++ b/core/agent-runtime/budgets.test.ts
@@ -157,6 +157,52 @@ describe('resolveEscalatedBudgets', () => {
     const result = resolveEscalatedBudgets('implement', { perAgentMaxUsd: 6 }, undefined, 6);
     expect(result?.budgets.maxBudgetUsd).toBe(6);
   });
+
+  it('lets DB escalation settings override config and skill defaults', () => {
+    const result = resolveEscalatedBudgets(
+      'implement',
+      {
+        skillBudgetOverrides: {
+          implement: { escalation: { modelTier: 'sonnet', maxBudgetUsd: 12 } },
+        },
+      },
+      undefined,
+      undefined,
+      {
+        escalationModelTier: 'opus',
+        escalationMaxBudgetUsd: 18,
+        escalationMaxTurns: 90,
+        escalationTimeoutMs: 420_000,
+      },
+    );
+
+    expect(result?.modelOverride).toContain('opus');
+    expect(result?.budgets).toEqual({
+      maxTurns: 90,
+      maxBudgetUsd: 18,
+      timeoutMs: 420_000,
+    });
+  });
+
+  it('uses the configured skill provider for the escalated model', () => {
+    const result = resolveEscalatedBudgets(
+      'implement',
+      {
+        skillBudgetOverrides: {
+          implement: { provider: 'codex' },
+        },
+      },
+      undefined,
+      undefined,
+      {
+        modelProvider: 'codex',
+        escalationModelTier: 'opus',
+        escalationMaxBudgetUsd: 18,
+      },
+    );
+
+    expect(result?.modelOverride).toBe('gpt-5.5');
+  });
 });
 
 describe('perAgentMaxUsd cap', () => {

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -282,10 +282,22 @@ export interface DbSkillOverride {
   modelTier?: ModelTier | string | null;
   modelProvider?: string | null;
   effort?: RuntimeEffort | string | null;
+  escalationModelTier?: ModelTier | string | null;
+  escalationMaxBudgetUsd?: number | null;
+  escalationMaxTurns?: number | null;
+  escalationTimeoutMs?: number | null;
 }
 
 function isRuntimeEffort(value: unknown): value is RuntimeEffort {
   return value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh';
+}
+
+function isModelTier(value: unknown): value is ModelTier {
+  return value === 'haiku' || value === 'sonnet' || value === 'opus';
+}
+
+function isModelProvider(value: unknown): value is ModelProvider {
+  return value === 'claude' || value === 'codex';
 }
 
 /**
@@ -377,11 +389,48 @@ export function resolveEscalatedBudgets(
   },
   dbPerWorkflowMaxUsd?: number | null,
   dbPerAgentMaxUsd?: number | null,
+  dbOverride?: DbSkillOverride | null,
 ): ResolvedBudget | null {
   const base = SKILL_BUDGETS[skill];
   const override = projectBudgets?.skillBudgetOverrides?.[skill];
 
-  const escalation = override?.escalation ?? base?.escalation;
+  const inheritedEscalation = override?.escalation ?? base?.escalation;
+  const hasDbEscalation =
+    isModelTier(dbOverride?.escalationModelTier) ||
+    dbOverride?.escalationMaxBudgetUsd != null ||
+    dbOverride?.escalationMaxTurns != null ||
+    dbOverride?.escalationTimeoutMs != null;
+  const escalation =
+    hasDbEscalation && inheritedEscalation != null
+      ? {
+          ...inheritedEscalation,
+          ...(isModelTier(dbOverride?.escalationModelTier)
+            ? { modelTier: dbOverride.escalationModelTier }
+            : {}),
+          ...(dbOverride?.escalationMaxBudgetUsd != null
+            ? { maxBudgetUsd: dbOverride.escalationMaxBudgetUsd }
+            : {}),
+          ...(dbOverride?.escalationMaxTurns != null
+            ? { maxTurns: dbOverride.escalationMaxTurns }
+            : {}),
+          ...(dbOverride?.escalationTimeoutMs != null
+            ? { timeoutMs: dbOverride.escalationTimeoutMs }
+            : {}),
+        }
+      : hasDbEscalation &&
+          isModelTier(dbOverride?.escalationModelTier) &&
+          dbOverride?.escalationMaxBudgetUsd != null
+        ? {
+            modelTier: dbOverride.escalationModelTier,
+            maxBudgetUsd: dbOverride.escalationMaxBudgetUsd,
+            ...(dbOverride.escalationMaxTurns != null
+              ? { maxTurns: dbOverride.escalationMaxTurns }
+              : {}),
+            ...(dbOverride.escalationTimeoutMs != null
+              ? { timeoutMs: dbOverride.escalationTimeoutMs }
+              : {}),
+          }
+        : inheritedEscalation;
   if (escalation == null) return null;
 
   const baseTurns = override?.maxTurns ?? base?.maxTurns ?? 10;
@@ -402,9 +451,12 @@ export function resolveEscalatedBudgets(
   }
 
   const effort = isRuntimeEffort(override?.effort) ? override.effort : undefined;
+  const provider = isModelProvider(dbOverride?.modelProvider)
+    ? dbOverride.modelProvider
+    : (override?.provider ?? base?.provider ?? 'claude');
   return {
     budgets: { maxTurns, maxBudgetUsd, timeoutMs },
-    modelOverride: defaultModelForTierAndProvider(escalation.modelTier, 'claude'),
+    modelOverride: defaultModelForTierAndProvider(escalation.modelTier, provider),
     ...(effort != null ? { effort } : {}),
   };
 }

--- a/core/agent-runtime/implement-wp-settings.ts
+++ b/core/agent-runtime/implement-wp-settings.ts
@@ -37,6 +37,7 @@ export type ImplementWpSettingsRow = Pick<
   | 'implementWpHighPriorityUsd'
   | 'implementWpManyFilesThreshold'
   | 'implementWpManyFilesUsd'
+  | 'implementWpContractKeywordsJson'
   | 'implementWpContractUsd'
 >;
 
@@ -55,6 +56,21 @@ export const DEFAULT_IMPLEMENT_WP_SETTINGS: ImplementWpSettings = {
     },
   },
 };
+
+function parseContractKeywords(value: string | null | undefined): string[] | null {
+  if (value == null) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    const keywords = parsed
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    return keywords.length > 0 ? keywords : [];
+  } catch {
+    return null;
+  }
+}
 
 export function resolveImplementWpSettings(
   budgetConfig?: Pick<BudgetConfig, 'implementWp'> | null,
@@ -114,6 +130,7 @@ export function resolveImplementWpSettings(
           sizing?.complexAdditions?.manyFilesUsd ??
           defaults.budgetSizing.complexAdditions.manyFilesUsd,
         contractKeywords:
+          parseContractKeywords(row?.implementWpContractKeywordsJson) ??
           sizing?.complexAdditions?.contractKeywords ??
           defaults.budgetSizing.complexAdditions.contractKeywords,
         contractUsd:

--- a/core/agent-runtime/resolve-for-project.ts
+++ b/core/agent-runtime/resolve-for-project.ts
@@ -1,4 +1,7 @@
-import { readProjectSettings } from '../db/repositories/project-settings.js';
+import {
+  readProjectSettings,
+  readProjectSkillSettings,
+} from '../db/repositories/project-settings.js';
 import {
   type ResolvedBudget,
   type SkillBudgetOverride,
@@ -91,10 +94,12 @@ export function resolveEscalatedBudgetsForProject(
   projectId: string,
 ): ResolvedBudget | null {
   const globalRow = readProjectSettings(projectId);
+  const skillRow = readProjectSkillSettings(projectId).get(skill);
   return resolveEscalatedBudgets(
     skill,
     projectBudgets,
     globalRow?.perWorkflowMaxUsd,
     globalRow?.perAgentMaxUsd,
+    skillRow,
   );
 }

--- a/core/agent-runtime/skill-contract-audit.test.ts
+++ b/core/agent-runtime/skill-contract-audit.test.ts
@@ -1,8 +1,8 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
+  type SkillContractAudit,
   auditSkillContracts,
   formatSkillContractAudit,
-  type SkillContractAudit,
 } from './skill-contract-audit.js';
 
 describe('skill-contract-audit', () => {

--- a/core/db/migrations/0043_right_ken_ellis.sql
+++ b/core/db/migrations/0043_right_ken_ellis.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `project_settings` ADD `implement_wp_contract_keywords_json` text;--> statement-breakpoint
+ALTER TABLE `project_skill_settings` ADD `escalation_model_tier` text;--> statement-breakpoint
+ALTER TABLE `project_skill_settings` ADD `escalation_max_budget_usd` real;--> statement-breakpoint
+ALTER TABLE `project_skill_settings` ADD `escalation_max_turns` integer;--> statement-breakpoint
+ALTER TABLE `project_skill_settings` ADD `escalation_timeout_ms` integer;

--- a/core/db/migrations/meta/0043_snapshot.json
+++ b/core/db/migrations/meta/0043_snapshot.json
@@ -1,0 +1,2713 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "195ff584-9eb7-4a58-a008-2a3e43c0c986",
+  "prevId": "b8cdc2e1-ce00-47a0-ad2c-87e7211643f5",
+  "tables": {
+    "agent_artifacts": {
+      "name": "agent_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_artifacts_artifact_key_uniq": {
+          "name": "agent_artifacts_artifact_key_uniq",
+          "columns": [
+            "artifact_key"
+          ],
+          "isUnique": true
+        },
+        "agent_artifacts_project_work_item_idx": {
+          "name": "agent_artifacts_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "agent_artifacts_run_id_idx": {
+          "name": "agent_artifacts_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "agent_artifacts_project_work_item_run_kind_idx": {
+          "name": "agent_artifacts_project_work_item_run_kind_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "run_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_decisions": {
+      "name": "agent_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what": {
+          "name": "what",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_decisions_run_kind_what_uniq": {
+          "name": "agent_decisions_run_kind_what_uniq",
+          "columns": [
+            "run_id",
+            "kind",
+            "what"
+          ],
+          "isUnique": true
+        },
+        "agent_decisions_run_idx": {
+          "name": "agent_decisions_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_run_costs": {
+      "name": "agent_run_costs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_output_tokens": {
+          "name": "reasoning_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_label": {
+          "name": "cost_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'estimated'"
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_run_costs_run_id_uniq": {
+          "name": "agent_run_costs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_run_costs_project_created_idx": {
+          "name": "agent_run_costs_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "agent_run_costs_work_item_idx": {
+          "name": "agent_run_costs_work_item_idx",
+          "columns": [
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_run_tool_stats": {
+      "name": "agent_run_tool_stats",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grep_count": {
+          "name": "grep_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "write_count": {
+          "name": "write_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "edit_count": {
+          "name": "edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_read": {
+          "name": "bytes_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_paths_read": {
+          "name": "unique_paths_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "redundant_reads": {
+          "name": "redundant_reads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_runs": {
+      "name": "agent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agent_runs_run_id_uniq": {
+          "name": "agent_runs_run_id_uniq",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "agent_runs_persona_idx": {
+          "name": "agent_runs_persona_idx",
+          "columns": [
+            "persona_id"
+          ],
+          "isUnique": false
+        },
+        "agent_runs_project_idx": {
+          "name": "agent_runs_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "archived_lifecycles": {
+      "name": "archived_lifecycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_summaries": {
+          "name": "decision_summaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "learning_entries": {
+          "name": "learning_entries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "quality_scores": {
+          "name": "quality_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "costs_usd": {
+          "name": "costs_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "run_ids": {
+          "name": "run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "archived_lifecycles_project_work_item_idx": {
+          "name": "archived_lifecycles_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "archived_lifecycles_project_closed_idx": {
+          "name": "archived_lifecycles_project_closed_idx",
+          "columns": [
+            "project_id",
+            "closed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_conversations": {
+      "name": "chat_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_conversations_scope_idx": {
+          "name": "chat_conversations_scope_idx",
+          "columns": [
+            "scope",
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        },
+        "chat_conversations_updated_idx": {
+          "name": "chat_conversations_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_messages_conversation_idx": {
+          "name": "chat_messages_conversation_idx",
+          "columns": [
+            "conversation_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_tool_invocations": {
+      "name": "chat_tool_invocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_json": {
+          "name": "input_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mutating": {
+          "name": "mutating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "chat_tool_invocations_conversation_idx": {
+          "name": "chat_tool_invocations_conversation_idx",
+          "columns": [
+            "conversation_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "chat_tool_invocations_status_idx": {
+          "name": "chat_tool_invocations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_patterns": {
+      "name": "decision_patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_summary": {
+          "name": "action_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_summary": {
+          "name": "reason_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consistency_score": {
+          "name": "consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "example_work_item_ids": {
+          "name": "example_work_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "decision_patterns_project_kind_role_uniq": {
+          "name": "decision_patterns_project_kind_role_uniq",
+          "columns": [
+            "project_id",
+            "kind",
+            "role"
+          ],
+          "isUnique": true
+        },
+        "decision_patterns_project_idx": {
+          "name": "decision_patterns_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engineering_specs": {
+      "name": "engineering_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "engineering_specs_project_work_item_uniq": {
+          "name": "engineering_specs_project_work_item_uniq",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": true
+        },
+        "engineering_specs_project_work_item_idx": {
+          "name": "engineering_specs_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "events_project_created_idx": {
+          "name": "events_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_work_item_idx": {
+          "name": "events_work_item_idx",
+          "columns": [
+            "work_item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governance_audit": {
+      "name": "governance_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "violations": {
+          "name": "violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_candidates": {
+      "name": "improvement_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggestion_text": {
+          "name": "suggestion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_note": {
+          "name": "error_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_diff": {
+          "name": "proposed_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_playbook_id": {
+          "name": "source_playbook_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "improvement_candidates_persona_status_idx": {
+          "name": "improvement_candidates_persona_status_idx",
+          "columns": [
+            "persona_name",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'feature'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_names": {
+      "name": "persona_names",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_index": {
+          "name": "slot_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "persona_names_slot_uniq": {
+          "name": "persona_names_slot_uniq",
+          "columns": [
+            "project_id",
+            "role",
+            "slot_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_routing": {
+      "name": "persona_routing",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_index": {
+          "name": "last_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "persona_routing_project_id_role_pk": {
+          "columns": [
+            "project_id",
+            "role"
+          ],
+          "name": "persona_routing_project_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persona_stats": {
+      "name": "persona_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "persona_name": {
+          "name": "persona_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runs_total": {
+          "name": "runs_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_succeeded": {
+          "name": "runs_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runs_failed": {
+          "name": "runs_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_quality_score": {
+          "name": "avg_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "persona_stats_persona_role_uniq": {
+          "name": "persona_stats_persona_role_uniq",
+          "columns": [
+            "persona_name",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playbooks": {
+      "name": "playbooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_count": {
+          "name": "lifecycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "playbooks_project_created_idx": {
+          "name": "playbooks_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "playbooks_project_window_idx": {
+          "name": "playbooks_project_window_idx",
+          "columns": [
+            "project_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_dev_review_settings": {
+      "name": "project_dev_review_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_on": {
+          "name": "trigger_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_revision_turns": {
+          "name": "max_revision_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_cycle_max_usd": {
+          "name": "per_cycle_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_review_settings": {
+      "name": "project_review_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_slots": {
+          "name": "reviewer_slots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "per_workflow_max_usd": {
+          "name": "per_workflow_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_agent_max_usd": {
+          "name": "per_agent_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_advisor_max_usd": {
+          "name": "per_advisor_max_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_tokens": {
+          "name": "daily_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_parallel_agents": {
+          "name": "max_parallel_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_scout_agents": {
+          "name": "max_scout_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "per_bash_command_max_seconds": {
+          "name": "per_bash_command_max_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_edit_test_loop_max_cycles": {
+          "name": "implement_wp_edit_test_loop_max_cycles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_bug_max_turns": {
+          "name": "implement_wp_bug_max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_bug_max_budget_usd": {
+          "name": "implement_wp_bug_max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_feature_max_turns": {
+          "name": "implement_wp_feature_max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_feature_max_budget_usd": {
+          "name": "implement_wp_feature_max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_complex_max_turns": {
+          "name": "implement_wp_complex_max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_complex_max_budget_usd": {
+          "name": "implement_wp_complex_max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_high_priority_usd": {
+          "name": "implement_wp_high_priority_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_many_files_threshold": {
+          "name": "implement_wp_many_files_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_many_files_usd": {
+          "name": "implement_wp_many_files_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_contract_keywords_json": {
+          "name": "implement_wp_contract_keywords_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implement_wp_contract_usd": {
+          "name": "implement_wp_contract_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_multi_agent_pipeline": {
+          "name": "use_multi_agent_pipeline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_investigation_swarm": {
+          "name": "use_investigation_swarm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coach_policy_enabled": {
+          "name": "coach_policy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coach_policy_consistency_threshold": {
+          "name": "coach_policy_consistency_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coach_policy_min_lifecycles": {
+          "name": "coach_policy_min_lifecycles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qa_e2e_mode": {
+          "name": "qa_e2e_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playwright_repro_enabled": {
+          "name": "playwright_repro_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "evidence_post_enabled": {
+          "name": "evidence_post_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "record_decision_tool": {
+          "name": "record_decision_tool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_skill_settings": {
+      "name": "project_skill_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_budget_usd": {
+          "name": "max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_tier": {
+          "name": "model_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "escalation_model_tier": {
+          "name": "escalation_model_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "escalation_max_budget_usd": {
+          "name": "escalation_max_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "escalation_max_turns": {
+          "name": "escalation_max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "escalation_timeout_ms": {
+          "name": "escalation_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_skill_settings_project_id_skill_name_pk": {
+          "columns": [
+            "project_id",
+            "skill_name"
+          ],
+          "name": "project_skill_settings_project_id_skill_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_state": {
+      "name": "project_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_milestone_number": {
+          "name": "active_milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_at": {
+          "name": "active_milestone_set_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_milestone_set_by": {
+          "name": "active_milestone_set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_quality_scores": {
+      "name": "run_quality_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "components_json": {
+          "name": "components_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_score": {
+          "name": "audit_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "run_quality_scores_run_iteration_uniq": {
+          "name": "run_quality_scores_run_iteration_uniq",
+          "columns": [
+            "run_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "run_quality_scores_project_ts_idx": {
+          "name": "run_quality_scores_project_ts_idx",
+          "columns": [
+            "project_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "run_quality_scores_pipeline_run_idx": {
+          "name": "run_quality_scores_pipeline_run_idx",
+          "columns": [
+            "pipeline_run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scout_reports": {
+      "name": "scout_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "investigation_run_id": {
+          "name": "investigation_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scout_skill": {
+          "name": "scout_skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report": {
+          "name": "report",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "scout_reports_project_work_item_run_skill_uniq": {
+          "name": "scout_reports_project_work_item_run_skill_uniq",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id",
+            "scout_skill"
+          ],
+          "isUnique": true
+        },
+        "scout_reports_project_work_item_run_idx": {
+          "name": "scout_reports_project_work_item_run_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "investigation_run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "work_item_intervention_events": {
+      "name": "work_item_intervention_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "intervention_id": {
+          "name": "intervention_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "work_item_intervention_events_intervention_idx": {
+          "name": "work_item_intervention_events_intervention_idx",
+          "columns": [
+            "intervention_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "work_item_intervention_events_project_work_item_idx": {
+          "name": "work_item_intervention_events_project_work_item_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "work_item_interventions": {
+      "name": "work_item_interventions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intervention_type": {
+          "name": "intervention_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_cause_signature": {
+          "name": "root_cause_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_options_json": {
+          "name": "proposed_options_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_action_type": {
+          "name": "decided_action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_action_payload_json": {
+          "name": "decided_action_payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_result_json": {
+          "name": "application_result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_json": {
+          "name": "verification_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_item_interventions_project_status_idx": {
+          "name": "work_item_interventions_project_status_idx",
+          "columns": [
+            "project_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "work_item_interventions_work_item_status_idx": {
+          "name": "work_item_interventions_work_item_status_idx",
+          "columns": [
+            "work_item_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "work_item_interventions_root_cause_idx": {
+          "name": "work_item_interventions_root_cause_idx",
+          "columns": [
+            "project_id",
+            "work_item_id",
+            "root_cause_signature"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wp_iterations": {
+      "name": "wp_iterations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wp_id": {
+          "name": "wp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "wp_iterations_run_wp_iteration_uniq": {
+          "name": "wp_iterations_run_wp_iteration_uniq",
+          "columns": [
+            "run_id",
+            "wp_id",
+            "iteration"
+          ],
+          "isUnique": true
+        },
+        "wp_iterations_run_wp_idx": {
+          "name": "wp_iterations_run_wp_idx",
+          "columns": [
+            "run_id",
+            "wp_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/core/db/migrations/meta/_journal.json
+++ b/core/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1779724800000,
       "tag": "0042_implement_wp_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1779770543086,
+      "tag": "0043_right_ken_ellis",
+      "breakpoints": true
     }
   ]
 }

--- a/core/db/repositories/project-review-settings.ts
+++ b/core/db/repositories/project-review-settings.ts
@@ -6,7 +6,6 @@ import { projectReviewSettings } from '../schema.js';
 export type ProjectReviewSettingsRow = typeof projectReviewSettings.$inferSelect;
 
 export type ReviewerSlot = {
-  model: 'claude' | 'codex';
   prompt: 'default' | 'unconstrained';
 };
 
@@ -26,7 +25,15 @@ export function readProjectReviewSettings(projectId: string): ProjectReviewSetti
 export function parseReviewerSlots(row: ProjectReviewSettingsRow | null): ReviewerSlot[] | null {
   if (!row?.reviewerSlots) return null;
   try {
-    return JSON.parse(row.reviewerSlots) as ReviewerSlot[];
+    const parsed = JSON.parse(row.reviewerSlots) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    const slots = parsed.flatMap((entry): ReviewerSlot[] => {
+      if (entry == null || typeof entry !== 'object') return [];
+      const prompt = (entry as { prompt?: unknown }).prompt;
+      if (prompt !== 'default' && prompt !== 'unconstrained') return [];
+      return [{ prompt }];
+    });
+    return slots.length > 0 ? slots.slice(0, 2) : null;
   } catch {
     logger.warn('parseReviewerSlots: invalid JSON, ignoring', { projectId: row.projectId });
     return null;

--- a/core/db/repositories/project-settings.test.ts
+++ b/core/db/repositories/project-settings.test.ts
@@ -28,6 +28,7 @@ function makeProjectSettingsRow(overrides: Partial<ProjectSettingsRow> = {}): Pr
     implementWpHighPriorityUsd: null,
     implementWpManyFilesThreshold: null,
     implementWpManyFilesUsd: null,
+    implementWpContractKeywordsJson: null,
     implementWpContractUsd: null,
     useMultiAgentPipeline: null,
     useInvestigationSwarm: null,

--- a/core/db/repositories/project-settings.ts
+++ b/core/db/repositories/project-settings.ts
@@ -26,6 +26,7 @@ export type GlobalBudgetPatch = {
   implementWpHighPriorityUsd?: number | null;
   implementWpManyFilesThreshold?: number | null;
   implementWpManyFilesUsd?: number | null;
+  implementWpContractKeywordsJson?: string | null;
   implementWpContractUsd?: number | null;
   useMultiAgentPipeline?: number | null;
   useInvestigationSwarm?: number | null;
@@ -45,6 +46,10 @@ export type SkillBudgetPatch = {
   modelTier?: string | null;
   modelProvider?: string | null;
   effort?: string | null;
+  escalationModelTier?: string | null;
+  escalationMaxBudgetUsd?: number | null;
+  escalationMaxTurns?: number | null;
+  escalationTimeoutMs?: number | null;
 };
 
 export const DEFAULT_COACH_POLICY: CoachPolicy = {
@@ -311,6 +316,7 @@ export function resetAllProjectBudgets(projectId: string): void {
       implementWpHighPriorityUsd: null,
       implementWpManyFilesThreshold: null,
       implementWpManyFilesUsd: null,
+      implementWpContractKeywordsJson: null,
       implementWpContractUsd: null,
       updatedAt: new Date().toISOString(),
       updatedBy: 'ui',

--- a/core/db/schema.ts
+++ b/core/db/schema.ts
@@ -356,6 +356,7 @@ export const projectSettings = sqliteTable('project_settings', {
   implementWpHighPriorityUsd: real('implement_wp_high_priority_usd'),
   implementWpManyFilesThreshold: integer('implement_wp_many_files_threshold'),
   implementWpManyFilesUsd: real('implement_wp_many_files_usd'),
+  implementWpContractKeywordsJson: text('implement_wp_contract_keywords_json'),
   implementWpContractUsd: real('implement_wp_contract_usd'),
   useMultiAgentPipeline: integer('use_multi_agent_pipeline'),
   useInvestigationSwarm: integer('use_investigation_swarm'),
@@ -384,6 +385,10 @@ export const projectSkillSettings = sqliteTable(
     modelTier: text('model_tier'),
     modelProvider: text('model_provider'),
     effort: text('effort'),
+    escalationModelTier: text('escalation_model_tier'),
+    escalationMaxBudgetUsd: real('escalation_max_budget_usd'),
+    escalationMaxTurns: integer('escalation_max_turns'),
+    escalationTimeoutMs: integer('escalation_timeout_ms'),
     updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
     updatedBy: text('updated_by'),
   },
@@ -470,10 +475,10 @@ export const projectDevReviewSettings = sqliteTable('project_dev_review_settings
 });
 
 // Per-project convergent-review settings (M19.20). `reviewer_slots` is a JSON
-// array of {model, prompt} objects — length drives reviewer count (1 or 2).
+// array of {prompt} objects — length drives reviewer count (1 or 2).
 export const projectReviewSettings = sqliteTable('project_review_settings', {
   projectId: text('project_id').primaryKey(),
-  reviewerSlots: text('reviewer_slots'), // JSON: Array<{model:'claude'|'codex', prompt:'default'|'unconstrained'}>
+  reviewerSlots: text('reviewer_slots'), // JSON: Array<{prompt:'default'|'unconstrained'}>
   updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   updatedBy: text('updated_by'),
 });

--- a/core/types.ts
+++ b/core/types.ts
@@ -149,6 +149,12 @@ export interface BudgetConfig {
       timeoutMs?: number;
       modelTier?: ModelTier;
       effort?: RuntimeEffort | null;
+      escalation?: {
+        modelTier: ModelTier;
+        maxBudgetUsd: number;
+        maxTurns?: number;
+        timeoutMs?: number;
+      };
     }
   >;
   implementWp?: {

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -259,6 +259,7 @@ describe('implement-wp budget sizing', () => {
         implementWpHighPriorityUsd: null,
         implementWpManyFilesThreshold: null,
         implementWpManyFilesUsd: null,
+        implementWpContractKeywordsJson: null,
         implementWpContractUsd: null,
       },
     );

--- a/slices/review/convergent-review.ts
+++ b/slices/review/convergent-review.ts
@@ -6,11 +6,10 @@ import type { AgentResult, AgentRuntime } from '@goose-hub/core/agent-runtime/in
 import { safeParseOutputForSchema } from '@goose-hub/core/agent-runtime/output-normalization.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { reconcileDecisionSummaries } from '@goose-hub/core/agent-runtime/reconcile-decisions.js';
-import { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
-import type { ReviewerSlot } from '@goose-hub/core/db/repositories/project-review-settings.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import {
   parseReviewerSlots,
   readProjectReviewSettings,
@@ -86,7 +85,14 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
 
   const projectConfig = await getProjectBySlug(projectSlug);
   const reviewJsonSchema = toJsonSchema(ReviewOutputSchema);
-  const resolvedBudgets = resolveBudgetsForProject('review', projectConfig?.budgets, projectSlug);
+  const resolvedRuntime = resolveSkillRuntimeForProject({
+    skill: 'review',
+    projectBudgets: projectConfig?.budgets,
+    projectId: projectSlug,
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    role: 'reviewer',
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+  });
 
   // Read configurable slots from DB; fall back to defaults.
   // verdictsDiverge escalation only applies when slots are explicitly configured (not defaults).
@@ -111,12 +117,12 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
       personaId: personaIds[i],
       reviewPrompt,
       reviewJsonSchema,
-      resolvedBudgets,
+      resolvedBudgets: resolvedRuntime,
       extraEventPayload: {
         reviewWorkflowRunId,
         round,
         slotIndex: i,
-        slotModel: slot.model,
+        slotModel: resolvedRuntime.provider,
         promptVariant: slot.prompt,
       },
     });
@@ -126,8 +132,8 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
   specs.forEach(assembleSpawnContext);
 
   const rawResults = await Promise.all(
-    specs.map((spec, i) =>
-      runtimeForSlot(slots[i].model)
+    specs.map((spec) =>
+      runtimeForSlot(resolvedRuntime.provider)
         .run(spec)
         .catch((err: unknown) => (err instanceof Error ? err : new Error(String(err)))),
     ),
@@ -147,7 +153,7 @@ export async function dispatchReviewWave(opts: DispatchReviewWaveOpts): Promise<
         runId: runIds[i],
         round,
         slotIndex: i,
-        slotModel: slot.model,
+        slotModel: resolvedRuntime.provider,
         promptVariant: slot.prompt,
       },
     ];
@@ -253,11 +259,13 @@ export async function runConvergentReviewWorkflow(
   const reviewWorkflowRunId = crypto.randomUUID();
   const reviewWorkflowPayload = { reviewWorkflowRunId };
   const injectedRuntime = deps.runtime;
+  const projectConfig = await getProjectBySlug(projectSlug);
   const runtimeForSlot = injectedRuntime
     ? () => injectedRuntime
-    : (model: ReviewerSlot['model']) =>
-        selectRuntime({ configRuntime: model === 'codex' ? 'codex-cli' : 'claude-cli' });
-  const projectConfig = await getProjectBySlug(projectSlug);
+    : (provider: 'claude' | 'codex') => {
+        const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
+        return selectRuntime({ configRuntime, skillProvider: provider });
+      };
   const maxReviewRounds = projectConfig?.maxReviewRounds ?? DEFAULT_MAX_REVIEW_ROUNDS;
 
   try {

--- a/slices/review/review-spec.ts
+++ b/slices/review/review-spec.ts
@@ -5,6 +5,7 @@ import { buildPrDiffWithContext } from '@goose-hub/core/agent-runtime/pr-diff-co
 import type { resolveBudgetsForProject } from '@goose-hub/core/agent-runtime/resolve-for-project.js';
 import type { ReviewerSlot } from '@goose-hub/core/db/repositories/project-review-settings.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
+import type { ModelProvider } from '@goose-hub/core/types.js';
 import type { ReviewOutput } from '@goose-hub/skills/review/schema.js';
 
 export const DEFAULT_MAX_REVIEW_ROUNDS = 3;
@@ -25,7 +26,7 @@ export interface ReviewWaveResult {
     runId: string;
     round: number;
     slotIndex: number;
-    slotModel: ReviewerSlot['model'];
+    slotModel: ModelProvider;
     promptVariant: ReviewerSlot['prompt'];
   }>;
   parseFailure: boolean;
@@ -48,8 +49,8 @@ export interface DispatchReviewWaveOpts {
   workItem: WorkItem;
   projectSlug: string;
   reviewWorkflowRunId: string;
-  /** Returns the runtime to use for a given slot model. */
-  runtimeForSlot: (model: ReviewerSlot['model']) => AgentRuntime;
+  /** Returns the runtime to use for the resolved review skill provider. */
+  runtimeForSlot: (provider: ModelProvider) => AgentRuntime;
 }
 
 export function toFindingKey(f: {
@@ -106,10 +107,10 @@ export function hasCanonicalCriteriaCoverage(
   return criteria.every((criterion) => checkedIds.has(criterion.id));
 }
 
-/** Default reviewer slots: constrained + unconstrained, both on claude. */
+/** Default reviewer slots: constrained + unconstrained. Model/provider come from Skill runtime. */
 export const DEFAULT_REVIEWER_SLOTS: ReviewerSlot[] = [
-  { model: 'claude', prompt: 'default' },
-  { model: 'claude', prompt: 'unconstrained' },
+  { prompt: 'default' },
+  { prompt: 'unconstrained' },
 ];
 
 /** Shared spec builder for both single and convergent review paths. */

--- a/slices/review/slice.test.ts
+++ b/slices/review/slice.test.ts
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── module mocks ─────────────────────────────────────────────────────────────
 
+const mockReadProjectSkillSettings = vi.hoisted(() => vi.fn().mockReturnValue(new Map()));
+
 vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
   readProjectSettings: vi.fn().mockReturnValue(null),
-  readProjectSkillSettings: vi.fn().mockReturnValue(new Map()),
+  readProjectSkillSettings: mockReadProjectSkillSettings,
 }));
 const mockReadProjectReviewSettings = vi.fn().mockReturnValue(null);
 vi.mock('@goose-hub/core/db/repositories/project-review-settings.js', () => ({
@@ -175,6 +177,7 @@ beforeEach(() => {
   mockExecSync.mockReset();
   mockExecSync.mockReturnValue('');
   mockAccumulatePersonaStats.mockClear();
+  mockReadProjectSkillSettings.mockReturnValue(new Map());
   mockReadProjectReviewSettings.mockReturnValue(null);
   vi.clearAllMocks();
 });
@@ -1078,10 +1081,7 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
       });
 
       mockReadProjectReviewSettings.mockReturnValue({
-        reviewerSlots: JSON.stringify([
-          { model: 'claude', prompt: 'default' },
-          { model: 'codex', prompt: 'unconstrained' },
-        ]),
+        reviewerSlots: JSON.stringify([{ prompt: 'default' }, { prompt: 'unconstrained' }]),
       });
 
       // Slot A (claude/default): approved
@@ -1109,6 +1109,46 @@ describe('runConvergentReviewWorkflow (M19.04)', () => {
       );
       // Must escalate after round 1 only (2 slot calls — no further rounds)
       expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the review skill runtime provider for reviewer slots', async () => {
+      const item = makeWorkItem();
+      const source = makeMockSource({
+        getPrDiff: vi.fn().mockResolvedValue('diff --git a/src/utils.ts b/src/utils.ts\n+added'),
+      });
+
+      mockReadProjectReviewSettings.mockReturnValue({
+        reviewerSlots: JSON.stringify([{ prompt: 'default' }, { prompt: 'unconstrained' }]),
+      });
+      mockReadProjectSkillSettings.mockReturnValue(
+        new Map([
+          [
+            'review',
+            {
+              projectId: 'test-project',
+              skillName: 'review',
+              modelTier: 'sonnet',
+              modelProvider: 'claude',
+              updatedAt: '2026-05-26T00:00:00Z',
+            },
+          ],
+        ]),
+      );
+
+      mockRun.mockResolvedValue(makeApprovedResultNoFindings());
+
+      const { runConvergentReviewWorkflow } = await import('./workflow.js');
+      const { ClaudeCliRuntime } = await import('@goose-hub/core/agent-runtime/claude-cli.js');
+      const { CodexCliRuntime } = await import('@goose-hub/core/agent-runtime/codex-cli.js');
+      await runConvergentReviewWorkflow(item, source, 'test-project', 'owner/repo');
+
+      expect(ClaudeCliRuntime).toHaveBeenCalled();
+      expect(CodexCliRuntime).not.toHaveBeenCalled();
+      const firstSpec = mockRun.mock.calls[0][0] as AgentSpec;
+      expect(firstSpec.extraEventPayload).toMatchObject({
+        slotModel: 'claude',
+        promptVariant: 'default',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- add Skill runtime tab controls for escalation model/budget settings, dev-review loop controls, and Implement-WP contract keywords
- route convergent review model/provider selection through the review skill runtime row, with reviewer slots now prompt-only
- add DB/API/DTO support plus migration for the new configurable runtime settings

## Verification
- pnpm typecheck
- pnpm vitest run core/agent-runtime/budgets.test.ts core/agent-runtime/skill-runtime-resolver.test.ts apps/server/src/domains/project-settings/router.test.ts apps/web/src/components/settings/components/ProjectBudgetPanel.test.tsx apps/web/src/components/settings/components/WorkflowMapPanel.test.tsx slices/review/slice.test.ts
- pnpm vitest run core/db/repositories/project-settings.test.ts slices/parallel-implement/slice.test.ts
- DB_PATH=/private/tmp/goose-hub-settings-runtime-migrate-0526.db pnpm tsx core/db/migrate.ts
- git diff --check