### PR TITLE
M19.XX: grill bug

### DIFF
--- a/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
@@ -58,6 +58,14 @@ describe('ReviewGroupWrapper', () => {
         kind: 'event',
         event: makeEvent('state.transitioned', {
           reviewWorkflowRunId,
+          from: 'factory:gate-pending',
+          to: 'factory:grilling',
+        }),
+      },
+      {
+        kind: 'event',
+        event: makeEvent('state.transitioned', {
+          reviewWorkflowRunId,
           to: 'factory:prd-drafting',
         }),
       },

--- a/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/ReviewGroupWrapper.test.tsx
@@ -2,7 +2,7 @@ import type { AgentEventDto } from '@/lib/types';
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { RenderItem } from '../../lib/timeline';
+import { type RenderItem, groupByReviewWorkflow } from '../../lib/timeline';
 import { ReviewGroupWrapper } from './ReviewGroupWrapper';
 
 afterEach(cleanup);
@@ -45,5 +45,44 @@ describe('ReviewGroupWrapper', () => {
     expect(screen.getByText('Review Run')).toBeTruthy();
     expect(screen.getByText('Complete')).toBeTruthy();
     expect(screen.queryByText('(Unknown) Run')).toBeNull();
+  });
+
+  it('renders a post-grill review workflow with the completed presentation', () => {
+    const reviewWorkflowRunId = 'review-grill-complete';
+    const grouped = groupByReviewWorkflow([
+      {
+        kind: 'event',
+        event: makeEvent('question.asked', { reviewWorkflowRunId }),
+      },
+      {
+        kind: 'event',
+        event: makeEvent('state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      },
+    ]);
+    const reviewGroup = grouped[0];
+
+    expect(reviewGroup?.kind).toBe('review-group');
+    if (reviewGroup?.kind !== 'review-group') return;
+
+    render(
+      <ul>
+        <ReviewGroupWrapper
+          reviewWorkflowRunId={reviewGroup.reviewWorkflowRunId}
+          items={reviewGroup.items}
+          status={reviewGroup.status}
+          startedAt={reviewGroup.startedAt}
+          endedAt={reviewGroup.endedAt}
+          lastEventAt={reviewGroup.lastEventAt}
+          renderItem={(child, idx) => <li key={`${child.kind}-${idx}`}>review child</li>}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Review Run')).toBeTruthy();
+    expect(screen.getByText('Complete')).toBeTruthy();
+    expect(screen.queryByText('Live')).toBeNull();
   });
 });

--- a/apps/web/src/components/detail/lib/timeline/index.test.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.test.ts
@@ -19,6 +19,17 @@ function makeReviewItems(...events: AgentEventDto[]): RenderItem[] {
 }
 
 describe('groupByReviewWorkflow grill completion status', () => {
+  function makeAnsweredGrillEvents(reviewWorkflowRunId: string): AgentEventDto[] {
+    return [
+      makeEvent(1, 'question.asked', { reviewWorkflowRunId }),
+      makeEvent(2, 'state.transitioned', {
+        reviewWorkflowRunId,
+        from: 'factory:gate-pending',
+        to: 'factory:grilling',
+      }),
+    ];
+  }
+
   it('keeps unrelated review workflows live when they only transition into a post-grill state', () => {
     const reviewWorkflowRunId = 'review-non-grill-transition';
 
@@ -44,8 +55,8 @@ describe('groupByReviewWorkflow grill completion status', () => {
 
     const result = groupByReviewWorkflow(
       makeReviewItems(
-        makeEvent(1, 'question.asked', { reviewWorkflowRunId }),
-        makeEvent(2, 'state.transitioned', {
+        ...makeAnsweredGrillEvents(reviewWorkflowRunId),
+        makeEvent(3, 'state.transitioned', {
           reviewWorkflowRunId,
           to: 'factory:prd-drafting',
         }),
@@ -60,6 +71,25 @@ describe('groupByReviewWorkflow grill completion status', () => {
     expect(result[0].endedAt).toBe(result[0].lastEventAt);
   });
 
+  it('keeps grill review groups live until a reply resumes grilling', () => {
+    const reviewWorkflowRunId = 'review-grill-unanswered';
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        makeEvent(1, 'question.asked', { reviewWorkflowRunId }),
+        makeEvent(2, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      ),
+    );
+
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe('live');
+  });
+
   it.each([
     ['review.wave-failed', 'failed'],
     ['agent.run-failed', 'failed'],
@@ -69,7 +99,8 @@ describe('groupByReviewWorkflow grill completion status', () => {
     const result = groupByReviewWorkflow(
       makeReviewItems(
         makeEvent(1, kind, { reviewWorkflowRunId }),
-        makeEvent(2, 'state.transitioned', {
+        ...makeAnsweredGrillEvents(reviewWorkflowRunId),
+        makeEvent(3, 'state.transitioned', {
           reviewWorkflowRunId,
           to: 'factory:prd-drafting',
         }),
@@ -95,7 +126,8 @@ describe('groupByReviewWorkflow grill completion status', () => {
     const result = groupByReviewWorkflow(
       makeReviewItems(
         makeEvent(1, kind, payload),
-        makeEvent(2, 'state.transitioned', {
+        ...makeAnsweredGrillEvents(reviewWorkflowRunId),
+        makeEvent(3, 'state.transitioned', {
           reviewWorkflowRunId,
           to: 'factory:prd-drafting',
         }),

--- a/apps/web/src/components/detail/lib/timeline/index.test.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.test.ts
@@ -19,6 +19,26 @@ function makeReviewItems(...events: AgentEventDto[]): RenderItem[] {
 }
 
 describe('groupByReviewWorkflow grill completion status', () => {
+  it('keeps unrelated review workflows live when they only transition into a post-grill state', () => {
+    const reviewWorkflowRunId = 'review-non-grill-transition';
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        makeEvent(1, 'review.started', { reviewWorkflowRunId }),
+        makeEvent(2, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      ),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe('live');
+  });
+
   it('marks a grill review group as completed after transitioning to a post-grill state', () => {
     const reviewWorkflowRunId = 'review-grill-complete';
 

--- a/apps/web/src/components/detail/lib/timeline/index.test.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.test.ts
@@ -1,0 +1,90 @@
+import type { AgentEventDto } from '@/lib/types';
+import { describe, expect, it } from 'vitest';
+import type { RenderItem } from './index';
+import { groupByReviewWorkflow } from './index';
+
+function makeEvent(id: number, kind: string, payload: Record<string, unknown>): AgentEventDto {
+  return {
+    id,
+    kind,
+    payload,
+    createdAt: new Date(1000 * id).toISOString(),
+    workItemId: 'item-1',
+    projectId: 'proj',
+  } as AgentEventDto;
+}
+
+function makeReviewItems(...events: AgentEventDto[]): RenderItem[] {
+  return events.map((event) => ({ kind: 'event', event }));
+}
+
+describe('groupByReviewWorkflow grill completion status', () => {
+  it('marks a grill review group as completed after transitioning to a post-grill state', () => {
+    const reviewWorkflowRunId = 'review-grill-complete';
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        makeEvent(1, 'question.asked', { reviewWorkflowRunId }),
+        makeEvent(2, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      ),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe('completed');
+    expect(result[0].endedAt).toBe(result[0].lastEventAt);
+  });
+
+  it.each([
+    ['review.wave-failed', 'failed'],
+    ['agent.run-failed', 'failed'],
+  ] as const)('keeps %s higher priority than grill completion', (kind, expectedStatus) => {
+    const reviewWorkflowRunId = `review-${kind}`;
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        makeEvent(1, kind, { reviewWorkflowRunId }),
+        makeEvent(2, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      ),
+    );
+
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe(expectedStatus);
+  });
+
+  it.each([
+    ['review.escalated', { reviewWorkflowRunId: 'review-escalated' }, 'needs-human'],
+    [
+      'state.transitioned',
+      { reviewWorkflowRunId: 'review-needs-human', to: 'factory:needs-human' },
+      'needs-human',
+    ],
+  ] as const)('keeps %s higher priority than grill completion', (kind, payload, expectedStatus) => {
+    const reviewWorkflowRunId = payload.reviewWorkflowRunId as string;
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        makeEvent(1, kind, payload),
+        makeEvent(2, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:prd-drafting',
+        }),
+      ),
+    );
+
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe(expectedStatus);
+  });
+});

--- a/apps/web/src/components/detail/lib/timeline/index.test.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.test.ts
@@ -19,13 +19,16 @@ function makeReviewItems(...events: AgentEventDto[]): RenderItem[] {
 }
 
 describe('groupByReviewWorkflow grill completion status', () => {
-  function makeAnsweredGrillEvents(reviewWorkflowRunId: string): AgentEventDto[] {
+  function makeAnsweredGrillEvents(
+    reviewWorkflowRunId: string,
+    transitionPayload: Record<string, unknown> = {},
+  ): AgentEventDto[] {
     return [
       makeEvent(1, 'question.asked', { reviewWorkflowRunId }),
       makeEvent(2, 'state.transitioned', {
         reviewWorkflowRunId,
-        from: 'factory:gate-pending',
         to: 'factory:grilling',
+        ...transitionPayload,
       }),
     ];
   }
@@ -69,6 +72,44 @@ describe('groupByReviewWorkflow grill completion status', () => {
 
     expect(result[0].status).toBe('completed');
     expect(result[0].endedAt).toBe(result[0].lastEventAt);
+  });
+
+  it('marks a grill review group completed when grilling resumes from a different state', () => {
+    const reviewWorkflowRunId = 'review-grill-resumed';
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        ...makeAnsweredGrillEvents(reviewWorkflowRunId, { from: 'factory:reviewing' }),
+        makeEvent(3, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:any-post-grill-state',
+        }),
+      ),
+    );
+
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe('completed');
+  });
+
+  it('marks a grill review group completed when the resume transition omits from', () => {
+    const reviewWorkflowRunId = 'review-grill-no-from';
+
+    const result = groupByReviewWorkflow(
+      makeReviewItems(
+        ...makeAnsweredGrillEvents(reviewWorkflowRunId),
+        makeEvent(3, 'state.transitioned', {
+          reviewWorkflowRunId,
+          to: 'factory:post-grill-follow-up',
+        }),
+      ),
+    );
+
+    expect(result[0]?.kind).toBe('review-group');
+    if (result[0]?.kind !== 'review-group') return;
+
+    expect(result[0].status).toBe('completed');
   });
 
   it('keeps grill review groups live until a reply resumes grilling', () => {

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -859,9 +859,20 @@ function hasGrillActivity(events: AgentEventDto[]): boolean {
   );
 }
 
+function hasAnsweredGrillFlow(events: AgentEventDto[]): boolean {
+  if (!hasGrillActivity(events)) return false;
+  return events.some((event) => {
+    const payload = event.payload as { from?: string; to?: string } | null;
+    return (
+      event.kind === 'state.transitioned' &&
+      payload?.from === 'factory:gate-pending' &&
+      payload.to === 'factory:grilling'
+    );
+  });
+}
+
 function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs-human' | 'failed' {
   const events = items.flatMap(eventFromRenderItem);
-  const hasAnsweredGrillFlow = hasGrillActivity(events);
   if (events.some((event) => event.kind === 'review.wave-failed')) return 'failed';
   if (events.some((event) => event.kind === 'agent.run-failed')) return 'failed';
   if (events.some((event) => event.kind === 'review.escalated')) return 'needs-human';
@@ -884,8 +895,9 @@ function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs
   const verdict = (completed?.payload as { verdict?: string } | null)?.verdict;
   if (verdict === 'needs-human') return 'needs-human';
   if (verdict === 'approved' || verdict === 'needs-fix') return 'completed';
+  const answeredGrillFlow = hasAnsweredGrillFlow(events);
   if (
-    hasAnsweredGrillFlow &&
+    answeredGrillFlow &&
     events.some((event) => {
       const payload = event.payload as { to?: string; toState?: string } | null;
       return (

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -845,6 +845,14 @@ function reviewWorkflowRunIdsForItem(
   return [...ids];
 }
 
+const GRILL_COMPLETED_STATES = new Set([
+  'factory:prd-drafting',
+  'factory:prd-review',
+  'factory:decomposing',
+  'factory:issues-created',
+  'factory:done',
+]);
+
 function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs-human' | 'failed' {
   const events = items.flatMap(eventFromRenderItem);
   if (events.some((event) => event.kind === 'review.wave-failed')) return 'failed';
@@ -869,6 +877,18 @@ function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs
   const verdict = (completed?.payload as { verdict?: string } | null)?.verdict;
   if (verdict === 'needs-human') return 'needs-human';
   if (verdict === 'approved' || verdict === 'needs-fix') return 'completed';
+  if (
+    events.some((event) => {
+      const payload = event.payload as { to?: string; toState?: string } | null;
+      return (
+        event.kind === 'state.transitioned' &&
+        (GRILL_COMPLETED_STATES.has(payload?.to ?? '') ||
+          GRILL_COMPLETED_STATES.has(payload?.toState ?? ''))
+      );
+    })
+  ) {
+    return 'completed';
+  }
   return 'live';
 }
 

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -845,13 +845,7 @@ function reviewWorkflowRunIdsForItem(
   return [...ids];
 }
 
-const GRILL_COMPLETED_STATES = new Set([
-  'factory:prd-drafting',
-  'factory:prd-review',
-  'factory:decomposing',
-  'factory:issues-created',
-  'factory:done',
-]);
+const GRILL_ACTIVE_STATES = new Set(['factory:gate-pending', 'factory:grilling']);
 
 function hasGrillActivity(events: AgentEventDto[]): boolean {
   return events.some(
@@ -859,14 +853,43 @@ function hasGrillActivity(events: AgentEventDto[]): boolean {
   );
 }
 
-function hasAnsweredGrillFlow(events: AgentEventDto[]): boolean {
+function getOrderedEvents(events: AgentEventDto[]): AgentEventDto[] {
+  return [...events].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() || a.id - b.id,
+  );
+}
+
+function getTransitionDestination(event: AgentEventDto): string | null {
+  if (event.kind !== 'state.transitioned') return null;
+  const payload = event.payload as { to?: string; toState?: string } | null;
+  return payload?.to ?? payload?.toState ?? null;
+}
+
+function findAnsweredGrillResumeIndex(orderedEvents: AgentEventDto[]): number {
+  const latestQuestionIndex = orderedEvents.findLastIndex(
+    (event) => event.kind === 'question.asked',
+  );
+  if (latestQuestionIndex < 0) return -1;
+
+  return orderedEvents.findIndex(
+    (event, index) =>
+      index > latestQuestionIndex && getTransitionDestination(event) === 'factory:grilling',
+  );
+}
+
+function hasCompletedAnsweredGrillFlow(events: AgentEventDto[]): boolean {
   if (!hasGrillActivity(events)) return false;
-  return events.some((event) => {
-    const payload = event.payload as { from?: string; to?: string } | null;
+  const orderedEvents = getOrderedEvents(events);
+  const answeredResumeIndex = findAnsweredGrillResumeIndex(orderedEvents);
+  if (answeredResumeIndex < 0) return false;
+
+  return orderedEvents.some((event, index) => {
+    if (index <= answeredResumeIndex) return false;
+    const destination = getTransitionDestination(event);
     return (
-      event.kind === 'state.transitioned' &&
-      payload?.from === 'factory:gate-pending' &&
-      payload.to === 'factory:grilling'
+      destination != null &&
+      !GRILL_ACTIVE_STATES.has(destination) &&
+      destination !== 'factory:needs-human'
     );
   });
 }
@@ -895,18 +918,7 @@ function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs
   const verdict = (completed?.payload as { verdict?: string } | null)?.verdict;
   if (verdict === 'needs-human') return 'needs-human';
   if (verdict === 'approved' || verdict === 'needs-fix') return 'completed';
-  const answeredGrillFlow = hasAnsweredGrillFlow(events);
-  if (
-    answeredGrillFlow &&
-    events.some((event) => {
-      const payload = event.payload as { to?: string; toState?: string } | null;
-      return (
-        event.kind === 'state.transitioned' &&
-        (GRILL_COMPLETED_STATES.has(payload?.to ?? '') ||
-          GRILL_COMPLETED_STATES.has(payload?.toState ?? ''))
-      );
-    })
-  ) {
+  if (hasCompletedAnsweredGrillFlow(events)) {
     return 'completed';
   }
   return 'live';

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -853,8 +853,15 @@ const GRILL_COMPLETED_STATES = new Set([
   'factory:done',
 ]);
 
+function hasGrillActivity(events: AgentEventDto[]): boolean {
+  return events.some(
+    (event) => event.kind === 'question.asked' || eventSkill(event) === 'grill-me',
+  );
+}
+
 function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs-human' | 'failed' {
   const events = items.flatMap(eventFromRenderItem);
+  const hasAnsweredGrillFlow = hasGrillActivity(events);
   if (events.some((event) => event.kind === 'review.wave-failed')) return 'failed';
   if (events.some((event) => event.kind === 'agent.run-failed')) return 'failed';
   if (events.some((event) => event.kind === 'review.escalated')) return 'needs-human';
@@ -878,6 +885,7 @@ function resolveReviewStatus(items: RenderItem[]): 'live' | 'completed' | 'needs
   if (verdict === 'needs-human') return 'needs-human';
   if (verdict === 'approved' || verdict === 'needs-fix') return 'completed';
   if (
+    hasAnsweredGrillFlow &&
     events.some((event) => {
       const payload = event.payload as { to?: string; toState?: string } | null;
       return (


### PR DESCRIPTION
## Summary

grill bug

## Work Packages

- ✓ **WP1**: In apps/web/src/components/detail/lib/timeline/index.ts around resolveReviewStatus(), keep review.wave-failed and agent.

Closes #1151
