### PR TITLE
PR F: Add Bitbucket PR diff linking

### DIFF
--- a/core/integrations/atlassian/adapters.ts
+++ b/core/integrations/atlassian/adapters.ts
@@ -1,5 +1,6 @@
 import type {
   BitbucketPullRequestDetailDto,
+  BitbucketPullRequestDiffDto,
   JiraIssueCardDto,
   JiraIssueDetailDto,
 } from './dtos.js';
@@ -61,4 +62,9 @@ export interface BitbucketProviderAdapter {
   searchPullRequests(
     input: BitbucketPullRequestSearchRequest,
   ): Promise<ProviderResult<AtlassianSearchPage<BitbucketPullRequestDetailDto>>>;
+  getPullRequestDiff(input: {
+    workspace: string;
+    repo: string;
+    pullRequestId: string;
+  }): Promise<ProviderResult<BitbucketPullRequestDiffDto>>;
 }

--- a/core/integrations/atlassian/dtos.test.ts
+++ b/core/integrations/atlassian/dtos.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { AtlassianDetailSchema, AtlassianEvidenceSchema, AtlassianHeadlineSchema } from './dtos.js';
+import {
+  AtlassianDetailSchema,
+  AtlassianEvidenceSchema,
+  AtlassianHeadlineSchema,
+  BitbucketPullRequestDiffSchema,
+} from './dtos.js';
 
 describe('Atlassian DTO schemas', () => {
   it('accepts headline, detail, and evidence tiers with artifact refs for provider bodies', () => {
@@ -76,6 +81,17 @@ describe('Atlassian DTO schemas', () => {
         ],
       }),
     ).toMatchObject({ provider: 'bitbucket', tier: 'evidence' });
+
+    expect(
+      BitbucketPullRequestDiffSchema.parse({
+        provider: 'bitbucket',
+        resourceKind: 'pull_request',
+        repoRef: 'company/api',
+        externalId: '45',
+        diff: 'diff --git a/a.ts b/a.ts',
+        url: 'https://bitbucket.org/company/api/pull-requests/45',
+      }),
+    ).toMatchObject({ provider: 'bitbucket', resourceKind: 'pull_request' });
   });
 
   it('rejects inline raw provider payloads at the service boundary', () => {

--- a/core/integrations/atlassian/dtos.ts
+++ b/core/integrations/atlassian/dtos.ts
@@ -103,6 +103,17 @@ export const BitbucketPullRequestDetailSchema = AtlassianDetailSchema.extend({
   resourceKind: z.literal('pull_request'),
 }).strict();
 
+export const BitbucketPullRequestDiffSchema = z
+  .object({
+    provider: z.literal('bitbucket'),
+    resourceKind: z.literal('pull_request'),
+    repoRef: z.string().min(1),
+    externalId: z.string().min(1),
+    diff: z.string(),
+    url: z.string().url().optional(),
+  })
+  .strict();
+
 export type AtlassianProvider = z.infer<typeof AtlassianProviderSchema>;
 export type AtlassianTier = z.infer<typeof AtlassianTierSchema>;
 export type AtlassianArtifactRef = z.infer<typeof AtlassianArtifactRefSchema>;
@@ -116,3 +127,4 @@ export type JiraIssueDetailDto = z.infer<typeof JiraIssueDetailSchema>;
 export type BitbucketPullRequestHeadlineDto = z.infer<typeof BitbucketPullRequestHeadlineSchema>;
 export type BitbucketPullRequestCardDto = z.infer<typeof BitbucketPullRequestCardSchema>;
 export type BitbucketPullRequestDetailDto = z.infer<typeof BitbucketPullRequestDetailSchema>;
+export type BitbucketPullRequestDiffDto = z.infer<typeof BitbucketPullRequestDiffSchema>;

--- a/core/integrations/bitbucket/external-refs.test.ts
+++ b/core/integrations/bitbucket/external-refs.test.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { LocalDbWorkItemRepository } from '../../state-source/local-db-repository.js';
+import { upsertBitbucketPullRequestRef } from './external-refs.js';
+
+function makeRepository() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  const migrationsFolder = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'db',
+    'migrations',
+  );
+  migrate(db, { migrationsFolder });
+  const repository = new LocalDbWorkItemRepository({
+    db,
+    now: () => new Date('2026-05-26T00:00:00.000Z'),
+  });
+  return { sqlite, repository };
+}
+
+describe('Bitbucket external refs', () => {
+  const handles: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const handle of handles.splice(0)) handle.close();
+  });
+
+  function trackedRepository(): ReturnType<typeof makeRepository> {
+    const result = makeRepository();
+    handles.push(result.sqlite);
+    return result;
+  }
+
+  it('upserts pull request refs idempotently with Bitbucket provider identity', () => {
+    const { repository } = trackedRepository();
+    const item = repository.createWorkItem({ projectId: 'proj', title: 'Bitbucket PR' });
+
+    const first = upsertBitbucketPullRequestRef({
+      projectId: 'proj',
+      workItemId: item.id,
+      workspace: 'workspace',
+      repo: 'repo',
+      pullRequestId: 45,
+      metadata: { state: 'OPEN' },
+      repository,
+    });
+    const second = upsertBitbucketPullRequestRef({
+      projectId: 'proj',
+      workItemId: item.id,
+      workspace: 'workspace',
+      repo: 'repo',
+      pullRequestId: '45',
+      metadata: { state: 'MERGED' },
+      repository,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(repository.listExternalRefs('proj', item.id)).toEqual([
+      expect.objectContaining({
+        provider: 'bitbucket',
+        kind: 'pull_request',
+        repoRef: 'workspace/repo',
+        externalId: '45',
+        url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+        metadataJson: JSON.stringify({ state: 'MERGED' }),
+      }),
+    ]);
+  });
+});

