### PR TITLE
Tighten tool binding drift handling

### DIFF
--- a/apps/server/src/domains/chat/tools.test.ts
+++ b/apps/server/src/domains/chat/tools.test.ts
@@ -162,10 +162,19 @@ vi.mock('@goose-hub/core/conversations/repository.js', () => ({
   setToolInvocationRunId: (...args: unknown[]) => mockSetToolInvocationRunId(...args),
 }));
 
+import { CHAT_TOOL_REGISTRY } from '@goose-hub/core/chat-tools/registry.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { CHAT_TOOL_IMPLEMENTATIONS, ToolExecutionError } from './tools.js';
 
 const ctx = { conversationId: 'conv_test', projectId: null, workItemId: null };
+
+describe('chat-tools — registry parity', () => {
+  it('implements every registered chat tool and no unregistered tools', () => {
+    expect(Object.keys(CHAT_TOOL_IMPLEMENTATIONS).sort()).toEqual(
+      CHAT_TOOL_REGISTRY.map((entry) => entry.name).sort(),
+    );
+  });
+});
 
 function workItem(
   overrides: Partial<{ id: string; externalId: string; title: string; state: string }>,

--- a/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
@@ -182,6 +182,29 @@ describe('QA timeline events', () => {
     expect(screen.getByText('Product')).toBeTruthy();
   });
 
+  it('labels regression tier as a suite and surfaces the actual command', () => {
+    const event = makeEvent('qa.completed', {
+      verdict: 'fail',
+      overallScore: 40,
+      threshold: 70,
+      tierResults: {
+        structural: { passed: true, findings: [] },
+        functional: { passed: true, findings: [] },
+        regression: {
+          passed: false,
+          command: 'pnpm --filter @goose-hub/web test:e2e:pipeline',
+          findings: [],
+        },
+      },
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Regression suite')).toBeTruthy();
+    expect(screen.getByText('pnpm --filter @goose-hub/web test:e2e:pipeline')).toBeTruthy();
+    expect(document.body.textContent).not.toContain('Regression (playwright)');
+  });
+
   it('renders verification-blocked failure category badges', () => {
     const event = makeEvent('qa.verification-blocked', {
       failedTier: 2,

--- a/apps/web/src/components/detail/components/timeline/QaEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.tsx
@@ -271,7 +271,7 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
   const tierRows: { key: 'structural' | 'functional' | 'regression'; label: string }[] = [
     { key: 'structural', label: 'Structural' },
     { key: 'functional', label: 'Functional' },
-    { key: 'regression', label: 'Regression (playwright)' },
+    { key: 'regression', label: 'Regression suite' },
   ];
 
   return (

--- a/core/agent-runtime/claude-cli.test.ts
+++ b/core/agent-runtime/claude-cli.test.ts
@@ -17,6 +17,7 @@ const {
     mcpServerBundles: [],
     mcpServerNames: [],
     sandboxMode: 'read-only',
+    warnings: [],
     fingerprints: {
       toolBindingHash: 'binding-hash',
       toolAllowlistHash: 'allowlist-hash',
@@ -125,6 +126,7 @@ beforeEach(() => {
     mcpServerBundles: [],
     mcpServerNames: [],
     sandboxMode: 'read-only',
+    warnings: [],
     fingerprints: {
       toolBindingHash: 'binding-hash',
       toolAllowlistHash: 'allowlist-hash',
@@ -265,6 +267,50 @@ describe('ClaudeCliRuntime — agentRuns write path', () => {
           mcpServerSetHash: 'server-hash',
           nativeToolCount: 0,
           mcpServerNames: [],
+          toolBindingWarningCount: 0,
+          toolBindingWarnings: [],
+        }),
+      }),
+    );
+  });
+
+  it('emits tool binding warnings on run-started and telemetry log events', async () => {
+    const envelope = JSON.stringify({ is_error: false, result: '{"ok":true}' });
+    mockSpawn.mockReturnValue(makeChild(0, envelope));
+    vi.mocked(bindToolsForAgentSpec).mockReturnValueOnce({
+      allowlist: [],
+      enabledToolsByServer: {},
+      nativeTools: [],
+      mcpServerBundles: [],
+      mcpServerNames: [],
+      sandboxMode: 'read-only',
+      warnings: [{ kind: 'unknown-bundle', name: 'legacy' }],
+      fingerprints: {
+        toolBindingHash: 'binding-hash',
+        toolAllowlistHash: 'allowlist-hash',
+        mcpServerSetHash: 'server-hash',
+      },
+    });
+
+    const runtime = new ClaudeCliRuntime();
+    await runtime.run(makeSpec());
+
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.run-started',
+        payload: expect.objectContaining({
+          toolBindingWarningCount: 1,
+          toolBindingWarnings: [{ kind: 'unknown-bundle', name: 'legacy' }],
+        }),
+      }),
+    );
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.log',
+        payload: expect.objectContaining({
+          metric: 'tool_binding_warnings',
+          warningCount: 1,
+          warnings: [{ kind: 'unknown-bundle', name: 'legacy' }],
         }),
       }),
     );

--- a/core/agent-runtime/claude-cli.ts
+++ b/core/agent-runtime/claude-cli.ts
@@ -111,8 +111,7 @@ export class ClaudeCliRuntime implements AgentRuntime {
     const toolBinding = bindToolsForAgentSpec(spec);
     // Per-run MCP config under <worktree>/.factory/mcp-config.json (ADR 0045).
     // Always written; the factory-tools server entry carries the run's
-    // identity via env. Bundle-specific servers (playwright-mcp) are
-    // merged in from their workspace-relative configs when declared.
+    // identity via env.
     const { configPath: factoryMcpConfigPath } = buildFactoryMcpConfig({
       workspaceDir,
       runId,
@@ -149,7 +148,26 @@ export class ClaudeCliRuntime implements AgentRuntime {
           mcpServerSetHash: toolBinding.fingerprints.mcpServerSetHash,
           nativeToolCount: toolBinding.nativeTools.length,
           mcpServerNames: toolBinding.mcpServerNames,
+          toolBindingWarningCount: toolBinding.warnings.length,
+          toolBindingWarnings: toolBinding.warnings,
           ...spec.extraEventPayload,
+        },
+        runId,
+        personaId: spec.personaId,
+      });
+    }
+    if (toolBinding.warnings.length > 0) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId,
+        kind: 'agent.log',
+        payload: {
+          runId,
+          skill: spec.skill,
+          stream: 'telemetry',
+          metric: 'tool_binding_warnings',
+          warningCount: toolBinding.warnings.length,
+          warnings: toolBinding.warnings,
         },
         runId,
         personaId: spec.personaId,

--- a/core/agent-runtime/codex-cli-runtime.test.ts
+++ b/core/agent-runtime/codex-cli-runtime.test.ts
@@ -93,6 +93,7 @@ function makeToolBinding(overrides: Partial<ToolBinding> = {}): ToolBinding {
     mcpServerBundles: [],
     mcpServerNames: [],
     sandboxMode: 'read-only' as const,
+    warnings: [],
     fingerprints: {
       toolBindingHash: 'binding-hash',
       toolAllowlistHash: 'allowlist-hash',
@@ -107,7 +108,6 @@ function defaultToolBindingForSpec(spec: { skill?: string; toolBundles?: Readonl
   const needsBrowser = spec.skill === 'playwright-repro' && bundles.includes('validate');
   const needsWrite = bundles.includes('dev-tools');
   return makeToolBinding({
-    mcpServerBundles: bundles.includes('playwright-mcp') ? ['playwright-mcp'] : [],
     sandboxMode: needsBrowser ? 'danger-full-access' : needsWrite ? 'workspace-write' : 'read-only',
     ...(needsBrowser ? { approvalPolicy: 'never' } : {}),
   });
@@ -445,6 +445,36 @@ describe('CodexCliRuntime timeout handling', () => {
           mcpServerSetHash: 'server-hash',
           nativeToolCount: 0,
           mcpServerNames: [],
+          toolBindingWarningCount: 0,
+          toolBindingWarnings: [],
+        }),
+      }),
+    );
+  });
+
+  it('emits tool binding warnings on run-started and telemetry log events', async () => {
+    vi.mocked(bindToolsForAgentSpec).mockReturnValueOnce(
+      makeToolBinding({ warnings: [{ kind: 'unknown-tool-extra', name: 'legacy-tool' }] }),
+    );
+
+    await runSuccessfulCodexSpec();
+
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.run-started',
+        payload: expect.objectContaining({
+          toolBindingWarningCount: 1,
+          toolBindingWarnings: [{ kind: 'unknown-tool-extra', name: 'legacy-tool' }],
+        }),
+      }),
+    );
+    expect(mockEventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.log',
+        payload: expect.objectContaining({
+          metric: 'tool_binding_warnings',
+          warningCount: 1,
+          warnings: [{ kind: 'unknown-tool-extra', name: 'legacy-tool' }],
         }),
       }),
     );

--- a/core/agent-runtime/codex-cli.ts
+++ b/core/agent-runtime/codex-cli.ts
@@ -341,7 +341,26 @@ export class CodexCliRuntime implements AgentRuntime {
           mcpServerSetHash: toolBinding.fingerprints.mcpServerSetHash,
           nativeToolCount: toolBinding.nativeTools.length,
           mcpServerNames: toolBinding.mcpServerNames,
+          toolBindingWarningCount: toolBinding.warnings.length,
+          toolBindingWarnings: toolBinding.warnings,
           ...spec.extraEventPayload,
+        },
+        runId,
+        personaId,
+      });
+    }
+    if (toolBinding.warnings.length > 0) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId,
+        kind: 'agent.log',
+        payload: {
+          runId,
+          skill: spec.skill,
+          stream: 'telemetry',
+          metric: 'tool_binding_warnings',
+          warningCount: toolBinding.warnings.length,
+          warnings: toolBinding.warnings,
         },
         runId,
         personaId,

