### PR TITLE
Add assigned-to-me Jira import

### DIFF
--- a/apps/server/src/domains/integrations/router.test.ts
+++ b/apps/server/src/domains/integrations/router.test.ts
@@ -1,11 +1,13 @@
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockImportJiraIssue } = vi.hoisted(() => ({
+const { mockImportAssignedJiraIssues, mockImportJiraIssue } = vi.hoisted(() => ({
+  mockImportAssignedJiraIssues: vi.fn(),
   mockImportJiraIssue: vi.fn(),
 }));
 
 vi.mock('./service.js', () => ({
+  importAssignedJiraIssues: mockImportAssignedJiraIssues,
   importJiraIssue: mockImportJiraIssue,
 }));
 
@@ -17,6 +19,31 @@ function makeApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe('POST /projects/:slug/integrations/jira/import-assigned-to-me', () => {
+  it('returns assigned sync result counts from the service', async () => {
+    mockImportAssignedJiraIssues.mockResolvedValue({
+      ok: true,
+      data: {
+        counts: { imported: 1, updated: 2, skipped: 0, stale: 1, failed: 1 },
+        failures: [{ jiraKey: 'TAS-404', error: 'Jira issue not found' }],
+      },
+    });
+
+    const res = await makeApp().request('/projects/proj/integrations/jira/import-assigned-to-me', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxResults: 25 }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      counts: { imported: 1, updated: 2, stale: 1, failed: 1 },
+      failures: [{ jiraKey: 'TAS-404' }],
+    });
+    expect(mockImportAssignedJiraIssues).toHaveBeenCalledWith('proj', { maxResults: 25 });
+  });
 });
 
 describe('POST /projects/:slug/integrations/jira/import', () => {

--- a/apps/server/src/domains/integrations/router.ts
+++ b/apps/server/src/domains/integrations/router.ts
@@ -1,6 +1,11 @@
 import { Hono } from 'hono';
 import { parseBody } from '#shared/middleware.js';
-import { type JiraImportRequestDto, importJiraIssue } from './service.js';
+import {
+  type JiraAssignedImportRequestDto,
+  type JiraImportRequestDto,
+  importAssignedJiraIssues,
+  importJiraIssue,
+} from './service.js';
 
 const router = new Hono();
 
@@ -8,6 +13,15 @@ router.post('/:slug/integrations/jira/import', async (c) => {
   const body = await parseBody<JiraImportRequestDto>(c);
   if (!body.ok) return body.error;
   const result = await importJiraIssue(c.req.param('slug'), body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 401 | 403 | 404 | 429 | 502);
+});
+
+router.post('/:slug/integrations/jira/import-assigned-to-me', async (c) => {
+  const body = await parseBody<JiraAssignedImportRequestDto>(c);
+  if (!body.ok) return body.error;
+  const result = await importAssignedJiraIssues(c.req.param('slug'), body.data);
   return result.ok
     ? c.json(result.data)
     : c.json({ error: result.error }, result.status as 400 | 401 | 403 | 404 | 429 | 502);

--- a/apps/server/src/domains/integrations/service.test.ts
+++ b/apps/server/src/domains/integrations/service.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetMilestone, mockGetProject, mockImportJiraIssueToLocalDb } = vi.hoisted(() => ({
+const {
+  mockGetMilestone,
+  mockGetProject,
+  mockImportAssignedJiraIssuesToLocalDb,
+  mockImportJiraIssueToLocalDb,
+} = vi.hoisted(() => ({
   mockGetProject: vi.fn(),
+  mockImportAssignedJiraIssuesToLocalDb: vi.fn(),
   mockImportJiraIssueToLocalDb: vi.fn(),
   mockGetMilestone: vi.fn(),
 }));
@@ -14,8 +20,16 @@ vi.mock('@goose-hub/core/integrations/jira/import-issue.js', () => ({
   importJiraIssueToLocalDb: mockImportJiraIssueToLocalDb,
 }));
 
+vi.mock('@goose-hub/core/integrations/jira/import-assigned.js', () => ({
+  importAssignedJiraIssuesToLocalDb: mockImportAssignedJiraIssuesToLocalDb,
+}));
+
 vi.mock('@goose-hub/core/integrations/jira/rest.js', () => ({
-  createJiraRestAdapterFromEnv: vi.fn(() => ({ getIssue: vi.fn() })),
+  createJiraRestAdapterFromEnv: vi.fn(() => ({
+    getIssue: vi.fn(),
+    searchIssues: vi.fn(),
+    getCurrentUser: vi.fn(),
+  })),
 }));
 
 vi.mock('@goose-hub/core/state-source/local-db-repository.js', () => ({
@@ -24,7 +38,7 @@ vi.mock('@goose-hub/core/state-source/local-db-repository.js', () => ({
   })),
 }));
 
-import { importJiraIssue } from './service.js';
+import { importAssignedJiraIssues, importJiraIssue } from './service.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -58,6 +72,14 @@ beforeEach(() => {
       jiraKey: 'TAS-123',
       jiraUrl: 'https://company.atlassian.net/browse/TAS-123',
       title: 'Manual Jira import',
+    },
+  });
+  mockImportAssignedJiraIssuesToLocalDb.mockResolvedValue({
+    ok: true,
+    data: {
+      counts: { imported: 1, updated: 2, skipped: 0, stale: 1, failed: 1 },
+      failures: [{ jiraKey: 'TAS-404', error: 'Jira issue not found' }],
+      user: { accountId: 'ada-1', displayName: 'Ada Lovelace' },
     },
   });
 });
@@ -109,5 +131,79 @@ describe('importJiraIssue', () => {
       error: 'Jira issue not found',
       status: 404,
     });
+  });
+});
+
+describe('importAssignedJiraIssues', () => {
+  it('runs an assigned-to-me Jira sync and returns counts plus per-issue failures', async () => {
+    mockGetProject.mockResolvedValueOnce({
+      id: 'proj',
+      slug: 'proj',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          jira: {
+            enabled: true,
+            baseUrl: 'https://company.atlassian.net',
+            projectKeys: ['TAS'],
+            importMode: 'assigned-to-me',
+          },
+        },
+      },
+      repos: ['owner/repo'],
+    });
+
+    const result = await importAssignedJiraIssues('proj', {
+      milestoneNumber: 7,
+      maxResults: 100,
+      updatedSince: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        counts: { imported: 1, updated: 2, skipped: 0, stale: 1, failed: 1 },
+        failures: [{ jiraKey: 'TAS-404', error: 'Jira issue not found' }],
+      },
+    });
+    expect(mockImportAssignedJiraIssuesToLocalDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectConfig: expect.objectContaining({ id: 'proj' }),
+        milestone: {
+          id: '7',
+          title: 'M7: Atlassian imports',
+        },
+        maxResults: 100,
+        updatedSince: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('requires assigned-to-me import mode', async () => {
+    mockGetProject.mockResolvedValueOnce({
+      id: 'proj',
+      slug: 'proj',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          jira: {
+            enabled: true,
+            baseUrl: 'https://company.atlassian.net',
+            projectKeys: ['TAS'],
+            importMode: 'manual',
+          },
+        },
+      },
+      repos: ['owner/repo'],
+    });
+
+    await expect(importAssignedJiraIssues('proj', {})).resolves.toEqual({
+      ok: false,
+      error: 'Jira assigned-to-me import is not enabled for this project',
+      status: 400,
+    });
+    expect(mockImportAssignedJiraIssuesToLocalDb).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/domains/integrations/service.ts
+++ b/apps/server/src/domains/integrations/service.ts
@@ -2,6 +2,7 @@ import type {
   ProviderError,
   ProviderErrorKind,
 } from '@goose-hub/core/integrations/atlassian/errors.js';
+import { importAssignedJiraIssuesToLocalDb } from '@goose-hub/core/integrations/jira/import-assigned.js';
 import { importJiraIssueToLocalDb } from '@goose-hub/core/integrations/jira/import-issue.js';
 import { createJiraRestAdapterFromEnv } from '@goose-hub/core/integrations/jira/rest.js';
 import { LocalDbWorkItemRepository } from '@goose-hub/core/state-source/local-db-repository.js';
@@ -24,6 +25,31 @@ export interface JiraImportResponseDto {
 export interface JiraImportRequestDto {
   input?: unknown;
   milestoneNumber?: unknown;
+}
+
+export interface JiraAssignedImportCountsDto {
+  imported: number;
+  updated: number;
+  skipped: number;
+  stale: number;
+  failed: number;
+}
+
+export interface JiraAssignedImportFailureDto {
+  jiraKey: string;
+  error: string;
+}
+
+export interface JiraAssignedImportResponseDto {
+  counts: JiraAssignedImportCountsDto;
+  failures: JiraAssignedImportFailureDto[];
+}
+
+export interface JiraAssignedImportRequestDto {
+  milestoneNumber?: unknown;
+  maxResults?: unknown;
+  updatedSince?: unknown;
+  updatedUntil?: unknown;
 }
 
 export async function importJiraIssue(
@@ -78,6 +104,56 @@ export async function importJiraIssue(
   };
 }
 
+export async function importAssignedJiraIssues(
+  slug: string,
+  body: JiraAssignedImportRequestDto,
+): Promise<Result<JiraAssignedImportResponseDto>> {
+  const projectConfig = await getProject(slug);
+  if (projectConfig == null) return { ok: false, error: 'project not found', status: 404 };
+  const jira =
+    projectConfig.source.kind === 'local-db' ? projectConfig.source.integrations?.jira : undefined;
+  if (projectConfig.source.kind !== 'local-db' || jira?.enabled !== true) {
+    return { ok: false, error: 'Jira integration is not enabled for this project', status: 400 };
+  }
+  if (jira.importMode !== 'assigned-to-me') {
+    return {
+      ok: false,
+      error: 'Jira assigned-to-me import is not enabled for this project',
+      status: 400,
+    };
+  }
+
+  const repository = new LocalDbWorkItemRepository();
+  const milestone = resolveMilestone(projectConfig.id, body.milestoneNumber, repository);
+  if (!milestone.ok) return milestone;
+  const options = resolveAssignedOptions(body);
+  if (!options.ok) return options;
+
+  const result = await importAssignedJiraIssuesToLocalDb({
+    projectConfig,
+    milestone: milestone.data,
+    repository,
+    adapter: createJiraRestAdapterFromEnv({
+      baseUrl: jira.baseUrl,
+      artifactContext: {
+        projectId: projectConfig.id,
+        runId: `jira-assigned-import:${projectConfig.id}`,
+      },
+    }),
+    ...options.data,
+  });
+
+  if (!result.ok) return providerErrorToHttp(result.error);
+
+  return {
+    ok: true,
+    data: {
+      counts: result.data.counts,
+      failures: result.data.failures,
+    },
+  };
+}
+
 function resolveMilestone(
   projectId: string,
   rawMilestoneNumber: unknown,
@@ -96,6 +172,43 @@ function resolveMilestone(
       title: row.title,
     },
   };
+}
+
+function resolveAssignedOptions(body: JiraAssignedImportRequestDto): Result<{
+  maxResults?: number;
+  updatedSince?: string;
+  updatedUntil?: string;
+}> {
+  const maxResults = optionalInteger(body.maxResults, 'maxResults');
+  if (!maxResults.ok) return maxResults;
+  const updatedSince = optionalString(body.updatedSince, 'updatedSince');
+  if (!updatedSince.ok) return updatedSince;
+  const updatedUntil = optionalString(body.updatedUntil, 'updatedUntil');
+  if (!updatedUntil.ok) return updatedUntil;
+  return {
+    ok: true,
+    data: {
+      ...(maxResults.data != null ? { maxResults: maxResults.data } : {}),
+      ...(updatedSince.data != null ? { updatedSince: updatedSince.data } : {}),
+      ...(updatedUntil.data != null ? { updatedUntil: updatedUntil.data } : {}),
+    },
+  };
+}
+
+function optionalInteger(value: unknown, name: string): Result<number | undefined> {
+  if (value == null) return { ok: true, data: undefined };
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return { ok: false, error: `${name} must be an integer`, status: 400 };
+  }
+  return { ok: true, data: value };
+}
+
+function optionalString(value: unknown, name: string): Result<string | undefined> {
+  if (value == null) return { ok: true, data: undefined };
+  if (typeof value !== 'string') {
+    return { ok: false, error: `${name} must be a string`, status: 400 };
+  }
+  return { ok: true, data: value };
 }
 
 function providerErrorToHttp(error: ProviderError): Result<never> {

--- a/apps/web/src/components/board/components/Board.tsx
+++ b/apps/web/src/components/board/components/Board.tsx
@@ -11,8 +11,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, Download, Eye, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { canUseManualJiraImport } from '../lib/jira-import';
+import { canUseAssignedToMeJiraImport, canUseManualJiraImport } from '../lib/jira-import';
 import { BoardColumn } from './BoardColumn';
+import { JiraAssignedImportAction } from './JiraAssignedImportAction';
 import { JiraImportDialog } from './JiraImportDialog';
 
 interface BoardProps {
@@ -29,6 +30,7 @@ export function Board({ projectSlug }: BoardProps) {
   const { data: budgetStatus } = useProjectBudgetStatus(projectSlug);
   const currentProject = projects.find((project) => project.slug === projectSlug);
   const showJiraImport = canUseManualJiraImport(currentProject);
+  const showAssignedJiraImport = canUseAssignedToMeJiraImport(currentProject);
 
   const {
     data: items = [],
@@ -158,6 +160,20 @@ export function Board({ projectSlug }: BoardProps) {
           >
             <Download size={12} /> Import Jira
           </button>
+        )}
+        {showAssignedJiraImport && (
+          <JiraAssignedImportAction
+            projectSlug={projectSlug}
+            milestoneNumber={resolvedMilestone}
+            onImported={() => {
+              void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
+              if (resolvedMilestone != null) {
+                void queryClient.invalidateQueries({
+                  queryKey: ['milestone-issues', projectSlug, resolvedMilestone],
+                });
+              }
+            }}
+          />
         )}
         {hiddenLanes.length > 0 && (
           <details className="relative">

--- a/apps/web/src/components/board/components/JiraAssignedImportAction.test.tsx
+++ b/apps/web/src/components/board/components/JiraAssignedImportAction.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JiraAssignedImportAction } from './JiraAssignedImportAction';
+
+vi.mock('@/lib/api', () => ({
+  importAssignedJiraIssues: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderAction(milestoneNumber: number | null = null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onImported = vi.fn();
+  render(
+    <QueryClientProvider client={client}>
+      <JiraAssignedImportAction
+        projectSlug="proj"
+        milestoneNumber={milestoneNumber}
+        onImported={onImported}
+      />
+    </QueryClientProvider>,
+  );
+  return { onImported };
+}
+
+describe('JiraAssignedImportAction', () => {
+  it('imports assigned Jira issues and shows result counts plus per-issue failures', async () => {
+    const { importAssignedJiraIssues } = await import('@/lib/api');
+    vi.mocked(importAssignedJiraIssues).mockResolvedValue({
+      counts: { imported: 1, updated: 2, skipped: 0, stale: 1, failed: 1 },
+      failures: [{ jiraKey: 'TAS-404', error: 'Jira issue not found' }],
+    });
+    const user = userEvent.setup();
+    const { onImported } = renderAction(7);
+
+    await user.click(screen.getByTestId('jira-assigned-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('jira-assigned-import-result').textContent).toContain(
+        'Imported 1 Updated 2 Skipped 0 Stale 1 Failed 1',
+      ),
+    );
+    expect(screen.getByText('TAS-404: Jira issue not found')).toBeTruthy();
+    expect(importAssignedJiraIssues).toHaveBeenCalledWith('proj', { milestoneNumber: 7 });
+    expect(onImported).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces sync failures without clearing the board action', async () => {
+    const { importAssignedJiraIssues } = await import('@/lib/api');
+    vi.mocked(importAssignedJiraIssues).mockRejectedValue(
+      new Error('Jira credentials are not configured'),
+    );
+    const user = userEvent.setup();
+    renderAction();
+
+    await user.click(screen.getByTestId('jira-assigned-import-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('jira-assigned-import-error')).toBeTruthy());
+    expect(screen.getByTestId('jira-assigned-import-error').textContent).toContain(
+      'Jira credentials are not configured',
+    );
+  });
+});

--- a/apps/web/src/components/board/components/JiraAssignedImportAction.tsx
+++ b/apps/web/src/components/board/components/JiraAssignedImportAction.tsx
@@ -1,0 +1,71 @@
+import { type JiraAssignedImportResponseDto, importAssignedJiraIssues } from '@/lib/api';
+import { Download } from 'lucide-react';
+import { useState } from 'react';
+
+interface JiraAssignedImportActionProps {
+  projectSlug: string;
+  milestoneNumber?: number | null;
+  onImported: () => void;
+}
+
+export function JiraAssignedImportAction({
+  projectSlug,
+  milestoneNumber,
+  onImported,
+}: JiraAssignedImportActionProps) {
+  const [result, setResult] = useState<JiraAssignedImportResponseDto | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function runImport() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await importAssignedJiraIssues(projectSlug, { milestoneNumber });
+      setResult(response);
+      onImported();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => void runImport()}
+        disabled={submitting}
+        data-testid="jira-assigned-import-submit"
+        className="inline-flex h-6 items-center gap-1.5 rounded border border-line px-2 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg disabled:opacity-60"
+      >
+        <Download size={12} /> {submitting ? 'Importing...' : 'Import my Jira issues'}
+      </button>
+      {result != null && (
+        <div
+          data-testid="jira-assigned-import-result"
+          className="flex max-w-[560px] items-center gap-2 truncate text-[12px] text-fg-3"
+        >
+          <span>
+            Imported {result.counts.imported} Updated {result.counts.updated} Skipped{' '}
+            {result.counts.skipped} Stale {result.counts.stale} Failed {result.counts.failed}
+          </span>
+          {result.failures.length > 0 && (
+            <span className="truncate text-[color:var(--danger)]">
+              {result.failures.map((failure) => `${failure.jiraKey}: ${failure.error}`).join('; ')}
+            </span>
+          )}
+        </div>
+      )}
+      {error != null && (
+        <div
+          data-testid="jira-assigned-import-error"
+          className="max-w-[360px] truncate text-[12px] text-[color:var(--danger)]"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/board/lib/jira-import.test.ts
+++ b/apps/web/src/components/board/lib/jira-import.test.ts
@@ -1,6 +1,6 @@
 import type { ProjectSummary } from '@/lib/types';
 import { describe, expect, it } from 'vitest';
-import { canUseManualJiraImport } from './jira-import';
+import { canUseAssignedToMeJiraImport, canUseManualJiraImport } from './jira-import';
 
 function project(source: ProjectSummary['source']): ProjectSummary {
   return {
@@ -42,5 +42,39 @@ describe('canUseManualJiraImport', () => {
       ),
     ).toBe(false);
     expect(canUseManualJiraImport(project({ kind: 'local-db' }))).toBe(false);
+  });
+});
+
+describe('canUseAssignedToMeJiraImport', () => {
+  it('allows only local-db projects with enabled assigned-to-me Jira import', () => {
+    expect(
+      canUseAssignedToMeJiraImport(
+        project({
+          kind: 'local-db',
+          integrations: {
+            jira: {
+              enabled: true,
+              importMode: 'assigned-to-me',
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(canUseAssignedToMeJiraImport(project({ kind: 'github', repo: 'owner/repo' }))).toBe(
+      false,
+    );
+    expect(
+      canUseAssignedToMeJiraImport(
+        project({
+          kind: 'local-db',
+          integrations: {
+            jira: {
+              enabled: true,
+              importMode: 'manual',
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/board/lib/jira-import.ts
+++ b/apps/web/src/components/board/lib/jira-import.ts
@@ -1,6 +1,17 @@
 import type { ProjectSummary } from '@/lib/types';
 
 export function canUseManualJiraImport(project: ProjectSummary | undefined): boolean {
+  return hasJiraImportMode(project, 'manual');
+}
+
+export function canUseAssignedToMeJiraImport(project: ProjectSummary | undefined): boolean {
+  return hasJiraImportMode(project, 'assigned-to-me');
+}
+
+function hasJiraImportMode(
+  project: ProjectSummary | undefined,
+  importMode: 'manual' | 'assigned-to-me',
+): boolean {
   if (project?.source.kind !== 'local-db') return false;
   const integrations = project.source.integrations;
   if (integrations == null || typeof integrations !== 'object') return false;
@@ -8,6 +19,6 @@ export function canUseManualJiraImport(project: ProjectSummary | undefined): boo
   if (jira == null || typeof jira !== 'object') return false;
   return (
     (jira as { enabled?: unknown }).enabled === true &&
-    (jira as { importMode?: unknown }).importMode === 'manual'
+    (jira as { importMode?: unknown }).importMode === importMode
   );
 }

--- a/apps/web/src/lib/api/integrations.ts
+++ b/apps/web/src/lib/api/integrations.ts
@@ -13,6 +13,24 @@ export interface JiraImportResponseDto {
   item: JiraImportItemDto;
 }
 
+export interface JiraAssignedImportCountsDto {
+  imported: number;
+  updated: number;
+  skipped: number;
+  stale: number;
+  failed: number;
+}
+
+export interface JiraAssignedImportFailureDto {
+  jiraKey: string;
+  error: string;
+}
+
+export interface JiraAssignedImportResponseDto {
+  counts: JiraAssignedImportCountsDto;
+  failures: JiraAssignedImportFailureDto[];
+}
+
 export interface JiraImportOptions {
   milestoneNumber?: number | null;
 }
@@ -26,4 +44,16 @@ export async function importJiraIssue(
     input,
     ...(options.milestoneNumber != null ? { milestoneNumber: options.milestoneNumber } : {}),
   });
+}
+
+export async function importAssignedJiraIssues(
+  slug: string,
+  options: JiraImportOptions = {},
+): Promise<JiraAssignedImportResponseDto> {
+  return postJson<JiraAssignedImportResponseDto>(
+    `/projects/${slug}/integrations/jira/import-assigned-to-me`,
+    {
+      ...(options.milestoneNumber != null ? { milestoneNumber: options.milestoneNumber } : {}),
+    },
+  );
 }

--- a/core/integrations/jira/import-assigned.test.ts
+++ b/core/integrations/jira/import-assigned.test.ts
@@ -254,6 +254,107 @@ describe('importAssignedJiraIssuesToLocalDb', () => {
     });
   });
 
+  it('does not stale missing assigned refs when the Jira search page is partial', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123'), jiraCard('TAS-456')],
+          totalCount: 2,
+          hasMore: false,
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T01:00:00.000Z'),
+    });
+
+    const result = await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123')],
+          totalCount: 51,
+          hasMore: true,
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T02:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: { counts: { imported: 0, updated: 1, skipped: 0, stale: 0, failed: 0 } },
+    });
+    const ref = repository.getExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-456',
+    });
+    expect(ref).not.toBeNull();
+    if (ref == null) throw new Error('expected Jira ref');
+    expect(parseExternalRefMetadata(ref)).toMatchObject({ stale: false, hidden: false });
+  });
+
+  it('does not stale missing assigned refs outside the current updated-date query window', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123'), jiraCard('TAS-456')],
+          totalCount: 2,
+          hasMore: false,
+        },
+        details: {
+          'TAS-456': jiraDetail('TAS-456', { updated: '2026-01-01T00:00:00.000Z' }),
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T01:00:00.000Z'),
+    });
+
+    const result = await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123')],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T02:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: { counts: { imported: 0, updated: 1, skipped: 0, stale: 0, failed: 0 } },
+    });
+    const ref = repository.getExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-456',
+    });
+    expect(ref).not.toBeNull();
+    if (ref == null) throw new Error('expected Jira ref');
+    expect(parseExternalRefMetadata(ref)).toMatchObject({ stale: false, hidden: false });
+  });
+
   it('reports per-issue failures and does not stale returned-but-failed keys', async () => {
     const { sqlite, repository } = makeRepository();
     handles.push(sqlite);

--- a/core/integrations/jira/import-assigned.test.ts
+++ b/core/integrations/jira/import-assigned.test.ts
@@ -1,0 +1,299 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import {
+  LocalDbWorkItemRepository,
+  parseExternalRefMetadata,
+} from '../../state-source/local-db-repository.js';
+import type { ProjectConfig } from '../../types.js';
+import type { AtlassianSearchPage, JiraProviderAdapter } from '../atlassian/adapters.js';
+import type { JiraIssueCardDto, JiraIssueDetailDto } from '../atlassian/dtos.js';
+import { providerFailure } from '../atlassian/errors.js';
+import { importAssignedJiraIssuesToLocalDb } from './import-assigned.js';
+
+function makeRepository() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, {
+    migrationsFolder: path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'db',
+      'migrations',
+    ),
+  });
+  return {
+    sqlite,
+    repository: new LocalDbWorkItemRepository({
+      db,
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    }),
+  };
+}
+
+const projectConfig = {
+  id: 'proj',
+  slug: 'proj',
+  name: 'Project',
+  source: {
+    kind: 'local-db',
+    stateMachine: 'db',
+    integrations: {
+      jira: {
+        enabled: true,
+        baseUrl: 'https://company.atlassian.net',
+        projectKeys: ['TAS', 'OPS'],
+        importMode: 'assigned-to-me',
+      },
+    },
+  },
+  repos: ['owner/repo'],
+} as ProjectConfig;
+
+function jiraCard(key: string, overrides: Partial<JiraIssueCardDto> = {}): JiraIssueCardDto {
+  return {
+    provider: 'jira',
+    resourceKind: 'issue',
+    tier: 'card',
+    id: key,
+    key,
+    title: `${key} card`,
+    status: 'In Progress',
+    url: `https://company.atlassian.net/browse/${key}`,
+    project: key.split('-')[0],
+    updated: '2026-05-27T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function jiraDetail(key: string, overrides: Partial<JiraIssueDetailDto> = {}): JiraIssueDetailDto {
+  return {
+    provider: 'jira',
+    resourceKind: 'issue',
+    tier: 'detail',
+    id: key,
+    key,
+    title: `${key} detail`,
+    status: 'In Progress',
+    url: `https://company.atlassian.net/browse/${key}`,
+    project: key.split('-')[0],
+    issueType: 'Task',
+    priority: 'Medium',
+    assignee: { displayName: 'Ada Lovelace', accountId: 'ada-1' },
+    created: '2026-05-26T00:00:00.000Z',
+    updated: '2026-05-27T00:00:00.000Z',
+    bodyPreview: `${key} imported body`,
+    labels: [],
+    components: [],
+    linkedKeys: [],
+    ...overrides,
+  };
+}
+
+function assignedAdapter(input: {
+  page?: AtlassianSearchPage<JiraIssueCardDto>;
+  details?: Record<string, JiraIssueDetailDto>;
+  failDetails?: Record<string, string>;
+}): JiraProviderAdapter {
+  return {
+    getCurrentUser: vi.fn(async () => ({
+      ok: true as const,
+      data: { accountId: 'ada-1', displayName: 'Ada Lovelace' },
+    })),
+    searchIssues: vi.fn(async () => ({
+      ok: true as const,
+      data:
+        input.page ??
+        ({
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123')],
+          totalCount: 1,
+          hasMore: false,
+        } satisfies AtlassianSearchPage<JiraIssueCardDto>),
+    })),
+    getIssue: vi.fn(async ({ key }) => {
+      const failure = input.failDetails?.[key];
+      if (failure != null) return providerFailure('not_found', failure);
+      const detail = input.details?.[key] ?? jiraDetail(key);
+      return { ok: true as const, data: detail };
+    }),
+  };
+}
+
+describe('importAssignedJiraIssuesToLocalDb', () => {
+  const handles: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const handle of handles.splice(0)) handle.close();
+  });
+
+  it('imports and updates only issues returned for the current Jira user and configured projects', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123')],
+          totalCount: 1,
+          hasMore: false,
+        },
+        details: { 'TAS-123': jiraDetail('TAS-123', { title: 'First title' }) },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T01:00:00.000Z'),
+    });
+
+    const adapter = assignedAdapter({
+      page: {
+        provider: 'jira',
+        tier: 'card',
+        issues: [jiraCard('TAS-123'), jiraCard('OPS-9')],
+        totalCount: 2,
+        hasMore: false,
+      },
+      details: {
+        'TAS-123': jiraDetail('TAS-123', { title: 'Updated title' }),
+        'OPS-9': jiraDetail('OPS-9', { title: 'New OPS issue' }),
+      },
+    });
+    const result = await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter,
+      repository,
+      maxResults: 200,
+      updatedSince: '2025-01-01T00:00:00.000Z',
+      now: () => new Date('2026-05-27T02:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        counts: { imported: 1, updated: 1, skipped: 0, stale: 0, failed: 0 },
+      },
+    });
+    expect(adapter.getCurrentUser).toHaveBeenCalledOnce();
+    expect(adapter.searchIssues).toHaveBeenCalledWith({
+      level: 'L2',
+      projects: ['TAS', 'OPS'],
+      updated: {
+        from: '2026-02-26T02:00:00.000Z',
+        to: '2026-05-27T02:00:00.000Z',
+      },
+      maxResults: 50,
+      assignee: { accountId: 'ada-1' },
+    });
+    expect(repository.listWorkItems('proj').map((item) => item.title)).toEqual([
+      'Updated title',
+      'New OPS issue',
+    ]);
+  });
+
+  it('marks previously assigned imported Jira refs stale and hidden without deleting local rows', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123'), jiraCard('TAS-456')],
+          totalCount: 2,
+          hasMore: false,
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T01:00:00.000Z'),
+    });
+
+    const result = await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-123')],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+      repository,
+      now: () => new Date('2026-05-27T02:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: { counts: { imported: 0, updated: 1, skipped: 0, stale: 1, failed: 0 } },
+    });
+    expect(repository.listWorkItems('proj')).toHaveLength(2);
+
+    const staleRef = repository.getExternalRef({
+      projectId: 'proj',
+      provider: 'jira',
+      kind: 'issue',
+      repoRef: null,
+      externalId: 'TAS-456',
+    });
+    expect(staleRef).not.toBeNull();
+    if (staleRef == null) throw new Error('expected stale Jira ref');
+    expect(parseExternalRefMetadata(staleRef)).toMatchObject({
+      assignedToMe: { accountId: 'ada-1' },
+      stale: true,
+      hidden: true,
+      staleReason: 'not_assigned_to_current_user',
+      lastAssignedSyncAt: '2026-05-27T02:00:00.000Z',
+    });
+  });
+
+  it('reports per-issue failures and does not stale returned-but-failed keys', async () => {
+    const { sqlite, repository } = makeRepository();
+    handles.push(sqlite);
+    await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-404')],
+          totalCount: 1,
+          hasMore: false,
+        },
+        failDetails: { 'TAS-404': 'Jira issue not found' },
+      }),
+      repository,
+    });
+
+    const result = await importAssignedJiraIssuesToLocalDb({
+      projectConfig,
+      adapter: assignedAdapter({
+        page: {
+          provider: 'jira',
+          tier: 'card',
+          issues: [jiraCard('TAS-404')],
+          totalCount: 1,
+          hasMore: false,
+        },
+        failDetails: { 'TAS-404': 'Jira issue not found' },
+      }),
+      repository,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        counts: { imported: 0, updated: 0, skipped: 0, stale: 0, failed: 1 },
+        failures: [{ jiraKey: 'TAS-404', error: 'Jira issue not found' }],
+      },
+    });
+    expect(repository.listWorkItems('proj')).toEqual([]);
+  });
+});

