### PR TITLE
Gate failed WP verification before QA repair loops

### DIFF
--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,6 @@
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollTo !== 'function') {
+  Object.defineProperty(Element.prototype, 'scrollTo', {
+    configurable: true,
+    value: () => {},
+  });
+}

--- a/core/agent-runtime/budgets.test.ts
+++ b/core/agent-runtime/budgets.test.ts
@@ -120,7 +120,14 @@ describe('resolveBudgets', () => {
   });
 
   it('sonnet skills resolve to sonnet model IDs', () => {
-    for (const skill of ['feature-frame', 'investigate', 'qa', 'review', 'retrospective-deep']) {
+    for (const skill of [
+      'feature-frame',
+      'fix-feedback',
+      'investigate',
+      'qa',
+      'review',
+      'retrospective-deep',
+    ]) {
       const { modelOverride } = resolveBudgets(skill);
       expect(modelOverride, `${skill} should use sonnet`).toContain('sonnet');
     }

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -236,6 +236,15 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     modelTier: 'sonnet',
     escalation: { modelTier: 'opus', maxBudgetUsd: 20.0 },
   },
+  // Repair/debug loops need their own tier so cheap implement overrides do not
+  // send verification recovery into a weaker model by accident.
+  'fix-feedback': {
+    maxTurns: 100,
+    maxBudgetUsd: 6.0,
+    timeoutMs: 900_000,
+    modelTier: 'sonnet',
+    escalation: { modelTier: 'opus', maxBudgetUsd: 12.0 },
+  },
   // M19.22 (#698) — code-quality-audit. Opus-tier qualitative scoring across
   // 8 categories; read-only + git log/blame access. Higher turn cap to allow
   // the auditor to verify evidence across multiple files.

--- a/core/qa/failure-category.test.ts
+++ b/core/qa/failure-category.test.ts
@@ -14,4 +14,10 @@ describe('classifyQaFailure', () => {
   it('keeps failed executable checks in the spec-contract category when no product finding exists', () => {
     expect(classifyQaFailure({ hasFailedExecutableCheck: true })).toBe('spec-contract');
   });
+
+  it('keeps verification infrastructure distinct from product and spec failures', () => {
+    expect(classifyQaFailure({ failedTier: 'functional', verificationInfrastructure: true })).toBe(
+      'verification-infrastructure',
+    );
+  });
 });

--- a/core/qa/failure-category.ts
+++ b/core/qa/failure-category.ts
@@ -3,6 +3,7 @@ export const QA_FAILURE_CATEGORIES = [
   'product',
   'regression-unrelated',
   'orchestration',
+  'verification-infrastructure',
 ] as const;
 
 export type QaFailureCategory = (typeof QA_FAILURE_CATEGORIES)[number];
@@ -14,7 +15,9 @@ export function classifyQaFailure(input: {
   hasActionableFinding?: boolean;
   hasFailedExecutableCheck?: boolean;
   orchestration?: boolean;
+  verificationInfrastructure?: boolean;
 }): QaFailureCategory {
+  if (input.verificationInfrastructure === true) return 'verification-infrastructure';
   if (input.orchestration === true) return 'orchestration';
   if (input.hasFailedExecutableCheck === true) return 'spec-contract';
   if (input.hasActionableFinding === true) return 'product';

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -35,6 +35,10 @@ const duplicateCounters = new Map<
   Map<string, { count: number; nudged: boolean; paths: string[] }>
 >();
 const testRetryCounters = new Map<string, Map<string, number>>();
+const testFailureSignatureCounters = new Map<
+  string,
+  Map<string, { count: number; paths: Set<string> }>
+>();
 const redundantReadCounters = new Map<string, Map<string, { count: number; nudged: boolean }>>();
 
 /** Total read_file calls per run (all paths, including first reads). */
@@ -145,6 +149,12 @@ export function readCount(runId: string, canonicalPath: string): number {
 export function testRetryCap(env: NodeJS.ProcessEnv = process.env): number {
   const value = Number.parseInt(env.FACTORY_RUN_TESTS_RETRY_CAP ?? '', 10);
   return Number.isFinite(value) && value >= 1 ? value : 3;
+}
+
+export interface TestFailureSignatureRecord {
+  signature: string;
+  count: number;
+  paths: string[];
 }
 
 /** Sentinel key for `run_tests` invocations without a narrowed path. */
@@ -289,6 +299,10 @@ export function invalidateRunCacheForPaths(runId: string, rawPaths: string[]): v
   }
   if (retryMap?.size === 0) testRetryCounters.delete(runId);
 
+  // A write can legitimately change the next failure signature. Keep the
+  // signature guard focused on unproductive test rotation between edits.
+  testFailureSignatureCounters.delete(runId);
+
   // Writes also reset redundant-read counters for overlapping paths: the
   // file has changed, so reading it again is no longer redundant.
   const readMap = redundantReadCounters.get(runId);
@@ -304,6 +318,7 @@ export function clearRunCache(runId: string): void {
   runCaches.delete(runId);
   duplicateCounters.delete(runId);
   testRetryCounters.delete(runId);
+  testFailureSignatureCounters.delete(runId);
   redundantReadCounters.delete(runId);
   totalReadCounters.delete(runId);
   clearRunCommandInvocationCounter(runId);
@@ -326,6 +341,24 @@ export function recordTestFailure(runId: string, canonicalPath: string | null): 
   return next;
 }
 
+export function recordTestFailureSignature(
+  runId: string,
+  signature: string,
+  canonicalPath: string | null,
+): TestFailureSignatureRecord {
+  const pathKey = normalizeTestPathKey(canonicalPath);
+  let runMap = testFailureSignatureCounters.get(runId);
+  if (runMap == null) {
+    runMap = new Map();
+    testFailureSignatureCounters.set(runId, runMap);
+  }
+  const existing = runMap.get(signature) ?? { count: 0, paths: new Set<string>() };
+  existing.count += 1;
+  existing.paths.add(pathKey);
+  runMap.set(signature, existing);
+  return { signature, count: existing.count, paths: [...existing.paths].sort() };
+}
+
 /**
  * Clears the consecutive-failure counter for the given path. Call on
  * successful test runs and on writes/edits that mutate the target file
@@ -337,6 +370,10 @@ export function clearTestFailureCounter(runId: string, canonicalPath: string | n
   if (runMap == null) return;
   runMap.delete(key);
   if (runMap.size === 0) testRetryCounters.delete(runId);
+}
+
+export function clearTestFailureSignatureCounters(runId: string): void {
+  testFailureSignatureCounters.delete(runId);
 }
 
 /**

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -192,6 +192,71 @@ describe('runTestsTool retry cap', () => {
     expect(other.status).toBe('failed');
   });
 
+  it('blocks repeated failure signatures across different test paths', async () => {
+    writeFileSync(join(workspace, 'apps/web/src/bar.test.ts'), 'test("y", () => {});\n');
+    const vitestJson = (file: string) =>
+      JSON.stringify({
+        numTotalTests: 1,
+        numPassedTests: 0,
+        numFailedTests: 1,
+        testResults: [
+          {
+            name: `/work/apps/web/src/${file}`,
+            status: 'failed',
+            assertionResults: [
+              {
+                ancestorTitles: ['suite'],
+                title: 'renders',
+                status: 'failed',
+                failureMessages: [
+                  `TypeError: React.act is not a function\n    at /work/apps/web/src/${file}:5:7`,
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    mockRunCommand.mockResolvedValueOnce({
+      status: 'failed',
+      exitCode: 1,
+      stdout: vitestJson('foo.test.ts'),
+      stderr: '',
+      durationMs: 18,
+      truncated: false,
+    });
+    mockRunCommand.mockResolvedValueOnce({
+      status: 'failed',
+      exitCode: 1,
+      stdout: vitestJson('bar.test.ts'),
+      stderr: '',
+      durationMs: 18,
+      truncated: false,
+    });
+    mockRunCommand.mockResolvedValueOnce({
+      status: 'failed',
+      exitCode: 1,
+      stdout: vitestJson('bar.test.ts'),
+      stderr: '',
+      durationMs: 18,
+      truncated: false,
+    });
+
+    await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+    await runTestsTool(ctx, { path: 'src/bar.test.ts' });
+    const blocked = await runTestsTool(ctx, { path: 'src/bar.test.ts' });
+
+    expect(blocked.status).toBe('failed');
+    expect(blocked.exitCode).toBeNull();
+    expect(blocked.stderr).toMatch(/repeated failure signature/i);
+    const violations = (await import('../../../event-stream/store.js')).eventStore
+      .replay({ runId: ctx.runId, kind: 'tool.violation' })
+      .filter(
+        (event) =>
+          (event.payload as { reason?: unknown }).reason === 'repeated-test-failure-signature',
+      );
+    expect(violations).toHaveLength(1);
+  });
+
   it('attaches a parsed failureSummary when the test command exits non-zero with vitest JSON output', async () => {
     const vitestJson = JSON.stringify({
       numTotalTests: 1,

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -14,6 +14,7 @@ import {
   clearTestFailureCounter,
   consecutiveTestFailures,
   recordTestFailure,
+  recordTestFailureSignature,
   testRetryCap,
 } from '../run-cache.js';
 import type {
@@ -214,6 +215,14 @@ export async function runTestsTool(
     result.status === 'failed'
       ? parseTestFailures({ stdout: result.stdout, stderr: result.stderr })
       : undefined;
+  const failureSignature =
+    result.status === 'failed'
+      ? buildTestFailureSignature({ stdout: result.stdout, stderr: result.stderr, failureSummary })
+      : null;
+  const signatureRecord =
+    failureSignature != null
+      ? recordTestFailureSignature(ctx.runId, failureSignature, retryPathKey)
+      : null;
 
   emitToolCall(ctx, {
     tool: 'run_tests',
@@ -228,6 +237,27 @@ export async function runTestsTool(
     durationMs: result.durationMs,
     truncated: result.truncated,
   });
+  if (signatureRecord != null && signatureRecord.count >= cap && signatureRecord.paths.length > 1) {
+    eventStore.appendEvent({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId,
+      runId: ctx.runId,
+      personaId: ctx.personaId ?? null,
+      kind: 'tool.violation',
+      payload: {
+        tool: 'run_tests',
+        reason: 'repeated-test-failure-signature',
+        signature: signatureRecord.signature,
+        paths: signatureRecord.paths,
+        consecutiveFailures: signatureRecord.count,
+        cap,
+        guidance:
+          'The same test failure signature repeated across targets. Stop rotating test files; classify whether this is product code, test setup, or verification infrastructure, then edit the relevant source or setup.',
+      },
+    });
+    const blocked = buildRetrySignatureBlockedResult(argv, signatureRecord);
+    return failureSummary != null ? { ...blocked, failureSummary } : blocked;
+  }
   const verifyResult = toVerifyResult(argv, result, pathMetadata);
   return failureSummary != null ? { ...verifyResult, failureSummary } : verifyResult;
 }
@@ -249,6 +279,68 @@ function buildRetryCapBlockedResult(
     displayTruncated: false,
     command: argv,
   };
+}
+
+function buildRetrySignatureBlockedResult(
+  argv: ReadonlyArray<string>,
+  record: { signature: string; count: number; paths: string[] },
+): VerifyResult {
+  return {
+    status: 'failed',
+    exitCode: null,
+    stdout: '',
+    stderr: `[harness] run_tests stopped after repeated failure signature (${record.count} failures across ${record.paths.length} targets): ${record.signature}. Stop rotating test files; classify whether this is product code, test setup, or verification infrastructure, then edit the relevant source or setup.`,
+    durationMs: 0,
+    truncated: false,
+    displayTruncated: false,
+    command: argv,
+  };
+}
+
+function buildTestFailureSignature(input: {
+  stdout: string;
+  stderr: string;
+  failureSummary?: ParsedTestFailures;
+}): string | null {
+  const parsedFailure = input.failureSummary?.failures[0];
+  const parsedAssertion = normalizeFailureSignatureText(parsedFailure?.assertion);
+  if (parsedAssertion != null) {
+    return `${parsedFailure?.category ?? 'unknown'}:${parsedAssertion}`;
+  }
+
+  const raw = normalizeFailureSignatureText(
+    firstUsefulFailureLine(`${input.stdout}\n${input.stderr}`),
+  );
+  return raw != null ? `raw:${raw}` : null;
+}
+
+function firstUsefulFailureLine(text: string): string | null {
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    if (/^(run|test files|tests|start at|duration)\b/i.test(line)) continue;
+    if (/^(stdout|stderr)\s*\|/i.test(line)) continue;
+    if (
+      /(error|typeerror|referenceerror|cannot find module|failed to load|uncaught|unhandled)/i.test(
+        line,
+      )
+    ) {
+      return line;
+    }
+  }
+  return null;
+}
+
+function normalizeFailureSignatureText(text: string | undefined | null): string | null {
+  if (text == null) return null;
+  const trimmed = text
+    .replace(/\/[^\s)]+\/([^/\s)]+\.(?:t|j)sx?)(?::\d+)?(?::\d+)?/g, '$1')
+    .replace(/\b\d+ms\b/g, '<duration>')
+    .replace(/\b\d+:\d+\b/g, '<line>')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, 240);
 }
 
 export async function runLintTool(

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -313,6 +313,30 @@ describe('Tier 2 (Functional) — golden test', () => {
     expect(result.findings[0]?.code).toBe('verification-runner-missing');
   });
 
+  it('classifies React/jsdom harness runtime failures as verification infrastructure', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'focused test',
+          command: 'pnpm vitest run apps/web/src/components/chat/components/ChatDock.test.tsx',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp', {
+      runVerificationCommandImpl: async () => ({
+        passed: false,
+        output:
+          'TypeError: React.act is not a function\nTypeError: scrollRef.current?.scrollTo is not a function',
+      }),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('verification-infrastructure');
+    expect(result.findings[0]?.code).toBe('verification-harness-runtime');
+  });
+
   it('passes vacuously when no verificationTooling is declared', async () => {
     const spec = makeSpec({ verificationTooling: [] });
     const result = await verifyFunctional(spec, '/tmp');

--- a/core/verify/tiers.test.ts
+++ b/core/verify/tiers.test.ts
@@ -337,6 +337,50 @@ describe('Tier 2 (Functional) — golden test', () => {
     expect(result.findings[0]?.code).toBe('verification-harness-runtime');
   });
 
+  it('keeps app import resolution failures as product failures', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'focused test',
+          command: 'pnpm vitest run apps/web/src/components/foo.test.tsx',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp', {
+      runVerificationCommandImpl: async () => ({
+        passed: false,
+        output: "Error: Cannot find module '@/components/MissingWidget'",
+      }),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('product');
+  });
+
+  it('keeps Testing Library assertion errors as product failures', async () => {
+    const spec = makeSpec({
+      verificationTooling: [
+        {
+          name: 'focused test',
+          command: 'pnpm vitest run apps/web/src/components/foo.test.tsx',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    const result = await verifyFunctional(spec, '/tmp', {
+      runVerificationCommandImpl: async () => ({
+        passed: false,
+        output: 'TestingLibraryElementError: Unable to find an element with the role "button"',
+      }),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.findings[0]?.category).toBe('product');
+  });
+
   it('passes vacuously when no verificationTooling is declared', async () => {
     const spec = makeSpec({ verificationTooling: [] });
     const result = await verifyFunctional(spec, '/tmp');

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -220,9 +220,7 @@ function isLikelyVerificationHarnessFailure(detail: string): boolean {
   return (
     /react\.act is not a function/i.test(detail) ||
     /(?:element|html\w*element)\.prototype\.scrollto|scrollto is not a function/i.test(detail) ||
-    /testinglibrary(?:element)?error/i.test(detail) ||
     /cleanup is not a function/i.test(detail) ||
-    /failed to resolve import|cannot find module|cannot find package/i.test(detail) ||
     /referenceerror:\s*(?:window|document|element|html\w*element|localstorage|matchmedia|resizeobserver|intersectionobserver)\s+is not defined/i.test(
       detail,
     ) ||

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -210,7 +210,24 @@ function classifyVerificationCommandFailure(
   ) {
     return { category: 'verification-infrastructure', code: 'verification-harness-config' };
   }
+  if (isLikelyVerificationHarnessFailure(detail)) {
+    return { category: 'verification-infrastructure', code: 'verification-harness-runtime' };
+  }
   return { category: 'product' };
+}
+
+function isLikelyVerificationHarnessFailure(detail: string): boolean {
+  return (
+    /react\.act is not a function/i.test(detail) ||
+    /(?:element|html\w*element)\.prototype\.scrollto|scrollto is not a function/i.test(detail) ||
+    /testinglibrary(?:element)?error/i.test(detail) ||
+    /cleanup is not a function/i.test(detail) ||
+    /failed to resolve import|cannot find module|cannot find package/i.test(detail) ||
+    /referenceerror:\s*(?:window|document|element|html\w*element|localstorage|matchmedia|resizeobserver|intersectionobserver)\s+is not defined/i.test(
+      detail,
+    ) ||
+    /typeerror:.*(?:render|cleanup|act)\b.*is not a function/i.test(detail)
+  );
 }
 
 function normalizeVerificationCommand(command: string): string {
@@ -459,6 +476,9 @@ export async function runTier(
           ? 'qa.functional-failed'
           : 'qa.regression-failed';
 
+    const verificationInfrastructure = result.findings.some(
+      (finding) => finding.category === 'verification-infrastructure',
+    );
     deps.appendEvent({
       projectId: runArtifacts.projectId,
       workItemId: runArtifacts.workItemId ?? null,
@@ -469,7 +489,20 @@ export async function runTier(
         evidence: result.evidence,
         findingCount: result.findings.length,
         runId: runArtifacts.runId,
-        ...(!result.passed ? { failureCategory: classifyQaFailure({ failedTier: tier }) } : {}),
+        ...(!result.passed
+          ? {
+              failureCategory: classifyQaFailure({
+                failedTier: tier,
+                verificationInfrastructure,
+              }),
+              findings: result.findings.map((finding) => ({
+                severity: finding.severity,
+                description: finding.message,
+                code: finding.code,
+                category: finding.category,
+              })),
+            }
+          : {}),
       },
       runId: runArtifacts.runId,
     });

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -303,6 +303,44 @@ describe('runFixFeedbackWorkflow', () => {
     );
   });
 
+  it('skips implement and escalates when QA reports deterministic verification infrastructure failure', async () => {
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        id: 3,
+        kind: 'qa.verification-blocked' as EventKind,
+        payload: {
+          failedTier: 2,
+          reason: 'verification-harness-runtime',
+          findings: ['TypeError: React.act is not a function'],
+          deterministic: true,
+          agentSkipped: true,
+          failureCategory: 'verification-infrastructure',
+        },
+        projectId: 'proj',
+        workItemId: 'github:owner/repo#42',
+        createdAt: new Date().toISOString(),
+        runId: 'qa-run-1',
+      },
+    ]);
+    const workItem = makeWorkItem();
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo');
+
+    expect(mockClaudeCliRun).not.toHaveBeenCalled();
+    expect(stateSource.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    expect(vi.mocked(eventStore.appendEvent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.fix-feedback-skipped',
+        payload: expect.objectContaining({ reason: 'verification-infrastructure' }),
+      }),
+    );
+  });
+
   it('passes existing worktreePath as runtime workspaceDir', async () => {
     vi.mocked(eventStore.replay).mockReturnValue([makePrOpenedEvent('/work/existing-wt')]);
     mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -160,14 +160,24 @@ type QaPayload = {
   verdict?: string;
   overallScore?: number;
   threshold?: number;
-  findings?: Array<{
-    tier?: string;
-    severity?: string;
-    description: string;
-    suggestion?: string;
-    disposition?: 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
-    dispositionRef?: string;
-  }>;
+  deterministic?: boolean;
+  agentSkipped?: boolean;
+  failureCategory?: string;
+  reason?: string;
+  failedTier?: number | string;
+  // qa.verification-blocked payload uses string findings, while qa.completed
+  // uses structured QA findings. Keep this union local to the source-failure
+  // formatter instead of widening the shared skill schemas.
+  findings?:
+    | string[]
+    | Array<{
+        tier?: string;
+        severity?: string;
+        description: string;
+        suggestion?: string;
+        disposition?: 'fixed' | 'needs-fix' | 'out-of-scope' | 'follow-up';
+        dispositionRef?: string;
+      }>;
   criteriaResults?: Array<{
     criterionId: string;
     checkId: string;
@@ -205,6 +215,8 @@ type SourceFailure = {
   runId?: string;
   feedback: string;
   actionable: boolean;
+  verificationInfrastructure?: boolean;
+  skipReason?: string;
 };
 
 function compactPayload(payload: Record<string, unknown>): Record<string, unknown> {
@@ -260,7 +272,7 @@ async function verifiedFollowUpRefsForPayload(
   stateSource: StateSource,
 ): Promise<Set<string>> {
   const refs = new Set<string>();
-  for (const finding of payload.findings ?? []) {
+  for (const finding of structuredQaFindings(payload)) {
     if (finding.disposition !== 'follow-up') continue;
     const localId = localIssueRef(finding.dispositionRef);
     if (localId == null) continue;
@@ -274,6 +286,39 @@ async function verifiedFollowUpRefsForPayload(
   return refs;
 }
 
+function structuredQaFindings(
+  payload: QaPayload,
+): NonNullable<Extract<QaPayload['findings'], Array<{ description: string }>>> {
+  return Array.isArray(payload.findings) && typeof payload.findings[0] !== 'string'
+    ? (payload.findings as NonNullable<
+        Extract<QaPayload['findings'], Array<{ description: string }>>
+      >)
+    : [];
+}
+
+function isVerificationInfrastructurePayload(payload: QaPayload): boolean {
+  return (
+    payload.failureCategory === 'verification-infrastructure' ||
+    (payload.deterministic === true &&
+      payload.agentSkipped === true &&
+      payload.failureCategory === 'orchestration')
+  );
+}
+
+function formatVerificationBlockedFeedback(payload: QaPayload): string {
+  const lines = [
+    'QA verification blocked before product assertions could run.',
+    `Failure category: ${payload.failureCategory ?? 'verification-infrastructure'}`,
+  ];
+  if (payload.failedTier != null) lines.push(`Failed tier: ${payload.failedTier}`);
+  if (payload.reason != null) lines.push(`Reason: ${payload.reason}`);
+  const findings = Array.isArray(payload.findings) ? payload.findings : [];
+  for (const finding of findings.slice(0, 5)) {
+    lines.push(`- ${typeof finding === 'string' ? finding : finding.description}`);
+  }
+  return lines.join('\n');
+}
+
 async function findLatestSourceFailure(
   events: ReturnType<typeof eventStore.replay>,
   stateSource: StateSource,
@@ -282,7 +327,10 @@ async function findLatestSourceFailure(
   let qaEvent: (typeof events)[number] | null = null;
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
-    if (e.kind === 'qa.completed' && (e.payload as QaPayload).verdict !== 'pass') {
+    if (
+      (e.kind === 'qa.completed' && (e.payload as QaPayload).verdict !== 'pass') ||
+      e.kind === 'qa.verification-blocked'
+    ) {
       qaIdx = i;
       qaEvent = e;
       break;
@@ -317,9 +365,25 @@ async function findLatestSourceFailure(
 
   if (qaEvent != null) {
     const payload = qaEvent.payload as QaPayload;
+    if (
+      qaEvent.kind === 'qa.verification-blocked' ||
+      isVerificationInfrastructurePayload(payload)
+    ) {
+      return {
+        kind: 'qa',
+        runId: sourceRunId(qaEvent),
+        feedback: formatVerificationBlockedFeedback(payload),
+        actionable: false,
+        verificationInfrastructure: true,
+        skipReason: 'verification-infrastructure',
+      };
+    }
     const { verdict = 'fail', overallScore = 0, threshold = 70 } = payload;
     const verifiedFollowUpRefs = await verifiedFollowUpRefsForPayload(payload, stateSource);
-    const actionableItems = collectActionableQaItems(payload, { verifiedFollowUpRefs });
+    const actionableItems = collectActionableQaItems(
+      { ...payload, findings: structuredQaFindings(payload) },
+      { verifiedFollowUpRefs },
+    );
     return {
       kind: 'qa',
       runId: sourceRunId(qaEvent),
@@ -388,12 +452,50 @@ export async function runFixFeedbackWorkflow(
   const commitAllFn = deps.orchestratorCommitAllImpl ?? orchestratorCommitAll;
   const pushBranchFn = deps.orchestratorPushBranchImpl ?? orchestratorPushBranch;
   const { runtime, resolvedBudget } = resolveProjectAgentExecution({
-    skill: 'implement',
+    skill: 'fix-feedback',
     role: 'developer',
     projectId,
     projectConfig,
     injectedRuntime: deps.runtime,
   });
+
+  if (sourceFailure?.verificationInfrastructure === true) {
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Dev',
+        'Verification Blocked',
+        'Skipping fix-feedback because QA failed in deterministic verification infrastructure before product assertions could run.',
+        [sourceFailure.feedback],
+      ),
+    );
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    emitStateTransitionEvent({
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:needs-fix',
+      to: 'factory:needs-human',
+      by: 'fix-feedback',
+      runId,
+      extraPayload: repairPayload,
+    });
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.fix-feedback-skipped',
+      payload: {
+        ...repairPayload,
+        reason: sourceFailure.skipReason ?? 'verification-infrastructure',
+        sourceFeedback: sourceFailure.feedback,
+      },
+      runId,
+    });
+    return;
+  }
 
   const worktreePath = prLifecycle?.worktreePath;
   if (worktreePath == null) {

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -888,6 +888,88 @@ describe('parallel-implement repo-relative path normalization', () => {
 });
 
 describe('implement-wp ownership gate', () => {
+  it('fails schema-valid WPs that wrote tests without passing matching run_tests', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const reverted: string[][] = [];
+    const iterations: Array<{ wpId: string; status: string; reason?: string }> = [];
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      },
+      confidence: 'low',
+      decisionSummaries: [
+        {
+          kind: 'TOOL_FAILURE',
+          summary: 'Targeted test is blocked by the harness',
+          evidence: 'TypeError: React.act is not a function',
+        },
+      ],
+    };
+    const testEvent: AgentEvent = {
+      id: 1001,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId: 'run-wp-acceptance:wp:WP1:iter:1',
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'failed',
+        tool_input: {
+          path: 'apps/web/src/foo.test.ts',
+          paths: ['apps/web/src/foo.test.ts'],
+        },
+      },
+      runId: 'run-wp-acceptance:wp:WP1:iter:1',
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-acceptance',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: { run: vi.fn().mockResolvedValue({ output, events: [testEvent] }) },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: (_worktreePath, filesOwned) => {
+        reverted.push(filesOwned);
+      },
+      recordIterationFn: (_runId, wpId, _iteration, status, reason) => {
+        iterations.push({ wpId, status, reason });
+      },
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('TOOL_FAILURE'),
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-committed')).toBe(false);
+    expect(reverted).toHaveLength(1);
+    expect(iterations).toContainEqual({
+      wpId: 'WP1',
+      status: 'failed',
+      reason: expect.stringContaining('TOOL_FAILURE'),
+    });
+  });
+
   it('blocks ambiguous filesOwned before the WP builder starts', async () => {
     const scratchWorktree = makeTempRepo(['apps/web/src/index.ts', 'packages/admin/src/index.ts']);
     const { fn: appendEvent, events } = makeAppendEvent();

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -970,6 +970,121 @@ describe('implement-wp ownership gate', () => {
     });
   });
 
+  it('requires run_tests to pass for each written test file, not just self-reported test paths', async () => {
+    const scratchWorktree = makeTempRepo([
+      'apps/web/src/foo.ts',
+      'apps/web/src/foo.test.ts',
+      'apps/web/src/unrelated.test.ts',
+    ]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/unrelated.test.ts',
+        paths: ['apps/web/src/unrelated.test.ts'],
+      },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+    const unrelatedPassingTest: AgentEvent = {
+      id: 1002,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId: 'run-wp-written-test:wp:WP1:iter:1',
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src/unrelated.test.ts',
+          paths: ['apps/web/src/unrelated.test.ts'],
+        },
+      },
+      runId: 'run-wp-written-test:wp:WP1:iter:1',
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-written-test',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: { run: vi.fn().mockResolvedValue({ output, events: [unrelatedPassingTest] }) },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('apps/web/src/foo.test.ts'),
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
+  });
+
+  it('fails required verification when no verification tool passed even with high confidence', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts']);
+    const { fn: appendEvent } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Implement behavior',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [],
+      testsRun: { command: 'pnpm test', paths: [] },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts']),
+      iteration: 1,
+      runId: 'run-wp-required-verification',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: { run: vi.fn().mockResolvedValue({ output, events: [] }) },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+      verificationCommands: [
+        {
+          id: 'AC1-check',
+          command: 'pnpm test apps/web/src/foo.ts',
+          expectedExitCodes: [0],
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: 'verification was required but no verification tool passed',
+    });
+  });
+
   it('blocks ambiguous filesOwned before the WP builder starts', async () => {
     const scratchWorktree = makeTempRepo(['apps/web/src/index.ts', 'packages/admin/src/index.ts']);
     const { fn: appendEvent, events } = makeAppendEvent();

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -119,6 +119,92 @@ function isEditToolCall(event: AgentEvent): boolean {
   );
 }
 
+function toolCallStatus(event: AgentEvent): string | null {
+  if (event.kind !== 'agent.tool-call') return null;
+  const payload = event.payload as { status?: unknown };
+  return typeof payload.status === 'string' ? payload.status : null;
+}
+
+function toolCallPaths(event: AgentEvent): string[] {
+  const payload = event.payload as {
+    raw_path?: unknown;
+    canonical_path?: unknown;
+    tool_input?: unknown;
+  };
+  const input = toolCallInput(event);
+  const paths = new Set<string>();
+  const add = (value: unknown) => {
+    if (typeof value === 'string' && value.length > 0) paths.add(value);
+  };
+  const addArray = (value: unknown) => {
+    if (!Array.isArray(value)) return;
+    for (const entry of value) add(entry);
+  };
+  add(payload.raw_path);
+  const canonical = payload.canonical_path;
+  if (canonical != null && typeof canonical === 'object' && !Array.isArray(canonical)) {
+    add((canonical as { path?: unknown }).path);
+  }
+  add(input.path);
+  addArray(input.paths);
+  addArray(input.rawPaths);
+  return [...paths];
+}
+
+function normalizePathForCompare(path: string): string {
+  return path.replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function pathsMatch(left: string, right: string): boolean {
+  const a = normalizePathForCompare(left);
+  const b = normalizePathForCompare(right);
+  return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+}
+
+function hasBlockingDecision(output: ImplementWpOutput, events: AgentEvent[]): boolean {
+  const outputKinds = output.decisionSummaries.map((summary) => summary.kind);
+  const eventKinds = events
+    .filter((event) => event.kind === 'agent.decision-summary')
+    .map((event) => (event.payload as { kind?: unknown }).kind)
+    .filter((kind): kind is string => typeof kind === 'string');
+  return [...outputKinds, ...eventKinds].some(
+    (kind) => kind === 'TOOL_FAILURE' || kind === 'BLOCKER',
+  );
+}
+
+function latestRunTestsStatusForPath(events: AgentEvent[], path: string): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (toolCallName(event) !== 'run_tests') continue;
+    const paths = toolCallPaths(event);
+    if (paths.length > 0 && !paths.some((candidate) => pathsMatch(candidate, path))) continue;
+    return toolCallStatus(event);
+  }
+  return null;
+}
+
+function implementWpAcceptanceFailure(input: {
+  output: ImplementWpOutput;
+  events: AgentEvent[];
+  verificationRequired: boolean;
+}): string | null {
+  if (hasBlockingDecision(input.output, input.events)) {
+    return 'implement-wp emitted TOOL_FAILURE or BLOCKER';
+  }
+  if (input.output.confidence === 'low' && input.verificationRequired) {
+    return 'implement-wp returned low confidence while verification was required';
+  }
+  if (input.output.testsWritten.length > 0) {
+    const failedPaths = input.output.testsRun.paths.filter(
+      (path) => latestRunTestsStatusForPath(input.events, path) !== 'ok',
+    );
+    if (failedPaths.length > 0) {
+      return `tests were written but required run_tests did not pass for: ${failedPaths.join(', ')}`;
+    }
+  }
+  return null;
+}
+
 function isVerificationToolCall(event: AgentEvent): boolean {
   const name = toolCallName(event)?.toLowerCase();
   if (name == null) return false;
@@ -639,6 +725,34 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
     'implement-wp',
     output.decisionSummaries,
   );
+
+  const acceptanceFailure = implementWpAcceptanceFailure({
+    output,
+    events: result.events,
+    verificationRequired:
+      output.testsWritten.length > 0 ||
+      output.testsRun.paths.length > 0 ||
+      verificationCommands.length > 0,
+  });
+  if (acceptanceFailure != null) {
+    opts.appendEvent({
+      projectId,
+      workItemId: workItemId ?? null,
+      kind: 'parallel-implement.wp-failed',
+      payload: {
+        wpId: wp.id,
+        wpRunId,
+        errorReason: acceptanceFailure,
+        confidence: output.confidence,
+        testsWritten: output.testsWritten.map((test) => test.path),
+        testsRun: output.testsRun.paths,
+      },
+      runId: wpRunId,
+    });
+    opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
+    opts.recordIterationFn(runId, wp.id, iteration, 'failed', acceptanceFailure);
+    return { status: 'failed', wpId: wp.id, errorReason: acceptanceFailure, runId: wpRunId };
+  }
 
   // Build succeeded — return files for the serial commit phase.
   const commitMsg = `M:${wp.id} ${wp.changes.slice(0, 60)}\n\nBuilt by ${opts.personaId}`;

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -183,6 +183,15 @@ function latestRunTestsStatusForPath(events: AgentEvent[], path: string): string
   return null;
 }
 
+function hasSuccessfulVerificationToolCall(events: AgentEvent[]): boolean {
+  return events.some((event) => {
+    if (event.kind !== 'agent.tool-call') return false;
+    if (toolCallStatus(event) !== 'ok') return false;
+    const name = toolCallName(event);
+    return name === 'run_tests' || name === 'run_lint' || name === 'run_typecheck';
+  });
+}
+
 function implementWpAcceptanceFailure(input: {
   output: ImplementWpOutput;
   events: AgentEvent[];
@@ -194,13 +203,22 @@ function implementWpAcceptanceFailure(input: {
   if (input.output.confidence === 'low' && input.verificationRequired) {
     return 'implement-wp returned low confidence while verification was required';
   }
-  if (input.output.testsWritten.length > 0) {
-    const failedPaths = input.output.testsRun.paths.filter(
+  const requiredTestPaths = [
+    ...new Set([
+      ...input.output.testsWritten.map((test) => test.path),
+      ...input.output.testsRun.paths,
+    ]),
+  ];
+  if (requiredTestPaths.length > 0) {
+    const failedPaths = requiredTestPaths.filter(
       (path) => latestRunTestsStatusForPath(input.events, path) !== 'ok',
     );
     if (failedPaths.length > 0) {
-      return `tests were written but required run_tests did not pass for: ${failedPaths.join(', ')}`;
+      return `required run_tests did not pass for: ${failedPaths.join(', ')}`;
     }
+  }
+  if (input.verificationRequired && !hasSuccessfulVerificationToolCall(input.events)) {
+    return 'verification was required but no verification tool passed';
   }
   return null;
 }

--- a/slices/qa/slice.test.ts
+++ b/slices/qa/slice.test.ts
@@ -2347,7 +2347,7 @@ describe('runQaWorkflow', () => {
         failedTier: 2,
         reason: 'malformed-verification-command',
         agentSkipped: true,
-        failureCategory: 'orchestration',
+        failureCategory: 'verification-infrastructure',
       });
     });
 

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -476,7 +476,7 @@ export async function runQaWorkflow(
             findings: infrastructureFailure.findings,
             deterministic: true,
             agentSkipped: true,
-            failureCategory: classifyQaFailure({ orchestration: true }),
+            failureCategory: classifyQaFailure({ verificationInfrastructure: true }),
             ...(prHints.pipelineRunId != null ? { pipelineRunId: prHints.pipelineRunId } : {}),
           },
           runId,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   test: {
     maxWorkers: 2,
     minWorkers: 1,
+    setupFiles: ['apps/web/vitest.setup.ts'],
     include: ['**/*.test.ts', '**/*.test.tsx'],
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
## Summary
- fail implement-WP builds before commit/persist when required tests do not pass, confidence is low, or TOOL_FAILURE/BLOCKER is emitted
- classify React/jsdom/Vitest harness runtime failures as verification infrastructure and skip normal fix-feedback for those deterministic QA failures
- add a run_tests failure-signature guard so agents cannot bypass retry caps by rotating test files
- add a minimal web Vitest setup for jsdom browser API shims only
- give fix-feedback its own sonnet-tier runtime budget key

## Verification
- pnpm lint
- pnpm typecheck
- pnpm vitest run core/tool-layer/mcp/tools/verify.test.ts core/verify/tiers.test.ts core/qa/failure-category.test.ts core/agent-runtime/budgets.test.ts slices/fix-feedback/slice.test.ts slices/parallel-implement/slice.test.ts slices/qa/slice.test.ts apps/web/src/components/chat/components/ChatThread.test.tsx --reporter=verbose