### PR TITLE
Add local-db external ref read model

### DIFF
--- a/apps/server/src/domains/issues/router.test.ts
+++ b/apps/server/src/domains/issues/router.test.ts
@@ -312,6 +312,40 @@ describe('GET /projects/:slug/issues/:id/artifacts/:artifactKey', () => {
     expect(mockGetIssueArtifact).toHaveBeenCalledWith('my-project', '42', 'pr-diff:abc');
   });
 
+  it('passes bounded slice params to artifact retrieval', async () => {
+    const artifact = {
+      artifactKey: 'provider-evidence:abc',
+      projectId: 'my-project',
+      workItemId: 'local:my-project#42',
+      runId: 'run-abc',
+      kind: 'provider-evidence',
+      summary: 'Provider evidence',
+      bytes: 100,
+      createdAt: '2026-05-14T00:00:00Z',
+      expiresAt: null,
+      offset: 10,
+      limit: 20,
+      returnedBytes: 20,
+      hasMore: true,
+      payloadSlice: '01234567890123456789',
+      encoding: 'json',
+    };
+    mockGetIssueArtifact.mockResolvedValue({ ok: true, data: { artifact } });
+
+    const app = makeApp();
+    const res = await app.request(
+      '/projects/my-project/issues/42/artifacts/provider-evidence:abc?offset=10&limit=20',
+      { method: 'GET' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ artifact });
+    expect(mockGetIssueArtifact).toHaveBeenCalledWith('my-project', '42', 'provider-evidence:abc', {
+      offset: 10,
+      limit: 20,
+    });
+  });
+
   it('returns 404 for unknown or unauthorized artifacts', async () => {
     mockGetIssueArtifact.mockResolvedValue({
       ok: false,

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -92,11 +92,15 @@ router.get('/:slug/issues/:id/prd', async (c) => {
 });
 
 router.get('/:slug/issues/:id/artifacts/:artifactKey', async (c) => {
-  const result = await getIssueArtifact(
-    c.req.param('slug'),
-    c.req.param('id'),
-    c.req.param('artifactKey'),
-  );
+  const offset = c.req.query('offset');
+  const limit = c.req.query('limit');
+  const result =
+    offset != null || limit != null
+      ? await getIssueArtifact(c.req.param('slug'), c.req.param('id'), c.req.param('artifactKey'), {
+          offset: offset == null ? undefined : Number(offset),
+          limit: limit == null ? undefined : Number(limit),
+        })
+      : await getIssueArtifact(c.req.param('slug'), c.req.param('id'), c.req.param('artifactKey'));
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
 });
 

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -27,6 +27,7 @@ vi.mock('@goose-hub/core/event-stream/store.js', () => ({
 }));
 vi.mock('@goose-hub/core/agent-artifacts/repository.js', () => ({
   getArtifact: vi.fn(),
+  getArtifactSlice: vi.fn(),
 }));
 vi.mock('@goose-hub/core/engineering-specs/repository.js', () => ({
   getEngineeringSpec: vi.fn(),
@@ -77,7 +78,7 @@ vi.mock('../../shared/resolve-milestone.js', () => ({
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { getArtifact } from '@goose-hub/core/agent-artifacts/repository.js';
+import { getArtifact, getArtifactSlice } from '@goose-hub/core/agent-artifacts/repository.js';
 import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { open } from '@goose-hub/core/interventions/reducer.js';
@@ -190,6 +191,7 @@ beforeEach(() => {
   );
   vi.mocked(getSourceForSlug).mockResolvedValue(mockSource as never);
   vi.mocked(getArtifact).mockReturnValue(null);
+  vi.mocked(getArtifactSlice).mockReturnValue(null);
   vi.mocked(getEngineeringSpec).mockReturnValue(null);
 });
 
@@ -746,6 +748,68 @@ describe('listIssues', () => {
     expect(result).toMatchObject({ ok: true, data: { items: [{ id: 'github:owner/repo#42' }] } });
   });
 
+  it('returns canonical work item ids and provider-neutral external refs', async () => {
+    mockSource.listOpenWork.mockResolvedValueOnce([
+      {
+        id: 'local:proj#1',
+        externalId: '1',
+        repoRef: 'owner/repo',
+        title: 'Imported Jira work',
+        externalRefs: [
+          {
+            id: 1,
+            provider: 'jira',
+            kind: 'issue',
+            repoRef: null,
+            externalId: 'TAS-123',
+            url: 'https://company.atlassian.net/browse/TAS-123',
+            metadata: { status: 'To Do' },
+            createdAt: '2026-05-27T00:00:00Z',
+          },
+          {
+            id: 2,
+            provider: 'bitbucket',
+            kind: 'pull_request',
+            repoRef: 'workspace/repo',
+            externalId: '45',
+            url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+            metadata: { state: 'OPEN' },
+            createdAt: '2026-05-27T00:00:00Z',
+          },
+        ],
+      },
+    ]);
+
+    const result = await listIssues('proj', { all: true });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: 'local:proj#1',
+            canonicalWorkItemId: 'local:proj#1',
+            externalRefs: [
+              {
+                provider: 'jira',
+                kind: 'issue',
+                externalId: 'TAS-123',
+                metadata: { status: 'To Do' },
+              },
+              {
+                provider: 'bitbucket',
+                kind: 'pull_request',
+                repoRef: 'workspace/repo',
+                externalId: '45',
+                metadata: { state: 'OPEN' },
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
   it('two projects with different active milestones produce independent filtered sets', async () => {
     const sourceA = {
       ...mockSource,
@@ -779,6 +843,45 @@ describe('getIssue', () => {
     vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
     const result = await getIssue('unknown', '1');
     expect(result).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it('returns canonical work item id and external refs for item detail', async () => {
+    mockSource.getItem.mockResolvedValueOnce({
+      ...defaultMockItem('1'),
+      id: 'local:proj#1',
+      externalRefs: [
+        {
+          id: 1,
+          provider: 'jira',
+          kind: 'issue',
+          repoRef: null,
+          externalId: 'TAS-123',
+          url: 'https://company.atlassian.net/browse/TAS-123',
+          metadata: { status: 'To Do' },
+          createdAt: '2026-05-27T00:00:00Z',
+        },
+      ],
+    });
+
+    const result = await getIssue('proj', '1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          id: 'local:proj#1',
+          canonicalWorkItemId: 'local:proj#1',
+          externalRefs: [
+            {
+              provider: 'jira',
+              kind: 'issue',
+              externalId: 'TAS-123',
+              metadata: { status: 'To Do' },
+            },
+          ],
+        },
+      },
+    });
   });
 });
 
@@ -1431,6 +1534,51 @@ describe('getIssueArtifact', () => {
         payload: 'diff',
       });
     }
+  });
+
+  it('returns bounded artifact slices without returning the full payload', async () => {
+    vi.mocked(getArtifactSlice).mockReturnValueOnce({
+      id: 1,
+      artifactKey: 'provider-evidence:abc',
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+      runId: 'run-1',
+      kind: 'provider-evidence',
+      summary: 'Provider evidence',
+      bytes: 100,
+      createdAt: '2026-05-14T00:00:00Z',
+      expiresAt: null,
+      offset: 10,
+      limit: 20,
+      returnedBytes: 20,
+      hasMore: true,
+      payloadSlice: '01234567890123456789',
+      encoding: 'json',
+    });
+
+    const result = await getIssueArtifact('proj', '1', 'provider-evidence:abc', {
+      offset: 10,
+      limit: 20,
+    });
+
+    expect(getArtifact).not.toHaveBeenCalled();
+    expect(getArtifactSlice).toHaveBeenCalledWith('provider-evidence:abc', {
+      offset: 10,
+      limit: 20,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        artifact: {
+          artifactKey: 'provider-evidence:abc',
+          payloadSlice: '01234567890123456789',
+          offset: 10,
+          limit: 20,
+          hasMore: true,
+        },
+      },
+    });
+    if (result.ok) expect(result.data.artifact).not.toHaveProperty('payload');
   });
 
   it('rejects artifacts from another project', async () => {

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -1,5 +1,5 @@
 import { resolveAcceptanceContract } from '@goose-hub/core/acceptance-contracts/resolver.js';
-import { getArtifact } from '@goose-hub/core/agent-artifacts/repository.js';
+import { getArtifact, getArtifactSlice } from '@goose-hub/core/agent-artifacts/repository.js';
 import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { isIssueTimelineEvent } from '@goose-hub/core/event-stream/issue-timeline.js';
 import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
@@ -216,6 +216,14 @@ function buildPrdRelationships(projectId: string): {
   return { byParent, byChild };
 }
 
+function workItemServerDto(item: { id: string; externalRefs?: unknown }): object {
+  return {
+    ...(item as object),
+    canonicalWorkItemId: item.id,
+    externalRefs: Array.isArray(item.externalRefs) ? item.externalRefs : [],
+  };
+}
+
 // Public surface for the issues domain. The implementation is split across
 // sibling files to keep each concern focused; this barrel re-exports the
 // pieces the router and tests depend on.
@@ -239,8 +247,8 @@ export async function listIssues(
   const titleByExternalId = new Map(items.map((i) => [i.externalId, i.title]));
   const { byParent, byChild } = buildPrdRelationships(slug);
   const enriched = items.map((item) => ({
-    ...(item as object),
-    lastPersonaId: lastPersonaMap.get((item as { id: string }).id) ?? null,
+    ...workItemServerDto(item),
+    lastPersonaId: lastPersonaMap.get(item.id) ?? null,
     dependsOnTitles: Object.fromEntries(
       (item.dependsOn ?? [])
         .filter((ref) => titleByExternalId.has(ref))
@@ -261,7 +269,7 @@ export async function getIssue(slug: string, id: string): Promise<Result<{ item:
   const { byParent, byChild } = buildPrdRelationships(slug);
   const externalId = (item as { externalId: string }).externalId;
   const enriched = {
-    ...(item as object),
+    ...workItemServerDto(item as { id: string; externalRefs?: unknown }),
     lastPersonaId: lastPersonaMap.get(workItemId) ?? null,
     prdChildren: byParent.get(externalId),
     prdParent: byChild.get(externalId),
@@ -409,6 +417,7 @@ export async function getIssueArtifact(
   slug: string,
   id: string,
   artifactKey: string,
+  slice?: { offset?: number; limit?: number },
 ): Promise<
   Result<{
     artifact: {
@@ -421,13 +430,52 @@ export async function getIssueArtifact(
       bytes: number;
       createdAt: string;
       expiresAt: string | null;
-      payload: unknown;
+      payload?: unknown;
+      offset?: number;
+      limit?: number;
+      returnedBytes?: number;
+      hasMore?: boolean;
+      payloadSlice?: string;
+      encoding?: 'json';
     };
   }>
 > {
   const resolved = await resolveCanonicalWorkItemForRoute(slug, id);
   if (!resolved.ok) return resolved;
   const expectedWorkItemId = resolved.data.canonicalWorkItemId;
+
+  if (slice?.offset != null || slice?.limit != null) {
+    const artifact = getArtifactSlice(artifactKey, slice);
+    if (artifact == null) return { ok: false, error: 'artifact not found', status: 404 };
+    if (artifact.projectId !== slug) return { ok: false, error: 'artifact not found', status: 404 };
+    if (artifact.workItemId !== expectedWorkItemId) {
+      return { ok: false, error: 'artifact not found', status: 404 };
+    }
+
+    return {
+      ok: true,
+      data: {
+        artifact: {
+          artifactKey: artifact.artifactKey,
+          projectId: artifact.projectId,
+          workItemId: artifact.workItemId,
+          runId: artifact.runId,
+          kind: artifact.kind,
+          summary: artifact.summary,
+          bytes: artifact.bytes,
+          createdAt: artifact.createdAt,
+          expiresAt: artifact.expiresAt,
+          offset: artifact.offset,
+          limit: artifact.limit,
+          returnedBytes: artifact.returnedBytes,
+          hasMore: artifact.hasMore,
+          payloadSlice: artifact.payloadSlice,
+          encoding: artifact.encoding,
+        },
+      },
+    };
+  }
+
   const artifact = getArtifact(artifactKey);
   if (artifact == null) return { ok: false, error: 'artifact not found', status: 404 };
   if (artifact.projectId !== slug) return { ok: false, error: 'artifact not found', status: 404 };

--- a/apps/web/src/components/detail/components/DetailPage.test.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.test.tsx
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DetailPage } from './DetailPage';
+
+const { fetchIssue, fetchIssues, fetchEventsPage } = vi.hoisted(() => ({
+  fetchIssue: vi.fn(),
+  fetchIssues: vi.fn(),
+  fetchEventsPage: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  fetchIssue,
+  fetchIssues,
+  fetchEventsPage,
+}));
+
+vi.mock('@/state/active-milestone', () => ({
+  useActiveMilestone: () => ({ activeNumber: null }),
+}));
+
+vi.mock('@/lib/project-budget', () => ({
+  useProjectBudgetStatus: () => ({ data: null }),
+}));
+
+vi.mock('@/components/ui/ProjectBudgetBanner', () => ({
+  ProjectBudgetBanner: () => null,
+}));
+
+vi.mock('../lib/useHasOpenDep', () => ({
+  useHasOpenDep: () => false,
+}));
+
+vi.mock('./TaskHeader', () => ({
+  TaskHeader: ({ item }: { item?: { id: string } }) => (
+    <div data-testid="task-header">{item?.id}</div>
+  ),
+}));
+vi.mock('./GatePendingBanner', () => ({ GatePendingBanner: () => null }));
+vi.mock('./PendingNextRunBanner', () => ({ PendingNextRunBanner: () => null }));
+vi.mock('./ApprovalGateSection', () => ({ ApprovalGateSection: () => null }));
+vi.mock('./LeftRail', () => ({ LeftRail: () => null }));
+vi.mock('./OverviewSection', () => ({ OverviewSection: () => <div data-testid="overview" /> }));
+vi.mock('./TriageResultsSection', () => ({ TriageResultsSection: () => null }));
+vi.mock('./TimelineSection', () => ({ TimelineSection: () => null }));
+vi.mock('./InvestigationSection', () => ({ InvestigationSection: () => null }));
+vi.mock('./PRDSection', () => ({ PRDSection: () => null }));
+vi.mock('./GrillSection', () => ({ GrillSection: () => null }));
+vi.mock('./CodeDiffSection', () => ({ CodeDiffSection: () => null }));
+vi.mock('./QASection', () => ({ QASection: () => null }));
+vi.mock('./ReviewSection', () => ({ ReviewSection: () => null }));
+vi.mock('./RetrospectiveSection', () => ({ RetrospectiveSection: () => null }));
+vi.mock('./CostsSection', () => ({ CostsSection: () => null }));
+vi.mock('./DeferredSurface', () => ({ DeferredSurface: () => null }));
+
+class MockEventSource {
+  static urls: string[] = [];
+
+  constructor(url: string) {
+    MockEventSource.urls.push(url);
+  }
+
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  close = vi.fn();
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+}
+
+function renderDetailPage(path = '/projects/proj/items/1') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/projects/:slug/items/:id" element={<DetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('DetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockEventSource.urls = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    fetchEventsPage.mockResolvedValue({ events: [], hasMore: false });
+    fetchIssues.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('subscribes local-db detail pages with the canonical local Work Item id', async () => {
+    fetchIssue.mockResolvedValue({
+      id: 'local:proj#1',
+      canonicalWorkItemId: 'local:proj#1',
+      externalId: '1',
+      repoRef: 'owner/repo',
+      title: 'Local item',
+      body: '',
+      type: 'feature',
+      priority: 'medium',
+      mode: 'supervised',
+      state: 'factory:triaging',
+      authorIsOwner: true,
+      schedule: 'current',
+      exec: 'serial',
+      dependsOn: [],
+      blocks: [],
+      createdAt: '2026-05-27T00:00:00Z',
+      externalRefs: [],
+    });
+
+    renderDetailPage();
+
+    await waitFor(() => expect(MockEventSource.urls).toHaveLength(1));
+    const url = new URL(MockEventSource.urls[0], 'http://localhost');
+    expect(url.searchParams.get('workItemId')).toBe('local:proj#1');
+  });
+});

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -149,7 +149,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
   const { data: budgetStatus } = useProjectBudgetStatus(slug);
 
   const currentSection = SECTIONS.find((s) => s.key === section) ?? SECTIONS[0];
-  const workItemId = item != null ? `github:${item.repoRef}#${item.externalId}` : '';
+  const workItemId = item?.canonicalWorkItemId ?? item?.id ?? '';
 
   const safetyRefetchTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 

--- a/apps/web/src/components/detail/components/ExternalRefsSection.test.tsx
+++ b/apps/web/src/components/detail/components/ExternalRefsSection.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ExternalRefsSection } from './ExternalRefsSection';
+
+describe('ExternalRefsSection', () => {
+  it('shows local-only status when no external refs are linked', () => {
+    render(<ExternalRefsSection refs={[]} />);
+
+    expect(screen.getByText('Local-only')).toBeTruthy();
+    expect(screen.getByText('No external tracker or pull request linked')).toBeTruthy();
+  });
+
+  it('shows linked Jira and Bitbucket refs', () => {
+    render(
+      <ExternalRefsSection
+        refs={[
+          {
+            id: 1,
+            provider: 'jira',
+            kind: 'issue',
+            repoRef: null,
+            externalId: 'TAS-123',
+            url: 'https://company.atlassian.net/browse/TAS-123',
+            metadata: { status: 'To Do' },
+            createdAt: '2026-05-27T00:00:00Z',
+          },
+          {
+            id: 2,
+            provider: 'bitbucket',
+            kind: 'pull_request',
+            repoRef: 'workspace/repo',
+            externalId: '45',
+            url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+            metadata: { state: 'OPEN' },
+            createdAt: '2026-05-27T00:00:00Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Linked external refs')).toBeTruthy();
+    expect(screen.getByText('jira issue')).toBeTruthy();
+    expect(screen.getByText('TAS-123')).toBeTruthy();
+    expect(screen.getByText('bitbucket pull request')).toBeTruthy();
+    expect(screen.getByText('workspace/repo #45')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/ExternalRefsSection.tsx
+++ b/apps/web/src/components/detail/components/ExternalRefsSection.tsx
@@ -1,0 +1,80 @@
+import type { WorkItemExternalRefDto } from '@/lib/types';
+import { Link2 } from 'lucide-react';
+
+interface ExternalRefsSectionProps {
+  refs: WorkItemExternalRefDto[];
+}
+
+function labelForRef(ref: WorkItemExternalRefDto): string {
+  return `${ref.provider} ${ref.kind.replaceAll('_', ' ')}`;
+}
+
+function displayId(ref: WorkItemExternalRefDto): string {
+  return ref.repoRef == null ? ref.externalId : `${ref.repoRef} #${ref.externalId}`;
+}
+
+function ExternalRefRowContent({ externalRef }: { externalRef: WorkItemExternalRefDto }) {
+  return (
+    <>
+      <span className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line bg-bg-elev-2 text-fg-3 shrink-0">
+        <Link2 size={14} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12px] uppercase tracking-wider text-fg-3">
+          {labelForRef(externalRef)}
+        </span>
+        <span className="block font-mono text-[13px] text-fg truncate">
+          {displayId(externalRef)}
+        </span>
+      </span>
+    </>
+  );
+}
+
+export function ExternalRefsSection({ refs }: ExternalRefsSectionProps) {
+  if (refs.length === 0) {
+    return (
+      <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
+        <div className="px-4 py-3 border-b border-line bg-bg-elev-2">
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-2">External refs</div>
+        </div>
+        <div className="px-4 py-4 flex items-center gap-3">
+          <span className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line bg-bg-elev-2 text-fg-3">
+            <Link2 size={14} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[13px] font-medium text-fg">Local-only</div>
+            <div className="text-[12px] text-fg-3">No external tracker or pull request linked</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
+      <div className="px-4 py-3 border-b border-line bg-bg-elev-2">
+        <div className="text-[10.5px] uppercase tracking-wider text-fg-2">Linked external refs</div>
+      </div>
+      <div className="divide-y divide-line">
+        {refs.map((ref) => {
+          return ref.url == null ? (
+            <div key={ref.id} className="px-4 py-3 flex items-center gap-3">
+              <ExternalRefRowContent externalRef={ref} />
+            </div>
+          ) : (
+            <a
+              key={ref.id}
+              href={ref.url}
+              target="_blank"
+              rel="noreferrer"
+              className="px-4 py-3 flex items-center gap-3 hover:bg-bg-hover"
+            >
+              <ExternalRefRowContent externalRef={ref} />
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -11,6 +11,7 @@ import { parseDiff } from '../lib/code-diff';
 import { useIssueCostsBreakdown } from '../lib/costs';
 import { CommentsSection } from './CommentsSection';
 import { DependenciesSection } from './DependenciesSection';
+import { ExternalRefsSection } from './ExternalRefsSection';
 import { StatCard } from './StatCard';
 
 interface OverviewSectionProps {
@@ -101,6 +102,8 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
 
       {/* Main content grid */}
       <div className="grid gap-4">
+        <ExternalRefsSection refs={item?.externalRefs ?? []} />
+
         {/* Brief card */}
         <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
           <div className="px-4 py-3 border-b border-line bg-bg-elev-2">

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -7,8 +7,20 @@ export interface ProjectSummary {
   defaultBranch?: string;
 }
 
+export interface WorkItemExternalRefDto {
+  id: number;
+  provider: string;
+  kind: string;
+  repoRef: string | null;
+  externalId: string;
+  url: string | null;
+  metadata: unknown | null;
+  createdAt: string;
+}
+
 export interface WorkItemDto {
   id: string;
+  canonicalWorkItemId: string;
   externalId: string;
   repoRef: string;
   title: string;
@@ -27,6 +39,7 @@ export interface WorkItemDto {
   blocks: string[];
   prdChildren?: string[];
   prdParent?: string;
+  externalRefs: WorkItemExternalRefDto[];
   createdAt: string;
   lastPersonaId?: string | null;
 }

--- a/core/agent-artifacts/repository.test.ts
+++ b/core/agent-artifacts/repository.test.ts
@@ -5,6 +5,7 @@ import { agentArtifacts } from '../db/schema.js';
 import {
   deterministicArtifactKey,
   getArtifact,
+  getArtifactSlice,
   listArtifactsForRun,
   listArtifactsForWorkItem,
   maybeStoreLargePayload,
@@ -168,6 +169,34 @@ describe('agent artifact repository', () => {
       summary: 'Large payload',
     });
     expect(getArtifact('large:test')?.payload).toEqual({ body: 'x'.repeat(64) });
+  });
+
+  it('returns bounded serialized payload slices without parsing the full artifact payload', () => {
+    storeArtifact({
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      runId: RUN_ID,
+      kind: 'provider-evidence',
+      summary: 'Provider evidence',
+      payload: { body: 'abcdefghijklmnopqrstuvwxyz' },
+      artifactKey: 'provider-evidence:test',
+    });
+
+    const slice = getArtifactSlice('provider-evidence:test', { offset: 9, limit: 10 });
+
+    expect(slice).toMatchObject({
+      artifactKey: 'provider-evidence:test',
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      kind: 'provider-evidence',
+      offset: 9,
+      limit: 10,
+      returnedBytes: 10,
+      hasMore: true,
+      payloadSlice: 'abcdefghij',
+      encoding: 'json',
+    });
+    expect(slice).not.toHaveProperty('payload');
   });
 
   it('measures UTF-8 bytes rather than string length', () => {

--- a/core/agent-artifacts/repository.ts
+++ b/core/agent-artifacts/repository.ts
@@ -3,9 +3,10 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { db } from '../db/db.js';
 import { agentArtifacts } from '../db/schema.js';
 import { redactSecrets } from '../tool-layer/secret-redaction.js';
-import type { ArtifactRef, StoredArtifact } from './types.js';
+import type { ArtifactRef, StoredArtifact, StoredArtifactSlice } from './types.js';
 
 export const DEFAULT_ARTIFACT_THRESHOLD_BYTES = 25 * 1024;
+export const MAX_ARTIFACT_SLICE_BYTES = 64 * 1024;
 
 export type StoreArtifactInput = {
   projectId: string;
@@ -57,6 +58,11 @@ function isExpired(expiresAt: string | null): boolean {
 
 function serializePayload(payload: unknown): string {
   return JSON.stringify(payload ?? null);
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
 }
 
 function rowToArtifact(row: typeof agentArtifacts.$inferSelect): StoredArtifact | null {
@@ -132,6 +138,47 @@ export function getArtifact(artifactKey: string): StoredArtifact | null {
     .where(eq(agentArtifacts.artifactKey, artifactKey))
     .get();
   return row == null ? null : rowToArtifact(row);
+}
+
+export function getArtifactSlice(
+  artifactKey: string,
+  slice: { offset?: number; limit?: number },
+): StoredArtifactSlice | null {
+  const row = db
+    .select()
+    .from(agentArtifacts)
+    .where(eq(agentArtifacts.artifactKey, artifactKey))
+    .get();
+  if (row == null || isExpired(row.expiresAt)) return null;
+
+  const offset = nonNegativeInteger(slice.offset, 0);
+  const limit = Math.min(
+    MAX_ARTIFACT_SLICE_BYTES,
+    nonNegativeInteger(slice.limit, MAX_ARTIFACT_SLICE_BYTES),
+  );
+  const payloadBytes = Buffer.from(row.payloadJson, 'utf8');
+  const byteSlice = payloadBytes.subarray(offset, offset + limit);
+  const payloadSlice = byteSlice.toString('utf8');
+  const returnedBytes = byteSlice.length;
+
+  return {
+    id: row.id,
+    artifactKey: row.artifactKey,
+    projectId: row.projectId,
+    workItemId: row.workItemId,
+    runId: row.runId,
+    kind: row.kind,
+    summary: row.summary,
+    bytes: row.bytes,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    offset,
+    limit,
+    returnedBytes,
+    hasMore: offset + returnedBytes < payloadBytes.length,
+    payloadSlice,
+    encoding: 'json',
+  };
 }
 
 export function listArtifactsForRun(runId: string): StoredArtifact[] {

--- a/core/agent-artifacts/types.ts
+++ b/core/agent-artifacts/types.ts
@@ -20,6 +20,15 @@ export type StoredArtifact = {
   expiresAt: string | null;
 };
 
+export type StoredArtifactSlice = Omit<StoredArtifact, 'payload'> & {
+  offset: number;
+  limit: number;
+  returnedBytes: number;
+  hasMore: boolean;
+  payloadSlice: string;
+  encoding: 'json';
+};
+
 export type InlinePayload<T = unknown> = {
   stored: false;
   payload: T;

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -7,6 +7,17 @@ export type Mode = 'interactive' | 'supervised' | 'autonomous';
 export type Schedule = 'current' | 'next' | 'later' | 'blocked-by';
 export type ExecMode = 'serial' | 'parallel';
 
+export interface WorkItemExternalRef {
+  id: number;
+  provider: string;
+  kind: string;
+  repoRef: string | null;
+  externalId: string;
+  url: string | null;
+  metadata: unknown | null;
+  createdAt: string;
+}
+
 /**
  * Default values applied when a work item has no label in the corresponding
  * group. Used by the ingress parsers in `github-labels.ts` so the fallback
@@ -37,6 +48,7 @@ export interface WorkItem {
   dependsOn: string[]; // repo-qualified refs parsed from body
   blocks: string[];
   createdAt: Date;
+  externalRefs?: WorkItemExternalRef[];
 }
 
 export interface Milestone {

--- a/core/state-source/local-db-repository.test.ts
+++ b/core/state-source/local-db-repository.test.ts
@@ -206,6 +206,51 @@ describe('LocalDbWorkItemRepository', () => {
     ]);
   });
 
+  it('returns typed external ref read models with parsed metadata', () => {
+    const { repository } = trackedRepository();
+    const item = repository.createWorkItem({ projectId: 'proj', title: 'Imported Jira issue' });
+
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: item.id,
+      provider: 'jira',
+      kind: 'issue',
+      externalId: 'TAS-123',
+      url: 'https://company.atlassian.net/browse/TAS-123',
+      metadata: { status: 'In Progress', issueType: 'Bug' },
+    });
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: item.id,
+      provider: 'bitbucket',
+      kind: 'pull_request',
+      repoRef: 'workspace/repo',
+      externalId: '45',
+      url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+      metadata: { branch: 'feature/local-state', state: 'OPEN' },
+    });
+
+    expect(repository.listExternalRefReadModels('proj', item.id)).toEqual([
+      expect.objectContaining({
+        provider: 'jira',
+        kind: 'issue',
+        repoRef: null,
+        externalId: 'TAS-123',
+        metadata: { status: 'In Progress', issueType: 'Bug' },
+      }),
+      expect.objectContaining({
+        provider: 'bitbucket',
+        kind: 'pull_request',
+        repoRef: 'workspace/repo',
+        externalId: '45',
+        metadata: { branch: 'feature/local-state', state: 'OPEN' },
+      }),
+    ]);
+    expect(
+      repository.listExternalRefReadModelsByKind({ projectId: 'proj', provider: 'jira' }),
+    ).toEqual([expect.objectContaining({ provider: 'jira', externalId: 'TAS-123' })]);
+  });
+
   it('creates, updates, lists, and resolves Bitbucket pull request refs by repo identity', () => {
     const { repository } = trackedRepository();
     const item = repository.createWorkItem({ projectId: 'proj', title: 'Linked Bitbucket PR' });

--- a/core/state-source/local-db-repository.ts
+++ b/core/state-source/local-db-repository.ts
@@ -18,6 +18,7 @@ import type {
   Mode,
   Priority,
   Schedule,
+  WorkItemExternalRef,
   WorkItemType,
 } from './interface.js';
 
@@ -27,6 +28,7 @@ export type LocalDbMilestoneRow = typeof workItemMilestones.$inferSelect;
 export type LocalDbRepoLinkRow = typeof workItemRepoLinks.$inferSelect;
 export type LocalDbExternalRefRow = typeof workItemExternalRefs.$inferSelect;
 export type LocalDbStateEventRow = typeof workItemStateEvents.$inferSelect;
+export type LocalDbExternalRefReadModel = WorkItemExternalRef;
 
 export interface LocalDbCreateWorkItemInput {
   projectId: string;
@@ -61,6 +63,28 @@ function externalIdFromItemId(projectId: string, itemId: string): string {
   const localPrefix = `local:${projectId}#`;
   if (itemId.startsWith(localPrefix)) return itemId.slice(localPrefix.length);
   return itemId.match(/#([^#]+)$/)?.[1] ?? itemId;
+}
+
+export function parseExternalRefMetadata(row: LocalDbExternalRefRow): unknown | null {
+  if (row.metadataJson == null) return null;
+  try {
+    return JSON.parse(row.metadataJson) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function toExternalRefReadModel(row: LocalDbExternalRefRow): LocalDbExternalRefReadModel {
+  return {
+    id: row.id,
+    provider: row.provider,
+    kind: row.kind,
+    repoRef: row.repoRef,
+    externalId: row.externalId,
+    url: row.url,
+    metadata: parseExternalRefMetadata(row),
+    createdAt: row.createdAt,
+  };
 }
 
 export class LocalDbWorkItemRepository {
@@ -508,6 +532,14 @@ export class LocalDbWorkItemRepository {
       .all();
   }
 
+  listExternalRefReadModelsByKind(input: {
+    projectId: string;
+    provider?: string;
+    kind?: string;
+  }): LocalDbExternalRefReadModel[] {
+    return this.listExternalRefsByKind(input).map(toExternalRefReadModel);
+  }
+
   listExternalRefs(projectId: string, itemId: string): LocalDbExternalRefRow[] {
     const item = this.requireWorkItem(projectId, itemId);
     return this.db
@@ -516,6 +548,10 @@ export class LocalDbWorkItemRepository {
       .where(eq(workItemExternalRefs.workItemId, item.id))
       .orderBy(asc(workItemExternalRefs.id))
       .all();
+  }
+
+  listExternalRefReadModels(projectId: string, itemId: string): LocalDbExternalRefReadModel[] {
+    return this.listExternalRefs(projectId, itemId).map(toExternalRefReadModel);
   }
 
   listStateEvents(projectId: string, itemId: string): LocalDbStateEventRow[] {

--- a/core/state-source/local-db.test.ts
+++ b/core/state-source/local-db.test.ts
@@ -103,6 +103,63 @@ describe('LocalDbStateSource', () => {
     });
   });
 
+  it('includes provider-neutral external refs on listed and fetched Work Items', async () => {
+    const { source, repository } = trackedSource();
+    const created = await source.createIssue({
+      title: 'Imported Jira work',
+      body: '',
+    });
+
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: created.id,
+      provider: 'jira',
+      kind: 'issue',
+      externalId: 'TAS-123',
+      url: 'https://company.atlassian.net/browse/TAS-123',
+      metadata: { status: 'To Do' },
+    });
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: created.id,
+      provider: 'bitbucket',
+      kind: 'pull_request',
+      repoRef: 'workspace/repo',
+      externalId: '45',
+      url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+      metadata: { state: 'OPEN' },
+    });
+
+    await expect(source.getItem(created.id)).resolves.toMatchObject({
+      id: 'local:proj#1',
+      externalRefs: [
+        {
+          provider: 'jira',
+          kind: 'issue',
+          repoRef: null,
+          externalId: 'TAS-123',
+          metadata: { status: 'To Do' },
+        },
+        {
+          provider: 'bitbucket',
+          kind: 'pull_request',
+          repoRef: 'workspace/repo',
+          externalId: '45',
+          metadata: { state: 'OPEN' },
+        },
+      ],
+    });
+    await expect(source.listOpenWork()).resolves.toMatchObject([
+      {
+        id: 'local:proj#1',
+        externalRefs: [
+          expect.objectContaining({ provider: 'jira', externalId: 'TAS-123' }),
+          expect.objectContaining({ provider: 'bitbucket', externalId: '45' }),
+        ],
+      },
+    ]);
+  });
+
   it('rejects illegal transitions and records forced transition history', async () => {
     const { source, repository } = trackedSource();
     const created = await source.createIssue({ title: 'A', body: '' });

--- a/core/state-source/local-db.ts
+++ b/core/state-source/local-db.ts
@@ -100,6 +100,7 @@ export class LocalDbStateSource implements StateSource {
       dependsOn: mapDependencyRefs(row.body, 'depends-on', repoRef),
       blocks: mapDependencyRefs(row.body, 'blocks', repoRef),
       createdAt: new Date(row.createdAt),
+      externalRefs: this.repository.listExternalRefReadModels(this.projectId, row.id),
     };
   }
 


### PR DESCRIPTION
## Summary

Implements PR A from `docs/superpowers/plans/2026-05-27-local-state-over-jira-bitbucket-plan.md`: Local-DB External Ref Read Model and Canonical IDs.

This keeps Jira and Bitbucket as provider-neutral external refs only. It does not add provider network integration.

## Changes

- Adds typed local-db external-ref read models so callers do not parse `metadata_json` directly.
- Surfaces `canonicalWorkItemId` and `externalRefs` on Work Item DTOs from `listIssues` and `getIssue`.
- Updates local-db detail pages to subscribe with the canonical local Work Item id.
- Adds detail UI for linked external refs and explicit local-only Work Items.
- Adds bounded artifact slice retrieval through the existing issue artifact route.

## Explicit Non-Goals

- No Jira REST calls.
- No Bitbucket REST calls.
- No raw JQL or CQL.
- No assigned-to-me import.
- No post-back comments.

## Verification

- `pnpm test core/state-source/local-db-repository.test.ts core/state-source/local-db.test.ts core/agent-artifacts/repository.test.ts apps/server/src/domains/issues/service.test.ts apps/server/src/domains/issues/router.test.ts apps/web/src/components/detail/components/DetailPage.test.tsx apps/web/src/components/detail/components/ExternalRefsSection.test.tsx`
- `pnpm test core/integrations/github/import-issues.test.ts core/integrations/github/label-mirror.test.ts`
- `pnpm exec biome check ...touched files...`
- `pnpm typecheck`
