### PR TITLE
M19.XX: workflow snapshot 4

### DIFF
--- a/apps/web/src/components/detail/components/OverviewSection.test.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.test.tsx
@@ -1,0 +1,187 @@
+/** @vitest-environment jsdom */
+import { fetchEvents, fetchIssueDiff, fetchTriageResult } from '@/lib/api';
+import type { AgentEventDto, TriageResultDto, WorkItemDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OverviewSection } from './OverviewSection';
+
+const useParamsMock = vi.fn();
+const buildOverviewWorkflowCardsMock = vi.fn();
+const useIssueCostsBreakdownMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  fetchEvents: vi.fn(),
+  fetchIssueDiff: vi.fn(),
+  fetchTriageResult: vi.fn(),
+}));
+
+vi.mock('@/lib/markdown', () => ({
+  renderMarkdownToHtml: vi.fn(() => '<p>Brief body</p>'),
+}));
+
+vi.mock('@/lib/usePersonaMap', () => ({
+  usePersonaMap: vi.fn(() => ({})),
+  getPersonaLabel: vi.fn(() => 'Rogue Pinion (GRL)'),
+  getPersonaInitials: vi.fn(() => 'RP'),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => useParamsMock(),
+  };
+});
+
+vi.mock('../lib/costs', () => ({
+  useIssueCostsBreakdown: () => useIssueCostsBreakdownMock(),
+}));
+
+vi.mock('../lib/overview-workflow-summary', () => ({
+  buildOverviewWorkflowCards: (...args: unknown[]) => buildOverviewWorkflowCardsMock(...args),
+}));
+
+vi.mock('./CommentsSection', () => ({
+  CommentsSection: () => <div data-testid="comments-section" />,
+}));
+
+vi.mock('./DependenciesSection', () => ({
+  DependenciesSection: () => <div data-testid="dependencies-section" />,
+}));
+
+afterEach(cleanup);
+
+const ITEM: WorkItemDto = {
+  id: 'github:test/repo#42',
+  externalId: '42',
+  repoRef: 'test/repo',
+  title: 'Workflow snapshot',
+  body: 'Brief body',
+  type: 'feature',
+  priority: 'medium',
+  mode: 'default',
+  state: 'factory:prd-review',
+  authorIsOwner: false,
+  schedule: 'normal',
+  exec: 'serial',
+  dependsOn: [],
+  blocks: [],
+  createdAt: '2026-05-27T00:00:00Z',
+  lastPersonaId: 'persona-1',
+};
+
+const TRIAGE: TriageResultDto = {
+  priority: 'high',
+  type: 'feature',
+  candidates: [{ repo: 'shaunnez/goose-hub', confidence: 85, evidence: 'match', tier: 1 }],
+  overrideRepo: null,
+};
+
+const EVENTS: AgentEventDto[] = [
+  {
+    id: 1,
+    projectId: 'proj',
+    workItemId: ITEM.id,
+    kind: 'review.completed',
+    payload: { verdict: 'approved', confidence: 0.91, criteriaChecks: [], findings: [] },
+    createdAt: '2026-05-27T00:00:01Z',
+  },
+];
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderSection() {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <OverviewSection item={ITEM} projectSlug="proj" />
+    </QueryClientProvider>,
+  );
+}
+
+describe('OverviewSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useParamsMock.mockReturnValue({ slug: 'proj', id: '42' });
+    vi.mocked(fetchEvents).mockResolvedValue(EVENTS);
+    vi.mocked(fetchIssueDiff).mockResolvedValue({ diff: null, runId: null });
+    vi.mocked(fetchTriageResult).mockResolvedValue(TRIAGE);
+    useIssueCostsBreakdownMock.mockReturnValue({
+      byRun: new Map(),
+      byStage: new Map(),
+      bySkill: new Map(),
+      total: 0,
+      totalTokens: 0,
+      hasEstimated: false,
+      totalLabel: 'exact',
+      runCount: 0,
+      isLoading: false,
+    });
+    buildOverviewWorkflowCardsMock.mockReturnValue([
+      {
+        key: 'triage',
+        title: 'Triage',
+        status: 'Complete',
+        statusTone: 'success',
+        metrics: [
+          { label: 'Priority', value: 'high' },
+          { label: 'Repo', value: 'shaunnez/goose-hub' },
+        ],
+        hrefSection: 'triage',
+      },
+      {
+        key: 'review',
+        title: 'Review',
+        status: 'Approved',
+        statusTone: 'success',
+        metrics: [{ label: 'Confidence', value: '91%' }],
+      },
+    ]);
+  });
+
+  it('renders the workflow snapshot grid with readable labels from partial data', async () => {
+    renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Workflow Snapshot')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Triage')).toBeTruthy();
+    expect(screen.getByText('Review')).toBeTruthy();
+    expect(screen.getByText('Priority')).toBeTruthy();
+    expect(screen.getByText('shaunnez/goose-hub')).toBeTruthy();
+    expect(screen.getByText('Approved')).toBeTruthy();
+  });
+
+  it('queries canonical triage data and passes overview inputs into the summary builder', async () => {
+    renderSection();
+
+    await waitFor(() => {
+      expect(fetchTriageResult).toHaveBeenCalledWith('proj', '42');
+    });
+
+    await waitFor(() => {
+      expect(buildOverviewWorkflowCardsMock).toHaveBeenLastCalledWith({
+        item: ITEM,
+        events: EVENTS,
+        costs: expect.objectContaining({ byStage: expect.any(Map), bySkill: expect.any(Map) }),
+        diff: { diff: null, runId: null },
+        triage: TRIAGE,
+      });
+    });
+  });
+
+  it('uses the responsive 1/2/3-column grid classes for the workflow cards', async () => {
+    const { container } = renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Workflow Snapshot')).toBeTruthy();
+    });
+    const grid = container.querySelector('[data-testid="workflow-snapshot-grid"]');
+    expect(grid?.className).toContain('grid-cols-1');
+    expect(grid?.className).toContain('md:grid-cols-2');
+    expect(grid?.className).toContain('xl:grid-cols-3');
+  });
+});

--- a/apps/web/src/components/detail/components/OverviewSection.tsx
+++ b/apps/web/src/components/detail/components/OverviewSection.tsx
@@ -1,4 +1,4 @@
-import { fetchEvents, fetchIssueDiff } from '@/lib/api';
+import { fetchEvents, fetchIssueDiff, fetchTriageResult } from '@/lib/api';
 import { laneForState } from '@/lib/lanes.config';
 import { renderMarkdownToHtml } from '@/lib/markdown';
 import type { AgentEventDto, IssueDiffDto, WorkItemDto } from '@/lib/types';
@@ -9,9 +9,11 @@ import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { parseDiff } from '../lib/code-diff';
 import { useIssueCostsBreakdown } from '../lib/costs';
+import { buildOverviewWorkflowCards } from '../lib/overview-workflow-summary';
 import { CommentsSection } from './CommentsSection';
 import { DependenciesSection } from './DependenciesSection';
 import { StatCard } from './StatCard';
+import { WorkflowSummaryCard } from './WorkflowSummaryCard';
 
 interface OverviewSectionProps {
   item?: WorkItemDto;
@@ -51,10 +53,27 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
     staleTime: 10_000,
     enabled: id !== '',
   });
