### PR TITLE
Fix seeded scout evidence retry and repo-intel input canonicalization

### DIFF
--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -176,6 +176,7 @@ export async function runOneScout(
     ...resolvedBudget.budgets,
     ...(ctx.scoutTimeoutMs != null ? { timeoutMs: ctx.scoutTimeoutMs } : {}),
   };
+  const runtime = ctx.resolveScoutRuntime?.(resolvedBudget, spec.scoutName) ?? ctx.runtime;
   const spawnSpec: AgentSpec = {
     runId,
     role: 'investigator',
@@ -204,7 +205,6 @@ export async function runOneScout(
   let errorReason: string | undefined;
 
   try {
-    const runtime = ctx.resolveScoutRuntime?.(resolvedBudget, spec.scoutName) ?? ctx.runtime;
     result = await runtime.run(spawnSpec);
   } catch (err) {
     if (isTimeoutError(err, budgets.timeoutMs)) {
@@ -283,9 +283,101 @@ export async function runOneScout(
   }
 
   const scoutOutput = normalizeScoutOutput(parsed.data);
-  const findings = scoutOutput.findings;
-  const decisionSummaries =
+  let findings = scoutOutput.findings;
+  let decisionSummaries =
     result.decisionSummaries.length > 0 ? result.decisionSummaries : scoutOutput.decisionSummaries;
+  const seedFile = firstInvestigationSeedCandidateFile(fullContext);
+  if (
+    findings.length === 0 &&
+    !hasSuccessfulFactoryEvidenceCall(result.events) &&
+    seedFile != null
+  ) {
+    const retrySpec = buildEvidenceRetrySpec(spawnSpec, seedFile);
+    assembleSpawnContext(retrySpec);
+    try {
+      const retryResult = await runtime.run(retrySpec);
+      const retryParsed = safeParseOutputForSchema(ScoutOutputSchema, retryResult.output);
+      if (!retryParsed.success) {
+        const reason = `scout output failed schema validation: ${retryParsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; ')}`;
+        append({
+          projectId: ctx.projectId,
+          workItemId: ctx.workItemId ?? null,
+          kind: 'swarm.scout-failed',
+          payload: { runId, scoutName: spec.scoutName, errorReason: reason },
+          runId,
+        });
+        return {
+          scoutName: spec.scoutName,
+          status: 'error',
+          findings: [],
+          decisionSummaries: retryResult.decisionSummaries ?? decisionSummaries,
+          errorReason: reason,
+          runId,
+        };
+      }
+      const retryOutput = normalizeScoutOutput(retryParsed.data);
+      const retryFindings = retryOutput.findings;
+      if (retryFindings.length > 0 || hasSuccessfulFactoryEvidenceCall(retryResult.events)) {
+        result = retryResult;
+        findings = retryFindings;
+        decisionSummaries =
+          retryResult.decisionSummaries.length > 0
+            ? retryResult.decisionSummaries
+            : retryOutput.decisionSummaries;
+      }
+    } catch (err) {
+      if (isTimeoutError(err, budgets.timeoutMs)) {
+        timedOut = true;
+      } else {
+        errorReason = err instanceof Error ? err.message : String(err);
+      }
+    }
+  }
+
+  if (timedOut) {
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'agent.cancelled',
+      payload: { runId, reason: 'timeout', elapsedMs: Date.now() - start },
+      runId,
+    });
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-timeout',
+      payload: { runId, scoutName: spec.scoutName, scoutTimeoutMs: budgets.timeoutMs },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'timeout',
+      findings: [],
+      decisionSummaries: [],
+      runId,
+    };
+  }
+
+  if (errorReason != null) {
+    append({
+      projectId: ctx.projectId,
+      workItemId: ctx.workItemId ?? null,
+      kind: 'swarm.scout-failed',
+      payload: { runId, scoutName: spec.scoutName, errorReason },
+      runId,
+    });
+    return {
+      scoutName: spec.scoutName,
+      status: 'error',
+      findings: [],
+      decisionSummaries,
+      errorReason,
+      runId,
+    };
+  }
+
   if (findings.length === 0 && !hasSuccessfulFactoryEvidenceCall(result.events)) {
     append({
       projectId: ctx.projectId,
@@ -323,6 +415,39 @@ export async function runOneScout(
     findings,
     decisionSummaries,
     runId,
+  };
+}
+
+function firstInvestigationSeedCandidateFile(context: Record<string, unknown>): string | null {
+  const seed = payloadRecord(context.investigationSeed);
+  const candidates = Array.isArray(seed?.candidateFiles) ? seed.candidateFiles : [];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) return candidate;
+    const record = payloadRecord(candidate);
+    if (typeof record?.path === 'string' && record.path.length > 0) return record.path;
+  }
+  return null;
+}
+
+function buildEvidenceRetrySpec(spawnSpec: AgentSpec, seedFile: string): AgentSpec {
+  const instruction = `Evidence retry: ignore resources/list advisory noise and perform one read_file or search_text call against the seeded file '${seedFile}' before returning JSON.`;
+  const context =
+    spawnSpec.context != null &&
+    typeof spawnSpec.context === 'object' &&
+    !Array.isArray(spawnSpec.context)
+      ? {
+          ...(spawnSpec.context as Record<string, unknown>),
+          scoutFocus: `${String((spawnSpec.context as Record<string, unknown>).scoutFocus ?? '')}\n\n${instruction}`,
+        }
+      : spawnSpec.context;
+  return {
+    ...spawnSpec,
+    runId: `${spawnSpec.runId}:evidence-retry`,
+    context,
+    appendSystemPrompt:
+      spawnSpec.appendSystemPrompt != null && spawnSpec.appendSystemPrompt.length > 0
+        ? `${spawnSpec.appendSystemPrompt}\n\n${instruction}`
+        : instruction,
   };
 }
 

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -176,7 +176,6 @@ export async function runOneScout(
     ...resolvedBudget.budgets,
     ...(ctx.scoutTimeoutMs != null ? { timeoutMs: ctx.scoutTimeoutMs } : {}),
   };
-  const runtime = ctx.resolveScoutRuntime?.(resolvedBudget, spec.scoutName) ?? ctx.runtime;
   const spawnSpec: AgentSpec = {
     runId,
     role: 'investigator',
@@ -203,8 +202,10 @@ export async function runOneScout(
   let result: AgentResult | undefined;
   let timedOut = false;
   let errorReason: string | undefined;
+  let runtime: AgentRuntime | undefined;
 
   try {
+    runtime = ctx.resolveScoutRuntime?.(resolvedBudget, spec.scoutName) ?? ctx.runtime;
     result = await runtime.run(spawnSpec);
   } catch (err) {
     if (isTimeoutError(err, budgets.timeoutMs)) {
@@ -286,52 +287,62 @@ export async function runOneScout(
   let findings = scoutOutput.findings;
   let decisionSummaries =
     result.decisionSummaries.length > 0 ? result.decisionSummaries : scoutOutput.decisionSummaries;
+  let effectiveRunId = runId;
   const seedFile = firstInvestigationSeedCandidateFile(fullContext);
   if (
     findings.length === 0 &&
     !hasSuccessfulFactoryEvidenceCall(result.events) &&
     seedFile != null
   ) {
-    const retrySpec = buildEvidenceRetrySpec(spawnSpec, seedFile);
-    assembleSpawnContext(retrySpec);
-    try {
-      const retryResult = await runtime.run(retrySpec);
-      const retryParsed = safeParseOutputForSchema(ScoutOutputSchema, retryResult.output);
-      if (!retryParsed.success) {
-        const reason = `scout output failed schema validation: ${retryParsed.error.issues
-          .map((i) => `${i.path.join('.')}: ${i.message}`)
-          .join('; ')}`;
-        append({
-          projectId: ctx.projectId,
-          workItemId: ctx.workItemId ?? null,
-          kind: 'swarm.scout-failed',
-          payload: { runId, scoutName: spec.scoutName, errorReason: reason },
-          runId,
-        });
-        return {
-          scoutName: spec.scoutName,
-          status: 'error',
-          findings: [],
-          decisionSummaries: retryResult.decisionSummaries ?? decisionSummaries,
-          errorReason: reason,
-          runId,
-        };
-      }
-      const retryOutput = normalizeScoutOutput(retryParsed.data);
-      const retryFindings = retryOutput.findings;
-      if (retryFindings.length > 0 || hasSuccessfulFactoryEvidenceCall(retryResult.events)) {
-        result = retryResult;
-        findings = retryFindings;
-        decisionSummaries =
-          retryResult.decisionSummaries.length > 0
-            ? retryResult.decisionSummaries
-            : retryOutput.decisionSummaries;
-      }
-    } catch (err) {
-      if (isTimeoutError(err, budgets.timeoutMs)) {
-        timedOut = true;
-      } else {
-        errorReason = err instanceof Error ? err.message : String(err);
+    const retryTimeoutMs = remainingTimeoutMs(start, budgets.timeoutMs);
+    if (retryTimeoutMs <= 0) {
+      timedOut = true;
+    } else if (runtime != null) {
+      const retrySpec = buildEvidenceRetrySpec(spawnSpec, seedFile, retryTimeoutMs);
+      assembleSpawnContext(retrySpec);
+      try {
+        const retryResult = await runtime.run(retrySpec);
+        const retryParsed = safeParseOutputForSchema(ScoutOutputSchema, retryResult.output);
+        if (!retryParsed.success) {
+          const reason = `scout output failed schema validation: ${retryParsed.error.issues
+            .map((i) => `${i.path.join('.')}: ${i.message}`)
+            .join('; ')}`;
+          append({
+            projectId: ctx.projectId,
+            workItemId: ctx.workItemId ?? null,
+            kind: 'swarm.scout-failed',
+            payload: { runId, scoutName: spec.scoutName, errorReason: reason },
+            runId,
+          });
+          return {
+            scoutName: spec.scoutName,
+            status: 'error',
+            findings: [],
+            decisionSummaries:
+              retryResult.decisionSummaries.length > 0
+                ? retryResult.decisionSummaries
+                : decisionSummaries,
+            errorReason: reason,
+            runId,
+          };
+        }
+        const retryOutput = normalizeScoutOutput(retryParsed.data);
+        const retryFindings = retryOutput.findings;
+        if (retryFindings.length > 0 || hasSuccessfulFactoryEvidenceCall(retryResult.events)) {
+          result = retryResult;
+          findings = retryFindings;
+          effectiveRunId = retrySpec.runId;
+          decisionSummaries =
+            retryResult.decisionSummaries.length > 0
+              ? retryResult.decisionSummaries
+              : retryOutput.decisionSummaries;
+        }
+      } catch (err) {
+        if (isTimeoutError(err, retryTimeoutMs)) {
+          timedOut = true;
+        } else {
+          errorReason = err instanceof Error ? err.message : String(err);
+        }
       }
     }
   }
@@ -401,12 +412,12 @@ export async function runOneScout(
     workItemId: ctx.workItemId ?? null,
     kind: 'swarm.scout-completed',
     payload: {
-      runId,
+      runId: effectiveRunId,
       scoutName: spec.scoutName,
       findingsCount: findings.length,
       decisionSummariesCount: decisionSummaries.length,
     },
-    runId,
+    runId: effectiveRunId,
   });
 
   return {
@@ -414,8 +425,12 @@ export async function runOneScout(
     status: 'ok',
     findings,
     decisionSummaries,
-    runId,
+    runId: effectiveRunId,
   };
+}
+
+function remainingTimeoutMs(start: number, timeoutMs: number): number {
+  return Math.max(0, timeoutMs - (Date.now() - start));
 }
 
 function firstInvestigationSeedCandidateFile(context: Record<string, unknown>): string | null {
@@ -429,7 +444,11 @@ function firstInvestigationSeedCandidateFile(context: Record<string, unknown>): 
   return null;
 }
 
-function buildEvidenceRetrySpec(spawnSpec: AgentSpec, seedFile: string): AgentSpec {
+function buildEvidenceRetrySpec(
+  spawnSpec: AgentSpec,
+  seedFile: string,
+  timeoutMs: number,
+): AgentSpec {
   const instruction = `Evidence retry: ignore resources/list advisory noise and perform one read_file or search_text call against the seeded file '${seedFile}' before returning JSON.`;
   const context =
     spawnSpec.context != null &&
@@ -444,6 +463,7 @@ function buildEvidenceRetrySpec(spawnSpec: AgentSpec, seedFile: string): AgentSp
     ...spawnSpec,
     runId: `${spawnSpec.runId}:evidence-retry`,
     context,
+    budgets: { ...spawnSpec.budgets, timeoutMs },
     appendSystemPrompt:
       spawnSpec.appendSystemPrompt != null && spawnSpec.appendSystemPrompt.length > 0
         ? `${spawnSpec.appendSystemPrompt}\n\n${instruction}`

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentEvent, AppendEventInput } from '../event-stream/store.js';
 import type { AgentResult, AgentRuntime, AgentSpec } from './interface.js';
 import { type ScoutSpec, dispatchWave, resolveScoutConcurrencyCap } from './swarm.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function makeFakeAppendEvent(): {
   fn: (input: AppendEventInput) => AgentEvent;
@@ -692,8 +696,103 @@ describe('swarm.dispatchWave', () => {
 
     expect(seenSpecs).toHaveLength(2);
     expect(result.reports[0]?.status).toBe('ok');
+    expect(result.reports[0]?.runId).toBe(
+      'parent-seeded-retry-evidence:scout:scout-schema:0:evidence-retry',
+    );
+    const completed = events.find((e) => e.kind === 'swarm.scout-completed');
+    expect((completed?.payload as { runId?: string }).runId).toBe(
+      'parent-seeded-retry-evidence:scout:scout-schema:0:evidence-retry',
+    );
     expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
     expect(result.shouldAdvance).toBe(true);
+  });
+
+  it('caps seeded evidence retry to the remaining scout timeout budget', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-schema': (spec) => {
+        seenSpecs.push(spec);
+        if (seenSpecs.length === 1) {
+          now = 1_060;
+          return Promise.resolve(
+            emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+          );
+        }
+        return Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'read_file', 'ok')]));
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-seeded-retry-timeout',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-schema'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 100,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+      minSuccessfulScouts: 1,
+    });
+
+    expect(result.reports[0]?.status).toBe('ok');
+    expect(seenSpecs).toHaveLength(2);
+    expect(seenSpecs[1].budgets.timeoutMs).toBe(40);
+  });
+
+  it('preserves first-attempt decision summaries when retry output fails schema validation without summaries', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-schema': (spec) => {
+        seenSpecs.push(spec);
+        if (seenSpecs.length === 1) {
+          return Promise.resolve({
+            ...emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+            decisionSummaries: [{ kind: 'READ', summary: 'first attempt summary' }],
+          });
+        }
+        return Promise.resolve({
+          output: { invalid: true },
+          decisionSummaries: [],
+          events: [],
+        } as unknown as AgentResult);
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-seeded-retry-invalid',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-schema'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      decisionSummaries: [{ kind: 'READ', summary: 'first attempt summary' }],
+    });
   });
 
   it('does not halt a wave when seeded retry evidence leaves only one no-evidence scout', async () => {
@@ -1028,6 +1127,36 @@ describe('swarm.dispatchWave', () => {
     expect(defaultSpecs).toHaveLength(0);
     expect(perScoutSpecs).toHaveLength(1);
     expect(perScoutSpecs[0].modelOverride).toBe('gpt-5.4-mini');
+  });
+
+  it('converts resolveScoutRuntime exceptions into scout error reports', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-schema': () => Promise.resolve(okResult('scout-schema')),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-runtime-resolver-error',
+      scoutSpecs: [makeScoutSpec('scout-schema')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      heartbeatIntervalMs: 60_000,
+      scoutTimeoutMs: 1_000,
+      resolveScoutBudget: testBudgetResolver,
+      resolveScoutRuntime: () => {
+        throw new Error('runtime selection failed');
+      },
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason: 'runtime selection failed',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
   });
 
   it('routes each child spawn through assembleSpawnContext (freshContext: true per scout)', async () => {

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -37,6 +37,17 @@ function makeScoutSpec(scoutName: string): ScoutSpec {
   };
 }
 
+function makeInvestigationSeed() {
+  return {
+    candidateFiles: [{ path: 'src/auth.ts', root: 'worktree' }],
+    candidateSymbols: [],
+    testFiles: [],
+    recentlyChangedFiles: [],
+    priorInvestigationRunIds: [],
+    builtAt: '2026-05-23T00:00:00.000Z',
+  };
+}
+
 function okResult(scoutName: string): AgentResult {
   return {
     output: {
@@ -559,9 +570,14 @@ describe('swarm.dispatchWave', () => {
 
   it('fails an empty scout with only resources/list advisory for no evidence, not resource misuse', async () => {
     const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
     const runtime = makeRuntime({
-      'scout-schema': (spec) =>
-        Promise.resolve(emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')])),
+      'scout-schema': (spec) => {
+        seenSpecs.push(spec);
+        return Promise.resolve(
+          emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+        );
+      },
     });
 
     const result = await dispatchWave({
@@ -591,6 +607,142 @@ describe('swarm.dispatchWave', () => {
     expect((failed?.payload as { errorReason?: string }).errorReason).not.toContain(
       'forbidden MCP resource probes',
     );
+    expect(seenSpecs).toHaveLength(1);
+  });
+
+  it('gives a seeded empty scout one evidence retry before failing no-evidence', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-schema': (spec) => {
+        seenSpecs.push(spec);
+        return Promise.resolve(
+          emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+        );
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-seeded-retry-empty',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-schema'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(seenSpecs).toHaveLength(2);
+    expect(seenSpecs[1].runId).toBe(
+      'parent-seeded-retry-empty:scout:scout-schema:0:evidence-retry',
+    );
+    expect(seenSpecs[1].appendSystemPrompt).toContain('ignore resources/list advisory noise');
+    expect(seenSpecs[1].appendSystemPrompt).toContain('read_file or search_text');
+    expect(seenSpecs[1].appendSystemPrompt).toContain('src/auth.ts');
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+  });
+
+  it('accepts a seeded scout when the evidence retry records a successful read_file call', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-schema': (spec) => {
+        seenSpecs.push(spec);
+        if (seenSpecs.length === 1) {
+          return Promise.resolve(
+            emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+          );
+        }
+        return Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'read_file', 'ok')]));
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-seeded-retry-evidence',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-schema'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+      minSuccessfulScouts: 1,
+    });
+
+    expect(seenSpecs).toHaveLength(2);
+    expect(result.reports[0]?.status).toBe('ok');
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
+    expect(result.shouldAdvance).toBe(true);
+  });
+
+  it('does not halt a wave when seeded retry evidence leaves only one no-evidence scout', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const seenBySkill: Record<string, AgentSpec[]> = {};
+    const runtime = makeRuntime({
+      'scout-schema': (spec) => {
+        seenBySkill[spec.skill] = [...(seenBySkill[spec.skill] ?? []), spec];
+        if ((seenBySkill[spec.skill] ?? []).length === 1) {
+          return Promise.resolve(
+            emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+          );
+        }
+        return Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'read_file', 'ok')]));
+      },
+      'scout-pattern': (spec) => {
+        seenBySkill[spec.skill] = [...(seenBySkill[spec.skill] ?? []), spec];
+        return Promise.resolve(
+          emptyResult([runtimeAdvisoryEvent(spec.runId, 'resources/list failed')]),
+        );
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-seeded-wave',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-schema'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+        makeScoutSpec('scout-pattern'),
+      ],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+      minSuccessfulScouts: 1,
+    });
+
+    expect(seenBySkill['scout-schema']).toHaveLength(2);
+    expect(seenBySkill['scout-pattern']).toHaveLength(1);
+    expect(result.status).toBe('ok');
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.failedScouts).toEqual(['scout-pattern']);
   });
 
   it('fails an empty scout with only resources/templates/list advisory for no evidence, not resource misuse', async () => {

--- a/core/tool-layer/mcp/tools/repo-intel.test.ts
+++ b/core/tool-layer/mcp/tools/repo-intel.test.ts
@@ -341,6 +341,7 @@ describe('repoIntelQueryTool', () => {
 
   it.each([
     ['find-symbol', 'name'],
+    ['find-route', 'pathPattern'],
     ['find-callers', 'symbol'],
     ['find-calls-of', 'symbol'],
     ['find-jsx-usages', 'component'],
@@ -348,6 +349,7 @@ describe('repoIntelQueryTool', () => {
     ['find-tests-for', 'target'],
     ['related-files', 'target'],
     ['fetch-artifact', 'artifactKey'],
+    ['route-for-url', 'url'],
   ])(
     'returns invalid-args with field-specific hint when %s missing %s',
     async (intent, missingField) => {
@@ -424,6 +426,106 @@ describe('repoIntelQueryTool', () => {
     const payload = events[0].payload as Record<string, unknown>;
     expect(payload.tool_name).toBe('repo_intel.query');
     expect(payload.inputKeys).toEqual(['intent', 'kind', 'name']);
+  });
+
+  it.each([
+    [
+      'route-for-url',
+      {
+        intent: 'route-for-url',
+        url: 'http://localhost:5173/projects/goose-hub-self',
+        limit: 5,
+        workItemId: 'github:demo/repo#1084',
+      },
+      {
+        lookupRouteForUrl: vi.fn(() => [
+          {
+            pathPattern: '/projects/:slug',
+            filePath: 'apps/web/src/App.tsx',
+            line: 12,
+            component: 'ProjectPage',
+          },
+        ]),
+      },
+    ],
+    [
+      'find-route',
+      {
+        intent: 'find-route',
+        pathPattern: '/projects/:slug',
+        limit: 5,
+      },
+      {
+        lookupRoute: vi.fn(() => [
+          {
+            pathPattern: '/projects/:slug',
+            filePath: 'apps/web/src/App.tsx',
+            line: 12,
+            component: 'ProjectPage',
+          },
+        ]),
+      },
+    ],
+    [
+      'find-symbol',
+      {
+        intent: 'find-symbol',
+        name: 'AuthService',
+        limit: 5,
+      },
+      {
+        lookupSymbol: vi.fn(() => [
+          {
+            name: 'AuthService',
+            kind: 'function' as const,
+            filePath: 'src/auth.ts',
+            line: 1,
+            exported: true,
+          },
+        ]),
+      },
+    ],
+  ])(
+    'canonicalizes benign extra keys for %s before refined validation',
+    async (_name, query, deps) => {
+      const result = await repoIntelQueryTool(
+        makeCtx(),
+        query as unknown as RepoIntelQuery,
+        deps as RepoIntelDeps,
+      );
+
+      expect(result).toMatchObject({ ok: true, intent: query.intent });
+    },
+  );
+
+  it('audits original input keys when canonicalizing repo-intel input', async () => {
+    const ctx = makeCtx({ runId: 'repo-intel-canonical-audit-keys' });
+    await repoIntelQueryTool(
+      ctx,
+      {
+        intent: 'route-for-url',
+        url: 'http://localhost:5173/projects/goose-hub-self',
+        limit: 5,
+        workItemId: 'github:demo/repo#1084',
+      } as unknown as RepoIntelQuery,
+      {
+        lookupRouteForUrl: vi.fn(() => [
+          {
+            pathPattern: '/projects/:slug',
+            filePath: 'apps/web/src/App.tsx',
+            line: 12,
+            component: 'ProjectPage',
+          },
+        ]),
+      },
+    );
+
+    const events = eventStore.replay({ runId: ctx.runId, kind: 'agent.tool-call' });
+    expect(events[0].payload).toMatchObject({
+      tool_name: 'repo_intel.query',
+      status: 'ok',
+      inputKeys: ['intent', 'limit', 'url', 'workItemId'],
+    });
   });
 
   describe('grounding intents', () => {

--- a/core/tool-layer/mcp/tools/repo-intel.ts
+++ b/core/tool-layer/mcp/tools/repo-intel.ts
@@ -146,7 +146,8 @@ export async function repoIntelQueryTool(
   deps: RepoIntelDeps = {},
 ): Promise<RepoIntelResult> {
   const inputKeys = sortedKeys(input);
-  const refined = RepoIntelQueryRefined.safeParse(input);
+  const canonicalInput = canonicalizeRepoIntelInput(input);
+  const refined = RepoIntelQueryRefined.safeParse(canonicalInput);
   if (!refined.success) {
     const result: RepoIntelResult = {
       ok: false,
@@ -165,7 +166,7 @@ export async function repoIntelQueryTool(
     return result;
   }
 
-  const normalized = normalizePathInputs(ctx, input);
+  const normalized = normalizePathInputs(ctx, refined.data as RepoIntelToolInput);
   const cacheKey = normalizeRunCacheKey({
     toolName: 'repo_intel.query',
     args: normalized,
@@ -201,6 +202,36 @@ export async function repoIntelQueryTool(
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, result);
   return result;
 }
+
+function canonicalizeRepoIntelInput(input: RepoIntelToolInput): RepoIntelToolInput {
+  const allowedFields = INTENT_FIELDS[input.intent] ?? ['intent'];
+  const out: Partial<RepoIntelToolInput> = { intent: input.intent };
+  for (const field of allowedFields) {
+    if (field === 'intent') continue;
+    const value = input[field];
+    if (value !== undefined) out[field] = value as never;
+  }
+  return out as RepoIntelToolInput;
+}
+
+const INTENT_FIELDS = {
+  'find-symbol': ['intent', 'name', 'kind'],
+  'find-callers': ['intent', 'symbol'],
+  'find-calls-of': ['intent', 'symbol', 'literalArg'],
+  'find-jsx-usages': ['intent', 'component', 'withProp'],
+  'find-importers': ['intent', 'module', 'symbol'],
+  'find-route': ['intent', 'pathPattern'],
+  'find-component': ['intent', 'component'],
+  'route-for-component': ['intent', 'component'],
+  'find-tests-for': ['intent', 'target'],
+  'related-files': ['intent', 'target'],
+  'recent-changes': ['intent', 'path', 'sinceDays'],
+  'prior-investigation': ['intent', 'workItemId', 'targetFile'],
+  'fetch-artifact': ['intent', 'artifactKey'],
+  'route-for-url': ['intent', 'url'],
+  'fuzzy-component': ['intent', 'phrase', 'limit'],
+  'recent-touched': ['intent', 'sinceDays', 'limit'],
+} satisfies Record<RepoIntelIntent, readonly (keyof RepoIntelToolInput)[]>;
 
 async function dispatchRepoIntel(
   ctx: FactoryContext,


### PR DESCRIPTION
## Summary
- canonicalize repo_intel.query inputs per intent before refined validation while preserving original audit inputKeys
- keep missing required fields as invalid-args and add regressions for benign extra-key payloads
- retry seeded empty scouts once with explicit read_file/search_text evidence guidance, preserving the existing no-evidence failure when retry still has no Factory evidence

## Verification
- pnpm exec biome check core/tool-layer/mcp/tools/repo-intel.ts core/tool-layer/mcp/tools/repo-intel.test.ts core/agent-runtime/scout-runner.ts core/agent-runtime/swarm.test.ts
- pnpm vitest core/tool-layer/mcp/tools/repo-intel.test.ts core/agent-runtime/swarm.test.ts slices/investigate/slice.test.ts
- pnpm typecheck