### PR TITLE
M19: fix e2e pipeline workflow drift

### DIFF
--- a/apps/server/src/shared/dispatch-qa-review.ts
+++ b/apps/server/src/shared/dispatch-qa-review.ts
@@ -191,7 +191,17 @@ export async function dispatchNeedsFix(slug: string, issueNumber: number): Promi
       });
       return;
     }
-    await runFixFeedbackWorkflow(item, source, slug, item.repoRef ?? slug);
+    const mockDeps: Record<string, unknown> | undefined =
+      process.env.MOCK_AGENTS === 'true' || process.env.MOCK_OPEN_PR === 'true'
+        ? {
+            orchestratorCommitAllImpl: () => ({
+              status: 'committed',
+              sha: 'mock-fix-feedback-sha',
+            }),
+            orchestratorPushBranchImpl: () => undefined,
+          }
+        : undefined;
+    await runFixFeedbackWorkflow(item, source, slug, item.repoRef ?? slug, mockDeps);
   });
 }
 

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -42,9 +42,9 @@ Specs:
 - `merge-conflict.spec.ts` — merge conflict resolution path
 - `qa-fail-loop.spec.ts` — QA fail → needs-fix → re-QA pass
 - `review-sendback-loop.spec.ts` — review sendback → needs-fix → re-review → approved
