### PR TITLE
PR E: Local-only Work Item and PR semantics

### DIFF
--- a/apps/server/src/domains/issues/router.test.ts
+++ b/apps/server/src/domains/issues/router.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockListIssues,
+  mockCreateIssue,
   mockGetIssue,
   mockGetIssueLegalTargets,
   mockGetIssueEvents,
@@ -30,6 +31,7 @@ const {
   mockGetIssueSpec,
 } = vi.hoisted(() => ({
   mockListIssues: vi.fn(),
+  mockCreateIssue: vi.fn(),
   mockGetIssue: vi.fn(),
   mockGetIssueLegalTargets: vi.fn(),
   mockGetIssueEvents: vi.fn(),
@@ -57,6 +59,7 @@ const {
 
 vi.mock('./service.js', () => ({
   listIssues: mockListIssues,
+  createIssue: mockCreateIssue,
   getIssue: mockGetIssue,
   getIssueLegalTargets: mockGetIssueLegalTargets,
   getIssueEvents: mockGetIssueEvents,
@@ -132,6 +135,46 @@ describe('GET /projects/:slug/issues', () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('project not found');
+  });
+});
+
+describe('POST /projects/:slug/issues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a local Work Item', async () => {
+    const item = { id: 'local:proj#1', externalId: '1', externalRefs: [] };
+    mockCreateIssue.mockResolvedValue({ ok: true, data: { item } });
+
+    const app = makeApp();
+    const res = await postJson(app, '/projects/my-project/issues', {
+      title: 'Local-only task',
+      body: 'Details',
+      type: 'chore',
+      priority: 'high',
+      milestoneNumber: 3,
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ item });
+    expect(mockCreateIssue).toHaveBeenCalledWith('my-project', {
+      title: 'Local-only task',
+      body: 'Details',
+      type: 'chore',
+      priority: 'high',
+      milestoneNumber: 3,
+    });
+  });
+
+  it('returns service validation failures', async () => {
+    mockCreateIssue.mockResolvedValue({ ok: false, error: 'title is required', status: 400 });
+
+    const app = makeApp();
+    const res = await postJson(app, '/projects/my-project/issues', { title: '' });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'title is required' });
   });
 });
 