--- a/core/integrations/bitbucket/external-refs.ts
+++ b/core/integrations/bitbucket/external-refs.ts
@@ -1,0 +1,55 @@
+import { LocalDbWorkItemRepository } from '../../state-source/local-db-repository.js';
+import type { LocalDbExternalRefRow } from '../../state-source/local-db-repository.js';
+
+export interface BitbucketPullRequestExternalRefInput {
+  projectId: string;
+  workItemId: string;
+  workspace: string;
+  repo: string;
+  pullRequestId: number | string;
+  url?: string | null;
+  metadata?: unknown;
+  repository?: LocalDbWorkItemRepository;
+}
+
+export function bitbucketRepoRef(input: { workspace: string; repo: string }): string {
+  return `${input.workspace}/${input.repo}`;
+}
+
+export function bitbucketPullRequestUrl(input: {
+  workspace: string;
+  repo: string;
+  pullRequestId: number | string;
+}): string {
+  return `https://bitbucket.org/${encodeURIComponent(input.workspace)}/${encodeURIComponent(
+    input.repo,
+  )}/pull-requests/${encodeURIComponent(String(input.pullRequestId))}`;
+}
+
+export function upsertBitbucketPullRequestRef(
+  input: BitbucketPullRequestExternalRefInput,
+): LocalDbExternalRefRow {
+  const repository = input.repository ?? new LocalDbWorkItemRepository();
+  return repository.upsertExternalRef({
+    projectId: input.projectId,
+    itemId: input.workItemId,
+    provider: 'bitbucket',
+    kind: 'pull_request',
+    repoRef: bitbucketRepoRef(input),
+    externalId: String(input.pullRequestId),
+    url: input.url ?? bitbucketPullRequestUrl(input),
+    metadata: input.metadata,
+  });
+}
+
+export function latestBitbucketPullRequestRef(input: {
+  projectId: string;
+  workItemId: string;
+  repository?: LocalDbWorkItemRepository;
+}): LocalDbExternalRefRow | null {
+  const repository = input.repository ?? new LocalDbWorkItemRepository();
+  const refs = repository
+    .listExternalRefs(input.projectId, input.workItemId)
+    .filter((ref) => ref.provider === 'bitbucket' && ref.kind === 'pull_request');
+  return refs.at(-1) ?? null;
+}

--- a/core/integrations/bitbucket/index.ts
+++ b/core/integrations/bitbucket/index.ts
@@ -1,0 +1,2 @@
+export * from './external-refs.js';
+export * from './rest.js';