+  const { data: triage } = useQuery({
+    queryKey: ['triage', slug, id],
+    queryFn: () => fetchTriageResult(slug, id),
+    staleTime: 10_000,
+    enabled: id !== '',
+  });
   const qaPayload = events.find((e) => e.kind === 'qa.completed')?.payload as
     | { testRun?: { passed: number; failed: number; skipped: number } }
     | undefined;
   const testRun = qaPayload?.testRun ?? null;
+  const workflowCards = useMemo(
+    () =>
+      buildOverviewWorkflowCards({
+        item,
+        events,
+        costs,
+        diff: diffData,
+        triage: triage ?? null,
+      }),
+    [costs, diffData, events, item, triage],
+  );
 
   return (
     <div data-testid="overview-section" className="px-8 py-6 flex flex-col gap-5">
@@ -98,6 +117,23 @@ export function OverviewSection({ item, projectSlug }: OverviewSectionProps) {
         <StatCard label="Last agent" value={lastAgentLabel} />
         <StatCard label="Spent" value={spentValue} sub={spentSub} />
       </div>
+
+      <section className="flex flex-col gap-3">
+        <div>
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-2 mb-1">
+            Workflow Snapshot
+          </div>
+          <p className="text-[12px] text-fg-3">Stage status, key outputs, and cost at a glance.</p>
+        </div>
+        <div
+          data-testid="workflow-snapshot-grid"
+          className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
+        >
+          {workflowCards.map((card) => (
+            <WorkflowSummaryCard key={card.key} card={card} />
+          ))}
+        </div>
+      </section>
 
       {/* Main content grid */}
       <div className="grid gap-4">

--- a/apps/web/src/components/detail/components/WorkflowSummaryCard.test.tsx
+++ b/apps/web/src/components/detail/components/WorkflowSummaryCard.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { OverviewWorkflowCard } from '../lib/overview-workflow-summary';
 import { WorkflowSummaryCard } from './WorkflowSummaryCard';
@@ -23,7 +24,7 @@ const CARD: OverviewWorkflowCard = {
 
 describe('WorkflowSummaryCard', () => {
   it('renders compact metrics, status, and cost footer', () => {
-    render(<WorkflowSummaryCard card={CARD} />);
+    renderCard();
 
     expect(screen.getByText('Review')).toBeTruthy();
     expect(screen.getByText('Approved')).toBeTruthy();
@@ -34,17 +35,34 @@ describe('WorkflowSummaryCard', () => {
   });
 
   it('renders a usable section link when hrefSection exists', () => {
-    render(<WorkflowSummaryCard card={CARD} />);
+    renderCard();
 
     const link = screen.getByRole('link', { name: /open review section/i });
-    expect(link.getAttribute('href')).toBe('#review');
+    expect(link.getAttribute('href')).toBe('/projects/proj/items/42/review');
   });
 
   it('renders a readable static card when hrefSection is missing', () => {
-    render(<WorkflowSummaryCard card={{ ...CARD, hrefSection: undefined }} />);
+    renderCard({ ...CARD, hrefSection: undefined });
 
     expect(screen.queryByRole('link', { name: /open review section/i })).toBeNull();
     expect(screen.getByText('Review')).toBeTruthy();
     expect(screen.getByText('Approved')).toBeTruthy();
   });
+
+  it('maps snapshot-only section keys onto detail routes', () => {
+    renderCard({ ...CARD, key: 'triage', title: 'Triage', hrefSection: 'triage' });
+
+    const link = screen.getByRole('link', { name: /open triage section/i });
+    expect(link.getAttribute('href')).toBe('/projects/proj/items/42/repo');
+  });
 });
+
+function renderCard(card: OverviewWorkflowCard = CARD) {
+  return render(
+    <MemoryRouter initialEntries={['/projects/proj/items/42']}>
+      <Routes>
+        <Route path="/projects/:slug/items/:id" element={<WorkflowSummaryCard card={card} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}

--- a/apps/web/src/components/detail/components/WorkflowSummaryCard.test.tsx
+++ b/apps/web/src/components/detail/components/WorkflowSummaryCard.test.tsx
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { OverviewWorkflowCard } from '../lib/overview-workflow-summary';
+import { WorkflowSummaryCard } from './WorkflowSummaryCard';
+
+afterEach(cleanup);
+
+const CARD: OverviewWorkflowCard = {
+  key: 'review',
+  title: 'Review',
+  status: 'Approved',
+  statusTone: 'success',
+  metrics: [
+    { label: 'Confidence', value: '92%' },
+    { label: 'Criteria', value: '5/6 met' },
+    { label: 'Blockers', value: '0' },
+    { label: 'PR', value: '#123 open' },
+  ],
+  footer: { tokens: 1234, usd: 0.12, label: 'estimated' },
+  hrefSection: 'review',
+};
+
+describe('WorkflowSummaryCard', () => {
+  it('renders compact metrics, status, and cost footer', () => {
+    render(<WorkflowSummaryCard card={CARD} />);
+
+    expect(screen.getByText('Review')).toBeTruthy();
+    expect(screen.getByText('Approved')).toBeTruthy();
+    expect(screen.getByText('Confidence')).toBeTruthy();
+    expect(screen.getByText('92%')).toBeTruthy();
+    expect(screen.getByTestId('cost-badge').textContent).toContain('1.2k');
+    expect(screen.getByTestId('cost-badge').textContent).toContain('~$0.12');
+  });
+
+  it('renders a usable section link when hrefSection exists', () => {
+    render(<WorkflowSummaryCard card={CARD} />);
+
+    const link = screen.getByRole('link', { name: /open review section/i });
+    expect(link.getAttribute('href')).toBe('#review');
+  });
+
+  it('renders a readable static card when hrefSection is missing', () => {
+    render(<WorkflowSummaryCard card={{ ...CARD, hrefSection: undefined }} />);
+
+    expect(screen.queryByRole('link', { name: /open review section/i })).toBeNull();
+    expect(screen.getByText('Review')).toBeTruthy();
+    expect(screen.getByText('Approved')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/detail/components/WorkflowSummaryCard.tsx
+++ b/apps/web/src/components/detail/components/WorkflowSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/cn';
 import { ChevronRight } from 'lucide-react';
 import type { JSX } from 'react';
+import { useParams } from 'react-router-dom';
 import type {
   OverviewWorkflowCard,
   OverviewWorkflowStatusTone,
@@ -21,7 +22,17 @@ const TONE_CLASSES: Record<OverviewWorkflowStatusTone, string> = {
   muted: 'border-line bg-bg-elev-2 text-fg-3',
 };
 
+const SECTION_ROUTE_KEY: Record<string, string> = {
+  triage: 'repo',
+  retro: 'retrospective',
+};
+
 export function WorkflowSummaryCard({ card }: WorkflowSummaryCardProps): JSX.Element {
+  const { slug = 'goose-hub-self', id = '' } = useParams<{ slug: string; id: string }>();
+  const routeSection =
+    card.hrefSection == null ? null : (SECTION_ROUTE_KEY[card.hrefSection] ?? card.hrefSection);
+  const href = routeSection == null ? null : `/projects/${slug}/items/${id}/${routeSection}`;
+
   const content = (
     <>
       <div className="flex items-start justify-between gap-3">
@@ -38,7 +49,7 @@ export function WorkflowSummaryCard({ card }: WorkflowSummaryCardProps): JSX.Ele
             </span>
           </div>
         </div>
-        {card.hrefSection ? <ChevronRight size={14} className="mt-0.5 shrink-0 text-fg-4" /> : null}
+        {href ? <ChevronRight size={14} className="mt-0.5 shrink-0 text-fg-4" /> : null}
       </div>
 
       <dl className="mt-4 grid grid-cols-2 gap-x-3 gap-y-2.5">
@@ -66,10 +77,10 @@ export function WorkflowSummaryCard({ card }: WorkflowSummaryCardProps): JSX.Ele
   const className =
     'rounded-lg border border-line bg-bg-elev px-4 py-3 transition-colors hover:border-line/80';
 
-  if (card.hrefSection) {
+  if (href) {
     return (
       <a
-        href={`#${card.hrefSection}`}
+        href={href}
         aria-label={`Open ${card.title} section`}
         className={cn(className, 'block focus:outline-none focus:ring-2 focus:ring-accent/30')}
       >

--- a/apps/web/src/components/detail/components/WorkflowSummaryCard.tsx
+++ b/apps/web/src/components/detail/components/WorkflowSummaryCard.tsx
@@ -1,0 +1,82 @@
+import { cn } from '@/lib/cn';
+import { ChevronRight } from 'lucide-react';
+import type { JSX } from 'react';
+import type {
+  OverviewWorkflowCard,
+  OverviewWorkflowStatusTone,
+} from '../lib/overview-workflow-summary';
+import { CostBadge } from './CostBadge';
+
+export interface WorkflowSummaryCardProps {
+  card: OverviewWorkflowCard;
+}
+
+const TONE_CLASSES: Record<OverviewWorkflowStatusTone, string> = {
+  neutral: 'border-line bg-bg text-fg-2',
+  active: 'border-accent/30 bg-accent/10 text-accent',
+  success:
+    'border-[color:var(--success)]/30 bg-[color:var(--success)]/10 text-[color:var(--success)]',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
+  danger: 'border-red-500/30 bg-red-500/10 text-red-700',
+  muted: 'border-line bg-bg-elev-2 text-fg-3',
+};
+
+export function WorkflowSummaryCard({ card }: WorkflowSummaryCardProps): JSX.Element {
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10.5px] uppercase tracking-wider text-fg-2">{card.title}</div>
+          <div className="mt-2 flex items-center gap-2">
+            <span
+              className={cn(
+                'inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                TONE_CLASSES[card.statusTone],
+              )}
+            >
+              {card.status}
+            </span>
+          </div>
+        </div>
+        {card.hrefSection ? <ChevronRight size={14} className="mt-0.5 shrink-0 text-fg-4" /> : null}
+      </div>
+
+      <dl className="mt-4 grid grid-cols-2 gap-x-3 gap-y-2.5">
+        {card.metrics.map((metric) => (
+          <div key={`${card.key}-${metric.label}`} className="min-w-0">
+            <dt className="text-[10.5px] uppercase tracking-wider text-fg-3">{metric.label}</dt>
+            <dd className="mt-1 truncate text-[12.5px] font-medium text-fg">{metric.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {card.footer ? (
+        <div className="mt-4 border-t border-line pt-3">
+          <CostBadge
+            tokens={card.footer.tokens}
+            usd={card.footer.usd}
+            label={card.footer.label}
+            size="sm"
+          />
+        </div>
+      ) : null}
+    </>
+  );
+
+  const className =
+    'rounded-lg border border-line bg-bg-elev px-4 py-3 transition-colors hover:border-line/80';
+
+  if (card.hrefSection) {
+    return (
+      <a
+        href={`#${card.hrefSection}`}
+        aria-label={`Open ${card.title} section`}
+        className={cn(className, 'block focus:outline-none focus:ring-2 focus:ring-accent/30')}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <div className={className}>{content}</div>;
+}

--- a/apps/web/src/components/detail/lib/costs.test.ts
+++ b/apps/web/src/components/detail/lib/costs.test.ts
@@ -49,6 +49,7 @@ describe('useIssueCostsBreakdown', () => {
     expect(result.current.runCount).toBe(0);
     expect(result.current.byRun.size).toBe(0);
     expect(result.current.byStage.size).toBe(0);
+    expect(result.current.bySkill.size).toBe(0);
   });
 
   it('keys cost rows by runId and aggregates by stage', async () => {
@@ -123,5 +124,78 @@ describe('useIssueCostsBreakdown', () => {
 
     expect(result.current.totalLabel).toBe('estimated');
     expect(result.current.byStage.get('review')?.label).toBe('estimated');
+  });
+
+  it('aggregates costs by skill without changing stage totals', async () => {
+    const data: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.22,
+      hasEstimated: true,
+      rows: [
+        row({
+          runId: 'discover-grill-1',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.05,
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 40,
+          reasoningOutputTokens: 10,
+          cacheHitRatio: 0.2,
+          costLabel: 'exact',
+        }),
+        row({
+          runId: 'discover-grill-2',
+          stage: 'discover',
+          skill: 'grill-me',
+          costUsd: 0.04,
+          inputTokens: 80,
+          cachedInputTokens: 40,
+          outputTokens: 20,
+          reasoningOutputTokens: 5,
+          cacheHitRatio: 0.5,
+          costLabel: 'estimated',
+        }),
+        row({
+          runId: 'discover-prd-1',
+          stage: 'discover',
+          skill: 'write-prd',
+          costUsd: 0.13,
+          inputTokens: 300,
+          cachedInputTokens: 60,
+          outputTokens: 120,
+          reasoningOutputTokens: 30,
+          cacheHitRatio: 0.2,
+          costLabel: 'exact',
+        }),
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useIssueCostsBreakdown('proj', '42'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.runCount).toBe(3);
+    });
+
+    const grill = result.current.bySkill.get('grill-me');
+    expect(grill?.runCount).toBe(2);
+    expect(grill?.usd).toBeCloseTo(0.09, 5);
+    expect(grill?.tokens).toBe(240);
+    expect(grill?.cachedInputTokens).toBe(60);
+    expect(grill?.reasoningOutputTokens).toBe(15);
+    expect(grill?.cacheHitRatio).toBeCloseTo(60 / 180, 5);
+    expect(grill?.label).toBe('estimated');
+
+    const prd = result.current.bySkill.get('write-prd');
+    expect(prd?.runCount).toBe(1);
+    expect(prd?.usd).toBeCloseTo(0.13, 5);
+    expect(prd?.tokens).toBe(420);
+    expect(prd?.label).toBe('exact');
+
+    const discover = result.current.byStage.get('discover');
+    expect(discover?.usd).toBeCloseTo(0.22, 5);
+    expect(discover?.tokens).toBe(660);
+    expect(discover?.runCount).toBe(3);
+    expect(discover?.label).toBe('estimated');
   });
 });

--- a/apps/web/src/components/detail/lib/costs.ts
+++ b/apps/web/src/components/detail/lib/costs.ts
@@ -18,6 +18,7 @@ export type StageBreakdown = {
 export interface IssueCostsBreakdown {
   byRun: Map<string, CostRowDto>;
   byStage: Map<CostRowDto['stage'], StageBreakdown>;
+  bySkill: Map<string, StageBreakdown>;
   total: number;
   totalTokens: number;
   hasEstimated: boolean;
@@ -29,12 +30,45 @@ export interface IssueCostsBreakdown {
 const EMPTY: Omit<IssueCostsBreakdown, 'isLoading'> = {
   byRun: new Map(),
   byStage: new Map(),
+  bySkill: new Map(),
   total: 0,
   totalTokens: 0,
   hasEstimated: false,
   totalLabel: 'exact',
   runCount: 0,
 };
+
+function accumulateBreakdown(
+  map: Map<string, StageBreakdown>,
+  key: string,
+  row: CostRowDto,
+  tokens: number,
+): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.usd += row.costUsd;
+    existing.tokens += tokens;
+    existing.inputTokens += row.inputTokens;
+    existing.cachedInputTokens += row.cachedInputTokens;
+    existing.reasoningOutputTokens += row.reasoningOutputTokens;
+    existing.cacheHitRatio = existing.cachedInputTokens / Math.max(existing.inputTokens, 1);
+    existing.runCount += 1;
+    if (row.costLabel === 'estimated') existing.label = 'estimated';
+    return;
+  }
+
+  map.set(key, {
+    stage: row.stage,
+    usd: row.costUsd,
+    tokens,
+    inputTokens: row.inputTokens,
+    cachedInputTokens: row.cachedInputTokens,
+    reasoningOutputTokens: row.reasoningOutputTokens,
+    cacheHitRatio: row.cacheHitRatio,
+    label: row.costLabel,
+    runCount: 1,
+  });
+}
 
 /**
  * One cached fetch per work item (`['issue-costs', slug, id]`) sliced by run
@@ -55,41 +89,21 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
 
     const byRun = new Map<string, CostRowDto>();
     const byStage = new Map<CostRowDto['stage'], StageBreakdown>();
+    const bySkill = new Map<string, StageBreakdown>();
     let totalTokens = 0;
 
     for (const row of data.rows) {
       byRun.set(row.runId, row);
       const tokens = row.inputTokens + row.outputTokens;
       totalTokens += tokens;
-
-      const existing = byStage.get(row.stage);
-      if (existing) {
-        existing.usd += row.costUsd;
-        existing.tokens += tokens;
-        existing.inputTokens += row.inputTokens;
-        existing.cachedInputTokens += row.cachedInputTokens;
-        existing.reasoningOutputTokens += row.reasoningOutputTokens;
-        existing.cacheHitRatio = existing.cachedInputTokens / Math.max(existing.inputTokens, 1);
-        existing.runCount += 1;
-        if (row.costLabel === 'estimated') existing.label = 'estimated';
-      } else {
-        byStage.set(row.stage, {
-          stage: row.stage,
-          usd: row.costUsd,
-          tokens,
-          inputTokens: row.inputTokens,
-          cachedInputTokens: row.cachedInputTokens,
-          reasoningOutputTokens: row.reasoningOutputTokens,
-          cacheHitRatio: row.cacheHitRatio,
-          label: row.costLabel,
-          runCount: 1,
-        });
-      }
+      accumulateBreakdown(byStage, row.stage, row, tokens);
+      accumulateBreakdown(bySkill, row.skill, row, tokens);
     }
 
     return {
       byRun,
       byStage,
+      bySkill,
       total: data.totalUsd,
       totalTokens,
       hasEstimated: data.hasEstimated,

--- a/apps/web/src/components/detail/lib/overview-workflow-summary.test.ts
+++ b/apps/web/src/components/detail/lib/overview-workflow-summary.test.ts
@@ -292,8 +292,15 @@ describe('buildOverviewWorkflowCards', () => {
       item: makeItem(),
       events: [
         makeEvent({
+          kind: 'agent.tool-call',
+          id: 6,
+          runId: 'older-run',
+          payload: { tool_name: 'Read' },
+        }),
+        makeEvent({
           kind: 'agent.investigation-complete',
           id: 8,
+          runId: 'older-run',
           createdAt: '2026-05-20T03:00:00Z',
           payload: {
             investigate: {
@@ -305,11 +312,34 @@ describe('buildOverviewWorkflowCards', () => {
             },
           },
         }),
-        makeEvent({ kind: 'agent.tool-call', id: 9, payload: { tool_name: 'Read' } }),
-        makeEvent({ kind: 'agent.tool-call', id: 10, payload: { tool_name: 'Grep' } }),
+        makeEvent({
+          kind: 'agent.tool-call',
+          id: 9,
+          runId: 'latest-run',
+          payload: { tool_name: 'Read' },
+        }),
+        makeEvent({
+          kind: 'agent.tool-call',
+          id: 10,
+          runId: 'latest-run',
+          payload: { tool_name: 'Grep' },
+        }),
+        makeEvent({
+          kind: 'agent.tool-call',
+          id: 11,
+          runId: 'post-review-run',
+          payload: { tool_name: 'Read' },
+        }),
+        makeEvent({
+          kind: 'agent.tool-call',
+          id: 12,
+          runId: 'post-review-run',
+          payload: { tool_name: 'Grep' },
+        }),
         makeEvent({
           kind: 'agent.investigation-complete',
           id: 7,
+          runId: 'latest-run',
           createdAt: '2026-05-20T04:00:00Z',
           payload: {
             investigate: {

--- a/apps/web/src/components/detail/lib/overview-workflow-summary.test.ts
+++ b/apps/web/src/components/detail/lib/overview-workflow-summary.test.ts
@@ -1,0 +1,457 @@
+import type { AgentEventDto, IssueDiffDto, TriageResultDto, WorkItemDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import type { IssueCostsBreakdown, StageBreakdown } from './costs';
+import { buildOverviewWorkflowCards } from './overview-workflow-summary';
+
+function makeItem(partial: Partial<WorkItemDto> = {}): WorkItemDto {
+  return {
+    id: 'wi-1',
+    externalId: '42',
+    repoRef: 'shaunnez/goose-hub',
+    title: 'Workflow snapshot',
+    body: 'body',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'default',
+    state: 'factory:triage',
+    authorIsOwner: false,
+    schedule: 'unplanned',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: '2026-05-20T00:00:00Z',
+    ...partial,
+  };
+}
+
+function makeEvent(partial: Partial<AgentEventDto> & Pick<AgentEventDto, 'kind'>): AgentEventDto {
+  return {
+    id: 1,
+    projectId: 'proj',
+    workItemId: 'wi-1',
+    kind: partial.kind,
+    payload: partial.payload ?? {},
+    runId: partial.runId ?? null,
+    personaId: partial.personaId ?? null,
+    createdAt: partial.createdAt ?? '2026-05-20T00:00:00Z',
+    ...partial,
+  };
+}
+
+function makeBreakdown(
+  partial: Partial<StageBreakdown> & Pick<StageBreakdown, 'stage'>,
+): StageBreakdown {
+  return {
+    stage: partial.stage,
+    usd: partial.usd ?? 0,
+    tokens: partial.tokens ?? 0,
+    inputTokens: partial.inputTokens ?? 0,
+    cachedInputTokens: partial.cachedInputTokens ?? 0,
+    reasoningOutputTokens: partial.reasoningOutputTokens ?? 0,
+    cacheHitRatio: partial.cacheHitRatio ?? 0,
+    label: partial.label ?? 'exact',
+    runCount: partial.runCount ?? 1,
+  };
+}
+
+function makeCosts(
+  partial: Partial<Pick<IssueCostsBreakdown, 'byStage' | 'bySkill'>> = {},
+): Pick<IssueCostsBreakdown, 'byStage' | 'bySkill'> {
+  return {
+    byStage: partial.byStage ?? new Map(),
+    bySkill: partial.bySkill ?? new Map(),
+  };
+}
+
+function makeTriage(partial: Partial<TriageResultDto> = {}): TriageResultDto {
+  return {
+    type: 'feature',
+    priority: 'high',
+    candidates: [{ repo: 'shaunnez/goose-hub', confidence: 91, evidence: 'match', tier: 1 }],
+    overrideRepo: null,
+    ...partial,
+  };
+}
+
+const DIFF: IssueDiffDto = { diff: null, runId: null };
+
+describe('buildOverviewWorkflowCards', () => {
+  it('returns six stable cards with readable empty and N/A fallbacks', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem({ type: 'bug', state: 'factory:triage' }),
+      events: [],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.map((card) => card.key)).toEqual([
+      'triage',
+      'investigation',
+      'grill',
+      'prd',
+      'review',
+      'retro',
+    ]);
+    expect(cards.find((card) => card.key === 'triage')?.status).toBe('Not run');
+    expect(cards.find((card) => card.key === 'investigation')?.status).toBe('Not run');
+    expect(cards.find((card) => card.key === 'grill')?.status).toBe('N/A');
+    expect(cards.find((card) => card.key === 'prd')?.status).toBe('N/A');
+    expect(cards.find((card) => card.key === 'review')?.status).toBe('Not run');
+    expect(cards.find((card) => card.key === 'retro')?.status).toBe('Not run');
+  });
+
+  it('summarizes triage routing details and stage cost', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem(),
+      events: [],
+      costs: makeCosts({
+        byStage: new Map([
+          ['triage', makeBreakdown({ stage: 'triage', usd: 0.03, tokens: 1200, label: 'exact' })],
+        ]),
+      }),
+      diff: DIFF,
+      triage: makeTriage({
+        type: 'bug',
+        priority: 'critical',
+        candidates: [
+          { repo: 'shaunnez/goose-hub', confidence: 86, evidence: 'signal', tier: 1 },
+          { repo: 'shaunnez/other', confidence: 33, evidence: 'fallback', tier: 2 },
+        ],
+        overrideRepo: 'shaunnez/manual',
+      }),
+    });
+
+    const triage = cards[0];
+    expect(triage.status).toBe('Complete');
+    expect(triage.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Priority', value: 'critical' }),
+        expect.objectContaining({ label: 'Type', value: 'bug' }),
+        expect.objectContaining({ label: 'Repo', value: 'shaunnez/manual' }),
+        expect.objectContaining({ label: 'Confidence', value: '86%' }),
+        expect.objectContaining({ label: 'Candidates', value: '2' }),
+        expect.objectContaining({ label: 'Override', value: 'Yes' }),
+      ]),
+    );
+    expect(triage.footer).toEqual({ tokens: 1200, usd: 0.03, label: 'exact' });
+  });
+
+  it('uses skill costs to split discover-lane Grill and PRD summaries', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem({ state: 'factory:prd-review' }),
+      events: [
+        makeEvent({ kind: 'grill.question-posted', id: 1, payload: { roundNumber: 1 } }),
+        makeEvent({ kind: 'grill.completed', id: 2, payload: { rounds: 2, forced: true } }),
+        makeEvent({
+          kind: 'prd.drafted',
+          id: 3,
+          payload: {
+            prd: {
+              estimatedComplexity: 'medium',
+              acceptanceCriteria: [{ id: 'AC-1' }],
+              journeys: [{ id: 'J-1' }],
+              verticalSlices: [{ title: 'Slice 1' }],
+            },
+          },
+        }),
+      ],
+      costs: makeCosts({
+        byStage: new Map([
+          [
+            'discover',
+            makeBreakdown({ stage: 'discover', usd: 0.4, tokens: 5000, label: 'estimated' }),
+          ],
+        ]),
+        bySkill: new Map([
+          [
+            'grill-me',
+            makeBreakdown({ stage: 'discover', usd: 0.11, tokens: 1200, label: 'exact' }),
+          ],
+          [
+            'write-prd',
+            makeBreakdown({ stage: 'discover', usd: 0.29, tokens: 3800, label: 'estimated' }),
+          ],
+        ]),
+      }),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.find((card) => card.key === 'grill')?.footer).toEqual({
+      tokens: 1200,
+      usd: 0.11,
+      label: 'exact',
+    });
+    expect(cards.find((card) => card.key === 'prd')?.footer).toEqual({
+      tokens: 3800,
+      usd: 0.29,
+      label: 'estimated',
+    });
+    expect(cards.find((card) => card.key === 'grill')?.status).toBe('Force completed');
+    expect(cards.find((card) => card.key === 'prd')?.status).toBe('In review');
+  });
+
+  it('counts PRD acceptance criteria, journeys, slices, and advisor concerns from prd.drafted only', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem({ state: 'factory:prd-review' }),
+      events: [
+        makeEvent({
+          kind: 'prd.drafted',
+          id: 4,
+          payload: {
+            prd: {
+              estimatedComplexity: 'high',
+              acceptanceCriteria: [{ id: 'AC-1' }, { id: 'AC-2' }, { id: 'AC-3' }],
+              journeys: [{ id: 'J-1' }, { id: 'J-2' }],
+              verticalSlices: [{ title: 'Slice 1' }, { title: 'Slice 2' }],
+            },
+            advisorConcerns: '- first\n- second',
+          },
+        }),
+      ],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.find((card) => card.key === 'prd')?.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Complexity', value: 'high' }),
+        expect.objectContaining({ label: 'ACs', value: '3' }),
+        expect.objectContaining({ label: 'Journeys', value: '2' }),
+        expect.objectContaining({ label: 'Slices', value: '2' }),
+        expect.objectContaining({ label: 'Advisor', value: '2' }),
+      ]),
+    );
+  });
+
+  it('uses the latest matching event and computes review severity counts', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem({ state: 'factory:done' }),
+      events: [
+        makeEvent({
+          kind: 'review.completed',
+          id: 10,
+          createdAt: '2026-05-20T01:00:00Z',
+          payload: {
+            verdict: 'approved',
+            confidence: 0.91,
+            criteriaChecks: [{ criterion: 'AC-1', status: 'met' }],
+            findings: [],
+          },
+        }),
+        makeEvent({
+          kind: 'review.completed',
+          id: 11,
+          createdAt: '2026-05-20T02:00:00Z',
+          payload: {
+            verdict: 'needs-fix',
+            confidence: 0.66,
+            criteriaChecks: [
+              { criterion: 'AC-1', status: 'met' },
+              { criterion: 'AC-2', status: 'unmet' },
+              { criterion: 'AC-3', status: 'met' },
+            ],
+            findings: [
+              { severity: 'blocker', description: 'a' },
+              { severity: 'major', description: 'b' },
+              { severity: 'major', description: 'c' },
+              { severity: 'minor', description: 'd' },
+            ],
+          },
+        }),
+        makeEvent({
+          kind: 'pr.opened',
+          id: 12,
+          payload: { prNumber: 55, prUrl: 'https://example.test/pr/55' },
+        }),
+      ],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.find((card) => card.key === 'review')).toEqual(
+      expect.objectContaining({
+        status: 'Needs fix',
+        metrics: expect.arrayContaining([
+          expect.objectContaining({ label: 'Confidence', value: '66%' }),
+          expect.objectContaining({ label: 'Criteria', value: '2/3 met' }),
+          expect.objectContaining({ label: 'Blockers', value: '1' }),
+          expect.objectContaining({ label: 'Major', value: '2' }),
+          expect.objectContaining({ label: 'Minor', value: '1' }),
+          expect.objectContaining({ label: 'PR', value: '#55 open' }),
+        ]),
+      }),
+    );
+  });
+
+  it('prefers latest createdAt and id when selecting investigation data', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem(),
+      events: [
+        makeEvent({
+          kind: 'agent.investigation-complete',
+          id: 8,
+          createdAt: '2026-05-20T03:00:00Z',
+          payload: {
+            investigate: {
+              findings: 'older',
+              keyFiles: [{ path: 'a.ts', reason: 'a' }],
+              confidence: 'low',
+              openQuestions: ['one'],
+              decisionSummaries: [],
+            },
+          },
+        }),
+        makeEvent({ kind: 'agent.tool-call', id: 9, payload: { tool_name: 'Read' } }),
+        makeEvent({ kind: 'agent.tool-call', id: 10, payload: { tool_name: 'Grep' } }),
+        makeEvent({
+          kind: 'agent.investigation-complete',
+          id: 7,
+          createdAt: '2026-05-20T04:00:00Z',
+          payload: {
+            investigate: {
+              findings: 'newer',
+              keyFiles: [
+                { path: 'b.ts', reason: 'b' },
+                { path: 'c.ts', reason: 'c' },
+              ],
+              confidence: 'high',
+              openQuestions: [],
+              decisionSummaries: [],
+            },
+            playwrightRepro: {
+              reproduced: true,
+              screenshots: [],
+              gifPath: null,
+              consoleErrors: [],
+              reproSteps: [],
+            },
+          },
+        }),
+      ],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.find((card) => card.key === 'investigation')?.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Confidence', value: 'high' }),
+        expect.objectContaining({ label: 'Key files', value: '2' }),
+        expect.objectContaining({ label: 'Questions', value: '0' }),
+        expect.objectContaining({ label: 'Reads', value: '1' }),
+        expect.objectContaining({ label: 'Searches', value: '1' }),
+        expect.objectContaining({ label: 'Repro', value: 'Reproduced' }),
+      ]),
+    );
+  });
+
+  it('distinguishes light versus deep retrospectives', () => {
+    const lightCards = buildOverviewWorkflowCards({
+      item: makeItem(),
+      events: [
+        makeEvent({
+          kind: 'retrospective.completed',
+          id: 20,
+          payload: {
+            tier: 'light',
+            output: {
+              outcome: 'partial',
+              workItemNumber: 42,
+              summary: { wentWell: '', didNotGoWell: '', architecturalTakeaway: '' },
+              improvementCandidates: [
+                { kind: 'workflow', targetPath: 'a', suggestionText: 'a', confidence: 'high' },
+                { kind: 'persona', targetPath: 'b', suggestionText: 'b', confidence: 'low' },
+              ],
+              decisionSummaries: [],
+            },
+          },
+        }),
+      ],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    const deepCards = buildOverviewWorkflowCards({
+      item: makeItem(),
+      events: [
+        makeEvent({
+          kind: 'retrospective.completed',
+          id: 21,
+          payload: {
+            tier: 'deep',
+            output: {
+              outcome: 'success',
+              workItemNumber: 42,
+              summary: { wentWell: '', didNotGoWell: '', architecturalTakeaway: '' },
+              improvementCandidates: [
+                { kind: 'workflow', targetPath: 'a', suggestionText: 'a', confidence: 'high' },
+              ],
+              decisionSummaries: [],
+              triggerReasons: ['quality'],
+              personaQualityScores: [
+                { personaId: 'p1', score: 0.9, trend: 'improving', sampleCount: 1 },
+              ],
+              learningEntries: [
+                {
+                  observation: 'o',
+                  rationale: 'r',
+                  improvementKind: 'workflow',
+                  confidence: 'medium',
+                },
+              ],
+              decisionPatterns: [{ pattern: 'p', occurrences: 2, confidence: 'high' }],
+            },
+          },
+        }),
+      ],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(lightCards.find((card) => card.key === 'retro')).toEqual(
+      expect.objectContaining({
+        status: 'Partial',
+        metrics: expect.arrayContaining([
+          expect.objectContaining({ label: 'Candidates', value: '2' }),
+          expect.objectContaining({ label: 'High conf', value: '1' }),
+        ]),
+      }),
+    );
+    expect(deepCards.find((card) => card.key === 'retro')).toEqual(
+      expect.objectContaining({
+        status: 'Success',
+        metrics: expect.arrayContaining([
+          expect.objectContaining({ label: 'Quality', value: '1' }),
+          expect.objectContaining({ label: 'Patterns', value: '1' }),
+          expect.objectContaining({ label: 'Learnings', value: '1' }),
+        ]),
+      }),
+    );
+  });
+
+  it('keeps PRD sparse and event-only when no prd.drafted event exists', () => {
+    const cards = buildOverviewWorkflowCards({
+      item: makeItem({ state: 'factory:prd-review' }),
+      events: [makeEvent({ kind: 'prd.revised', payload: { concerns: ['More detail'] } })],
+      costs: makeCosts(),
+      diff: DIFF,
+      triage: null,
+    });
+
+    expect(cards.find((card) => card.key === 'prd')).toEqual(
+      expect.objectContaining({
+        status: 'Revised',
+        metrics: expect.arrayContaining([
+          expect.objectContaining({ label: 'Complexity', value: 'N/A' }),
+          expect.objectContaining({ label: 'ACs', value: 'N/A' }),
+        ]),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/detail/lib/overview-workflow-summary.ts
+++ b/apps/web/src/components/detail/lib/overview-workflow-summary.ts
@@ -1,0 +1,387 @@
+import type { AgentEventDto, IssueDiffDto, TriageResultDto, WorkItemDto } from '@/lib/types';
+import type { IssueCostsBreakdown, StageBreakdown } from './costs';
+import {
+  READ_TOOLS,
+  SEARCH_TOOLS,
+  countToolCalls,
+  extractInvestigationPayload,
+} from './investigation';
+import type { RetroPayload } from './retrospective';
+import type { ReviewPayload, ReviewVerdict } from './review';
+
+export type OverviewWorkflowStageKey =
+  | 'triage'
+  | 'investigation'
+  | 'grill'
+  | 'prd'
+  | 'review'
+  | 'retro';
+
+export type OverviewWorkflowStatusTone =
+  | 'neutral'
+  | 'active'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'muted';
+
+export interface OverviewWorkflowCard {
+  key: OverviewWorkflowStageKey;
+  title: string;
+  status: string;
+  statusTone: OverviewWorkflowStatusTone;
+  metrics: Array<{ label: string; value: string; tone?: OverviewWorkflowStatusTone }>;
+  footer?: { tokens: number; usd: number; label: 'exact' | 'estimated' };
+  hrefSection?: string;
+}
+
+export interface BuildOverviewWorkflowCardsInput {
+  item?: WorkItemDto;
+  events: AgentEventDto[];
+  costs: Pick<IssueCostsBreakdown, 'byStage' | 'bySkill'>;
+  diff?: IssueDiffDto | null;
+  triage?: TriageResultDto | null;
+}
+
+type PrdDraftedPayload = {
+  prd?: {
+    estimatedComplexity?: string;
+    acceptanceCriteria?: unknown[];
+    journeys?: unknown[];
+    verticalSlices?: unknown[];
+  };
+  advisorConcerns?: string | null;
+} | null;
+
+type GrillCompletedPayload = { rounds?: number; forced?: boolean } | null;
+type GrillQuestionPayload = { roundNumber?: number } | null;
+type PrOpenedPayload = { prNumber?: number; prUrl?: string } | null;
+
+const STAGE_ORDER: Array<{ key: OverviewWorkflowStageKey; title: string }> = [
+  { key: 'triage', title: 'Triage' },
+  { key: 'investigation', title: 'Investigation' },
+  { key: 'grill', title: 'Grill' },
+  { key: 'prd', title: 'PRD' },
+  { key: 'review', title: 'Review' },
+  { key: 'retro', title: 'Retro' },
+];
+
+export function buildOverviewWorkflowCards(
+  input: BuildOverviewWorkflowCardsInput,
+): OverviewWorkflowCard[] {
+  void input.diff;
+
+  return [
+    buildTriageCard(input),
+    buildInvestigationCard(input),
+    buildGrillCard(input),
+    buildPrdCard(input),
+    buildReviewCard(input),
+    buildRetroCard(input),
+  ];
+}
+
+function buildTriageCard({ triage, costs }: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const pickedCandidate = triage?.candidates[0];
+  return {
+    key: 'triage',
+    title: titleFor('triage'),
+    status: triage ? 'Complete' : 'Not run',
+    statusTone: triage ? 'success' : 'muted',
+    metrics: [
+      metric('Priority', triage?.priority ?? 'N/A'),
+      metric('Type', triage?.type ?? 'N/A'),
+      metric('Repo', triage?.overrideRepo ?? pickedCandidate?.repo ?? 'N/A'),
+      metric('Confidence', formatPercent(pickedCandidate?.confidence)),
+      metric('Candidates', triage != null ? String(triage.candidates.length) : 'N/A'),
+      metric('Override', triage == null ? 'N/A' : triage.overrideRepo ? 'Yes' : 'No'),
+    ],
+    footer: footerFor(costs.byStage.get('triage')),
+    hrefSection: 'triage',
+  };
+}
+
+function buildInvestigationCard({
+  events,
+  costs,
+}: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const event = latestEvent(events, ['agent.investigation-complete']);
+  const payload = event ? extractInvestigationPayload(event) : null;
+  const repro = extractReproStatus(event);
+
+  return {
+    key: 'investigation',
+    title: titleFor('investigation'),
+    status: event ? 'Complete' : 'Not run',
+    statusTone: event ? 'success' : 'muted',
+    metrics: [
+      metric('Confidence', payload?.investigate.confidence ?? 'N/A'),
+      metric('Key files', payload ? String(payload.investigate.keyFiles.length) : 'N/A'),
+      metric('Questions', payload ? String(payload.investigate.openQuestions.length) : 'N/A'),
+      metric('Reads', event ? String(countToolCalls(events, READ_TOOLS)) : 'N/A'),
+      metric('Searches', event ? String(countToolCalls(events, SEARCH_TOOLS)) : 'N/A'),
+      metric('Repro', repro),
+    ],
+    footer: footerFor(costs.byStage.get('investigate')),
+    hrefSection: 'investigation',
+  };
+}
+
+function buildGrillCard({
+  item,
+  events,
+  costs,
+}: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const isDiscoverNarrowedOut = item?.type === 'bug';
+  const completed = latestEvent(events, ['grill.completed']);
+  const questionEvents = events.filter((event) => event.kind === 'grill.question-posted');
+  const latestQuestion = latestEvent(events, ['grill.question-posted']);
+  const completedPayload = (completed?.payload as GrillCompletedPayload) ?? null;
+  const latestQuestionPayload = (latestQuestion?.payload as GrillQuestionPayload) ?? null;
+  const rounds =
+    completedPayload?.rounds ??
+    latestQuestionPayload?.roundNumber ??
+    (questionEvents.length > 0 ? questionEvents.length : null);
+
+  let status = 'Not run';
+  let statusTone: OverviewWorkflowStatusTone = 'muted';
+  if (isDiscoverNarrowedOut) {
+    status = 'N/A';
+  } else if (completedPayload?.forced) {
+    status = 'Force completed';
+    statusTone = 'warning';
+  } else if (completed != null) {
+    status = 'Complete';
+    statusTone = 'success';
+  } else if (questionEvents.length > 0 || item?.state === 'factory:grilling') {
+    status = item?.state === 'factory:gate-pending' ? 'Awaiting reply' : 'In progress';
+    statusTone = 'active';
+  }
+
+  return {
+    key: 'grill',
+    title: titleFor('grill'),
+    status,
+    statusTone,
+    metrics: [
+      metric('Questions', isDiscoverNarrowedOut ? 'N/A' : String(questionEvents.length)),
+      metric('Rounds', isDiscoverNarrowedOut ? 'N/A' : rounds == null ? 'N/A' : String(rounds)),
+      metric(
+        'Forced',
+        isDiscoverNarrowedOut
+          ? 'N/A'
+          : completedPayload == null
+            ? 'N/A'
+            : completedPayload.forced
+              ? 'Yes'
+              : 'No',
+      ),
+    ],
+    footer: footerFor(costs.bySkill.get('grill-me')),
+    hrefSection: 'grill',
+  };
+}
+
+function buildPrdCard({
+  item,
+  events,
+  costs,
+}: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const isDiscoverNarrowedOut = item?.type === 'bug';
+  const drafted = latestEvent(events, ['prd.drafted']);
+  const draftedPayload = (drafted?.payload as PrdDraftedPayload) ?? null;
+  const prd = draftedPayload?.prd;
+  const lifecycleEvent = latestEvent(events, [
+    'prd.approved',
+    'prd.rejected',
+    'prd.revised',
+    'prd.declined',
+  ]);
+
+  const { status, tone } = prdStatus(
+    item?.state,
+    lifecycleEvent?.kind,
+    drafted != null,
+    isDiscoverNarrowedOut,
+  );
+
+  return {
+    key: 'prd',
+    title: titleFor('prd'),
+    status,
+    statusTone: tone,
+    metrics: [
+      metric('Complexity', prd?.estimatedComplexity ?? 'N/A'),
+      metric('ACs', countMetric(prd?.acceptanceCriteria)),
+      metric('Journeys', countMetric(prd?.journeys)),
+      metric('Slices', countMetric(prd?.verticalSlices)),
+      metric(
+        'Advisor',
+        draftedPayload != null
+          ? String(countAdvisorConcerns(draftedPayload.advisorConcerns))
+          : 'N/A',
+      ),
+    ],
+    footer: footerFor(costs.bySkill.get('write-prd')),
+    hrefSection: 'prd',
+  };
+}
+
+function buildReviewCard({ events, costs }: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const event = latestEvent(events, ['review.completed']);
+  const payload = (event?.payload as ReviewPayload | undefined) ?? undefined;
+  const severity = { blocker: 0, major: 0, minor: 0 };
+  for (const finding of payload?.findings ?? []) {
+    if (finding.severity in severity) {
+      severity[finding.severity] += 1;
+    }
+  }
+  const met = payload?.criteriaChecks.filter((check) => check.status === 'met').length ?? 0;
+  const total = payload?.criteriaChecks.length ?? 0;
+  const prOpened = latestEvent(events, ['pr.opened']);
+  const prPayload = (prOpened?.payload as PrOpenedPayload) ?? null;
+  const { label, tone } = reviewMeta(payload?.verdict);
+
+  return {
+    key: 'review',
+    title: titleFor('review'),
+    status: payload ? label : 'Not run',
+    statusTone: payload ? tone : 'muted',
+    metrics: [
+      metric('Confidence', payload ? formatPercent(payload.confidence) : 'N/A'),
+      metric('Criteria', payload ? `${met}/${total} met` : 'N/A'),
+      metric('Blockers', payload ? String(severity.blocker) : 'N/A'),
+      metric('Major', payload ? String(severity.major) : 'N/A'),
+      metric('Minor', payload ? String(severity.minor) : 'N/A'),
+      metric('PR', prPayload?.prNumber != null ? `#${prPayload.prNumber} open` : 'N/A'),
+    ],
+    footer: footerFor(costs.byStage.get('review')),
+    hrefSection: 'review',
+  };
+}
+
+function buildRetroCard({ events, costs }: BuildOverviewWorkflowCardsInput): OverviewWorkflowCard {
+  const event = latestEvent(events, ['retrospective.completed']);
+  const payload = (event?.payload as RetroPayload | undefined) ?? undefined;
+  const output = payload?.output;
+  const candidates = output?.improvementCandidates ?? [];
+  const highConfidence = candidates.filter((candidate) => candidate.confidence === 'high').length;
+  const deepMetrics =
+    payload?.tier === 'deep'
+      ? [
+          metric('Quality', String(payload.output.personaQualityScores.length)),
+          metric('Patterns', String(payload.output.decisionPatterns.length)),
+          metric('Learnings', String(payload.output.learningEntries.length)),
+        ]
+      : [];
+
+  return {
+    key: 'retro',
+    title: titleFor('retro'),
+    status: output ? capitalize(output.outcome) : 'Not run',
+    statusTone: output ? retroTone(output.outcome) : 'muted',
+    metrics: [
+      metric('Tier', payload?.tier ?? 'N/A'),
+      metric('Candidates', output ? String(candidates.length) : 'N/A'),
+      metric('High conf', output ? String(highConfidence) : 'N/A'),
+      ...deepMetrics,
+    ],
+    footer: footerFor(costs.byStage.get('retrospective')),
+    hrefSection: 'retro',
+  };
+}
+
+function latestEvent(events: AgentEventDto[], kinds: string[]): AgentEventDto | null {
+  return events
+    .filter((event) => kinds.includes(event.kind))
+    .reduce<AgentEventDto | null>((latest, event) => {
+      if (latest == null) return event;
+      if (event.createdAt !== latest.createdAt) {
+        return event.createdAt > latest.createdAt ? event : latest;
+      }
+      return event.id > latest.id ? event : latest;
+    }, null);
+}
+
+function footerFor(breakdown: StageBreakdown | undefined): OverviewWorkflowCard['footer'] {
+  if (breakdown == null) return undefined;
+  return { tokens: breakdown.tokens, usd: breakdown.usd, label: breakdown.label };
+}
+
+function metric(
+  label: string,
+  value: string,
+  tone?: OverviewWorkflowStatusTone,
+): OverviewWorkflowCard['metrics'][number] {
+  return tone == null ? { label, value } : { label, value, tone };
+}
+
+function titleFor(key: OverviewWorkflowStageKey): string {
+  return STAGE_ORDER.find((stage) => stage.key === key)?.title ?? key;
+}
+
+function formatPercent(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) return 'N/A';
+  return `${Math.round(value <= 1 ? value * 100 : value)}%`;
+}
+
+function countMetric(value: unknown[] | undefined): string {
+  return value == null ? 'N/A' : String(value.length);
+}
+
+function countAdvisorConcerns(value: string | null | undefined): number {
+  if (value == null || value.trim().length === 0) return 0;
+  const lines = value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const listItems = lines.filter((line) => /^([-*]|\d+\.)\s+/.test(line));
+  return (listItems.length > 0 ? listItems : lines).length;
+}
+
+function extractReproStatus(event: AgentEventDto | null): string {
+  const payload = event?.payload as
+    | { playwrightRepro?: { reproduced?: boolean } }
+    | null
+    | undefined;
+  if (payload?.playwrightRepro?.reproduced === true) return 'Reproduced';
+  if (payload?.playwrightRepro?.reproduced === false) return 'Not reproduced';
+  return 'N/A';
+}
+
+function prdStatus(
+  state: string | undefined,
+  latestKind: string | undefined,
+  hasDraft: boolean,
+  isNotApplicable: boolean,
+): { status: string; tone: OverviewWorkflowStatusTone } {
+  if (isNotApplicable) return { status: 'N/A', tone: 'muted' };
+  if (latestKind === 'prd.declined') return { status: 'Declined', tone: 'danger' };
+  if (latestKind === 'prd.revised' || latestKind === 'prd.rejected')
+    return { status: 'Revised', tone: 'warning' };
+  if (latestKind === 'prd.approved') return { status: 'Approved', tone: 'success' };
+  if (state === 'factory:prd-drafting') return { status: 'Drafting', tone: 'active' };
+  if (state === 'factory:prd-review') return { status: 'In review', tone: 'active' };
+  if (hasDraft) return { status: 'Drafted', tone: 'success' };
+  return { status: 'Not run', tone: 'muted' };
+}
+
+function reviewMeta(verdict: ReviewVerdict | undefined): {
+  label: string;
+  tone: OverviewWorkflowStatusTone;
+} {
+  if (verdict === 'approved') return { label: 'Approved', tone: 'success' };
+  if (verdict === 'needs-fix') return { label: 'Needs fix', tone: 'warning' };
+  if (verdict === 'needs-human') return { label: 'Needs human', tone: 'danger' };
+  return { label: 'Not run', tone: 'muted' };
+}
+
+function retroTone(outcome: 'success' | 'failure' | 'partial'): OverviewWorkflowStatusTone {
+  if (outcome === 'success') return 'success';
+  if (outcome === 'failure') return 'danger';
+  return 'warning';
+}
+
+function capitalize(value: string): string {
+  return value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`;
+}

--- a/apps/web/src/components/detail/lib/overview-workflow-summary.ts
+++ b/apps/web/src/components/detail/lib/overview-workflow-summary.ts
@@ -108,6 +108,8 @@ function buildInvestigationCard({
   const event = latestEvent(events, ['agent.investigation-complete']);
   const payload = event ? extractInvestigationPayload(event) : null;
   const repro = extractReproStatus(event);
+  const runScopedEvents =
+    event?.runId != null ? events.filter((entry) => entry.runId === event.runId) : [];
 
   return {
     key: 'investigation',
@@ -118,8 +120,8 @@ function buildInvestigationCard({
       metric('Confidence', payload?.investigate.confidence ?? 'N/A'),
       metric('Key files', payload ? String(payload.investigate.keyFiles.length) : 'N/A'),
       metric('Questions', payload ? String(payload.investigate.openQuestions.length) : 'N/A'),
-      metric('Reads', event ? String(countToolCalls(events, READ_TOOLS)) : 'N/A'),
-      metric('Searches', event ? String(countToolCalls(events, SEARCH_TOOLS)) : 'N/A'),
+      metric('Reads', event ? String(countToolCalls(runScopedEvents, READ_TOOLS)) : 'N/A'),
+      metric('Searches', event ? String(countToolCalls(runScopedEvents, SEARCH_TOOLS)) : 'N/A'),
       metric('Repro', repro),
     ],
     footer: footerFor(costs.byStage.get('investigate')),


### PR DESCRIPTION
## Summary

workflow snapshot 4

## Work Packages

- ✓ **WP2**: Extend the existing useIssueCostsBreakdown reducer in apps/web/src/components/detail/lib/costs.ts:46-85 to also aggregat
- ✓ **WP1**: Create the pure summary builder. Use apps/web/src/components/detail/components/OverviewSection.tsx:45-61 as the existing
- ✓ **WP3**: Add a compact card component following the border/density conventions in apps/web/src/components/detail/components/StatC

Closes #1130