--- a/core/agent-runtime/dev-review-advisor.test.ts
+++ b/core/agent-runtime/dev-review-advisor.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { getArtifact } from '../agent-artifacts/repository.js';
 import { db } from '../db/db.js';
 import { agentArtifacts } from '../db/schema.js';
-import { preparePrDiffContext, runDevReviewResponse } from './dev-review-advisor.js';
+import { preparePrDiffContext, runDevReview, runDevReviewResponse } from './dev-review-advisor.js';
 import { buildDiffDigest } from './diff-digest.js';
 import type { AgentSpec } from './interface.js';
 
@@ -216,6 +216,47 @@ describe('preparePrDiffContext', () => {
 });
 
 describe('runDevReviewResponse runtime resolution', () => {
+  it('runs dev-review inside the integration worktree', async () => {
+    const runtimeCalls: AgentSpec[] = [];
+    const runtime = {
+      async run(spec: AgentSpec) {
+        runtimeCalls.push(spec);
+        return {
+          output: {
+            verdict: 'no-blockers',
+            findings: [],
+            decisionSummaries: [{ kind: 'VERDICT', summary: 'No blockers found.' }],
+          },
+          decisionSummaries: [],
+          events: [],
+        };
+      },
+    };
+
+    await runDevReview({
+      runId: RUN_ID,
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      workItem: { title: 'Fix ordering', body: 'body', number: 77, priority: 'high' },
+      worktreePath: process.cwd(),
+      baseBranch: 'HEAD',
+      stack: { testCommand: 'pnpm test' },
+      runtime,
+      appendEvent: (input) => ({
+        ...input,
+        workItemId: input.workItemId ?? null,
+        id: 1,
+        createdAt: new Date().toISOString(),
+      }),
+    });
+
+    expect(runtimeCalls).toHaveLength(1);
+    expect(runtimeCalls[0]).toMatchObject({
+      skill: 'dev-review',
+      workspaceDir: process.cwd(),
+    });
+  });
+
   it('honours project skill provider settings when no runtime is injected', async () => {
     await runDevReviewResponse({
       runId: RUN_ID,

--- a/core/agent-runtime/dev-review-advisor.ts
+++ b/core/agent-runtime/dev-review-advisor.ts
@@ -300,6 +300,7 @@ export async function runDevReview(input: RunDevReviewInput): Promise<DevReviewO
     personaId,
     outputJsonSchema,
     appendSystemPrompt: prompt,
+    workspaceDir: input.worktreePath,
   });
   emitSymbolIndexHintsUsedEvent({
     projectId: input.projectId,

--- a/core/audit/slice.test.ts
+++ b/core/audit/slice.test.ts
@@ -38,7 +38,6 @@ function projectStub(slug: string, localPath: string): import('../types.js').Pro
       runtime: 'auto',
       rolesModels: {},
       fallbackPolicy: {},
-      toolAllowlists: {},
       advisorMode: {
         enabled: false,
         triggerOn: { priorities: [] },

--- a/core/tool-layer/README.md
+++ b/core/tool-layer/README.md
@@ -37,13 +37,14 @@ Named bundles passed via `AgentSpec.toolBundles`. At spawn, `bindToolsForAgentSp
 | `validate` | `mcp__factory-tools__*` context, read/search, evidence tools | Playwright/evidence validation skills |
 | `core` | no tools | Prompt-only skills |
 | `emergency-debug` | `Bash` | Explicit opt-in escape hatch |
-| `playwright-mcp` | `mcp__playwright-test__*` (browser/planner/generator) | `spec-author` skill (auto-merges `apps/web/.mcp.json`) |
 
 Every default agent-facing bundle is composed of `mcp__factory-tools__*` names only. Native `Read`, `Write`, `Edit`, `Glob`, `Grep`, and broad `Bash` are not in default bundles; native `Bash` is available only through `emergency-debug`.
 
+Playwright automation runs through workflow-owned commands and evidence tools (`write_playwright_spec`, `run_playwright_spec`, `collect_evidence`), not a separate `playwright-mcp` bundle. Unknown bundle names and unknown `toolExtras` are skipped and recorded as `ToolBinding.warnings`; they are visible in `agent.run-started` payloads and telemetry logs without aborting the run.
+
 `mcp__factory-tools__record_decision` is part of the context tools and stays available to holdout roles so QA/reviewer runs can emit their own live decision summaries without seeing implementation reasoning. There is no separate single-tool decision bundle; runtime code should use the MCP context tool.
 
-`ToolBinding` is the orchestrator-owned runtime contract for a run's tool surface. It contains the flat Claude allowlist, Codex `enabled_tools` grouped by MCP server, optional MCP server bundles, native tool names, sandbox/approval policy, and stable fingerprints for cache/cost analysis. Runtime code consumes this artifact instead of re-deriving bundle policy.
+`ToolBinding` is the orchestrator-owned runtime contract for a run's tool surface. It contains the flat Claude allowlist, Codex `enabled_tools` grouped by MCP server, native tool names, sandbox/approval policy, non-fatal drift warnings, and stable fingerprints for cache/cost analysis. Runtime code consumes this artifact instead of re-deriving bundle policy.
 
 ## Canonical Path Contract
 

--- a/core/tool-layer/mcp/README.md
+++ b/core/tool-layer/mcp/README.md
@@ -48,9 +48,10 @@ Written to `<worktree>/.factory/mcp-config.json` at spawn time by the runtime. T
 - `validate` — context + read/search + evidence
 - `core` — empty (no-tool skills)
 - `emergency-debug` — `Bash` only; opt-in
-- `playwright-mcp` — Microsoft's playwright-test MCP server tools
 
 Every agent-facing bundle is `mcp__factory-tools__*` only — no native `Read` / `Write` / `Edit` / `Glob` / `Grep` / `Bash`. Enforced by a slice test. The MCP `record_decision` context tool remains available to holdout roles for their own live decision summaries; there is no separate single-tool decision bundle.
+
+Playwright evidence is owned by Factory workflows through the evidence tools (`write_playwright_spec`, `run_playwright_spec`, `collect_evidence`) and project commands. There is no separate `playwright-mcp` bundle or per-run merge of `apps/web/.mcp.json`.
 
 ## GitHub-backed tools
 

--- a/core/tool-layer/mcp/build-config.test.ts
+++ b/core/tool-layer/mcp/build-config.test.ts
@@ -80,17 +80,7 @@ describe('buildFactoryMcpConfig', () => {
     expect(env?.FACTORY_PERSONA_ID).toBe('demo/developer/0');
   });
 
-  it('merges playwright-mcp entries from apps/web/.mcp.json when the bundle is declared', () => {
-    mkdirSync(join(workspace, 'apps/web'), { recursive: true });
-    writeFileSync(
-      join(workspace, 'apps/web/.mcp.json'),
-      JSON.stringify({
-        mcpServers: {
-          'playwright-test': { command: 'node', args: ['playwright-mcp.js'] },
-        },
-      }),
-    );
-
+  it('does not merge legacy bundle-specific MCP server entries', () => {
     const result = buildFactoryMcpConfig({
       workspaceDir: workspace,
       runId: 'run-1',
@@ -100,35 +90,6 @@ describe('buildFactoryMcpConfig', () => {
       orchestratorRoot,
     });
 
-    expect(Object.keys(result.config.mcpServers).sort()).toEqual(
-      ['factory-tools', 'playwright-test'].sort(),
-    );
-  });
-
-  it('silently skips bundle MCP files that do not exist', () => {
-    const result = buildFactoryMcpConfig({
-      workspaceDir: workspace,
-      runId: 'run-1',
-      projectId: 'demo',
-      workItemId: null,
-      toolBundles: ['playwright-mcp'],
-      orchestratorRoot,
-    });
-    expect(Object.keys(result.config.mcpServers)).toEqual(['factory-tools']);
-  });
-
-  it('silently skips malformed bundle MCP files', () => {
-    mkdirSync(join(workspace, 'apps/web'), { recursive: true });
-    writeFileSync(join(workspace, 'apps/web/.mcp.json'), 'not valid json');
-
-    const result = buildFactoryMcpConfig({
-      workspaceDir: workspace,
-      runId: 'run-1',
-      projectId: 'demo',
-      workItemId: null,
-      toolBundles: ['playwright-mcp'],
-      orchestratorRoot,
-    });
     expect(Object.keys(result.config.mcpServers)).toEqual(['factory-tools']);
   });
 

--- a/core/tool-layer/mcp/build-config.ts
+++ b/core/tool-layer/mcp/build-config.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // SERVER_SCRIPT_RELATIVE is the path relative to the orchestrator root.
@@ -22,7 +22,7 @@ export interface BuildFactoryMcpConfigInput {
   /** Skill name for timeline attribution of tool-originated events. */
   skill?: string | null;
   personaId?: string | null;
-  /** Bundle names declared on the skill spec; used to merge bundle-specific MCP servers. */
+  /** Bundle names declared on the skill spec. Kept for caller parity; factory-tools is always used. */
   toolBundles: ReadonlyArray<string>;
   /** Optional orchestrator HTTP port to expose via FACTORY_SERVER_PORT. */
   serverPort?: number | string;
@@ -47,18 +47,11 @@ export interface McpConfigJson {
   mcpServers: Record<string, McpServerEntry>;
 }
 
-const BUNDLE_TO_MCP_RELATIVE: Record<string, string> = {
-  'playwright-mcp': 'apps/web/.mcp.json',
-};
-
 /**
  * Builds and writes the per-run MCP config that Claude/Codex CLIs pass via
  * `--mcp-config`. Always includes the `factory-tools` server entry, with
  * the run-scoped identity propagated via env vars (the agent never sees
  * these — it gets the MCP tools from the spawned server).
- *
- * Bundle-specific servers (today: `playwright-mcp`) are merged in from
- * their workspace-relative config files when those bundles are declared.
  *
  * The config file lives at `<workspaceDir>/.factory/mcp-config.json` so
  * each worktree owns its own config — that removes the race between
@@ -99,7 +92,6 @@ export function buildFactoryMcpConfig(
         args: [...launcher.argsPrefix, serverScript],
         env,
       },
-      ...resolveBundleServers(input.toolBundles, workspaceDir),
     },
   };
 
@@ -134,31 +126,6 @@ function resolveTsxBinary(orchestratorRoot: string): string {
   const local = join(orchestratorRoot, TSX_BIN_RELATIVE);
   if (existsSync(local)) return local;
   return 'tsx';
-}
-
-function resolveBundleServers(
-  toolBundles: ReadonlyArray<string>,
-  workspaceDir: string,
-): Record<string, McpServerEntry> {
-  const merged: Record<string, McpServerEntry> = {};
-  for (const bundle of toolBundles) {
-    const relPath = BUNDLE_TO_MCP_RELATIVE[bundle];
-    if (relPath == null) continue;
-    const candidate = isAbsolute(relPath) ? relPath : join(workspaceDir, relPath);
-    if (!existsSync(candidate)) continue;
-    try {
-      const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as Partial<McpConfigJson>;
-      const servers = parsed.mcpServers ?? {};
-      for (const [name, entry] of Object.entries(servers)) {
-        merged[name] = entry as McpServerEntry;
-      }
-    } catch {
-      // Malformed bundle MCP config — skip silently rather than aborting
-      // the run; factory-tools will still be available, which is what the
-      // agent actually needs.
-    }
-  }
-  return merged;
 }
 
 /**

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -286,13 +286,13 @@ export function invalidateRunCacheForPaths(runId: string, rawPaths: string[]): v
     }
   }
   if (duplicateMap?.size === 0) duplicateCounters.delete(runId);
-  // Writes invalidate the retry cap for any path they touch — and for the
-  // full-suite sentinel, since the next full run may now produce different
-  // results.
+  // Keep retry caps strict for unrelated edits while allowing one clean rerun
+  // after the failing test, a sibling source file, or the full-suite sentinel
+  // has actually changed.
   for (const [retryKey] of retryMap ?? []) {
     if (
       retryKey === TEST_RETRY_ALL_KEY ||
-      changedPaths.some((changedPath) => pathsOverlap(retryKey, changedPath))
+      changedPaths.some((changedPath) => retryKeyInvalidatedByChange(retryKey, changedPath))
     ) {
       retryMap?.delete(retryKey);
     }
@@ -455,6 +455,21 @@ function pathsOverlap(left: string, right: string): boolean {
   const b = normalizePathForOverlap(right);
   if (a === '.' || b === '.') return true;
   return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function implementationBase(path: string): string | null {
+  const normalized = normalizePathForOverlap(path);
+  const testBase = normalized.replace(/\.(test|spec)\.(ts|tsx)$/, '');
+  if (testBase !== normalized) return testBase;
+  const sourceBase = normalized.replace(/\.(ts|tsx)$/, '');
+  return sourceBase !== normalized ? sourceBase : null;
+}
+
+function retryKeyInvalidatedByChange(retryKey: string, changedPath: string): boolean {
+  if (pathsOverlap(retryKey, changedPath)) return true;
+  const retryBase = implementationBase(retryKey);
+  const changedBase = implementationBase(changedPath);
+  return retryBase != null && changedBase != null && retryBase === changedBase;
 }
 
 function cloneResult<T>(result: T): T {

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -133,6 +133,38 @@ describe('runTestsTool', () => {
       },
     });
   });
+
+  it('rejects Playwright e2e spec paths because e2e is QA/evidence-owned', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+    mkdirSync(join(workspace, 'apps/web/e2e'), { recursive: true });
+    writeFileSync(join(workspace, 'apps/web/e2e/issue-1107.spec.ts'), 'test("x", () => {});\n');
+
+    mockRunCommand.mockClear();
+    const result = await runTestsTool(ctx, { path: 'apps/web/e2e/issue-1107.spec.ts' });
+
+    expect(result.status).toBe('failed');
+    expect(result.stderr).toContain('QA/evidence-owned');
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(result.paths?.map((path) => path.path)).toEqual(['apps/web/e2e/issue-1107.spec.ts']);
+  });
+
+  it('rejects Playwright e2e directory paths because e2e is QA/evidence-owned', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+    mkdirSync(join(workspace, 'apps/web/e2e/pipeline'), { recursive: true });
+    writeFileSync(join(workspace, 'apps/web/e2e/pipeline/seed.spec.ts'), 'test("x", () => {});\n');
+
+    mockRunCommand.mockClear();
+    const result = await runTestsTool(ctx, { path: 'apps/web/e2e/pipeline' });
+
+    expect(result.status).toBe('failed');
+    expect(result.stderr).toContain('QA/evidence-owned');
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(result.paths?.map((path) => path.path)).toEqual(['apps/web/e2e/pipeline']);
+  });
 });
 
 describe('runTargetedCommandTool', () => {
@@ -196,6 +228,33 @@ describe('runTestsTool retry cap', () => {
     const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
     expect(mockRunCommand).toHaveBeenCalledOnce();
     expect(next.status).toBe('failed');
+  });
+
+  it('resets the cap after a source edit, allowing one final exact test rerun', async () => {
+    const { invalidateRunCacheForPaths } = await import('../run-cache.js');
+    mockFailed();
+    for (let i = 0; i < 3; i++) await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+
+    invalidateRunCacheForPaths(ctx.runId, ['apps/web/src/foo.ts']);
+
+    mockRunCommand.mockClear();
+    const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+    expect(mockRunCommand).toHaveBeenCalledOnce();
+    expect(next.status).toBe('failed');
+  });
+
+  it('does not reset a capped test path after an unrelated edit', async () => {
+    const { invalidateRunCacheForPaths } = await import('../run-cache.js');
+    mockFailed();
+    for (let i = 0; i < 3; i++) await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+
+    invalidateRunCacheForPaths(ctx.runId, ['apps/web/src/other.ts']);
+
+    mockRunCommand.mockClear();
+    const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(next.status).toBe('failed');
+    expect(next.stderr).toMatch(/retry cap/i);
   });
 
   it('counters are isolated per path', async () => {

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -29,6 +29,7 @@ const TEST_TIMEOUT_MS = 5 * 60 * 1000;
 const LINT_TIMEOUT_MS = 90 * 1000;
 const TYPECHECK_TIMEOUT_MS = 3 * 60 * 1000;
 const PACKAGE_SCRIPT_TIMEOUT_MS = 5 * 60 * 1000;
+const E2E_PATH_PREFIX = 'apps/web/e2e';
 
 export class StackCommandMissingError extends Error {
   readonly kind = 'StackCommandMissingError' as const;
@@ -158,6 +159,24 @@ export async function runTestsTool(
     pathMetadata = { rawPaths: [input.path], paths: [canonical] };
   }
 
+  if (pathMetadata?.paths.some((path) => isE2eOwnedPath(path.path)) === true) {
+    const blocked = buildE2eOwnedBlockedResult(argv, pathMetadata);
+    emitToolCall(ctx, {
+      tool: 'run_tests',
+      input: {
+        path: input.path ?? null,
+        command: argv.join(' '),
+        rawPaths: pathMetadata.rawPaths,
+        paths: pathMetadata.paths.map((path) => path.path),
+      },
+      status: 'failed',
+      exitCode: blocked.exitCode,
+      durationMs: blocked.durationMs,
+      truncated: false,
+    });
+    return blocked;
+  }
+
   const retryPathKey = pathMetadata?.paths[0]?.path ?? null;
   const cap = testRetryCap();
   const priorFailures = consecutiveTestFailures(ctx.runId, retryPathKey);
@@ -260,6 +279,30 @@ export async function runTestsTool(
   }
   const verifyResult = toVerifyResult(argv, result, pathMetadata);
   return failureSummary != null ? { ...verifyResult, failureSummary } : verifyResult;
+}
+
+function isE2eOwnedPath(path: string): boolean {
+  const normalized = path.replace(/^\.\//, '').replace(/\/+$/, '');
+  return normalized === E2E_PATH_PREFIX || normalized.startsWith(`${E2E_PATH_PREFIX}/`);
+}
+
+function buildE2eOwnedBlockedResult(
+  argv: ReadonlyArray<string>,
+  paths: { rawPaths: string[]; paths: RepoRelativePath[] },
+): VerifyResult {
+  const canonicalPaths = paths.paths.map((path) => path.path);
+  return {
+    status: 'failed',
+    exitCode: null,
+    stdout: '',
+    stderr: `[harness] run_tests does not run Playwright e2e paths (${canonicalPaths.join(', ')}). E2e specs are QA/evidence-owned; add or run unit/component tests here, or let QA run the project's e2eCommand.`,
+    durationMs: 0,
+    truncated: false,
+    displayTruncated: false,
+    command: argv,
+    rawPaths: paths.rawPaths,
+    paths: paths.paths,
+  };
 }
 
 function buildRetryCapBlockedResult(

--- a/core/tool-layer/slice.test.ts
+++ b/core/tool-layer/slice.test.ts
@@ -166,19 +166,8 @@ describe('TOOL_BUNDLES', () => {
     expect(TOOL_BUNDLES['emergency-debug']).toEqual(['Bash']);
   });
 
-  it('playwright-mcp bundle contains browser_* and planner_* and generator_* tools', () => {
-    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__browser_navigate');
-    expect(TOOL_BUNDLES['playwright-mcp']).toContain(
-      'mcp__playwright-test__browser_take_screenshot',
-    );
-    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__planner_save_plan');
-    expect(TOOL_BUNDLES['playwright-mcp']).toContain('mcp__playwright-test__generator_write_test');
-  });
-
-  it('playwright-mcp bundle entries are all mcp__playwright-test__ prefixed', () => {
-    for (const tool of TOOL_BUNDLES['playwright-mcp']) {
-      expect(tool.startsWith('mcp__playwright-test__')).toBe(true);
-    }
+  it('does not expose the legacy playwright-mcp bundle', () => {
+    expect(TOOL_BUNDLES).not.toHaveProperty('playwright-mcp');
   });
 });
 
@@ -215,6 +204,11 @@ describe('computeAllowlist', () => {
 
   it('ignores unknown bundle names', () => {
     const list = computeAllowlist({ toolBundles: ['unknown-bundle'], toolExtras: [] });
+    expect(list).toEqual([]);
+  });
+
+  it('ignores unknown extra tool names', () => {
+    const list = computeAllowlist({ toolBundles: [], toolExtras: ['mcp__unknown__surface'] });
     expect(list).toEqual([]);
   });
 });
@@ -275,7 +269,7 @@ describe('bindToolsForAgentSpec', () => {
     expect(binding.approvalPolicy).toBeUndefined();
   });
 
-  it('adds optional MCP server bundles separately from the flat allowlist', () => {
+  it('records warnings for unknown bundle names without failing binding', () => {
     const binding = bindToolsForAgentSpec({
       toolBundles: ['read', 'playwright-mcp'],
       toolExtras: [],
@@ -283,9 +277,25 @@ describe('bindToolsForAgentSpec', () => {
       skill: 'spec-author',
     });
 
-    expect(binding.mcpServerBundles).toEqual(['playwright-mcp']);
-    expect(binding.enabledToolsByServer['playwright-test']).toContain('browser_navigate');
-    expect(binding.allowlist).toContain('mcp__playwright-test__browser_navigate');
+    expect(binding.mcpServerBundles).toEqual([]);
+    expect(binding.enabledToolsByServer['playwright-test']).toBeUndefined();
+    expect(binding.allowlist).not.toContain('mcp__playwright-test__browser_navigate');
+    expect(binding.warnings).toEqual([{ kind: 'unknown-bundle', name: 'playwright-mcp' }]);
+  });
+
+  it('records warnings and skips unknown toolExtras', () => {
+    const binding = bindToolsForAgentSpec({
+      toolBundles: [],
+      toolExtras: ['mcp__factory-tools__read_file', 'mcp__unknown__surface'],
+      role: 'developer',
+      skill: 'spec-author',
+    });
+
+    expect(binding.allowlist).toEqual(['mcp__factory-tools__read_file']);
+    expect(binding.enabledToolsByServer).toEqual({ 'factory-tools': ['read_file'] });
+    expect(binding.warnings).toEqual([
+      { kind: 'unknown-tool-extra', name: 'mcp__unknown__surface' },
+    ]);
   });
 
   it('keeps MCP record_decision available to QA holdouts', () => {

--- a/core/tool-layer/tool-binding.ts
+++ b/core/tool-layer/tool-binding.ts
@@ -1,6 +1,8 @@
 import type { Role } from '../types.js';
 import {
   bundleTools,
+  isKnownBundleName,
+  isKnownToolName,
   isOptionalMcpServerBundle,
   isToolAllowedForRole,
   lookupTool,
@@ -23,6 +25,10 @@ export interface ToolBindingFingerprints {
   mcpServerSetHash: string;
 }
 
+export type ToolBindingWarning =
+  | { kind: 'unknown-bundle'; name: string }
+  | { kind: 'unknown-tool-extra'; name: string };
+
 export interface ToolBinding {
   allowlist: string[];
   enabledToolsByServer: Record<string, string[]>;
@@ -32,6 +38,7 @@ export interface ToolBinding {
   sandboxMode: ToolBindingSandboxMode;
   approvalPolicy?: ToolBindingApprovalPolicy;
   fingerprints: ToolBindingFingerprints;
+  warnings: ToolBindingWarning[];
 }
 
 const BROWSER_PROCESS_ACCESS_SKILLS = new Set(['playwright-repro', 'evidence-post']);
@@ -39,8 +46,13 @@ const BROWSER_PROCESS_ACCESS_SKILLS = new Set(['playwright-repro', 'evidence-pos
 export function bindToolsForAgentSpec(input: ToolBindingInput): ToolBinding {
   const selectedTools = new Set<string>();
   const mcpServerBundles = new Set<string>();
+  const warnings: ToolBindingWarning[] = [];
 
   for (const bundle of input.toolBundles) {
+    if (!isKnownBundleName(bundle)) {
+      warnings.push({ kind: 'unknown-bundle', name: bundle });
+      continue;
+    }
     if (isOptionalMcpServerBundle(bundle)) mcpServerBundles.add(bundle);
     for (const tool of bundleTools(bundle)) {
       addToolIfAllowed(selectedTools, tool, input.role);
@@ -48,6 +60,10 @@ export function bindToolsForAgentSpec(input: ToolBindingInput): ToolBinding {
   }
 
   for (const tool of input.toolExtras) {
+    if (!isKnownToolName(tool)) {
+      warnings.push({ kind: 'unknown-tool-extra', name: tool });
+      continue;
+    }
     addToolIfAllowed(selectedTools, tool, input.role);
   }
 
@@ -94,6 +110,7 @@ export function bindToolsForAgentSpec(input: ToolBindingInput): ToolBinding {
     mcpServerNames,
     sandboxMode,
     ...(needsBrowserProcessAccess ? { approvalPolicy: 'never' as const } : {}),
+    warnings,
     fingerprints: {
       toolAllowlistHash: stableHash(allowlist),
       mcpServerSetHash: stableHash({

--- a/core/tool-layer/tool-repository.ts
+++ b/core/tool-layer/tool-repository.ts
@@ -83,40 +83,11 @@ export const TOOL_BUNDLE_DEFINITIONS = {
   'qa-tools': [...FT_CONTEXT, ...FT_READ, ...FT_GIT_READ, ...FT_QA],
   validate: [...FT_CONTEXT, ...FT_READ, ...FT_EVIDENCE],
   'emergency-debug': ['Bash'],
-  'playwright-mcp': [
-    'mcp__playwright-test__browser_click',
-    'mcp__playwright-test__browser_close',
-    'mcp__playwright-test__browser_console_messages',
-    'mcp__playwright-test__browser_drag',
-    'mcp__playwright-test__browser_evaluate',
-    'mcp__playwright-test__browser_file_upload',
-    'mcp__playwright-test__browser_handle_dialog',
-    'mcp__playwright-test__browser_hover',
-    'mcp__playwright-test__browser_navigate',
-    'mcp__playwright-test__browser_navigate_back',
-    'mcp__playwright-test__browser_network_requests',
-    'mcp__playwright-test__browser_press_key',
-    'mcp__playwright-test__browser_run_code',
-    'mcp__playwright-test__browser_select_option',
-    'mcp__playwright-test__browser_snapshot',
-    'mcp__playwright-test__browser_take_screenshot',
-    'mcp__playwright-test__browser_type',
-    'mcp__playwright-test__browser_wait_for',
-    'mcp__playwright-test__browser_verify_element_visible',
-    'mcp__playwright-test__browser_verify_list_visible',
-    'mcp__playwright-test__browser_verify_text_visible',
-    'mcp__playwright-test__browser_verify_value',
-    'mcp__playwright-test__planner_setup_page',
-    'mcp__playwright-test__planner_save_plan',
-    'mcp__playwright-test__generator_read_log',
-    'mcp__playwright-test__generator_setup_page',
-    'mcp__playwright-test__generator_write_test',
-  ],
 } satisfies Record<string, string[]>;
 
 export type BundleName = keyof typeof TOOL_BUNDLE_DEFINITIONS;
 
-const OPTIONAL_MCP_SERVER_BUNDLES = new Set<BundleName>(['playwright-mcp']);
+const OPTIONAL_MCP_SERVER_BUNDLES = new Set<BundleName>();
 const HOLDOUT_FORBIDDEN_CAPABILITIES = new Set<ToolCapability>(['write', 'native-shell']);
 
 const TOOL_DEFINITIONS = new Map<string, ToolDefinition>();
@@ -128,9 +99,6 @@ for (const externalName of FT_VERIFY) defineTool(externalName, ['verify']);
 for (const externalName of FT_GIT_READ) defineTool(externalName, ['git-read']);
 for (const externalName of FT_QA) defineTool(externalName, ['qa']);
 for (const externalName of FT_EVIDENCE) defineTool(externalName, ['evidence']);
-for (const externalName of TOOL_BUNDLE_DEFINITIONS['playwright-mcp']) {
-  defineTool(externalName, ['evidence']);
-}
 defineNativeTool('Bash', ['native-shell']);
 
 function defineTool(externalName: string, capabilities: ReadonlyArray<ToolCapability>): void {
@@ -171,8 +139,16 @@ export function bundleTools(bundleName: string): string[] {
   return [...(TOOL_BUNDLE_DEFINITIONS[bundleName as BundleName] ?? [])];
 }
 
+export function isKnownBundleName(bundleName: string): boolean {
+  return Object.hasOwn(TOOL_BUNDLE_DEFINITIONS, bundleName);
+}
+
 export function isOptionalMcpServerBundle(bundleName: string): boolean {
   return OPTIONAL_MCP_SERVER_BUNDLES.has(bundleName as BundleName);
+}
+
+export function isKnownToolName(externalName: string): boolean {
+  return TOOL_DEFINITIONS.has(externalName);
 }
 
 export function isToolAllowedForRole(externalName: string, role?: Role): boolean {

--- a/core/types.ts
+++ b/core/types.ts
@@ -71,11 +71,6 @@ export interface RoleModel {
   advisorProvider?: ModelProvider;
 }
 
-export interface ToolAllowlist {
-  bundles: string[];
-  extras?: string[];
-}
-
 export interface CoachPolicy {
   /** Whether the auto-trigger is active. Default false in supervised mode. */
   enabled: boolean;
@@ -94,7 +89,6 @@ export interface AgentConfig {
   runtime: 'claude-cli' | 'codex-cli' | 'auto';
   rolesModels: Partial<Record<Role, RoleModel>>;
   fallbackPolicy: Record<string, FallbackPolicy>;
-  toolAllowlists: Partial<Record<Role, ToolAllowlist>>;
   advisorMode: {
     enabled: boolean;
     triggerOn: { priorities: string[] };

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -28,6 +28,8 @@ export interface TierResult {
   passed: boolean;
   evidence: string[];
   findings: VerifyFinding[];
+  command?: string;
+  output?: string;
 }
 
 export interface RunArtifacts {
@@ -52,7 +54,7 @@ export interface TierDeps {
   runRegressionTestsImpl?: (
     command: string,
     cwd: string,
-  ) => Promise<{ passed: boolean; failedTests: string[] }>;
+  ) => Promise<{ passed: boolean; failedTests: string[]; output?: string }>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -376,7 +378,7 @@ function extractFailedTests(output: string): string[] {
 async function defaultRunRegressionTests(
   command: string,
   cwd: string,
-): Promise<{ passed: boolean; failedTests: string[] }> {
+): Promise<{ passed: boolean; failedTests: string[]; output?: string }> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     const child = spawn('sh', ['-c', command], {
@@ -388,10 +390,10 @@ async function defaultRunRegressionTests(
     child.stderr?.on('data', (d: Buffer) => chunks.push(d));
     child.on('exit', (code) => {
       const output = Buffer.concat(chunks).toString('utf8');
-      resolve({ passed: (code ?? 1) === 0, failedTests: extractFailedTests(output) });
+      resolve({ passed: (code ?? 1) === 0, failedTests: extractFailedTests(output), output });
     });
     child.on('error', (err) => {
-      resolve({ passed: false, failedTests: [err.message] });
+      resolve({ passed: false, failedTests: [err.message], output: err.message });
     });
   });
 }
@@ -448,6 +450,8 @@ export async function verifyRegression(
     passed: findings.filter((f) => f.severity === 'error').length === 0,
     evidence,
     findings,
+    command: testCommand,
+    output: testResult.output,
   };
 }
 

--- a/core/workflows/bootstrap-renderers.ts
+++ b/core/workflows/bootstrap-renderers.ts
@@ -127,18 +127,6 @@ const config: ProjectConfig = {
       medium: 'allow-down-tier',
       low: 'allow-down-tier',
     },
-    toolAllowlists: {
-      triager: { bundles: ['core'] },
-      griller: { bundles: ['core'] },
-      'prd-writer': { bundles: ['read', 'core'] },
-      decomposer: { bundles: ['read', 'core'] },
-      investigator: { bundles: ['read', 'core'] },
-      developer: { bundles: ['dev-tools'] },
-      qa: { bundles: ['qa-tools'] },
-      reviewer: { bundles: ['read', 'qa-tools'] },
-      retrospector: { bundles: ['core'] },
-      researcher: { bundles: ['read'] },
-    },
     advisorMode: {
       enabled: false,
       triggerOn: { priorities: [] },

--- a/skills/hub-chat/prompt.md
+++ b/skills/hub-chat/prompt.md
@@ -77,9 +77,9 @@ Return a single JSON object conforming exactly to the output schema. Free-text-o
   "say": "<the user-facing reply>",
   "proposals": [
     {
-      "toolName": "<one of CHAT_TOOL_REGISTRY names>",
-      "input": "{\"...\":\"...\"}",
-      "rationale": "<one sentence shown in the tool card; conditional only for mutating tools>"
+      "toolName": "list_projects",
+      "input": "{}",
+      "rationale": "List registered projects before answering the project selection question."
     }
   ],
   "done": false,

--- a/skills/hub-chat/schema.ts
+++ b/skills/hub-chat/schema.ts
@@ -1,3 +1,4 @@
+import { ChatToolNameSchema } from '@goose-hub/core/chat-tools/registry.js';
 import { DecisionSummarySchema } from '@goose-hub/core/retrospective/schemas.js';
 import { z } from 'zod';
 
@@ -21,7 +22,7 @@ export { DecisionSummarySchema };
  * the dispatcher runs it.
  */
 export const HubChatProposalSchema = z.object({
-  toolName: z.string().describe('Must match a name in core/chat-tools/registry.ts'),
+  toolName: ChatToolNameSchema.describe('Must match a name in core/chat-tools/registry.ts'),
   input: z
     .string()
     .min(2)

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -95,6 +95,7 @@ If a test harness/import/runtime failure appears, compare against an adjacent pa
 
 - Write test cases that fail with the current code. Cover the WP's acceptance criteria and
   at least one negative path.
+- Do not add or run Playwright e2e specs for ordinary product WPs. Use unit/component tests near the changed surface. E2e/browser validation belongs to QA/evidence workflows unless this WP is explicitly e2e/test-infra.
 - Run the targeted test command via `run_tests` (Claude name: `mcp__factory-tools__run_tests`; pass only the new test file paths).
 - Confirm the new tests fail and pre-existing tests still pass.
 - Emit: `[decision] RED: Wrote N failing tests for <surface>`
@@ -114,7 +115,7 @@ Only refactor if required to make the test pass cleanly.
 
 - If `stack.lintCommand` is provided, run it. Fix failures.
 - If `stack.typecheckCommand` is provided, run it. Fix errors.
-- Re-run targeted tests one final time to confirm still green. In `testsRun.paths`, return the canonical `paths[].path` values from `run_tests` / `mcp__factory-tools__run_tests`.
+- Re-run each written test file one final time by exact file path after the last edit to that test file. Directory-level or full-suite passes do not satisfy this final check. In `testsRun.paths`, return the canonical `paths[].path` values from `run_tests` / `mcp__factory-tools__run_tests`.
 - If executable checks fail because of infrastructure or tooling, retry once only. If the same infrastructure/tooling failure repeats, return `confidence: low` with a `BLOCKER` or `UNCERTAINTY` decision summary instead of searching for alternate commands.
 - Emit: `[decision] LINT: Lint and typecheck clean`
 

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -115,14 +115,15 @@ If a test harness/import/runtime failure appears, compare against an adjacent pa
 
 - Implement the smallest slice that satisfies the tests and every criterion in `<acceptanceContract>` when present.
 - Re-run targeted tests only after a real write has occurred, then iterate until green or blocked.
-- For frontend changes with evidence enabled, create/update `apps/web/e2e/issue-<number>.spec.ts` or the provided `relatedSurface.evidenceSpecPath`. Use bounded discovery; if blocked, return `evidenceSpecPath: null` with `TOOL_FAILURE` or `UNCERTAINTY`.
-- If `priorEvidenceSpecPath` is provided and your changes still touch `apps/web/`, reuse it as `evidenceSpecPath` unless the prior spec is now stale for the changed surface. If you cannot reuse it and cannot author a new one, return `evidenceSpecPath: null` with a `SKIP_GATE` decision summary explaining why (e.g., "evidence skipped: type-only handler export, no UI surface changed").
+- Do not add or run Playwright e2e specs for ordinary product fixes. Browser/e2e validation is owned by QA/evidence workflows unless the work item is explicitly e2e/test-infra.
+- For frontend product changes, add unit/component coverage near the changed surface. Return `evidenceSpecPath: null` unless an existing evidence path is provided and still applies.
+- If `priorEvidenceSpecPath` is provided and your changes still touch `apps/web/`, preserve it as `evidenceSpecPath` only when it remains applicable; do not inspect, rewrite, or execute that e2e spec from the implement run. If it is stale or not applicable, return `evidenceSpecPath: null` with a `SKIP_GATE` decision summary.
 - If evidence is disabled, return `evidenceSpecPath: null` with a `SKIP_GATE` summary.
 - Emit `[decision] GREEN: Targeted tests pass`.
 
 ### Bounded frontend evidence rule
 
-Do not inspect old e2e specs, Playwright config, or screenshot conventions before writing the implementation when the investigation already identifies the UI surface. Use the provided evidence path or the default `apps/web/e2e/issue-<number>.spec.ts`; if the route or e2e directory is unclear after one bounded check, ship the implementation plus targeted tests and return a `TOOL_FAILURE` or `UNCERTAINTY` summary instead of spending more discovery budget.
+Do not inspect old e2e specs, Playwright config, or screenshot conventions before writing the implementation when the investigation already identifies the UI surface. Ship the implementation plus targeted unit/component tests; QA/evidence will own browser validation.
 
 ### 5. Refactor, Score, Verify
 

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -81,6 +81,10 @@ If a WP owns production `.ts` or `.tsx` files, that same WP must also include a
 relevant `*.test.ts`, `*.test.tsx`, `*.spec.ts`, or `*.spec.tsx` file in
 `filesOwned`. Do not put the test file only in `verificationTooling` or
 `acceptanceCriteria`; it must be owned by the WP that owns the production edit.
+For ordinary product fixes, this paired coverage should be unit/component
+coverage near the changed surface. Do not assign `apps/web/e2e/*.spec.ts` to an
+implement WP unless the work item or WP is explicitly about e2e/test
+infrastructure. Browser/e2e validation is owned by QA/evidence workflows.
 
 Test-only WPs are allowed. Files that are not implementation surfaces, such as
 `*.config.ts`, `*.d.ts`, `*types.ts`, `*interfaces.ts`, `*schema.ts`,

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -759,6 +759,8 @@ describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () =
     expect(prompt).toContain('`*.spec.ts`');
     expect(prompt).toContain('Do not put the test file only in `verificationTooling`');
     expect(prompt).toContain('Test-only WPs are allowed');
+    expect(prompt).toContain('Do not assign `apps/web/e2e/*.spec.ts`');
+    expect(prompt).toContain('QA/evidence workflows');
   });
 
   it('rejects WP with production .ts files but no test file', () => {
@@ -939,6 +941,52 @@ describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () =
       (e) => e.rule === 'wp-missing-test-file',
     );
     expect(testFileErrors).toHaveLength(0);
+  });
+
+  it('rejects ordinary product WP ownership of apps/web/e2e specs', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: [
+            'apps/web/src/components/HealthBadge.tsx',
+            'apps/web/e2e/issue-1107.spec.ts',
+          ],
+          changes: 'Add HealthBadge component and browser regression coverage.',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      interfaceContracts: [],
+    });
+
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'wp-e2e-owned-for-product')).toBe(true);
+  });
+
+  it('allows e2e spec ownership for explicit e2e test-infra WPs', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP-e2e',
+          filesOwned: ['apps/web/e2e/issue-1107.spec.ts'],
+          changes: 'Update Playwright e2e test infrastructure for the browser flow.',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP-e2e'] }],
+      interfaceContracts: [],
+    });
+
+    const result = validateEngineeringSpec(spec);
+    const e2eErrors = (result.ok ? [] : result.errors).filter(
+      (e) => e.rule === 'wp-e2e-owned-for-product',
+    );
+    expect(e2eErrors).toHaveLength(0);
   });
 });
 

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -51,7 +51,8 @@ export type ValidationRule =
   | 'self-check-verification-tooling'
   | 'verification-tool-command-malformed'
   | 'verification-tool-command-package-relative'
-  | 'wp-missing-test-file';
+  | 'wp-missing-test-file'
+  | 'wp-e2e-owned-for-product';
 
 export type ValidationResult = { ok: true } | { ok: false; errors: ValidationError[] };
 
@@ -74,6 +75,7 @@ export interface ValidationOptions {
 
 const DEFAULT_SENSITIVE_PATTERN = /(auth|session|crypto|secret)/i;
 const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
+const WEB_E2E_SPEC_PATTERN = /^apps\/web\/e2e\/.*\.spec\.ts$/;
 
 function isBareRepoPathCommand(command: string): boolean {
   const trimmed = command.trim();
@@ -332,10 +334,21 @@ export function validateEngineeringSpec(
   const isProductionTs = (f: string) =>
     (f.endsWith('.ts') || f.endsWith('.tsx')) && !EXEMPT_SUFFIX.test(f);
   const isTestFile = (f: string) => /\.(test|spec)\.(ts|tsx)$/.test(f);
+  const isWebE2eSpec = (f: string) => WEB_E2E_SPEC_PATTERN.test(f.replace(/^\.\//, ''));
+  const isExplicitE2eWp = (wp: EngineeringSpec['workPackages'][number]) =>
+    /\b(e2e|playwright|test[- ]?infra|test infrastructure)\b/i.test(`${wp.id} ${wp.changes}`);
   for (const wp of spec.workPackages) {
     const paths = wp.filesOwned.map(fileOwnedPath);
     const hasProductionTs = paths.some(isProductionTs);
     const hasTestFile = paths.some(isTestFile);
+    const e2eSpecs = paths.filter(isWebE2eSpec);
+    if (e2eSpecs.length > 0 && !isExplicitE2eWp(wp)) {
+      errors.push({
+        rule: 'wp-e2e-owned-for-product',
+        message: `WP '${wp.id}' owns e2e spec path(s) ${e2eSpecs.join(', ')} without explicit e2e/test-infra scope; product WPs should use unit/component tests and leave e2e to QA/evidence`,
+        ref: wp.id,
+      });
+    }
     if (hasProductionTs && !hasTestFile) {
       errors.push({
         rule: 'wp-missing-test-file',

--- a/slices/chat-orchestrator/slice.test.ts
+++ b/slices/chat-orchestrator/slice.test.ts
@@ -249,7 +249,7 @@ describe('chat-orchestrator slice', () => {
     expect(result.telemetry.tokens.estimatedInput.contextSections.priorMessages).toBeGreaterThan(0);
   });
 
-  it('drops proposals for unknown tool names', async () => {
+  it('rejects output with unknown proposal tool names', async () => {
     mockInvokeOnce({
       resolve: {
         ...baseInvokeResult,
@@ -269,7 +269,11 @@ describe('chat-orchestrator slice', () => {
       history: [],
       runId: 'chat_test_run_2',
     });
-    expect(result.reply?.proposals.map((p) => p.toolName)).toEqual(['list_projects']);
+    expect(result.reply).toMatchObject({
+      say: 'I tried to reply but the structured output failed validation. Please try again.',
+      proposals: [],
+      done: false,
+    });
   });
 
   it('decodes proposal input JSON before returning dispatcher-ready proposals', async () => {

--- a/slices/chat-orchestrator/workflow.ts
+++ b/slices/chat-orchestrator/workflow.ts
@@ -459,11 +459,11 @@ export async function runChatOrchestratorTurn(input: ChatTurnInput): Promise<Cha
         telemetry,
       };
     }
-    // Reconcile proposals: drop unknown tools and malformed JSON inputs before
-    // handing off to the dispatcher.
+    // Reconcile proposals: drop malformed JSON inputs before handing off to
+    // the dispatcher. Tool-name validity is owned by HubChatOutputSchema.
     const validProposals = parsed.data.proposals
       .map(decodeProposalInput)
-      .filter((p): p is HubChatProposal => p != null && manifestHas(p.toolName));
+      .filter((p): p is HubChatProposal => p != null);
     telemetry.durationMs.postModelParsing = elapsedSince(parsingStarted);
     telemetry.durationMs.total = elapsedSince(totalStarted);
     Object.assign(telemetry.tokens, readActualTokens(runId));
@@ -507,10 +507,6 @@ function decodeProposalInput(proposal: HubChatWireProposal): HubChatProposal | n
   } catch {
     return null;
   }
-}
-
-function manifestHas(name: string): boolean {
-  return listToolManifests().some((t) => t.name === name);
 }
 
 type ThinkingCheckpoint = 'skill-invoked' | 'structured-output-received';

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -412,6 +412,121 @@ describe('runFixFeedbackWorkflow', () => {
     );
   });
 
+  it('routes regression-unrelated QA failures to needs-human instead of issue repair', async () => {
+    const workItem = makeWorkItem();
+    const compareBaseline = vi.fn().mockResolvedValue({
+      status: 'same-failures-on-base',
+      feedback: 'Baseline comparison: same failures on origin/main',
+    });
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        ...makeQaCompletedEvent(false),
+        payload: {
+          verdict: 'fail',
+          overallScore: 40,
+          threshold: 70,
+          failureCategory: 'regression-unrelated',
+          tierResults: {
+            structural: { passed: true, findings: [] },
+            functional: { passed: true, findings: [] },
+            regression: {
+              passed: false,
+              findings: [
+                {
+                  tier: 'regression',
+                  severity: 'error',
+                  description: 'Global e2e seed fails on base',
+                  suggestion: 'Fix pipeline seed data',
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo', {
+      baselineRegressionComparisonImpl: compareBaseline,
+    });
+
+    expect(compareBaseline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreePath: '/work/wt',
+        baseBranch: 'main',
+      }),
+    );
+    expect(mockClaudeCliRun).not.toHaveBeenCalled();
+    expect(stateSource.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    expect(eventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.fix-feedback-skipped',
+        payload: expect.objectContaining({
+          reason: 'baseline-red-global',
+          sourceFeedback: expect.stringContaining('regression suite failed'),
+        }),
+      }),
+    );
+  });
+
+  it('repairs regression-unrelated QA failures when baseline comparison is head-only', async () => {
+    const workItem = makeWorkItem();
+    const compareBaseline = vi.fn().mockResolvedValue({
+      status: 'head-only-failure',
+      feedback: 'Baseline comparison: regression passed on origin/main',
+    });
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        ...makeQaCompletedEvent(false),
+        payload: {
+          verdict: 'fail',
+          overallScore: 40,
+          threshold: 70,
+          failureCategory: 'regression-unrelated',
+          tierResults: {
+            structural: { passed: true, findings: [] },
+            functional: { passed: true, findings: [] },
+            regression: {
+              passed: false,
+              findings: [
+                {
+                  tier: 'regression',
+                  severity: 'error',
+                  description: 'Regression [escalate]: failing head-only suite',
+                  suggestion: 'Repair the regression',
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo', {
+      baselineRegressionComparisonImpl: compareBaseline,
+    });
+
+    expect(mockClaudeCliRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          advisorFeedback: expect.stringContaining('head-only'),
+        }),
+      }),
+    );
+    expect(stateSource.transitionState).toHaveBeenNthCalledWith(
+      1,
+      '42',
+      'factory:needs-fix',
+      'factory:in-progress',
+    );
+  });
+
   it('commits repair edits and pushes the existing PR branch before completion', async () => {
     mockDeriveObservedChangedFiles.mockReturnValue({
       count: 2,

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -1,4 +1,7 @@
-import { posix as pathPosix } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin, posix as pathPosix } from 'node:path';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { getChangedFilesSince } from '@goose-hub/core/agent-runtime/git-intel.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
@@ -115,6 +118,7 @@ export interface FixFeedbackDeps {
   runtime?: AgentRuntime;
   orchestratorCommitAllImpl?: typeof orchestratorCommitAll;
   orchestratorPushBranchImpl?: typeof orchestratorPushBranch;
+  baselineRegressionComparisonImpl?: typeof compareRegressionAgainstBaseline;
 }
 
 /**
@@ -153,7 +157,22 @@ function findPrLifecycle(events: ReturnType<typeof eventStore.replay>): PrLifecy
 
 type TierResult = {
   passed: boolean;
+  command?: string | null;
+  output?: string | null;
   findings: Array<{ tier: string; severity: string; description: string; suggestion?: string }>;
+};
+
+type BaselineComparisonStatus = 'same-failures-on-base' | 'head-only-failure' | 'unavailable';
+
+type BaselineComparisonResult = {
+  status: BaselineComparisonStatus;
+  feedback: string;
+};
+
+type BaselineComparisonInput = {
+  payload: QaPayload;
+  worktreePath: string;
+  baseBranch?: string;
 };
 
 type QaPayload = {
@@ -216,6 +235,9 @@ type SourceFailure = {
   feedback: string;
   actionable: boolean;
   verificationInfrastructure?: boolean;
+  baselineRedGlobal?: boolean;
+  requiresBaselineComparison?: boolean;
+  payload?: QaPayload;
   skipReason?: string;
 };
 
@@ -319,6 +341,135 @@ function formatVerificationBlockedFeedback(payload: QaPayload): string {
   return lines.join('\n');
 }
 
+function formatRegressionUnrelatedFeedback(payload: QaPayload): string {
+  const lines = [
+    'QA regression suite failed outside the issue-specific implementation surface.',
+    `Failure category: ${payload.failureCategory ?? 'regression-unrelated'}`,
+    'Compare against base/main before deciding whether this belongs to the issue repair loop.',
+  ];
+  const regressionFindings = payload.tierResults?.regression?.findings ?? [];
+  for (const finding of regressionFindings.slice(0, 5)) {
+    lines.push(`- ${finding.description}`);
+  }
+  return lines.join('\n');
+}
+
+function regressionCommandForPayload(payload: QaPayload): string | null {
+  const command = payload.tierResults?.regression?.command;
+  return typeof command === 'string' && command.trim().length > 0 ? command.trim() : null;
+}
+
+function regressionFailureDescriptions(payload: QaPayload): string[] {
+  return (payload.tierResults?.regression?.findings ?? [])
+    .map((finding) => finding.description)
+    .filter((description) => description.trim().length > 0);
+}
+
+function normalizeFailureSignature(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^regression\s*\[[^\]]+\]:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 240);
+}
+
+function extractFailedTestLines(output: string): string[] {
+  const failed: string[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.length > 240) continue;
+    if (trimmed.includes('FAIL') || trimmed.includes('✗') || trimmed.includes('× ')) {
+      failed.push(trimmed);
+    }
+  }
+  return failed.slice(0, 20);
+}
+
+function signaturesOverlap(left: string, right: string): boolean {
+  if (left.length === 0 || right.length === 0) return false;
+  return left === right || left.includes(right) || right.includes(left);
+}
+
+async function compareRegressionAgainstBaseline({
+  payload,
+  worktreePath,
+  baseBranch = 'main',
+}: BaselineComparisonInput): Promise<BaselineComparisonResult> {
+  const command = regressionCommandForPayload(payload);
+  if (command == null) {
+    return {
+      status: 'unavailable',
+      feedback:
+        'Baseline comparison unavailable: regression tier payload did not include a command.',
+    };
+  }
+
+  const baselineDir = mkdtempSync(pathJoin(tmpdir(), 'goose-hub-baseline-'));
+  const baseRef = baseBranch.startsWith('origin/') ? baseBranch : `origin/${baseBranch}`;
+  try {
+    const add = spawnSync(
+      'git',
+      ['-C', worktreePath, 'worktree', 'add', '--detach', baselineDir, baseRef],
+      {
+        encoding: 'utf8',
+        timeout: 120_000,
+      },
+    );
+    if (add.status !== 0) {
+      return {
+        status: 'unavailable',
+        feedback: `Baseline comparison unavailable: could not create ${baseRef} worktree (${add.stderr || add.stdout || 'git worktree add failed'}).`,
+      };
+    }
+
+    const run = spawnSync('sh', ['-c', command], {
+      cwd: baselineDir,
+      encoding: 'utf8',
+      env: { ...process.env, CI: '1', FORCE_COLOR: '0' },
+      timeout: 10 * 60_000,
+    });
+    if (run.error != null) {
+      return {
+        status: 'unavailable',
+        feedback: `Baseline comparison unavailable: ${run.error.message}.`,
+      };
+    }
+    if ((run.status ?? 1) === 0) {
+      return {
+        status: 'head-only-failure',
+        feedback: `Baseline comparison: ${command} passed on ${baseRef}; regression appears head-only.`,
+      };
+    }
+
+    const baseOutput = `${run.stdout ?? ''}\n${run.stderr ?? ''}`;
+    const baseFailures = extractFailedTestLines(baseOutput).map(normalizeFailureSignature);
+    const headFailures = regressionFailureDescriptions(payload).map(normalizeFailureSignature);
+    const sameFailures =
+      baseFailures.length > 0 && headFailures.length > 0
+        ? headFailures.some((head) => baseFailures.some((base) => signaturesOverlap(head, base)))
+        : baseFailures.length > 0;
+
+    if (sameFailures) {
+      return {
+        status: 'same-failures-on-base',
+        feedback: `Baseline comparison: ${command} also failed on ${baseRef}; route as baseline-red/global instead of issue repair.`,
+      };
+    }
+
+    return {
+      status: 'head-only-failure',
+      feedback: `Baseline comparison: ${command} failed on ${baseRef}, but not with the same failure signature; repair the head regression.`,
+    };
+  } finally {
+    spawnSync('git', ['-C', worktreePath, 'worktree', 'remove', '--force', baselineDir], {
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+    rmSync(baselineDir, { recursive: true, force: true });
+  }
+}
+
 async function findLatestSourceFailure(
   events: ReturnType<typeof eventStore.replay>,
   stateSource: StateSource,
@@ -378,6 +529,16 @@ async function findLatestSourceFailure(
         skipReason: 'verification-infrastructure',
       };
     }
+    if (payload.failureCategory === 'regression-unrelated') {
+      return {
+        kind: 'qa',
+        runId: sourceRunId(qaEvent),
+        feedback: formatRegressionUnrelatedFeedback(payload),
+        actionable: false,
+        requiresBaselineComparison: true,
+        payload,
+      };
+    }
     const { verdict = 'fail', overallScore = 0, threshold = 70 } = payload;
     const verifiedFollowUpRefs = await verifiedFollowUpRefsForPayload(payload, stateSource);
     const actionableItems = collectActionableQaItems(
@@ -432,7 +593,7 @@ export async function runFixFeedbackWorkflow(
   const attemptId = crypto.randomUUID();
   const events = eventStore.replay({ workItemId: workItem.id });
   const prLifecycle = findPrLifecycle(events);
-  const sourceFailure = await findLatestSourceFailure(events, stateSource);
+  let sourceFailure = await findLatestSourceFailure(events, stateSource);
   const repairCycle = nextRepairCycle(events);
   const repairPayload = compactPayload({
     pipelineRunId: prLifecycle?.pipelineRunId,
@@ -451,6 +612,8 @@ export async function runFixFeedbackWorkflow(
   const projectConfig = await getProjectBySlug(projectId);
   const commitAllFn = deps.orchestratorCommitAllImpl ?? orchestratorCommitAll;
   const pushBranchFn = deps.orchestratorPushBranchImpl ?? orchestratorPushBranch;
+  const compareRegressionFn =
+    deps.baselineRegressionComparisonImpl ?? compareRegressionAgainstBaseline;
   const { runtime, resolvedBudget } = resolveProjectAgentExecution({
     skill: 'fix-feedback',
     role: 'developer',
@@ -458,6 +621,41 @@ export async function runFixFeedbackWorkflow(
     projectConfig,
     injectedRuntime: deps.runtime,
   });
+
+  if (sourceFailure?.requiresBaselineComparison === true && sourceFailure.payload != null) {
+    const worktreePath = prLifecycle?.worktreePath;
+    if (worktreePath == null) {
+      sourceFailure = {
+        ...sourceFailure,
+        baselineRedGlobal: true,
+        skipReason: 'baseline-compare-unavailable',
+        feedback: `${sourceFailure.feedback}\n\nBaseline comparison unavailable: no integration worktree was recorded.`,
+      };
+    } else {
+      const comparison = await compareRegressionFn({
+        payload: sourceFailure.payload,
+        worktreePath,
+        baseBranch: prLifecycle?.baseBranch,
+      });
+      if (comparison.status === 'head-only-failure') {
+        sourceFailure = {
+          ...sourceFailure,
+          actionable: true,
+          feedback: `${sourceFailure.feedback}\n\n${comparison.feedback}`,
+        };
+      } else {
+        sourceFailure = {
+          ...sourceFailure,
+          baselineRedGlobal: true,
+          skipReason:
+            comparison.status === 'same-failures-on-base'
+              ? 'baseline-red-global'
+              : 'baseline-compare-unavailable',
+          feedback: `${sourceFailure.feedback}\n\n${comparison.feedback}`,
+        };
+      }
+    }
+  }
 
   if (sourceFailure?.verificationInfrastructure === true) {
     await stateSource.comment(
@@ -490,6 +688,44 @@ export async function runFixFeedbackWorkflow(
       payload: {
         ...repairPayload,
         reason: sourceFailure.skipReason ?? 'verification-infrastructure',
+        sourceFeedback: sourceFailure.feedback,
+      },
+      runId,
+    });
+    return;
+  }
+
+  if (sourceFailure?.baselineRedGlobal === true) {
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Dev',
+        'Baseline Red',
+        'Skipping fix-feedback because QA found regression-suite failures outside this issue-specific change.',
+        [sourceFailure.feedback],
+      ),
+    );
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    emitStateTransitionEvent({
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:needs-fix',
+      to: 'factory:needs-human',
+      by: 'fix-feedback',
+      runId,
+      extraPayload: repairPayload,
+    });
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.fix-feedback-skipped',
+      payload: {
+        ...repairPayload,
+        reason: sourceFailure.skipReason ?? 'baseline-red-global',
         sourceFeedback: sourceFailure.feedback,
       },
       runId,

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1394,6 +1394,191 @@ describe('implement-wp ownership gate', () => {
     expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
   });
 
+  it('requires exact-file run_tests success after the last edit to each written test', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+    const runId = 'run-wp-exact-final:wp:WP1:iter:1';
+    const passingBeforeEdit: AgentEvent = {
+      id: 1003,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src/foo.test.ts',
+          paths: ['apps/web/src/foo.test.ts'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const editAfterPass: AgentEvent = {
+      id: 1004,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'edit_file',
+        status: 'ok',
+        tool_input: { path: 'apps/web/src/foo.test.ts' },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const directoryPassAfterEdit: AgentEvent = {
+      id: 1005,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src',
+          paths: ['apps/web/src'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-exact-final',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: {
+        run: vi.fn().mockResolvedValue({
+          output,
+          events: [passingBeforeEdit, editAfterPass, directoryPassAfterEdit],
+        }),
+      },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('exact-file run_tests success'),
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
+  });
+
+  it('treats pathless successful shell writes as invalidating written-test proof', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
+    const { fn: appendEvent } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+    const runId = 'run-wp-pathless-edit:wp:WP1:iter:1';
+    const exactPassBeforePathlessEdit: AgentEvent = {
+      id: 1013,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src/foo.test.ts',
+          paths: ['apps/web/src/foo.test.ts'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const pathlessWriteAfterPass: AgentEvent = {
+      id: 1014,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'bash',
+        status: 'ok',
+        tool_input: { command: "sed -i '' 's/a/b/' apps/web/src/foo.test.ts" },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-pathless-edit',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: {
+        run: vi.fn().mockResolvedValue({
+          output,
+          events: [exactPassBeforePathlessEdit, pathlessWriteAfterPass],
+        }),
+      },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('exact-file run_tests success'),
+    });
+  });
+
   it('fails required verification when no verification tool passed even with high confidence', async () => {
     const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts']);
     const { fn: appendEvent } = makeAppendEvent();

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -181,6 +181,10 @@ function pathsMatch(left: string, right: string): boolean {
   return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
 }
 
+function pathsExactlyMatch(left: string, right: string): boolean {
+  return normalizePathForCompare(left) === normalizePathForCompare(right);
+}
+
 function isTerminalDecisionKind(kind: unknown): kind is TerminalDecisionKind {
   return kind === 'TOOL_FAILURE' || kind === 'BLOCKER';
 }
@@ -230,6 +234,32 @@ function latestRunTestsStatusForPath(events: AgentEvent[], path: string): string
   return null;
 }
 
+function latestExactRunTestsStatusForPathAfterLastEdit(
+  events: AgentEvent[],
+  path: string,
+): string | null {
+  let lastEditIndex = -1;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (toolCallStatus(event) !== 'ok') continue;
+    if (!isEditToolCall(event)) continue;
+    const editedPaths = toolCallPaths(event);
+    if (editedPaths.length === 0 || editedPaths.some((candidate) => pathsMatch(candidate, path))) {
+      lastEditIndex = i;
+    }
+  }
+
+  for (let i = events.length - 1; i > lastEditIndex; i--) {
+    const event = events[i];
+    if (toolCallName(event) !== 'run_tests') continue;
+    const paths = toolCallPaths(event);
+    if (paths.length === 0) continue;
+    if (!paths.some((candidate) => pathsExactlyMatch(candidate, path))) continue;
+    return toolCallStatus(event);
+  }
+  return null;
+}
+
 function hasSuccessfulVerificationToolCall(events: AgentEvent[]): boolean {
   return events.some((event) => {
     if (event.kind !== 'agent.tool-call') return false;
@@ -254,14 +284,21 @@ function implementWpAcceptanceFailure(input: {
       reason: 'implement-wp returned low confidence while verification was required',
     };
   }
-  const requiredTestPaths = [
-    ...new Set([
-      ...input.output.testsWritten.map((test) => test.path),
-      ...input.output.testsRun.paths,
-    ]),
-  ];
-  if (requiredTestPaths.length > 0) {
-    const failedPaths = requiredTestPaths.filter(
+  const writtenTestPaths = [...new Set(input.output.testsWritten.map((test) => test.path))];
+  if (writtenTestPaths.length > 0) {
+    const failedWrittenTestPaths = writtenTestPaths.filter(
+      (path) => latestExactRunTestsStatusForPathAfterLastEdit(input.events, path) !== 'ok',
+    );
+    if (failedWrittenTestPaths.length > 0) {
+      return {
+        kind: 'verification-failed',
+        reason: `written test files need exact-file run_tests success after their last edit: ${failedWrittenTestPaths.join(', ')}`,
+      };
+    }
+  }
+  const reportedRunPaths = [...new Set(input.output.testsRun.paths)];
+  if (reportedRunPaths.length > 0) {
+    const failedPaths = reportedRunPaths.filter(
       (path) => latestRunTestsStatusForPath(input.events, path) !== 'ok',
     );
     if (failedPaths.length > 0) {

--- a/slices/qa/synthetic-output.ts
+++ b/slices/qa/synthetic-output.ts
@@ -51,6 +51,8 @@ function asTierResult(tier: 1 | 2 | 3, vt: VerifyTierResult): TierResult {
   return {
     passed: vt.passed,
     findings: vt.findings.map((f) => mapVerifyFinding(tier, f)),
+    ...(vt.command != null ? { command: vt.command } : {}),
+    ...(vt.output != null ? { output: vt.output } : {}),
   };
 }
 

--- a/slices/smoke-gate/slice.test.ts
+++ b/slices/smoke-gate/slice.test.ts
@@ -63,7 +63,6 @@ function makeConfig(
       runtime: 'claude-cli',
       rolesModels: {} as ProjectConfig['agentConfig']['rolesModels'],
       fallbackPolicy: {} as ProjectConfig['agentConfig']['fallbackPolicy'],
-      toolAllowlists: {} as ProjectConfig['agentConfig']['toolAllowlists'],
       advisorMode: {
         enabled: false,
         triggerOn: { priorities: [] },

--- a/target-projects/goose-hub-self/project.config.ts
+++ b/target-projects/goose-hub-self/project.config.ts
@@ -52,23 +52,6 @@ const config: ProjectConfig = {
       medium: 'allow-down-tier',
       low: 'allow-down-tier',
     },
-    toolAllowlists: {
-      triager: { bundles: ['core'], extras: ['work-item-label'] },
-      griller: { bundles: ['core'], extras: ['work-item-comment'] },
-      'prd-writer': { bundles: ['read', 'core'], extras: ['work-item-comment'] },
-      decomposer: { bundles: ['read', 'core', 'workItemAdmin'] },
-      investigator: { bundles: ['read', 'core'] },
-      developer: { bundles: ['read', 'write', 'shell'] },
-      qa: { bundles: ['read', 'shell', 'validate'] },
-      reviewer: { bundles: ['read', 'validate'] },
-      retrospector: { bundles: ['core'], extras: ['event-read', 'persona-stats'] },
-      researcher: { bundles: ['web', 'workItemAdmin'] },
-      auditor: { bundles: ['read', 'shell'] },
-      // Hub Chat assistant needs broad read across the workspace; tool
-      // permissions for chat-tool dispatch are scoped per-tool in
-      // core/chat-tools/registry.ts (mutating tools always require approval).
-      assistant: { bundles: ['read', 'core'] },
-    },
     advisorMode: {
       enabled: true,
       triggerOn: { priorities: ['critical', 'high'] },


### PR DESCRIPTION
## Summary
- remove legacy project tool allowlist config and bootstrap rendering
- warn and skip unknown tool bundles/extras in tool binding instead of expanding them
- remove the legacy playwright-mcp bundle/config merge path
- constrain Hub Chat proposal tool names to the chat registry and add registry/implementation parity coverage

## Verification
- pnpm test core/tool-layer/slice.test.ts core/tool-layer/mcp/build-config.test.ts core/chat-tools/registry.test.ts apps/server/src/domains/chat/tools.test.ts slices/chat-orchestrator/slice.test.ts core/agent-runtime/claude-cli.test.ts core/agent-runtime/codex-cli-runtime.test.ts
- pnpm typecheck
- pnpm skill-contract:audit
- pnpm audit-docs
- pnpm exec biome check apps/server/src/domains/chat/tools.test.ts core/agent-runtime/claude-cli.test.ts core/agent-runtime/claude-cli.ts core/agent-runtime/codex-cli-runtime.test.ts core/agent-runtime/codex-cli.ts core/audit/slice.test.ts core/tool-layer/mcp/build-config.test.ts core/tool-layer/mcp/build-config.ts core/tool-layer/slice.test.ts core/tool-layer/tool-binding.ts core/tool-layer/tool-repository.ts core/types.ts core/workflows/bootstrap-renderers.ts skills/hub-chat/schema.ts slices/chat-orchestrator/slice.test.ts slices/chat-orchestrator/workflow.ts slices/smoke-gate/slice.test.ts target-projects/goose-hub-self/project.config.ts