### PR TITLE
M19.XX: api bug

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -87,7 +87,36 @@ describe('POST /inbox', () => {
       body: 'null',
     });
     expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid request body');
     expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing title validation error for missing title', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'no title here' }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('title is required');
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('passes unknown type values through so the service can normalize them', async () => {
+    mockCreateInboxItem.mockResolvedValue({ ok: true, data: { item: { id: 1 } } });
+
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Needs triage', body: 'details', type: 'unexpected-type' }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockCreateInboxItem).toHaveBeenCalledWith('Needs triage', 'details', 'unexpected-type');
   });
 });
 

--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -53,18 +53,19 @@ describe('POST /inbox', () => {
     expect(mockCreateInboxItem).toHaveBeenCalledWith('New feature', 'details', 'feature');
   });
 
-  it('returns 400 when service rejects (e.g. missing title)', async () => {
-    mockCreateInboxItem.mockResolvedValue({ ok: false, error: 'title is required', status: 400 });
+  it('returns 400 when service rejects a valid payload', async () => {
+    mockCreateInboxItem.mockResolvedValue({ ok: false, error: 'duplicate title', status: 400 });
 
     const app = makeApp();
     const res = await app.request('/inbox', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ body: 'no title here' }),
+      body: JSON.stringify({ title: 'Existing title', body: 'details', type: 'feature' }),
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe('title is required');
+    expect(body.error).toBe('duplicate title');
+    expect(mockCreateInboxItem).toHaveBeenCalledWith('Existing title', 'details', 'feature');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -73,6 +74,17 @@ describe('POST /inbox', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: 'not-json',
+    });
+    expect(res.status).toBe(400);
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for JSON null body without calling the service', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
     });
     expect(res.status).toBe(400);
     expect(mockCreateInboxItem).not.toHaveBeenCalled();

--- a/apps/server/src/domains/inbox/router.ts
+++ b/apps/server/src/domains/inbox/router.ts
@@ -1,16 +1,29 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import { parseBody } from '#shared/middleware.js';
 import { createInboxItem, deleteInboxItem, getInboxItems, promoteInboxItem } from './service.js';
+
+const CreateInboxBodySchema = z.object({
+  title: z.string().trim().min(1, 'title is required'),
+  body: z.string().optional().default(''),
+  type: z.enum(['feature', 'bug', 'chore', 'research']).optional().default('feature'),
+});
 
 const router = new Hono();
 
 router.post('/', async (c) => {
   const body = await parseBody<{ title?: string; body?: string; type?: string }>(c);
   if (!body.ok) return body.error;
-  const result = await createInboxItem(body.data.title, body.data.body, body.data.type);
-  return result.ok
-    ? c.json(result.data, 201)
-    : c.json({ error: result.error }, result.status as 400);
+
+  const result = CreateInboxBodySchema.safeParse(body.data);
+  if (!result.success) {
+    return c.json({ error: 'validation failed', issues: result.error.issues }, 400);
+  }
+
+  const createResult = await createInboxItem(result.data.title, result.data.body, result.data.type);
+  return createResult.ok
+    ? c.json(createResult.data, 201)
+    : c.json({ error: createResult.error }, createResult.status as 400);
 });
 
 router.get('/', async (c) => {

--- a/apps/server/src/domains/inbox/router.ts
+++ b/apps/server/src/domains/inbox/router.ts
@@ -6,7 +6,7 @@ import { createInboxItem, deleteInboxItem, getInboxItems, promoteInboxItem } fro
 const CreateInboxBodySchema = z.object({
   title: z.string().trim().min(1, 'title is required'),
   body: z.string().optional().default(''),
-  type: z.enum(['feature', 'bug', 'chore', 'research']).optional().default('feature'),
+  type: z.string().optional().default('feature'),
 });
 
 const router = new Hono();
@@ -17,7 +17,11 @@ router.post('/', async (c) => {
 
   const result = CreateInboxBodySchema.safeParse(body.data);
   if (!result.success) {
-    return c.json({ error: 'validation failed', issues: result.error.issues }, 400);
+    const titleIssue = result.error.issues.find((issue) => issue.path[0] === 'title');
+    if (titleIssue != null) {
+      return c.json({ error: 'title is required' }, 400);
+    }
+    return c.json({ error: 'invalid request body' }, 400);
   }
 
   const createResult = await createInboxItem(result.data.title, result.data.body, result.data.type);


### PR DESCRIPTION
## Summary

api bug

## Work Packages

- ✓ **WP1**: In apps/server/src/domains/inbox/router.ts near router.post('/'), import/use zod if not already present, define CreateIn

Closes #1132
