### PR TITLE
Add CLI issue restart command

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -18,6 +18,16 @@ Prints the live state of a target project's GitHub issues:
 
 Lists all non-terminal issues in a milestone, then prompts to bulk-archive them. Used at milestone exit to clean up stale issues before closing.
 
+### `goose issue restart <project-slug> <issue-id> [--state=...] [--schedule=...] [--yes]`
+
+Creates a fresh issue from an existing issue and archives the original.
+
+- Clones title, body, type, priority, milestone, and safe auxiliary labels.
+- Defaults the new issue state to `factory:triaging`.
+- Defaults the new issue schedule to the original issue schedule unless `--schedule` is provided.
+- Links the old and new issues with comments.
+- Without `--yes`, prints the restart plan and makes no changes.
+
 ### `goose run-agent --skill=<name> --input='<json>' [--dry-run]`
 
 Runs a named skill against the Claude CLI runtime.
@@ -39,6 +49,7 @@ Known projects are loaded from a hardcoded registry in `src/index.ts`. Adding a 
 ```bash
 pnpm goose status goose-hub-self
 pnpm goose sweep goose-hub-self 5
+pnpm goose issue restart goose-hub-self 123 --state=factory:triaging --schedule=current --yes
 pnpm goose run-agent --skill=triage --input='{"projectId":"goose-hub-self","workItemId":"123"}'
 ```
 

--- a/apps/cli/src/commands/issue-restart.ts
+++ b/apps/cli/src/commands/issue-restart.ts
@@ -1,0 +1,119 @@
+import { loadProjects } from '@goose-hub/core/projects/loader.js';
+import { restartIssue } from '@goose-hub/core/projects/restart-issue.js';
+import { STATES, type StateName } from '@goose-hub/core/state-machine/states.js';
+import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
+import type { Schedule } from '@goose-hub/core/state-source/interface.js';
+import { targetProjectsRoot } from '@goose-hub/target-projects';
+
+const VALID_SCHEDULES = new Set<Schedule>(['current', 'next', 'later', 'blocked-by']);
+
+interface ParsedRestartArgs {
+  slug: string;
+  id: string;
+  state?: StateName;
+  schedule?: Schedule;
+  yes: boolean;
+}
+
+function usage(): string {
+  return [
+    'Usage: goose issue restart <project-slug> <issue-id> [--state=factory:triaging] [--schedule=current|next|later|blocked-by] [--yes]',
+    '',
+    'Without --yes, prints the restart plan without creating or archiving issues.',
+  ].join('\n');
+}
+
+function parseArgs(rawArgs: string[]): ParsedRestartArgs | null {
+  const [slug = '', id = '', ...rest] = rawArgs;
+  let state: StateName | undefined;
+  let schedule: Schedule | undefined;
+  let yes = false;
+
+  for (const arg of rest) {
+    if (arg.startsWith('--state=')) {
+      const rawState = arg.slice('--state='.length);
+      if (!(STATES as readonly string[]).includes(rawState)) {
+        console.error(`Invalid --state: ${rawState}`);
+        return null;
+      }
+      state = rawState as StateName;
+    } else if (arg.startsWith('--schedule=')) {
+      const rawSchedule = arg.slice('--schedule='.length);
+      if (!VALID_SCHEDULES.has(rawSchedule as Schedule)) {
+        console.error(`Invalid --schedule: ${rawSchedule}`);
+        return null;
+      }
+      schedule = rawSchedule as Schedule;
+    } else if (arg === '--yes') {
+      yes = true;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      return null;
+    }
+  }
+
+  if (!slug || !id) return null;
+  return { slug, id, state, schedule, yes };
+}
+
+export async function issueRestartCommand(rawArgs: string[]): Promise<void> {
+  const args = parseArgs(rawArgs);
+  if (args == null) {
+    console.error(usage());
+    process.exit(1);
+  }
+
+  const projects = await loadProjects(targetProjectsRoot);
+  const config = projects.find((p) => p.slug === args.slug);
+  if (!config) {
+    console.error(`Unknown project: ${args.slug}`);
+    console.error(`Known projects: ${projects.map((p) => p.slug).join(', ')}`);
+    process.exit(1);
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('GITHUB_TOKEN is required. Set it in .env or the environment.');
+    process.exit(1);
+  }
+
+  if (config.source.kind !== 'github') {
+    console.error(
+      `goose issue restart currently supports github-labels projects only. ${args.slug} uses ${config.source.kind}.`,
+    );
+    process.exit(1);
+  }
+
+  const source = new GitHubLabelsSource(config.id, config.source.repo, token);
+  const oldItem = await source.getItem(args.id);
+  const targetState = args.state ?? 'factory:triaging';
+  const schedule = args.schedule ?? oldItem.schedule;
+
+  if (!args.yes) {
+    console.log('Issue restart plan:');
+    console.log(`  project:      ${args.slug}`);
+    console.log(`  original:     ${oldItem.repoRef}#${oldItem.externalId}`);
+    console.log(`  title:        ${oldItem.title}`);
+    console.log(`  old state:    ${oldItem.state}`);
+    console.log(`  new state:    ${targetState}`);
+    console.log(`  new schedule: ${schedule}`);
+    console.log(`  milestone:    ${oldItem.milestoneTitle ?? oldItem.milestoneId ?? '<none>'}`);
+    console.log('');
+    console.log('Re-run with --yes to create the fresh issue and archive the original.');
+    return;
+  }
+
+  const result = await restartIssue({
+    source,
+    projectId: args.slug,
+    itemId: oldItem.id,
+    targetState,
+    schedule,
+  });
+
+  console.log(`Restarted ${oldItem.repoRef}#${oldItem.externalId}.`);
+  console.log(`  fresh issue:  ${result.newItem.repoRef}#${result.newItem.externalId}`);
+  console.log('  old state:    factory:archived');
+  console.log(`  new state:    ${result.targetState}`);
+  console.log(`  new schedule: ${result.schedule}`);
+}

