### PR TITLE
Restore implement WP progress after terminal blockers

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -425,6 +425,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <ParallelWpPersistedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-failed':
     case 'parallel-implement.wp-loop-cap-hit':
+    case 'parallel-implement.wp-terminal-blocked':
     case 'parallel-implement.wp-commit-failed':
       return <ParallelWpFailedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-timeout':

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
@@ -150,4 +150,25 @@ describe('ParallelImplementEvents', () => {
     expect(rendered).not.toContain('rawProbeKey');
     expect(rendered).not.toContain('raw-value');
   });
+
+  it('renders terminal-blocked WPs as failure cards', () => {
+    const event = makeEvent('parallel-implement.wp-terminal-blocked', {
+      wpId: 'WP1',
+      wpRunId: 'pipeline-terminal-tool-failure:wp:WP1:iter:1',
+      decisionKind: 'TOOL_FAILURE',
+      errorReason: 'implement-wp emitted TOOL_FAILURE: test harness unavailable',
+      pipelineRunId: '805e37ae-2c79-40ef-b017-07b82dafbd09',
+      rawProbeKey: 'raw-value',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    const rendered = document.body.textContent ?? '';
+    expect(screen.getByText('WP1 terminal blocker')).toBeTruthy();
+    expect(rendered).toContain('test harness unavailable');
+    expect(rendered).toContain('Decision: TOOL_FAILURE');
+    expect(rendered).toContain('pipeline 805e37ae');
+    expect(rendered).not.toContain('rawProbeKey');
+    expect(rendered).not.toContain('raw-value');
+  });
 });

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
@@ -23,6 +23,7 @@ type ParallelPayload = {
   wpCount?: number;
   wpIds?: string[];
   errorReason?: string;
+  decisionKind?: string;
   diagnosis?: string;
   elapsedMs?: number;
   failedWpIds?: string[];
@@ -282,18 +283,28 @@ export function ParallelWpFailedEvent({ event }: { event: AgentEventDto }) {
   const p = event.payload as ParallelPayload | null;
   const isCommitFailure = event.kind === 'parallel-implement.wp-commit-failed';
   const isLoopCap = event.kind === 'parallel-implement.wp-loop-cap-hit';
+  const isTerminalBlocker = event.kind === 'parallel-implement.wp-terminal-blocked';
 
   return (
     <ParallelEventShell
       event={event}
       icon={<AlertTriangle size={13} className="shrink-0 text-[color:var(--danger)]" />}
       title={`${p?.wpId ?? 'Work package'} ${
-        isCommitFailure ? 'commit failed' : isLoopCap ? 'loop cap hit' : 'failed'
+        isCommitFailure
+          ? 'commit failed'
+          : isLoopCap
+            ? 'loop cap hit'
+            : isTerminalBlocker
+              ? 'terminal blocker'
+              : 'failed'
       }`}
       tone="danger"
     >
       <div className="space-y-1">
         {p?.errorReason != null && <DetailRow>{p.errorReason}</DetailRow>}
+        {isTerminalBlocker && p?.decisionKind != null && (
+          <DetailRow>Decision: {p.decisionKind}</DetailRow>
+        )}
         {isLoopCap && p?.diagnosis != null && <DetailRow>{p.diagnosis}</DetailRow>}
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
           {formatShortId(p?.wpRunId) != null && (

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
@@ -74,6 +74,7 @@ export function RunGroupWrapper({
       event.kind === 'parallel-implement.wp-failed' ||
       event.kind === 'parallel-implement.wp-timeout' ||
       event.kind === 'parallel-implement.wp-commit-failed' ||
+      event.kind === 'parallel-implement.wp-terminal-blocked' ||
       /^qa\..*-failed$/.test(event.kind),
   );
   const codexTransportWarnings = groupEventList.filter(isCodexTransportWarningLog);

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -382,6 +382,15 @@ describe('computeIsLive', () => {
       computeIsLive([makeEvent(1, 'agent.run-started', 'r1'), makeEvent(2, 'prd.drafted', 'r1')]),
     ).toBe(false);
   });
+
+  it('returns false when parallel implement stops on a terminal WP blocker', () => {
+    expect(
+      computeIsLive([
+        makeEvent(1, 'agent.run-started', 'r1'),
+        makeEvent(2, 'parallel-implement.wp-terminal-blocked', 'r1'),
+      ]),
+    ).toBe(false);
+  });
 });
 
 describe('computeIsWritePrdStuck', () => {
@@ -1767,6 +1776,32 @@ describe('groupByDevPhase', () => {
     >;
 
     expect(pg.status).toBe('failed');
+  });
+
+  it('marks dev phase failed when parallel implement hits a terminal WP blocker', () => {
+    const PID = 'pipe-terminal-123';
+    const events: AgentEventDto[] = [
+      makeEvent(1, 'agent.run-started', PID, { payload: { skill: 'spec-author' } }),
+      makeEvent(2, 'spec.completed', PID, { payload: { pipelineRunId: PID } }),
+      makeEvent(3, 'agent.run-completed', PID),
+      makeEvent(4, 'parallel-implement.wp-terminal-blocked', 'parallel-run-456:wp:WP1:iter:1', {
+        payload: {
+          pipelineRunId: PID,
+          wpId: 'WP1',
+          decisionKind: 'TOOL_FAILURE',
+          errorReason: 'test harness unavailable',
+        },
+      }),
+    ];
+
+    const result = groupEvents(events);
+    const pg = result.find((item) => item.kind === 'phase-group') as Extract<
+      (typeof result)[0],
+      { kind: 'phase-group' }
+    >;
+
+    expect(pg.status).toBe('failed');
+    expect(pg.endedAt).toBe(events[3].createdAt);
   });
 
   it('groups dev-review.* events with matching pipelineRunId into the phase-group', () => {

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -71,6 +71,7 @@ function resolveDevPhaseStatus(
       event.kind === 'parallel-implement.wp-failed' ||
       event.kind === 'parallel-implement.wp-timeout' ||
       event.kind === 'parallel-implement.wp-commit-failed' ||
+      event.kind === 'parallel-implement.wp-terminal-blocked' ||
       event.kind === 'dev-review.failed' ||
       event.kind === 'dev-review.error' ||
       (event.kind === 'agent.run-failed' &&

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -129,6 +129,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'parallel-implement.wp-persisted': 'Work package persisted',
   'parallel-implement.wp-failed': 'Work package failed',
   'parallel-implement.wp-loop-cap-hit': 'Work package loop cap hit',
+  'parallel-implement.wp-terminal-blocked': 'Work package terminal blocker',
   'parallel-implement.wp-timeout': 'Work package timed out',
   'parallel-implement.wp-commit-failed': 'Work package commit failed',
   'parallel-implement.exhausted': 'Parallel implement exhausted',

--- a/apps/web/src/components/detail/lib/timeline/render-items.ts
+++ b/apps/web/src/components/detail/lib/timeline/render-items.ts
@@ -223,6 +223,7 @@ export function extractPhaseTimes(items: RenderItem[]): {
       event.kind === 'agent.investigation-complete' ||
       event.kind === 'agent.run-completed' ||
       event.kind === 'agent.run-failed' ||
+      event.kind === 'parallel-implement.wp-terminal-blocked' ||
       event.kind === 'swarm.wave-halted'
     ) {
       if (endedAt == null || ms > new Date(endedAt).getTime()) endedAt = event.createdAt;

--- a/apps/web/src/components/detail/lib/timeline/run-groups.ts
+++ b/apps/web/src/components/detail/lib/timeline/run-groups.ts
@@ -134,6 +134,7 @@ export function extractRunMeta(items: RenderItem[]): {
       if (
         ev.kind === 'pr.opened' ||
         ev.kind === 'parallel-implement.exhausted' ||
+        ev.kind === 'parallel-implement.wp-terminal-blocked' ||
         (ev.kind === 'state.transitioned' &&
           ((ev.payload as { to?: string; toState?: string } | null)?.to === 'factory:needs-qa' ||
             (ev.payload as { to?: string; toState?: string } | null)?.toState ===

--- a/apps/web/src/components/detail/lib/timeline/state.ts
+++ b/apps/web/src/components/detail/lib/timeline/state.ts
@@ -10,6 +10,7 @@ const TERMINAL_EVENTS = new Set([
   'prd.drafted',
   'pr.opened',
   'parallel-implement.exhausted',
+  'parallel-implement.wp-terminal-blocked',
   'qa.completed',
   'qa.verification-blocked',
 ]);

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -100,6 +100,7 @@ export const EVENT_KINDS = [
   'parallel-implement.wp-persisted',
   'parallel-implement.wp-failed',
   'parallel-implement.wp-loop-cap-hit',
+  'parallel-implement.wp-terminal-blocked',
   'parallel-implement.wp-timeout',
   'parallel-implement.wp-commit-failed',
   'parallel-implement.exhausted',

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -18,7 +18,7 @@ const { mockMinimalEnv, mockRunCommand } = vi.hoisted(() => ({
 }));
 
 vi.mock('../command-policy.js', () => ({
-  minimalEnv: (...args: unknown[]) => mockMinimalEnv(...args),
+  minimalEnv: (extras?: Record<string, string>) => mockMinimalEnv(extras),
   runCommand: (...args: unknown[]) => mockRunCommand(...args),
 }));
 

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -12,12 +12,13 @@ import {
 } from './verify.js';
 
 const REAL_PROJECT_SLUG = 'goose-hub-self';
-const { mockRunCommand } = vi.hoisted(() => ({
+const { mockMinimalEnv, mockRunCommand } = vi.hoisted(() => ({
+  mockMinimalEnv: vi.fn((extras: Record<string, string> = {}) => extras),
   mockRunCommand: vi.fn(),
 }));
 
 vi.mock('../command-policy.js', () => ({
-  minimalEnv: () => ({}),
+  minimalEnv: (...args: unknown[]) => mockMinimalEnv(...args),
   runCommand: (...args: unknown[]) => mockRunCommand(...args),
 }));
 
@@ -25,6 +26,7 @@ let workspace: string;
 let ctx: FactoryContext;
 
 beforeEach(() => {
+  mockMinimalEnv.mockClear();
   mockRunCommand.mockResolvedValue({
     status: 'ok',
     exitCode: 0,
@@ -84,6 +86,21 @@ describe('runTypecheckTool', () => {
 });
 
 describe('runTestsTool', () => {
+  it('runs tests with NODE_ENV=test so React test builds expose act()', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+
+    await runTestsTool(ctx, {});
+
+    expect(mockMinimalEnv).toHaveBeenCalledWith({ NODE_ENV: 'test' });
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { NODE_ENV: 'test' },
+      }),
+    );
+  });
+
   it('returns raw and canonical test paths for a targeted test run', async () => {
     writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
     writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -202,7 +202,7 @@ export async function runTestsTool(
     runId: ctx.runId,
     displayOutput: true,
     timeoutMs: TEST_TIMEOUT_MS,
-    env: minimalEnv(),
+    env: minimalEnv({ NODE_ENV: 'test' }),
   });
 
   if (result.status === 'ok') {

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -888,6 +888,102 @@ describe('parallel-implement repo-relative path normalization', () => {
 });
 
 describe('implement-wp ownership gate', () => {
+  it('stops retrying when a WP returns a terminal TOOL_FAILURE decision', async () => {
+    const repoPath = makeTempRepo(['core/a.ts']);
+    const issueWorktree = makeTempRepo(['core/a.ts']);
+    const scratchWorktree = makeTempRepo(['core/a.ts']);
+    const spec = makeSpec([makeWp('WP1', ['core/a.ts'])]);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const stateSource = makeStateSource();
+    const replaySpy = vi.spyOn(eventStore, 'replay').mockReturnValue([]);
+    const iterations: Array<{ wpId: string; status: string; reason?: string }> = [];
+    let runtimeCalls = 0;
+
+    try {
+      const result = await runParallelImplementWorkflow(
+        makeWorkItem({ priority: 'medium' }),
+        spec,
+        'pipeline-terminal-tool-failure',
+        stateSource,
+        'goose-hub-self',
+        repoPath,
+        {
+          runtime: {
+            run: async () => {
+              runtimeCalls++;
+              const output: ImplementWpOutput = {
+                wpId: 'WP1',
+                plan: 'Cannot verify while harness is unavailable',
+                filesWritten: [],
+                testsWritten: [],
+                testsRun: { command: 'not run', paths: [] },
+                confidence: 'high',
+                decisionSummaries: [{ kind: 'TOOL_FAILURE', summary: 'test harness unavailable' }],
+              };
+              return { output, decisionSummaries: [], events: [] };
+            },
+          },
+          resolveWorkflowBaseImpl: () => ({
+            branch: 'main',
+            ref: 'origin/main',
+            source: 'configured-default',
+          }),
+          createIssueWorktreeImpl: () => issueWorktree,
+          createWpWorktreeImpl: () => scratchWorktree,
+          cleanupWpWorktreesImpl: () => undefined,
+          orchestratorCommitWpImpl: vi.fn(),
+          revertWpChangesImpl: () => undefined,
+          recordIterationImpl: (_runId, wpId, _iteration, status, reason) => {
+            iterations.push({ wpId, status, reason });
+          },
+          getLastStatusImpl: (_runId, wpId) => {
+            const last = [...iterations].reverse().find((entry) => entry.wpId === wpId);
+            return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+          },
+          openPRImpl: vi.fn(),
+          devReviewConfigOverride: {
+            enabled: false,
+            triggerOn: 'priority:high+',
+            perCycleMaxUsd: 0,
+            maxRevisionTurns: 1,
+            timeoutMs: 1_000,
+          },
+          appendEvent,
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        errorReason: expect.stringContaining('TOOL_FAILURE'),
+      });
+      expect(runtimeCalls).toBe(1);
+      expect(
+        events.filter((event) => event.kind === 'parallel-implement.iteration-started'),
+      ).toHaveLength(1);
+      expect(
+        events.some(
+          (event) =>
+            event.kind === 'parallel-implement.iteration-started' &&
+            (event.payload as { iteration?: number }).iteration === 2,
+        ),
+      ).toBe(false);
+      const terminalEvent = events.find(
+        (event) => event.kind === 'parallel-implement.wp-terminal-blocked',
+      );
+      expect(terminalEvent?.payload).toMatchObject({
+        wpId: 'WP1',
+        decisionKind: 'TOOL_FAILURE',
+        errorReason: expect.stringContaining('test harness unavailable'),
+      });
+      expect(stateSource.comment).toHaveBeenCalledWith(
+        '560',
+        expect.stringContaining('Parallel implement stopped on terminal WP blocker'),
+      );
+    } finally {
+      replaySpy.mockRestore();
+    }
+  });
+
   it('fails schema-valid WPs that wrote tests without passing matching run_tests', async () => {
     const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
     const { fn: appendEvent, events } = makeAppendEvent();

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -899,6 +899,37 @@ export async function runParallelImplementWorkflow(
               errorReason: r.errorReason,
               runId: r.runId,
             });
+            if (r.acceptanceFailure?.kind === 'terminal-blocker') {
+              const reason =
+                r.errorReason ??
+                `implement-wp emitted terminal ${r.acceptanceFailure.decisionKind}`;
+              append({
+                projectId,
+                workItemId: workItem.id,
+                kind: 'parallel-implement.wp-terminal-blocked',
+                payload: {
+                  wpId: r.wpId,
+                  wpRunId: r.runId,
+                  decisionKind: r.acceptanceFailure.decisionKind,
+                  errorReason: reason,
+                },
+                runId: r.runId,
+              });
+              await stateSource.comment(
+                workItem.externalId,
+                buildAgentComment(
+                  'Dev',
+                  'Failed',
+                  'Parallel implement stopped on terminal WP blocker',
+                  [`${r.wpId}: ${reason}`],
+                ),
+              );
+              return {
+                status: 'failed',
+                devRunId: runId,
+                errorReason: `Terminal implement-wp ${r.acceptanceFailure.decisionKind} for ${r.wpId}: ${reason}`,
+              };
+            }
             continue;
           }
 

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -32,6 +32,13 @@ import type { ImplementWpControlConfig } from './wp-budget.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+type TerminalDecisionKind = 'TOOL_FAILURE' | 'BLOCKER';
+
+export type ImplementWpAcceptanceFailure =
+  | { kind: 'terminal-blocker'; reason: string; decisionKind: TerminalDecisionKind }
+  | { kind: 'verification-failed'; reason: string }
+  | { kind: 'low-confidence'; reason: string };
+
 // Internal result from the concurrent build phase, before the serial commit phase.
 export type WpBuildPhaseResult =
   | {
@@ -43,7 +50,13 @@ export type WpBuildPhaseResult =
       scratchWorktreePath: string;
       budgetExceeded?: BudgetExceededMetadata;
     }
-  | { status: 'failed' | 'timeout'; wpId: string; errorReason?: string; runId: string };
+  | {
+      status: 'failed' | 'timeout';
+      wpId: string;
+      errorReason?: string;
+      runId: string;
+      acceptanceFailure?: ImplementWpAcceptanceFailure;
+    };
 
 export interface RunOneWpBuilderOptions {
   wp: WorkPackage;
@@ -161,15 +174,42 @@ function pathsMatch(left: string, right: string): boolean {
   return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
 }
 
-function hasBlockingDecision(output: ImplementWpOutput, events: AgentEvent[]): boolean {
-  const outputKinds = output.decisionSummaries.map((summary) => summary.kind);
-  const eventKinds = events
-    .filter((event) => event.kind === 'agent.decision-summary')
-    .map((event) => (event.payload as { kind?: unknown }).kind)
-    .filter((kind): kind is string => typeof kind === 'string');
-  return [...outputKinds, ...eventKinds].some(
-    (kind) => kind === 'TOOL_FAILURE' || kind === 'BLOCKER',
-  );
+function isTerminalDecisionKind(kind: unknown): kind is TerminalDecisionKind {
+  return kind === 'TOOL_FAILURE' || kind === 'BLOCKER';
+}
+
+function terminalDecisionReason(kind: TerminalDecisionKind, summary?: unknown): string {
+  return typeof summary === 'string' && summary.trim().length > 0
+    ? `implement-wp emitted ${kind}: ${summary.trim()}`
+    : `implement-wp emitted ${kind}`;
+}
+
+function terminalDecisionFailure(
+  output: ImplementWpOutput,
+  events: AgentEvent[],
+): Extract<ImplementWpAcceptanceFailure, { kind: 'terminal-blocker' }> | null {
+  for (const summary of output.decisionSummaries) {
+    if (isTerminalDecisionKind(summary.kind)) {
+      return {
+        kind: 'terminal-blocker',
+        reason: terminalDecisionReason(summary.kind, summary.summary),
+        decisionKind: summary.kind,
+      };
+    }
+  }
+
+  for (const event of events) {
+    if (event.kind !== 'agent.decision-summary') continue;
+    const payload = event.payload as { kind?: unknown; summary?: unknown };
+    if (isTerminalDecisionKind(payload.kind)) {
+      return {
+        kind: 'terminal-blocker',
+        reason: terminalDecisionReason(payload.kind, payload.summary),
+        decisionKind: payload.kind,
+      };
+    }
+  }
+  return null;
 }
 
 function latestRunTestsStatusForPath(events: AgentEvent[], path: string): string | null {
@@ -196,12 +236,16 @@ function implementWpAcceptanceFailure(input: {
   output: ImplementWpOutput;
   events: AgentEvent[];
   verificationRequired: boolean;
-}): string | null {
-  if (hasBlockingDecision(input.output, input.events)) {
-    return 'implement-wp emitted TOOL_FAILURE or BLOCKER';
+}): ImplementWpAcceptanceFailure | null {
+  const terminalFailure = terminalDecisionFailure(input.output, input.events);
+  if (terminalFailure != null) {
+    return terminalFailure;
   }
   if (input.output.confidence === 'low' && input.verificationRequired) {
-    return 'implement-wp returned low confidence while verification was required';
+    return {
+      kind: 'low-confidence',
+      reason: 'implement-wp returned low confidence while verification was required',
+    };
   }
   const requiredTestPaths = [
     ...new Set([
@@ -214,11 +258,17 @@ function implementWpAcceptanceFailure(input: {
       (path) => latestRunTestsStatusForPath(input.events, path) !== 'ok',
     );
     if (failedPaths.length > 0) {
-      return `required run_tests did not pass for: ${failedPaths.join(', ')}`;
+      return {
+        kind: 'verification-failed',
+        reason: `required run_tests did not pass for: ${failedPaths.join(', ')}`,
+      };
     }
   }
   if (input.verificationRequired && !hasSuccessfulVerificationToolCall(input.events)) {
-    return 'verification was required but no verification tool passed';
+    return {
+      kind: 'verification-failed',
+      reason: 'verification was required but no verification tool passed',
+    };
   }
   return null;
 }
@@ -760,7 +810,11 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       payload: {
         wpId: wp.id,
         wpRunId,
-        errorReason: acceptanceFailure,
+        errorReason: acceptanceFailure.reason,
+        failureKind: acceptanceFailure.kind,
+        ...(acceptanceFailure.kind === 'terminal-blocker'
+          ? { decisionKind: acceptanceFailure.decisionKind }
+          : {}),
         confidence: output.confidence,
         testsWritten: output.testsWritten.map((test) => test.path),
         testsRun: output.testsRun.paths,
@@ -768,8 +822,14 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       runId: wpRunId,
     });
     opts.revertWpChangesFn(opts.scratchWorktreePath, wp.filesOwned.map(fileOwnedPath));
-    opts.recordIterationFn(runId, wp.id, iteration, 'failed', acceptanceFailure);
-    return { status: 'failed', wpId: wp.id, errorReason: acceptanceFailure, runId: wpRunId };
+    opts.recordIterationFn(runId, wp.id, iteration, 'failed', acceptanceFailure.reason);
+    return {
+      status: 'failed',
+      wpId: wp.id,
+      errorReason: acceptanceFailure.reason,
+      runId: wpRunId,
+      acceptanceFailure,
+    };
   }
 
   // Build succeeded — return files for the serial commit phase.


### PR DESCRIPTION
## Summary
- run Factory run_tests with NODE_ENV=test so Vitest loads React test builds with act()
- preserve implement-wp acceptance failures as typed metadata
- stop parallel implement immediately when a WP reports TOOL_FAILURE or BLOCKER and emit terminal-blocked telemetry

## Tests
- env TMPDIR=/private/tmp PATH=/Users/shaunnesbitt/projects/goose-hub/node_modules/.bin:/Users/shaunnesbitt/.nodenv/shims:/Library/Frameworks/Python.framework/Versions/3.14/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/share/dotnet:~/.dotnet/tools:/opt/homebrew/bin:/Users/shaunnesbitt/.codex/tmp/arg0/codex-arg0jq4k7b:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/shaunnesbitt/.bun/bin:/Users/shaunnesbitt/.antigravity/antigravity/bin:/Users/shaunnesbitt/.local/bin:/opt/homebrew/opt/node@22/bin:/Users/shaunnesbitt/.nodenv/shims:/Library/Frameworks/Python.framework/Versions/3.14/bin:/Applications/Ghostty.app/Contents/MacOS /Users/shaunnesbitt/projects/goose-hub/node_modules/.bin/tsx scripts/run-vitest-with-db.ts core/tool-layer/mcp/tools/verify.test.ts slices/parallel-implement/slice.test.ts