### PR TITLE
Group bug enhance with investigation timeline

### DIFF
--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -1482,6 +1482,107 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     ).toBe(true);
   });
 
+  it('collapses lazy bug-enhance into its parent investigation section', () => {
+    const investigationRunId = 'investigate-run';
+    const bugEnhanceRunId = `${investigationRunId}:bug-enhance`;
+
+    const items = groupTimelineEventsByCanonicalSection([
+      makeEvent(1, 'agent.run-started', investigationRunId, {
+        payload: { skill: 'investigate' },
+      }),
+      makeEvent(2, 'agent.run-started', bugEnhanceRunId, {
+        payload: {
+          skill: 'bug-enhance',
+          parentRunId: investigationRunId,
+          investigationRunId,
+        },
+      }),
+      makeEvent(3, 'agent.tool-call', bugEnhanceRunId, {
+        payload: { tool_name: 'read_file' },
+      }),
+      makeEvent(4, 'agent.run-completed', bugEnhanceRunId, {
+        payload: { skill: 'bug-enhance' },
+      }),
+      makeEvent(5, 'agent.bug-enhance-lazy', investigationRunId, {
+        payload: { producedSeed: true, candidateFileCount: 1 },
+      }),
+      makeEvent(6, 'agent.investigation-complete', investigationRunId),
+    ]);
+
+    const investigationSections = items.filter(
+      (item): item is Extract<typeof item, { kind: 'timeline-section' }> =>
+        item.kind === 'timeline-section' && item.section === 'investigation',
+    );
+
+    expect(investigationSections).toHaveLength(1);
+    expect(investigationSections[0].items.some((item) => item.kind === 'investigation-phase')).toBe(
+      false,
+    );
+    expect(
+      investigationSections[0].items.some(
+        (item) => item.kind === 'run-group' && item.runId === investigationRunId,
+      ),
+    ).toBe(true);
+    expect(
+      investigationSections[0].items.some(
+        (item) => item.kind === 'run-group' && item.runId === bugEnhanceRunId,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps lazy bug-enhance attached to the correct investigation when there are multiple runs', () => {
+    const firstInvestigation = 'investigate-first';
+    const secondInvestigation = 'investigate-second';
+
+    const items = groupTimelineEventsByCanonicalSection([
+      makeEvent(1, 'agent.run-started', firstInvestigation, {
+        payload: { skill: 'investigate' },
+      }),
+      makeEvent(2, 'agent.run-started', `${firstInvestigation}:bug-enhance`, {
+        payload: { skill: 'bug-enhance', parentRunId: firstInvestigation },
+      }),
+      makeEvent(3, 'agent.run-completed', `${firstInvestigation}:bug-enhance`),
+      makeEvent(4, 'agent.investigation-complete', firstInvestigation),
+      makeEvent(5, 'agent.run-started', secondInvestigation, {
+        payload: { skill: 'investigate' },
+      }),
+      makeEvent(6, 'agent.run-started', `${secondInvestigation}:bug-enhance`, {
+        payload: { skill: 'bug-enhance', parentRunId: secondInvestigation },
+      }),
+      makeEvent(7, 'agent.run-completed', `${secondInvestigation}:bug-enhance`),
+      makeEvent(8, 'agent.investigation-complete', secondInvestigation),
+    ]);
+
+    const investigationSections = items.filter(
+      (item): item is Extract<typeof item, { kind: 'timeline-section' }> =>
+        item.kind === 'timeline-section' && item.section === 'investigation',
+    );
+
+    expect(investigationSections).toHaveLength(2);
+    const firstSection = investigationSections.find((section) =>
+      section.items.some((item) => item.kind === 'run-group' && item.runId === firstInvestigation),
+    );
+    const secondSection = investigationSections.find((section) =>
+      section.items.some((item) => item.kind === 'run-group' && item.runId === secondInvestigation),
+    );
+
+    expect(
+      firstSection?.items.some(
+        (item) => item.kind === 'run-group' && item.runId === `${firstInvestigation}:bug-enhance`,
+      ),
+    ).toBe(true);
+    expect(
+      secondSection?.items.some(
+        (item) => item.kind === 'run-group' && item.runId === `${secondInvestigation}:bug-enhance`,
+      ),
+    ).toBe(true);
+    expect(
+      firstSection?.items.some(
+        (item) => item.kind === 'run-group' && item.runId === `${secondInvestigation}:bug-enhance`,
+      ),
+    ).toBe(false);
+  });
+
   it('keeps section cost attribution limited to runs inside that section', () => {
     const items = groupTimelineEventsByCanonicalSection([
       makeEvent(1, 'agent.run-started', 'run-grill-cost', { payload: { skill: 'grill-me' } }),

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -425,8 +425,11 @@ function timelineSegmentExplicitKey(
 
 function getInvestigationRunIdFromRunId(runId: string | null): string | null {
   if (runId == null) return null;
-  const markerIndex = runId.indexOf(':scout:');
-  return markerIndex > 0 ? runId.slice(0, markerIndex) : null;
+  for (const marker of [':scout:', ':bug-enhance']) {
+    const markerIndex = runId.indexOf(marker);
+    if (markerIndex > 0) return runId.slice(0, markerIndex);
+  }
+  return null;
 }
 
 function getPipelineRunIdFromRunId(runId: string | null): string | null {

--- a/apps/web/src/components/detail/lib/timeline/phases/investigation.ts
+++ b/apps/web/src/components/detail/lib/timeline/phases/investigation.ts
@@ -10,10 +10,11 @@ function getRenderItemRunId(item: RenderItem): string | null {
 function getInvestigationChildParentRunId(item: RenderItem): string | null {
   const runId = getRenderItemRunId(item);
   if (runId == null) return null;
-  const marker = ':scout:';
-  const markerIndex = runId.indexOf(marker);
-  if (markerIndex <= 0) return null;
-  return runId.slice(0, markerIndex);
+  for (const marker of [':scout:', ':bug-enhance']) {
+    const markerIndex = runId.indexOf(marker);
+    if (markerIndex > 0) return runId.slice(0, markerIndex);
+  }
+  return null;
 }
 
 function getInvestigationPayloadParentRunIds(item: RenderItem): string[] {

--- a/core/agent-runtime/bug-enhance-runner.test.ts
+++ b/core/agent-runtime/bug-enhance-runner.test.ts
@@ -114,6 +114,20 @@ describe('runBugEnhance — path-existence pruning', () => {
     expect(result.groundedHints?.candidateFiles[0].path).toBe('real.ts');
   });
 
+  it('uses a parent investigation child run id when provided', async () => {
+    await runBugEnhance({ ...BASE_INPUT, parentRunId: 'investigate-parent' });
+
+    expect(mockRunFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'investigate-parent:bug-enhance',
+        extraEventPayload: {
+          parentRunId: 'investigate-parent',
+          investigationRunId: 'investigate-parent',
+        },
+      }),
+    );
+  });
+
   it('emits agent.bug-enhance-hallucinated and returns null when all candidateFiles pruned', async () => {
     mockRunFn.mockResolvedValue(makeAgentResult(makeHints(['fake.ts', 'also-fake.ts'])));
 

--- a/core/agent-runtime/bug-enhance-runner.ts
+++ b/core/agent-runtime/bug-enhance-runner.ts
@@ -38,6 +38,8 @@ export interface RunBugEnhanceInput {
   body: string;
   /** Optional working directory for tool execution (e.g. worktree path). */
   workspaceDir?: string;
+  /** Parent investigation run when bug-enhance runs lazily inside investigation. */
+  parentRunId?: string;
 }
 
 /**
@@ -61,7 +63,9 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
     model: bugEnhanceRuntime.modelOverride,
     skillProvider: bugEnhanceRuntime.provider,
   });
-  const runId = crypto.randomUUID();
+  const parentRunId = input.parentRunId?.trim();
+  const runId =
+    parentRunId != null && parentRunId !== '' ? `${parentRunId}:bug-enhance` : crypto.randomUUID();
   const { personaId } = selectPersona(input.projectId, 'triager');
 
   let prompt: string;
@@ -96,6 +100,14 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
       personaId,
       outputJsonSchema: jsonSchema,
       appendSystemPrompt,
+      ...(parentRunId != null && parentRunId !== ''
+        ? {
+            extraEventPayload: {
+              parentRunId,
+              investigationRunId: parentRunId,
+            },
+          }
+        : {}),
     });
 
     const parsed = safeParseOutputForSchema(BugEnhanceOutputSchema, result.output);

--- a/core/workflows/timeline-sections.test.ts
+++ b/core/workflows/timeline-sections.test.ts
@@ -118,6 +118,10 @@ describe('timeline sections', () => {
     for (const event of events) {
       expect(resolveTimelineSection(event, { runMetadata: metadata })).toBe('investigation');
     }
+
+    expect(
+      resolveTimelineSection({ kind: 'agent.tool-call', runId: 'investigate-1:bug-enhance' }),
+    ).toBe('investigation');
   });
 
   it('maps control flow to transitions and unknown telemetry to system', () => {

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -406,6 +406,7 @@ function timelineSectionFromHistoricalRunId(
 ): TimelineSectionId | null {
   if (runId == null) return null;
   if (runId.includes(':scout:')) return 'investigation';
+  if (runId.includes(':bug-enhance')) return 'investigation';
   if (runId.endsWith(':grill-me')) return 'grill';
   if (runId.endsWith(':write-prd') || runId.endsWith(':advise-on-prd')) return 'prd';
   if (runId.endsWith(':decompose-issues')) return 'decompose';

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -1610,6 +1610,7 @@ describe('runInvestigateWorkflow', () => {
           title: workItem.title,
           body: workItem.body,
           workspaceDir: '/tmp/test-worktree',
+          parentRunId: expect.any(String),
         }),
       );
       expect(mockPersistGroundedSeed).toHaveBeenCalledWith(

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -395,6 +395,7 @@ export async function runInvestigateWorkflow(
             title: workItem.title,
             body: workItem.body,
             workspaceDir: worktreePath,
+            parentRunId: runId,
           });
           const hasUsable = enhancement.groundedHints != null;
           if (hasUsable && enhancement.groundedHints != null) {


### PR DESCRIPTION
## Summary
- run lazy bug-enhance as an investigation child run when invoked from investigate
- attach bug-enhance runtime metadata to the parent investigation run
- group :bug-enhance child runs with their parent investigation section without nesting an investigation phase

## Tests
- pnpm exec biome check core/agent-runtime/bug-enhance-runner.ts core/agent-runtime/bug-enhance-runner.test.ts core/workflows/timeline-sections.ts core/workflows/timeline-sections.test.ts slices/investigate/workflow.ts slices/investigate/slice.test.ts apps/web/src/components/detail/lib/timeline/index.ts apps/web/src/components/detail/lib/timeline/phases/investigation.ts apps/web/src/components/detail/lib/timeline.test.ts
- env TMPDIR=/private/tmp pnpm test core/agent-runtime/bug-enhance-runner.test.ts core/workflows/timeline-sections.test.ts apps/web/src/components/detail/lib/timeline.test.ts slices/investigate/slice.test.ts