--- a/apps/server/src/domains/issues/router.ts
+++ b/apps/server/src/domains/issues/router.ts
@@ -6,6 +6,7 @@ import {
   approveIssue,
   approvePRD,
   commentOnIssue,
+  createIssue,
   declinePRD,
   getIssue,
   getIssueAcceptanceContract,
@@ -36,6 +37,21 @@ router.get('/:slug/issues', async (c) => {
     ? await listIssues(c.req.param('slug'), { all })
     : await listIssues(c.req.param('slug'));
   return result.ok ? c.json(result.data) : c.json({ error: result.error }, result.status as 404);
+});
+
+router.post('/:slug/issues', async (c) => {
+  const body = await parseBody<{
+    title?: unknown;
+    body?: unknown;
+    type?: unknown;
+    priority?: unknown;
+    milestoneNumber?: unknown;
+  }>(c);
+  if (!body.ok) return body.error;
+  const result = await createIssue(c.req.param('slug'), body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 404);
 });
 
 router.get('/:slug/issues/:id', async (c) => {

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -93,6 +93,7 @@ import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
 import {
   commentOnIssue,
+  createIssue,
   getIssue,
   getIssueArtifact,
   getIssueLegalTargets,
@@ -113,6 +114,7 @@ type MockSource = {
   listOpenWork: ReturnType<typeof vi.fn>;
   getItem: ReturnType<typeof vi.fn>;
   listComments: ReturnType<typeof vi.fn>;
+  createIssue: ReturnType<typeof vi.fn>;
 };
 
 const mockSource: MockSource = {
@@ -123,6 +125,7 @@ const mockSource: MockSource = {
   setMilestone: vi.fn().mockResolvedValue(undefined),
   setLabelInGroup: vi.fn().mockResolvedValue(undefined),
   listOpenWork: vi.fn().mockResolvedValue([]),
+  createIssue: vi.fn(),
   getItem: vi.fn(async (itemId: string) => ({
     id: `github:owner/repo#${itemId}`,
     externalId: itemId,
@@ -180,6 +183,22 @@ beforeEach(() => {
   mockSource.setMilestone.mockReset().mockResolvedValue(undefined);
   mockSource.setLabelInGroup.mockReset().mockResolvedValue(undefined);
   mockSource.listOpenWork.mockReset().mockResolvedValue([]);
+  mockSource.createIssue.mockReset().mockResolvedValue({
+    id: 'local:test-proj#1',
+    externalId: '1',
+    repoRef: 'owner/repo',
+    title: 'Local item',
+    body: '',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:triaging',
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    externalRefs: [],
+  });
   mockGetProject.mockImplementation(async (slug) =>
     slug === 'unknown'
       ? null
@@ -193,6 +212,59 @@ beforeEach(() => {
   vi.mocked(getArtifact).mockReturnValue(null);
   vi.mocked(getArtifactSlice).mockReturnValue(null);
   vi.mocked(getEngineeringSpec).mockReturnValue(null);
+});
+
+describe('createIssue', () => {
+  it('creates a local-db Work Item without requiring external refs', async () => {
+    mockGetProject.mockResolvedValueOnce({
+      id: 'test-proj',
+      source: { kind: 'local-db', stateMachine: 'db' },
+      repos: ['owner/repo'],
+    } as never);
+
+    const result = await createIssue('local-proj', {
+      title: '  Local-only task  ',
+      body: 'Track this locally.',
+      type: 'chore',
+      priority: 'high',
+      milestoneNumber: 2,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          canonicalWorkItemId: 'local:test-proj#1',
+          externalRefs: [],
+        },
+      },
+    });
+    expect(mockSource.createIssue).toHaveBeenCalledWith({
+      title: 'Local-only task',
+      body: 'Track this locally.',
+      type: 'chore',
+      priority: 'high',
+      milestoneId: '2',
+    });
+  });
+
+  it('rejects issue creation for non-local-db projects', async () => {
+    const result = await createIssue('github-proj', { title: 'Do not create remotely' });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'local Work Item creation requires a local-db project',
+      status: 400,
+    });
+    expect(mockSource.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('validates title before calling the source', async () => {
+    const result = await createIssue('local-proj', { title: '   ' });
+
+    expect(result).toEqual({ ok: false, error: 'title is required', status: 400 });
+    expect(mockSource.createIssue).not.toHaveBeenCalled();
+  });
 });
 
 describe('getIssueSpec', () => {

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -12,6 +12,7 @@ import {
   type ScheduleUIValue,
 } from '@goose-hub/core/state-source/github-labels.js';
 import type { Result } from '#shared/middleware.js';
+import { getProject } from '#shared/projects.js';
 import { resolveActiveMilestone } from '#shared/resolve-milestone.js';
 import { getSourceForSlug } from '#shared/source.js';
 import {
@@ -224,6 +225,14 @@ function workItemServerDto(item: { id: string; externalRefs?: unknown }): object
   };
 }
 
+export interface CreateIssueRequestDto {
+  title?: unknown;
+  body?: unknown;
+  type?: unknown;
+  priority?: unknown;
+  milestoneNumber?: unknown;
+}
+
 // Public surface for the issues domain. The implementation is split across
 // sibling files to keep each concern focused; this barrel re-exports the
 // pieces the router and tests depend on.
@@ -258,6 +267,56 @@ export async function listIssues(
     prdParent: byChild.get(item.externalId),
   }));
   return { ok: true, data: { items: enriched } };
+}
+
+export async function createIssue(
+  slug: string,
+  body: CreateIssueRequestDto,
+): Promise<Result<{ item: unknown }>> {
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  if (title.length === 0) return { ok: false, error: 'title is required', status: 400 };
+
+  const project = await getProject(slug);
+  if (project == null) return { ok: false, error: 'project not found', status: 404 };
+  if (project.source.kind !== 'local-db') {
+    return {
+      ok: false,
+      error: 'local Work Item creation requires a local-db project',
+      status: 400,
+    };
+  }
+
+  const source = await getSourceForSlug(slug);
+  if (source == null) return { ok: false, error: 'project not found', status: 404 };
+
+  const type =
+    body.type === 'feature' ||
+    body.type === 'bug' ||
+    body.type === 'chore' ||
+    body.type === 'research'
+      ? body.type
+      : undefined;
+  const priority =
+    body.priority === 'critical' ||
+    body.priority === 'high' ||
+    body.priority === 'medium' ||
+    body.priority === 'low'
+      ? body.priority
+      : undefined;
+  const milestoneId =
+    typeof body.milestoneNumber === 'number' && Number.isInteger(body.milestoneNumber)
+      ? String(body.milestoneNumber)
+      : undefined;
+
+  const item = await source.createIssue({
+    title,
+    body: typeof body.body === 'string' ? body.body : '',
+    ...(type != null ? { type } : {}),
+    ...(priority != null ? { priority } : {}),
+    ...(milestoneId != null ? { milestoneId } : {}),
+  });
+
+  return { ok: true, data: { item: workItemServerDto(item) } };
 }
 
 export async function getIssue(slug: string, id: string): Promise<Result<{ item: unknown }>> {

--- a/apps/web/src/components/board/components/Board.tsx
+++ b/apps/web/src/components/board/components/Board.tsx
@@ -8,13 +8,14 @@ import { useActiveMilestone } from '@/state/active-milestone';
 import { useActiveProject } from '@/state/active-project';
 import { useLaneVisibility } from '@/state/lane-visibility';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ChevronDown, Download, Eye, RefreshCw } from 'lucide-react';
+import { ChevronDown, Download, Eye, Plus, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { canUseAssignedToMeJiraImport, canUseManualJiraImport } from '../lib/jira-import';
 import { BoardColumn } from './BoardColumn';
 import { JiraAssignedImportAction } from './JiraAssignedImportAction';
 import { JiraImportDialog } from './JiraImportDialog';
+import { NewLocalIssueDialog } from './NewLocalIssueDialog';
 
 interface BoardProps {
   projectSlug: string;
@@ -24,6 +25,7 @@ export function Board({ projectSlug }: BoardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [jiraImportOpen, setJiraImportOpen] = useState(false);
+  const [newLocalOpen, setNewLocalOpen] = useState(false);
   const { projects } = useActiveProject();
   const { hidden, toggle, reset } = useLaneVisibility();
   const { activeNumber: resolvedMilestone, milestones, setActiveNumber } = useActiveMilestone();
@@ -31,6 +33,7 @@ export function Board({ projectSlug }: BoardProps) {
   const currentProject = projects.find((project) => project.slug === projectSlug);
   const showJiraImport = canUseManualJiraImport(currentProject);
   const showAssignedJiraImport = canUseAssignedToMeJiraImport(currentProject);
+  const showLocalCreate = currentProject?.source.kind === 'local-db';
 
   const {
     data: items = [],
@@ -152,6 +155,15 @@ export function Board({ projectSlug }: BoardProps) {
           {items.length} issue{items.length === 1 ? '' : 's'}
         </span>
         <span className="grow" />
+        {showLocalCreate && (
+          <button
+            type="button"
+            onClick={() => setNewLocalOpen(true)}
+            className="inline-flex h-6 items-center gap-1.5 rounded border border-line px-2 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
+          >
+            <Plus size={12} /> New local
+          </button>
+        )}
         {showJiraImport && (
           <button
             type="button"
@@ -220,6 +232,21 @@ export function Board({ projectSlug }: BoardProps) {
         milestoneNumber={resolvedMilestone}
         onClose={() => setJiraImportOpen(false)}
         onImported={(item) => {
+          void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
+          if (resolvedMilestone != null) {
+            void queryClient.invalidateQueries({
+              queryKey: ['milestone-issues', projectSlug, resolvedMilestone],
+            });
+          }
+          navigate(`/projects/${projectSlug}/items/${item.externalId}`);
+        }}
+      />
+      <NewLocalIssueDialog
+        open={showLocalCreate && newLocalOpen}
+        projectSlug={projectSlug}
+        milestoneNumber={resolvedMilestone}
+        onClose={() => setNewLocalOpen(false)}
+        onCreated={(item) => {
           void queryClient.invalidateQueries({ queryKey: ['issues', projectSlug] });
           if (resolvedMilestone != null) {
             void queryClient.invalidateQueries({

--- a/apps/web/src/components/board/components/IssueCard.test.tsx
+++ b/apps/web/src/components/board/components/IssueCard.test.tsx
@@ -24,7 +24,8 @@ beforeEach(() => {
 });
 
 const BASE_ITEM: WorkItemDto = {
-  id: '1',
+  id: 'github:shaunnez/goose-hub#42',
+  canonicalWorkItemId: 'github:shaunnez/goose-hub#42',
   externalId: '42',
   repoRef: 'shaunnez/goose-hub',
   title: 'Fix the login bug',
@@ -38,6 +39,18 @@ const BASE_ITEM: WorkItemDto = {
   exec: 'serial',
   dependsOn: [],
   blocks: [],
+  externalRefs: [
+    {
+      id: 1,
+      provider: 'github',
+      kind: 'issue',
+      repoRef: 'shaunnez/goose-hub',
+      externalId: '42',
+      url: 'https://github.com/shaunnez/goose-hub/issues/42',
+      metadata: null,
+      createdAt: new Date().toISOString(),
+    },
+  ],
   createdAt: new Date(Date.now() - 3600000).toISOString(),
 };
 
@@ -157,6 +170,26 @@ describe('IssueCard', () => {
     vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
     renderCard({ ...BASE_ITEM, schedule: 'current' });
     expect(screen.queryByTestId('blocked-indicator')).toBeNull();
+  });
+
+  it('shows local-only when no external refs are linked', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
+    renderCard({
+      ...BASE_ITEM,
+      id: 'local:proj#1',
+      canonicalWorkItemId: 'local:proj#1',
+      externalId: '1',
+      externalRefs: [],
+    });
+    expect(screen.getByTestId('local-only-indicator')).toBeTruthy();
+    expect(screen.getByText('Local-only')).toBeTruthy();
+  });
+
+  it('does not show local-only for GitHub Work Items with normalized empty refs', () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValueOnce(costsResponse([]));
+    renderCard({ ...BASE_ITEM, externalRefs: [] });
+
+    expect(screen.queryByTestId('local-only-indicator')).toBeNull();
   });
 
   it('blocked indicator tooltip lists same-repo dep as short ref', () => {

--- a/apps/web/src/components/board/components/IssueCard.tsx
+++ b/apps/web/src/components/board/components/IssueCard.tsx
@@ -6,7 +6,7 @@ import type { WorkItemCostsDto, WorkItemDto } from '@/lib/types';
 import { getPersonaInitials, usePersonaMap } from '@/lib/usePersonaMap';
 import { ageLabel, formatCost } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
-import { Ban, GitFork } from 'lucide-react';
+import { Ban, Database, GitFork } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 /** Shorten a repo-qualified dep ref to issue-number-only when it's in the same repo. */
@@ -31,6 +31,8 @@ export function IssueCard({
   const personaMap = usePersonaMap();
   const initials = getPersonaInitials(personaMap, item.lastPersonaId);
   const isBlocked = item.schedule === 'blocked-by';
+  const isLocalOnly =
+    item.canonicalWorkItemId.startsWith('local:') && item.externalRefs.length === 0;
 
   // Per-card fetch; TanStack Query dedupes by key so the issue detail page
   // shares the same cache. Boards with many cards trigger N requests on mount —
@@ -107,6 +109,16 @@ export function IssueCard({
         <Pill tone="default" className="h-5 text-[10.5px] px-2 capitalize">
           {item.priority}
         </Pill>
+        {isLocalOnly && (
+          <Pill
+            tone="default"
+            className="h-5 text-[10.5px] px-2 gap-1"
+            data-testid="local-only-indicator"
+          >
+            <Database size={9} aria-hidden />
+            Local-only
+          </Pill>
+        )}
         {item.milestoneTitle != null && (
           <Pill
             tone="default"

--- a/apps/web/src/components/board/components/NewLocalIssueDialog.test.tsx
+++ b/apps/web/src/components/board/components/NewLocalIssueDialog.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import { createLocalIssue } from '@/lib/api';
+import type { WorkItemDto } from '@/lib/types';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NewLocalIssueDialog } from './NewLocalIssueDialog';
+
+vi.mock('@/lib/api', () => ({
+  createLocalIssue: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const CREATED_ITEM: WorkItemDto = {
+  id: 'local:proj#1',
+  canonicalWorkItemId: 'local:proj#1',
+  externalId: '1',
+  repoRef: 'owner/repo',
+  title: 'Local task',
+  body: '',
+  type: 'chore',
+  priority: 'medium',
+  mode: 'supervised',
+  state: 'factory:triaging',
+  authorIsOwner: true,
+  schedule: 'current',
+  exec: 'serial',
+  dependsOn: [],
+  blocks: [],
+  externalRefs: [],
+  createdAt: new Date().toISOString(),
+};
+
+describe('NewLocalIssueDialog', () => {
+  it('creates a local-only Work Item and reports the created item', async () => {
+    vi.mocked(createLocalIssue).mockResolvedValueOnce(CREATED_ITEM);
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <NewLocalIssueDialog
+        open
+        projectSlug="local-proj"
+        milestoneNumber={5}
+        onCreated={onCreated}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: ' Local task ' } });
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: 'Track locally.' } });
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'chore' } });
+    fireEvent.change(screen.getByLabelText('Priority'), { target: { value: 'high' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(createLocalIssue).toHaveBeenCalledTimes(1));
+    expect(createLocalIssue).toHaveBeenCalledWith('local-proj', {
+      title: 'Local task',
+      body: 'Track locally.',
+      type: 'chore',
+      priority: 'high',
+      milestoneNumber: 5,
+    });
+    expect(onCreated).toHaveBeenCalledWith(CREATED_ITEM);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('requires a title before submitting', () => {
+    render(
+      <NewLocalIssueDialog
+        open
+        projectSlug="local-proj"
+        milestoneNumber={null}
+        onCreated={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(screen.getByTestId('new-local-issue-error').textContent).toContain('title is required');
+    expect(createLocalIssue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/board/components/NewLocalIssueDialog.tsx
+++ b/apps/web/src/components/board/components/NewLocalIssueDialog.tsx
@@ -1,0 +1,152 @@
+import { createLocalIssue } from '@/lib/api';
+import type { WorkItemDto } from '@/lib/types';
+import { X } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+
+interface NewLocalIssueDialogProps {
+  open: boolean;
+  projectSlug: string;
+  milestoneNumber?: number | null;
+  onClose: () => void;
+  onCreated: (item: WorkItemDto) => void;
+}
+
+export function NewLocalIssueDialog({
+  open,
+  projectSlug,
+  milestoneNumber,
+  onClose,
+  onCreated,
+}: NewLocalIssueDialogProps) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [type, setType] = useState('feature');
+  const [priority, setPriority] = useState('medium');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedTitle = title.trim();
+    if (trimmedTitle.length === 0) {
+      setError('title is required');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await createLocalIssue(projectSlug, {
+        title: trimmedTitle,
+        body,
+        type,
+        priority,
+        ...(milestoneNumber != null ? { milestoneNumber } : {}),
+      });
+      setTitle('');
+      setBody('');
+      setType('feature');
+      setPriority('medium');
+      onCreated(created);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      data-testid="new-local-issue-dialog"
+    >
+      <div className="w-full max-w-[460px] rounded-md border border-line bg-bg-elev shadow-xl">
+        <header className="flex items-center justify-between border-b border-line px-4 py-3">
+          <h2 className="text-[13px] font-semibold text-fg">New Local Work Item</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="grid h-7 w-7 place-items-center rounded text-fg-3 hover:bg-bg-hover hover:text-fg"
+          >
+            <X size={14} />
+          </button>
+        </header>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 px-4 py-4">
+          <label className="flex flex-col gap-1.5 text-[12px] text-fg-2">
+            Title
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="h-8 rounded border border-line bg-bg px-2 text-[13px] text-fg outline-none focus:border-accent-line"
+            />
+          </label>
+          <label className="flex flex-col gap-1.5 text-[12px] text-fg-2">
+            Body
+            <textarea
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              rows={5}
+              className="min-h-[110px] rounded border border-line bg-bg px-2 py-2 text-[13px] text-fg outline-none focus:border-accent-line"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1.5 text-[12px] text-fg-2">
+              Type
+              <select
+                value={type}
+                onChange={(event) => setType(event.target.value)}
+                className="h-8 rounded border border-line bg-bg px-2 text-[13px] text-fg outline-none focus:border-accent-line"
+              >
+                <option value="feature">Feature</option>
+                <option value="bug">Bug</option>
+                <option value="chore">Chore</option>
+                <option value="research">Research</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1.5 text-[12px] text-fg-2">
+              Priority
+              <select
+                value={priority}
+                onChange={(event) => setPriority(event.target.value)}
+                className="h-8 rounded border border-line bg-bg px-2 text-[13px] text-fg outline-none focus:border-accent-line"
+              >
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+          </div>
+          {error != null && (
+            <div
+              data-testid="new-local-issue-error"
+              className="rounded border border-[color:var(--danger)]/30 bg-[color:var(--danger)]/10 px-3 py-2 text-[12px] text-[color:var(--danger)]"
+            >
+              {error}
+            </div>
+          )}
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-8 rounded border border-line px-3 text-[12px] text-fg-2 hover:bg-bg-hover hover:text-fg"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="h-8 rounded border border-accent-line bg-[color:var(--accent)]/15 px-3 text-[12px] font-medium text-[color:var(--accent)] hover:bg-[color:var(--accent)]/20 disabled:opacity-60"
+            >
+              {submitting ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/issues.ts
+++ b/apps/web/src/lib/api/issues.ts
@@ -23,6 +23,20 @@ export async function fetchIssue(slug: string, id: string): Promise<WorkItemDto>
   return item;
 }
 
+export async function createLocalIssue(
+  slug: string,
+  input: {
+    title: string;
+    body?: string;
+    type?: string;
+    priority?: string;
+    milestoneNumber?: number | null;
+  },
+): Promise<WorkItemDto> {
+  const { item } = await postJson<{ item: WorkItemDto }>(`/projects/${slug}/issues`, input);
+  return item;
+}
+
 export async function fetchEngineeringSpec(
   slug: string,
   id: string,

--- a/core/state-source/local-db.test.ts
+++ b/core/state-source/local-db.test.ts
@@ -61,6 +61,7 @@ describe('LocalDbStateSource', () => {
       state: 'factory:triaging',
       dependsOn: ['7'],
       blocks: ['9'],
+      externalRefs: [],
     });
     expect((await source.getItem('1')).id).toBe(created.id);
     expect((await source.listOpenWork()).map((item) => item.id)).toEqual([created.id]);

--- a/core/tool-layer/mcp/tools/workflow.ts
+++ b/core/tool-layer/mcp/tools/workflow.ts
@@ -17,7 +17,7 @@
  * dead code if that refactor never happens.
  */
 import type { z } from 'zod';
-import { openPR } from '../../../connectors/github/open-pr.js';
+import { openLocalDbPR, openPR } from '../../../connectors/github/open-pr.js';
 import { transitionAndEmitState } from '../../../event-stream/state-transition.js';
 import type { StateName } from '../../../state-machine/states.js';
 import { emitBlockedToolCall, emitToolCall } from '../audit.js';
@@ -177,8 +177,8 @@ export interface OpenPrResult {
 
 /**
  * Pushes the current branch to origin and opens a pull request via the
- * GitHub REST API. Caller must ensure body contains `Closes #N` (the
- * underlying `openPR` connector validates this).
+ * GitHub REST API. GitHub-backed Work Items keep `Closes #N`; local-db
+ * Work Items use a non-closing local reference.
  *
  * Workflow-owned — not exposed to agents. Branch name is derived from
  * the current HEAD's branch (read via `git rev-parse --abbrev-ref HEAD`)
@@ -199,30 +199,41 @@ export async function openPrTool(
   const branchName = branchResult.stdout.trim();
 
   const source = await getStateSourceForProject(ctx.projectId);
+  const isLocalWorkItem = ctx.workItemId.startsWith('local:');
   const issueMatch = ctx.workItemId.match(/#(\d+)$/);
-  if (issueMatch == null) {
+  if (!isLocalWorkItem && issueMatch == null) {
     throw new GitMutationError(
       null,
       '',
       `open_pr: cannot derive issue number from workItemId '${ctx.workItemId}'.`,
     );
   }
-  const issueNumber = Number.parseInt(issueMatch[1], 10);
+  const issueNumber = issueMatch == null ? null : Number.parseInt(issueMatch[1], 10);
 
-  const result = await openPR({
-    worktreePath: ctx.workspaceRoot,
-    repo: source.repoRef,
-    issueNumber,
-    title: input.title,
-    body: input.body ?? `Closes #${issueNumber}`,
-    branchName,
-    baseBranch: input.base,
-    token: resolveGitHubToken(),
-  });
+  const result = isLocalWorkItem
+    ? await openLocalDbPR({
+        worktreePath: ctx.workspaceRoot,
+        repo: source.repoRef,
+        title: input.title,
+        body: input.body ?? `Local Work Item: ${ctx.workItemId}`,
+        branchName,
+        baseBranch: input.base,
+        token: resolveGitHubToken(),
+      })
+    : await openPR({
+        worktreePath: ctx.workspaceRoot,
+        repo: source.repoRef,
+        issueNumber: issueNumber ?? 0,
+        title: input.title,
+        body: input.body ?? `Closes #${issueNumber}`,
+        branchName,
+        baseBranch: input.base,
+        token: resolveGitHubToken(),
+      });
 
   emitToolCall(ctx, {
     tool: 'open_pr',
-    input: { issueNumber, branchName, base: input.base ?? 'main' },
+    input: { workItemId: ctx.workItemId, issueNumber, branchName, base: input.base ?? 'main' },
     status: 'ok',
   });
   return { prNumber: result.prNumber, prUrl: result.prUrl };

--- a/slices/parallel-implement/parallel-helpers.ts
+++ b/slices/parallel-implement/parallel-helpers.ts
@@ -80,6 +80,7 @@ export function buildParallelPrBody(opts: {
   workItem: WorkItem;
   spec: EngineeringSpec;
   wpResults: WpDispatchResult[];
+  closesIssueNumber?: number | null;
 }): string {
   const wpChangelog = opts.wpResults
     .map((r) => {
@@ -89,6 +90,15 @@ export function buildParallelPrBody(opts: {
     })
     .join('\n');
 
+  const closeTarget =
+    opts.closesIssueNumber === undefined
+      ? opts.workItem.id.startsWith('local:')
+        ? null
+        : opts.workItem.externalId
+      : opts.closesIssueNumber;
+  const closingLine =
+    closeTarget == null ? `Local Work Item: ${opts.workItem.id}` : `Closes #${closeTarget}`;
+
   return `## Summary
 
 ${opts.workItem.title}
@@ -97,6 +107,6 @@ ${opts.workItem.title}
 
 ${wpChangelog}
 
-Closes #${opts.workItem.externalId}
+${closingLine}
 `;
 }

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -23,6 +23,7 @@ import type { DevReviewResponseOutput } from '@goose-hub/skills/dev-review-respo
 import type { DevReviewOutput } from '@goose-hub/skills/dev-review/schema.js';
 import type { ImplementWpOutput } from '@goose-hub/skills/implement-wp/schema.js';
 import type { EngineeringSpec, WorkPackage } from '@goose-hub/skills/spec-author/schema.js';
+import { buildParallelPrBody } from './parallel-helpers.js';
 import { runParallelImplementWorkflow } from './workflow.js';
 import { resolveImplementWpBudget, resolveImplementWpControl } from './wp-budget.js';
 import { runOneWpBuilder } from './wp-builder.js';
@@ -88,6 +89,45 @@ function makeSpec(workPackages: WorkPackage[]): EngineeringSpec {
     decisionSummaries: [{ kind: 'PLAN', summary: 'Test spec' }],
   };
 }
+
+describe('parallel PR body local-db semantics', () => {
+  it('uses a local Work Item reference instead of fake GitHub close keywords', () => {
+    const body = buildParallelPrBody({
+      workItem: makeWorkItem({
+        id: 'local:proj#1',
+        externalId: '1',
+        externalRefs: [
+          {
+            id: 1,
+            provider: 'jira',
+            kind: 'issue',
+            repoRef: null,
+            externalId: 'TAS-123',
+            url: 'https://company.atlassian.net/browse/TAS-123',
+            metadata: null,
+            createdAt: '2026-05-27T00:00:00.000Z',
+          },
+        ],
+      }),
+      spec: makeSpec([makeWp('WP1', ['core/a.ts'])]),
+      wpResults: [{ wpId: 'WP1', status: 'ok', runId: 'wp-run-1' }],
+    });
+
+    expect(body).toContain('Local Work Item: local:proj#1');
+    expect(body).not.toMatch(/(?:Closes|Fixes|Resolves) #1/);
+    expect(body).not.toContain('TAS-123');
+  });
+
+  it('keeps close keywords for GitHub Work Items', () => {
+    const body = buildParallelPrBody({
+      workItem: makeWorkItem(),
+      spec: makeSpec([makeWp('WP1', ['core/a.ts'])]),
+      wpResults: [{ wpId: 'WP1', status: 'ok', runId: 'wp-run-1' }],
+    });
+
+    expect(body).toContain('Closes #560');
+  });
+});
 
 function makeInvestigationEvent(workItem: WorkItem) {
   return {
@@ -1473,6 +1513,99 @@ describe('parallel-implement durable integration branch persistence', () => {
       skill: 'parallel-implement',
       runDisposition: 'completed',
     });
+  });
+
+  it('opens local-db Work Item PRs without GitHub close keywords and stores PR refs', async () => {
+    const wp1 = makeWp('WP1', ['core/a.ts']);
+    const spec = makeSpec([wp1]);
+    const { fn: appendEvent } = makeAppendEvent();
+    const iterations: Array<{ wpId: string; status: string }> = [];
+    const openPRImpl = vi.fn();
+    const localPrCalls: Array<{ body: string; repo: string }> = [];
+    const upsertedRefs: Array<{ kind: string; externalId: string; repoRef: string }> = [];
+
+    const result = await runParallelImplementWorkflow(
+      makeWorkItem({
+        id: 'local:proj#1',
+        externalId: '1',
+        externalRefs: [
+          {
+            id: 1,
+            provider: 'jira',
+            kind: 'issue',
+            repoRef: null,
+            externalId: 'TAS-123',
+            url: 'https://company.atlassian.net/browse/TAS-123',
+            metadata: null,
+            createdAt: '2026-05-27T00:00:00.000Z',
+          },
+        ],
+      }),
+      spec,
+      'pipeline-run-local',
+      makeStateSource(),
+      'goose-hub-self',
+      '/tmp/repo',
+      {
+        runtime: makeRuntime({ WP1: async () => makeOkResult('WP1') }),
+        createIntegrationWorktreeImpl: () => ({
+          worktreePath: '/tmp/issue-wt',
+          previousHeadSha: 'base-sha',
+        }),
+        createWpWorktreeImpl: (_repo, _runId, wpId) => `/tmp/wp-${wpId}`,
+        cleanupWpWorktreesImpl: () => undefined,
+        cleanupIssueWorktreeImpl: () => undefined,
+        orchestratorCommitWpImpl: () => 'sha-wp1',
+        pushBranchImpl: () => undefined,
+        resolveRemoteBranchHeadImpl: () => 'sha-wp1',
+        revertWpChangesImpl: () => undefined,
+        recordIterationImpl: (_runId, wpId, _iteration, status) => {
+          iterations.push({ wpId, status });
+        },
+        getLastStatusImpl: (_runId, wpId) => {
+          const last = [...iterations].reverse().find((i) => i.wpId === wpId);
+          return (last?.status as 'ok' | 'failed' | 'in-progress' | null) ?? null;
+        },
+        openPRImpl,
+        openLocalDbPRImpl: async (input) => {
+          localPrCalls.push({ body: input.body, repo: input.repo });
+          return {
+            prNumber: 5,
+            prUrl: 'https://github.com/owner/repo/pull/5',
+            branch: input.branchName,
+            base: input.baseBranch ?? 'main',
+          };
+        },
+        upsertGithubExternalRefImpl: (input) => {
+          upsertedRefs.push({
+            kind: input.kind,
+            externalId: input.externalId,
+            repoRef: input.repoRef,
+          });
+          return {} as never;
+        },
+        appendEvent,
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(openPRImpl).not.toHaveBeenCalled();
+    expect(localPrCalls).toEqual([
+      expect.objectContaining({
+        repo: 'shaunnez/goose-hub',
+        body: expect.stringContaining('Local Work Item: local:proj#1'),
+      }),
+    ]);
+    expect(localPrCalls[0]?.body).not.toMatch(/(?:Closes|Fixes|Resolves) #1/);
+    expect(localPrCalls[0]?.body).not.toContain('TAS-123');
+    expect(upsertedRefs).toEqual([
+      { kind: 'pull_request', repoRef: 'shaunnez/goose-hub', externalId: '5' },
+      {
+        kind: 'branch',
+        repoRef: 'shaunnez/goose-hub',
+        externalId: 'factory/run/pipeline-run-local',
+      },
+    ]);
   });
 
   it('persists green WP work before stopping a post-run budget-killed workflow', async () => {

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -23,11 +23,12 @@ import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/r
 import { resolveProjectAgentExecution } from '@goose-hub/core/agent-runtime/resolve-runtime-for-project.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
-import { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
+import { openLocalDbPR, openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { readProjectSettings } from '@goose-hub/core/db/repositories/project-settings.js';
 import type { RunDisposition } from '@goose-hub/core/event-stream/run-disposition.js';
 import type { AgentEvent, AppendEventInput } from '@goose-hub/core/event-stream/store.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { upsertGithubExternalRef } from '@goose-hub/core/integrations/github/external-refs.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -88,6 +89,8 @@ export interface ParallelImplementDeps {
   /** Separate runtime for the dev-review-response pass (defaults to project skill settings). */
   devReviewResponseRuntime?: AgentRuntime;
   openPRImpl?: typeof openPR;
+  openLocalDbPRImpl?: typeof openLocalDbPR;
+  upsertGithubExternalRefImpl?: typeof upsertGithubExternalRef;
   createWpWorktreeImpl?: typeof createWpScratchWorktree;
   createIssueWorktreeImpl?: typeof createWorktree;
   /** Override dependency prewarm for tests or alternate package managers. */
@@ -314,6 +317,14 @@ class BlockedGateError extends Error {
     super(message);
     this.name = 'BlockedGateError';
   }
+}
+
+function latestLinkedGithubIssue(workItem: WorkItem) {
+  return (
+    (workItem.externalRefs ?? [])
+      .filter((ref) => ref.provider === 'github' && ref.kind === 'issue' && ref.repoRef != null)
+      .at(-1) ?? null
+  );
 }
 
 function errorMessage(err: unknown): string {
@@ -555,6 +566,8 @@ export async function runParallelImplementWorkflow(
     return baseAppend({ ...input, payload });
   };
   const openPRFn = deps.openPRImpl ?? openPR;
+  const openLocalDbPRFn = deps.openLocalDbPRImpl ?? openLocalDbPR;
+  const upsertGithubExternalRefFn = deps.upsertGithubExternalRefImpl ?? upsertGithubExternalRef;
   const createWpFn = deps.createWpWorktreeImpl ?? createWpScratchWorktree;
   const createIssueFn = deps.createIssueWorktreeImpl ?? createWorktree;
   const usesInjectedWorkflowWorktree =
@@ -1425,9 +1438,23 @@ export async function runParallelImplementWorkflow(
       throw new Error('GITHUB_TOKEN env var is required to open PR');
     }
 
+    const linkedIssueRef = workItem.id.startsWith('local:')
+      ? latestLinkedGithubIssue(workItem)
+      : null;
+    const repoRef = linkedIssueRef?.repoRef ?? stateSource.repoRef;
     const branchName = integrationBranch;
     const title = `M19.XX: ${workItem.title.slice(0, 50)}`;
-    const body = buildParallelPrBody({ workItem, spec: specForRun, wpResults: allWpResults });
+    const closesIssueNumber =
+      linkedIssueRef != null ? Number(linkedIssueRef.externalId) : Number(workItem.externalId);
+    const shouldCloseGithubIssue =
+      Number.isFinite(closesIssueNumber) &&
+      (linkedIssueRef != null || !workItem.id.startsWith('local:'));
+    const body = buildParallelPrBody({
+      workItem,
+      spec: specForRun,
+      wpResults: allWpResults,
+      closesIssueNumber: shouldCloseGithubIssue ? closesIssueNumber : null,
+    });
     const expectedRemoteHead = devReviewResponseCommitSha ?? integrationHeadSha;
     if (expectedRemoteHead == null) {
       throw new PersistenceFailureError(
@@ -1446,17 +1473,47 @@ export async function runParallelImplementWorkflow(
       allowUnverifiedTestPersistence,
     });
 
-    const prResult = await openPRFn({
-      worktreePath: issueWorktreePath ?? '',
-      repo: stateSource.repoRef,
-      issueNumber: Number(workItem.externalId),
-      title,
-      body,
-      branchName,
-      baseBranch: workflowBase.branch,
-      token,
-      skipPush: true,
-    });
+    const prResult = shouldCloseGithubIssue
+      ? await openPRFn({
+          worktreePath: issueWorktreePath ?? '',
+          repo: repoRef,
+          issueNumber: closesIssueNumber,
+          title,
+          body,
+          branchName,
+          baseBranch: workflowBase.branch,
+          token,
+          skipPush: true,
+        })
+      : await openLocalDbPRFn({
+          worktreePath: issueWorktreePath ?? '',
+          repo: repoRef,
+          title,
+          body,
+          branchName,
+          baseBranch: workflowBase.branch,
+          token,
+          skipPush: true,
+        });
+
+    if (workItem.id.startsWith('local:')) {
+      upsertGithubExternalRefFn({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'pull_request',
+        repoRef,
+        externalId: String(prResult.prNumber),
+        url: prResult.prUrl,
+      });
+      upsertGithubExternalRefFn({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'branch',
+        repoRef,
+        externalId: prResult.branch,
+        metadata: { baseBranch: prResult.base },
+      });
+    }
 
     append({
       projectId,


### PR DESCRIPTION
## Summary
- Add local-db-only Work Item creation API and board dialog, preserving empty externalRefs for local-only items.
- Surface local-only state on board cards through the existing externalRefs DTO shape.
- Harden workflow PR open/body paths so local-db Work Items use local references instead of fake GitHub close keywords, while linked GitHub issues still close normally.

## Verification
- pnpm test apps/server/src/domains/issues/service.test.ts apps/server/src/domains/issues/router.test.ts core/state-source/local-db.test.ts core/connectors/github/slice.test.ts apps/web/src/components/board/components/IssueCard.test.tsx apps/web/src/components/board/components/NewLocalIssueDialog.test.tsx slices/parallel-implement/slice.test.ts
- pnpm typecheck
- git diff --check