--- a/apps/cli/src/commands/issue-restart.ts
+++ b/apps/cli/src/commands/issue-restart.ts
@@ -1,8 +1,8 @@
 import { loadProjects } from '@goose-hub/core/projects/loader.js';
-import { restartIssue } from '@goose-hub/core/projects/restart-issue.js';
+import { type RestartIssueResult, restartIssue } from '@goose-hub/core/projects/restart-issue.js';
 import { STATES, type StateName } from '@goose-hub/core/state-machine/states.js';
 import { GitHubLabelsSource } from '@goose-hub/core/state-source/github-labels.js';
-import type { Schedule } from '@goose-hub/core/state-source/interface.js';
+import type { Schedule, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { targetProjectsRoot } from '@goose-hub/target-projects';
 
 const VALID_SCHEDULES = new Set<Schedule>(['current', 'next', 'later', 'blocked-by']);
@@ -56,6 +56,10 @@ function parseArgs(rawArgs: string[]): ParsedRestartArgs | null {
   return { slug, id, state, schedule, yes };
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function issueRestartCommand(rawArgs: string[]): Promise<void> {
   const args = parseArgs(rawArgs);
   if (args == null) {
@@ -85,7 +89,13 @@ export async function issueRestartCommand(rawArgs: string[]): Promise<void> {
   }
 
   const source = new GitHubLabelsSource(config.id, config.source.repo, token);
-  const oldItem = await source.getItem(args.id);
+  let oldItem: WorkItem;
+  try {
+    oldItem = await source.getItem(args.id);
+  } catch (err) {
+    console.error(`Failed to fetch issue #${args.id}: ${errorMessage(err)}`);
+    process.exit(1);
+  }
   const targetState = args.state ?? 'factory:triaging';
   const schedule = args.schedule ?? oldItem.schedule;
 
@@ -103,17 +113,33 @@ export async function issueRestartCommand(rawArgs: string[]): Promise<void> {
     return;
   }
 
-  const result = await restartIssue({
-    source,
-    projectId: args.slug,
-    itemId: oldItem.id,
-    targetState,
-    schedule,
-  });
+  let result: RestartIssueResult;
+  try {
+    result = await restartIssue({
+      source,
+      projectId: config.id,
+      itemId: oldItem.id,
+      targetState,
+      schedule,
+    });
+  } catch (err) {
+    console.error(`Issue restart failed: ${errorMessage(err)}`);
+    console.error(
+      'If --yes was used, the operation may have partially completed. Check the issue comments and labels before retrying.',
+    );
+    process.exit(1);
+  }
+
+  let verifiedOldState = 'archive requested';
+  try {
+    verifiedOldState = (await source.getItem(oldItem.id)).state;
+  } catch {
+    // Keep the success output honest when post-restart verification cannot read GitHub.
+  }
 
   console.log(`Restarted ${oldItem.repoRef}#${oldItem.externalId}.`);
   console.log(`  fresh issue:  ${result.newItem.repoRef}#${result.newItem.externalId}`);
-  console.log('  old state:    factory:archived');
+  console.log(`  old state:    ${verifiedOldState}`);
   console.log(`  new state:    ${result.targetState}`);
   console.log(`  new schedule: ${result.schedule}`);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@ import 'dotenv/config';
 import { bootstrapProject } from '@goose-hub/core/workflows/bootstrap-project.js';
 import { bootstrapCommand } from './bootstrap-command.js';
 import { runAgentCommand } from './commands/agent.js';
+import { issueRestartCommand } from './commands/issue-restart.js';
 import { playbookCommand } from './commands/playbook.js';
 import { skillCommand } from './commands/skill.js';
 import { statusCommand } from './commands/status.js';
@@ -27,6 +28,16 @@ switch (command) {
     } else {
       console.error(
         'Usage: goose task move <project-slug> <issue-id> --to=current [--with-dependencies | --ignore-dependencies]',
+      );
+      process.exit(1);
+    }
+    break;
+  case 'issue':
+    if (args[0] === 'restart') {
+      await issueRestartCommand(args.slice(1));
+    } else {
+      console.error(
+        'Usage: goose issue restart <project-slug> <issue-id> [--state=factory:triaging] [--schedule=current|next|later|blocked-by] [--yes]',
       );
       process.exit(1);
     }
@@ -62,6 +73,9 @@ switch (command) {
     );
     console.error(
       '  task move <project-slug> <issue-id> --to=current [--with-dependencies | --ignore-dependencies]',
+    );
+    console.error(
+      '  issue restart <project-slug> <issue-id> [--state=factory:triaging] [--schedule=current|next|later|blocked-by] [--yes]',
     );
     console.error('  playbook export|import <project-slug> [--json]');
     console.error('  skill triggers <skill-name> [--json]');

--- a/core/bootstrap/github-repo-inspector.ts
+++ b/core/bootstrap/github-repo-inspector.ts
@@ -1,9 +1,9 @@
-import { detectStackFromFiles, type StackInfo } from './stack-detector.js';
 import {
-  auditAgentInstructionsFromFiles,
   type AuditResult,
   type InstructionFileReader,
+  auditAgentInstructionsFromFiles,
 } from './claude-md-auditor.js';
+import { type StackInfo, detectStackFromFiles } from './stack-detector.js';
 
 export interface InspectedGithubRepo {
   repoRef: string;

--- a/core/projects/restart-issue.ts
+++ b/core/projects/restart-issue.ts
@@ -40,7 +40,7 @@ function oldIssueComment(oldItem: WorkItem, newItem: WorkItem): string {
     'Restarted via Goose Hub.',
     '',
     `Fresh issue: ${issueRef(newItem)}`,
-    `Previous lifecycle archived from state: ${oldItem.state}`,
+    `Previous lifecycle restart requested from state: ${oldItem.state}`,
   ].join('\n');
 }
 

--- a/core/projects/restart-issue.ts
+++ b/core/projects/restart-issue.ts
@@ -1,0 +1,110 @@
+import { transitionAndEmitState } from '../event-stream/state-transition.js';
+import { eventStore } from '../event-stream/store.js';
+import { STATES, type StateName } from '../state-machine/states.js';
+import type { Schedule, StateSource, WorkItem } from '../state-source/interface.js';
+
+export interface RestartIssueInput {
+  source: StateSource;
+  projectId: string;
+  itemId: string;
+  targetState?: StateName;
+  schedule?: Schedule;
+  actor?: string;
+}
+
+export interface RestartIssueResult {
+  oldItem: WorkItem;
+  newItem: WorkItem;
+  targetState: StateName;
+  schedule: Schedule;
+}
+
+const OWNED_LABEL_PREFIXES = ['priority:', 'schedule:', 'type:', 'mode:', 'exec:'] as const;
+const STATE_LABELS = new Set<string>(STATES);
+
+function isRestartSafeAuxiliaryLabel(label: string): boolean {
+  if (STATE_LABELS.has(label)) return false;
+  return !OWNED_LABEL_PREFIXES.some((prefix) => label.startsWith(prefix));
+}
+
+export function filterRestartAuxiliaryLabels(labels: readonly string[]): string[] {
+  return Array.from(new Set(labels.filter(isRestartSafeAuxiliaryLabel)));
+}
+
+function issueRef(item: WorkItem): string {
+  return `${item.repoRef}#${item.externalId}`;
+}
+
+function oldIssueComment(oldItem: WorkItem, newItem: WorkItem): string {
+  return [
+    'Restarted via Goose Hub.',
+    '',
+    `Fresh issue: ${issueRef(newItem)}`,
+    `Previous lifecycle archived from state: ${oldItem.state}`,
+  ].join('\n');
+}
+
+function newIssueComment(oldItem: WorkItem): string {
+  return ['Restarted via Goose Hub.', '', `Original issue: ${issueRef(oldItem)}`].join('\n');
+}
+
+export async function restartIssue(input: RestartIssueInput): Promise<RestartIssueResult> {
+  const actor = input.actor ?? 'cli:issue-restart';
+  const oldItem = await input.source.getItem(input.itemId);
+  const targetState = input.targetState ?? 'factory:triaging';
+  const schedule = input.schedule ?? oldItem.schedule;
+  const existingLabels =
+    input.source.listLabels != null ? await input.source.listLabels(oldItem.id) : [];
+  const extraLabels = filterRestartAuxiliaryLabels(existingLabels);
+
+  const newItem = await input.source.createIssue({
+    title: oldItem.title,
+    body: oldItem.body,
+    type: oldItem.type,
+    priority: oldItem.priority,
+    milestoneId: oldItem.milestoneId,
+    initialState: targetState,
+    extraLabels,
+  });
+
+  if (schedule !== 'current') {
+    await input.source.setLabelInGroup(newItem.id, 'schedule', schedule);
+  }
+
+  await input.source.comment(newItem.id, newIssueComment(oldItem));
+  await input.source.comment(oldItem.id, oldIssueComment(oldItem, newItem));
+
+  if (oldItem.state !== 'factory:archived') {
+    await transitionAndEmitState({
+      mode: 'forced',
+      source: input.source,
+      itemId: oldItem.id,
+      projectId: input.projectId,
+      workItemId: oldItem.id,
+      from: oldItem.state,
+      to: 'factory:archived',
+      by: actor,
+      reason: 'issue restarted as a fresh work item',
+      extraPayload: {
+        restartedAsWorkItemId: newItem.id,
+        restartedAsExternalId: newItem.externalId,
+        targetState,
+      },
+    });
+  }
+
+  eventStore.appendEvent({
+    projectId: input.projectId,
+    workItemId: newItem.id,
+    kind: 'manual.action',
+    payload: {
+      action: 'issue-restarted',
+      originalWorkItemId: oldItem.id,
+      originalExternalId: oldItem.externalId,
+      targetState,
+      schedule,
+    },
+  });
+
+  return { oldItem, newItem, targetState, schedule };
+}

--- a/core/workflows/bootstrap-project.ts
+++ b/core/workflows/bootstrap-project.ts
@@ -32,13 +32,13 @@ import {
   auditClaudeMd as defaultAuditClaudeMd,
 } from '../bootstrap/claude-md-auditor.js';
 import {
-  type InstallResult,
-  installLabels as defaultInstallLabels,
-} from '../bootstrap/label-installer.js';
-import {
   type InspectedGithubRepo,
   inspectGithubRepo as defaultInspectGithubRepo,
 } from '../bootstrap/github-repo-inspector.js';
+import {
+  type InstallResult,
+  installLabels as defaultInstallLabels,
+} from '../bootstrap/label-installer.js';
 import { type StackInfo, detectStack as defaultDetectStack } from '../bootstrap/stack-detector.js';
 import {
   applyLabels,

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -14,7 +14,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `server` | yes | API + SSE host for the Goose Hub web UI. Stands up the server process the UI talks to. Closes M2.01 (#26). |
 | `web` | yes | Vite + React 19 + Tailwind 4 + React Router v6. Closes M2.02 (#27). |
 
-## core/ (36 entries, 0 missing README)
+## core/ (37 entries, 1 missing README)
 
 | Name | README | Summary |
 |---|---|---|
@@ -32,6 +32,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `engineering-specs` | yes | Per-work-item storage for `EngineeringSpec` JSON blobs produced by the `spec-author` skill. One row per `(projectId, workItemId)`; the latest pipeline run wins. |
 | `event-stream` | yes | Single-writer chokepoint for operational events. All writes go through `appendEvent()` in `store.ts`; the SQLite write is durable before listeners are notified, so SSE consumers never see an event the DB hasn't recorded. |
 | `findings` | yes | Shared Zod schema for holdout-emitted findings. QA and Review re-export `DispositionSchema` from here so the two skills cannot drift on what counts as a recorded disposition. |
+| `integrations` | **missing** | _(no README)_ |
 | `interventions` | yes | Durable operator intervention control plane for stuck work items. |
 | `learning` | yes | Cross-run learning loop for Goose Hub (M11.11). |
 | `orchestrator` | yes | Cross-cutting orchestration concerns that don't belong to a single slice. The orchestrator is stateless across ticks (FACTORY_RULES rule 7); these modules are pure or scoped to a single dispatch. |
@@ -55,7 +56,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `workflows` | yes | Orchestration workflows that compose skills, persist results, and transition work-item state. |
 | `workspaces` | yes | Git worktree lifecycle management for Factory investigation runs. |
 
-## slices/ (40 entries, 0 missing README)
+## slices/ (41 entries, 0 missing README)
 
 | Name | README | Summary |
 |---|---|---|
@@ -81,6 +82,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `grill-prd-ui` | yes | Ships the **Grill** and **PRD** tabs on the work-item detail page. They expose |
 | `holdout-boundary-test` | yes | Verification slice for M8 exit criteria: deliberate context injection attempts on holdout roles (QA, Reviewer) must fail at the runtime layer. |
 | `investigate` | yes | Workflow slice that drives `type:bug` and `type:chore` work items through the investigation phase. |
+| `issue-restart` | yes | Operator-facing issue restart primitive for dogfooding and stuck workflow recovery. |
 | `label-installer` | yes | Idempotent factory label installer. Closes M12.03 (#306). |
 | `merge-decision` | yes | Per-cycle merge-decision gate (M19.21 #697). Deterministic gate that runs |
 | `model-routing` | yes | M19.09 — provider-aware model routing with config-based complexity overrides. |

--- a/slices/issue-restart/README.md
+++ b/slices/issue-restart/README.md
@@ -1,0 +1,17 @@
+# Issue Restart
+
+Operator-facing issue restart primitive for dogfooding and stuck workflow recovery.
+
+`restartIssue()` creates a new work item from an existing one instead of mutating
+the existing event history. It clones the stable GitHub-owned fields, links old
+and new issues with comments, archives the previous issue, and emits local
+manual/action transition events for auditability.
+
+The CLI entrypoint is:
+
+```bash
+pnpm goose issue restart goose-hub-self 123 --state=factory:triaging --schedule=current --yes
+```
+
+Without `--yes`, the command runs as a dry plan and prints the operation it
+would perform.

--- a/slices/issue-restart/slice.test.ts
+++ b/slices/issue-restart/slice.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { filterRestartAuxiliaryLabels, restartIssue } from '../../core/projects/restart-issue.js';
+import { InMemoryLabelsSource } from '../../core/state-source/in-memory-labels.js';
+
+describe('issue restart', () => {
+  it('filters lifecycle-owned labels but preserves auxiliary labels', () => {
+    expect(
+      filterRestartAuxiliaryLabels([
+        'factory:in-progress',
+        'factory:from-prd',
+        'priority:high',
+        'schedule:current',
+        'type:bug',
+        'mode:autonomous',
+        'exec:parallel',
+        'area:web',
+        'custom:dogfood',
+        'area:web',
+      ]),
+    ).toEqual(['factory:from-prd', 'area:web', 'custom:dogfood']);
+  });
+
+  it('creates a fresh issue, archives the original, and links both issues', async () => {
+    const source = new InMemoryLabelsSource('goose-hub-self', 'shaunnez/goose-hub');
+    const oldItem = await source.seedIssue({
+      title: 'Dogfood the reset flow',
+      body: 'Acceptance criteria\n- Reset starts from scratch',
+      type: 'bug',
+      priority: 'critical',
+      state: 'factory:needs-human',
+      schedule: 'blocked-by',
+      milestoneId: '1',
+    });
+    await source.addLabels(oldItem.id, [
+      'area:web',
+      'factory:from-prd',
+      'factory:needs-human',
+      'schedule:blocked-by',
+    ]);
+
+    const result = await restartIssue({
+      source,
+      projectId: 'goose-hub-self',
+      itemId: oldItem.id,
+      targetState: 'factory:dev-ready',
+      schedule: 'current',
+    });
+
+    const archivedOld = await source.getItem(oldItem.id);
+    const fresh = await source.getItem(result.newItem.id);
+    const oldComments = await source.listComments(oldItem.id);
+    const newComments = await source.listComments(result.newItem.id);
+
+    expect(fresh.externalId).not.toBe(oldItem.externalId);
+    expect(fresh.title).toBe(oldItem.title);
+    expect(fresh.body).toBe(oldItem.body);
+    expect(fresh.type).toBe('bug');
+    expect(fresh.priority).toBe('critical');
+    expect(fresh.state).toBe('factory:dev-ready');
+    expect(fresh.schedule).toBe('current');
+    expect(fresh.milestoneId).toBe('1');
+    expect(archivedOld.state).toBe('factory:archived');
+    expect(source.getExtraLabels(fresh.id)).toEqual(new Set(['area:web', 'factory:from-prd']));
+    expect(oldComments.at(-1)?.body).toContain(
+      `Fresh issue: shaunnez/goose-hub#${fresh.externalId}`,
+    );
+    expect(newComments.at(-1)?.body).toContain(
+      `Original issue: shaunnez/goose-hub#${oldItem.externalId}`,
+    );
+  });
+
+  it('preserves the original schedule when no override is provided', async () => {
+    const source = new InMemoryLabelsSource('goose-hub-self', 'shaunnez/goose-hub');
+    const oldItem = await source.seedIssue({
+      title: 'Restart later item',
+      state: 'factory:accepted',
+      schedule: 'later',
+    });
+
+    const result = await restartIssue({
+      source,
+      projectId: 'goose-hub-self',
+      itemId: oldItem.id,
+    });
+
+    const fresh = await source.getItem(result.newItem.id);
+    expect(fresh.state).toBe('factory:triaging');
+    expect(fresh.schedule).toBe('later');
+  });
+});


### PR DESCRIPTION
## Summary
- add a restartIssue service that creates a fresh replacement issue instead of mutating old event history
- add pnpm goose issue restart with dry-run default and --yes for the mutating path
- document and test the issue restart slice

## Validation
- pnpm test slices/issue-restart/slice.test.ts
- pnpm exec biome check core/projects/restart-issue.ts slices/issue-restart/slice.test.ts apps/cli/src/commands/issue-restart.ts apps/cli/src/index.ts apps/cli/README.md slices/issue-restart/README.md
- pnpm typecheck
- git diff --check