--- a/core/integrations/bitbucket/rest.test.ts
+++ b/core/integrations/bitbucket/rest.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBitbucketRestAdapter } from './rest.js';
+
+function response(status: number, body: unknown, statusText = 'OK') {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => String(body),
+  } as Response;
+}
+
+describe('Bitbucket REST adapter', () => {
+  it('maps pull request metadata into a validated detail DTO', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response(200, {
+        id: 45,
+        title: 'Ship provider-specific PR diffs',
+        state: 'OPEN',
+        description: 'Use the Bitbucket diff endpoint.',
+        created_on: '2026-05-26T00:00:00.000Z',
+        updated_on: '2026-05-27T00:00:00.000Z',
+        links: {
+          html: {
+            href: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+          },
+        },
+        destination: {
+          repository: {
+            full_name: 'workspace/repo',
+          },
+        },
+      }),
+    );
+    const adapter = createBitbucketRestAdapter({
+      username: 'ada',
+      appPassword: 'secret-token',
+      fetchImpl,
+    });
+
+    await expect(
+      adapter.getPullRequest({
+        workspace: 'workspace',
+        repo: 'repo',
+        pullRequestId: '45',
+        tier: 'detail',
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        provider: 'bitbucket',
+        resourceKind: 'pull_request',
+        tier: 'detail',
+        id: '45',
+        title: 'Ship provider-specific PR diffs',
+        status: 'OPEN',
+        repoRef: 'workspace/repo',
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/45',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          Authorization: expect.stringMatching(/^Basic /),
+        }),
+      }),
+    );
+  });
+
+  it('returns typed pull request diffs from the diff endpoint', async () => {
+    const fetchImpl = vi.fn(async () => response(200, 'diff --git a/a.ts b/a.ts'));
+    const adapter = createBitbucketRestAdapter({
+      accessToken: 'access-token',
+      fetchImpl,
+    });
+
+    await expect(
+      adapter.getPullRequestDiff({
+        workspace: 'workspace',
+        repo: 'repo',
+        pullRequestId: '45',
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        provider: 'bitbucket',
+        resourceKind: 'pull_request',
+        repoRef: 'workspace/repo',
+        externalId: '45',
+        diff: 'diff --git a/a.ts b/a.ts',
+        url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/45/diff',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'text/plain',
+          Authorization: 'Bearer access-token',
+        }),
+      }),
+    );
+  });
+
+  it('maps provider HTTP errors into typed failures', async () => {
+    const adapter = createBitbucketRestAdapter({
+      accessToken: 'access-token',
+      fetchImpl: vi.fn(async () => response(404, { error: { message: 'Not found' } }, 'Not Found')),
+    });
+
+    await expect(
+      adapter.getPullRequestDiff({
+        workspace: 'workspace',
+        repo: 'repo',
+        pullRequestId: '45',
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { kind: 'not_found', status: 404 },
+    });
+  });
+});