--- a/core/integrations/jira/import-assigned.ts
+++ b/core/integrations/jira/import-assigned.ts
@@ -1,0 +1,203 @@
+import {
+  type LocalDbExternalRefRow,
+  LocalDbWorkItemRepository,
+  parseExternalRefMetadata,
+} from '../../state-source/local-db-repository.js';
+import type { ProjectConfig } from '../../types.js';
+import type { AtlassianSearchPage, JiraProviderAdapter } from '../atlassian/adapters.js';
+import type { JiraIssueCardDto } from '../atlassian/dtos.js';
+import { type ProviderResult, providerFailure } from '../atlassian/errors.js';
+import { executeJiraQuery } from '../atlassian/query.js';
+import { importJiraIssueDetailToLocalDb } from './import-issue.js';
+
+export interface ImportAssignedJiraIssuesToLocalDbInput {
+  projectConfig: ProjectConfig;
+  adapter: JiraProviderAdapter;
+  milestone?: {
+    id: string;
+    title?: string | null;
+  };
+  repository?: LocalDbWorkItemRepository;
+  maxResults?: number;
+  updatedSince?: string;
+  updatedUntil?: string;
+  now?: () => Date;
+}
+
+export interface AssignedJiraImportCounts {
+  imported: number;
+  updated: number;
+  skipped: number;
+  stale: number;
+  failed: number;
+}
+
+export interface AssignedJiraImportFailure {
+  jiraKey: string;
+  error: string;
+}
+
+export interface ImportAssignedJiraIssuesToLocalDbResult {
+  counts: AssignedJiraImportCounts;
+  failures: AssignedJiraImportFailure[];
+  user: {
+    accountId: string;
+    displayName?: string;
+  };
+}
+
+export async function importAssignedJiraIssuesToLocalDb(
+  input: ImportAssignedJiraIssuesToLocalDbInput,
+): Promise<ProviderResult<ImportAssignedJiraIssuesToLocalDbResult>> {
+  const cfg = input.projectConfig;
+  const jira = cfg.source.kind === 'local-db' ? cfg.source.integrations?.jira : undefined;
+  if (cfg.source.kind !== 'local-db' || jira?.enabled !== true) {
+    return providerFailure('validation', 'Jira integration is not enabled for this project');
+  }
+  if (jira.importMode !== 'assigned-to-me') {
+    return providerFailure(
+      'validation',
+      'Jira assigned-to-me import is not enabled for this project',
+    );
+  }
+
+  const user = await input.adapter.getCurrentUser();
+  if (!user.ok) return user;
+
+  const page = await executeJiraQuery<AtlassianSearchPage<JiraIssueCardDto>>({
+    config: {
+      baseUrl: jira.baseUrl,
+      projectKeys: jira.projectKeys,
+    },
+    input: {
+      kind: 'assigned-to-me',
+      accountId: user.data.accountId,
+      maxResults: input.maxResults,
+      updatedSince: input.updatedSince,
+      updatedUntil: input.updatedUntil,
+    },
+    caps: { maxResults: 50, maxLookbackDays: 90 },
+    now: input.now?.() ?? new Date(),
+    adapter: input.adapter,
+  });
+  if (!page.ok) return page;
+
+  const repository = input.repository ?? new LocalDbWorkItemRepository();
+  const counts: AssignedJiraImportCounts = {
+    imported: 0,
+    updated: 0,
+    skipped: 0,
+    stale: 0,
+    failed: 0,
+  };
+  const failures: AssignedJiraImportFailure[] = [];
+  const returnedKeys = new Set<string>();
+  const syncNow = (input.now?.() ?? new Date()).toISOString();
+
+  for (const issue of page.data.issues ?? []) {
+    const key = issue.key?.trim();
+    if (key == null || key.length === 0 || returnedKeys.has(key)) {
+      counts.skipped += 1;
+      continue;
+    }
+    returnedKeys.add(key);
+
+    const detail = await input.adapter.getIssue({ key, tier: 'detail' });
+    if (!detail.ok) {
+      counts.failed += 1;
+      failures.push({ jiraKey: key, error: detail.error.message });
+      continue;
+    }
+
+    const imported = await importJiraIssueDetailToLocalDb({
+      projectConfig: cfg,
+      detail: detail.data,
+      milestone: input.milestone,
+      repository,
+      now: () => new Date(syncNow),
+      metadataPatch: {
+        assignedToMe: {
+          accountId: user.data.accountId,
+          displayName: user.data.displayName,
+        },
+        stale: false,
+        hidden: false,
+        staleReason: null,
+        lastAssignedSyncAt: syncNow,
+      },
+    });
+    if (!imported.ok) {
+      counts.failed += 1;
+      failures.push({ jiraKey: key, error: imported.error.message });
+      continue;
+    }
+    if (imported.data.imported) counts.imported += 1;
+    else counts.updated += 1;
+  }
+
+  counts.stale = markStaleAssignedRefs({
+    cfg,
+    repository,
+    currentAccountId: user.data.accountId,
+    returnedKeys,
+    syncNow,
+  });
+
+  return {
+    ok: true,
+    data: {
+      counts,
+      failures,
+      user: user.data,
+    },
+  };
+}
+
+function markStaleAssignedRefs(input: {
+  cfg: ProjectConfig;
+  repository: LocalDbWorkItemRepository;
+  currentAccountId: string;
+  returnedKeys: Set<string>;
+  syncNow: string;
+}): number {
+  let stale = 0;
+  const refs = input.repository.listExternalRefsByKind({
+    projectId: input.cfg.id,
+    provider: 'jira',
+    kind: 'issue',
+  });
+  for (const ref of refs) {
+    if (input.returnedKeys.has(ref.externalId)) continue;
+    const metadata = metadataRecord(ref);
+    const assigned = metadataRecordValue(metadata.assignedToMe);
+    if (assigned.accountId !== input.currentAccountId) continue;
+
+    input.repository.upsertExternalRef({
+      projectId: input.cfg.id,
+      itemId: ref.workItemId,
+      provider: ref.provider,
+      kind: ref.kind,
+      repoRef: ref.repoRef,
+      externalId: ref.externalId,
+      url: ref.url,
+      metadata: {
+        ...metadata,
+        stale: true,
+        hidden: true,
+        staleReason: 'not_assigned_to_current_user',
+        lastAssignedSyncAt: input.syncNow,
+      },
+    });
+    stale += 1;
+  }
+  return stale;
+}
+
+function metadataRecord(ref: LocalDbExternalRefRow): Record<string, unknown> {
+  return metadataRecordValue(parseExternalRefMetadata(ref));
+}
+
+function metadataRecordValue(value: unknown): Record<string, unknown> {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}

