### PR TITLE
Filter Codex resource discovery probe noise

### DIFF
--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -642,7 +642,7 @@ describe('CodexCliRuntime timeout handling', () => {
     });
   });
 
-  it('does not fail on the startup resources/list probe', async () => {
+  it('records resources/list failed as a non-fatal advisory and filters it from stderr logs', async () => {
     const child = makeHangingChild();
     mockSpawn.mockReturnValue(child);
 
@@ -662,15 +662,68 @@ describe('CodexCliRuntime timeout handling', () => {
     child.emit('close', 0);
 
     await expect(run).resolves.toMatchObject({ output: { ok: true } });
+    const calls: Parameters<typeof mockEventStore.appendEvent>[0][] =
+      mockEventStore.appendEvent.mock.calls.map((c: unknown[]) => c[0]);
+    expect(
+      calls.some(
+        (e) =>
+          e.kind === 'agent.runtime-advisory' &&
+          (e.payload as { surface?: string }).surface === 'resources/list failed',
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (e) =>
+          e.kind === 'agent.log' &&
+          (e.payload as { stream?: string; text?: string }).stream === 'stderr' &&
+          (e.payload as { text?: string }).text?.includes('resources/list failed'),
+      ),
+    ).toBe(false);
     expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: 'agent.log',
-        payload: expect.objectContaining({
-          stream: 'stderr',
-          text: 'resources/list failed: startup probe',
-        }),
-      }),
+      expect.objectContaining({ kind: 'agent.run-completed' }),
     );
+  });
+
+  it('records resources/templates/list failed as a non-fatal advisory and filters it from stderr logs', async () => {
+    const child = makeHangingChild();
+    mockSpawn.mockReturnValue(child);
+
+    const runtime = new CodexCliRuntime();
+    const run = runtime.run(makeSpec());
+
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '{"ok":true}' },
+        })}\n`,
+      ),
+    );
+    child.stderr.emit(
+      'data',
+      Buffer.from('resources/templates/list failed: startup template probe\n'),
+    );
+    child.emit('close', 0);
+
+    await expect(run).resolves.toMatchObject({ output: { ok: true } });
+    const calls: Parameters<typeof mockEventStore.appendEvent>[0][] =
+      mockEventStore.appendEvent.mock.calls.map((c: unknown[]) => c[0]);
+    expect(
+      calls.some(
+        (e) =>
+          e.kind === 'agent.runtime-advisory' &&
+          (e.payload as { surface?: string }).surface === 'resources/templates/list failed',
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (e) =>
+          e.kind === 'agent.log' &&
+          (e.payload as { stream?: string; text?: string }).stream === 'stderr' &&
+          (e.payload as { text?: string }).text?.includes('resources/templates/list failed'),
+      ),
+    ).toBe(false);
     expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'agent.run-completed' }),
     );

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -82,6 +82,16 @@ const ADVISORY_RUNTIME_SURFACE_PATTERNS: Array<{
   re: RegExp;
 }> = [
   {
+    surface: 'resources/templates/list failed',
+    toolName: 'resources/templates/list',
+    re: /resources\/templates\/list(?:\s+failed|[^\n]*transient stderr)/i,
+  },
+  {
+    surface: 'resources/list failed',
+    toolName: 'resources/list',
+    re: /resources\/list(?:\s+failed|[^\n]*transient stderr)/i,
+  },
+  {
     surface: 'resources/read failed',
     toolName: 'resources/read',
     re: /resources\/read(?:\?path=[^\s]+)?(?:\s+failed|[^\n]*transient stderr)/i,

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -6,6 +6,20 @@ import { safeParseOutputForSchema } from './output-normalization.js';
 import { resolveBudgetsForProject } from './resolve-for-project.js';
 import { ScoutOutputSchema, normalizeScoutOutput } from './scout-output.js';
 
+const SCOUT_NO_EVIDENCE_REASON =
+  'scout returned no findings and made no successful Factory read/search/file tool calls';
+
+const FACTORY_EVIDENCE_TOOL_NAMES = new Set([
+  'file_exists',
+  'file_info',
+  'list_dir',
+  'list_files',
+  'read_file',
+  'read_many_files',
+  'repo_intel.query',
+  'search_text',
+]);
+
 /** Per-scout findings. Mirrors `ScoutOutputSchema` in each scout's schema.ts. */
 export interface ScoutFinding {
   file: string;
@@ -84,6 +98,30 @@ export interface RunOneScoutContext {
     appendSystemPrompt?: string;
     outputJsonSchema?: Record<string, unknown>;
   };
+}
+
+function payloadRecord(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizedToolName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (value.startsWith('mcp__factory-tools__')) {
+    return value.slice('mcp__factory-tools__'.length);
+  }
+  return value;
+}
+
+function hasSuccessfulFactoryEvidenceCall(events: readonly AgentEvent[]): boolean {
+  return events.some((event) => {
+    if (event.kind !== 'agent.tool-call') return false;
+    const payload = payloadRecord(event.payload);
+    if (payload == null) return false;
+    if (payload.blocked === true || payload.status !== 'ok') return false;
+    const toolName = normalizedToolName(payload.tool_name ?? payload.toolName ?? payload.tool);
+    return toolName != null && FACTORY_EVIDENCE_TOOL_NAMES.has(toolName);
+  });
 }
 
 export async function runOneScout(
@@ -248,6 +286,24 @@ export async function runOneScout(
   const findings = scoutOutput.findings;
   const decisionSummaries =
     result.decisionSummaries.length > 0 ? result.decisionSummaries : scoutOutput.decisionSummaries;
+
+  if (findings.length === 0 && !hasSuccessfulFactoryEvidenceCall(result.events)) {
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-failed',
+      payload: { runId, scoutName: spec.scoutName, errorReason: SCOUT_NO_EVIDENCE_REASON },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'error',
+      findings: [],
+      decisionSummaries,
+      errorReason: SCOUT_NO_EVIDENCE_REASON,
+      runId,
+    };
+  }
 
   append({
     projectId: ctx.projectId,

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -49,6 +49,51 @@ function okResult(scoutName: string): AgentResult {
   };
 }
 
+function emptyResult(events: AgentResult['events'] = []): AgentResult {
+  return {
+    output: {
+      findings: [],
+      decisionSummaries: [{ kind: 'READ', summary: 'scout completed without findings' }],
+      status: 'ok',
+    },
+    decisionSummaries: [{ kind: 'READ', summary: 'scout completed without findings' }],
+    events,
+  };
+}
+
+function runtimeAdvisoryEvent(
+  runId: string,
+  surface: 'resources/list failed' | 'resources/templates/list failed' | 'resources/read failed',
+): AgentResult['events'][number] {
+  return {
+    id: 1,
+    projectId: 'goose-hub-self',
+    workItemId: 'github:owner/repo#558',
+    kind: 'agent.runtime-advisory',
+    payload: { runId, surface, toolName: surface.replace(' failed', '') },
+    runId,
+    personaId: 'goose-hub-self/investigator/0',
+    createdAt: new Date(0).toISOString(),
+  };
+}
+
+function toolCallEvent(
+  runId: string,
+  toolName: string,
+  status?: 'ok' | 'failed' | 'timed_out',
+): AgentResult['events'][number] {
+  return {
+    id: 2,
+    projectId: 'goose-hub-self',
+    workItemId: 'github:owner/repo#558',
+    kind: 'agent.tool-call',
+    payload: { run_id: runId, tool_name: toolName, ...(status != null ? { status } : {}) },
+    runId,
+    personaId: 'goose-hub-self/investigator/0',
+    createdAt: new Date(0).toISOString(),
+  };
+}
+
 function makeRuntime(
   impls: Record<string, (spec: AgentSpec) => Promise<AgentResult>>,
 ): AgentRuntime {
@@ -508,6 +553,193 @@ describe('swarm.dispatchWave', () => {
     const patternReport = result.reports.find((r) => r.scoutName === 'scout-pattern');
     expect(patternReport?.status).toBe('ok');
     expect(patternReport?.decisionSummaries.some((d) => d.kind === 'UNKNOWN')).toBe(true);
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
+    expect(result.shouldAdvance).toBe(true);
+  });
+
+  it('fails an empty scout with only resources/list advisory for no evidence, not resource misuse', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')])),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-list-advisory',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    const failed = events.find((e) => e.kind === 'swarm.scout-failed');
+    expect(failed?.payload as { errorReason?: string }).toMatchObject({
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect((failed?.payload as { errorReason?: string }).errorReason).not.toContain(
+      'forbidden MCP resource probes',
+    );
+  });
+
+  it('fails an empty scout with only resources/templates/list advisory for no evidence, not resource misuse', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(
+          emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/templates/list failed')]),
+        ),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-template-advisory',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]?.status).toBe('error');
+    const failed = events.find((e) => e.kind === 'swarm.scout-failed');
+    expect((failed?.payload as { errorReason?: string }).errorReason).toBe(
+      'scout returned no findings and made no successful Factory read/search/file tool calls',
+    );
+  });
+
+  it('fails an empty scout with resources/read advisory and no successful evidence calls', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/read failed')])),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-read-advisory',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+  });
+
+  it('fails an empty scout when Factory evidence calls only have pre-execution audits', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'read_file')])),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-pre-tool-audit',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+  });
+
+  it('fails an empty scout when Factory evidence calls timed out', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'search_text', 'timed_out')])),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-timed-out-evidence',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+  });
+
+  it('keeps an empty scout ok when resource discovery advisories accompany successful evidence calls', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': (spec) =>
+        Promise.resolve(
+          emptyResult([
+            runtimeAdvisoryEvent(spec.runId, 'resources/list failed'),
+            runtimeAdvisoryEvent(spec.runId, 'resources/templates/list failed'),
+            toolCallEvent(spec.runId, 'read_file', 'ok'),
+            toolCallEvent(spec.runId, 'search_text', 'ok'),
+          ]),
+        ),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-evidence',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+      minSuccessfulScouts: 1,
+    });
+
+    expect(result.reports[0]?.status).toBe('ok');
     expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
     expect(result.shouldAdvance).toBe(true);
   });


### PR DESCRIPTION
## Summary
- treat Codex resources/list and resources/templates/list startup probe failures as non-fatal runtime advisories
- filter resource discovery advisory lines out of visible stderr logs
- fail empty scouts with no successful Factory evidence calls using the no-evidence reason instead of resource misuse language

## Verification
- pnpm vitest run core/agent-runtime/codex-cli-runtime.test.ts core/agent-runtime/swarm.test.ts
- pnpm exec biome check core/agent-runtime/codex-cli.ts core/agent-runtime/codex-cli-runtime.test.ts core/agent-runtime/scout-runner.ts core/agent-runtime/swarm.test.ts
- pnpm typecheck