### PR TITLE
Render WP context timeline event

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -73,6 +73,7 @@ import {
   ParallelExhaustedEvent,
   ParallelIterationStartedEvent,
   ParallelWpCommittedEvent,
+  ParallelWpContextAssembledEvent,
   ParallelWpFailedEvent,
   ParallelWpPersistedEvent,
   ParallelWpStartedEvent,
@@ -422,6 +423,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <ParallelIterationStartedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-started':
       return <ParallelWpStartedEvent key={event.id} event={event} />;
+    case 'parallel-implement.wp-context-assembled':
+      return <ParallelWpContextAssembledEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-committed':
       return <ParallelWpCommittedEvent key={event.id} event={event} />;
     case 'parallel-implement.wp-persisted':

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
@@ -108,6 +108,44 @@ describe('ParallelImplementEvents', () => {
     expect(document.body.textContent).not.toContain('"scratchPath"');
   });
 
+  it('renders wp-context-assembled as context counts instead of raw JSON', () => {
+    const event = makeEvent('parallel-implement.wp-context-assembled', {
+      schemaVersion: 1,
+      pipelineRunId: '805e37ae-2c79-40ef-b017-07b82dafbd09',
+      devRunId: '13ab9ca2-54fe-4ea9-a6fb-e0dc227cd8f7',
+      wpId: 'WP1',
+      wpRunId: '13ab9ca2-54fe-4ea9-a6fb-e0dc227cd8f7:wp:WP1:iter:1',
+      iteration: 1,
+      counts: {
+        ownedFiles: 2,
+        newOwnedFiles: 2,
+        codeSnippets: 0,
+        codeContextEntries: 0,
+        specContracts: 1,
+        relevantAcceptanceCriteria: 1,
+        verificationCommands: 2,
+        referenceFiles: 0,
+      },
+      rawProbeKey: 'raw-value',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    const rendered = document.body.textContent ?? '';
+    expect(screen.getByText('WP1 context assembled')).toBeTruthy();
+    expect(rendered).toContain('Iteration 1');
+    expect(rendered).toContain('2 owned files');
+    expect(rendered).toContain('2 new files');
+    expect(rendered).toContain('1 spec contract');
+    expect(rendered).toContain('1 acceptance criterion');
+    expect(rendered).toContain('2 verification commands');
+    expect(rendered).toContain('pipeline 805e37ae');
+    expect(rendered).not.toContain('"schemaVersion"');
+    expect(rendered).not.toContain('"pipelineRunId"');
+    expect(rendered).not.toContain('rawProbeKey');
+    expect(rendered).not.toContain('raw-value');
+  });
+
   it('renders wp-committed with a short commit sha', () => {
     render(
       <ul>

--- a/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx
@@ -13,6 +13,7 @@ type ParallelPayload = {
   wpId?: string;
   iteration?: number;
   wpRunId?: string;
+  devRunId?: string;
   scratchPath?: string;
   commitSha?: string;
   pushedSha?: string;
@@ -29,6 +30,16 @@ type ParallelPayload = {
   failedWpIds?: string[];
   workItemId?: string;
   runId?: string;
+  counts?: {
+    ownedFiles?: number;
+    newOwnedFiles?: number;
+    codeSnippets?: number;
+    codeContextEntries?: number;
+    specContracts?: number;
+    relevantAcceptanceCriteria?: number;
+    verificationCommands?: number;
+    referenceFiles?: number;
+  };
 };
 
 type SpecPrdContextAttachedPayload = {
@@ -60,6 +71,15 @@ function formatFilesPersisted(value: string[] | number | undefined): string | nu
   const count = Array.isArray(value) ? value.length : value;
   if (typeof count !== 'number') return null;
   return `${count} file${count === 1 ? '' : 's'} persisted`;
+}
+
+function formatCount(
+  value: number | undefined,
+  singular: string,
+  plural = `${singular}s`,
+): string | null {
+  if (typeof value !== 'number' || value <= 0) return null;
+  return `${value} ${value === 1 ? singular : plural}`;
 }
 
 function PipelineChip({ pipelineRunId }: { pipelineRunId?: string }) {
@@ -222,6 +242,47 @@ export function ParallelWpStartedEvent({ event }: { event: AgentEventDto }) {
               {p.scratchPath.replace(/^.*\/workspaces\//, '')}
             </span>
           </DetailRow>
+        )}
+      </div>
+    </ParallelEventShell>
+  );
+}
+
+export function ParallelWpContextAssembledEvent({ event }: { event: AgentEventDto }) {
+  const p = event.payload as ParallelPayload | null;
+  const counts = p?.counts;
+  const facts = [
+    formatCount(counts?.ownedFiles, 'owned file'),
+    formatCount(counts?.newOwnedFiles, 'new file'),
+    formatCount(counts?.codeSnippets, 'code snippet'),
+    formatCount(counts?.codeContextEntries, 'code context entry', 'code context entries'),
+    formatCount(counts?.specContracts, 'spec contract'),
+    formatCount(counts?.relevantAcceptanceCriteria, 'acceptance criterion', 'acceptance criteria'),
+    formatCount(counts?.verificationCommands, 'verification command'),
+    formatCount(counts?.referenceFiles, 'reference file'),
+  ].filter((fact): fact is string => fact != null);
+
+  return (
+    <ParallelEventShell
+      event={event}
+      icon={<Layers size={13} className="shrink-0 text-[color:var(--accent)]" />}
+      title={`${p?.wpId ?? 'Work package'} context assembled`}
+      tone="info"
+    >
+      <div className="space-y-1">
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
+          {p?.iteration != null && <span>Iteration {p.iteration}</span>}
+          {formatShortId(p?.wpRunId) != null && (
+            <span className="font-mono text-fg-4">run {formatShortId(p?.wpRunId)}</span>
+          )}
+          <PipelineChip pipelineRunId={p?.pipelineRunId} />
+        </div>
+        {facts.length > 0 && (
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11.5px] text-fg-2">
+            {facts.map((fact) => (
+              <span key={fact}>{fact}</span>
+            ))}
+          </div>
         )}
       </div>
     </ParallelEventShell>


### PR DESCRIPTION
## Summary
- add a dedicated JSX card for parallel-implement.wp-context-assembled
- route the event kind through the detail timeline renderer
- cover the binding with a focused component regression test

## Verification
- pnpm test apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx
- pnpm exec biome check apps/web/src/components/detail/components/TimelineEvents.tsx apps/web/src/components/detail/components/timeline/ParallelImplementEvents.tsx apps/web/src/components/detail/components/timeline/ParallelImplementEvents.test.tsx