--- a/core/integrations/jira/import-assigned.ts
+++ b/core/integrations/jira/import-assigned.ts
@@ -7,7 +7,7 @@ import type { ProjectConfig } from '../../types.js';
 import type { AtlassianSearchPage, JiraProviderAdapter } from '../atlassian/adapters.js';
 import type { JiraIssueCardDto } from '../atlassian/dtos.js';
 import { type ProviderResult, providerFailure } from '../atlassian/errors.js';
-import { executeJiraQuery } from '../atlassian/query.js';
+import { resolveJiraQuery } from '../atlassian/query.js';
 import { importJiraIssueDetailToLocalDb } from './import-issue.js';
 
 export interface ImportAssignedJiraIssuesToLocalDbInput {
@@ -64,7 +64,7 @@ export async function importAssignedJiraIssuesToLocalDb(
   const user = await input.adapter.getCurrentUser();
   if (!user.ok) return user;
 
-  const page = await executeJiraQuery<AtlassianSearchPage<JiraIssueCardDto>>({
+  const resolved = resolveJiraQuery({
     config: {
       baseUrl: jira.baseUrl,
       projectKeys: jira.projectKeys,
@@ -78,8 +78,13 @@ export async function importAssignedJiraIssuesToLocalDb(
     },
     caps: { maxResults: 50, maxLookbackDays: 90 },
     now: input.now?.() ?? new Date(),
-    adapter: input.adapter,
   });
+  if (!resolved.ok) return resolved;
+  if (resolved.query.level === 'L0') {
+    return providerFailure('validation', 'Assigned Jira import must use a scoped search query');
+  }
+
+  const page = await input.adapter.searchIssues(resolved.query.search);
   if (!page.ok) return page;
 
   const repository = input.repository ?? new LocalDbWorkItemRepository();
@@ -141,6 +146,8 @@ export async function importAssignedJiraIssuesToLocalDb(
     currentAccountId: user.data.accountId,
     returnedKeys,
     syncNow,
+    searchUpdated: resolved.query.search.updated,
+    mayBePartial: page.data.hasMore,
   });
 
   return {
@@ -159,7 +166,11 @@ function markStaleAssignedRefs(input: {
   currentAccountId: string;
   returnedKeys: Set<string>;
   syncNow: string;
+  searchUpdated: { from: string; to: string };
+  mayBePartial: boolean;
 }): number {
+  if (input.mayBePartial) return 0;
+
   let stale = 0;
   const refs = input.repository.listExternalRefsByKind({
     projectId: input.cfg.id,
@@ -171,6 +182,7 @@ function markStaleAssignedRefs(input: {
     const metadata = metadataRecord(ref);
     const assigned = metadataRecordValue(metadata.assignedToMe);
     if (assigned.accountId !== input.currentAccountId) continue;
+    if (!isMetadataUpdatedWithinRange(metadata.updated, input.searchUpdated)) continue;
 
     input.repository.upsertExternalRef({
       projectId: input.cfg.id,
@@ -200,4 +212,16 @@ function metadataRecord(ref: LocalDbExternalRefRow): Record<string, unknown> {
 function metadataRecordValue(value: unknown): Record<string, unknown> {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) return {};
   return value as Record<string, unknown>;
+}
+
+function isMetadataUpdatedWithinRange(
+  value: unknown,
+  range: { from: string; to: string },
+): boolean {
+  if (typeof value !== 'string') return false;
+  const updated = Date.parse(value);
+  const from = Date.parse(range.from);
+  const to = Date.parse(range.to);
+  if (!Number.isFinite(updated) || !Number.isFinite(from) || !Number.isFinite(to)) return false;
+  return updated >= from && updated <= to;
 }

--- a/core/integrations/jira/import-issue.ts
+++ b/core/integrations/jira/import-issue.ts
@@ -181,6 +181,8 @@ function jiraExternalRefMetadata(issue: JiraIssueDetailDto, syncedAt: Date) {
     issueType: issue.issueType ?? null,
     priority: issue.priority ?? null,
     project: issue.project ?? null,
+    created: issue.created ?? null,
+    updated: issue.updated ?? null,
     labels: issue.labels,
     components: issue.components,
     linkedKeys: issue.linkedKeys,

--- a/core/integrations/jira/import-issue.ts
+++ b/core/integrations/jira/import-issue.ts
@@ -27,6 +27,29 @@ export interface ImportJiraIssueToLocalDbResult {
   title: string;
 }
 
+export interface JiraImportMetadataPatch {
+  assignedToMe?: {
+    accountId: string;
+    displayName?: string;
+  };
+  stale?: boolean;
+  hidden?: boolean;
+  staleReason?: string | null;
+  lastAssignedSyncAt?: string;
+}
+
+export interface ImportJiraIssueDetailToLocalDbInput {
+  projectConfig: ProjectConfig;
+  detail: JiraIssueDetailDto;
+  milestone?: {
+    id: string;
+    title?: string | null;
+  };
+  repository?: LocalDbWorkItemRepository;
+  now?: () => Date;
+  metadataPatch?: JiraImportMetadataPatch;
+}
+
 export async function importJiraIssueToLocalDb(
   input: ImportJiraIssueToLocalDbInput,
 ): Promise<ProviderResult<ImportJiraIssueToLocalDbResult>> {
@@ -53,9 +76,31 @@ export async function importJiraIssueToLocalDb(
   });
   if (!detail.ok) return detail;
 
-  const jiraKey = detail.data.key;
+  return importJiraIssueDetailToLocalDb({
+    projectConfig: cfg,
+    detail: detail.data,
+    milestone: input.milestone,
+    repository: input.repository,
+    now: input.now,
+  });
+}
+
+export async function importJiraIssueDetailToLocalDb(
+  input: ImportJiraIssueDetailToLocalDbInput,
+): Promise<ProviderResult<ImportJiraIssueToLocalDbResult>> {
+  const cfg = input.projectConfig;
+  const jira = cfg.source.kind === 'local-db' ? cfg.source.integrations?.jira : undefined;
+  if (cfg.source.kind !== 'local-db' || jira?.enabled !== true) {
+    return providerFailure('validation', 'Jira integration is not enabled for this project');
+  }
+
+  const jiraKey = input.detail.key;
   if (jiraKey == null || jiraKey.trim().length === 0) {
     return providerFailure('validation', 'Jira issue detail is missing a key');
+  }
+  const projectKey = jiraKey.includes('-') ? jiraKey.split('-')[0] : jiraKey;
+  if (!jira.projectKeys.includes(projectKey)) {
+    return providerFailure('validation', `Jira project key '${projectKey}' is not configured`);
   }
 
   const repository = input.repository ?? new LocalDbWorkItemRepository();
@@ -66,7 +111,7 @@ export async function importJiraIssueToLocalDb(
     repoRef: null,
     externalId: jiraKey,
   });
-  const mapped = mapJiraIssueToWorkItem(detail.data);
+  const mapped = mapJiraIssueToWorkItem(input.detail);
   const row =
     existing == null
       ? repository.createWorkItem({
@@ -95,8 +140,11 @@ export async function importJiraIssueToLocalDb(
     kind: 'issue',
     repoRef: null,
     externalId: jiraKey,
-    url: detail.data.url,
-    metadata: jiraExternalRefMetadata(detail.data, input.now?.() ?? new Date()),
+    url: input.detail.url,
+    metadata: {
+      ...jiraExternalRefMetadata(input.detail, input.now?.() ?? new Date()),
+      ...(input.metadataPatch ?? {}),
+    },
   });
 
   return {
@@ -106,7 +154,7 @@ export async function importJiraIssueToLocalDb(
       itemId: row.id,
       externalId: row.externalId,
       jiraKey,
-      jiraUrl: detail.data.url,
+      jiraUrl: input.detail.url,
       title: row.title,
     },
   };

--- a/core/integrations/jira/rest.test.ts
+++ b/core/integrations/jira/rest.test.ts
@@ -98,4 +98,98 @@ describe('Jira REST adapter', () => {
       error: { kind: 'auth', status: 401 },
     });
   });
+
+  it('resolves the current Jira user from the myself endpoint', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response(200, {
+        accountId: 'ada-1',
+        displayName: 'Ada Lovelace',
+      }),
+    );
+    const adapter = createJiraRestAdapter({
+      baseUrl: 'https://company.atlassian.net',
+      email: 'ada@example.com',
+      apiToken: 'secret-token',
+      fetchImpl,
+    });
+
+    await expect(adapter.getCurrentUser()).resolves.toEqual({
+      ok: true,
+      data: { accountId: 'ada-1', displayName: 'Ada Lovelace' },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://company.atlassian.net/rest/api/3/myself',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('searches assigned Jira issues with internally built JQL and maps card DTOs', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      response(200, {
+        issues: [
+          {
+            id: '10001',
+            key: 'TAS-123',
+            fields: {
+              summary: 'Assigned issue',
+              status: { name: 'In Progress' },
+              issuetype: { name: 'Task' },
+              priority: { name: 'Medium' },
+              assignee: { displayName: 'Ada Lovelace', accountId: 'ada-1' },
+              created: '2026-05-26T00:00:00.000Z',
+              updated: '2026-05-27T00:00:00.000Z',
+            },
+          },
+        ],
+        total: 1,
+        isLast: true,
+      }),
+    );
+    const adapter = createJiraRestAdapter({
+      baseUrl: 'https://company.atlassian.net',
+      email: 'ada@example.com',
+      apiToken: 'secret-token',
+      fetchImpl,
+    });
+
+    await expect(
+      adapter.searchIssues({
+        level: 'L2',
+        projects: ['TAS', 'OPS'],
+        maxResults: 25,
+        updated: {
+          from: '2026-04-27T00:00:00.000Z',
+          to: '2026-05-27T00:00:00.000Z',
+        },
+        assignee: { accountId: 'ada-1' },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        provider: 'jira',
+        tier: 'card',
+        issues: [{ key: 'TAS-123', title: 'Assigned issue' }],
+        totalCount: 1,
+        hasMore: false,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('/rest/api/3/search/jql?'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      }),
+    );
+    const firstCall = fetchImpl.mock.calls[0];
+    if (firstCall == null) throw new Error('expected Jira search fetch call');
+    const url = new URL(String(firstCall[0]));
+    expect(url.searchParams.get('maxResults')).toBe('25');
+    expect(url.searchParams.get('fields')).toContain('summary');
+    expect(url.searchParams.get('jql')).toBe(
+      'project in ("TAS","OPS") AND assignee = "ada-1" AND updated >= "2026-04-27T00:00:00.000Z" AND updated <= "2026-05-27T00:00:00.000Z" ORDER BY updated DESC',
+    );
+  });
 });

--- a/core/integrations/jira/rest.ts
+++ b/core/integrations/jira/rest.ts
@@ -1,6 +1,14 @@
-import type { JiraProviderAdapter } from '../atlassian/adapters.js';
-import type { AtlassianArtifactRef, JiraIssueDetailDto } from '../atlassian/dtos.js';
-import { JiraIssueDetailSchema } from '../atlassian/dtos.js';
+import type {
+  AtlassianSearchPage,
+  JiraIssueSearchRequest,
+  JiraProviderAdapter,
+} from '../atlassian/adapters.js';
+import type {
+  AtlassianArtifactRef,
+  JiraIssueCardDto,
+  JiraIssueDetailDto,
+} from '../atlassian/dtos.js';
+import { JiraIssueCardSchema, JiraIssueDetailSchema } from '../atlassian/dtos.js';
 import {
   type ProviderResult,
   mapHttpStatusToProviderErrorKind,
@@ -50,6 +58,12 @@ interface JiraRestIssue {
     updated?: unknown;
     issuelinks?: unknown;
   };
+}
+
+interface JiraRestSearchResponse {
+  issues?: unknown;
+  total?: unknown;
+  isLast?: unknown;
 }
 
 export function createJiraRestAdapterFromEnv(
@@ -115,14 +129,102 @@ export function createJiraRestAdapter(options: JiraRestAdapterOptions): JiraProv
         );
       }
     },
-    async searchIssues() {
-      return providerFailure('query', 'Jira search is not implemented for manual import');
+    async searchIssues(
+      input: JiraIssueSearchRequest,
+    ): Promise<ProviderResult<AtlassianSearchPage<JiraIssueCardDto>>> {
+      const url = new URL(`${baseUrl}/rest/api/3/search/jql`);
+      url.searchParams.set('jql', buildJql(input));
+      url.searchParams.set('maxResults', String(input.maxResults));
+      url.searchParams.set(
+        'fields',
+        ['summary', 'status', 'issuetype', 'priority', 'assignee', 'created', 'updated'].join(','),
+      );
+
+      let response: Response;
+      try {
+        response = await fetchImpl(url.toString(), {
+          headers: {
+            Accept: 'application/json',
+            Authorization: authorization,
+          },
+        });
+      } catch (err) {
+        return providerFailure('connection', `Failed to connect to Jira: ${String(err)}`);
+      }
+
+      if (!response.ok) {
+        return providerFailure(
+          mapHttpStatusToProviderErrorKind(response.status, 'read'),
+          response.statusText || `Jira search failed with ${response.status}`,
+          { status: response.status },
+        );
+      }
+
+      let raw: unknown;
+      try {
+        raw = await response.json();
+      } catch (err) {
+        return providerFailure(
+          'connection',
+          `Failed to parse Jira search response: ${String(err)}`,
+        );
+      }
+
+      try {
+        return {
+          ok: true,
+          data: mapSearchResponse(raw, input, baseUrl),
+        };
+      } catch (err) {
+        return providerFailure(
+          'validation',
+          `Jira search response failed validation: ${String(err)}`,
+        );
+      }
     },
     async getCurrentUser() {
-      return providerFailure(
-        'auth',
-        'Jira current-user lookup is not implemented for manual import',
-      );
+      let response: Response;
+      try {
+        response = await fetchImpl(`${baseUrl}/rest/api/3/myself`, {
+          headers: {
+            Accept: 'application/json',
+            Authorization: authorization,
+          },
+        });
+      } catch (err) {
+        return providerFailure('connection', `Failed to connect to Jira: ${String(err)}`);
+      }
+
+      if (!response.ok) {
+        return providerFailure(
+          mapHttpStatusToProviderErrorKind(response.status, 'read'),
+          response.statusText || `Jira current-user lookup failed with ${response.status}`,
+          { status: response.status },
+        );
+      }
+
+      let raw: unknown;
+      try {
+        raw = await response.json();
+      } catch (err) {
+        return providerFailure(
+          'connection',
+          `Failed to parse Jira current-user response: ${String(err)}`,
+        );
+      }
+
+      const user = raw as { accountId?: unknown; displayName?: unknown };
+      const accountId = stringValue(user.accountId);
+      if (accountId.length === 0) {
+        return providerFailure('validation', 'Jira current-user response is missing accountId');
+      }
+      return {
+        ok: true,
+        data: {
+          accountId,
+          displayName: stringValue(user.displayName) || undefined,
+        },
+      };
     },
   };
 }
@@ -189,6 +291,64 @@ function mapRestIssue(
     components: arrayOfNamedValues(fields.components),
     linkedKeys: linkedIssueKeys(fields.issuelinks),
   };
+}
+
+function mapSearchResponse(
+  raw: unknown,
+  input: JiraIssueSearchRequest,
+  baseUrl: string,
+): AtlassianSearchPage<JiraIssueCardDto> {
+  const response = raw as JiraRestSearchResponse;
+  const issues = Array.isArray(response.issues) ? response.issues : [];
+  const cards = issues.map((issue) => JiraIssueCardSchema.parse(mapRestIssueCard(issue, baseUrl)));
+  const total = numberValue(response.total) ?? cards.length;
+  return {
+    provider: 'jira',
+    tier: 'card',
+    issues: cards,
+    totalCount: total,
+    hasMore:
+      typeof response.isLast === 'boolean'
+        ? !response.isLast
+        : cards.length < total && cards.length >= input.maxResults,
+  };
+}
+
+function mapRestIssueCard(raw: unknown, baseUrl: string): JiraIssueCardDto {
+  const issue = raw as JiraRestIssue;
+  const fields = issue.fields ?? {};
+  const key = stringValue(issue.key);
+  return {
+    provider: 'jira',
+    resourceKind: 'issue',
+    tier: 'card',
+    id: stringValue(issue.id) || key,
+    key,
+    title: stringValue(fields.summary) || key,
+    status: stringValue(fields.status?.name) || 'Unknown',
+    url: `${baseUrl}/browse/${encodeURIComponent(key)}`,
+    project: key.includes('-') ? key.split('-')[0] : undefined,
+    issueType: stringValue(fields.issuetype?.name) || undefined,
+    priority: stringValue(fields.priority?.name) || undefined,
+    assignee: mapAssignee(fields.assignee),
+    created: stringValue(fields.created) || undefined,
+    updated: stringValue(fields.updated) || undefined,
+  };
+}
+
+function buildJql(input: JiraIssueSearchRequest): string {
+  const clauses = [
+    `project in (${input.projects.map(jqlString).join(',')})`,
+    input.assignee != null ? `assignee = ${jqlString(input.assignee.accountId)}` : undefined,
+    `updated >= ${jqlString(input.updated.from)}`,
+    `updated <= ${jqlString(input.updated.to)}`,
+    input.text != null ? `text ~ ${jqlString(input.text)}` : undefined,
+  ].filter((clause): clause is string => clause != null);
+  return `${clauses.join(' AND ')} ORDER BY updated DESC`;
+}
+
+function jqlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 function offloadArtifactRef(input: {
@@ -292,4 +452,8 @@ function linkedIssueKeys(value: unknown): string[] {
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }


### PR DESCRIPTION
## Summary
- add assigned-to-me Jira sync using current Jira user, configured project bounds, capped date-bounded search, and the manual import upsert path
- mark previously assigned local Jira imports stale/hidden in external-ref metadata without deleting Work Items or mutating Jira
- add server route and board UI action with sync counts and per-issue failures

## Verification
- pnpm test core/integrations/jira/import-assigned.test.ts core/integrations/jira/import-issue.test.ts core/integrations/jira/rest.test.ts core/integrations/atlassian/query.test.ts apps/server/src/domains/integrations/service.test.ts apps/server/src/domains/integrations/router.test.ts apps/web/src/components/board/lib/jira-import.test.ts apps/web/src/components/board/components/JiraAssignedImportAction.test.tsx apps/web/src/components/board/components/JiraImportDialog.test.tsx
- pnpm test core/integrations/github/import-issues.test.ts apps/server/src/domains/issues/service.test.ts apps/web/src/components/board/slice.test.ts
- pnpm exec biome check core/integrations/jira/import-assigned.ts core/integrations/jira/import-assigned.test.ts core/integrations/jira/import-issue.ts core/integrations/jira/rest.ts core/integrations/jira/rest.test.ts apps/server/src/domains/integrations/service.ts apps/server/src/domains/integrations/service.test.ts apps/server/src/domains/integrations/router.ts apps/server/src/domains/integrations/router.test.ts apps/web/src/lib/api/integrations.ts apps/web/src/components/board/lib/jira-import.ts apps/web/src/components/board/lib/jira-import.test.ts apps/web/src/components/board/components/JiraAssignedImportAction.tsx apps/web/src/components/board/components/JiraAssignedImportAction.test.tsx apps/web/src/components/board/components/Board.tsx
- pnpm typecheck