### PR TITLE
M19.XX: chat bug 3

### DIFF
--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -62,10 +62,21 @@ function message(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('ChatDock', () => {
   it('resets the active conversation when the launcher closes the dock', async () => {
     const existingConversation = conversation();
-    listConversations.mockResolvedValue([existingConversation]);
+    const reopenList = deferred<ChatConversationDto[]>();
+    listConversations
+      .mockResolvedValueOnce([existingConversation])
+      .mockImplementationOnce(() => reopenList.promise);
     fetchConversation.mockResolvedValue({
       conversation: existingConversation,
       messages: [message()],
@@ -94,6 +105,11 @@ describe('ChatDock', () => {
     });
 
     fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();
+    expect(screen.queryByText('Thread message')).toBeNull();
+
+    reopenList.resolve([existingConversation]);
 
     await waitFor(() => {
       expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();

--- a/apps/web/src/components/chat/components/ChatDock.test.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.test.tsx
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+import type { ChatConversationDto, ChatMessageDto, ChatToolManifestDto } from '@/lib/types';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatDock } from './ChatDock';
+
+const listConversations = vi.fn();
+const fetchConversation = vi.fn();
+const fetchToolManifest = vi.fn();
+
+vi.mock('@/lib/api/chat', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  fetchConversation: (...args: unknown[]) => fetchConversation(...args),
+  fetchToolManifest: (...args: unknown[]) => fetchToolManifest(...args),
+  listConversations: (...args: unknown[]) => listConversations(...args),
+  postMessage: vi.fn(),
+  resolveInvocation: vi.fn(),
+}));
+
+vi.mock('../lib/useChatEvents', () => ({
+  useChatEvents: () => [],
+}));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  listConversations.mockReset();
+  fetchConversation.mockReset();
+  fetchToolManifest.mockReset();
+  fetchToolManifest.mockResolvedValue([]);
+});
+
+function conversation(overrides: Partial<ChatConversationDto> = {}): ChatConversationDto {
+  return {
+    id: 'conv-1',
+    scope: 'project',
+    projectId: 'goose-hub-self',
+    workItemId: null,
+    title: 'Existing chat',
+    runtime: 'codex',
+    createdAt: '2026-05-18T00:00:00Z',
+    updatedAt: '2026-05-18T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
+  return {
+    id: 1,
+    conversationId: 'conv-1',
+    role: 'agent',
+    content: 'Thread message',
+    runId: null,
+    meta: null,
+    createdAt: '2026-05-18T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ChatDock', () => {
+  it('resets the active conversation when the launcher closes the dock', async () => {
+    const existingConversation = conversation();
+    listConversations.mockResolvedValue([existingConversation]);
+    fetchConversation.mockResolvedValue({
+      conversation: existingConversation,
+      messages: [message()],
+      invocations: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <ChatDock />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    expect(await screen.findByText('Existing chat')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('chat-conversation-select'));
+
+    expect(await screen.findByText('Thread message')).toBeTruthy();
+    expect(localStorage.getItem('hub-chat-active-conversation-id')).toBe('conv-1');
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => {
+      expect(localStorage.getItem('hub-chat-active-conversation-id')).toBeNull();
+    });
+
+    fireEvent.click(screen.getByTestId('chat-launcher'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-conversation-list')).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -17,6 +17,7 @@ export function ChatDock() {
       return false;
     }
   });
+  const [panelInstanceKey, setPanelInstanceKey] = useState(0);
 
   useEffect(() => {
     try {
@@ -34,6 +35,7 @@ export function ChatDock() {
 
   const handleLauncherClose = () => {
     clearActiveConversationSelection();
+    setPanelInstanceKey((current) => current + 1);
     setOpen(false);
   };
 
@@ -47,7 +49,7 @@ export function ChatDock() {
 
   return (
     <>
-      <ChatPanel open={open} onClose={handlePanelClose} />
+      <ChatPanel key={panelInstanceKey} open={open} onClose={handlePanelClose} />
       <ChatLauncher open={open} onToggle={handleLauncherToggle} />
     </>
   );

--- a/apps/web/src/components/chat/components/ChatDock.tsx
+++ b/apps/web/src/components/chat/components/ChatDock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ChatLauncher } from './ChatLauncher';
-import { ChatPanel } from './ChatPanel';
+import { ChatPanel, clearActiveConversationSelection } from './ChatPanel';
 
 const STORAGE_KEY = 'hub-chat-open';
 
@@ -24,10 +24,31 @@ export function ChatDock() {
     } catch {}
   }, [open]);
 
+  const handlePanelClose = () => {
+    setOpen(false);
+  };
+
+  const handleLauncherOpen = () => {
+    setOpen(true);
+  };
+
+  const handleLauncherClose = () => {
+    clearActiveConversationSelection();
+    setOpen(false);
+  };
+
+  const handleLauncherToggle = () => {
+    if (open) {
+      handleLauncherClose();
+      return;
+    }
+    handleLauncherOpen();
+  };
+
   return (
     <>
-      <ChatPanel open={open} onClose={() => setOpen(false)} />
-      <ChatLauncher open={open} onToggle={() => setOpen((o) => !o)} />
+      <ChatPanel open={open} onClose={handlePanelClose} />
+      <ChatLauncher open={open} onToggle={handleLauncherToggle} />
     </>
   );
 }

--- a/apps/web/src/components/chat/components/ChatPanel.tsx
+++ b/apps/web/src/components/chat/components/ChatPanel.tsx
@@ -31,6 +31,14 @@ import { ConversationList } from './ConversationList';
 
 const ACTIVE_CONVERSATION_STORAGE_KEY = 'hub-chat-active-conversation-id';
 
+export function clearActiveConversationSelection(): void {
+  try {
+    localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+  } catch {
+    // localStorage unavailable — accept the loss; selection is best-effort.
+  }
+}
+
 interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
@@ -129,7 +137,7 @@ export function ChatPanel({ open, onClose }: ChatPanelProps) {
 
   const writeActiveId = useCallback((id: string | null) => {
     try {
-      if (id == null) localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+      if (id == null) clearActiveConversationSelection();
       else localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, id);
     } catch {
       // localStorage unavailable — accept the loss; selection is best-effort.


### PR DESCRIPTION
## Summary

chat bug 3

## Work Packages

- ✓ **WP1**: In `ChatDock.tsx:12`, replace the bare `setOpen((o) => !o)` launcher toggle with named open/close handlers. When the cur

Closes #1143
