### PR TITLE
Add manual Jira import boundary

### DIFF
--- a/apps/server/src/domains/integrations/router.test.ts
+++ b/apps/server/src/domains/integrations/router.test.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockImportJiraIssue } = vi.hoisted(() => ({
+  mockImportJiraIssue: vi.fn(),
+}));
+
+vi.mock('./service.js', () => ({
+  importJiraIssue: mockImportJiraIssue,
+}));
+
+import { integrationsRouter } from './router.js';
+
+function makeApp() {
+  return new Hono().route('/projects', integrationsRouter);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /projects/:slug/integrations/jira/import', () => {
+  it('returns the imported item DTO from the service', async () => {
+    mockImportJiraIssue.mockResolvedValue({
+      ok: true,
+      data: {
+        item: {
+          id: 'local:proj#1',
+          externalId: '1',
+          jiraKey: 'TAS-123',
+          jiraUrl: 'https://company.atlassian.net/browse/TAS-123',
+          title: 'Manual Jira import',
+          imported: true,
+        },
+      },
+    });
+
+    const res = await makeApp().request('/projects/proj/integrations/jira/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: 'TAS-123' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ item: { externalId: '1', jiraKey: 'TAS-123' } });
+    expect(mockImportJiraIssue).toHaveBeenCalledWith('proj', { input: 'TAS-123' });
+  });
+
+  it('returns the service error status', async () => {
+    mockImportJiraIssue.mockResolvedValue({
+      ok: false,
+      error: 'Jira issue not found',
+      status: 404,
+    });
+
+    const res = await makeApp().request('/projects/proj/integrations/jira/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: 'TAS-404' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Jira issue not found' });
+  });
+});

--- a/apps/server/src/domains/integrations/router.ts
+++ b/apps/server/src/domains/integrations/router.ts
@@ -1,0 +1,16 @@
+import { Hono } from 'hono';
+import { parseBody } from '#shared/middleware.js';
+import { type JiraImportRequestDto, importJiraIssue } from './service.js';
+
+const router = new Hono();
+
+router.post('/:slug/integrations/jira/import', async (c) => {
+  const body = await parseBody<JiraImportRequestDto>(c);
+  if (!body.ok) return body.error;
+  const result = await importJiraIssue(c.req.param('slug'), body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 401 | 403 | 404 | 429 | 502);
+});
+
+export { router as integrationsRouter };

--- a/apps/server/src/domains/integrations/service.test.ts
+++ b/apps/server/src/domains/integrations/service.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetProject, mockImportJiraIssueToLocalDb } = vi.hoisted(() => ({
+  mockGetProject: vi.fn(),
+  mockImportJiraIssueToLocalDb: vi.fn(),
+}));
+
+vi.mock('#shared/projects.js', () => ({
+  getProject: mockGetProject,
+}));
+
+vi.mock('@goose-hub/core/integrations/jira/import-issue.js', () => ({
+  importJiraIssueToLocalDb: mockImportJiraIssueToLocalDb,
+}));
+
+vi.mock('@goose-hub/core/integrations/jira/rest.js', () => ({
+  createJiraRestAdapterFromEnv: vi.fn(() => ({ getIssue: vi.fn() })),
+}));
+
+import { importJiraIssue } from './service.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProject.mockResolvedValue({
+    id: 'proj',
+    slug: 'proj',
+    source: {
+      kind: 'local-db',
+      stateMachine: 'db',
+      integrations: {
+        jira: {
+          enabled: true,
+          baseUrl: 'https://company.atlassian.net',
+          projectKeys: ['TAS'],
+          importMode: 'manual',
+        },
+      },
+    },
+    repos: ['owner/repo'],
+  });
+  mockImportJiraIssueToLocalDb.mockResolvedValue({
+    ok: true,
+    data: {
+      imported: true,
+      itemId: 'local:proj#1',
+      externalId: '1',
+      jiraKey: 'TAS-123',
+      jiraUrl: 'https://company.atlassian.net/browse/TAS-123',
+      title: 'Manual Jira import',
+    },
+  });
+});
+
+describe('importJiraIssue', () => {
+  it('imports a configured local-db Jira issue and returns a navigation target', async () => {
+    const result = await importJiraIssue('proj', { input: 'TAS-123' });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          id: 'local:proj#1',
+          externalId: '1',
+          jiraKey: 'TAS-123',
+          title: 'Manual Jira import',
+        },
+      },
+    });
+    expect(mockImportJiraIssueToLocalDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectConfig: expect.objectContaining({ id: 'proj' }),
+        input: 'TAS-123',
+      }),
+    );
+  });
+
+  it('requires a non-empty input', async () => {
+    await expect(importJiraIssue('proj', { input: '   ' })).resolves.toEqual({
+      ok: false,
+      error: 'input is required',
+      status: 400,
+    });
+    expect(mockImportJiraIssueToLocalDb).not.toHaveBeenCalled();
+  });
+
+  it('returns provider errors without creating a server exception', async () => {
+    mockImportJiraIssueToLocalDb.mockResolvedValue({
+      ok: false,
+      error: { kind: 'not_found', message: 'Jira issue not found' },
+    });
+
+    await expect(importJiraIssue('proj', { input: 'TAS-404' })).resolves.toEqual({
+      ok: false,
+      error: 'Jira issue not found',
+      status: 404,
+    });
+  });
+});