--- a/core/integrations/bitbucket/rest.ts
+++ b/core/integrations/bitbucket/rest.ts
@@ -1,0 +1,355 @@
+import type {
+  AtlassianSearchPage,
+  BitbucketProviderAdapter,
+  BitbucketPullRequestSearchRequest,
+} from '../atlassian/adapters.js';
+import type {
+  BitbucketPullRequestDetailDto,
+  BitbucketPullRequestDiffDto,
+} from '../atlassian/dtos.js';
+import {
+  BitbucketPullRequestDetailSchema,
+  BitbucketPullRequestDiffSchema,
+} from '../atlassian/dtos.js';
+import {
+  type ProviderResult,
+  mapHttpStatusToProviderErrorKind,
+  providerFailure,
+} from '../atlassian/errors.js';
+
+export interface BitbucketRestAdapterOptions {
+  baseUrl?: string;
+  username?: string;
+  appPassword?: string;
+  accessToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface BitbucketRestAdapterFromEnvOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface BitbucketPullRequestRest {
+  id?: unknown;
+  title?: unknown;
+  state?: unknown;
+  description?: unknown;
+  created_on?: unknown;
+  updated_on?: unknown;
+  links?: {
+    html?: {
+      href?: unknown;
+    };
+  };
+  source?: {
+    repository?: {
+      full_name?: unknown;
+    };
+  };
+  destination?: {
+    repository?: {
+      full_name?: unknown;
+    };
+  };
+}
+
+interface BitbucketPullRequestSearchResponse {
+  values?: unknown;
+  size?: unknown;
+  pagelen?: unknown;
+  next?: unknown;
+}
+
+export function createBitbucketRestAdapterFromEnv(
+  options: BitbucketRestAdapterFromEnvOptions = {},
+): BitbucketProviderAdapter {
+  return createBitbucketRestAdapter({
+    ...options,
+    username: process.env.BITBUCKET_USERNAME,
+    appPassword: process.env.BITBUCKET_APP_PASSWORD,
+    accessToken: process.env.BITBUCKET_TOKEN,
+  });
+}
+
+export function createBitbucketRestAdapter(
+  options: BitbucketRestAdapterOptions,
+): BitbucketProviderAdapter {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = (options.baseUrl ?? 'https://api.bitbucket.org/2.0').replace(/\/+$/, '');
+  const authorization = authorizationHeader(options);
+
+  if (authorization == null) return missingCredentialsAdapter();
+
+  return {
+    async getPullRequest(input): Promise<ProviderResult<BitbucketPullRequestDetailDto>> {
+      const url = pullRequestApiUrl(baseUrl, input);
+      const response = await requestBitbucket(fetchImpl, url, authorization, 'application/json');
+      if (!response.ok) return response;
+
+      let raw: unknown;
+      try {
+        raw = await response.data.json();
+      } catch (err) {
+        return providerFailure('connection', `Failed to parse Bitbucket response: ${String(err)}`);
+      }
+
+      try {
+        return {
+          ok: true,
+          data: BitbucketPullRequestDetailSchema.parse(mapPullRequest(raw, input)),
+        };
+      } catch (err) {
+        return providerFailure(
+          'validation',
+          `Bitbucket pull request response failed validation: ${String(err)}`,
+        );
+      }
+    },
+
+    async searchPullRequests(
+      input: BitbucketPullRequestSearchRequest,
+    ): Promise<ProviderResult<AtlassianSearchPage<BitbucketPullRequestDetailDto>>> {
+      const pullRequests: BitbucketPullRequestDetailDto[] = [];
+      let totalCount = 0;
+      let hasMore = false;
+
+      for (const repo of input.repos) {
+        const url = new URL(
+          `${baseUrl}/repositories/${encodeURIComponent(input.workspace)}/${encodeURIComponent(
+            repo,
+          )}/pullrequests`,
+        );
+        url.searchParams.set('pagelen', String(input.maxResults));
+        url.searchParams.set('q', buildPullRequestQuery(input));
+
+        const response = await requestBitbucket(
+          fetchImpl,
+          url.toString(),
+          authorization,
+          'application/json',
+        );
+        if (!response.ok) return response;
+
+        let raw: unknown;
+        try {
+          raw = await response.data.json();
+        } catch (err) {
+          return providerFailure(
+            'connection',
+            `Failed to parse Bitbucket search response: ${String(err)}`,
+          );
+        }
+
+        try {
+          const page = mapSearchResponse(raw, input.workspace, repo);
+          totalCount += page.totalCount;
+          hasMore = hasMore || page.hasMore;
+          pullRequests.push(...page.pullRequests);
+        } catch (err) {
+          return providerFailure(
+            'validation',
+            `Bitbucket search response failed validation: ${String(err)}`,
+          );
+        }
+      }
+
+      return {
+        ok: true,
+        data: {
+          provider: 'bitbucket',
+          tier: 'detail',
+          pullRequests: pullRequests.slice(0, input.maxResults),
+          totalCount,
+          hasMore: hasMore || pullRequests.length > input.maxResults,
+        },
+      };
+    },
+
+    async getPullRequestDiff(input): Promise<ProviderResult<BitbucketPullRequestDiffDto>> {
+      const url = `${pullRequestApiUrl(baseUrl, input)}/diff`;
+      const response = await requestBitbucket(fetchImpl, url, authorization, 'text/plain');
+      if (!response.ok) return response;
+
+      let diff: string;
+      try {
+        diff = await response.data.text();
+      } catch (err) {
+        return providerFailure('connection', `Failed to read Bitbucket diff: ${String(err)}`);
+      }
+
+      try {
+        return {
+          ok: true,
+          data: BitbucketPullRequestDiffSchema.parse({
+            provider: 'bitbucket',
+            resourceKind: 'pull_request',
+            repoRef: `${input.workspace}/${input.repo}`,
+            externalId: input.pullRequestId,
+            diff,
+            url: bitbucketWebPullRequestUrl(input),
+          }),
+        };
+      } catch (err) {
+        return providerFailure(
+          'validation',
+          `Bitbucket pull request diff failed validation: ${String(err)}`,
+        );
+      }
+    },
+  };
+}
+
+function missingCredentialsAdapter(): BitbucketProviderAdapter {
+  return {
+    async getPullRequest() {
+      return providerFailure('auth', 'Bitbucket credentials are not configured');
+    },
+    async searchPullRequests() {
+      return providerFailure('auth', 'Bitbucket credentials are not configured');
+    },
+    async getPullRequestDiff() {
+      return providerFailure('auth', 'Bitbucket credentials are not configured');
+    },
+  };
+}
+
+async function requestBitbucket(
+  fetchImpl: typeof fetch,
+  url: string,
+  authorization: string,
+  accept: string,
+): Promise<ProviderResult<Response>> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Accept: accept,
+        Authorization: authorization,
+      },
+    });
+  } catch (err) {
+    return providerFailure('connection', `Failed to connect to Bitbucket: ${String(err)}`);
+  }
+
+  if (!response.ok) {
+    return providerFailure(
+      mapHttpStatusToProviderErrorKind(response.status, 'read'),
+      response.statusText || `Bitbucket request failed with ${response.status}`,
+      { status: response.status },
+    );
+  }
+
+  return { ok: true, data: response };
+}
+
+function authorizationHeader(options: BitbucketRestAdapterOptions): string | null {
+  if (options.accessToken != null && options.accessToken.trim().length > 0) {
+    return `Bearer ${options.accessToken.trim()}`;
+  }
+  if (
+    options.username != null &&
+    options.username.trim().length > 0 &&
+    options.appPassword != null &&
+    options.appPassword.trim().length > 0
+  ) {
+    return `Basic ${Buffer.from(`${options.username}:${options.appPassword}`).toString('base64')}`;
+  }
+  return null;
+}
+
+function pullRequestApiUrl(
+  baseUrl: string,
+  input: { workspace: string; repo: string; pullRequestId: string },
+): string {
+  return `${baseUrl}/repositories/${encodeURIComponent(input.workspace)}/${encodeURIComponent(
+    input.repo,
+  )}/pullrequests/${encodeURIComponent(input.pullRequestId)}`;
+}
+
+function bitbucketWebPullRequestUrl(input: {
+  workspace: string;
+  repo: string;
+  pullRequestId: string;
+}): string {
+  return `https://bitbucket.org/${encodeURIComponent(input.workspace)}/${encodeURIComponent(
+    input.repo,
+  )}/pull-requests/${encodeURIComponent(input.pullRequestId)}`;
+}
+
+function mapPullRequest(
+  raw: unknown,
+  input: { workspace: string; repo: string; pullRequestId: string },
+): BitbucketPullRequestDetailDto {
+  const pullRequest = raw as BitbucketPullRequestRest;
+  const id = stringValue(pullRequest.id) || input.pullRequestId;
+  const title = stringValue(pullRequest.title) || `Pull request ${id}`;
+  const repoRef =
+    stringValue(pullRequest.destination?.repository?.full_name) ||
+    stringValue(pullRequest.source?.repository?.full_name) ||
+    `${input.workspace}/${input.repo}`;
+  return {
+    provider: 'bitbucket',
+    resourceKind: 'pull_request',
+    tier: 'detail',
+    id,
+    title,
+    status: stringValue(pullRequest.state) || 'UNKNOWN',
+    url: stringValue(pullRequest.links?.html?.href) || bitbucketWebPullRequestUrl(input),
+    repoRef,
+    created: stringValue(pullRequest.created_on) || undefined,
+    updated: stringValue(pullRequest.updated_on) || undefined,
+    bodyPreview: stringValue(pullRequest.description) || undefined,
+    labels: [],
+    components: [],
+    linkedKeys: [],
+  };
+}
+
+function mapSearchResponse(
+  raw: unknown,
+  workspace: string,
+  repo: string,
+): { pullRequests: BitbucketPullRequestDetailDto[]; totalCount: number; hasMore: boolean } {
+  const response = raw as BitbucketPullRequestSearchResponse;
+  const values = Array.isArray(response.values) ? response.values : [];
+  const pullRequests = values.map((value) =>
+    BitbucketPullRequestDetailSchema.parse(
+      mapPullRequest(value, {
+        workspace,
+        repo,
+        pullRequestId: stringValue((value as BitbucketPullRequestRest).id),
+      }),
+    ),
+  );
+  return {
+    pullRequests,
+    totalCount: numberValue(response.size) ?? pullRequests.length,
+    hasMore: stringValue(response.next).length > 0,
+  };
+}
+
+function buildPullRequestQuery(input: BitbucketPullRequestSearchRequest): string {
+  const clauses = [
+    `updated_on >= ${bitbucketQueryString(input.updated.from)}`,
+    `updated_on <= ${bitbucketQueryString(input.updated.to)}`,
+    input.text != null && input.text.trim().length > 0
+      ? `title ~ ${bitbucketQueryString(input.text)}`
+      : undefined,
+  ].filter((clause): clause is string => clause != null);
+  return clauses.join(' AND ');
+}
+
+function bitbucketQueryString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return '';
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}

