### PR TITLE
M19.XX: api bug

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -77,6 +77,18 @@ describe('POST /inbox', () => {
     expect(res.status).toBe(400);
     expect(mockCreateInboxItem).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for JSON null body', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid request body' });
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /inbox', () => {

--- a/apps/server/src/shared/middleware.test.ts
+++ b/apps/server/src/shared/middleware.test.ts
@@ -18,6 +18,21 @@ describe('parseBody', () => {
     expect(result).toEqual({ ok: true, data: { name: 'hello' } });
   });
 
+  it('returns ok:false with 400 response for JSON null', async () => {
+    const app = new Hono();
+    let result: unknown;
+    app.post('/test', async (c) => {
+      result = await parseBody<{ name: string }>(c);
+      return c.json({});
+    });
+    await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(result).toMatchObject({ ok: false });
+  });
+
   it('returns ok:false with 400 response for invalid JSON', async () => {
     const app = new Hono();
     let result: unknown;

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -3,12 +3,26 @@ import type { Context } from 'hono';
 
 export type Result<T> = { ok: true; data: T } | { ok: false; error: string; status: number };
 
-export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response };
+export type ParsedBody<T extends Record<string, unknown>> =
+  | { ok: true; data: T }
+  | { ok: false; error: Response };
 
-export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
+export async function parseBody<T>(
+  c: Context,
+): Promise<ParsedBody<T extends Record<string, unknown> ? T : Record<string, unknown>>> {
   try {
-    const data = (await c.req.json()) as T;
-    return { ok: true, data };
+    const data = await c.req.json();
+    if (data === null || Array.isArray(data) || typeof data !== 'object') {
+      logger.warn('request body parse failed', {
+        err: 'Error: request body must be a JSON object',
+      });
+      return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
+    }
+
+    return {
+      ok: true,
+      data: data as T extends Record<string, unknown> ? T : Record<string, unknown>,
+    };
   } catch (err) {
     logger.warn('request body parse failed', { err: String(err) });
     return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };


### PR DESCRIPTION
## Summary

api bug

## Work Packages

- ✓ **WP1**: In `apps/server/src/shared/middleware.ts:6-15`, constrain `ParsedBody`/`parseBody` to object payloads and add a runtime 

Closes #1123
