### PR TITLE
M19: make search_text summary-first

### DIFF
--- a/core/tool-layer/mcp/audit.ts
+++ b/core/tool-layer/mcp/audit.ts
@@ -14,7 +14,9 @@ export interface ToolCallAudit {
   input: Record<string, unknown>;
   durationMs?: number;
   truncated?: boolean;
+  truncationReason?: string;
   bytesRead?: number;
+  resultBytes?: number;
   cached?: boolean;
   duplicateCount?: number;
   repo_intel_intent?: string;

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -231,7 +231,7 @@ export function normalizeRunCacheKey(input: {
           canonicalPath,
           input.args.glob ?? '',
           input.args.contextLines ?? 0,
-          input.args.maxMatches ?? 200,
+          input.args.maxMatches ?? 20,
         ],
         [canonicalPath],
       );

--- a/core/tool-layer/mcp/server.ts
+++ b/core/tool-layer/mcp/server.ts
@@ -254,7 +254,7 @@ export function buildFactoryMcpServer(ctx: FactoryContext): McpServer {
     'search_text',
     {
       description:
-        'Search file contents via ripgrep. Returns structured `{path, line, text}` matches; capped at 200 matches per call.',
+        'Search file contents via ripgrep. Returns compact `{path, line, preview}` matches; defaults to 20 matches with an 8KB result cap.',
       inputSchema: SearchTextInput.shape,
     },
     async (input) => {

--- a/core/tool-layer/mcp/tools/read.test.ts
+++ b/core/tool-layer/mcp/tools/read.test.ts
@@ -218,17 +218,23 @@ describe('listFilesTool', () => {
 });
 
 describe('searchTextTool', () => {
-  it('finds a literal needle and returns structured matches', async () => {
+  it('finds a literal needle and returns compact structured matches', async () => {
     const result = await searchTextTool(ctx, { query: 'NEEDLE' });
+    expect(result.query).toBe('NEEDLE');
+    expect(result.matchCount).toBeGreaterThan(0);
+    expect(result.resultBytes).toBeGreaterThan(0);
     expect(result.matches.length).toBeGreaterThan(0);
     const hit = result.matches.find((m) => m.path.path.endsWith('index.ts'));
     expect(hit).toBeTruthy();
     expect(hit?.line).toBe(1);
-    expect(hit?.text).toContain('NEEDLE');
+    expect(hit?.preview).toContain('NEEDLE');
+    expect(hit).not.toHaveProperty('text');
   });
 
   it('returns empty matches array when nothing matches (rg exit 1)', async () => {
     const result = await searchTextTool(ctx, { query: 'NO_SUCH_TOKEN_xyzzy' });
+    expect(result.query).toBe('NO_SUCH_TOKEN_xyzzy');
+    expect(result.matchCount).toBe(0);
     expect(result.matches).toEqual([]);
     expect(result.truncated).toBe(false);
 
@@ -237,6 +243,32 @@ describe('searchTextTool', () => {
       (e) => (e.payload as { tool_name?: string }).tool_name === 'search_text',
     );
     expect(audit?.payload).toMatchObject({ status: 'ok', noMatches: true });
+  });
+
+  it('defaults to 20 matches so search stays an index instead of a context dump', async () => {
+    writeFileSync(
+      join(workspace, 'many.txt'),
+      Array.from({ length: 30 }, (_, i) => `TOKEN ${i + 1}`).join('\n'),
+    );
+
+    const result = await searchTextTool(ctx, { query: 'TOKEN' });
+
+    expect(result.matches).toHaveLength(20);
+    expect(result.matchCount).toBe(20);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('caps default search result bytes and reports byte truncation', async () => {
+    writeFileSync(
+      join(workspace, 'wide.txt'),
+      Array.from({ length: 40 }, (_, i) => `BLOAT ${i + 1} ${'x'.repeat(260)}`).join('\n'),
+    );
+
+    const result = await searchTextTool(ctx, { query: 'BLOAT', maxMatches: 40 });
+
+    expect(result.resultBytes).toBeLessThanOrEqual(8 * 1024);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReason).toBe('result_bytes');
   });
 });
 

--- a/core/tool-layer/mcp/tools/read.ts
+++ b/core/tool-layer/mcp/tools/read.ts
@@ -35,7 +35,10 @@ const READ_FILE_CAP_BYTES = 256 * 1024;
 const READ_FILE_DEFAULT_LINE_COUNT = 2000;
 const LIST_DIR_CAP_ENTRIES = 500;
 const LIST_FILES_CAP = 500;
+const SEARCH_DEFAULT_MAX_MATCHES = 20;
 const SEARCH_MAX_MATCHES = 200;
+const SEARCH_RESULT_MAX_BYTES = 8 * 1024;
+const SEARCH_PREVIEW_MAX_CHARS = 240;
 const SEARCH_TIMEOUT_MS = 15_000;
 const LIST_FILES_TIMEOUT_MS = 10_000;
 
@@ -94,12 +97,16 @@ export interface ListFilesResult {
 export interface SearchMatch {
   path: RepoRelativePath;
   line: number;
-  text: string;
+  preview: string;
 }
 
 export interface SearchTextResult {
+  query: string;
   matches: SearchMatch[];
+  matchCount: number;
   truncated: boolean;
+  resultBytes: number;
+  truncationReason?: 'matches' | 'result_bytes' | 'command_output';
   cached?: true;
   duplicateNudge?: string;
 }
@@ -157,6 +164,73 @@ function duplicateNudgeFields(duplicate: ReturnType<typeof recordDuplicateToolCa
 function rawPathToCanonical(rawPath: string, workspaceRoot: string): RepoRelativePath {
   const result = canonicalizeFactoryToolPath({ rawPath, worktreePath: workspaceRoot });
   return result.ok ? result.path : { path: rawPath, root: 'worktree' };
+}
+
+function compactSearchPreview(text: string): string {
+  const compact = text.trim().replace(/\s+/g, ' ');
+  return compact.length > SEARCH_PREVIEW_MAX_CHARS
+    ? `${compact.slice(0, SEARCH_PREVIEW_MAX_CHARS - 3)}...`
+    : compact;
+}
+
+function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function searchTruncationReason(input: {
+  byteCapped: boolean;
+  commandOutputTruncated: boolean;
+  matchCapped: boolean;
+}): SearchTextResult['truncationReason'] {
+  if (input.byteCapped) return 'result_bytes';
+  if (input.commandOutputTruncated) return 'command_output';
+  if (input.matchCapped) return 'matches';
+  return undefined;
+}
+
+function buildSearchTextResult(input: {
+  query: string;
+  matches: SearchMatch[];
+  commandOutputTruncated: boolean;
+  matchCapped: boolean;
+}): SearchTextResult {
+  const matches = [...input.matches];
+  let byteCapped = false;
+
+  while (matches.length > 0) {
+    const candidate = {
+      query: input.query,
+      matches,
+      matchCount: matches.length,
+      truncated: input.commandOutputTruncated || input.matchCapped || byteCapped,
+      resultBytes: 0,
+      truncationReason: searchTruncationReason({
+        byteCapped,
+        commandOutputTruncated: input.commandOutputTruncated,
+        matchCapped: input.matchCapped,
+      }),
+    };
+    const resultBytes = jsonByteLength({ ...candidate, resultBytes: SEARCH_RESULT_MAX_BYTES });
+    if (resultBytes <= SEARCH_RESULT_MAX_BYTES) {
+      return { ...candidate, resultBytes };
+    }
+    byteCapped = true;
+    matches.pop();
+  }
+
+  const empty = {
+    query: input.query,
+    matches,
+    matchCount: 0,
+    truncated: input.commandOutputTruncated || input.matchCapped || byteCapped,
+    resultBytes: 0,
+    truncationReason: searchTruncationReason({
+      byteCapped,
+      commandOutputTruncated: input.commandOutputTruncated,
+      matchCapped: input.matchCapped,
+    }),
+  };
+  return { ...empty, resultBytes: jsonByteLength(empty) };
 }
 
 function rgAuditStatus(result: CommandResult): CommandStatus {
@@ -258,7 +332,7 @@ async function fallbackSearchText(input: {
   query: string;
   limit: number;
   glob?: string;
-}): Promise<SearchTextResult> {
+}): Promise<{ matches: SearchMatch[]; truncated: boolean }> {
   const matches: SearchMatch[] = [];
   const listing = await walkFilePaths({
     workspaceRoot: input.workspaceRoot,
@@ -281,7 +355,7 @@ async function fallbackSearchText(input: {
       if (matches.length >= input.limit) break;
       query.lastIndex = 0;
       if (!query.test(lines[index])) continue;
-      matches.push({ path: file, line: index + 1, text: lines[index] });
+      matches.push({ path: file, line: index + 1, preview: compactSearchPreview(lines[index]) });
     }
   }
 
@@ -624,19 +698,20 @@ export async function listFilesTool(
 /**
  * Full-text search via ripgrep. The query is passed as a positional argv
  * (no shell expansion); path/glob filter narrows the search. Output is
- * parsed into structured `{path, line, text}` matches to keep the agent
- * out of the raw rg format.
+ * parsed into compact structured `{path, line, preview}` matches so search
+ * stays an index/navigation tool instead of injecting large source chunks.
  */
 export async function searchTextTool(
   ctx: FactoryContext,
   input: z.infer<typeof SearchTextInput>,
 ): Promise<SearchTextResult> {
+  const limit = Math.min(input.maxMatches ?? SEARCH_DEFAULT_MAX_MATCHES, SEARCH_MAX_MATCHES);
   const args: string[] = [
     '--no-heading',
     '--with-filename',
     '--line-number',
     '--max-count',
-    String(SEARCH_MAX_MATCHES),
+    String(limit),
     '--max-columns',
     '300',
   ];
@@ -656,7 +731,6 @@ export async function searchTextTool(
   }
   args.push('--', input.query, searchPath);
 
-  const limit = Math.min(input.maxMatches ?? SEARCH_MAX_MATCHES, SEARCH_MAX_MATCHES);
   const cacheKey = normalizeRunCacheKey({
     toolName: 'search_text',
     args: { ...input, maxMatches: limit },
@@ -671,7 +745,9 @@ export async function searchTextTool(
       input: { query: input.query, path: input.path ?? null, glob: input.glob ?? null },
       status: 'ok',
       truncated: cached.truncated,
-      noMatches: cached.matches.length === 0,
+      noMatches: cached.matchCount === 0,
+      resultBytes: cached.resultBytes,
+      truncationReason: cached.truncationReason,
       cached: true,
       ...duplicateAuditFields(duplicate),
     });
@@ -689,7 +765,8 @@ export async function searchTextTool(
   });
 
   let matches: SearchMatch[];
-  let truncated: boolean;
+  let commandOutputTruncated: boolean;
+  let matchCapped: boolean;
 
   if (rgSpawnFailed(result)) {
     const fallback = await fallbackSearchText({
@@ -700,7 +777,8 @@ export async function searchTextTool(
       glob: input.glob,
     });
     matches = fallback.matches;
-    truncated = fallback.truncated;
+    commandOutputTruncated = false;
+    matchCapped = fallback.truncated;
   } else {
     matches = [];
     for (const line of result.stdout.split('\n')) {
@@ -717,22 +795,35 @@ export async function searchTextTool(
       const lineNum = Number.parseInt(line.slice(firstColon + 1, secondColon), 10);
       const text = line.slice(secondColon + 1);
       if (!Number.isFinite(lineNum)) continue;
-      matches.push({ path: rawPathToCanonical(rawPath, ctx.workspaceRoot), line: lineNum, text });
+      matches.push({
+        path: rawPathToCanonical(rawPath, ctx.workspaceRoot),
+        line: lineNum,
+        preview: compactSearchPreview(text),
+      });
     }
 
-    truncated = result.truncated || matches.length >= limit;
+    commandOutputTruncated = result.truncated;
+    matchCapped = matches.length >= limit;
   }
+
+  const output = buildSearchTextResult({
+    query: input.query,
+    matches,
+    commandOutputTruncated,
+    matchCapped,
+  });
 
   emitToolCall(ctx, {
     tool: 'search_text',
     input: { query: input.query, path: input.path ?? null, glob: input.glob ?? null },
     status: rgSpawnFailed(result) ? 'ok' : rgAuditStatus(result),
     durationMs: result.durationMs,
-    truncated,
-    noMatches: matches.length === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
+    truncated: output.truncated,
+    truncationReason: output.truncationReason,
+    resultBytes: output.resultBytes,
+    noMatches: output.matchCount === 0 && (rgSpawnFailed(result) || rgNoMatches(result)),
     ...duplicateAuditFields(duplicate),
   });
-  const output = { matches, truncated };
   if (cacheKey != null) setCachedRunResult(ctx.runId, cacheKey, output);
   return output;
 }


### PR DESCRIPTION
Summary
- Make factory search_text return compact preview matches with query, matchCount, resultBytes, and truncationReason.
- Default search_text to 20 matches and cap serialized tool results at 8KB.
- Include result byte/truncation metadata in tool-call audit payloads.

Tests
- pnpm test core/tool-layer/mcp/tools/read.test.ts core/tool-layer/mcp/slice.test.ts core/tool-layer/mcp/schemas.test.ts
- pnpm typecheck
- pnpm exec biome check core/tool-layer/mcp/audit.ts core/tool-layer/mcp/tools/read.ts core/tool-layer/mcp/tools/read.test.ts core/tool-layer/mcp/run-cache.ts core/tool-layer/mcp/server.ts

No linked issue; direct user-requested slice.