--- a/core/state-source/local-db.test.ts
+++ b/core/state-source/local-db.test.ts
@@ -3,12 +3,13 @@ import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../db/schema.js';
 import { LocalDbWorkItemRepository } from './local-db-repository.js';
 import { LocalDbStateSource } from './local-db.js';
+import type { LocalDbPrDiffAdapters } from './local-db.js';
 
-function makeSource() {
+function makeSource(prDiffAdapters?: LocalDbPrDiffAdapters) {
   const sqlite = new Database(':memory:');
   const db = drizzle(sqlite, { schema });
   const migrationsFolder = path.join(
@@ -25,7 +26,7 @@ function makeSource() {
   return {
     sqlite,
     repository,
-    source: new LocalDbStateSource('proj', 'owner/repo', repository),
+    source: new LocalDbStateSource('proj', 'owner/repo', repository, undefined, prDiffAdapters),
   };
 }
 
@@ -33,11 +34,12 @@ describe('LocalDbStateSource', () => {
   const handles: Database.Database[] = [];
 
   afterEach(() => {
+    vi.restoreAllMocks();
     for (const handle of handles.splice(0)) handle.close();
   });
 
-  function trackedSource(): ReturnType<typeof makeSource> {
-    const result = makeSource();
+  function trackedSource(prDiffAdapters?: LocalDbPrDiffAdapters): ReturnType<typeof makeSource> {
+    const result = makeSource(prDiffAdapters);
     handles.push(result.sqlite);
     return result;
   }
@@ -195,7 +197,69 @@ describe('LocalDbStateSource', () => {
     expect(await source.listLabels(created.id)).not.toContain('custom:manual');
   });
 
-  it('uses no-op compatibility methods until local pubsub and PR diff linking are implemented', async () => {
+  it('routes GitHub PR diff refs through the GitHub diff adapter', async () => {
+    const githubDiff = vi.fn(async () => 'diff --git a/src/github.ts b/src/github.ts');
+    const bitbucketDiff = vi.fn(async () => 'unexpected');
+    const { source, repository } = trackedSource({
+      github: { getPullRequestDiff: githubDiff },
+      bitbucket: { getPullRequestDiff: bitbucketDiff },
+    });
+    const created = await source.createIssue({ title: 'GitHub-linked work', body: '' });
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: created.id,
+      provider: 'github',
+      kind: 'pull_request',
+      repoRef: 'owner/repo',
+      externalId: '9',
+      url: 'https://github.com/owner/repo/pull/9',
+    });
+
+    await expect(source.getPrDiff(created.id)).resolves.toBe(
+      'diff --git a/src/github.ts b/src/github.ts',
+    );
+    expect(githubDiff).toHaveBeenCalledWith({ repoRef: 'owner/repo', pullRequestId: '9' });
+    expect(bitbucketDiff).not.toHaveBeenCalled();
+  });
+
+  it('routes Bitbucket PR diff refs through the Bitbucket adapter without driving local state', async () => {
+    const githubDiff = vi.fn(async () => 'unexpected');
+    const bitbucketDiff = vi.fn(async () => 'diff --git a/src/bitbucket.ts b/src/bitbucket.ts');
+    const { source, repository } = trackedSource({
+      github: { getPullRequestDiff: githubDiff },
+      bitbucket: { getPullRequestDiff: bitbucketDiff },
+    });
+    const created = await source.createIssue({ title: 'Bitbucket-linked work', body: '' });
+    repository.upsertExternalRef({
+      projectId: 'proj',
+      itemId: created.id,
+      provider: 'bitbucket',
+      kind: 'pull_request',
+      repoRef: 'workspace/repo',
+      externalId: '45',
+      url: 'https://bitbucket.org/workspace/repo/pull-requests/45',
+      metadata: { state: 'MERGED' },
+    });
+
+    await expect(source.getPrDiff(created.id)).resolves.toBe(
+      'diff --git a/src/bitbucket.ts b/src/bitbucket.ts',
+    );
+    expect(bitbucketDiff).toHaveBeenCalledWith({ repoRef: 'workspace/repo', pullRequestId: '45' });
+    expect(githubDiff).not.toHaveBeenCalled();
+    await expect(source.getItem(created.id)).resolves.toMatchObject({
+      state: 'factory:triaging',
+      externalRefs: [
+        expect.objectContaining({
+          provider: 'bitbucket',
+          kind: 'pull_request',
+          metadata: { state: 'MERGED' },
+        }),
+      ],
+    });
+    expect(repository.listStateEvents('proj', created.id)).toHaveLength(1);
+  });
+
+  it('keeps attach, watch, and missing PR diff methods as compatibility no-ops', async () => {
     const { source } = trackedSource();
     const created = await source.createIssue({ title: 'A', body: '' });
     const subscription = await source.watchForUpdates(() => {});

--- a/core/state-source/local-db.ts
+++ b/core/state-source/local-db.ts
@@ -1,3 +1,4 @@
+import { createBitbucketRestAdapterFromEnv } from '../integrations/bitbucket/rest.js';
 import { mirrorGithubLabels } from '../integrations/github/label-mirror.js';
 import type { StateName } from '../state-machine/states.js';
 import { STATES } from '../state-machine/states.js';
@@ -24,6 +25,19 @@ const PRIORITIES = new Set<Priority>(['critical', 'high', 'medium', 'low']);
 const SCHEDULES = new Set<Schedule>(['current', 'next', 'later', 'blocked-by']);
 const TYPES = new Set<WorkItemType>(['feature', 'bug', 'chore', 'research']);
 const STATE_LABELS = new Set<string>(STATES);
+
+export interface LocalDbGithubPrDiffAdapter {
+  getPullRequestDiff(input: { repoRef: string; pullRequestId: string }): Promise<string>;
+}
+
+export interface LocalDbBitbucketPrDiffAdapter {
+  getPullRequestDiff(input: { repoRef: string; pullRequestId: string }): Promise<string>;
+}
+
+export interface LocalDbPrDiffAdapters {
+  github?: LocalDbGithubPrDiffAdapter;
+  bitbucket?: LocalDbBitbucketPrDiffAdapter;
+}
 
 function parseStateLabel(label: string): StateName | null {
   return STATE_LABELS.has(label) ? (label as StateName) : null;
@@ -75,6 +89,7 @@ export class LocalDbStateSource implements StateSource {
     readonly repoRef: string,
     private readonly repository = new LocalDbWorkItemRepository(),
     private readonly integrations?: LocalDbSourceConfig['integrations'],
+    private readonly prDiffAdapters: LocalDbPrDiffAdapters = defaultPrDiffAdapters(),
   ) {}
 
   private toWorkItem(row: LocalDbWorkItemRow): WorkItem {
@@ -289,23 +304,26 @@ export class LocalDbStateSource implements StateSource {
     const item = this.repository.requireWorkItem(this.projectId, itemId);
     const prRefs = this.repository
       .listExternalRefs(this.projectId, item.id)
-      .filter((ref) => ref.provider === 'github' && ref.kind === 'pull_request');
+      .filter((ref) => ref.kind === 'pull_request');
     const ref = prRefs[prRefs.length - 1];
     if (ref == null || ref.repoRef == null) return '';
-    const token = process.env.GITHUB_TOKEN ?? '';
-    if (token.length === 0) return '';
-    const response = await fetch(
-      `https://api.github.com/repos/${ref.repoRef}/pulls/${ref.externalId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github.v3.diff',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      },
-    );
-    if (!response.ok) return '';
-    return response.text();
+    if (ref.provider === 'github') {
+      return (
+        (await this.prDiffAdapters.github?.getPullRequestDiff({
+          repoRef: ref.repoRef,
+          pullRequestId: ref.externalId,
+        })) ?? ''
+      );
+    }
+    if (ref.provider === 'bitbucket') {
+      return (
+        (await this.prDiffAdapters.bitbucket?.getPullRequestDiff({
+          repoRef: ref.repoRef,
+          pullRequestId: ref.externalId,
+        })) ?? ''
+      );
+    }
+    return '';
   }
 
   async watchForUpdates(_callback: (event: SourceEvent) => void): Promise<Subscription> {
@@ -321,4 +339,41 @@ export class LocalDbStateSource implements StateSource {
       repository: this.repository,
     });
   }
+}
+
+function defaultPrDiffAdapters(): LocalDbPrDiffAdapters {
+  return {
+    github: {
+      async getPullRequestDiff(input) {
+        const token = process.env.GITHUB_TOKEN ?? '';
+        if (token.length === 0) return '';
+        const response = await fetch(
+          `https://api.github.com/repos/${input.repoRef}/pulls/${input.pullRequestId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: 'application/vnd.github.v3.diff',
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+          },
+        );
+        if (!response.ok) return '';
+        return response.text();
+      },
+    },
+    bitbucket: {
+      async getPullRequestDiff(input) {
+        const [workspace, ...repoParts] = input.repoRef.split('/');
+        const repo = repoParts.join('/');
+        if (workspace == null || workspace.length === 0 || repo.length === 0) return '';
+        const adapter = createBitbucketRestAdapterFromEnv();
+        const result = await adapter.getPullRequestDiff({
+          workspace,
+          repo,
+          pullRequestId: input.pullRequestId,
+        });
+        return result.ok ? result.data.diff : '';
+      },
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add typed Bitbucket pull request external-ref helpers for provider/kind/repo identity
- add Bitbucket REST adapter methods for pull request metadata and typed diff retrieval
- route local-db PR diff lookup by external-ref provider while preserving GitHub diff behavior

## Verification
- pnpm test core/integrations/bitbucket/rest.test.ts core/integrations/bitbucket/external-refs.test.ts core/state-source/local-db.test.ts core/integrations/atlassian/dtos.test.ts
- pnpm test core/state-source/local-db-repository.test.ts apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/components/ExternalRefsSection.test.tsx
- pnpm exec biome check core/integrations/atlassian/adapters.ts core/integrations/atlassian/dtos.ts core/integrations/atlassian/dtos.test.ts core/integrations/bitbucket/external-refs.ts core/integrations/bitbucket/external-refs.test.ts core/integrations/bitbucket/index.ts core/integrations/bitbucket/rest.ts core/integrations/bitbucket/rest.test.ts core/state-source/local-db.ts core/state-source/local-db.test.ts
- pnpm typecheck