-- `discover-lane.spec.ts` — M13 Discover Lane: type:feature triaging → grilling (Grill tab visible, PRD tab absent), grill chat (agent question + user reply + state transition), PRD tab + content render + Approve PRD flow through to factory:dev-ready/spec-author.
-- `golden-feature.spec.ts` — legacy mock feature happy path: one issue walked seed → grill → PRD → manual decompose → child delivery → done. Covers Overview / Grill / PRD / Timeline / QA / Review surfaces. Trace + video on every run.
-- `golden-feature-prd-revised.spec.ts` — golden feature with PRD revision (ADR 0033 three-path flow, shipped in M13.12 #631): one test for **Request Changes** (PRD v1 → revise → PRD v2 → approve → done, state stays at prd-review throughout) and one for **Decline Feature** (prd-review → done, no decompose).
+- `discover-lane.spec.ts` — Discover Lane: clean type:feature triaging → grilling, grill chat (agent question + user reply + state transition), PRD tab + content render, and Approve PRD flow into delivery.
+- `golden-feature.spec.ts` — golden feature happy path: one issue walked seed → grill → PRD → delivery → QA → review → approve → done. Covers Overview / Grill / PRD / Timeline / QA / Review surfaces. Trace + video on every run.
+- `golden-feature-prd-revised.spec.ts` — golden feature with PRD revision (ADR 0033 three-path flow, shipped in M13.12 #631): one test for **Request Changes** (PRD v1 → revise → PRD v2 → approve → delivery, state stays at prd-review until approval) and one for **Decline Feature** (prd-review → done, no decompose).
 - `golden-bug.spec.ts` — golden bug happy path: seed → investigate (high-confidence) → dev → QA → review → approve → done. Covers Investigation / QA / Review / Timeline (pr.opened) surfaces. Trace + video on every run.
 - `golden-bug-iterations.spec.ts` — golden bug with multi-iteration QA loop: two QA fails then pass, exercising `dispatchQaFailed` (qa-failed → needs-fix → in-progress → needs-qa) twice before review/approve.
 - `golden-chore.spec.ts` — golden chore happy path: seed → triage → dev → QA → review → approve → done. Simplest type (no grilling, no investigation); proves the minimal pipeline while still touching every applicable UI surface.

--- a/apps/web/e2e/pipeline/discover-lane.spec.ts
+++ b/apps/web/e2e/pipeline/discover-lane.spec.ts
@@ -3,12 +3,12 @@
  *
  * Tests the UI-visible Discover Lane flow: a fresh type:feature issue is seeded
  * and walked through triaging → grilling → gate-pending (grill chat) →
- * prd-review (PRD rendered) → dev-ready/spec-author using the
+ * prd-review (PRD rendered) → delivery using the
  * MOCK_AGENTS + MOCK_SOURCE harness.
  *
  * What this covers vs. the unit-level grill-prd-flow.spec.ts:
  *   - Full server round-trip: seed-issue → tick (triage) → dispatch (grill)
- *   - State-gated UI: Grill tab present in grilling state, PRD tab absent
+ *   - State-gated UI: Grill tab present in grilling state
  *   - Grill chat: agent question renders, user reply posts + transitions state
  *   - PRD tab appears once state is factory:prd-review
  *   - PRD content (title, problem, slices) renders from the mock prd.drafted event
@@ -16,7 +16,7 @@
  *
  * What is intentionally deferred (see TODO comments below):
  *   - Optional WP projection issue cards with factory:from-prd label after
- *     spec-author.
+ *     delivery.
  *   - Sprint-review issue filing (covered by slices/discover-lane-e2e/slice.test.ts).
  *
  * NOTE on triage→grilling routing (#592): the routing from factory:triaging to
@@ -30,6 +30,13 @@ import { expect, test } from '@playwright/test';
 
 const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+const CLEAN_FEATURE_BODY = [
+  'Surface: apps/web/src/components/search',
+  'Acceptance criteria:',
+  '- Search should return keyword matches for factory rules queries.',
+  '- Results should preserve current filtering behavior.',
+  '- Verify with a focused pipeline regression test.',
+].join('\n');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,10 +57,15 @@ async function postServer(path: string, body?: unknown): Promise<Response> {
 
 async function seedIssue(opts: {
   title: string;
+  body?: string;
   type?: string;
   state?: string;
 }): Promise<{ issueNumber: number; workItemId: string }> {
-  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, {
+    ...opts,
+    body:
+      opts.body ?? (opts.type === 'feature' && opts.state == null ? CLEAN_FEATURE_BODY : undefined),
+  });
   return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
 }
 
@@ -133,7 +145,7 @@ test.describe('Discover Lane (MOCK_AGENTS + MOCK_SOURCE)', () => {
   // regresses the statePill assertion below will time-out with a clear
   // indication that the routing is broken.
   // ─────────────────────────────────────────────────────────────────────────
-  test('feature triages to grilling, grill tab visible, PRD tab absent', async ({ page }) => {
+  test('clean feature triages to grilling and shows the grill tab', async ({ page }) => {
     test.setTimeout(120_000);
 
     const { issueNumber } = await seedIssue({
@@ -145,7 +157,7 @@ test.describe('Discover Lane (MOCK_AGENTS + MOCK_SOURCE)', () => {
     const statePill = page.getByTestId('state-pill');
     await expect(statePill).toHaveText('triaging', { timeout: 15_000 });
 
-    // Tick the orchestrator: triaging → accepted → grilling (type:feature routing)
+    // Tick the orchestrator: clean type:feature routes triaging → accepted → grilling.
     await postServer(`/projects/${SLUG}/tick`);
     await expect(statePill).toHaveText('grilling', { timeout: 60_000 });
 
@@ -312,12 +324,10 @@ test.describe('Discover Lane (MOCK_AGENTS + MOCK_SOURCE)', () => {
     const slices = page.getByTestId('prd-slice');
     await expect(slices).toHaveCount(1);
 
-    // Approve PRD → dev-ready/spec-author
+    // Approve PRD → dev-ready, then the mock delivery workflow advances to needs-qa.
     const approveBtn = page.getByTestId('prd-approve-btn');
     await expect(approveBtn).toBeVisible();
     await approveBtn.click();
-    // After approve-prd: the mock delivery workflow advances the parent toward
-    // done before the UI polls.
-    await expect(statePill).toHaveText('done', { timeout: 30_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 30_000 });
   });
 });

--- a/apps/web/e2e/pipeline/golden-feature-prd-revised.spec.ts
+++ b/apps/web/e2e/pipeline/golden-feature-prd-revised.spec.ts
@@ -6,7 +6,7 @@
  * M13.12 (#631) shipped the three-path PRD review flow defined in ADR 0033,
  * replacing the legacy single "Reject / re-grill" button with:
  *
- *   - Approve         → prd-review → dev-ready/spec-author → done (covered by
+ *   - Approve         → prd-review → dev-ready → delivery (covered by
  *                       golden-feature.spec.ts)
  *   - Request Changes → re-runs write-prd with priorPrd + humanConcerns,
  *                       state remains prd-review, new PRD comment posted.
@@ -19,6 +19,13 @@ import { type Locator, expect, test } from '@playwright/test';
 
 const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+const CLEAN_FEATURE_BODY = [
+  'Surface: apps/web/src/components/search',
+  'Acceptance criteria:',
+  '- Search should return keyword matches for factory rules queries.',
+  '- Results should preserve current filtering behavior.',
+  '- Verify with a focused pipeline regression test.',
+].join('\n');
 
 test.use({ trace: 'on', video: 'on' });
 
@@ -37,9 +44,13 @@ async function postServer(path: string, body?: unknown): Promise<Response> {
 
 async function seedIssue(opts: {
   title: string;
+  body?: string;
   type?: string;
 }): Promise<{ issueNumber: number; workItemId: string }> {
-  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, {
+    ...opts,
+    body: opts.body ?? (opts.type === 'feature' ? CLEAN_FEATURE_BODY : undefined),
+  });
   return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
 }
 
@@ -101,7 +112,7 @@ async function driveFeatureToPrdReview(
 }
 
 test.describe('Golden Feature — PRD revision (ADR 0033 three-path flow)', () => {
-  test('Request Changes: PRD v1 → revise → PRD v2 → approve → done', async ({ page }) => {
+  test('Request Changes: PRD v1 → revise → PRD v2 → approve → delivery', async ({ page }) => {
     test.setTimeout(240_000);
 
     const title = goldenTitle('PRD-REVISE');
@@ -145,12 +156,12 @@ test.describe('Golden Feature — PRD revision (ADR 0033 three-path flow)', () =
 
     // ── Approve PRD v2 ──────────────────────────────────────────────────────
     await page.getByTestId('prd-approve-btn').click();
-    await expect(statePill).toHaveText('done', { timeout: 60_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 60_000 });
 
     await page.goto(`/projects/${SLUG}/items/${issueNumber}/timeline`);
     await expect(page.getByTestId('timeline-section')).toBeVisible({ timeout: 10_000 });
 
-    await expect(page.locator('[data-event-kind="decompose.completed"]')).toBeAttached({
+    await expect(page.locator('[data-event-kind="prd.approved"]').first()).toBeAttached({
       timeout: 10_000,
     });
   });

--- a/apps/web/e2e/pipeline/golden-feature.spec.ts
+++ b/apps/web/e2e/pipeline/golden-feature.spec.ts
@@ -5,22 +5,17 @@
  *
  * Flow (one issue, one trace):
  *   1. Seed a feature with a unique emoji+timestamp title.
- *   2. /tick: triaging → grilling. Confirm Grill tab visible, PRD tab absent.
+ *   2. /tick: clean feature triaging → grilling. Confirm Grill tab visible.
  *   3. /dispatch: grilling → gate-pending. Agent question rendered.
  *   4. UI reply via grill-reply-input + grill-send-btn → state returns to grilling.
  *   5. Manual transitions grilling → prd-drafting → prd-review (legal per
  *      core/state-machine/transitions.ts) to bypass the multi-round grill loop —
  *      that loop is already covered by discover-lane.spec.ts.
  *   6. Seed a PRD event so PRDSection renders content; assert it.
- *   7. Click prd-approve-btn. Legacy mock decompose-prd runs synchronously:
- *      parent goes decomposing → issues-created → done and child issues are
- *      created. The spec-first PRD approval path is covered by
- *      discover-lane.spec.ts and workflow/slice tests.
- *   8. Read parent comments to extract child issue numbers.
- *   9. Return to the board, confirm child cards exist.
- *  10. Walk the FIRST child through its dev cycle:
- *      triaging → dev-ready → needs-qa → needs-review → approved → done.
- *      Capture overview / qa / review / timeline (pr.opened) along the way.
+ *   7. Click prd-approve-btn. Current PRD approval routes the parent into
+ *      delivery: dev-ready → needs-qa.
+ *   8. Walk the parent through QA → review → approve → done and capture
+ *      overview / qa / review / timeline surfaces along the way.
  *
  * Trace + video are recorded for every run (not just retries) so the artefact
  * is the report itself.
@@ -30,6 +25,13 @@ import { type Locator, expect, test } from '@playwright/test';
 
 const SLUG = process.env.PROJECT_SLUG ?? 'goose-hub-self';
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001';
+const CLEAN_FEATURE_BODY = [
+  'Surface: apps/web/src/components/search',
+  'Acceptance criteria:',
+  '- Search should return keyword matches for factory rules queries.',
+  '- Results should preserve current filtering behavior.',
+  '- Verify with a focused pipeline regression test.',
+].join('\n');
 
 // Trace+video on every run for the golden specs (not just on-first-retry).
 test.use({ trace: 'on', video: 'on' });
@@ -51,21 +53,17 @@ async function postServer(path: string, body?: unknown): Promise<Response> {
   return res;
 }
 
-async function getJson<T>(path: string): Promise<T> {
-  const res = await fetch(`${SERVER_URL}${path}`);
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`GET ${path} → ${res.status}: ${text}`);
-  }
-  return res.json() as Promise<T>;
-}
-
 async function seedIssue(opts: {
   title: string;
+  body?: string;
   type?: string;
   state?: string;
 }): Promise<{ issueNumber: number; workItemId: string }> {
-  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, opts);
+  const res = await postServer(`/projects/test/${SLUG}/seed-issue`, {
+    ...opts,
+    body:
+      opts.body ?? (opts.type === 'feature' && opts.state == null ? CLEAN_FEATURE_BODY : undefined),
+  });
   return res.json() as Promise<{ issueNumber: number; workItemId: string }>;
 }
 
@@ -107,7 +105,7 @@ function buildMockPrd(title: string) {
     outOfScope: ['Real GitHub roundtrip'],
     successCriteria: ['Each UI surface renders for its state'],
     acceptanceCriteria: [
-      { id: 'AC-1', statement: 'Feature reaches done with child issues.', journeyId: 'J-1' },
+      { id: 'AC-1', statement: 'Feature reaches done after delivery.', journeyId: 'J-1' },
     ],
     journeys: [
       {
@@ -117,12 +115,12 @@ function buildMockPrd(title: string) {
         steps: [
           {
             userAction: 'Approves the PRD',
-            systemResponse: 'Legacy mock decomposition creates child issues',
-            dataShown: 'Child issue list',
-            stateChange: 'Parent → done',
+            systemResponse: 'Mock delivery opens a PR for the parent issue',
+            dataShown: 'PR, QA, and review status',
+            stateChange: 'Parent enters delivery',
           },
         ],
-        successState: 'Children created and visible on the board',
+        successState: 'Feature delivered and approved',
         errorStates: [],
         edgeCases: [],
       },
@@ -133,14 +131,14 @@ function buildMockPrd(title: string) {
           when: 'Approve PRD is clicked',
           given: 'state is prd-review',
           // biome-ignore lint/suspicious/noThenProperty: BDD then clause, not Promise#then
-          then: 'legacy mock path creates child issues for delivery',
+          then: 'mock delivery completes the parent issue',
         },
       ],
     },
     verticalSlices: [
       {
-        title: 'Slice 1: child cycle',
-        goal: 'Walk a child to done',
+        title: 'Slice 1: delivery cycle',
+        goal: 'Walk the parent issue to done',
         estimatedSize: 'S',
         journeyRefs: ['J-1'],
       },
@@ -151,36 +149,12 @@ function buildMockPrd(title: string) {
   return prd;
 }
 
-// Parses `- #123 — title` lines from the parent's `## Child issues` comment.
-function parseChildIssueNumbers(commentBody: string): number[] {
-  const out: number[] = [];
-  for (const line of commentBody.split('\n')) {
-    const m = /^- #(\d+)\b/.exec(line.trim());
-    if (m) out.push(Number(m[1]));
-  }
-  return out;
-}
-
-interface CommentResponse {
-  comments: Array<{ id: string; body: string }>;
-}
-
-async function findChildIssuesComment(parentNumber: number): Promise<number[]> {
-  const data = await getJson<CommentResponse>(`/projects/${SLUG}/issues/${parentNumber}/comments`);
-  for (const c of data.comments) {
-    if (c.body.includes('## Child issues')) {
-      return parseChildIssueNumbers(c.body);
-    }
-  }
-  return [];
-}
-
 // ---------------------------------------------------------------------------
 // Test
 // ---------------------------------------------------------------------------
 
 test.describe('Golden Feature flow (MOCK_AGENTS + MOCK_SOURCE + MOCK_OPEN_PR)', () => {
-  test('seed → grill → PRD → decompose → child cycle → done', async ({ page }) => {
+  test('seed → grill → PRD → delivery → done', async ({ page }) => {
     test.setTimeout(180_000);
 
     const title = goldenTitle();
@@ -232,60 +206,40 @@ test.describe('Golden Feature flow (MOCK_AGENTS + MOCK_SOURCE + MOCK_OPEN_PR)', 
     await expect(page.getByTestId('prd-title')).toHaveText(title);
     await expect(page.getByTestId('prd-slice')).toHaveCount(1);
 
-    // ── 7. Approve PRD. Legacy mock delivery decomposes the parent into child
-    //      issues and advances the parent to done.
+    // ── 7. Approve PRD. Current delivery routes the parent through dev work.
     await page.getByTestId('prd-approve-btn').click();
-    await expect(statePill).toHaveText('done', { timeout: 30_000 });
+    await expect(statePill).toHaveText('needs-qa', { timeout: 30_000 });
 
-    // Decompose timeline event should be present.
+    // PRD approval timeline event should be present.
     await page.goto(`/projects/${SLUG}/items/${issueNumber}/timeline`);
     await expect(page.getByTestId('timeline-section')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('[data-event-kind="decompose.completed"]')).toBeAttached({
+    await expect(page.locator('[data-event-kind="prd.approved"]').first()).toBeAttached({
       timeout: 10_000,
     });
 
-    // ── 8. Read parent's `## Child issues` comment to find children.
-    const childNumbers = await findChildIssuesComment(issueNumber);
-    expect(childNumbers.length).toBeGreaterThan(0);
-
-    // ── 9. Return to the board; confirm at least one child card is visible.
-    await page.goto(`/projects/${SLUG}`);
-    await expect(page.getByTestId('board')).toBeVisible({ timeout: 15_000 });
-    const firstChild = childNumbers[0];
-    const childCard = page.locator(`[data-testid="issue-card"][data-issue-number="${firstChild}"]`);
-    await expect(childCard).toBeVisible({ timeout: 15_000 });
-
-    // ── 10. Walk the first child through its dev cycle.
-    await page.goto(`/projects/${SLUG}/items/${firstChild}`);
+    // ── 8. Walk the parent through QA/review/approval.
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}`);
     await expect(page.getByTestId('detail-page')).toBeVisible({ timeout: 15_000 });
-    const childPill = page.getByTestId('state-pill');
-    // decompose-prd creates children directly at dev-ready (skips triage; see
-    // core/workflows/decompose-prd.ts), so the child opens at dev-ready.
-    await expect(childPill).toHaveText('dev-ready', { timeout: 15_000 });
-
-    // Dispatch fix-issue: dev-ready → needs-qa.
-    await postServer(`/projects/${SLUG}/dispatch/${firstChild}`);
-    await expect(childPill).toHaveText('needs-qa', { timeout: 60_000 });
 
     // QA: needs-qa → needs-review. QA section should render its content.
-    await postServer(`/projects/${SLUG}/run-qa/${firstChild}`);
-    await expect(childPill).toHaveText('needs-review', { timeout: 60_000 });
-    await page.goto(`/projects/${SLUG}/items/${firstChild}/qa`);
+    await postServer(`/projects/${SLUG}/run-qa/${issueNumber}`);
+    await expect(statePill).toHaveText('needs-review', { timeout: 60_000 });
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}/qa`);
     await expect(page.getByTestId('qa-section')).toBeVisible({ timeout: 15_000 });
 
     // Review: needs-review → approved. Review section renders + PR link.
-    await postServer(`/projects/${SLUG}/run-review/${firstChild}`);
-    await expect(childPill).toHaveText('approved', { timeout: 60_000 });
-    await page.goto(`/projects/${SLUG}/items/${firstChild}/review`);
+    await postServer(`/projects/${SLUG}/run-review/${issueNumber}`);
+    await expect(statePill).toHaveText('approved', { timeout: 60_000 });
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}/review`);
     await expect(page.getByTestId('review-section')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('review-open-pr')).toBeVisible();
 
     // Approval gate → retrospecting → done.
-    await postServer(`/projects/${SLUG}/issues/${firstChild}/approve`);
-    await expect(childPill).toHaveText('done', { timeout: 60_000 });
+    await postServer(`/projects/${SLUG}/issues/${issueNumber}/approve`);
+    await expect(statePill).toHaveText('done', { timeout: 60_000 });
 
-    // Final timeline check: pr.opened event must exist on the child.
-    await page.goto(`/projects/${SLUG}/items/${firstChild}/timeline`);
+    // Final timeline check: merge event must exist on the parent.
+    await page.goto(`/projects/${SLUG}/items/${issueNumber}/timeline`);
     await expect(page.getByTestId('timeline-section')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('[data-event-kind="pr.merged"]')).toBeAttached({
       timeout: 10_000,

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -92,6 +92,13 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
     case 'qa': {
       if (testOutcome === 'fail') {
         const emptyTier = { passed: false, findings: [] };
+        const finding = {
+          tier: 'functional' as const,
+          severity: 'error' as const,
+          description: 'mock qa failure',
+          disposition: 'needs-fix' as const,
+          dispositionRef: 'e2e-test',
+        };
         return {
           output: {
             verdict: 'fail',
@@ -101,15 +108,7 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
               structural: emptyTier,
               functional: {
                 passed: false,
-                findings: [
-                  {
-                    tier: 'functional',
-                    severity: 'error',
-                    description: 'mock qa failure',
-                    disposition: 'registered',
-                    dispositionRef: 'e2e-test',
-                  },
-                ],
+                findings: [finding],
               },
               regression: emptyTier,
             },
@@ -123,7 +122,7 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
               gallsLaw: 0,
               cyclomaticComplexity: 0,
             },
-            findings: [],
+            findings: [finding],
             decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA fail for e2e test' }],
           },
           decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock QA fail for e2e test' }],
@@ -198,12 +197,24 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
     }
 
     case 'review': {
+      const acceptanceCriteria =
+        (
+          spec.context.acceptanceContract as
+            | { criteria?: Array<{ id?: string; statement?: string }> }
+            | undefined
+        )?.criteria ?? [];
+      const criteriaChecks = acceptanceCriteria.map((criterion) => ({
+        criterionId: criterion.id,
+        criterion: criterion.statement ?? criterion.id ?? 'Mock acceptance criterion',
+        status: 'met' as const,
+        notes: 'Mock review checked canonical acceptance criterion',
+      }));
       if (testOutcome === 'needs-fix') {
         return {
           output: {
             verdict: 'needs-fix',
             confidence: 0.4,
-            criteriaChecks: [],
+            criteriaChecks,
             findings: [],
             decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review needs-fix for e2e test' }],
           },
@@ -215,7 +226,7 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
         output: {
           verdict: 'approved',
           confidence: 0.95,
-          criteriaChecks: [],
+          criteriaChecks,
           findings: [],
           decisionSummaries: [{ kind: 'VERDICT', summary: 'Mock review approval for e2e test' }],
         },
@@ -436,7 +447,14 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
       const scoutSummary = `Mock ${spec.skill} for e2e test`;
       return {
         output: {
-          findings: [],
+          findings: [
+            {
+              file: 'apps/web/e2e/pipeline/README.md',
+              line: 1,
+              fact: scoutSummary,
+              confidence: 'high' as const,
+            },
+          ],
           status: 'ok' as const,
           decisionSummaries: [{ kind: 'INSIGHT', summary: scoutSummary }],
         },


### PR DESCRIPTION
Summary
- Align pipeline feature specs with current PRD approval delivery flow.
- Refresh mock agent outputs for current QA, scout, and review schema expectations.
- Keep mock fix-feedback from invoking real git in the pipeline harness.

Verification
- pnpm typecheck
- pnpm test core/agent-runtime/mock-outputs.test.ts slices/fix-feedback/slice.test.ts slices/qa/slice.test.ts slices/review/slice.test.ts
- pnpm exec biome check core/agent-runtime/mock-outputs.ts apps/server/src/shared/dispatch-qa-review.ts apps/web/e2e/pipeline/discover-lane.spec.ts apps/web/e2e/pipeline/golden-feature.spec.ts apps/web/e2e/pipeline/golden-feature-prd-revised.spec.ts apps/web/e2e/README.md
- git diff --check
- WEB_PORT=5605 MOCK_SERVER_PORT=3205 pnpm test:e2e:pipeline

No linked issue: direct maintainer request to restore test:e2e:pipeline.