### PR TITLE
Harden post-cleanup verification boundaries

### DIFF
--- a/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
@@ -182,6 +182,29 @@ describe('QA timeline events', () => {
     expect(screen.getByText('Product')).toBeTruthy();
   });
 
+  it('labels regression tier as a suite and surfaces the actual command', () => {
+    const event = makeEvent('qa.completed', {
+      verdict: 'fail',
+      overallScore: 40,
+      threshold: 70,
+      tierResults: {
+        structural: { passed: true, findings: [] },
+        functional: { passed: true, findings: [] },
+        regression: {
+          passed: false,
+          command: 'pnpm --filter @goose-hub/web test:e2e:pipeline',
+          findings: [],
+        },
+      },
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Regression suite')).toBeTruthy();
+    expect(screen.getByText('pnpm --filter @goose-hub/web test:e2e:pipeline')).toBeTruthy();
+    expect(document.body.textContent).not.toContain('Regression (playwright)');
+  });
+
   it('renders verification-blocked failure category badges', () => {
     const event = makeEvent('qa.verification-blocked', {
       failedTier: 2,

--- a/apps/web/src/components/detail/components/timeline/QaEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.tsx
@@ -271,7 +271,7 @@ export function QaCompletedEvent({ event }: { event: AgentEventDto }) {
   const tierRows: { key: 'structural' | 'functional' | 'regression'; label: string }[] = [
     { key: 'structural', label: 'Structural' },
     { key: 'functional', label: 'Functional' },
-    { key: 'regression', label: 'Regression (playwright)' },
+    { key: 'regression', label: 'Regression suite' },
   ];
 
   return (

--- a/core/agent-runtime/dev-review-advisor.test.ts
+++ b/core/agent-runtime/dev-review-advisor.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { getArtifact } from '../agent-artifacts/repository.js';
 import { db } from '../db/db.js';
 import { agentArtifacts } from '../db/schema.js';
-import { preparePrDiffContext, runDevReviewResponse } from './dev-review-advisor.js';
+import { preparePrDiffContext, runDevReview, runDevReviewResponse } from './dev-review-advisor.js';
 import { buildDiffDigest } from './diff-digest.js';
 import type { AgentSpec } from './interface.js';
 
@@ -216,6 +216,47 @@ describe('preparePrDiffContext', () => {
 });
 
 describe('runDevReviewResponse runtime resolution', () => {
+  it('runs dev-review inside the integration worktree', async () => {
+    const runtimeCalls: AgentSpec[] = [];
+    const runtime = {
+      async run(spec: AgentSpec) {
+        runtimeCalls.push(spec);
+        return {
+          output: {
+            verdict: 'no-blockers',
+            findings: [],
+            decisionSummaries: [{ kind: 'VERDICT', summary: 'No blockers found.' }],
+          },
+          decisionSummaries: [],
+          events: [],
+        };
+      },
+    };
+
+    await runDevReview({
+      runId: RUN_ID,
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      workItem: { title: 'Fix ordering', body: 'body', number: 77, priority: 'high' },
+      worktreePath: process.cwd(),
+      baseBranch: 'HEAD',
+      stack: { testCommand: 'pnpm test' },
+      runtime,
+      appendEvent: (input) => ({
+        ...input,
+        workItemId: input.workItemId ?? null,
+        id: 1,
+        createdAt: new Date().toISOString(),
+      }),
+    });
+
+    expect(runtimeCalls).toHaveLength(1);
+    expect(runtimeCalls[0]).toMatchObject({
+      skill: 'dev-review',
+      workspaceDir: process.cwd(),
+    });
+  });
+
   it('honours project skill provider settings when no runtime is injected', async () => {
     await runDevReviewResponse({
       runId: RUN_ID,

--- a/core/agent-runtime/dev-review-advisor.ts
+++ b/core/agent-runtime/dev-review-advisor.ts
@@ -300,6 +300,7 @@ export async function runDevReview(input: RunDevReviewInput): Promise<DevReviewO
     personaId,
     outputJsonSchema,
     appendSystemPrompt: prompt,
+    workspaceDir: input.worktreePath,
   });
   emitSymbolIndexHintsUsedEvent({
     projectId: input.projectId,

--- a/core/tool-layer/mcp/run-cache.ts
+++ b/core/tool-layer/mcp/run-cache.ts
@@ -286,13 +286,13 @@ export function invalidateRunCacheForPaths(runId: string, rawPaths: string[]): v
     }
   }
   if (duplicateMap?.size === 0) duplicateCounters.delete(runId);
-  // Writes invalidate the retry cap for any path they touch — and for the
-  // full-suite sentinel, since the next full run may now produce different
-  // results.
+  // Keep retry caps strict for unrelated edits while allowing one clean rerun
+  // after the failing test, a sibling source file, or the full-suite sentinel
+  // has actually changed.
   for (const [retryKey] of retryMap ?? []) {
     if (
       retryKey === TEST_RETRY_ALL_KEY ||
-      changedPaths.some((changedPath) => pathsOverlap(retryKey, changedPath))
+      changedPaths.some((changedPath) => retryKeyInvalidatedByChange(retryKey, changedPath))
     ) {
       retryMap?.delete(retryKey);
     }
@@ -455,6 +455,21 @@ function pathsOverlap(left: string, right: string): boolean {
   const b = normalizePathForOverlap(right);
   if (a === '.' || b === '.') return true;
   return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function implementationBase(path: string): string | null {
+  const normalized = normalizePathForOverlap(path);
+  const testBase = normalized.replace(/\.(test|spec)\.(ts|tsx)$/, '');
+  if (testBase !== normalized) return testBase;
+  const sourceBase = normalized.replace(/\.(ts|tsx)$/, '');
+  return sourceBase !== normalized ? sourceBase : null;
+}
+
+function retryKeyInvalidatedByChange(retryKey: string, changedPath: string): boolean {
+  if (pathsOverlap(retryKey, changedPath)) return true;
+  const retryBase = implementationBase(retryKey);
+  const changedBase = implementationBase(changedPath);
+  return retryBase != null && changedBase != null && retryBase === changedBase;
 }
 
 function cloneResult<T>(result: T): T {

--- a/core/tool-layer/mcp/tools/verify.test.ts
+++ b/core/tool-layer/mcp/tools/verify.test.ts
@@ -133,6 +133,38 @@ describe('runTestsTool', () => {
       },
     });
   });
+
+  it('rejects Playwright e2e spec paths because e2e is QA/evidence-owned', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+    mkdirSync(join(workspace, 'apps/web/e2e'), { recursive: true });
+    writeFileSync(join(workspace, 'apps/web/e2e/issue-1107.spec.ts'), 'test("x", () => {});\n');
+
+    mockRunCommand.mockClear();
+    const result = await runTestsTool(ctx, { path: 'apps/web/e2e/issue-1107.spec.ts' });
+
+    expect(result.status).toBe('failed');
+    expect(result.stderr).toContain('QA/evidence-owned');
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(result.paths?.map((path) => path.path)).toEqual(['apps/web/e2e/issue-1107.spec.ts']);
+  });
+
+  it('rejects Playwright e2e directory paths because e2e is QA/evidence-owned', async () => {
+    writeFileSync(join(workspace, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({ name: 'demo' }));
+    writeFileSync(join(workspace, 'README.md'), '# demo\n');
+    mkdirSync(join(workspace, 'apps/web/e2e/pipeline'), { recursive: true });
+    writeFileSync(join(workspace, 'apps/web/e2e/pipeline/seed.spec.ts'), 'test("x", () => {});\n');
+
+    mockRunCommand.mockClear();
+    const result = await runTestsTool(ctx, { path: 'apps/web/e2e/pipeline' });
+
+    expect(result.status).toBe('failed');
+    expect(result.stderr).toContain('QA/evidence-owned');
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(result.paths?.map((path) => path.path)).toEqual(['apps/web/e2e/pipeline']);
+  });
 });
 
 describe('runTargetedCommandTool', () => {
@@ -196,6 +228,33 @@ describe('runTestsTool retry cap', () => {
     const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
     expect(mockRunCommand).toHaveBeenCalledOnce();
     expect(next.status).toBe('failed');
+  });
+
+  it('resets the cap after a source edit, allowing one final exact test rerun', async () => {
+    const { invalidateRunCacheForPaths } = await import('../run-cache.js');
+    mockFailed();
+    for (let i = 0; i < 3; i++) await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+
+    invalidateRunCacheForPaths(ctx.runId, ['apps/web/src/foo.ts']);
+
+    mockRunCommand.mockClear();
+    const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+    expect(mockRunCommand).toHaveBeenCalledOnce();
+    expect(next.status).toBe('failed');
+  });
+
+  it('does not reset a capped test path after an unrelated edit', async () => {
+    const { invalidateRunCacheForPaths } = await import('../run-cache.js');
+    mockFailed();
+    for (let i = 0; i < 3; i++) await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+
+    invalidateRunCacheForPaths(ctx.runId, ['apps/web/src/other.ts']);
+
+    mockRunCommand.mockClear();
+    const next = await runTestsTool(ctx, { path: 'src/foo.test.ts' });
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(next.status).toBe('failed');
+    expect(next.stderr).toMatch(/retry cap/i);
   });
 
   it('counters are isolated per path', async () => {

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -29,6 +29,7 @@ const TEST_TIMEOUT_MS = 5 * 60 * 1000;
 const LINT_TIMEOUT_MS = 90 * 1000;
 const TYPECHECK_TIMEOUT_MS = 3 * 60 * 1000;
 const PACKAGE_SCRIPT_TIMEOUT_MS = 5 * 60 * 1000;
+const E2E_PATH_PREFIX = 'apps/web/e2e';
 
 export class StackCommandMissingError extends Error {
   readonly kind = 'StackCommandMissingError' as const;
@@ -158,6 +159,24 @@ export async function runTestsTool(
     pathMetadata = { rawPaths: [input.path], paths: [canonical] };
   }
 
+  if (pathMetadata?.paths.some((path) => isE2eOwnedPath(path.path)) === true) {
+    const blocked = buildE2eOwnedBlockedResult(argv, pathMetadata);
+    emitToolCall(ctx, {
+      tool: 'run_tests',
+      input: {
+        path: input.path ?? null,
+        command: argv.join(' '),
+        rawPaths: pathMetadata.rawPaths,
+        paths: pathMetadata.paths.map((path) => path.path),
+      },
+      status: 'failed',
+      exitCode: blocked.exitCode,
+      durationMs: blocked.durationMs,
+      truncated: false,
+    });
+    return blocked;
+  }
+
   const retryPathKey = pathMetadata?.paths[0]?.path ?? null;
   const cap = testRetryCap();
   const priorFailures = consecutiveTestFailures(ctx.runId, retryPathKey);
@@ -260,6 +279,30 @@ export async function runTestsTool(
   }
   const verifyResult = toVerifyResult(argv, result, pathMetadata);
   return failureSummary != null ? { ...verifyResult, failureSummary } : verifyResult;
+}
+
+function isE2eOwnedPath(path: string): boolean {
+  const normalized = path.replace(/^\.\//, '').replace(/\/+$/, '');
+  return normalized === E2E_PATH_PREFIX || normalized.startsWith(`${E2E_PATH_PREFIX}/`);
+}
+
+function buildE2eOwnedBlockedResult(
+  argv: ReadonlyArray<string>,
+  paths: { rawPaths: string[]; paths: RepoRelativePath[] },
+): VerifyResult {
+  const canonicalPaths = paths.paths.map((path) => path.path);
+  return {
+    status: 'failed',
+    exitCode: null,
+    stdout: '',
+    stderr: `[harness] run_tests does not run Playwright e2e paths (${canonicalPaths.join(', ')}). E2e specs are QA/evidence-owned; add or run unit/component tests here, or let QA run the project's e2eCommand.`,
+    durationMs: 0,
+    truncated: false,
+    displayTruncated: false,
+    command: argv,
+    rawPaths: paths.rawPaths,
+    paths: paths.paths,
+  };
 }
 
 function buildRetryCapBlockedResult(

--- a/core/verify/tiers.ts
+++ b/core/verify/tiers.ts
@@ -28,6 +28,8 @@ export interface TierResult {
   passed: boolean;
   evidence: string[];
   findings: VerifyFinding[];
+  command?: string;
+  output?: string;
 }
 
 export interface RunArtifacts {
@@ -52,7 +54,7 @@ export interface TierDeps {
   runRegressionTestsImpl?: (
     command: string,
     cwd: string,
-  ) => Promise<{ passed: boolean; failedTests: string[] }>;
+  ) => Promise<{ passed: boolean; failedTests: string[]; output?: string }>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -376,7 +378,7 @@ function extractFailedTests(output: string): string[] {
 async function defaultRunRegressionTests(
   command: string,
   cwd: string,
-): Promise<{ passed: boolean; failedTests: string[] }> {
+): Promise<{ passed: boolean; failedTests: string[]; output?: string }> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     const child = spawn('sh', ['-c', command], {
@@ -388,10 +390,10 @@ async function defaultRunRegressionTests(
     child.stderr?.on('data', (d: Buffer) => chunks.push(d));
     child.on('exit', (code) => {
       const output = Buffer.concat(chunks).toString('utf8');
-      resolve({ passed: (code ?? 1) === 0, failedTests: extractFailedTests(output) });
+      resolve({ passed: (code ?? 1) === 0, failedTests: extractFailedTests(output), output });
     });
     child.on('error', (err) => {
-      resolve({ passed: false, failedTests: [err.message] });
+      resolve({ passed: false, failedTests: [err.message], output: err.message });
     });
   });
 }
@@ -448,6 +450,8 @@ export async function verifyRegression(
     passed: findings.filter((f) => f.severity === 'error').length === 0,
     evidence,
     findings,
+    command: testCommand,
+    output: testResult.output,
   };
 }
 

--- a/skills/implement-wp/prompt.md
+++ b/skills/implement-wp/prompt.md
@@ -95,6 +95,7 @@ If a test harness/import/runtime failure appears, compare against an adjacent pa
 
 - Write test cases that fail with the current code. Cover the WP's acceptance criteria and
   at least one negative path.
+- Do not add or run Playwright e2e specs for ordinary product WPs. Use unit/component tests near the changed surface. E2e/browser validation belongs to QA/evidence workflows unless this WP is explicitly e2e/test-infra.
 - Run the targeted test command via `run_tests` (Claude name: `mcp__factory-tools__run_tests`; pass only the new test file paths).
 - Confirm the new tests fail and pre-existing tests still pass.
 - Emit: `[decision] RED: Wrote N failing tests for <surface>`
@@ -114,7 +115,7 @@ Only refactor if required to make the test pass cleanly.
 
 - If `stack.lintCommand` is provided, run it. Fix failures.
 - If `stack.typecheckCommand` is provided, run it. Fix errors.
-- Re-run targeted tests one final time to confirm still green. In `testsRun.paths`, return the canonical `paths[].path` values from `run_tests` / `mcp__factory-tools__run_tests`.
+- Re-run each written test file one final time by exact file path after the last edit to that test file. Directory-level or full-suite passes do not satisfy this final check. In `testsRun.paths`, return the canonical `paths[].path` values from `run_tests` / `mcp__factory-tools__run_tests`.
 - If executable checks fail because of infrastructure or tooling, retry once only. If the same infrastructure/tooling failure repeats, return `confidence: low` with a `BLOCKER` or `UNCERTAINTY` decision summary instead of searching for alternate commands.
 - Emit: `[decision] LINT: Lint and typecheck clean`
 

--- a/skills/implement/prompt.md
+++ b/skills/implement/prompt.md
@@ -115,14 +115,15 @@ If a test harness/import/runtime failure appears, compare against an adjacent pa
 
 - Implement the smallest slice that satisfies the tests and every criterion in `<acceptanceContract>` when present.
 - Re-run targeted tests only after a real write has occurred, then iterate until green or blocked.
-- For frontend changes with evidence enabled, create/update `apps/web/e2e/issue-<number>.spec.ts` or the provided `relatedSurface.evidenceSpecPath`. Use bounded discovery; if blocked, return `evidenceSpecPath: null` with `TOOL_FAILURE` or `UNCERTAINTY`.
-- If `priorEvidenceSpecPath` is provided and your changes still touch `apps/web/`, reuse it as `evidenceSpecPath` unless the prior spec is now stale for the changed surface. If you cannot reuse it and cannot author a new one, return `evidenceSpecPath: null` with a `SKIP_GATE` decision summary explaining why (e.g., "evidence skipped: type-only handler export, no UI surface changed").
+- Do not add or run Playwright e2e specs for ordinary product fixes. Browser/e2e validation is owned by QA/evidence workflows unless the work item is explicitly e2e/test-infra.
+- For frontend product changes, add unit/component coverage near the changed surface. Return `evidenceSpecPath: null` unless an existing evidence path is provided and still applies.
+- If `priorEvidenceSpecPath` is provided and your changes still touch `apps/web/`, preserve it as `evidenceSpecPath` only when it remains applicable; do not inspect, rewrite, or execute that e2e spec from the implement run. If it is stale or not applicable, return `evidenceSpecPath: null` with a `SKIP_GATE` decision summary.
 - If evidence is disabled, return `evidenceSpecPath: null` with a `SKIP_GATE` summary.
 - Emit `[decision] GREEN: Targeted tests pass`.
 
 ### Bounded frontend evidence rule
 
-Do not inspect old e2e specs, Playwright config, or screenshot conventions before writing the implementation when the investigation already identifies the UI surface. Use the provided evidence path or the default `apps/web/e2e/issue-<number>.spec.ts`; if the route or e2e directory is unclear after one bounded check, ship the implementation plus targeted tests and return a `TOOL_FAILURE` or `UNCERTAINTY` summary instead of spending more discovery budget.
+Do not inspect old e2e specs, Playwright config, or screenshot conventions before writing the implementation when the investigation already identifies the UI surface. Ship the implementation plus targeted unit/component tests; QA/evidence will own browser validation.
 
 ### 5. Refactor, Score, Verify
 

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -81,6 +81,10 @@ If a WP owns production `.ts` or `.tsx` files, that same WP must also include a
 relevant `*.test.ts`, `*.test.tsx`, `*.spec.ts`, or `*.spec.tsx` file in
 `filesOwned`. Do not put the test file only in `verificationTooling` or
 `acceptanceCriteria`; it must be owned by the WP that owns the production edit.
+For ordinary product fixes, this paired coverage should be unit/component
+coverage near the changed surface. Do not assign `apps/web/e2e/*.spec.ts` to an
+implement WP unless the work item or WP is explicitly about e2e/test
+infrastructure. Browser/e2e validation is owned by QA/evidence workflows.
 
 Test-only WPs are allowed. Files that are not implementation surfaces, such as
 `*.config.ts`, `*.d.ts`, `*types.ts`, `*interfaces.ts`, `*schema.ts`,

--- a/skills/spec-author/slice.test.ts
+++ b/skills/spec-author/slice.test.ts
@@ -759,6 +759,8 @@ describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () =
     expect(prompt).toContain('`*.spec.ts`');
     expect(prompt).toContain('Do not put the test file only in `verificationTooling`');
     expect(prompt).toContain('Test-only WPs are allowed');
+    expect(prompt).toContain('Do not assign `apps/web/e2e/*.spec.ts`');
+    expect(prompt).toContain('QA/evidence workflows');
   });
 
   it('rejects WP with production .ts files but no test file', () => {
@@ -939,6 +941,52 @@ describe('validateEngineeringSpec — TDD contract (wp-missing-test-file)', () =
       (e) => e.rule === 'wp-missing-test-file',
     );
     expect(testFileErrors).toHaveLength(0);
+  });
+
+  it('rejects ordinary product WP ownership of apps/web/e2e specs', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP1',
+          filesOwned: [
+            'apps/web/src/components/HealthBadge.tsx',
+            'apps/web/e2e/issue-1107.spec.ts',
+          ],
+          changes: 'Add HealthBadge component and browser regression coverage.',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP1'] }],
+      interfaceContracts: [],
+    });
+
+    const result = validateEngineeringSpec(spec);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.rule === 'wp-e2e-owned-for-product')).toBe(true);
+  });
+
+  it('allows e2e spec ownership for explicit e2e test-infra WPs', () => {
+    const spec = baseSpec({
+      workPackages: [
+        {
+          id: 'WP-e2e',
+          filesOwned: ['apps/web/e2e/issue-1107.spec.ts'],
+          changes: 'Update Playwright e2e test infrastructure for the browser flow.',
+          dependsOn: [],
+          builderTier: 'haiku',
+        },
+      ],
+      executionOrder: [{ batch: 0, wpIds: ['WP-e2e'] }],
+      interfaceContracts: [],
+    });
+
+    const result = validateEngineeringSpec(spec);
+    const e2eErrors = (result.ok ? [] : result.errors).filter(
+      (e) => e.rule === 'wp-e2e-owned-for-product',
+    );
+    expect(e2eErrors).toHaveLength(0);
   });
 });
 

--- a/skills/spec-author/validate.ts
+++ b/skills/spec-author/validate.ts
@@ -51,7 +51,8 @@ export type ValidationRule =
   | 'self-check-verification-tooling'
   | 'verification-tool-command-malformed'
   | 'verification-tool-command-package-relative'
-  | 'wp-missing-test-file';
+  | 'wp-missing-test-file'
+  | 'wp-e2e-owned-for-product';
 
 export type ValidationResult = { ok: true } | { ok: false; errors: ValidationError[] };
 
@@ -74,6 +75,7 @@ export interface ValidationOptions {
 
 const DEFAULT_SENSITIVE_PATTERN = /(auth|session|crypto|secret)/i;
 const BARE_REPO_PATH_PATTERN = /^(?:\.\/)?[\w@./-]+\.[A-Za-z0-9]+$/;
+const WEB_E2E_SPEC_PATTERN = /^apps\/web\/e2e\/.*\.spec\.ts$/;
 
 function isBareRepoPathCommand(command: string): boolean {
   const trimmed = command.trim();
@@ -332,10 +334,21 @@ export function validateEngineeringSpec(
   const isProductionTs = (f: string) =>
     (f.endsWith('.ts') || f.endsWith('.tsx')) && !EXEMPT_SUFFIX.test(f);
   const isTestFile = (f: string) => /\.(test|spec)\.(ts|tsx)$/.test(f);
+  const isWebE2eSpec = (f: string) => WEB_E2E_SPEC_PATTERN.test(f.replace(/^\.\//, ''));
+  const isExplicitE2eWp = (wp: EngineeringSpec['workPackages'][number]) =>
+    /\b(e2e|playwright|test[- ]?infra|test infrastructure)\b/i.test(`${wp.id} ${wp.changes}`);
   for (const wp of spec.workPackages) {
     const paths = wp.filesOwned.map(fileOwnedPath);
     const hasProductionTs = paths.some(isProductionTs);
     const hasTestFile = paths.some(isTestFile);
+    const e2eSpecs = paths.filter(isWebE2eSpec);
+    if (e2eSpecs.length > 0 && !isExplicitE2eWp(wp)) {
+      errors.push({
+        rule: 'wp-e2e-owned-for-product',
+        message: `WP '${wp.id}' owns e2e spec path(s) ${e2eSpecs.join(', ')} without explicit e2e/test-infra scope; product WPs should use unit/component tests and leave e2e to QA/evidence`,
+        ref: wp.id,
+      });
+    }
     if (hasProductionTs && !hasTestFile) {
       errors.push({
         rule: 'wp-missing-test-file',

--- a/slices/fix-feedback/slice.test.ts
+++ b/slices/fix-feedback/slice.test.ts
@@ -412,6 +412,121 @@ describe('runFixFeedbackWorkflow', () => {
     );
   });
 
+  it('routes regression-unrelated QA failures to needs-human instead of issue repair', async () => {
+    const workItem = makeWorkItem();
+    const compareBaseline = vi.fn().mockResolvedValue({
+      status: 'same-failures-on-base',
+      feedback: 'Baseline comparison: same failures on origin/main',
+    });
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        ...makeQaCompletedEvent(false),
+        payload: {
+          verdict: 'fail',
+          overallScore: 40,
+          threshold: 70,
+          failureCategory: 'regression-unrelated',
+          tierResults: {
+            structural: { passed: true, findings: [] },
+            functional: { passed: true, findings: [] },
+            regression: {
+              passed: false,
+              findings: [
+                {
+                  tier: 'regression',
+                  severity: 'error',
+                  description: 'Global e2e seed fails on base',
+                  suggestion: 'Fix pipeline seed data',
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo', {
+      baselineRegressionComparisonImpl: compareBaseline,
+    });
+
+    expect(compareBaseline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreePath: '/work/wt',
+        baseBranch: 'main',
+      }),
+    );
+    expect(mockClaudeCliRun).not.toHaveBeenCalled();
+    expect(stateSource.transitionState).toHaveBeenCalledWith(
+      '42',
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    expect(eventStore.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.fix-feedback-skipped',
+        payload: expect.objectContaining({
+          reason: 'baseline-red-global',
+          sourceFeedback: expect.stringContaining('regression suite failed'),
+        }),
+      }),
+    );
+  });
+
+  it('repairs regression-unrelated QA failures when baseline comparison is head-only', async () => {
+    const workItem = makeWorkItem();
+    const compareBaseline = vi.fn().mockResolvedValue({
+      status: 'head-only-failure',
+      feedback: 'Baseline comparison: regression passed on origin/main',
+    });
+    vi.mocked(eventStore.replay).mockReturnValue([
+      makePrOpenedEvent(),
+      {
+        ...makeQaCompletedEvent(false),
+        payload: {
+          verdict: 'fail',
+          overallScore: 40,
+          threshold: 70,
+          failureCategory: 'regression-unrelated',
+          tierResults: {
+            structural: { passed: true, findings: [] },
+            functional: { passed: true, findings: [] },
+            regression: {
+              passed: false,
+              findings: [
+                {
+                  tier: 'regression',
+                  severity: 'error',
+                  description: 'Regression [escalate]: failing head-only suite',
+                  suggestion: 'Repair the regression',
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    mockClaudeCliRun.mockResolvedValue({ output: makeImplementOutput() });
+
+    await runFixFeedbackWorkflow(workItem, stateSource, 'proj', 'owner/repo', {
+      baselineRegressionComparisonImpl: compareBaseline,
+    });
+
+    expect(mockClaudeCliRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          advisorFeedback: expect.stringContaining('head-only'),
+        }),
+      }),
+    );
+    expect(stateSource.transitionState).toHaveBeenNthCalledWith(
+      1,
+      '42',
+      'factory:needs-fix',
+      'factory:in-progress',
+    );
+  });
+
   it('commits repair edits and pushes the existing PR branch before completion', async () => {
     mockDeriveObservedChangedFiles.mockReturnValue({
       count: 2,

--- a/slices/fix-feedback/workflow.ts
+++ b/slices/fix-feedback/workflow.ts
@@ -1,4 +1,7 @@
-import { posix as pathPosix } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin, posix as pathPosix } from 'node:path';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { getChangedFilesSince } from '@goose-hub/core/agent-runtime/git-intel.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
@@ -115,6 +118,7 @@ export interface FixFeedbackDeps {
   runtime?: AgentRuntime;
   orchestratorCommitAllImpl?: typeof orchestratorCommitAll;
   orchestratorPushBranchImpl?: typeof orchestratorPushBranch;
+  baselineRegressionComparisonImpl?: typeof compareRegressionAgainstBaseline;
 }
 
 /**
@@ -153,7 +157,22 @@ function findPrLifecycle(events: ReturnType<typeof eventStore.replay>): PrLifecy
 
 type TierResult = {
   passed: boolean;
+  command?: string | null;
+  output?: string | null;
   findings: Array<{ tier: string; severity: string; description: string; suggestion?: string }>;
+};
+
+type BaselineComparisonStatus = 'same-failures-on-base' | 'head-only-failure' | 'unavailable';
+
+type BaselineComparisonResult = {
+  status: BaselineComparisonStatus;
+  feedback: string;
+};
+
+type BaselineComparisonInput = {
+  payload: QaPayload;
+  worktreePath: string;
+  baseBranch?: string;
 };
 
 type QaPayload = {
@@ -216,6 +235,9 @@ type SourceFailure = {
   feedback: string;
   actionable: boolean;
   verificationInfrastructure?: boolean;
+  baselineRedGlobal?: boolean;
+  requiresBaselineComparison?: boolean;
+  payload?: QaPayload;
   skipReason?: string;
 };
 
@@ -319,6 +341,135 @@ function formatVerificationBlockedFeedback(payload: QaPayload): string {
   return lines.join('\n');
 }
 
+function formatRegressionUnrelatedFeedback(payload: QaPayload): string {
+  const lines = [
+    'QA regression suite failed outside the issue-specific implementation surface.',
+    `Failure category: ${payload.failureCategory ?? 'regression-unrelated'}`,
+    'Compare against base/main before deciding whether this belongs to the issue repair loop.',
+  ];
+  const regressionFindings = payload.tierResults?.regression?.findings ?? [];
+  for (const finding of regressionFindings.slice(0, 5)) {
+    lines.push(`- ${finding.description}`);
+  }
+  return lines.join('\n');
+}
+
+function regressionCommandForPayload(payload: QaPayload): string | null {
+  const command = payload.tierResults?.regression?.command;
+  return typeof command === 'string' && command.trim().length > 0 ? command.trim() : null;
+}
+
+function regressionFailureDescriptions(payload: QaPayload): string[] {
+  return (payload.tierResults?.regression?.findings ?? [])
+    .map((finding) => finding.description)
+    .filter((description) => description.trim().length > 0);
+}
+
+function normalizeFailureSignature(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^regression\s*\[[^\]]+\]:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 240);
+}
+
+function extractFailedTestLines(output: string): string[] {
+  const failed: string[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.length > 240) continue;
+    if (trimmed.includes('FAIL') || trimmed.includes('✗') || trimmed.includes('× ')) {
+      failed.push(trimmed);
+    }
+  }
+  return failed.slice(0, 20);
+}
+
+function signaturesOverlap(left: string, right: string): boolean {
+  if (left.length === 0 || right.length === 0) return false;
+  return left === right || left.includes(right) || right.includes(left);
+}
+
+async function compareRegressionAgainstBaseline({
+  payload,
+  worktreePath,
+  baseBranch = 'main',
+}: BaselineComparisonInput): Promise<BaselineComparisonResult> {
+  const command = regressionCommandForPayload(payload);
+  if (command == null) {
+    return {
+      status: 'unavailable',
+      feedback:
+        'Baseline comparison unavailable: regression tier payload did not include a command.',
+    };
+  }
+
+  const baselineDir = mkdtempSync(pathJoin(tmpdir(), 'goose-hub-baseline-'));
+  const baseRef = baseBranch.startsWith('origin/') ? baseBranch : `origin/${baseBranch}`;
+  try {
+    const add = spawnSync(
+      'git',
+      ['-C', worktreePath, 'worktree', 'add', '--detach', baselineDir, baseRef],
+      {
+        encoding: 'utf8',
+        timeout: 120_000,
+      },
+    );
+    if (add.status !== 0) {
+      return {
+        status: 'unavailable',
+        feedback: `Baseline comparison unavailable: could not create ${baseRef} worktree (${add.stderr || add.stdout || 'git worktree add failed'}).`,
+      };
+    }
+
+    const run = spawnSync('sh', ['-c', command], {
+      cwd: baselineDir,
+      encoding: 'utf8',
+      env: { ...process.env, CI: '1', FORCE_COLOR: '0' },
+      timeout: 10 * 60_000,
+    });
+    if (run.error != null) {
+      return {
+        status: 'unavailable',
+        feedback: `Baseline comparison unavailable: ${run.error.message}.`,
+      };
+    }
+    if ((run.status ?? 1) === 0) {
+      return {
+        status: 'head-only-failure',
+        feedback: `Baseline comparison: ${command} passed on ${baseRef}; regression appears head-only.`,
+      };
+    }
+
+    const baseOutput = `${run.stdout ?? ''}\n${run.stderr ?? ''}`;
+    const baseFailures = extractFailedTestLines(baseOutput).map(normalizeFailureSignature);
+    const headFailures = regressionFailureDescriptions(payload).map(normalizeFailureSignature);
+    const sameFailures =
+      baseFailures.length > 0 && headFailures.length > 0
+        ? headFailures.some((head) => baseFailures.some((base) => signaturesOverlap(head, base)))
+        : baseFailures.length > 0;
+
+    if (sameFailures) {
+      return {
+        status: 'same-failures-on-base',
+        feedback: `Baseline comparison: ${command} also failed on ${baseRef}; route as baseline-red/global instead of issue repair.`,
+      };
+    }
+
+    return {
+      status: 'head-only-failure',
+      feedback: `Baseline comparison: ${command} failed on ${baseRef}, but not with the same failure signature; repair the head regression.`,
+    };
+  } finally {
+    spawnSync('git', ['-C', worktreePath, 'worktree', 'remove', '--force', baselineDir], {
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+    rmSync(baselineDir, { recursive: true, force: true });
+  }
+}
+
 async function findLatestSourceFailure(
   events: ReturnType<typeof eventStore.replay>,
   stateSource: StateSource,
@@ -378,6 +529,16 @@ async function findLatestSourceFailure(
         skipReason: 'verification-infrastructure',
       };
     }
+    if (payload.failureCategory === 'regression-unrelated') {
+      return {
+        kind: 'qa',
+        runId: sourceRunId(qaEvent),
+        feedback: formatRegressionUnrelatedFeedback(payload),
+        actionable: false,
+        requiresBaselineComparison: true,
+        payload,
+      };
+    }
     const { verdict = 'fail', overallScore = 0, threshold = 70 } = payload;
     const verifiedFollowUpRefs = await verifiedFollowUpRefsForPayload(payload, stateSource);
     const actionableItems = collectActionableQaItems(
@@ -432,7 +593,7 @@ export async function runFixFeedbackWorkflow(
   const attemptId = crypto.randomUUID();
   const events = eventStore.replay({ workItemId: workItem.id });
   const prLifecycle = findPrLifecycle(events);
-  const sourceFailure = await findLatestSourceFailure(events, stateSource);
+  let sourceFailure = await findLatestSourceFailure(events, stateSource);
   const repairCycle = nextRepairCycle(events);
   const repairPayload = compactPayload({
     pipelineRunId: prLifecycle?.pipelineRunId,
@@ -451,6 +612,8 @@ export async function runFixFeedbackWorkflow(
   const projectConfig = await getProjectBySlug(projectId);
   const commitAllFn = deps.orchestratorCommitAllImpl ?? orchestratorCommitAll;
   const pushBranchFn = deps.orchestratorPushBranchImpl ?? orchestratorPushBranch;
+  const compareRegressionFn =
+    deps.baselineRegressionComparisonImpl ?? compareRegressionAgainstBaseline;
   const { runtime, resolvedBudget } = resolveProjectAgentExecution({
     skill: 'fix-feedback',
     role: 'developer',
@@ -458,6 +621,41 @@ export async function runFixFeedbackWorkflow(
     projectConfig,
     injectedRuntime: deps.runtime,
   });
+
+  if (sourceFailure?.requiresBaselineComparison === true && sourceFailure.payload != null) {
+    const worktreePath = prLifecycle?.worktreePath;
+    if (worktreePath == null) {
+      sourceFailure = {
+        ...sourceFailure,
+        baselineRedGlobal: true,
+        skipReason: 'baseline-compare-unavailable',
+        feedback: `${sourceFailure.feedback}\n\nBaseline comparison unavailable: no integration worktree was recorded.`,
+      };
+    } else {
+      const comparison = await compareRegressionFn({
+        payload: sourceFailure.payload,
+        worktreePath,
+        baseBranch: prLifecycle?.baseBranch,
+      });
+      if (comparison.status === 'head-only-failure') {
+        sourceFailure = {
+          ...sourceFailure,
+          actionable: true,
+          feedback: `${sourceFailure.feedback}\n\n${comparison.feedback}`,
+        };
+      } else {
+        sourceFailure = {
+          ...sourceFailure,
+          baselineRedGlobal: true,
+          skipReason:
+            comparison.status === 'same-failures-on-base'
+              ? 'baseline-red-global'
+              : 'baseline-compare-unavailable',
+          feedback: `${sourceFailure.feedback}\n\n${comparison.feedback}`,
+        };
+      }
+    }
+  }
 
   if (sourceFailure?.verificationInfrastructure === true) {
     await stateSource.comment(
@@ -490,6 +688,44 @@ export async function runFixFeedbackWorkflow(
       payload: {
         ...repairPayload,
         reason: sourceFailure.skipReason ?? 'verification-infrastructure',
+        sourceFeedback: sourceFailure.feedback,
+      },
+      runId,
+    });
+    return;
+  }
+
+  if (sourceFailure?.baselineRedGlobal === true) {
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Dev',
+        'Baseline Red',
+        'Skipping fix-feedback because QA found regression-suite failures outside this issue-specific change.',
+        [sourceFailure.feedback],
+      ),
+    );
+    await stateSource.transitionState(
+      workItem.externalId,
+      'factory:needs-fix',
+      'factory:needs-human',
+    );
+    emitStateTransitionEvent({
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:needs-fix',
+      to: 'factory:needs-human',
+      by: 'fix-feedback',
+      runId,
+      extraPayload: repairPayload,
+    });
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.fix-feedback-skipped',
+      payload: {
+        ...repairPayload,
+        reason: sourceFailure.skipReason ?? 'baseline-red-global',
         sourceFeedback: sourceFailure.feedback,
       },
       runId,

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -1394,6 +1394,191 @@ describe('implement-wp ownership gate', () => {
     expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
   });
 
+  it('requires exact-file run_tests success after the last edit to each written test', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
+    const { fn: appendEvent, events } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+    const runId = 'run-wp-exact-final:wp:WP1:iter:1';
+    const passingBeforeEdit: AgentEvent = {
+      id: 1003,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src/foo.test.ts',
+          paths: ['apps/web/src/foo.test.ts'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const editAfterPass: AgentEvent = {
+      id: 1004,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'edit_file',
+        status: 'ok',
+        tool_input: { path: 'apps/web/src/foo.test.ts' },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const directoryPassAfterEdit: AgentEvent = {
+      id: 1005,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src',
+          paths: ['apps/web/src'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-exact-final',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: {
+        run: vi.fn().mockResolvedValue({
+          output,
+          events: [passingBeforeEdit, editAfterPass, directoryPassAfterEdit],
+        }),
+      },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('exact-file run_tests success'),
+    });
+    expect(events.some((event) => event.kind === 'parallel-implement.wp-failed')).toBe(true);
+  });
+
+  it('treats pathless successful shell writes as invalidating written-test proof', async () => {
+    const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']);
+    const { fn: appendEvent } = makeAppendEvent();
+    const output: ImplementWpOutput = {
+      wpId: 'WP1',
+      plan: 'Add regression coverage',
+      filesWritten: [{ path: 'apps/web/src/foo.ts', reason: 'Implement behavior' }],
+      testsWritten: [{ path: 'apps/web/src/foo.test.ts', cases: 1 }],
+      testsRun: {
+        command: 'pnpm test apps/web/src/foo.test.ts',
+        paths: ['apps/web/src/foo.test.ts'],
+      },
+      confidence: 'high',
+      decisionSummaries: [{ kind: 'VERDICT', summary: 'Done' }],
+    };
+    const runId = 'run-wp-pathless-edit:wp:WP1:iter:1';
+    const exactPassBeforePathlessEdit: AgentEvent = {
+      id: 1013,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'run_tests',
+        status: 'ok',
+        tool_input: {
+          path: 'apps/web/src/foo.test.ts',
+          paths: ['apps/web/src/foo.test.ts'],
+        },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+    const pathlessWriteAfterPass: AgentEvent = {
+      id: 1014,
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      kind: 'agent.tool-call',
+      payload: {
+        runId,
+        skill: 'implement-wp',
+        tool_name: 'bash',
+        status: 'ok',
+        tool_input: { command: "sed -i '' 's/a/b/' apps/web/src/foo.test.ts" },
+      },
+      runId,
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await runOneWpBuilder({
+      wp: makeWp('WP1', ['apps/web/src/foo.ts', 'apps/web/src/foo.test.ts']),
+      iteration: 1,
+      runId: 'run-wp-pathless-edit',
+      projectId: 'goose-hub-self',
+      workItemId: 'wi-560',
+      workItem: makeWorkItem(),
+      scratchWorktreePath: scratchWorktree,
+      stack: { testCommand: 'pnpm test' },
+      runtime: {
+        run: vi.fn().mockResolvedValue({
+          output,
+          events: [exactPassBeforePathlessEdit, pathlessWriteAfterPass],
+        }),
+      },
+      budgets: { maxTurns: 3, maxBudgetUsd: 1, timeoutMs: 10_000 },
+      modelOverride: 'gpt-5.4-mini',
+      personaId: 'goose-hub-self/developer/0',
+      wpTimeoutMs: 10_000,
+      appendEvent,
+      revertWpChangesFn: vi.fn(),
+      recordIterationFn: vi.fn(),
+      implementWpPrompt: '# prompt',
+      implementWpJsonSchema: {},
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      wpId: 'WP1',
+      errorReason: expect.stringContaining('exact-file run_tests success'),
+    });
+  });
+
   it('fails required verification when no verification tool passed even with high confidence', async () => {
     const scratchWorktree = makeTempRepo(['apps/web/src/foo.ts']);
     const { fn: appendEvent } = makeAppendEvent();

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -181,6 +181,10 @@ function pathsMatch(left: string, right: string): boolean {
   return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
 }
 
+function pathsExactlyMatch(left: string, right: string): boolean {
+  return normalizePathForCompare(left) === normalizePathForCompare(right);
+}
+
 function isTerminalDecisionKind(kind: unknown): kind is TerminalDecisionKind {
   return kind === 'TOOL_FAILURE' || kind === 'BLOCKER';
 }
@@ -230,6 +234,32 @@ function latestRunTestsStatusForPath(events: AgentEvent[], path: string): string
   return null;
 }
 
+function latestExactRunTestsStatusForPathAfterLastEdit(
+  events: AgentEvent[],
+  path: string,
+): string | null {
+  let lastEditIndex = -1;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (toolCallStatus(event) !== 'ok') continue;
+    if (!isEditToolCall(event)) continue;
+    const editedPaths = toolCallPaths(event);
+    if (editedPaths.length === 0 || editedPaths.some((candidate) => pathsMatch(candidate, path))) {
+      lastEditIndex = i;
+    }
+  }
+
+  for (let i = events.length - 1; i > lastEditIndex; i--) {
+    const event = events[i];
+    if (toolCallName(event) !== 'run_tests') continue;
+    const paths = toolCallPaths(event);
+    if (paths.length === 0) continue;
+    if (!paths.some((candidate) => pathsExactlyMatch(candidate, path))) continue;
+    return toolCallStatus(event);
+  }
+  return null;
+}
+
 function hasSuccessfulVerificationToolCall(events: AgentEvent[]): boolean {
   return events.some((event) => {
     if (event.kind !== 'agent.tool-call') return false;
@@ -254,14 +284,21 @@ function implementWpAcceptanceFailure(input: {
       reason: 'implement-wp returned low confidence while verification was required',
     };
   }
-  const requiredTestPaths = [
-    ...new Set([
-      ...input.output.testsWritten.map((test) => test.path),
-      ...input.output.testsRun.paths,
-    ]),
-  ];
-  if (requiredTestPaths.length > 0) {
-    const failedPaths = requiredTestPaths.filter(
+  const writtenTestPaths = [...new Set(input.output.testsWritten.map((test) => test.path))];
+  if (writtenTestPaths.length > 0) {
+    const failedWrittenTestPaths = writtenTestPaths.filter(
+      (path) => latestExactRunTestsStatusForPathAfterLastEdit(input.events, path) !== 'ok',
+    );
+    if (failedWrittenTestPaths.length > 0) {
+      return {
+        kind: 'verification-failed',
+        reason: `written test files need exact-file run_tests success after their last edit: ${failedWrittenTestPaths.join(', ')}`,
+      };
+    }
+  }
+  const reportedRunPaths = [...new Set(input.output.testsRun.paths)];
+  if (reportedRunPaths.length > 0) {
+    const failedPaths = reportedRunPaths.filter(
       (path) => latestRunTestsStatusForPath(input.events, path) !== 'ok',
     );
     if (failedPaths.length > 0) {

--- a/slices/qa/synthetic-output.ts
+++ b/slices/qa/synthetic-output.ts
@@ -51,6 +51,8 @@ function asTierResult(tier: 1 | 2 | 3, vt: VerifyTierResult): TierResult {
   return {
     passed: vt.passed,
     findings: vt.findings.map((f) => mapVerifyFinding(tier, f)),
+    ...(vt.command != null ? { command: vt.command } : {}),
+    ...(vt.output != null ? { output: vt.output } : {}),
   };
 }
 


### PR DESCRIPTION
Stacked on PR #1117. Summary: wires dev-review runs to the integration worktree; keeps implement/spec-author flows off Playwright e2e and rejects e2e paths in run_tests; tightens WP test rerun acceptance and retry reset after edits; preserves Factory evidence tools without reintroducing playwright-mcp; relabels QA regression suite output; compares regression-unrelated QA failures against base/main via a baseline seam before deciding baseline-red needs-human versus head-only repair. Verification: pnpm test core/tool-layer/mcp/tools/verify.test.ts slices/parallel-implement/slice.test.ts core/agent-runtime/dev-review-advisor.test.ts apps/web/src/components/detail/components/timeline/QaEvents.test.tsx skills/spec-author/slice.test.ts slices/fix-feedback/slice.test.ts; pnpm test slices/fix-feedback/slice.test.ts core/verify/tiers.test.ts skills/qa/slice.test.ts; pnpm typecheck; pnpm skill-contract:audit; pnpm audit-docs; pnpm exec biome check on touched TS/TSX files.