### PR TITLE
Add Atlassian integration contract boundary

### DIFF
--- a/core/integrations/atlassian/adapters.ts
+++ b/core/integrations/atlassian/adapters.ts
@@ -1,0 +1,64 @@
+import type {
+  BitbucketPullRequestDetailDto,
+  JiraIssueCardDto,
+  JiraIssueDetailDto,
+} from './dtos.js';
+import type { ProviderResult } from './errors.js';
+
+export type JiraQueryLevel = 'L0' | 'L1' | 'L2' | 'L3';
+
+export interface JiraIssueSearchRequest {
+  level: Exclude<JiraQueryLevel, 'L0'>;
+  projects: string[];
+  maxResults: number;
+  updated: {
+    from: string;
+    to: string;
+  };
+  text?: string;
+  assignee?: {
+    accountId: string;
+  };
+}
+
+export interface AtlassianSearchPage<T> {
+  provider: 'jira' | 'bitbucket';
+  tier: 'headline' | 'card' | 'detail';
+  issues?: T[];
+  pullRequests?: T[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
+export interface JiraProviderAdapter {
+  getIssue(input: { key: string; tier: 'headline' | 'card' | 'detail' }): Promise<
+    ProviderResult<JiraIssueDetailDto>
+  >;
+  searchIssues(
+    input: JiraIssueSearchRequest,
+  ): Promise<ProviderResult<AtlassianSearchPage<JiraIssueCardDto>>>;
+  getCurrentUser(): Promise<ProviderResult<{ accountId: string; displayName?: string }>>;
+}
+
+export interface BitbucketPullRequestSearchRequest {
+  workspace: string;
+  repos: string[];
+  maxResults: number;
+  updated: {
+    from: string;
+    to: string;
+  };
+  text?: string;
+}
+
+export interface BitbucketProviderAdapter {
+  getPullRequest(input: {
+    workspace: string;
+    repo: string;
+    pullRequestId: string;
+    tier: 'headline' | 'card' | 'detail';
+  }): Promise<ProviderResult<BitbucketPullRequestDetailDto>>;
+  searchPullRequests(
+    input: BitbucketPullRequestSearchRequest,
+  ): Promise<ProviderResult<AtlassianSearchPage<BitbucketPullRequestDetailDto>>>;
+}

--- a/core/integrations/atlassian/dtos.test.ts
+++ b/core/integrations/atlassian/dtos.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { AtlassianDetailSchema, AtlassianEvidenceSchema, AtlassianHeadlineSchema } from './dtos.js';
+
+describe('Atlassian DTO schemas', () => {
+  it('accepts headline, detail, and evidence tiers with artifact refs for provider bodies', () => {
+    expect(
+      AtlassianHeadlineSchema.parse({
+        provider: 'jira',
+        resourceKind: 'issue',
+        tier: 'headline',
+        id: 'TAS-123',
+        key: 'TAS-123',
+        title: 'Ship the import boundary',
+        status: 'To Do',
+        url: 'https://company.atlassian.net/browse/TAS-123',
+        totalCount: 1,
+        hasMore: false,
+      }),
+    ).toMatchObject({ tier: 'headline', key: 'TAS-123' });
+
+    expect(
+      AtlassianDetailSchema.parse({
+        provider: 'jira',
+        resourceKind: 'issue',
+        tier: 'detail',
+        id: 'TAS-123',
+        key: 'TAS-123',
+        title: 'Ship the import boundary',
+        status: 'To Do',
+        url: 'https://company.atlassian.net/browse/TAS-123',
+        project: 'TAS',
+        issueType: 'Story',
+        assignee: { displayName: 'Ada Lovelace' },
+        priority: 'High',
+        created: '2026-05-27T00:00:00Z',
+        updated: '2026-05-27T01:00:00Z',
+        bodyPreview: 'A capped description preview',
+        bodyArtifactRef: {
+          stored: true,
+          artifactKey: 'atlassian:jira:detail:TAS-123:abc',
+          kind: 'atlassian:jira:detail:TAS-123',
+          summary: 'Full Jira description',
+          bytes: 1024,
+        },
+        labels: ['factory'],
+        components: ['hub'],
+        linkedKeys: ['TAS-456'],
+      }),
+    ).toMatchObject({ tier: 'detail', bodyPreview: 'A capped description preview' });
+
+    expect(
+      AtlassianEvidenceSchema.parse({
+        provider: 'bitbucket',
+        resourceKind: 'pull_request',
+        tier: 'evidence',
+        id: '45',
+        url: 'https://bitbucket.org/company/api/pull-requests/45',
+        commentsSummary: '3 comments stored as artifact',
+        historySummary: '2 state changes stored as artifact',
+        attachmentSummaries: ['build-log.txt'],
+        artifactRefs: [
+          {
+            stored: true,
+            artifactKey: 'atlassian:bitbucket:evidence:45:def',
+            kind: 'atlassian:bitbucket:evidence:45',
+            summary: 'Bitbucket comments',
+            bytes: 2048,
+          },
+        ],
+      }),
+    ).toMatchObject({ provider: 'bitbucket', tier: 'evidence' });
+  });
+
+  it('rejects inline raw provider payloads at the service boundary', () => {
+    const parsed = AtlassianDetailSchema.safeParse({
+      provider: 'jira',
+      resourceKind: 'issue',
+      tier: 'detail',
+      id: 'TAS-123',
+      key: 'TAS-123',
+      title: 'Raw issue',
+      status: 'To Do',
+      url: 'https://company.atlassian.net/browse/TAS-123',
+      raw: { fields: { summary: 'Raw issue' } },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/core/integrations/atlassian/dtos.ts
+++ b/core/integrations/atlassian/dtos.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+export const AtlassianProviderSchema = z.enum(['jira', 'bitbucket']);
+export const AtlassianTierSchema = z.enum(['headline', 'card', 'detail', 'evidence']);
+export const AtlassianResourceKindSchema = z.enum(['issue', 'pull_request']);
+
+export const AtlassianArtifactRefSchema = z
+  .object({
+    artifactKey: z.string().min(1),
+    kind: z.string().min(1),
+    summary: z.string().min(1),
+    bytes: z.number().int().nonnegative(),
+    stored: z.literal(true),
+  })
+  .strict();
+
+const AssigneeSchema = z
+  .object({
+    displayName: z.string().min(1),
+    accountId: z.string().min(1).optional(),
+    emailAddress: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const AtlassianHeadlineSchema = z
+  .object({
+    provider: AtlassianProviderSchema,
+    resourceKind: AtlassianResourceKindSchema,
+    tier: z.literal('headline'),
+    id: z.string().min(1),
+    key: z.string().min(1).optional(),
+    title: z.string().min(1),
+    status: z.string().min(1),
+    url: z.string().url(),
+    totalCount: z.number().int().nonnegative().optional(),
+    hasMore: z.boolean().optional(),
+  })
+  .strict();
+
+export const AtlassianCardSchema = AtlassianHeadlineSchema.extend({
+  tier: z.literal('card'),
+  project: z.string().min(1).optional(),
+  issueType: z.string().min(1).optional(),
+  repoRef: z.string().min(1).optional(),
+  assignee: AssigneeSchema.optional(),
+  priority: z.string().min(1).optional(),
+  created: z.string().min(1).optional(),
+  updated: z.string().min(1).optional(),
+}).strict();
+
+export const AtlassianDetailSchema = AtlassianCardSchema.extend({
+  tier: z.literal('detail'),
+  bodyPreview: z.string().optional(),
+  bodyArtifactRef: AtlassianArtifactRefSchema.optional(),
+  labels: z.array(z.string()).default([]),
+  components: z.array(z.string()).default([]),
+  linkedKeys: z.array(z.string()).default([]),
+}).strict();
+
+export const AtlassianEvidenceSchema = z
+  .object({
+    provider: AtlassianProviderSchema,
+    resourceKind: AtlassianResourceKindSchema,
+    tier: z.literal('evidence'),
+    id: z.string().min(1),
+    key: z.string().min(1).optional(),
+    url: z.string().url(),
+    commentsSummary: z.string().optional(),
+    historySummary: z.string().optional(),
+    attachmentSummaries: z.array(z.string()).default([]),
+    artifactRefs: z.array(AtlassianArtifactRefSchema).default([]),
+  })
+  .strict();
+
+export const JiraIssueHeadlineSchema = AtlassianHeadlineSchema.extend({
+  provider: z.literal('jira'),
+  resourceKind: z.literal('issue'),
+}).strict();
+
+export const JiraIssueCardSchema = AtlassianCardSchema.extend({
+  provider: z.literal('jira'),
+  resourceKind: z.literal('issue'),
+}).strict();
+
+export const JiraIssueDetailSchema = AtlassianDetailSchema.extend({
+  provider: z.literal('jira'),
+  resourceKind: z.literal('issue'),
+}).strict();
+
+export const BitbucketPullRequestHeadlineSchema = AtlassianHeadlineSchema.extend({
+  provider: z.literal('bitbucket'),
+  resourceKind: z.literal('pull_request'),
+}).strict();
+
+export const BitbucketPullRequestCardSchema = AtlassianCardSchema.extend({
+  provider: z.literal('bitbucket'),
+  resourceKind: z.literal('pull_request'),
+}).strict();
+
+export const BitbucketPullRequestDetailSchema = AtlassianDetailSchema.extend({
+  provider: z.literal('bitbucket'),
+  resourceKind: z.literal('pull_request'),
+}).strict();
+
+export type AtlassianProvider = z.infer<typeof AtlassianProviderSchema>;
+export type AtlassianTier = z.infer<typeof AtlassianTierSchema>;
+export type AtlassianArtifactRef = z.infer<typeof AtlassianArtifactRefSchema>;
+export type AtlassianHeadlineDto = z.infer<typeof AtlassianHeadlineSchema>;
+export type AtlassianCardDto = z.infer<typeof AtlassianCardSchema>;
+export type AtlassianDetailDto = z.infer<typeof AtlassianDetailSchema>;
+export type AtlassianEvidenceDto = z.infer<typeof AtlassianEvidenceSchema>;
+export type JiraIssueHeadlineDto = z.infer<typeof JiraIssueHeadlineSchema>;
+export type JiraIssueCardDto = z.infer<typeof JiraIssueCardSchema>;
+export type JiraIssueDetailDto = z.infer<typeof JiraIssueDetailSchema>;
+export type BitbucketPullRequestHeadlineDto = z.infer<typeof BitbucketPullRequestHeadlineSchema>;
+export type BitbucketPullRequestCardDto = z.infer<typeof BitbucketPullRequestCardSchema>;
+export type BitbucketPullRequestDetailDto = z.infer<typeof BitbucketPullRequestDetailSchema>;

--- a/core/integrations/atlassian/errors.test.ts
+++ b/core/integrations/atlassian/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ProviderErrorKindSchema,
+  mapHttpStatusToProviderErrorKind,
+  providerFailure,
+} from './errors.js';
+
+describe('Atlassian provider errors', () => {
+  it('covers the provider error kinds callers need to branch on', () => {
+    expect(ProviderErrorKindSchema.options).toEqual([
+      'validation',
+      'auth',
+      'permission',
+      'not_found',
+      'query',
+      'rate_limit',
+      'connection',
+      'post_back',
+    ]);
+  });
+
+  it('maps HTTP provider failures into typed result variants', () => {
+    expect(mapHttpStatusToProviderErrorKind(400)).toBe('query');
+    expect(mapHttpStatusToProviderErrorKind(401)).toBe('auth');
+    expect(mapHttpStatusToProviderErrorKind(403)).toBe('permission');
+    expect(mapHttpStatusToProviderErrorKind(404)).toBe('not_found');
+    expect(mapHttpStatusToProviderErrorKind(429)).toBe('rate_limit');
+    expect(mapHttpStatusToProviderErrorKind(503)).toBe('connection');
+    expect(mapHttpStatusToProviderErrorKind(403, 'post_back')).toBe('post_back');
+  });
+
+  it('returns provider errors as result variants', () => {
+    expect(providerFailure('not_found', 'Jira issue not found', { status: 404 })).toEqual({
+      ok: false,
+      error: {
+        kind: 'not_found',
+        message: 'Jira issue not found',
+        status: 404,
+      },
+    });
+  });
+});

--- a/core/integrations/atlassian/errors.ts
+++ b/core/integrations/atlassian/errors.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+export const ProviderErrorKindSchema = z.enum([
+  'validation',
+  'auth',
+  'permission',
+  'not_found',
+  'query',
+  'rate_limit',
+  'connection',
+  'post_back',
+]);
+
+export const ProviderErrorSchema = z
+  .object({
+    kind: ProviderErrorKindSchema,
+    message: z.string().min(1),
+    status: z.number().int().positive().optional(),
+    retryAfterSeconds: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export type ProviderErrorKind = z.infer<typeof ProviderErrorKindSchema>;
+export type ProviderError = z.infer<typeof ProviderErrorSchema>;
+export type ProviderResult<T> = { ok: true; data: T } | { ok: false; error: ProviderError };
+
+export function providerError(
+  kind: ProviderErrorKind,
+  message: string,
+  options: Omit<ProviderError, 'kind' | 'message'> = {},
+): ProviderError {
+  return ProviderErrorSchema.parse({
+    kind,
+    message,
+    ...options,
+  });
+}
+
+export function providerFailure(
+  kind: ProviderErrorKind,
+  message: string,
+  options: Omit<ProviderError, 'kind' | 'message'> = {},
+): ProviderResult<never> {
+  return {
+    ok: false,
+    error: providerError(kind, message, options),
+  };
+}
+
+export function mapHttpStatusToProviderErrorKind(
+  status: number,
+  operation?: 'read' | 'query' | 'post_back',
+): ProviderErrorKind {
+  if (operation === 'post_back') return 'post_back';
+  if (status === 400) return 'query';
+  if (status === 401) return 'auth';
+  if (status === 403) return 'permission';
+  if (status === 404) return 'not_found';
+  if (status === 408 || status >= 500) return 'connection';
+  if (status === 429) return 'rate_limit';
+  return 'connection';
+}

--- a/core/integrations/atlassian/index.ts
+++ b/core/integrations/atlassian/index.ts
@@ -1,0 +1,6 @@
+export * from './adapters.js';
+export * from './dtos.js';
+export * from './errors.js';
+export * from './jira.js';
+export * from './payload-offload.js';
+export * from './query.js';

--- a/core/integrations/atlassian/jira.test.ts
+++ b/core/integrations/atlassian/jira.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { parseJiraIssueRef } from './jira.js';
+
+const config = {
+  baseUrl: 'https://company.atlassian.net',
+  projectKeys: ['TAS', 'OPS'],
+};
+
+describe('Jira key and URL parsing', () => {
+  it('resolves exact Jira keys as L0 refs', () => {
+    expect(parseJiraIssueRef('TAS-123', config)).toEqual({
+      ok: true,
+      ref: {
+        provider: 'jira',
+        level: 'L0',
+        key: 'TAS-123',
+        projectKey: 'TAS',
+        url: 'https://company.atlassian.net/browse/TAS-123',
+      },
+    });
+  });
+
+  it('resolves configured browse URLs as L0 refs', () => {
+    expect(
+      parseJiraIssueRef('https://company.atlassian.net/browse/OPS-9?focusedCommentId=1', config),
+    ).toEqual({
+      ok: true,
+      ref: {
+        provider: 'jira',
+        level: 'L0',
+        key: 'OPS-9',
+        projectKey: 'OPS',
+        url: 'https://company.atlassian.net/browse/OPS-9',
+      },
+    });
+  });
+
+  it('rejects unconfigured project keys and browse hosts', () => {
+    expect(parseJiraIssueRef('ABC-1', config)).toMatchObject({
+      ok: false,
+      error: { kind: 'validation' },
+    });
+    expect(parseJiraIssueRef('https://evil.example/browse/TAS-123', config)).toMatchObject({
+      ok: false,
+      error: { kind: 'validation' },
+    });
+  });
+});

--- a/core/integrations/atlassian/jira.ts
+++ b/core/integrations/atlassian/jira.ts
@@ -1,0 +1,96 @@
+import type { ProviderError } from './errors.js';
+import { providerError } from './errors.js';
+
+const JIRA_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
+
+export interface JiraParseConfig {
+  baseUrl: string;
+  projectKeys: readonly string[];
+}
+
+export interface JiraIssueRef {
+  provider: 'jira';
+  level: 'L0';
+  key: string;
+  projectKey: string;
+  url: string;
+}
+
+export type JiraIssueRefResult =
+  | { ok: true; ref: JiraIssueRef }
+  | { ok: false; error: ProviderError };
+
+export function parseJiraIssueRef(input: string, config: JiraParseConfig): JiraIssueRefResult {
+  const value = input.trim();
+  const exactKey = normalizeJiraKey(value);
+  if (exactKey != null) return refFromKey(exactKey, config);
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return {
+      ok: false,
+      error: providerError(
+        'validation',
+        'Jira input must be an exact issue key or configured browse URL',
+      ),
+    };
+  }
+
+  const configuredBase = parseConfiguredBaseUrl(config.baseUrl);
+  if (configuredBase == null || url.origin !== configuredBase.origin) {
+    return {
+      ok: false,
+      error: providerError('validation', 'Jira browse URL does not match the configured base URL'),
+    };
+  }
+
+  const browseMatch = url.pathname.match(/^\/browse\/([A-Z][A-Z0-9]+-\d+)\/?$/);
+  if (browseMatch == null) {
+    return {
+      ok: false,
+      error: providerError('validation', 'Jira browse URL must use /browse/<KEY>'),
+    };
+  }
+
+  return refFromKey(browseMatch[1], config);
+}
+
+export function normalizeJiraKey(input: string): string | null {
+  const value = input.trim().toUpperCase();
+  return JIRA_KEY_PATTERN.test(value) ? value : null;
+}
+
+function refFromKey(key: string, config: JiraParseConfig): JiraIssueRefResult {
+  const projectKey = key.split('-')[0];
+  if (!config.projectKeys.includes(projectKey)) {
+    return {
+      ok: false,
+      error: providerError('validation', `Jira project key '${projectKey}' is not configured`),
+    };
+  }
+
+  return {
+    ok: true,
+    ref: {
+      provider: 'jira',
+      level: 'L0',
+      key,
+      projectKey,
+      url: `${trimTrailingSlash(config.baseUrl)}/browse/${key}`,
+    },
+  };
+}
+
+function parseConfiguredBaseUrl(baseUrl: string): URL | null {
+  try {
+    return new URL(trimTrailingSlash(baseUrl));
+  } catch {
+    return null;
+  }
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}

--- a/core/integrations/atlassian/payload-offload.test.ts
+++ b/core/integrations/atlassian/payload-offload.test.ts
@@ -1,0 +1,104 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getArtifact } from '../../agent-artifacts/repository.js';
+import { db } from '../../db/db.js';
+import { agentArtifacts } from '../../db/schema.js';
+import { offloadAtlassianPayload } from './payload-offload.js';
+
+const PROJECT = 'atlassian-offload-test';
+const WORK_ITEM = 'local:atlassian-offload-test#1';
+const RUN_ID = 'atlassian-run-1';
+
+beforeAll(() => {
+  db.run(sql`CREATE TABLE IF NOT EXISTS agent_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    artifact_key TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    work_item_id TEXT,
+    run_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    bytes INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at TEXT
+  )`);
+  db.run(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS agent_artifacts_artifact_key_uniq
+        ON agent_artifacts (artifact_key)`,
+  );
+});
+
+beforeEach(() => {
+  db.delete(agentArtifacts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+afterAll(() => {
+  db.delete(agentArtifacts).where(sql`project_id = ${PROJECT}`).run();
+});
+
+describe('Atlassian payload offload', () => {
+  it('stores large provider payloads as summaries plus artifact refs', () => {
+    const result = offloadAtlassianPayload({
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      runId: RUN_ID,
+      provider: 'jira',
+      tier: 'evidence',
+      resourceId: 'TAS-123',
+      userFacingArgs: {
+        key: 'TAS-123',
+        include: ['comments', 'history'],
+      },
+      payload: {
+        comments: ['x'.repeat(128)],
+        raw: { fields: { description: 'x'.repeat(128) } },
+      },
+      summary: 'Jira TAS-123 evidence: comments and history stored as artifact',
+      thresholdBytes: 10,
+    });
+
+    expect(result).toMatchObject({
+      stored: true,
+      summary: 'Jira TAS-123 evidence: comments and history stored as artifact',
+      artifactRef: {
+        stored: true,
+        kind: 'atlassian:jira:evidence:TAS-123',
+      },
+    });
+    expect(result).not.toHaveProperty('payload');
+    expect(result.artifactRef?.artifactKey).toMatch(/^atlassian:jira:evidence:TAS-123:/);
+    expect(getArtifact(result.artifactRef?.artifactKey ?? '')?.payload).toMatchObject({
+      raw: { fields: { description: expect.any(String) } },
+    });
+  });
+
+  it('derives deterministic artifact keys from provider, tier, resource, and user-facing args', () => {
+    const first = offloadAtlassianPayload({
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      runId: RUN_ID,
+      provider: 'bitbucket',
+      tier: 'detail',
+      resourceId: 'company/api#45',
+      userFacingArgs: { repo: 'api', pullRequest: '45' },
+      payload: { body: 'x'.repeat(64) },
+      summary: 'Bitbucket PR detail',
+      thresholdBytes: 1,
+    });
+    const second = offloadAtlassianPayload({
+      projectId: PROJECT,
+      workItemId: WORK_ITEM,
+      runId: RUN_ID,
+      provider: 'bitbucket',
+      tier: 'detail',
+      resourceId: 'company/api#45',
+      userFacingArgs: { pullRequest: '45', repo: 'api' },
+      payload: { body: 'changed' },
+      summary: 'Bitbucket PR detail',
+      thresholdBytes: 1,
+    });
+
+    expect(first.artifactRef?.artifactKey).toBe(second.artifactRef?.artifactKey);
+  });
+});

--- a/core/integrations/atlassian/payload-offload.ts
+++ b/core/integrations/atlassian/payload-offload.ts
@@ -1,0 +1,101 @@
+import {
+  deterministicArtifactKey,
+  maybeStoreLargePayload,
+} from '../../agent-artifacts/repository.js';
+import type { ArtifactRef } from '../../agent-artifacts/types.js';
+import type { AtlassianProvider, AtlassianTier } from './dtos.js';
+
+export interface AtlassianPayloadOffloadInput {
+  projectId: string;
+  workItemId?: string | null;
+  runId: string;
+  provider: AtlassianProvider;
+  tier: AtlassianTier;
+  resourceId?: string;
+  queryId?: string;
+  userFacingArgs: Record<string, unknown>;
+  payload: unknown;
+  summary: string;
+  thresholdBytes?: number;
+  expiresAt?: string | null;
+}
+
+export type AtlassianPayloadOffloadResult =
+  | {
+      stored: true;
+      summary: string;
+      artifactRef: ArtifactRef;
+    }
+  | {
+      stored: false;
+      summary: string;
+      artifactRef: null;
+    };
+
+export function offloadAtlassianPayload(
+  input: AtlassianPayloadOffloadInput,
+): AtlassianPayloadOffloadResult {
+  const id = input.resourceId ?? input.queryId ?? 'query';
+  const kind = `atlassian:${input.provider}:${input.tier}:${safeArtifactSegment(id)}`;
+  const artifactKey = deterministicArtifactKey({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    runId: input.runId,
+    kind,
+    discriminator: stableStringify({
+      provider: input.provider,
+      tier: input.tier,
+      resourceId: input.resourceId ?? null,
+      queryId: input.queryId ?? null,
+      userFacingArgs: input.userFacingArgs,
+    }),
+  });
+
+  const result = maybeStoreLargePayload({
+    projectId: input.projectId,
+    workItemId: input.workItemId,
+    runId: input.runId,
+    kind,
+    payload: input.payload,
+    summary: input.summary,
+    artifactKey,
+    thresholdBytes: input.thresholdBytes,
+    expiresAt: input.expiresAt,
+  });
+
+  if (result.stored) {
+    return {
+      stored: true,
+      summary: input.summary,
+      artifactRef: result,
+    };
+  }
+
+  return {
+    stored: false,
+    summary: input.summary,
+    artifactRef: null,
+  };
+}
+
+function safeArtifactSegment(value: string): string {
+  return value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortForStableStringify(value));
+}
+
+function sortForStableStringify(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForStableStringify);
+  if (value == null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, sortForStableStringify(child)]),
+  );
+}

--- a/core/integrations/atlassian/query.test.ts
+++ b/core/integrations/atlassian/query.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AtlassianSearchPage, JiraProviderAdapter } from './adapters.js';
+import type { JiraIssueCardDto, JiraIssueDetailDto } from './dtos.js';
+import { executeJiraQuery, resolveJiraQuery } from './query.js';
+
+const config = {
+  baseUrl: 'https://company.atlassian.net',
+  projectKeys: ['TAS', 'OPS'],
+};
+
+describe('Atlassian query resolution', () => {
+  it('short-circuits exact Jira keys to L0 without constructing search input', async () => {
+    const exactIssue = {
+      provider: 'jira',
+      resourceKind: 'issue',
+      tier: 'detail',
+      id: 'TAS-123',
+      key: 'TAS-123',
+      title: 'Exact issue',
+      status: 'To Do',
+      url: 'https://company.atlassian.net/browse/TAS-123',
+      labels: [],
+      components: [],
+      linkedKeys: [],
+    } satisfies JiraIssueDetailDto;
+    const adapter: JiraProviderAdapter = {
+      getIssue: vi.fn(async () => ({
+        ok: true as const,
+        data: exactIssue,
+      })),
+      searchIssues: vi.fn(),
+      getCurrentUser: vi.fn(),
+    };
+
+    const result = await executeJiraQuery({
+      config,
+      adapter,
+      input: { kind: 'manual', value: 'TAS-123', maxResults: 500 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(adapter.getIssue).toHaveBeenCalledWith({ key: 'TAS-123', tier: 'detail' });
+    expect(adapter.searchIssues).not.toHaveBeenCalled();
+  });
+
+  it('caps free-text search projects, dates, and max results before provider calls', async () => {
+    const searchPage = {
+      provider: 'jira',
+      tier: 'headline',
+      issues: [],
+      totalCount: 0,
+      hasMore: false,
+    } satisfies AtlassianSearchPage<JiraIssueCardDto>;
+    const adapter: JiraProviderAdapter = {
+      getIssue: vi.fn(),
+      searchIssues: vi.fn(async () => ({
+        ok: true as const,
+        data: searchPage,
+      })),
+      getCurrentUser: vi.fn(),
+    };
+
+    await executeJiraQuery({
+      config,
+      adapter,
+      now: new Date('2026-05-27T12:00:00Z'),
+      input: {
+        kind: 'free-text',
+        text: 'import boundary',
+        projects: ['TAS', 'OUTSIDE'],
+        updatedSince: '2025-01-01T00:00:00Z',
+        updatedUntil: '2027-01-01T00:00:00Z',
+        maxResults: 500,
+      },
+      caps: { maxResults: 50, maxLookbackDays: 90 },
+    });
+
+    expect(adapter.searchIssues).toHaveBeenCalledWith({
+      level: 'L3',
+      text: 'import boundary',
+      projects: ['TAS'],
+      updated: {
+        from: '2026-02-26T12:00:00.000Z',
+        to: '2026-05-27T12:00:00.000Z',
+      },
+      maxResults: 50,
+      assignee: undefined,
+    });
+  });
+
+  it('resolves explicit project searches as L1 with configured project bounds', () => {
+    expect(
+      resolveJiraQuery({
+        config,
+        now: new Date('2026-05-27T12:00:00Z'),
+        input: {
+          kind: 'project',
+          text: 'safe scoped search',
+          projects: ['OPS', 'OUTSIDE'],
+          maxResults: 10,
+        },
+      }),
+    ).toMatchObject({
+      ok: true,
+      query: {
+        provider: 'jira',
+        level: 'L1',
+        search: {
+          level: 'L1',
+          projects: ['OPS'],
+          text: 'safe scoped search',
+          maxResults: 10,
+        },
+      },
+    });
+  });
+
+  it('builds assigned-to-me queries from safe scoped inputs instead of raw JQL', () => {
+    const resolved = resolveJiraQuery({
+      config,
+      now: new Date('2026-05-27T12:00:00Z'),
+      input: {
+        kind: 'assigned-to-me',
+        accountId: 'abc-123',
+        maxResults: 200,
+      },
+      caps: { maxResults: 25, maxLookbackDays: 30 },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      query: {
+        provider: 'jira',
+        level: 'L2',
+        search: {
+          level: 'L2',
+          projects: ['TAS', 'OPS'],
+          updated: {
+            from: '2026-04-27T12:00:00.000Z',
+            to: '2026-05-27T12:00:00.000Z',
+          },
+          maxResults: 25,
+          assignee: { accountId: 'abc-123' },
+        },
+      },
+    });
+    expect(JSON.stringify(resolved)).not.toContain('jql');
+  });
+
+  it('rejects raw JQL and CQL-shaped normal inputs', () => {
+    expect(
+      resolveJiraQuery({
+        config,
+        input: {
+          kind: 'free-text',
+          text: 'project = TAS ORDER BY updated DESC',
+        },
+      }),
+    ).toMatchObject({ ok: false, error: { kind: 'validation' } });
+
+    expect(
+      resolveJiraQuery({
+        config,
+        input: {
+          kind: 'free-text',
+          text: 'space = DOCS AND type = page',
+        },
+      }),
+    ).toMatchObject({ ok: false, error: { kind: 'validation' } });
+  });
+});

--- a/core/integrations/atlassian/query.ts
+++ b/core/integrations/atlassian/query.ts
@@ -1,0 +1,209 @@
+import type { JiraIssueSearchRequest, JiraProviderAdapter, JiraQueryLevel } from './adapters.js';
+import type { ProviderError, ProviderResult } from './errors.js';
+import { providerError } from './errors.js';
+import { type JiraParseConfig, parseJiraIssueRef } from './jira.js';
+
+export interface JiraQueryCaps {
+  maxResults?: number;
+  maxLookbackDays?: number;
+}
+
+export type JiraSafeQueryInput =
+  | {
+      kind: 'manual';
+      value: string;
+      tier?: 'headline' | 'card' | 'detail';
+      maxResults?: number;
+    }
+  | {
+      kind: 'project';
+      text?: string;
+      projects?: string[];
+      updatedSince?: string;
+      updatedUntil?: string;
+      maxResults?: number;
+    }
+  | {
+      kind: 'assigned-to-me';
+      accountId: string;
+      projects?: string[];
+      updatedSince?: string;
+      updatedUntil?: string;
+      maxResults?: number;
+    }
+  | {
+      kind: 'free-text';
+      text: string;
+      projects?: string[];
+      updatedSince?: string;
+      updatedUntil?: string;
+      maxResults?: number;
+    };
+
+export type ResolvedJiraQuery =
+  | {
+      provider: 'jira';
+      level: 'L0';
+      exact: {
+        key: string;
+        url: string;
+        tier: 'headline' | 'card' | 'detail';
+      };
+    }
+  | {
+      provider: 'jira';
+      level: Exclude<JiraQueryLevel, 'L0'>;
+      search: JiraIssueSearchRequest;
+    };
+
+export type ResolvedJiraQueryResult =
+  | { ok: true; query: ResolvedJiraQuery }
+  | { ok: false; error: ProviderError };
+
+export interface ResolveJiraQueryOptions {
+  config: JiraParseConfig;
+  input: JiraSafeQueryInput;
+  caps?: JiraQueryCaps;
+  now?: Date;
+}
+
+export function resolveJiraQuery(options: ResolveJiraQueryOptions): ResolvedJiraQueryResult {
+  const { config, input } = options;
+  if (input.kind === 'manual') {
+    const parsed = parseJiraIssueRef(input.value, config);
+    if (!parsed.ok) return parsed;
+    return {
+      ok: true,
+      query: {
+        provider: 'jira',
+        level: 'L0',
+        exact: {
+          key: parsed.ref.key,
+          url: parsed.ref.url,
+          tier: input.tier ?? 'detail',
+        },
+      },
+    };
+  }
+
+  const rawText = 'text' in input ? input.text : undefined;
+  if (rawText != null && looksLikeRawProviderQuery(rawText)) {
+    return {
+      ok: false,
+      error: providerError('validation', 'Raw JQL/CQL is not accepted by Atlassian query helpers'),
+    };
+  }
+
+  const projects = resolveProjects(config.projectKeys, input.projects);
+  if (projects.length === 0) {
+    return {
+      ok: false,
+      error: providerError('validation', 'At least one configured Jira project is required'),
+    };
+  }
+
+  const maxResults = capMaxResults(input.maxResults, options.caps?.maxResults);
+  const updated = resolveUpdatedRange({
+    now: options.now ?? new Date(),
+    updatedSince: input.updatedSince,
+    updatedUntil: input.updatedUntil,
+    maxLookbackDays: options.caps?.maxLookbackDays,
+  });
+  if (!updated.ok) return updated;
+
+  const level = levelForInput(input.kind);
+  return {
+    ok: true,
+    query: {
+      provider: 'jira',
+      level,
+      search: {
+        level,
+        projects,
+        updated: updated.range,
+        maxResults,
+        text: rawText?.trim() || undefined,
+        assignee: input.kind === 'assigned-to-me' ? { accountId: input.accountId } : undefined,
+      },
+    },
+  };
+}
+
+export async function executeJiraQuery<T>({
+  adapter,
+  ...options
+}: ResolveJiraQueryOptions & {
+  adapter: JiraProviderAdapter;
+}): Promise<ProviderResult<T>> {
+  const resolved = resolveJiraQuery(options);
+  if (!resolved.ok) return resolved;
+
+  if (resolved.query.level === 'L0') {
+    return adapter.getIssue({
+      key: resolved.query.exact.key,
+      tier: resolved.query.exact.tier,
+    }) as Promise<ProviderResult<T>>;
+  }
+
+  return adapter.searchIssues(resolved.query.search) as Promise<ProviderResult<T>>;
+}
+
+function levelForInput(kind: JiraSafeQueryInput['kind']): Exclude<JiraQueryLevel, 'L0'> {
+  if (kind === 'project') return 'L1';
+  if (kind === 'assigned-to-me') return 'L2';
+  return 'L3';
+}
+
+function resolveProjects(configured: readonly string[], requested?: readonly string[]): string[] {
+  const configuredSet = new Set(configured);
+  const source = requested == null || requested.length === 0 ? configured : requested;
+  return [...new Set(source.filter((project) => configuredSet.has(project)))];
+}
+
+function capMaxResults(requested: number | undefined, cap = 50): number {
+  const effective = requested == null || !Number.isFinite(requested) ? cap : requested;
+  return Math.min(Math.max(1, Math.floor(effective)), cap);
+}
+
+function resolveUpdatedRange(input: {
+  now: Date;
+  updatedSince?: string;
+  updatedUntil?: string;
+  maxLookbackDays?: number;
+}): { ok: true; range: JiraIssueSearchRequest['updated'] } | { ok: false; error: ProviderError } {
+  const nowMs = input.now.getTime();
+  const lookbackDays = Math.max(1, Math.floor(input.maxLookbackDays ?? 90));
+  const earliestAllowed = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
+
+  const parsedTo = input.updatedUntil == null ? nowMs : Date.parse(input.updatedUntil);
+  if (!Number.isFinite(parsedTo)) {
+    return {
+      ok: false,
+      error: providerError('validation', 'updatedUntil must be an ISO date string'),
+    };
+  }
+  const toMs = Math.min(parsedTo, nowMs);
+
+  const parsedFrom = input.updatedSince == null ? earliestAllowed : Date.parse(input.updatedSince);
+  if (!Number.isFinite(parsedFrom)) {
+    return {
+      ok: false,
+      error: providerError('validation', 'updatedSince must be an ISO date string'),
+    };
+  }
+  const fromMs = Math.min(Math.max(parsedFrom, earliestAllowed), toMs);
+
+  return {
+    ok: true,
+    range: {
+      from: new Date(fromMs).toISOString(),
+      to: new Date(toMs).toISOString(),
+    },
+  };
+}
+
+function looksLikeRawProviderQuery(text: string): boolean {
+  return /\b(project|assignee|updated|status|issuekey|key|order\s+by|space|type)\s*(=|!=|~|>|<|\bin\b)/i.test(
+    text,
+  );
+}

--- a/core/types.local-db-atlassian.test.ts
+++ b/core/types.local-db-atlassian.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { LocalDbSourceConfig } from './types.js';
+
+describe('LocalDbSourceConfig Atlassian integration typing', () => {
+  it('permits Jira and Bitbucket integration blocks without credentials', () => {
+    const config = {
+      kind: 'local-db',
+      stateMachine: 'db',
+      integrations: {
+        jira: {
+          enabled: true,
+          baseUrl: 'https://company.atlassian.net',
+          projectKeys: ['TAS', 'OPS'],
+          importMode: 'manual',
+          postBack: {
+            comments: true,
+            transitions: false,
+          },
+        },
+        bitbucket: {
+          enabled: true,
+          workspace: 'company',
+          repos: ['api', 'web'],
+          postBack: {
+            pullRequests: true,
+            comments: true,
+          },
+        },
+      },
+    } satisfies LocalDbSourceConfig;
+
+    expect(config.integrations.jira.projectKeys).toEqual(['TAS', 'OPS']);
+    expect(config.integrations.bitbucket.repos).toEqual(['api', 'web']);
+  });
+});
+
+const _jiraCredentialsAreRejected = {
+  kind: 'local-db',
+  stateMachine: 'db',
+  integrations: {
+    jira: {
+      enabled: true,
+      baseUrl: 'https://company.atlassian.net',
+      projectKeys: ['TAS'],
+      importMode: 'manual',
+      // @ts-expect-error credentials must not be accepted in project config
+      token: 'secret',
+    },
+  },
+} satisfies LocalDbSourceConfig;
+
+const _bitbucketCredentialsAreRejected = {
+  kind: 'local-db',
+  stateMachine: 'db',
+  integrations: {
+    bitbucket: {
+      enabled: true,
+      workspace: 'company',
+      repos: ['api'],
+      postBack: {
+        pullRequests: true,
+        comments: true,
+      },
+      // @ts-expect-error credentials must not be accepted in project config
+      password: 'secret',
+    },
+  },
+} satisfies LocalDbSourceConfig;

--- a/core/types.ts
+++ b/core/types.ts
@@ -4,6 +4,27 @@ export interface GitHubSourceConfig {
   stateMachine: 'labels';
 }
 
+export interface LocalDbJiraIntegrationConfig {
+  enabled: boolean;
+  baseUrl: string;
+  projectKeys: string[];
+  importMode: 'manual' | 'assigned-to-me';
+  postBack?: {
+    comments: boolean;
+    transitions: false;
+  };
+}
+
+export interface LocalDbBitbucketIntegrationConfig {
+  enabled: boolean;
+  workspace: string;
+  repos: string[];
+  postBack?: {
+    pullRequests: boolean;
+    comments: boolean;
+  };
+}
+
 export interface LocalDbSourceConfig {
   kind: 'local-db';
   stateMachine: 'db';
@@ -13,6 +34,8 @@ export interface LocalDbSourceConfig {
       mirrorLabels?: boolean;
       importIssues?: boolean;
     };
+    jira?: LocalDbJiraIntegrationConfig;
+    bitbucket?: LocalDbBitbucketIntegrationConfig;
   };
 }
 


### PR DESCRIPTION
## Summary
- Extend local-db source config with credential-free Jira and Bitbucket integration blocks.
- Add shared Atlassian DTO schemas, Jira exact key/URL parsing, safe query resolution, typed provider errors, adapter interfaces, and artifact offload helpers.
- Keep Atlassian behavior contract-only: no import routes, UI actions, workflow calls, provider mutation, or raw provider payloads across DTO boundaries.

## Verification
- pnpm exec biome check core/types.ts core/types.local-db-atlassian.test.ts core/integrations/atlassian/adapters.ts core/integrations/atlassian/dtos.ts core/integrations/atlassian/dtos.test.ts core/integrations/atlassian/errors.ts core/integrations/atlassian/errors.test.ts core/integrations/atlassian/index.ts core/integrations/atlassian/jira.ts core/integrations/atlassian/jira.test.ts core/integrations/atlassian/payload-offload.ts core/integrations/atlassian/payload-offload.test.ts core/integrations/atlassian/query.ts core/integrations/atlassian/query.test.ts
- pnpm test core/types.local-db-atlassian.test.ts core/integrations/atlassian/dtos.test.ts core/integrations/atlassian/jira.test.ts core/integrations/atlassian/query.test.ts core/integrations/atlassian/errors.test.ts core/integrations/atlassian/payload-offload.test.ts core/integrations/github/import-issues.test.ts core/agent-artifacts/repository.test.ts core/state-source/local-db-repository.test.ts core/state-source/local-db.test.ts
- pnpm typecheck
- pnpm audit-docs