--- a/apps/server/src/domains/integrations/service.test.ts
+++ b/apps/server/src/domains/integrations/service.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetProject, mockImportJiraIssueToLocalDb } = vi.hoisted(() => ({
+const { mockGetMilestone, mockGetProject, mockImportJiraIssueToLocalDb } = vi.hoisted(() => ({
   mockGetProject: vi.fn(),
   mockImportJiraIssueToLocalDb: vi.fn(),
+  mockGetMilestone: vi.fn(),
 }));
 
 vi.mock('#shared/projects.js', () => ({
@@ -17,10 +18,20 @@ vi.mock('@goose-hub/core/integrations/jira/rest.js', () => ({
   createJiraRestAdapterFromEnv: vi.fn(() => ({ getIssue: vi.fn() })),
 }));
 
+vi.mock('@goose-hub/core/state-source/local-db-repository.js', () => ({
+  LocalDbWorkItemRepository: vi.fn(() => ({
+    getMilestone: mockGetMilestone,
+  })),
+}));
+
 import { importJiraIssue } from './service.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetMilestone.mockReturnValue({
+    number: 7,
+    title: 'M7: Atlassian imports',
+  });
   mockGetProject.mockResolvedValue({
     id: 'proj',
     slug: 'proj',
@@ -53,7 +64,7 @@ beforeEach(() => {
 
 describe('importJiraIssue', () => {
   it('imports a configured local-db Jira issue and returns a navigation target', async () => {
-    const result = await importJiraIssue('proj', { input: 'TAS-123' });
+    const result = await importJiraIssue('proj', { input: 'TAS-123', milestoneNumber: 7 });
 
     expect(result).toMatchObject({
       ok: true,
@@ -70,6 +81,10 @@ describe('importJiraIssue', () => {
       expect.objectContaining({
         projectConfig: expect.objectContaining({ id: 'proj' }),
         input: 'TAS-123',
+        milestone: {
+          id: '7',
+          title: 'M7: Atlassian imports',
+        },
       }),
     );
   });

--- a/apps/server/src/domains/integrations/service.ts
+++ b/apps/server/src/domains/integrations/service.ts
@@ -4,6 +4,7 @@ import type {
 } from '@goose-hub/core/integrations/atlassian/errors.js';
 import { importJiraIssueToLocalDb } from '@goose-hub/core/integrations/jira/import-issue.js';
 import { createJiraRestAdapterFromEnv } from '@goose-hub/core/integrations/jira/rest.js';
+import { LocalDbWorkItemRepository } from '@goose-hub/core/state-source/local-db-repository.js';
 import type { Result } from '#shared/middleware.js';
 import { getProject } from '#shared/projects.js';
 
@@ -22,6 +23,7 @@ export interface JiraImportResponseDto {
 
 export interface JiraImportRequestDto {
   input?: unknown;
+  milestoneNumber?: unknown;
 }
 
 export async function importJiraIssue(
@@ -41,9 +43,15 @@ export async function importJiraIssue(
     return { ok: false, error: 'Jira integration is not enabled for this project', status: 400 };
   }
 
+  const repository = new LocalDbWorkItemRepository();
+  const milestone = resolveMilestone(projectConfig.id, body.milestoneNumber, repository);
+  if (!milestone.ok) return milestone;
+
   const result = await importJiraIssueToLocalDb({
     projectConfig,
     input: rawInput,
+    milestone: milestone.data,
+    repository,
     adapter: createJiraRestAdapterFromEnv({
       baseUrl: jira.baseUrl,
       artifactContext: {
@@ -66,6 +74,26 @@ export async function importJiraIssue(
         title: result.data.title,
         imported: result.data.imported,
       },
+    },
+  };
+}
+
+function resolveMilestone(
+  projectId: string,
+  rawMilestoneNumber: unknown,
+  repository: LocalDbWorkItemRepository,
+): Result<{ id: string; title: string } | undefined> {
+  if (rawMilestoneNumber == null) return { ok: true, data: undefined };
+  if (typeof rawMilestoneNumber !== 'number' || !Number.isInteger(rawMilestoneNumber)) {
+    return { ok: false, error: 'milestoneNumber must be an integer', status: 400 };
+  }
+  const row = repository.getMilestone(projectId, rawMilestoneNumber);
+  if (row == null) return { ok: false, error: 'milestone not found', status: 404 };
+  return {
+    ok: true,
+    data: {
+      id: String(row.number),
+      title: row.title,
     },
   };
 }

--- a/apps/server/src/domains/integrations/service.ts
+++ b/apps/server/src/domains/integrations/service.ts
@@ -1,0 +1,98 @@
+import type {
+  ProviderError,
+  ProviderErrorKind,
+} from '@goose-hub/core/integrations/atlassian/errors.js';
+import { importJiraIssueToLocalDb } from '@goose-hub/core/integrations/jira/import-issue.js';
+import { createJiraRestAdapterFromEnv } from '@goose-hub/core/integrations/jira/rest.js';
+import type { Result } from '#shared/middleware.js';
+import { getProject } from '#shared/projects.js';
+
+export interface JiraImportItemDto {
+  id: string;
+  externalId: string;
+  jiraKey: string;
+  jiraUrl: string;
+  title: string;
+  imported: boolean;
+}
+
+export interface JiraImportResponseDto {
+  item: JiraImportItemDto;
+}
+
+export interface JiraImportRequestDto {
+  input?: unknown;
+}
+
+export async function importJiraIssue(
+  slug: string,
+  body: JiraImportRequestDto,
+): Promise<Result<JiraImportResponseDto>> {
+  const rawInput = typeof body.input === 'string' ? body.input.trim() : '';
+  if (rawInput.length === 0) {
+    return { ok: false, error: 'input is required', status: 400 };
+  }
+
+  const projectConfig = await getProject(slug);
+  if (projectConfig == null) return { ok: false, error: 'project not found', status: 404 };
+  const jira =
+    projectConfig.source.kind === 'local-db' ? projectConfig.source.integrations?.jira : undefined;
+  if (projectConfig.source.kind !== 'local-db' || jira?.enabled !== true) {
+    return { ok: false, error: 'Jira integration is not enabled for this project', status: 400 };
+  }
+
+  const result = await importJiraIssueToLocalDb({
+    projectConfig,
+    input: rawInput,
+    adapter: createJiraRestAdapterFromEnv({
+      baseUrl: jira.baseUrl,
+      artifactContext: {
+        projectId: projectConfig.id,
+        runId: `jira-import:${projectConfig.id}`,
+      },
+    }),
+  });
+
+  if (!result.ok) return providerErrorToHttp(result.error);
+
+  return {
+    ok: true,
+    data: {
+      item: {
+        id: result.data.itemId,
+        externalId: result.data.externalId,
+        jiraKey: result.data.jiraKey,
+        jiraUrl: result.data.jiraUrl,
+        title: result.data.title,
+        imported: result.data.imported,
+      },
+    },
+  };
+}
+
+function providerErrorToHttp(error: ProviderError): Result<never> {
+  return {
+    ok: false,
+    error: error.message,
+    status: httpStatusForProviderError(error.kind),
+  };
+}
+
+function httpStatusForProviderError(kind: ProviderErrorKind): number {
+  switch (kind) {
+    case 'validation':
+    case 'query':
+      return 400;
+    case 'auth':
+      return 401;
+    case 'permission':
+      return 403;
+    case 'not_found':
+      return 404;
+    case 'rate_limit':
+      return 429;
+    case 'connection':
+    case 'post_back':
+      return 502;
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -8,6 +8,7 @@ import { costsRouter } from './domains/costs/router.js';
 import { decisionsRouter } from './domains/decisions/router.js';
 import { eventsRouter } from './domains/events/router.js';
 import { inboxRouter } from './domains/inbox/router.js';
+import { integrationsRouter } from './domains/integrations/router.js';
 import { interventionsRouter, projectInterventionsRouter } from './domains/interventions/router.js';
 import { issuesRouter } from './domains/issues/router.js';
 import { milestonesRouter } from './domains/milestones/router.js';
@@ -38,6 +39,7 @@ app.route('/projects', issuesRouter); // GET/POST /projects/:slug/issues/**
 app.route('/projects', projectInterventionsRouter); // GET /projects/:slug/interventions
 app.route('/projects', workflowsRouter); // POST /projects/:slug/tick
 app.route('/projects', costsRouter); // GET /projects/:slug/costs/summary, /projects/:slug/issues/:id/costs
+app.route('/projects', integrationsRouter); // POST /projects/:slug/integrations/jira/import
 app.route('/projects', playbooksRouter); // GET/POST /projects/:slug/playbooks (M11.12)
 app.route('/projects', bootstrapRouter); // POST /projects/bootstrap/{preview,run} (M12.07)
 app.route('/projects', projectSettingsRouter); // GET/PATCH/DELETE /projects/:slug/settings/**

--- a/apps/web/src/components/board/components/Board.tsx
+++ b/apps/web/src/components/board/components/Board.tsx
@@ -5,11 +5,13 @@ import { logger } from '@/lib/logger';
 import { useProjectBudgetStatus } from '@/lib/project-budget';
 import type { WorkItemDto } from '@/lib/types';
 import { useActiveMilestone } from '@/state/active-milestone';
+import { useActiveProject } from '@/state/active-project';
 import { useLaneVisibility } from '@/state/lane-visibility';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, Download, Eye, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { canUseManualJiraImport } from '../lib/jira-import';
 import { BoardColumn } from './BoardColumn';
 import { JiraImportDialog } from './JiraImportDialog';
 
@@ -21,9 +23,12 @@ export function Board({ projectSlug }: BoardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [jiraImportOpen, setJiraImportOpen] = useState(false);
+  const { projects } = useActiveProject();
   const { hidden, toggle, reset } = useLaneVisibility();
   const { activeNumber: resolvedMilestone, milestones, setActiveNumber } = useActiveMilestone();
   const { data: budgetStatus } = useProjectBudgetStatus(projectSlug);
+  const currentProject = projects.find((project) => project.slug === projectSlug);
+  const showJiraImport = canUseManualJiraImport(currentProject);
 
   const {
     data: items = [],
@@ -145,13 +150,15 @@ export function Board({ projectSlug }: BoardProps) {
           {items.length} issue{items.length === 1 ? '' : 's'}
         </span>
         <span className="grow" />
-        <button
-          type="button"
-          onClick={() => setJiraImportOpen(true)}
-          className="inline-flex h-6 items-center gap-1.5 rounded border border-line px-2 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
-        >
-          <Download size={12} /> Import Jira
-        </button>
+        {showJiraImport && (
+          <button
+            type="button"
+            onClick={() => setJiraImportOpen(true)}
+            className="inline-flex h-6 items-center gap-1.5 rounded border border-line px-2 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
+          >
+            <Download size={12} /> Import Jira
+          </button>
+        )}
         {hiddenLanes.length > 0 && (
           <details className="relative">
             <summary className="cursor-pointer list-none flex items-center gap-1.5 hover:text-fg">
@@ -192,8 +199,9 @@ export function Board({ projectSlug }: BoardProps) {
         ))}
       </div>
       <JiraImportDialog
-        open={jiraImportOpen}
+        open={showJiraImport && jiraImportOpen}
         projectSlug={projectSlug}
+        milestoneNumber={resolvedMilestone}
         onClose={() => setJiraImportOpen(false)}
         onImported={(item) => {
           void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });

--- a/apps/web/src/components/board/components/Board.tsx
+++ b/apps/web/src/components/board/components/Board.tsx
@@ -7,9 +7,11 @@ import type { WorkItemDto } from '@/lib/types';
 import { useActiveMilestone } from '@/state/active-milestone';
 import { useLaneVisibility } from '@/state/lane-visibility';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ChevronDown, Eye, RefreshCw } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
+import { ChevronDown, Download, Eye, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { BoardColumn } from './BoardColumn';
+import { JiraImportDialog } from './JiraImportDialog';
 
 interface BoardProps {
   projectSlug: string;
@@ -17,6 +19,8 @@ interface BoardProps {
 
 export function Board({ projectSlug }: BoardProps) {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [jiraImportOpen, setJiraImportOpen] = useState(false);
   const { hidden, toggle, reset } = useLaneVisibility();
   const { activeNumber: resolvedMilestone, milestones, setActiveNumber } = useActiveMilestone();
   const { data: budgetStatus } = useProjectBudgetStatus(projectSlug);
@@ -141,6 +145,13 @@ export function Board({ projectSlug }: BoardProps) {
           {items.length} issue{items.length === 1 ? '' : 's'}
         </span>
         <span className="grow" />
+        <button
+          type="button"
+          onClick={() => setJiraImportOpen(true)}
+          className="inline-flex h-6 items-center gap-1.5 rounded border border-line px-2 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
+        >
+          <Download size={12} /> Import Jira
+        </button>
         {hiddenLanes.length > 0 && (
           <details className="relative">
             <summary className="cursor-pointer list-none flex items-center gap-1.5 hover:text-fg">
@@ -180,6 +191,20 @@ export function Board({ projectSlug }: BoardProps) {
           />
         ))}
       </div>
+      <JiraImportDialog
+        open={jiraImportOpen}
+        projectSlug={projectSlug}
+        onClose={() => setJiraImportOpen(false)}
+        onImported={(item) => {
+          void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
+          if (resolvedMilestone != null) {
+            void queryClient.invalidateQueries({
+              queryKey: ['milestone-issues', projectSlug, resolvedMilestone],
+            });
+          }
+          navigate(`/projects/${projectSlug}/items/${item.externalId}`);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/board/components/JiraImportDialog.test.tsx
+++ b/apps/web/src/components/board/components/JiraImportDialog.test.tsx
@@ -1,0 +1,74 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JiraImportDialog } from './JiraImportDialog';
+
+vi.mock('@/lib/api', () => ({
+  importJiraIssue: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderDialog(open = true) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onClose = vi.fn();
+  const onImported = vi.fn();
+  render(
+    <QueryClientProvider client={client}>
+      <JiraImportDialog open={open} projectSlug="proj" onClose={onClose} onImported={onImported} />
+    </QueryClientProvider>,
+  );
+  return { onClose, onImported };
+}
+
+describe('JiraImportDialog', () => {
+  it('does not render when closed', () => {
+    renderDialog(false);
+    expect(screen.queryByTestId('jira-import-dialog')).toBeNull();
+  });
+
+  it('imports a Jira key and reports the imported item', async () => {
+    const { importJiraIssue } = await import('@/lib/api');
+    vi.mocked(importJiraIssue).mockResolvedValue({
+      item: {
+        id: 'local:proj#1',
+        externalId: '1',
+        jiraKey: 'TAS-123',
+        jiraUrl: 'https://company.atlassian.net/browse/TAS-123',
+        title: 'Manual Jira import',
+        imported: true,
+      },
+    });
+    const user = userEvent.setup();
+    const { onImported } = renderDialog();
+
+    await user.type(screen.getByTestId('jira-import-input'), 'TAS-123');
+    await user.click(screen.getByTestId('jira-import-submit'));
+
+    await waitFor(() =>
+      expect(onImported).toHaveBeenCalledWith(
+        expect.objectContaining({ externalId: '1', jiraKey: 'TAS-123' }),
+      ),
+    );
+    expect(importJiraIssue).toHaveBeenCalledWith('proj', 'TAS-123');
+  });
+
+  it('surfaces provider failures without closing', async () => {
+    const { importJiraIssue } = await import('@/lib/api');
+    vi.mocked(importJiraIssue).mockRejectedValue(new Error('Jira issue not found'));
+    const user = userEvent.setup();
+    const { onClose } = renderDialog();
+
+    await user.type(screen.getByTestId('jira-import-input'), 'TAS-404');
+    await user.click(screen.getByTestId('jira-import-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('jira-import-error')).toBeTruthy());
+    expect(screen.getByTestId('jira-import-error').textContent).toContain('Jira issue not found');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/board/components/JiraImportDialog.test.tsx
+++ b/apps/web/src/components/board/components/JiraImportDialog.test.tsx
@@ -14,13 +14,19 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function renderDialog(open = true) {
+function renderDialog(open = true, milestoneNumber: number | null = null) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const onClose = vi.fn();
   const onImported = vi.fn();
   render(
     <QueryClientProvider client={client}>
-      <JiraImportDialog open={open} projectSlug="proj" onClose={onClose} onImported={onImported} />
+      <JiraImportDialog
+        open={open}
+        projectSlug="proj"
+        milestoneNumber={milestoneNumber}
+        onClose={onClose}
+        onImported={onImported}
+      />
     </QueryClientProvider>,
   );
   return { onClose, onImported };
@@ -55,7 +61,30 @@ describe('JiraImportDialog', () => {
         expect.objectContaining({ externalId: '1', jiraKey: 'TAS-123' }),
       ),
     );
-    expect(importJiraIssue).toHaveBeenCalledWith('proj', 'TAS-123');
+    expect(importJiraIssue).toHaveBeenCalledWith('proj', 'TAS-123', { milestoneNumber: null });
+  });
+
+  it('passes the active milestone through the import request', async () => {
+    const { importJiraIssue } = await import('@/lib/api');
+    vi.mocked(importJiraIssue).mockResolvedValue({
+      item: {
+        id: 'local:proj#1',
+        externalId: '1',
+        jiraKey: 'TAS-123',
+        jiraUrl: 'https://company.atlassian.net/browse/TAS-123',
+        title: 'Manual Jira import',
+        imported: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderDialog(true, 7);
+
+    await user.type(screen.getByTestId('jira-import-input'), 'TAS-123');
+    await user.click(screen.getByTestId('jira-import-submit'));
+
+    await waitFor(() =>
+      expect(importJiraIssue).toHaveBeenCalledWith('proj', 'TAS-123', { milestoneNumber: 7 }),
+    );
   });
 
   it('surfaces provider failures without closing', async () => {

--- a/apps/web/src/components/board/components/JiraImportDialog.tsx
+++ b/apps/web/src/components/board/components/JiraImportDialog.tsx
@@ -5,6 +5,7 @@ import { type FormEvent, useState } from 'react';
 interface JiraImportDialogProps {
   open: boolean;
   projectSlug: string;
+  milestoneNumber?: number | null;
   onClose: () => void;
   onImported: (item: JiraImportItemDto) => void;
 }
@@ -12,6 +13,7 @@ interface JiraImportDialogProps {
 export function JiraImportDialog({
   open,
   projectSlug,
+  milestoneNumber,
   onClose,
   onImported,
 }: JiraImportDialogProps) {
@@ -31,7 +33,7 @@ export function JiraImportDialog({
     setSubmitting(true);
     setError(null);
     try {
-      const result = await importJiraIssue(projectSlug, value);
+      const result = await importJiraIssue(projectSlug, value, { milestoneNumber });
       setInput('');
       onImported(result.item);
       onClose();

--- a/apps/web/src/components/board/components/JiraImportDialog.tsx
+++ b/apps/web/src/components/board/components/JiraImportDialog.tsx
@@ -1,0 +1,102 @@
+import { type JiraImportItemDto, importJiraIssue } from '@/lib/api';
+import { X } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+
+interface JiraImportDialogProps {
+  open: boolean;
+  projectSlug: string;
+  onClose: () => void;
+  onImported: (item: JiraImportItemDto) => void;
+}
+
+export function JiraImportDialog({
+  open,
+  projectSlug,
+  onClose,
+  onImported,
+}: JiraImportDialogProps) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const value = input.trim();
+    if (value.length === 0) {
+      setError('input is required');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await importJiraIssue(projectSlug, value);
+      setInput('');
+      onImported(result.item);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      data-testid="jira-import-dialog"
+    >
+      <div className="w-full max-w-[420px] rounded-md border border-line bg-bg-elev shadow-xl">
+        <header className="flex items-center justify-between border-b border-line px-4 py-3">
+          <h2 className="text-[13px] font-semibold text-fg">Import Jira Issue</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="grid h-7 w-7 place-items-center rounded text-fg-3 hover:bg-bg-hover hover:text-fg"
+          >
+            <X size={14} />
+          </button>
+        </header>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 px-4 py-4">
+          <label className="flex flex-col gap-1.5 text-[12px] text-fg-2">
+            Jira key or URL
+            <input
+              data-testid="jira-import-input"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="TAS-123"
+              className="h-8 rounded border border-line bg-bg px-2 text-[13px] text-fg outline-none focus:border-accent-line"
+            />
+          </label>
+          {error != null && (
+            <div
+              data-testid="jira-import-error"
+              className="rounded border border-[color:var(--danger)]/30 bg-[color:var(--danger)]/10 px-3 py-2 text-[12px] text-[color:var(--danger)]"
+            >
+              {error}
+            </div>
+          )}
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-8 rounded border border-line px-3 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="jira-import-submit"
+              disabled={submitting}
+              className="h-8 rounded border border-accent-line bg-[color:var(--accent)]/15 px-3 text-[12px] font-medium text-[color:var(--accent)] hover:bg-[color:var(--accent)]/20 disabled:opacity-60"
+            >
+              {submitting ? 'Importing...' : 'Import'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/board/lib/jira-import.test.ts
+++ b/apps/web/src/components/board/lib/jira-import.test.ts
@@ -1,0 +1,46 @@
+import type { ProjectSummary } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import { canUseManualJiraImport } from './jira-import';
+
+function project(source: ProjectSummary['source']): ProjectSummary {
+  return {
+    id: 'proj',
+    name: 'Project',
+    slug: 'proj',
+    color: '#fff',
+    source,
+  };
+}
+
+describe('canUseManualJiraImport', () => {
+  it('allows only local-db projects with enabled manual Jira import', () => {
+    expect(
+      canUseManualJiraImport(
+        project({
+          kind: 'local-db',
+          integrations: {
+            jira: {
+              enabled: true,
+              importMode: 'manual',
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(canUseManualJiraImport(project({ kind: 'github', repo: 'owner/repo' }))).toBe(false);
+    expect(
+      canUseManualJiraImport(
+        project({
+          kind: 'local-db',
+          integrations: {
+            jira: {
+              enabled: true,
+              importMode: 'assigned-to-me',
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
+    expect(canUseManualJiraImport(project({ kind: 'local-db' }))).toBe(false);
+  });
+});

--- a/apps/web/src/components/board/lib/jira-import.ts
+++ b/apps/web/src/components/board/lib/jira-import.ts
@@ -1,0 +1,13 @@
+import type { ProjectSummary } from '@/lib/types';
+
+export function canUseManualJiraImport(project: ProjectSummary | undefined): boolean {
+  if (project?.source.kind !== 'local-db') return false;
+  const integrations = project.source.integrations;
+  if (integrations == null || typeof integrations !== 'object') return false;
+  const jira = (integrations as { jira?: unknown }).jira;
+  if (jira == null || typeof jira !== 'object') return false;
+  return (
+    (jira as { enabled?: unknown }).enabled === true &&
+    (jira as { importMode?: unknown }).importMode === 'manual'
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,6 +6,7 @@ export * from './api/settings.js';
 export * from './api/roster.js';
 export * from './api/inbox.js';
 export * from './api/interventions.js';
+export * from './api/integrations.js';
 export * from './api/playbooks.js';
 export * from './api/bootstrap.js';
 export * from './api/chat.js';

--- a/apps/web/src/lib/api/integrations.ts
+++ b/apps/web/src/lib/api/integrations.ts
@@ -1,0 +1,18 @@
+import { postJson } from './client.js';
+
+export interface JiraImportItemDto {
+  id: string;
+  externalId: string;
+  jiraKey: string;
+  jiraUrl: string;
+  title: string;
+  imported: boolean;
+}
+
+export interface JiraImportResponseDto {
+  item: JiraImportItemDto;
+}
+
+export async function importJiraIssue(slug: string, input: string): Promise<JiraImportResponseDto> {
+  return postJson<JiraImportResponseDto>(`/projects/${slug}/integrations/jira/import`, { input });
+}

--- a/apps/web/src/lib/api/integrations.ts
+++ b/apps/web/src/lib/api/integrations.ts
@@ -13,6 +13,17 @@ export interface JiraImportResponseDto {
   item: JiraImportItemDto;
 }
 
-export async function importJiraIssue(slug: string, input: string): Promise<JiraImportResponseDto> {
-  return postJson<JiraImportResponseDto>(`/projects/${slug}/integrations/jira/import`, { input });
+export interface JiraImportOptions {
+  milestoneNumber?: number | null;
+}
+
+export async function importJiraIssue(
+  slug: string,
+  input: string,
+  options: JiraImportOptions = {},
+): Promise<JiraImportResponseDto> {
+  return postJson<JiraImportResponseDto>(`/projects/${slug}/integrations/jira/import`, {
+    input,
+    ...(options.milestoneNumber != null ? { milestoneNumber: options.milestoneNumber } : {}),
+  });
 }

--- a/core/integrations/atlassian/dtos.test.ts
+++ b/core/integrations/atlassian/dtos.test.ts
@@ -42,6 +42,13 @@ describe('Atlassian DTO schemas', () => {
           summary: 'Full Jira description',
           bytes: 1024,
         },
+        rawArtifactRef: {
+          stored: true,
+          artifactKey: 'atlassian:jira:evidence:TAS-123:def',
+          kind: 'atlassian:jira:evidence:TAS-123',
+          summary: 'Raw Jira issue response',
+          bytes: 2048,
+        },
         labels: ['factory'],
         components: ['hub'],
         linkedKeys: ['TAS-456'],

--- a/core/integrations/atlassian/dtos.ts
+++ b/core/integrations/atlassian/dtos.ts
@@ -52,6 +52,7 @@ export const AtlassianDetailSchema = AtlassianCardSchema.extend({
   tier: z.literal('detail'),
   bodyPreview: z.string().optional(),
   bodyArtifactRef: AtlassianArtifactRefSchema.optional(),
+  rawArtifactRef: AtlassianArtifactRefSchema.optional(),
   labels: z.array(z.string()).default([]),
   components: z.array(z.string()).default([]),
   linkedKeys: z.array(z.string()).default([]),

--- a/core/integrations/jira/import-issue.test.ts
+++ b/core/integrations/jira/import-issue.test.ts
@@ -163,6 +163,34 @@ describe('importJiraIssueToLocalDb', () => {
       lastSyncedAt: '2026-05-27T02:00:00.000Z',
     });
     expect(repository.listWorkItems('proj')).toHaveLength(1);
+    expect(repository.listRepoLinks('proj', 'local:proj#1')).toMatchObject([
+      {
+        repoRef: 'owner/repo',
+        role: 'primary',
+        source: 'jira-import',
+      },
+    ]);
+  });
+
+  it('preserves the requested milestone when creating a Jira Work Item', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+
+    await importJiraIssueToLocalDb({
+      projectConfig,
+      input: 'TAS-123',
+      adapter: adapterWith(jiraDetail()),
+      repository,
+      milestone: {
+        id: '7',
+        title: 'M7: Atlassian imports',
+      },
+    });
+
+    expect(repository.requireWorkItem('proj', 'local:proj#1')).toMatchObject({
+      milestoneId: '7',
+      milestoneTitle: 'M7: Atlassian imports',
+    });
   });
 
   it('does not create a partial Work Item when the provider fails', async () => {

--- a/core/integrations/jira/import-issue.test.ts
+++ b/core/integrations/jira/import-issue.test.ts
@@ -1,0 +1,244 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import {
+  LocalDbWorkItemRepository,
+  parseExternalRefMetadata,
+} from '../../state-source/local-db-repository.js';
+import type { ProjectConfig } from '../../types.js';
+import type { JiraProviderAdapter } from '../atlassian/adapters.js';
+import type { JiraIssueDetailDto } from '../atlassian/dtos.js';
+import { providerFailure } from '../atlassian/errors.js';
+import { importJiraIssueToLocalDb } from './import-issue.js';
+
+function makeRepository() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, {
+    migrationsFolder: path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'db',
+      'migrations',
+    ),
+  });
+  return {
+    sqlite,
+    repository: new LocalDbWorkItemRepository({
+      db,
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    }),
+  };
+}
+
+const projectConfig = {
+  id: 'proj',
+  slug: 'proj',
+  name: 'Project',
+  source: {
+    kind: 'local-db',
+    stateMachine: 'db',
+    integrations: {
+      jira: {
+        enabled: true,
+        baseUrl: 'https://company.atlassian.net',
+        projectKeys: ['TAS'],
+        importMode: 'manual',
+      },
+    },
+  },
+  repos: ['owner/repo'],
+} as ProjectConfig;
+
+function jiraDetail(overrides: Partial<JiraIssueDetailDto> = {}): JiraIssueDetailDto {
+  return {
+    provider: 'jira',
+    resourceKind: 'issue',
+    tier: 'detail',
+    id: '10001',
+    key: 'TAS-123',
+    title: 'Manual Jira import',
+    status: 'In Progress',
+    url: 'https://company.atlassian.net/browse/TAS-123',
+    project: 'TAS',
+    issueType: 'Bug',
+    priority: 'High',
+    assignee: { displayName: 'Ada Lovelace', accountId: 'ada-1' },
+    created: '2026-05-26T00:00:00.000Z',
+    updated: '2026-05-27T00:00:00.000Z',
+    bodyPreview: 'Investigate the importer failure.',
+    labels: ['factory'],
+    components: ['hub'],
+    linkedKeys: ['TAS-456'],
+    ...overrides,
+  };
+}
+
+function adapterWith(detail: JiraIssueDetailDto): JiraProviderAdapter {
+  return {
+    getIssue: vi.fn(async () => ({ ok: true as const, data: detail })),
+    searchIssues: vi.fn(),
+    getCurrentUser: vi.fn(),
+  };
+}
+
+describe('importJiraIssueToLocalDb', () => {
+  const handles: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const handle of handles.splice(0)) handle.close();
+  });
+
+  it('imports a Jira key idempotently into local Work Items with a Jira external ref', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    const adapter = adapterWith(jiraDetail());
+
+    const first = await importJiraIssueToLocalDb({
+      projectConfig,
+      input: 'TAS-123',
+      adapter,
+      repository,
+      now: () => new Date('2026-05-27T01:00:00.000Z'),
+    });
+    const second = await importJiraIssueToLocalDb({
+      projectConfig,
+      input: 'https://company.atlassian.net/browse/TAS-123',
+      adapter: adapterWith(jiraDetail({ title: 'Manual Jira import updated', status: 'Done' })),
+      repository,
+      now: () => new Date('2026-05-27T02:00:00.000Z'),
+    });
+
+    expect(first).toMatchObject({
+      ok: true,
+      data: { imported: true, jiraKey: 'TAS-123', externalId: '1' },
+    });
+    expect(second).toMatchObject({
+      ok: true,
+      data: { imported: false, jiraKey: 'TAS-123', externalId: '1' },
+    });
+    expect(adapter.getIssue).toHaveBeenCalledWith({ key: 'TAS-123', tier: 'detail' });
+    expect(adapter.searchIssues).not.toHaveBeenCalled();
+
+    const item = repository.getWorkItemByExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-123',
+    });
+    expect(item).toMatchObject({
+      id: 'local:proj#1',
+      externalId: '1',
+      title: 'Manual Jira import updated',
+      body: 'Investigate the importer failure.',
+      type: 'bug',
+      priority: 'high',
+      state: 'factory:triaging',
+    });
+
+    const ref = repository.getExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-123',
+    });
+    expect(ref).toMatchObject({
+      url: 'https://company.atlassian.net/browse/TAS-123',
+      repoRef: null,
+    });
+    expect(ref).not.toBeNull();
+    if (ref == null) throw new Error('expected Jira external ref');
+    expect(parseExternalRefMetadata(ref)).toMatchObject({
+      status: 'Done',
+      assignee: { displayName: 'Ada Lovelace', accountId: 'ada-1' },
+      issueType: 'Bug',
+      priority: 'High',
+      lastSyncedAt: '2026-05-27T02:00:00.000Z',
+    });
+    expect(repository.listWorkItems('proj')).toHaveLength(1);
+  });
+
+  it('does not create a partial Work Item when the provider fails', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    const adapter: JiraProviderAdapter = {
+      getIssue: vi.fn(async () => providerFailure('not_found', 'Jira issue not found')),
+      searchIssues: vi.fn(),
+      getCurrentUser: vi.fn(),
+    };
+
+    const result = await importJiraIssueToLocalDb({
+      projectConfig,
+      input: 'TAS-404',
+      adapter,
+      repository,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { kind: 'not_found', message: 'Jira issue not found' },
+    });
+    expect(repository.listWorkItems('proj')).toEqual([]);
+    expect(
+      repository.getExternalRef({
+        projectId: 'proj',
+        provider: 'jira',
+        kind: 'issue',
+        repoRef: null,
+        externalId: 'TAS-404',
+      }),
+    ).toBeNull();
+  });
+
+  it('carries provider artifact refs in external-ref metadata instead of raw provider objects', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+
+    await importJiraIssueToLocalDb({
+      projectConfig,
+      input: 'TAS-123',
+      adapter: adapterWith(
+        jiraDetail({
+          bodyArtifactRef: {
+            stored: true,
+            artifactKey: 'atlassian:jira:detail:TAS-123:body',
+            kind: 'atlassian:jira:detail:TAS-123',
+            summary: 'Full Jira description',
+            bytes: 2048,
+          },
+          rawArtifactRef: {
+            stored: true,
+            artifactKey: 'atlassian:jira:raw:TAS-123:raw',
+            kind: 'atlassian:jira:raw:TAS-123',
+            summary: 'Raw Jira issue response',
+            bytes: 4096,
+          },
+        }),
+      ),
+      repository,
+    });
+
+    const ref = repository.getExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-123',
+    });
+    expect(ref).not.toBeNull();
+    if (ref == null) throw new Error('expected Jira external ref');
+    const metadata = parseExternalRefMetadata(ref);
+    expect(metadata).toMatchObject({
+      bodyArtifactRef: { artifactKey: 'atlassian:jira:detail:TAS-123:body' },
+      rawArtifactRef: { artifactKey: 'atlassian:jira:raw:TAS-123:raw' },
+    });
+    expect(JSON.stringify(metadata)).not.toContain('"fields"');
+  });
+});

--- a/core/integrations/jira/import-issue.ts
+++ b/core/integrations/jira/import-issue.ts
@@ -10,6 +10,10 @@ export interface ImportJiraIssueToLocalDbInput {
   projectConfig: ProjectConfig;
   input: string;
   adapter: JiraProviderAdapter;
+  milestone?: {
+    id: string;
+    title?: string | null;
+  };
   repository?: LocalDbWorkItemRepository;
   now?: () => Date;
 }
@@ -65,8 +69,24 @@ export async function importJiraIssueToLocalDb(
   const mapped = mapJiraIssueToWorkItem(detail.data);
   const row =
     existing == null
-      ? repository.createWorkItem({ projectId: cfg.id, ...mapped })
+      ? repository.createWorkItem({
+          projectId: cfg.id,
+          ...mapped,
+          milestoneId: input.milestone?.id ?? null,
+          milestoneTitle: input.milestone?.title ?? null,
+        })
       : repository.updateWorkItem(cfg.id, existing.id, mapped);
+
+  const defaultRepoRef = cfg.repos[0];
+  if (defaultRepoRef != null && !defaultRepoRef.startsWith('local:')) {
+    repository.createRepoLink({
+      projectId: cfg.id,
+      itemId: row.id,
+      repoRef: defaultRepoRef,
+      role: 'primary',
+      source: 'jira-import',
+    });
+  }
 
   repository.upsertExternalRef({
     projectId: cfg.id,

--- a/core/integrations/jira/import-issue.ts
+++ b/core/integrations/jira/import-issue.ts
@@ -1,0 +1,143 @@
+import type { Priority, WorkItemType } from '../../state-source/interface.js';
+import { LocalDbWorkItemRepository } from '../../state-source/local-db-repository.js';
+import type { ProjectConfig } from '../../types.js';
+import type { JiraProviderAdapter } from '../atlassian/adapters.js';
+import type { JiraIssueDetailDto } from '../atlassian/dtos.js';
+import { type ProviderResult, providerFailure } from '../atlassian/errors.js';
+import { executeJiraQuery } from '../atlassian/query.js';
+
+export interface ImportJiraIssueToLocalDbInput {
+  projectConfig: ProjectConfig;
+  input: string;
+  adapter: JiraProviderAdapter;
+  repository?: LocalDbWorkItemRepository;
+  now?: () => Date;
+}
+
+export interface ImportJiraIssueToLocalDbResult {
+  imported: boolean;
+  itemId: string;
+  externalId: string;
+  jiraKey: string;
+  jiraUrl: string;
+  title: string;
+}
+
+export async function importJiraIssueToLocalDb(
+  input: ImportJiraIssueToLocalDbInput,
+): Promise<ProviderResult<ImportJiraIssueToLocalDbResult>> {
+  const cfg = input.projectConfig;
+  const jira = cfg.source.kind === 'local-db' ? cfg.source.integrations?.jira : undefined;
+  if (cfg.source.kind !== 'local-db' || jira?.enabled !== true) {
+    return providerFailure('validation', 'Jira integration is not enabled for this project');
+  }
+  if (jira.importMode !== 'manual') {
+    return providerFailure('validation', 'Jira manual import is not enabled for this project');
+  }
+
+  const detail = await executeJiraQuery<JiraIssueDetailDto>({
+    config: {
+      baseUrl: jira.baseUrl,
+      projectKeys: jira.projectKeys,
+    },
+    input: {
+      kind: 'manual',
+      value: input.input,
+      tier: 'detail',
+    },
+    adapter: input.adapter,
+  });
+  if (!detail.ok) return detail;
+
+  const jiraKey = detail.data.key;
+  if (jiraKey == null || jiraKey.trim().length === 0) {
+    return providerFailure('validation', 'Jira issue detail is missing a key');
+  }
+
+  const repository = input.repository ?? new LocalDbWorkItemRepository();
+  const existing = repository.getWorkItemByExternalRef({
+    projectId: cfg.id,
+    provider: 'jira',
+    kind: 'issue',
+    repoRef: null,
+    externalId: jiraKey,
+  });
+  const mapped = mapJiraIssueToWorkItem(detail.data);
+  const row =
+    existing == null
+      ? repository.createWorkItem({ projectId: cfg.id, ...mapped })
+      : repository.updateWorkItem(cfg.id, existing.id, mapped);
+
+  repository.upsertExternalRef({
+    projectId: cfg.id,
+    itemId: row.id,
+    provider: 'jira',
+    kind: 'issue',
+    repoRef: null,
+    externalId: jiraKey,
+    url: detail.data.url,
+    metadata: jiraExternalRefMetadata(detail.data, input.now?.() ?? new Date()),
+  });
+
+  return {
+    ok: true,
+    data: {
+      imported: existing == null,
+      itemId: row.id,
+      externalId: row.externalId,
+      jiraKey,
+      jiraUrl: detail.data.url,
+      title: row.title,
+    },
+  };
+}
+
+function mapJiraIssueToWorkItem(issue: JiraIssueDetailDto): {
+  title: string;
+  body: string;
+  type: WorkItemType;
+  priority: Priority;
+} {
+  return {
+    title: issue.title,
+    body: issue.bodyPreview ?? '',
+    type: mapJiraIssueType(issue.issueType),
+    priority: mapJiraPriority(issue.priority),
+  };
+}
+
+function jiraExternalRefMetadata(issue: JiraIssueDetailDto, syncedAt: Date) {
+  return {
+    status: issue.status,
+    assignee: issue.assignee ?? null,
+    issueType: issue.issueType ?? null,
+    priority: issue.priority ?? null,
+    project: issue.project ?? null,
+    labels: issue.labels,
+    components: issue.components,
+    linkedKeys: issue.linkedKeys,
+    bodyArtifactRef: issue.bodyArtifactRef ?? null,
+    rawArtifactRef: issue.rawArtifactRef ?? null,
+    lastSyncedAt: syncedAt.toISOString(),
+  };
+}
+
+function mapJiraIssueType(issueType: string | undefined): WorkItemType {
+  const normalized = issueType?.trim().toLowerCase() ?? '';
+  if (normalized.includes('bug') || normalized.includes('defect')) return 'bug';
+  if (normalized.includes('spike') || normalized.includes('research')) return 'research';
+  if (normalized.includes('task') || normalized.includes('chore')) return 'chore';
+  return 'feature';
+}
+
+function mapJiraPriority(priority: string | undefined): Priority {
+  const normalized = priority?.trim().toLowerCase() ?? '';
+  if (normalized.includes('critical') || normalized.includes('highest') || normalized === 'p0') {
+    return 'critical';
+  }
+  if (normalized.includes('high') || normalized === 'p1') return 'high';
+  if (normalized.includes('low') || normalized.includes('lowest') || normalized === 'p3') {
+    return 'low';
+  }
+  return 'medium';
+}

--- a/core/integrations/jira/rest.test.ts
+++ b/core/integrations/jira/rest.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getArtifact } from '../../agent-artifacts/repository.js';
+import { createJiraRestAdapter } from './rest.js';
+
+function response(status: number, body: unknown, statusText = 'OK') {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: new Headers(),
+    json: async () => body,
+  } as Response;
+}
+
+describe('Jira REST adapter', () => {
+  it('maps a Jira REST issue response into a validated detail DTO with artifact refs', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response(200, {
+        id: '10001',
+        key: 'TAS-123',
+        fields: {
+          summary: 'Manual Jira import',
+          description: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Long Jira description '.repeat(20) }],
+              },
+            ],
+          },
+          status: { name: 'To Do' },
+          issuetype: { name: 'Story' },
+          priority: { name: 'High' },
+          assignee: { displayName: 'Ada Lovelace', accountId: 'ada-1' },
+          labels: ['factory'],
+          components: [{ name: 'hub' }],
+          created: '2026-05-26T00:00:00.000Z',
+          updated: '2026-05-27T00:00:00.000Z',
+        },
+      }),
+    );
+    const adapter = createJiraRestAdapter({
+      baseUrl: 'https://company.atlassian.net',
+      email: 'ada@example.com',
+      apiToken: 'secret-token',
+      fetchImpl,
+      artifactContext: {
+        projectId: 'jira-rest-test',
+        runId: 'jira-rest-run',
+        thresholdBytes: 10,
+      },
+    });
+
+    const result = await adapter.getIssue({ key: 'TAS-123', tier: 'detail' });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        provider: 'jira',
+        resourceKind: 'issue',
+        tier: 'detail',
+        key: 'TAS-123',
+        title: 'Manual Jira import',
+        status: 'To Do',
+        bodyArtifactRef: { stored: true },
+        rawArtifactRef: { stored: true },
+      },
+    });
+    if (result.ok) {
+      expect(result.data).not.toHaveProperty('fields');
+      expect(getArtifact(result.data.rawArtifactRef?.artifactKey ?? '')?.payload).toMatchObject({
+        key: 'TAS-123',
+      });
+    }
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://company.atlassian.net/rest/api/3/issue/TAS-123',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('maps provider HTTP errors into typed failures', async () => {
+    const adapter = createJiraRestAdapter({
+      baseUrl: 'https://company.atlassian.net',
+      email: 'ada@example.com',
+      apiToken: 'secret-token',
+      fetchImpl: vi.fn(async () =>
+        response(401, { errorMessages: ['Unauthorized'] }, 'Unauthorized'),
+      ),
+    });
+
+    await expect(adapter.getIssue({ key: 'TAS-123', tier: 'detail' })).resolves.toMatchObject({
+      ok: false,
+      error: { kind: 'auth', status: 401 },
+    });
+  });
+});

--- a/core/integrations/jira/rest.ts
+++ b/core/integrations/jira/rest.ts
@@ -1,0 +1,295 @@
+import type { JiraProviderAdapter } from '../atlassian/adapters.js';
+import type { AtlassianArtifactRef, JiraIssueDetailDto } from '../atlassian/dtos.js';
+import { JiraIssueDetailSchema } from '../atlassian/dtos.js';
+import {
+  type ProviderResult,
+  mapHttpStatusToProviderErrorKind,
+  providerFailure,
+} from '../atlassian/errors.js';
+import { offloadAtlassianPayload } from '../atlassian/payload-offload.js';
+
+export interface JiraRestArtifactContext {
+  projectId: string;
+  workItemId?: string | null;
+  runId: string;
+  thresholdBytes?: number;
+}
+
+export interface JiraRestAdapterOptions {
+  baseUrl: string;
+  email: string;
+  apiToken: string;
+  fetchImpl?: typeof fetch;
+  artifactContext?: JiraRestArtifactContext;
+}
+
+export interface JiraRestAdapterFromEnvOptions {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+  artifactContext?: JiraRestArtifactContext;
+}
+
+interface JiraRestIssue {
+  id?: unknown;
+  key?: unknown;
+  self?: unknown;
+  fields?: {
+    summary?: unknown;
+    description?: unknown;
+    status?: { name?: unknown } | null;
+    issuetype?: { name?: unknown } | null;
+    priority?: { name?: unknown } | null;
+    assignee?: {
+      displayName?: unknown;
+      accountId?: unknown;
+      emailAddress?: unknown;
+    } | null;
+    labels?: unknown;
+    components?: unknown;
+    created?: unknown;
+    updated?: unknown;
+    issuelinks?: unknown;
+  };
+}
+
+export function createJiraRestAdapterFromEnv(
+  options: JiraRestAdapterFromEnvOptions,
+): JiraProviderAdapter {
+  const email = process.env.JIRA_EMAIL ?? process.env.ATLASSIAN_EMAIL ?? '';
+  const apiToken = process.env.JIRA_API_TOKEN ?? process.env.ATLASSIAN_API_TOKEN ?? '';
+  if (email.trim().length === 0 || apiToken.trim().length === 0) {
+    return missingCredentialsAdapter();
+  }
+  return createJiraRestAdapter({
+    ...options,
+    email,
+    apiToken,
+  });
+}
+
+export function createJiraRestAdapter(options: JiraRestAdapterOptions): JiraProviderAdapter {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = options.baseUrl.replace(/\/+$/, '');
+  const authorization = `Basic ${Buffer.from(`${options.email}:${options.apiToken}`).toString(
+    'base64',
+  )}`;
+
+  return {
+    async getIssue({ key }): Promise<ProviderResult<JiraIssueDetailDto>> {
+      let response: Response;
+      try {
+        response = await fetchImpl(`${baseUrl}/rest/api/3/issue/${encodeURIComponent(key)}`, {
+          headers: {
+            Accept: 'application/json',
+            Authorization: authorization,
+          },
+        });
+      } catch (err) {
+        return providerFailure('connection', `Failed to connect to Jira: ${String(err)}`);
+      }
+
+      if (!response.ok) {
+        return providerFailure(
+          mapHttpStatusToProviderErrorKind(response.status, 'read'),
+          response.statusText || `Jira request failed with ${response.status}`,
+          { status: response.status },
+        );
+      }
+
+      let raw: unknown;
+      try {
+        raw = await response.json();
+      } catch (err) {
+        return providerFailure('connection', `Failed to parse Jira response: ${String(err)}`);
+      }
+
+      try {
+        return {
+          ok: true,
+          data: JiraIssueDetailSchema.parse(mapRestIssue(raw, baseUrl, options.artifactContext)),
+        };
+      } catch (err) {
+        return providerFailure(
+          'validation',
+          `Jira issue response failed validation: ${String(err)}`,
+        );
+      }
+    },
+    async searchIssues() {
+      return providerFailure('query', 'Jira search is not implemented for manual import');
+    },
+    async getCurrentUser() {
+      return providerFailure(
+        'auth',
+        'Jira current-user lookup is not implemented for manual import',
+      );
+    },
+  };
+}
+
+function missingCredentialsAdapter(): JiraProviderAdapter {
+  return {
+    async getIssue() {
+      return providerFailure('auth', 'Jira credentials are not configured');
+    },
+    async searchIssues() {
+      return providerFailure('auth', 'Jira credentials are not configured');
+    },
+    async getCurrentUser() {
+      return providerFailure('auth', 'Jira credentials are not configured');
+    },
+  };
+}
+
+function mapRestIssue(
+  raw: unknown,
+  baseUrl: string,
+  artifactContext: JiraRestArtifactContext | undefined,
+): JiraIssueDetailDto {
+  const issue = raw as JiraRestIssue;
+  const fields = issue.fields ?? {};
+  const key = stringValue(issue.key);
+  const descriptionText = jiraRichTextToPlainText(fields.description);
+  const bodyArtifactRef = offloadArtifactRef({
+    context: artifactContext,
+    key,
+    tier: 'detail',
+    suffix: 'body',
+    payload: fields.description,
+    summary: `Full Jira description for ${key}`,
+  });
+  const rawArtifactRef = offloadArtifactRef({
+    context: artifactContext,
+    key,
+    tier: 'evidence',
+    suffix: 'raw',
+    payload: raw,
+    summary: `Raw Jira issue response for ${key}`,
+  });
+
+  return {
+    provider: 'jira',
+    resourceKind: 'issue',
+    tier: 'detail',
+    id: stringValue(issue.id) || key,
+    key,
+    title: stringValue(fields.summary) || key,
+    status: stringValue(fields.status?.name) || 'Unknown',
+    url: `${baseUrl}/browse/${encodeURIComponent(key)}`,
+    project: key.includes('-') ? key.split('-')[0] : undefined,
+    issueType: stringValue(fields.issuetype?.name) || undefined,
+    priority: stringValue(fields.priority?.name) || undefined,
+    assignee: mapAssignee(fields.assignee),
+    created: stringValue(fields.created) || undefined,
+    updated: stringValue(fields.updated) || undefined,
+    bodyPreview: descriptionText.length > 0 ? descriptionText.slice(0, 4000) : undefined,
+    bodyArtifactRef,
+    rawArtifactRef,
+    labels: arrayOfStrings(fields.labels),
+    components: arrayOfNamedValues(fields.components),
+    linkedKeys: linkedIssueKeys(fields.issuelinks),
+  };
+}
+
+function offloadArtifactRef(input: {
+  context: JiraRestArtifactContext | undefined;
+  key: string;
+  tier: 'detail' | 'evidence';
+  suffix: string;
+  payload: unknown;
+  summary: string;
+}): AtlassianArtifactRef | undefined {
+  if (input.context == null || input.payload == null) return undefined;
+  const result = offloadAtlassianPayload({
+    projectId: input.context.projectId,
+    workItemId: input.context.workItemId,
+    runId: input.context.runId,
+    provider: 'jira',
+    tier: input.tier,
+    resourceId: input.key,
+    userFacingArgs: {
+      key: input.key,
+      field: input.suffix,
+    },
+    payload: input.payload,
+    summary: input.summary,
+    thresholdBytes: input.context.thresholdBytes,
+  });
+  return result.artifactRef ?? undefined;
+}
+
+function mapAssignee(
+  assignee:
+    | {
+        displayName?: unknown;
+        accountId?: unknown;
+        emailAddress?: unknown;
+      }
+    | null
+    | undefined,
+) {
+  if (assignee == null || typeof assignee !== 'object') return undefined;
+  const value = assignee as {
+    displayName?: unknown;
+    accountId?: unknown;
+    emailAddress?: unknown;
+  };
+  const displayName = stringValue(value.displayName);
+  if (displayName.length === 0) return undefined;
+  return {
+    displayName,
+    accountId: stringValue(value.accountId) || undefined,
+    emailAddress: stringValue(value.emailAddress) || undefined,
+  };
+}
+
+function jiraRichTextToPlainText(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value)) return value.map(jiraRichTextToPlainText).filter(Boolean).join('\n');
+  if (value == null || typeof value !== 'object') return '';
+  const node = value as { text?: unknown; content?: unknown; type?: unknown };
+  const ownText = typeof node.text === 'string' ? node.text : '';
+  const childText = jiraRichTextToPlainText(node.content);
+  const separator = node.type === 'paragraph' ? '\n' : '';
+  return [ownText, childText].filter(Boolean).join(separator).trim();
+}
+
+function arrayOfStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const text = stringValue(entry);
+    return text.length > 0 ? [text] : [];
+  });
+}
+
+function arrayOfNamedValues(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (entry == null || typeof entry !== 'object') return [];
+    const name = stringValue((entry as { name?: unknown }).name);
+    return name.length > 0 ? [name] : [];
+  });
+}
+
+function linkedIssueKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.flatMap((link) => {
+        if (link == null || typeof link !== 'object') return [];
+        const candidate = link as {
+          inwardIssue?: { key?: unknown };
+          outwardIssue?: { key?: unknown };
+        };
+        return [
+          stringValue(candidate.inwardIssue?.key),
+          stringValue(candidate.outwardIssue?.key),
+        ].filter((key) => key.length > 0);
+      }),
+    ),
+  ];
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}


### PR DESCRIPTION
## Summary
- Add manual Jira import core service that resolves exact Jira keys/URLs through the Atlassian query boundary and upserts local-db Work Items by Jira external ref.
- Add Jira REST adapter behind the provider interface with DTO validation and artifact refs for large description/raw payloads.
- Add server import route and board UI dialog for importing a Jira key or URL and navigating to the local Work Item.

## Verification
- pnpm test core/integrations/jira/import-issue.test.ts core/integrations/jira/rest.test.ts core/integrations/atlassian/dtos.test.ts core/integrations/atlassian/jira.test.ts core/integrations/atlassian/query.test.ts core/integrations/atlassian/payload-offload.test.ts core/integrations/atlassian/errors.test.ts apps/server/src/domains/integrations/service.test.ts apps/server/src/domains/integrations/router.test.ts apps/web/src/components/board/components/JiraImportDialog.test.tsx core/state-source/local-db-repository.test.ts core/integrations/github/import-issues.test.ts
- pnpm typecheck
- pnpm exec biome check core/integrations/atlassian/dtos.ts core/integrations/atlassian/dtos.test.ts core/integrations/jira/import-issue.ts core/integrations/jira/import-issue.test.ts core/integrations/jira/rest.ts core/integrations/jira/rest.test.ts apps/server/src/domains/integrations/service.ts apps/server/src/domains/integrations/service.test.ts apps/server/src/domains/integrations/router.ts apps/server/src/domains/integrations/router.test.ts apps/server/src/server.ts apps/web/src/lib/api.ts apps/web/src/lib/api/integrations.ts apps/web/src/components/board/components/Board.tsx apps/web/src/components/board/components/JiraImportDialog.tsx apps/web/src/components/board/components/JiraImportDialog.test.tsx

## Known unrelated check failure
- pnpm --filter @goose-hub/web build still fails on existing app type errors in IssueCard.test.tsx, board/slice.test.ts, OperatorQueuePage.test.tsx, and ProjectBudgetPanel.tsx; the Jira dialog type issue is fixed.