### PR TITLE
M19.XX: grill bug

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -1,4 +1,5 @@
 import type { RenderItem, TimelineContext } from '../lib/timeline';
+import { resolveDecisionSummaryStatus } from '../lib/timeline/state';
 import { AgentImplementCompleteEvent } from './timeline/AgentImplementCompleteEvent';
 import { AgentInvestigationCompleteEvent } from './timeline/AgentInvestigationCompleteEvent';
 import {
@@ -9,10 +10,7 @@ import {
 import { AgentToolCallEvent } from './timeline/AgentToolCallEvent';
 import { AgentToolResultEvent } from './timeline/AgentToolResultEvent';
 import { AgentTriageCompleteEvent } from './timeline/AgentTriageCompleteEvent';
-import {
-  AgentDecisionSummaryEvent,
-  AgentDecisionSummaryLiveEvent,
-} from './timeline/DecisionSummaryEvents';
+import { AgentDecisionSummaryEventRow } from './timeline/DecisionSummaryEvents';
 import { DecomposeCompletedEvent } from './timeline/DecomposeEvents';
 import {
   DevReviewBudgetSkippedEvent,
@@ -221,6 +219,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
     );
   }
   const { event } = item;
+  const decisionSummaryStatus = resolveDecisionSummaryStatus(event, context?.events ?? [event]);
 
   switch (event.kind) {
     case 'dogfood.seed-applied':
@@ -285,9 +284,13 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
     case 'agent.spawned':
       return <AgentSpawnedEvent key={event.id} event={event} />;
     case 'agent.decision-summary':
-      return <AgentDecisionSummaryEvent key={event.id} event={event} />;
+      return (
+        <AgentDecisionSummaryEventRow key={event.id} event={event} status={decisionSummaryStatus} />
+      );
     case 'agent.decision-summary-live':
-      return <AgentDecisionSummaryLiveEvent key={event.id} event={event} />;
+      return (
+        <AgentDecisionSummaryEventRow key={event.id} event={event} status={decisionSummaryStatus} />
+      );
     case 'agent.disclosure':
       return <AgentDisclosureEvent key={event.id} event={event} />;
     case 'agent.log':

--- a/apps/web/src/components/detail/components/TimelineSection.test.ts
+++ b/apps/web/src/components/detail/components/TimelineSection.test.ts
@@ -1,6 +1,12 @@
+/** @vitest-environment jsdom */
 import type { AgentEventDto } from '@/lib/types';
-import { describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
 import { getAgentLogDisplayText, groupEvents } from '../lib/timeline';
+import { renderTimelineItem } from './TimelineEvents';
+
+afterEach(cleanup);
 
 function makeLogEvent(id: number): AgentEventDto {
   return {
@@ -670,5 +676,46 @@ describe('groupEvents — run-group metadata', () => {
     if (result[0].kind === 'run-group') {
       expect(result[0].skill).toBe('implement');
     }
+  });
+});
+
+describe('renderTimelineItem — decision summary status', () => {
+  it('renders a formerly live grill decision summary as completed after a terminal grill event', () => {
+    const decisionSummaryEvent: AgentEventDto = {
+      id: 1,
+      projectId: 'proj',
+      workItemId: 'wi-1',
+      kind: 'agent.decision-summary-live',
+      payload: { kind: 'INSIGHT', summary: 'Use the existing workflow.' },
+      runId: 'run-grill',
+      createdAt: '2026-05-27T00:00:00.000Z',
+    };
+
+    const grillCompletedEvent: AgentEventDto = {
+      id: 2,
+      projectId: 'proj',
+      workItemId: 'wi-1',
+      kind: 'grill.completed',
+      payload: { response: 'Yes' },
+      runId: 'workflow-grill',
+      createdAt: '2026-05-27T00:01:00.000Z',
+    };
+
+    render(
+      createElement(
+        'ul',
+        null,
+        renderTimelineItem({ kind: 'event', event: decisionSummaryEvent }, 0, {
+          slug: 'proj',
+          issueId: 'wi-1',
+          latestRunId: 'run-grill',
+          events: [decisionSummaryEvent, grillCompletedEvent],
+        }),
+      ),
+    );
+
+    expect(screen.queryByText('Live decision')).toBeNull();
+    expect(screen.getByText('Decision summary')).toBeTruthy();
+    expect(screen.getByText('Use the existing workflow.')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/detail/components/TimelineSection.tsx
+++ b/apps/web/src/components/detail/components/TimelineSection.tsx
@@ -124,7 +124,14 @@ export function TimelineSection({ projectSlug, id }: TimelineSectionProps) {
     ) || items.some((item: RenderItem) => item.kind === 'timeline-section');
   const latestRunId =
     allRunItems.find((item: RenderItem) => item.kind === 'run-group')?.runId ?? null;
-  const context = { slug: projectSlug, issueId: id, latestRunId, runCosts, expandSignal };
+  const context = {
+    slug: projectSlug,
+    issueId: id,
+    latestRunId,
+    events: visibleEvents,
+    runCosts,
+    expandSignal,
+  };
 
   const sendSignal = (open: boolean) => setExpandSignal((prev) => ({ tick: prev.tick + 1, open }));
 

--- a/apps/web/src/components/detail/components/timeline/DecisionSummaryEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/DecisionSummaryEvents.tsx
@@ -1,40 +1,14 @@
 import type { AgentEventDto } from '@/lib/types';
 import { Radio, Sparkles } from 'lucide-react';
 import { getPayloadStr } from '../../lib/timeline';
+import type { DecisionSummaryStatus } from '../../lib/timeline/state';
 
-export function AgentDecisionSummaryEvent({ event }: { event: AgentEventDto }) {
-  const p = event.payload as { summary?: string; kind?: string; step?: string } | null;
-  const summary = p?.summary ?? getPayloadStr(event.payload);
-  // #466 — kind is the post-migration field. step was used pre-migration.
-  // Fall back to step so legacy events still render a label rather than blank.
-  const rawKind =
-    typeof p?.kind === 'string' ? p.kind : typeof p?.step === 'string' ? p.step : null;
-  const kind = rawKind != null && rawKind.length > 0 ? rawKind : null;
-  return (
-    <li
-      data-event-kind={event.kind}
-      className="rounded-md border border-black bg-bg-elev/60 px-4 py-3"
-    >
-      <div className="flex items-center gap-2 mb-1 text-[11px] text-fg-3">
-        <Sparkles size={13} className="shrink-0" />
-        <span className="font-mono uppercase tracking-wider">Decision summary</span>
-        {kind != null && (
-          <span
-            data-testid="decision-kind-chip"
-            className="font-mono text-[10px] tracking-wider px-1.5 py-[1px] rounded bg-bg-elev-2 text-[color:var(--accent)]"
-          >
-            {kind}
-          </span>
-        )}
-        <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-        <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
-      </div>
-      <div className="text-[12.5px] text-fg-2">{summary}</div>
-    </li>
-  );
+export interface DecisionSummaryEventProps {
+  event: AgentEventDto;
+  status: DecisionSummaryStatus;
 }
 
-export function AgentDecisionSummaryLiveEvent({ event }: { event: AgentEventDto }) {
+export function AgentDecisionSummaryEventRow({ event, status }: DecisionSummaryEventProps) {
   const p = event.payload as { summary?: string; kind?: string; step?: string } | null;
   const summary = p?.summary ?? getPayloadStr(event.payload);
   // #466 — kind is the post-migration field. step was used pre-migration.
@@ -42,6 +16,32 @@ export function AgentDecisionSummaryLiveEvent({ event }: { event: AgentEventDto 
   const rawKind =
     typeof p?.kind === 'string' ? p.kind : typeof p?.step === 'string' ? p.step : null;
   const kind = rawKind != null && rawKind.length > 0 ? rawKind : null;
+
+  if (status === 'completed') {
+    return (
+      <li
+        data-event-kind={event.kind}
+        className="rounded-md border border-black bg-bg-elev/60 px-4 py-3"
+      >
+        <div className="flex items-center gap-2 mb-1 text-[11px] text-fg-3">
+          <Sparkles size={13} className="shrink-0" />
+          <span className="font-mono uppercase tracking-wider">Decision summary</span>
+          {kind != null && (
+            <span
+              data-testid="decision-kind-chip"
+              className="font-mono text-[10px] tracking-wider px-1.5 py-[1px] rounded bg-bg-elev-2 text-[color:var(--accent)]"
+            >
+              {kind}
+            </span>
+          )}
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
+        </div>
+        <div className="text-[12.5px] text-fg-2">{summary}</div>
+      </li>
+    );
+  }
+
   return (
     <li
       data-event-kind={event.kind}
@@ -68,4 +68,12 @@ export function AgentDecisionSummaryLiveEvent({ event }: { event: AgentEventDto 
       </div>
     </li>
   );
+}
+
+export function AgentDecisionSummaryEvent({ event }: { event: AgentEventDto }) {
+  return <AgentDecisionSummaryEventRow event={event} status="completed" />;
+}
+
+export function AgentDecisionSummaryLiveEvent({ event }: { event: AgentEventDto }) {
+  return <AgentDecisionSummaryEventRow event={event} status="live" />;
 }

--- a/apps/web/src/components/detail/lib/timeline/state.test.ts
+++ b/apps/web/src/components/detail/lib/timeline/state.test.ts
@@ -1,0 +1,70 @@
+import type { AgentEventDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+
+import { resolveDecisionSummaryStatus } from './state';
+
+function makeEvent(
+  id: number,
+  kind: string,
+  runId: string | null,
+  overrides: Partial<AgentEventDto> = {},
+): AgentEventDto {
+  return {
+    id,
+    projectId: 'proj',
+    workItemId: 'item-1',
+    kind,
+    payload: overrides.payload ?? null,
+    runId,
+    createdAt: new Date(1000 * id).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('resolveDecisionSummaryStatus', () => {
+  it('returns completed after a later grill terminal event', () => {
+    const event = makeEvent(2, 'agent.decision-summary-live', 'run-1');
+    const events = [
+      makeEvent(1, 'agent.run-started', 'run-1'),
+      event,
+      makeEvent(3, 'grill.completed', 'workflow-1'),
+    ];
+
+    expect(resolveDecisionSummaryStatus(event, events)).toBe('completed');
+  });
+
+  it('returns live when no later terminal event follows', () => {
+    const event = makeEvent(2, 'agent.decision-summary-live', 'run-1');
+    const events = [
+      makeEvent(1, 'agent.run-started', 'run-1'),
+      event,
+      makeEvent(3, 'agent.log', 'run-1'),
+    ];
+
+    expect(resolveDecisionSummaryStatus(event, events)).toBe('live');
+  });
+
+  it('does not complete from an earlier terminal event', () => {
+    const event = makeEvent(3, 'agent.decision-summary-live', 'run-1');
+    const events = [
+      makeEvent(1, 'grill.question-posted', 'workflow-1'),
+      makeEvent(2, 'agent.run-started', 'run-1'),
+      event,
+    ];
+
+    expect(resolveDecisionSummaryStatus(event, events)).toBe('live');
+  });
+
+  it('returns completed after a gate-pending to grilling transition', () => {
+    const event = makeEvent(2, 'agent.decision-summary-live', 'run-1');
+    const events = [
+      makeEvent(1, 'agent.run-started', 'run-1'),
+      event,
+      makeEvent(3, 'state.transitioned', null, {
+        payload: { fromState: 'factory:gate-pending', toState: 'factory:grilling' },
+      }),
+    ];
+
+    expect(resolveDecisionSummaryStatus(event, events)).toBe('completed');
+  });
+});

--- a/apps/web/src/components/detail/lib/timeline/state.ts
+++ b/apps/web/src/components/detail/lib/timeline/state.ts
@@ -15,6 +15,51 @@ const TERMINAL_EVENTS = new Set([
   'qa.verification-blocked',
 ]);
 
+export type DecisionSummaryStatus = 'live' | 'completed';
+
+function isGrillResumeTransition(event: AgentEventDto): boolean {
+  if (event.kind !== 'state.transitioned') return false;
+
+  const payload = (event.payload ?? {}) as {
+    from?: string;
+    fromState?: string;
+    to?: string;
+    toState?: string;
+  };
+
+  const from = payload.fromState ?? payload.from;
+  const to = payload.toState ?? payload.to;
+
+  return from === 'factory:gate-pending' && to === 'factory:grilling';
+}
+
+export function resolveDecisionSummaryStatus(
+  event: AgentEventDto,
+  events: readonly AgentEventDto[],
+): DecisionSummaryStatus {
+  if (event.kind !== 'agent.decision-summary-live') return 'completed';
+
+  const laterEvents = [...events]
+    .filter((candidate) => candidate.id > event.id)
+    .sort((a, b) => a.id - b.id);
+
+  for (const laterEvent of laterEvents) {
+    if (laterEvent.kind === 'grill.question-posted' || laterEvent.kind === 'grill.completed') {
+      return 'completed';
+    }
+
+    if (laterEvent.kind === 'agent.run-completed' && laterEvent.runId === event.runId) {
+      return 'completed';
+    }
+
+    if (isGrillResumeTransition(laterEvent)) {
+      return 'completed';
+    }
+  }
+
+  return 'live';
+}
+
 export function computeIsLive(events: AgentEventDto[]): boolean {
   const sorted = [...events].sort((a, b) => a.id - b.id);
   let lastStartedIdx = -1;

--- a/apps/web/src/components/detail/lib/timeline/types.ts
+++ b/apps/web/src/components/detail/lib/timeline/types.ts
@@ -5,6 +5,7 @@ export type TimelineContext = {
   slug: string;
   issueId: string;
   latestRunId: string | null;
+  events?: readonly AgentEventDto[];
   runCosts?: Map<string, CostRowDto>;
   /** Monotonic tick that increments each time the user clicks expand/collapse all. */
   expandSignal?: { tick: number; open: boolean };


### PR DESCRIPTION
## Summary

grill bug

## Work Packages

- ✓ **WP1**: In `apps/web/src/components/detail/lib/timeline/state.ts:3`, keep `TERMINAL_EVENTS` for page-level liveness and add `Dec
- ✓ **WP2**: In `apps/web/src/components/detail/components/timeline/DecisionSummaryEvents.tsx:4`, replace the split completed/live im

Closes #1131
