### PR TITLE
M19.XX: grill bug

### DIFF
--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -562,6 +562,50 @@ describe('groupEvents — run-group metadata', () => {
     }
   });
 
+  it('prefers an answered grill transition over an earlier grill question-posted endedAt', () => {
+    const startedAt = '2026-05-27T10:00:00.000Z';
+    const questionPostedAt = '2026-05-27T10:03:00.000Z';
+    const repliedAt = '2026-05-27T10:05:00.000Z';
+    const events: AgentEventDto[] = [
+      {
+        ...makeRunEvent(1, 'discover-run', 'agent.run-started', 'grill-me'),
+        payload: { skill: 'grill-me', discoverSessionId: 'discover-session-1' },
+        createdAt: startedAt,
+      },
+      {
+        ...makeRunEvent(2, 'discover-run', 'grill.question-posted'),
+        payload: {
+          displaySkill: 'grill-me',
+          discoverSessionId: 'discover-session-1',
+          question: 'What should happen next?',
+        },
+        createdAt: questionPostedAt,
+      },
+      {
+        ...makeRunEvent(3, 'discover-run', 'state.transitioned'),
+        payload: {
+          discoverSessionId: 'discover-session-1',
+          from: 'factory:gate-pending',
+          to: 'factory:grilling',
+        },
+        createdAt: repliedAt,
+      },
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('phase-group');
+    if (result[0].kind === 'phase-group') {
+      expect(result[0].items).toHaveLength(1);
+      expect(result[0].items[0].kind).toBe('run-group');
+      if (result[0].items[0].kind === 'run-group') {
+        expect(result[0].items[0].startedAt).toBe(startedAt);
+        expect(result[0].items[0].endedAt).toBe(repliedAt);
+      }
+    }
+  });
+
   it('infers fix-feedback display skill from the completion marker for legacy runs', () => {
     const events: AgentEventDto[] = [
       makeRunEvent(3, 'run-fix', 'agent.fix-feedback-complete'),

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -526,6 +526,42 @@ describe('groupEvents — run-group metadata', () => {
     }
   });
 
+  it('marks answered grill transitions as completed and preserves the reply transition as endedAt', () => {
+    const startedAt = '2026-05-27T10:00:00.000Z';
+    const repliedAt = '2026-05-27T10:05:00.000Z';
+    const events: AgentEventDto[] = [
+      {
+        ...makeRunEvent(1, 'discover-run', 'agent.run-started', 'grill-me'),
+        payload: { skill: 'grill-me', discoverSessionId: 'discover-session-1' },
+        createdAt: startedAt,
+      },
+      {
+        ...makeRunEvent(2, 'discover-run', 'state.transitioned'),
+        payload: {
+          discoverSessionId: 'discover-session-1',
+          from: 'factory:gate-pending',
+          to: 'factory:grilling',
+        },
+        createdAt: repliedAt,
+      },
+    ];
+
+    const result = groupEvents(events);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('phase-group');
+    if (result[0].kind === 'phase-group') {
+      expect(result[0].phase).toBe('grill');
+      expect(result[0].status).toBe('completed');
+      expect(result[0].items).toHaveLength(1);
+      expect(result[0].items[0].kind).toBe('run-group');
+      if (result[0].items[0].kind === 'run-group') {
+        expect(result[0].items[0].startedAt).toBe(startedAt);
+        expect(result[0].items[0].endedAt).toBe(repliedAt);
+      }
+    }
+  });
+
   it('infers fix-feedback display skill from the completion marker for legacy runs', () => {
     const events: AgentEventDto[] = [
       makeRunEvent(3, 'run-fix', 'agent.fix-feedback-complete'),

--- a/apps/web/src/components/detail/lib/timeline/phases/discover.ts
+++ b/apps/web/src/components/detail/lib/timeline/phases/discover.ts
@@ -42,6 +42,10 @@ export function getDiscoverPhaseId(
 
 function isGrillPhaseEvent(event: AgentEventDto): boolean {
   if (event.kind.startsWith('grill.')) return true;
+  return isAnsweredGrillTransitionEvent(event);
+}
+
+function isAnsweredGrillTransitionEvent(event: AgentEventDto): boolean {
   if (event.kind !== 'state.transitioned' || getDiscoverSessionId(event) == null) return false;
   const payload = event.payload as { from?: unknown; to?: unknown } | null;
   return payload?.from === 'factory:gate-pending' && payload.to === 'factory:grilling';
@@ -60,6 +64,7 @@ function resolveDiscoverPhaseStatus(
   if (phase === 'grill') {
     if (events.some((event) => event.kind === 'grill.completed')) return 'completed';
     if (events.some((event) => event.kind === 'grill.question-posted')) return 'completed';
+    if (events.some(isAnsweredGrillTransitionEvent)) return 'completed';
   } else if (
     events.some((event) =>
       ['prd.drafted', 'prd.approved', 'prd.rejected', 'prd.revised', 'prd.declined'].includes(

--- a/apps/web/src/components/detail/lib/timeline/run-groups.ts
+++ b/apps/web/src/components/detail/lib/timeline/run-groups.ts
@@ -2,6 +2,21 @@ import type { AgentEventDto } from '@/lib/types';
 import { isCodexTransportWarningLog } from './log-events';
 import type { RenderItem } from './types';
 
+function isAnsweredGrillTransitionEvent(event: AgentEventDto): boolean {
+  if (event.kind !== 'state.transitioned') return false;
+  const payload = event.payload as {
+    discoverSessionId?: unknown;
+    from?: unknown;
+    to?: unknown;
+  } | null;
+  return (
+    typeof payload?.discoverSessionId === 'string' &&
+    payload.discoverSessionId.trim() !== '' &&
+    payload.from === 'factory:gate-pending' &&
+    payload.to === 'factory:grilling'
+  );
+}
+
 export function collapseLogRuns(events: AgentEventDto[]): RenderItem[] {
   const items: RenderItem[] = [];
   const flushLogGroup = (group: AgentEventDto[]) => {
@@ -115,7 +130,11 @@ export function extractRunMeta(items: RenderItem[]): {
       if (endedAt == null) endedAt = ev.createdAt;
     } else if (ev.kind === 'prd.approved' || ev.kind === 'prd.rejected') {
       if (endedAt == null) endedAt = ev.createdAt;
-    } else if (ev.kind === 'grill.question-posted' || ev.kind === 'grill.completed') {
+    } else if (
+      ev.kind === 'grill.question-posted' ||
+      ev.kind === 'grill.completed' ||
+      isAnsweredGrillTransitionEvent(ev)
+    ) {
       // grill-me runs don't emit agent.run-completed - these are the terminal events
       if (endedAt == null) endedAt = ev.createdAt;
     } else if (ev.kind === 'decompose.completed') {

--- a/apps/web/src/components/detail/lib/timeline/run-groups.ts
+++ b/apps/web/src/components/detail/lib/timeline/run-groups.ts
@@ -135,8 +135,8 @@ export function extractRunMeta(items: RenderItem[]): {
       ev.kind === 'grill.completed' ||
       isAnsweredGrillTransitionEvent(ev)
     ) {
-      // grill-me runs don't emit agent.run-completed - these are the terminal events
-      if (endedAt == null) endedAt = ev.createdAt;
+      // grill-me runs don't emit agent.run-completed; prefer the latest terminal marker.
+      if (endedAt == null || ms > new Date(endedAt).getTime()) endedAt = ev.createdAt;
     } else if (ev.kind === 'decompose.completed') {
       if (endedAt == null) endedAt = ev.createdAt;
     } else if (ev.kind === 'parallel-implement.iteration-started') {


### PR DESCRIPTION
## Summary

grill bug

## Work Packages

- ✓ **WP1**: In `discover.ts:43-73`, extract or reuse the existing `state.transitioned` gate-pending-to-grilling recognition so `reso

Closes #1125
