### PR TITLE
Render fix-feedback regression timeline context

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -31,7 +31,10 @@ import {
   EvidencePostedEvent,
   EvidenceSkippedEvent,
 } from './timeline/EvidenceEvents';
-import { AgentFixFeedbackCompleteEvent } from './timeline/FixFeedbackEvents';
+import {
+  AgentFixFeedbackCompleteEvent,
+  AgentFixFeedbackSkippedEvent,
+} from './timeline/FixFeedbackEvents';
 import {
   GateApprovedEvent,
   GateAwaitingHumanEvent,
@@ -365,6 +368,8 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
       return <AgentImplementCompleteEvent key={event.id} event={event} />;
     case 'agent.fix-feedback-complete':
       return <AgentFixFeedbackCompleteEvent key={event.id} event={event} />;
+    case 'agent.fix-feedback-skipped':
+      return <AgentFixFeedbackSkippedEvent key={event.id} event={event} />;
     case 'agent.retry-escalated':
       return <AgentRetryEscalatedEvent key={event.id} event={event} />;
     case 'grill.question-posted':

--- a/apps/web/src/components/detail/components/timeline/FixFeedbackEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/FixFeedbackEvents.tsx
@@ -1,5 +1,11 @@
 import type { AgentEventDto } from '@/lib/types';
-import { CheckCircle, ClipboardCheck } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle,
+  ClipboardCheck,
+  GitBranch,
+  GitPullRequest,
+} from 'lucide-react';
 
 type FixFeedbackPayload = {
   filesWritten?: number;
@@ -7,12 +13,46 @@ type FixFeedbackPayload = {
   confidence?: string;
   repairMode?: string;
   repairCycle?: number;
+  sourceFailureKind?: string;
+  sourceFailureRunId?: string;
+  devRunId?: string;
+  reason?: string;
+  sourceFeedback?: string;
+  prNumber?: number;
+  branch?: string;
+  branchSource?: string;
   affectedWpIds?: string[];
   testsRun?: {
     command?: string;
     paths?: string[];
   };
 };
+
+function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g'), '');
+}
+
+function formatSlug(value: string): string {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .map((part) => (part.toLowerCase() === 'qa' ? 'QA' : part))
+    .join(' ');
+}
+
+function shortRunId(value: string): string {
+  return value.slice(0, 8);
+}
+
+function feedbackLines(value: string | undefined): string[] {
+  if (value == null) return [];
+  return stripAnsi(value)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4);
+}
 
 function TimelineDot() {
   return <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />;
@@ -22,6 +62,7 @@ export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto 
   const p = event.payload as FixFeedbackPayload | null;
   const command = p?.testsRun?.command;
   const paths = p?.testsRun?.paths ?? [];
+  const sourceFeedbackLines = feedbackLines(p?.sourceFeedback);
   const title =
     p?.repairMode === 'legacy-implement' && p.repairCycle != null
       ? `Legacy Repair Cycle ${p.repairCycle}`
@@ -39,6 +80,10 @@ export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto 
       </div>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-fg-3">
         {p?.repairMode === 'legacy-implement' && <span>legacy implement repair</span>}
+        {p?.sourceFailureKind != null && (
+          <span>{formatSlug(p.sourceFailureKind)} source failure</span>
+        )}
+        {p?.reason != null && <span>{formatSlug(p.reason)}</span>}
         {p?.filesWritten != null && (
           <span>
             {p.filesWritten} file{p.filesWritten === 1 ? '' : 's'} written
@@ -54,6 +99,51 @@ export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto 
           <span>{p.affectedWpIds.join(', ')}</span>
         )}
       </div>
+      {(p?.prNumber != null || p?.branch != null || p?.branchSource != null) && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-fg-3">
+          {p?.prNumber != null && (
+            <span className="inline-flex min-w-0 items-center gap-1">
+              <GitPullRequest size={12} className="shrink-0 text-fg-4" />
+              {`PR #${p.prNumber}`}
+            </span>
+          )}
+          {p?.branch != null && (
+            <span className="inline-flex min-w-0 items-center gap-1">
+              <GitBranch size={12} className="shrink-0 text-fg-4" />
+              <span className="font-mono break-all">{p.branch}</span>
+            </span>
+          )}
+          {p?.branchSource != null && <span>{`branch source ${p.branchSource}`}</span>}
+        </div>
+      )}
+      {(p?.sourceFailureRunId != null || p?.devRunId != null) && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-fg-3">
+          {p.sourceFailureRunId != null && (
+            <span className="font-mono">{`source run ${shortRunId(p.sourceFailureRunId)}`}</span>
+          )}
+          {p.devRunId != null && (
+            <span className="font-mono">{`dev run ${shortRunId(p.devRunId)}`}</span>
+          )}
+        </div>
+      )}
+      {sourceFeedbackLines.length > 0 && (
+        <div className="mt-2 rounded border border-yellow-500/20 bg-yellow-500/5 px-3 py-2">
+          <div className="mb-1 flex items-center gap-1.5 text-[10px] font-mono uppercase text-yellow-400">
+            <AlertTriangle size={11} className="shrink-0" />
+            Source feedback
+          </div>
+          <div className="flex flex-col gap-1">
+            {sourceFeedbackLines.map((line) => (
+              <div
+                key={line}
+                className="font-mono text-[10.5px] text-fg-3 whitespace-pre-wrap break-words"
+              >
+                {line}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       {command != null && (
         <div className="mt-2 flex items-start gap-2 text-[11.5px] text-fg-3">
           <CheckCircle size={12} className="mt-0.5 shrink-0 text-green-400" />

--- a/apps/web/src/components/detail/components/timeline/FixFeedbackEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/FixFeedbackEvents.tsx
@@ -6,6 +6,7 @@ import {
   GitBranch,
   GitPullRequest,
 } from 'lucide-react';
+import type { ComponentType } from 'react';
 
 type FixFeedbackPayload = {
   filesWritten?: number;
@@ -58,22 +59,53 @@ function TimelineDot() {
   return <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />;
 }
 
-export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto }) {
+type FixFeedbackVariant = {
+  fallbackTitle: string;
+  legacyTitle: (cycle: number) => string;
+  borderClass: string;
+  Icon: ComponentType<{ size?: number; className?: string }>;
+  iconClass: string;
+};
+
+const completeVariant: FixFeedbackVariant = {
+  fallbackTitle: 'Fix feedback complete',
+  legacyTitle: (cycle) => `Legacy Repair Cycle ${cycle}`,
+  borderClass: 'border-success bg-bg-elev/60',
+  Icon: ClipboardCheck,
+  iconClass: 'text-green-400',
+};
+
+const skippedVariant: FixFeedbackVariant = {
+  fallbackTitle: 'Fix feedback skipped',
+  legacyTitle: (cycle) => `Legacy Repair Cycle ${cycle} Skipped`,
+  borderClass: 'border-yellow-500/30 bg-yellow-500/5',
+  Icon: AlertTriangle,
+  iconClass: 'text-yellow-400',
+};
+
+function FixFeedbackEventCard({
+  event,
+  variant,
+}: {
+  event: AgentEventDto;
+  variant: FixFeedbackVariant;
+}) {
   const p = event.payload as FixFeedbackPayload | null;
   const command = p?.testsRun?.command;
   const paths = p?.testsRun?.paths ?? [];
   const sourceFeedbackLines = feedbackLines(p?.sourceFeedback);
   const title =
     p?.repairMode === 'legacy-implement' && p.repairCycle != null
-      ? `Legacy Repair Cycle ${p.repairCycle}`
-      : 'Fix feedback complete';
+      ? variant.legacyTitle(p.repairCycle)
+      : variant.fallbackTitle;
+  const Icon = variant.Icon;
   return (
     <li
       data-event-kind={event.kind}
-      className="rounded-md border border-success bg-bg-elev/60 px-4 py-3"
+      className={`rounded-md border ${variant.borderClass} px-4 py-3`}
     >
       <div className="flex flex-wrap items-center gap-2 mb-1 text-[11px] text-fg-3">
-        <ClipboardCheck size={13} className="shrink-0 text-green-400" />
+        <Icon size={13} className={`shrink-0 ${variant.iconClass}`} />
         <span className="font-mono uppercase tracking-wider">{title}</span>
         <TimelineDot />
         <span className="font-mono tnum">{new Date(event.createdAt).toLocaleString()}</span>
@@ -161,4 +193,12 @@ export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto 
       )}
     </li>
   );
+}
+
+export function AgentFixFeedbackCompleteEvent({ event }: { event: AgentEventDto }) {
+  return <FixFeedbackEventCard event={event} variant={completeVariant} />;
+}
+
+export function AgentFixFeedbackSkippedEvent({ event }: { event: AgentEventDto }) {
+  return <FixFeedbackEventCard event={event} variant={skippedVariant} />;
 }

--- a/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
@@ -139,8 +139,8 @@ describe('QA timeline events', () => {
     expect(document.body.textContent).not.toContain('"repairMode"');
   });
 
-  it('renders prompt-contract regression repair context without raw JSON or ANSI codes', () => {
-    const event = makeEvent('agent.fix-feedback-complete', {
+  it('renders skipped prompt-contract regression repair context without raw JSON or ANSI codes', () => {
+    const event = makeEvent('agent.fix-feedback-skipped', {
       pipelineRunId: 'a4ec956d-49c7-468d-a454-66d92b792d73',
       attemptId: 'd4bb85ec-fc83-4977-923e-30a68ff6b2fd',
       repairMode: 'legacy-implement',
@@ -158,7 +158,7 @@ describe('QA timeline events', () => {
 
     render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
 
-    expect(screen.getByText('Legacy Repair Cycle 1')).toBeTruthy();
+    expect(screen.getByText('Legacy Repair Cycle 1 Skipped')).toBeTruthy();
     expect(screen.getByText('QA source failure')).toBeTruthy();
     expect(screen.getAllByText('Prompt Contract Regression')).toHaveLength(1);
     expect(screen.getByText('PR #1145')).toBeTruthy();

--- a/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
@@ -139,6 +139,40 @@ describe('QA timeline events', () => {
     expect(document.body.textContent).not.toContain('"repairMode"');
   });
 
+  it('renders prompt-contract regression repair context without raw JSON or ANSI codes', () => {
+    const event = makeEvent('agent.fix-feedback-complete', {
+      pipelineRunId: 'a4ec956d-49c7-468d-a454-66d92b792d73',
+      attemptId: 'd4bb85ec-fc83-4977-923e-30a68ff6b2fd',
+      repairMode: 'legacy-implement',
+      repairCycle: 1,
+      sourceFailureKind: 'qa',
+      sourceFailureRunId: '8fb1f0bf-9389-49b2-a781-9cfde65cd87c',
+      prNumber: 1145,
+      devRunId: '9d83b68f-8c53-4019-b07f-ec8ebe4c1194',
+      branch: 'factory/run/a4ec956d-49c7-468d-a454-66d92b792d73',
+      branchSource: 'pr.opened',
+      reason: 'prompt-contract-regression',
+      sourceFeedback:
+        'QA regression suite failed on a prompt-contract test rather than this issue-specific implementation surface.\nFailure category: prompt-contract-regression\n- Regression [escalate]: \u001b[41m\u001b[1m FAIL \u001b[22m\u001b[49m skills/implement/slice.test.ts',
+    });
+
+    render(<ul>{renderTimelineItem({ kind: 'event', event }, 0)}</ul>);
+
+    expect(screen.getByText('Legacy Repair Cycle 1')).toBeTruthy();
+    expect(screen.getByText('QA source failure')).toBeTruthy();
+    expect(screen.getAllByText('Prompt Contract Regression')).toHaveLength(1);
+    expect(screen.getByText('PR #1145')).toBeTruthy();
+    expect(screen.getByText('factory/run/a4ec956d-49c7-468d-a454-66d92b792d73')).toBeTruthy();
+    expect(screen.getByText('branch source pr.opened')).toBeTruthy();
+    expect(screen.getByText('source run 8fb1f0bf')).toBeTruthy();
+    expect(screen.getByText('dev run 9d83b68f')).toBeTruthy();
+    expect(screen.getByText('Source feedback')).toBeTruthy();
+    expect(screen.getByText(/QA regression suite failed/)).toBeTruthy();
+    expect(screen.getByText(/FAIL\s+skills\/implement\/slice\.test\.ts/)).toBeTruthy();
+    expect(document.body.textContent).not.toContain('\u001b');
+    expect(document.body.textContent).not.toContain('"sourceFeedback"');
+  });
+
   it('only names affected WPs when affectedWpIds exists', () => {
     const event = makeEvent('agent.fix-feedback-complete', {
       repairMode: 'legacy-implement',


### PR DESCRIPTION
## Summary
- render legacy fix-feedback repair payload context in the timeline card
- show prompt-contract regression reason, source QA/dev runs, PR/branch context, and ANSI-stripped source feedback
- cover the supplied prompt-contract regression payload in the timeline component test

## Verification
- pnpm vitest apps/web/src/components/detail/components/timeline/QaEvents.test.tsx
- pnpm exec biome check apps/web/src/components/detail/components/timeline/FixFeedbackEvents.tsx apps/web/src/components/detail/components/timeline/QaEvents.test.tsx