### PR TITLE
M19.XX: investigation bug ui 10

### DIFF
--- a/apps/web/src/components/detail/components/AcceptanceContractDetails.test.tsx
+++ b/apps/web/src/components/detail/components/AcceptanceContractDetails.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import type { AcceptanceContractDto } from '@/lib/types';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AcceptanceContractDetails } from './AcceptanceContractDetails';
 
@@ -25,11 +25,23 @@ const CONTRACT: AcceptanceContractDto = {
 };
 
 describe('AcceptanceContractDetails', () => {
-  it('renders the resolved contract source and criteria', () => {
+  it('renders the header metadata while keeping criteria collapsed by default', () => {
     render(<AcceptanceContractDetails contract={CONTRACT} />);
 
-    expect(screen.getByText('Acceptance Contract')).toBeTruthy();
+    expect(screen.getByText('Acceptance Criteria')).toBeTruthy();
     expect(screen.getByText('Normalized · 1 AC')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /acceptance criteria/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
+    expect(screen.queryByText('Lane cards are ordered newest first.')).toBeNull();
+    expect(screen.queryByText('pnpm vitest run apps/web/src/lib/lanes.config.test.ts')).toBeNull();
+  });
+
+  it('expands to show criteria and executable checks when clicked', () => {
+    render(<AcceptanceContractDetails contract={CONTRACT} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /acceptance criteria/i }));
+
     expect(screen.getByText('Lane cards are ordered newest first.')).toBeTruthy();
     expect(screen.getByText('pnpm vitest run apps/web/src/lib/lanes.config.test.ts')).toBeTruthy();
   });

--- a/apps/web/src/components/detail/components/AcceptanceContractDetails.tsx
+++ b/apps/web/src/components/detail/components/AcceptanceContractDetails.tsx
@@ -12,9 +12,11 @@ const SOURCE_LABEL: Record<AcceptanceContractDto['source'], string> = {
 export function AcceptanceContractDetails({
   contract,
   defaultOpen = false,
+  resetKey,
 }: {
   contract: AcceptanceContractDto | null | undefined;
   defaultOpen?: boolean;
+  resetKey?: string;
 }) {
   if (contract == null || contract.criteria.length === 0) return null;
 
@@ -23,6 +25,7 @@ export function AcceptanceContractDetails({
       title="Acceptance Criteria"
       icon={ClipboardCheck}
       defaultOpen={defaultOpen}
+      resetKey={resetKey}
       badge={`${SOURCE_LABEL[contract.source]} · ${contract.criteria.length} AC`}
       contentTestId="acceptance-contract-content"
     >

--- a/apps/web/src/components/detail/components/AcceptanceContractDetails.tsx
+++ b/apps/web/src/components/detail/components/AcceptanceContractDetails.tsx
@@ -1,5 +1,6 @@
 import type { AcceptanceContractDto } from '@/lib/types';
 import { ClipboardCheck, Terminal } from 'lucide-react';
+import { InvestigationAccordionSection } from './InvestigationAccordionSection';
 
 const SOURCE_LABEL: Record<AcceptanceContractDto['source'], string> = {
   normalized: 'Normalized',
@@ -10,23 +11,22 @@ const SOURCE_LABEL: Record<AcceptanceContractDto['source'], string> = {
 
 export function AcceptanceContractDetails({
   contract,
+  defaultOpen = false,
 }: {
   contract: AcceptanceContractDto | null | undefined;
+  defaultOpen?: boolean;
 }) {
   if (contract == null || contract.criteria.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-[color:var(--accent)]/20 bg-bg-elev overflow-hidden">
-      <div className="px-4 py-3 bg-bg-elev-2 flex items-center gap-2">
-        <ClipboardCheck size={13} className="shrink-0 text-[color:var(--accent)]" />
-        <span className="text-[10.5px] uppercase tracking-wider text-fg-2">
-          Acceptance Contract
-        </span>
-        <span className="text-[11px] text-fg-4">
-          {SOURCE_LABEL[contract.source]} · {contract.criteria.length} AC
-        </span>
-      </div>
-      <ol className="px-4 py-3 flex flex-col gap-3 border-t border-line">
+    <InvestigationAccordionSection
+      title="Acceptance Criteria"
+      icon={ClipboardCheck}
+      defaultOpen={defaultOpen}
+      badge={`${SOURCE_LABEL[contract.source]} · ${contract.criteria.length} AC`}
+      contentTestId="acceptance-contract-content"
+    >
+      <ol className="flex flex-col gap-3">
         {contract.criteria.map((criterion) => (
           <li key={criterion.id} className="grid grid-cols-[3.5rem_1fr] gap-3 text-[12.5px]">
             <span className="font-mono text-[11px] text-fg-3">{criterion.id}</span>
@@ -57,6 +57,6 @@ export function AcceptanceContractDetails({
           </li>
         ))}
       </ol>
-    </div>
+    </InvestigationAccordionSection>
   );
 }

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FlaskConical } from 'lucide-react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { InvestigationAccordionSection } from './InvestigationAccordionSection';
+
+afterEach(cleanup);
+
+describe('InvestigationAccordionSection', () => {
+  it('renders content open by default when defaultOpen is true', () => {
+    render(
+      <InvestigationAccordionSection title="Findings" defaultOpen contentTestId="section-content">
+        <div>Root cause found.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(screen.getByRole('button', { name: /findings/i }).getAttribute('aria-expanded')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('section-content')).toBeTruthy();
+    expect(screen.getByText('Root cause found.')).toBeTruthy();
+  });
+
+  it('starts collapsed when defaultOpen is false', () => {
+    render(
+      <InvestigationAccordionSection
+        title="Acceptance Criteria"
+        defaultOpen={false}
+        contentTestId="section-content"
+      >
+        <div>Criterion body.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /acceptance criteria/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
+    expect(screen.queryByTestId('section-content')).toBeNull();
+    expect(screen.queryByText('Criterion body.')).toBeNull();
+  });
+
+  it('defaults to collapsed when defaultOpen is omitted', () => {
+    render(
+      <InvestigationAccordionSection title="Engineering Spec" contentTestId="section-content">
+        <div>Spec body.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /engineering spec/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
+    expect(screen.queryByTestId('section-content')).toBeNull();
+  });
+
+  it('renders optional metadata in the header', () => {
+    render(
+      <InvestigationAccordionSection
+        title="Open Questions"
+        badge={<span>2 unresolved</span>}
+        icon={FlaskConical}
+      >
+        <div>Question body.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(screen.getByText('2 unresolved')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /open questions/i })).toBeTruthy();
+    expect(document.querySelector('svg')).toBeTruthy();
+  });
+
+  it('toggles content visibility and aria-expanded when clicked', async () => {
+    render(
+      <InvestigationAccordionSection title="Investigation Trail" contentTestId="section-content">
+        <div>Decision timeline.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    const header = screen.getByRole('button', { name: /investigation trail/i });
+
+    await userEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('section-content')).toBeTruthy();
+    expect(screen.getByText('Decision timeline.')).toBeTruthy();
+
+    await userEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('section-content')).toBeNull();
+  });
+});

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
@@ -120,4 +120,37 @@ describe('InvestigationAccordionSection', () => {
     );
     expect(screen.queryByTestId('section-content')).toBeNull();
   });
+
+  it('reapplies defaultOpen when it changes for the same accordion identity', async () => {
+    const { rerender } = render(
+      <InvestigationAccordionSection
+        title="Proceed Gate"
+        defaultOpen={false}
+        resetKey="issue-1"
+        contentTestId="section-content"
+      >
+        <div>Gate content.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /proceed gate/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
+
+    rerender(
+      <InvestigationAccordionSection
+        title="Proceed Gate"
+        defaultOpen
+        resetKey="issue-1"
+        contentTestId="section-content"
+      >
+        <div>Gate content.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /proceed gate/i }).getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(screen.getByTestId('section-content')).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.test.tsx
@@ -87,4 +87,37 @@ describe('InvestigationAccordionSection', () => {
     expect(header.getAttribute('aria-expanded')).toBe('false');
     expect(screen.queryByTestId('section-content')).toBeNull();
   });
+
+  it('resets open state when the accordion identity changes', async () => {
+    const { rerender } = render(
+      <InvestigationAccordionSection
+        title="Findings"
+        defaultOpen={false}
+        resetKey="issue-1"
+        contentTestId="section-content"
+      >
+        <div>Issue one.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    const header = screen.getByRole('button', { name: /findings/i });
+    await userEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+
+    rerender(
+      <InvestigationAccordionSection
+        title="Findings"
+        defaultOpen={false}
+        resetKey="issue-2"
+        contentTestId="section-content"
+      >
+        <div>Issue two.</div>
+      </InvestigationAccordionSection>,
+    );
+
+    expect(screen.getByRole('button', { name: /findings/i }).getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    expect(screen.queryByTestId('section-content')).toBeNull();
+  });
 });

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
@@ -25,12 +25,19 @@ export function InvestigationAccordionSection({
   const [open, setOpen] = useState(defaultOpen);
   const identity = resetKey ?? title;
   const previousIdentity = useRef(identity);
+  const previousDefaultOpen = useRef(defaultOpen);
 
   useEffect(() => {
-    if (previousIdentity.current !== identity) {
-      previousIdentity.current = identity;
-      setOpen(defaultOpen);
+    const identityChanged = previousIdentity.current !== identity;
+    const defaultOpenChanged = previousDefaultOpen.current !== defaultOpen;
+
+    if (!identityChanged && !defaultOpenChanged) {
+      return;
     }
+
+    previousIdentity.current = identity;
+    previousDefaultOpen.current = defaultOpen;
+    setOpen(defaultOpen);
   }, [defaultOpen, identity]);
 
   return (

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
@@ -1,0 +1,56 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { type ComponentType, type ReactNode, useState } from 'react';
+
+export interface InvestigationAccordionSectionProps {
+  title: string;
+  defaultOpen?: boolean;
+  badge?: ReactNode;
+  icon?: ComponentType<{ size?: number; className?: string }>;
+  children: ReactNode;
+  testId?: string;
+  contentTestId?: string;
+}
+
+export function InvestigationAccordionSection({
+  title,
+  defaultOpen = false,
+  badge,
+  icon: Icon,
+  children,
+  testId,
+  contentTestId,
+}: InvestigationAccordionSectionProps): JSX.Element {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div
+      className="rounded-lg border border-[color:var(--accent)]/20 bg-bg-elev overflow-hidden"
+      data-testid={testId}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-4 py-3 bg-bg-elev-2 text-left cursor-pointer"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {Icon != null && <Icon size={12} className="shrink-0 text-[color:var(--accent)]" />}
+          <span className="text-[10.5px] uppercase tracking-wider text-fg-2 shrink-0">{title}</span>
+          {badge != null && <span className="text-[11px] text-fg-4 truncate">{badge}</span>}
+        </div>
+        <span className="shrink-0 text-fg-4">
+          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="px-4 py-4 flex flex-col gap-4 border-t border-line"
+          data-testid={contentTestId}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationAccordionSection.tsx
@@ -1,9 +1,10 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { type ComponentType, type ReactNode, useState } from 'react';
+import { type ComponentType, type ReactNode, useEffect, useRef, useState } from 'react';
 
 export interface InvestigationAccordionSectionProps {
   title: string;
   defaultOpen?: boolean;
+  resetKey?: string;
   badge?: ReactNode;
   icon?: ComponentType<{ size?: number; className?: string }>;
   children: ReactNode;
@@ -14,6 +15,7 @@ export interface InvestigationAccordionSectionProps {
 export function InvestigationAccordionSection({
   title,
   defaultOpen = false,
+  resetKey,
   badge,
   icon: Icon,
   children,
@@ -21,6 +23,15 @@ export function InvestigationAccordionSection({
   contentTestId,
 }: InvestigationAccordionSectionProps): JSX.Element {
   const [open, setOpen] = useState(defaultOpen);
+  const identity = resetKey ?? title;
+  const previousIdentity = useRef(identity);
+
+  useEffect(() => {
+    if (previousIdentity.current !== identity) {
+      previousIdentity.current = identity;
+      setOpen(defaultOpen);
+    }
+  }, [defaultOpen, identity]);
 
   return (
     <div

--- a/apps/web/src/components/detail/components/InvestigationSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.test.tsx
@@ -382,4 +382,51 @@ describe('InvestigationSection', () => {
     fireEvent.click(getAccordionButton('Bug Repro Capture'));
     expect(screen.getByTestId('playwright-capture-content')).toBeTruthy();
   });
+
+  it('shows the findings accordion even when only key files exist', () => {
+    renderSection({
+      events: [
+        investigationEvent({
+          payload: {
+            investigate: {
+              ...(INVESTIGATION_EVENT.payload as { investigate: Record<string, unknown> })
+                .investigate,
+              findings: '',
+              keyFiles: [{ path: 'src/auth/login.ts', reason: 'Only grounded evidence available' }],
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(getAccordionButton('Findings').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('findings-key-files-list')).toBeTruthy();
+    expect(screen.getByText('src/auth/login.ts')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /key files/i })).toBeNull();
+  });
+
+  it('renders the proceed gate as a collapsed accordion for ready investigations', () => {
+    renderSection({
+      events: [INVESTIGATION_EVENT],
+      itemState: 'factory:investigation-complete',
+    });
+
+    expect(getAccordionButton('Proceed Gate').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('investigation-proceed-gate-content')).toBeNull();
+
+    fireEvent.click(getAccordionButton('Proceed Gate'));
+    expect(screen.getByTestId('investigation-proceed-gate-content')).toBeTruthy();
+    expect(screen.getByTestId('investigation-notes-input')).toBeTruthy();
+  });
+
+  it('opens the proceed gate by default when human review is required', () => {
+    renderSection({
+      events: [INVESTIGATION_EVENT],
+      itemState: 'factory:gate-pending',
+    });
+
+    expect(getAccordionButton('Proceed Gate').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('investigation-proceed-gate-content')).toBeTruthy();
+    expect(screen.getByText(/Investigation confidence is low\./)).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/detail/components/InvestigationSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.test.tsx
@@ -2,8 +2,7 @@
 import type { AgentEventDto, EngineeringSpecDto } from '@/lib/types';
 import { ActiveProjectProvider } from '@/state/active-project';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
-import { cleanup } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InvestigationSection } from './InvestigationSection';
 
@@ -31,6 +30,12 @@ vi.mock('@/lib/api', () => ({
 
 vi.mock('@/lib/markdown', () => ({
   renderMarkdownToHtml: (s: string) => `<p>${s}</p>`,
+}));
+
+vi.mock('./PlaywrightCaptureSection', () => ({
+  PlaywrightCaptureSection: () => (
+    <div data-testid="playwright-capture-content">Bug repro capture</div>
+  ),
 }));
 
 const INVESTIGATION_EVENT: AgentEventDto = {
@@ -76,6 +81,19 @@ const ENGINEERING_SPEC: EngineeringSpecDto = {
   riskRegister: [],
 };
 
+const ACCEPTANCE_CONTRACT = {
+  source: 'engineering-spec' as const,
+  criteria: [{ id: 'AC-1', statement: 'Users can log in.' }],
+};
+
+const HUMAN_NOTES = [
+  {
+    id: 'note-1',
+    body: 'Human review notes:\n\nNeeds follow-up.',
+    createdAt: '2026-05-22T10:00:00Z',
+  },
+];
+
 function investigationEvent(partial: Partial<AgentEventDto> = {}): AgentEventDto {
   return {
     ...INVESTIGATION_EVENT,
@@ -101,55 +119,92 @@ function toolCallEvent(partial: Partial<AgentEventDto> = {}): AgentEventDto {
   };
 }
 
-function renderSection(events: AgentEventDto[] = [], spec?: EngineeringSpecDto | null) {
+function renderSection({
+  events = [],
+  spec,
+  acceptanceContract,
+  comments,
+  itemType,
+  itemState,
+}: {
+  events?: AgentEventDto[];
+  spec?: EngineeringSpecDto | null;
+  acceptanceContract?: typeof ACCEPTANCE_CONTRACT | null;
+  comments?: typeof HUMAN_NOTES;
+  itemType?: string;
+  itemState?: string;
+} = {}) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   qc.setQueryData(['events', 'test-proj', '42'], events);
   if (spec !== undefined) qc.setQueryData(['spec', 'test-proj', '42'], spec);
+  if (acceptanceContract !== undefined) {
+    qc.setQueryData(['acceptance-contract', 'test-proj', '42'], acceptanceContract);
+  }
+  if (comments !== undefined) qc.setQueryData(['comments', 'test-proj', '42'], comments);
   render(
     <QueryClientProvider client={qc}>
       <ActiveProjectProvider initialSlug="test-proj">
-        <InvestigationSection projectSlug="test-proj" id="42" />
+        <InvestigationSection
+          projectSlug="test-proj"
+          id="42"
+          itemType={itemType}
+          itemState={itemState}
+        />
       </ActiveProjectProvider>
     </QueryClientProvider>,
   );
 }
 
+function getAccordionButton(title: string) {
+  const match = screen
+    .getAllByRole('button')
+    .find((button) => within(button).queryByText(new RegExp(`^${title}$`, 'i')) != null);
+
+  if (match == null) {
+    throw new Error(`Accordion button not found for title: ${title}`);
+  }
+
+  return match;
+}
+
 describe('InvestigationSection', () => {
   it('shows empty state when no investigation events exist', () => {
-    renderSection([]);
+    renderSection();
     expect(screen.getByTestId('investigation-empty-state')).toBeTruthy();
     expect(screen.getByText('Investigation has not run yet.')).toBeTruthy();
   });
 
   it('renders findings when investigation event is present', () => {
-    renderSection([INVESTIGATION_EVENT]);
+    renderSection({ events: [INVESTIGATION_EVENT] });
     expect(screen.getByTestId('investigation-section')).toBeTruthy();
     expect(screen.getByTestId('findings-content')).toBeTruthy();
   });
 
   it('renders the Engineering Spec panel when a spec exists', () => {
-    renderSection([INVESTIGATION_EVENT], ENGINEERING_SPEC);
+    renderSection({ events: [INVESTIGATION_EVENT], spec: ENGINEERING_SPEC });
     expect(screen.getByText('Engineering Spec')).toBeTruthy();
     expect(screen.getByText('1 work package · 1 AC')).toBeTruthy();
   });
 
   it('displays the correct confidence badge for high confidence', () => {
-    renderSection([INVESTIGATION_EVENT]);
+    renderSection({ events: [INVESTIGATION_EVENT] });
     const badge = screen.getByTestId('confidence-badge');
     expect(badge).toBeTruthy();
     expect(badge.textContent).toContain('high');
   });
 
-  it('renders key files list', () => {
-    renderSection([INVESTIGATION_EVENT]);
+  it('renders key files list after expanding the accordion', () => {
+    renderSection({ events: [INVESTIGATION_EVENT] });
+    fireEvent.click(getAccordionButton('Key Files'));
     const filesList = screen.getByTestId('key-files-list');
     expect(filesList).toBeTruthy();
     expect(screen.getByText('src/auth/login.ts')).toBeTruthy();
     expect(screen.getByText('src/auth/session.ts')).toBeTruthy();
   });
 
-  it('renders open questions list', () => {
-    renderSection([INVESTIGATION_EVENT]);
+  it('renders open questions list after expanding the accordion', () => {
+    renderSection({ events: [INVESTIGATION_EVENT] });
+    fireEvent.click(getAccordionButton('Open Questions'));
     const questionsList = screen.getByTestId('open-questions-list');
     expect(questionsList).toBeTruthy();
     expect(screen.getByText('Does this affect the mobile app?')).toBeTruthy();
@@ -165,7 +220,7 @@ describe('InvestigationSection', () => {
         },
       },
     };
-    renderSection([lowConfEvent]);
+    renderSection({ events: [lowConfEvent] });
     const badge = screen.getByTestId('confidence-badge');
     expect(badge.textContent).toContain('low');
     expect(badge.className).toContain('text-red-400');
@@ -181,7 +236,7 @@ describe('InvestigationSection', () => {
         },
       },
     };
-    renderSection([medConfEvent]);
+    renderSection({ events: [medConfEvent] });
     const badge = screen.getByTestId('confidence-badge');
     expect(badge.textContent).toContain('medium');
     expect(badge.className).toContain('text-yellow-400');
@@ -197,8 +252,8 @@ describe('InvestigationSection', () => {
         },
       },
     };
-    renderSection([noFilesEvent]);
-    expect(screen.queryByTestId('key-files-list')).toBeNull();
+    renderSection({ events: [noFilesEvent] });
+    expect(screen.queryByRole('button', { name: /key files/i })).toBeNull();
   });
 
   it('does not render open questions when list is empty', () => {
@@ -211,8 +266,8 @@ describe('InvestigationSection', () => {
         },
       },
     };
-    renderSection([noQuestionsEvent]);
-    expect(screen.queryByTestId('open-questions-list')).toBeNull();
+    renderSection({ events: [noQuestionsEvent] });
+    expect(screen.queryByRole('button', { name: /open questions/i })).toBeNull();
   });
 
   it('renders the newest investigation event regardless of event order', () => {
@@ -237,7 +292,7 @@ describe('InvestigationSection', () => {
       },
     });
 
-    renderSection([newer, older]);
+    renderSection({ events: [newer, older] });
 
     expect(screen.getByText('New finding')).toBeTruthy();
     expect(screen.queryByText('Old finding')).toBeNull();
@@ -260,8 +315,71 @@ describe('InvestigationSection', () => {
       },
     });
 
-    renderSection([newer, newRunSearch, older, oldRunRead]);
+    renderSection({ events: [newer, newRunSearch, older, oldRunRead] });
 
     expect(screen.getByText('0 file reads · 1 search')).toBeTruthy();
+  });
+
+  it('shows findings expanded by default and keeps other sections collapsed initially', () => {
+    renderSection({
+      events: [INVESTIGATION_EVENT],
+      spec: ENGINEERING_SPEC,
+      acceptanceContract: ACCEPTANCE_CONTRACT,
+      comments: HUMAN_NOTES,
+      itemType: 'bug',
+    });
+
+    expect(getAccordionButton('Findings').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('findings-content')).toBeTruthy();
+
+    expect(getAccordionButton('Acceptance Criteria').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('acceptance-contract-content')).toBeNull();
+
+    expect(getAccordionButton('Engineering Spec').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
+
+    expect(getAccordionButton('Key Files').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('key-files-list')).toBeNull();
+
+    expect(getAccordionButton('Open Questions').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('open-questions-list')).toBeNull();
+
+    expect(getAccordionButton('Investigation Trail').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('investigation-trail')).toBeNull();
+
+    expect(getAccordionButton('Human Review Notes').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('investigation-human-notes')).toBeNull();
+
+    expect(getAccordionButton('Bug Repro Capture').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('playwright-capture-content')).toBeNull();
+  });
+
+  it('reveals collapsed investigation accordions when their headers are clicked', () => {
+    renderSection({
+      events: [INVESTIGATION_EVENT],
+      spec: ENGINEERING_SPEC,
+      acceptanceContract: ACCEPTANCE_CONTRACT,
+      comments: HUMAN_NOTES,
+      itemType: 'bug',
+    });
+
+    fireEvent.click(getAccordionButton('Acceptance Criteria'));
+    expect(screen.getByTestId('acceptance-contract-content')).toBeTruthy();
+    expect(screen.getByText('Users can log in.')).toBeTruthy();
+
+    fireEvent.click(getAccordionButton('Engineering Spec'));
+    expect(screen.getByText('Build the authentication flow with token refresh.')).toBeTruthy();
+
+    fireEvent.click(getAccordionButton('Open Questions'));
+    expect(screen.getByTestId('open-questions-list')).toBeTruthy();
+
+    fireEvent.click(getAccordionButton('Investigation Trail'));
+    expect(screen.getByTestId('investigation-trail')).toBeTruthy();
+
+    fireEvent.click(getAccordionButton('Human Review Notes'));
+    expect(screen.getByTestId('investigation-human-notes')).toBeTruthy();
+
+    fireEvent.click(getAccordionButton('Bug Repro Capture'));
+    expect(screen.getByTestId('playwright-capture-content')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/detail/components/InvestigationSection.test.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.test.tsx
@@ -94,6 +94,14 @@ const HUMAN_NOTES = [
   },
 ];
 
+const PLAYWRIGHT_REPRO = {
+  screenshots: [],
+  gifPath: null,
+  consoleErrors: [],
+  reproSteps: ['Open the page'],
+  reproduced: true,
+};
+
 function investigationEvent(partial: Partial<AgentEventDto> = {}): AgentEventDto {
   return {
     ...INVESTIGATION_EVENT,
@@ -141,21 +149,26 @@ function renderSection({
     qc.setQueryData(['acceptance-contract', 'test-proj', '42'], acceptanceContract);
   }
   if (comments !== undefined) qc.setQueryData(['comments', 'test-proj', '42'], comments);
-  render(
-    <QueryClientProvider client={qc}>
-      <ActiveProjectProvider initialSlug="test-proj">
-        <InvestigationSection
-          projectSlug="test-proj"
-          id="42"
-          itemType={itemType}
-          itemState={itemState}
-        />
-      </ActiveProjectProvider>
-    </QueryClientProvider>,
-  );
+  function WrappedSection(props: { itemType?: string; itemState?: string }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ActiveProjectProvider initialSlug="test-proj">
+          <InvestigationSection
+            projectSlug="test-proj"
+            id="42"
+            itemType={props.itemType}
+            itemState={props.itemState}
+          />
+        </ActiveProjectProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  const view = render(<WrappedSection itemType={itemType} itemState={itemState} />);
+  return { ...view, qc, WrappedSection };
 }
 
-function getAccordionButton(title: string) {
+function getAccordionButton(title: string): HTMLElement {
   const match = screen
     .getAllByRole('button')
     .find((button) => within(button).queryByText(new RegExp(`^${title}$`, 'i')) != null);
@@ -322,7 +335,17 @@ describe('InvestigationSection', () => {
 
   it('shows findings expanded by default and keeps other sections collapsed initially', () => {
     renderSection({
-      events: [INVESTIGATION_EVENT],
+      events: [
+        investigationEvent({
+          payload: {
+            investigate: {
+              ...(INVESTIGATION_EVENT.payload as { investigate: Record<string, unknown> })
+                .investigate,
+            },
+            playwrightRepro: PLAYWRIGHT_REPRO,
+          } as AgentEventDto['payload'],
+        }),
+      ],
       spec: ENGINEERING_SPEC,
       acceptanceContract: ACCEPTANCE_CONTRACT,
       comments: HUMAN_NOTES,
@@ -356,7 +379,17 @@ describe('InvestigationSection', () => {
 
   it('reveals collapsed investigation accordions when their headers are clicked', () => {
     renderSection({
-      events: [INVESTIGATION_EVENT],
+      events: [
+        investigationEvent({
+          payload: {
+            investigate: {
+              ...(INVESTIGATION_EVENT.payload as { investigate: Record<string, unknown> })
+                .investigate,
+            },
+            playwrightRepro: PLAYWRIGHT_REPRO,
+          } as AgentEventDto['payload'],
+        }),
+      ],
       spec: ENGINEERING_SPEC,
       acceptanceContract: ACCEPTANCE_CONTRACT,
       comments: HUMAN_NOTES,
@@ -428,5 +461,29 @@ describe('InvestigationSection', () => {
     expect(getAccordionButton('Proceed Gate').getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByTestId('investigation-proceed-gate-content')).toBeTruthy();
     expect(screen.getByText(/Investigation confidence is low\./)).toBeTruthy();
+  });
+
+  it('updates the proceed gate default state when itemState changes without a new run', () => {
+    const view = renderSection({
+      events: [INVESTIGATION_EVENT],
+      itemState: 'factory:investigation-complete',
+    });
+
+    expect(getAccordionButton('Proceed Gate').getAttribute('aria-expanded')).toBe('false');
+
+    view.rerender(<view.WrappedSection itemState="factory:gate-pending" />);
+
+    expect(getAccordionButton('Proceed Gate').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('investigation-proceed-gate-content')).toBeTruthy();
+  });
+
+  it('does not render the bug repro accordion when no capture payload exists', () => {
+    renderSection({
+      events: [INVESTIGATION_EVENT],
+      itemType: 'bug',
+    });
+
+    expect(screen.queryByRole('button', { name: /bug repro capture/i })).toBeNull();
+    expect(screen.queryByTestId('playwright-capture-content')).toBeNull();
   });
 });

--- a/apps/web/src/components/detail/components/InvestigationSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.tsx
@@ -161,6 +161,29 @@ export function InvestigationSection({
       : investigate.confidence === 'medium'
         ? 'plausible'
         : 'weak';
+  const hasFindingsSummary = investigate.findings.trim().length > 0;
+  const hasKeyFiles = investigate.keyFiles.length > 0;
+  const findingsAccordionContent = hasFindingsSummary || hasKeyFiles;
+  const accordionResetKey = `${projectSlug}:${id}:${latest.runId ?? latest.id}`;
+
+  function renderKeyFileCards() {
+    return investigate.keyFiles.map((f) => {
+      const basename = f.path.split('/').pop() ?? f.path;
+      return (
+        <FindingCard
+          key={f.path}
+          severity={investigate.confidence}
+          title={basename}
+          body={f.reason ? <span>{f.reason}</span> : <span className="text-fg-2">—</span>}
+          filePath={f.path}
+          viewUrl={githubBase != null ? `${githubBase}/${f.path}` : undefined}
+          conf={conf}
+          personaInitials={initials}
+          personaName={personaLabel}
+        />
+      );
+    });
+  }
 
   return (
     <div data-testid="investigation-section" className="px-8 py-6 flex flex-col gap-5">
@@ -232,63 +255,64 @@ export function InvestigationSection({
       </div>
 
       {/* Root-cause finding card */}
-      {investigate.findings.trim().length > 0 && (
-        <InvestigationAccordionSection title="Findings" defaultOpen>
-          <FindingCard
-            severity={investigate.confidence}
-            title="Root cause hypothesis"
-            body={
-              <div
-                data-testid="findings-content"
-                className="prose prose-sm prose-invert max-w-none text-[13px] text-fg-2 [&_p]:mb-2 [&_ul]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_code]:font-mono [&_code]:text-[12px]"
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by renderMarkdownToHtml
-                dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(investigate.findings) }}
-              />
-            }
-            conf={conf}
-            personaInitials={initials}
-            personaName={personaLabel}
-          />
+      {findingsAccordionContent && (
+        <InvestigationAccordionSection
+          title="Findings"
+          defaultOpen
+          resetKey={accordionResetKey}
+          contentTestId="findings-accordion-content"
+        >
+          {hasFindingsSummary && (
+            <FindingCard
+              severity={investigate.confidence}
+              title="Root cause hypothesis"
+              body={
+                <div
+                  data-testid="findings-content"
+                  className="prose prose-sm prose-invert max-w-none text-[13px] text-fg-2 [&_p]:mb-2 [&_ul]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_code]:font-mono [&_code]:text-[12px]"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by renderMarkdownToHtml
+                  dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(investigate.findings) }}
+                />
+              }
+              conf={conf}
+              personaInitials={initials}
+              personaName={personaLabel}
+            />
+          )}
+          {hasKeyFiles && !hasFindingsSummary && (
+            <div data-testid="findings-key-files-list" className="flex flex-col gap-3">
+              {renderKeyFileCards()}
+            </div>
+          )}
         </InvestigationAccordionSection>
       )}
 
       {/* Key files as long finding cards */}
-      {investigate.keyFiles.length > 0 && (
+      {hasKeyFiles && hasFindingsSummary && (
         <InvestigationAccordionSection
           title="Key Files"
           badge={`${investigate.keyFiles.length} file${investigate.keyFiles.length !== 1 ? 's' : ''}`}
+          resetKey={accordionResetKey}
         >
           <div data-testid="key-files-list" className="flex flex-col gap-3">
-            {investigate.keyFiles.map((f) => {
-              const basename = f.path.split('/').pop() ?? f.path;
-              return (
-                <FindingCard
-                  key={f.path}
-                  severity={investigate.confidence}
-                  title={basename}
-                  body={f.reason ? <span>{f.reason}</span> : <span className="text-fg-2">—</span>}
-                  filePath={f.path}
-                  viewUrl={githubBase != null ? `${githubBase}/${f.path}` : undefined}
-                  conf={conf}
-                  personaInitials={initials}
-                  personaName={personaLabel}
-                />
-              );
-            })}
+            {renderKeyFileCards()}
           </div>
         </InvestigationAccordionSection>
       )}
 
-      <AcceptanceContractDetails contract={acceptanceContract} />
+      <AcceptanceContractDetails contract={acceptanceContract} resetKey={accordionResetKey} />
 
       {/* Engineering spec */}
-      {spec != null && <SpecDetails spec={spec} itemState={itemState} />}
+      {spec != null && (
+        <SpecDetails spec={spec} itemState={itemState} resetKey={accordionResetKey} />
+      )}
 
       {/* Open questions */}
       {investigate.openQuestions.length > 0 && (
         <InvestigationAccordionSection
           title="Open Questions"
           badge={`${investigate.openQuestions.length} unresolved`}
+          resetKey={accordionResetKey}
         >
           <ul data-testid="open-questions-list" className="space-y-1 list-disc list-inside">
             {investigate.openQuestions.map((q) => (
@@ -305,6 +329,7 @@ export function InvestigationSection({
         <InvestigationAccordionSection
           title="Investigation Trail"
           badge="What was looked at, in order"
+          resetKey={accordionResetKey}
         >
           <ol data-testid="investigation-trail" className="flex flex-col gap-2">
             {investigate.decisionSummaries.map((s, i) => (
@@ -346,6 +371,7 @@ export function InvestigationSection({
         <InvestigationAccordionSection
           title="Human Review Notes"
           badge={`${humanNotes.length} note${humanNotes.length !== 1 ? 's' : ''}`}
+          resetKey={accordionResetKey}
         >
           <div data-testid="investigation-human-notes" className="space-y-2">
             {humanNotes.map((note) => (
@@ -371,57 +397,69 @@ export function InvestigationSection({
 
       {/* Playwright captures (bug items only) */}
       {itemType === 'bug' && (
-        <InvestigationAccordionSection title="Bug Repro Capture">
+        <InvestigationAccordionSection title="Bug Repro Capture" resetKey={accordionResetKey}>
           <PlaywrightCaptureSection projectSlug={projectSlug} id={id} itemType={itemType} />
         </InvestigationAccordionSection>
       )}
 
       {/* Human proceed gate */}
       {canProceed && (
-        <div
-          data-testid="investigation-proceed-gate"
-          className={`rounded-md border px-4 py-4 space-y-3 ${
-            itemState === 'factory:gate-pending'
-              ? 'border-yellow-500/30 bg-yellow-500/5'
-              : 'border-line bg-bg-elev/40'
-          }`}
+        <InvestigationAccordionSection
+          title="Proceed Gate"
+          badge={
+            itemState === 'factory:gate-pending' ? 'Human review required' : 'Ready to proceed'
+          }
+          defaultOpen={itemState === 'factory:gate-pending'}
+          resetKey={accordionResetKey}
+          testId="investigation-proceed-gate"
+          contentTestId="investigation-proceed-gate-content"
         >
-          <div className="flex items-center gap-2">
-            <h4 className="text-[11px] font-medium text-fg-3 uppercase tracking-wide">
-              {itemState === 'factory:gate-pending' ? 'Human review required' : 'Ready to proceed'}
-            </h4>
-            {itemState === 'factory:gate-pending' && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/15 text-yellow-400 font-medium">
-                low confidence
-              </span>
-            )}
-          </div>
-          {itemState === 'factory:gate-pending' && (
-            <p className="text-[12px] text-fg-3">
-              Investigation confidence is low. Review the open questions above before proceeding.
-            </p>
-          )}
-          <textarea
-            data-testid="investigation-notes-input"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes or answers to open questions…"
-            rows={3}
-            className="w-full rounded border border-line bg-bg px-3 py-2 text-[12px] text-fg placeholder:text-fg-2 focus:outline-none focus:border-[color:var(--accent)] resize-none"
-          />
-          {proceedError != null && (
-            <p className="text-[11px] text-[color:var(--danger)]">{proceedError}</p>
-          )}
-          <button
-            type="button"
-            data-testid="investigation-proceed-button"
-            onClick={handleProceed}
-            disabled={proceeding}
-            className="px-3 py-1.5 rounded text-[11px] font-medium bg-[color:var(--accent)]/15 text-[color:var(--accent)] border border-[color:var(--accent)]/30 hover:bg-[color:var(--accent)]/25 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          <div
+            className={`rounded-md border px-4 py-4 space-y-3 ${
+              itemState === 'factory:gate-pending'
+                ? 'border-yellow-500/30 bg-yellow-500/5'
+                : 'border-line bg-bg-elev/40'
+            }`}
           >
-            {proceeding ? 'Proceeding…' : 'Proceed to dev-ready'}
-          </button>
-        </div>
+            <div className="flex items-center gap-2">
+              <h4 className="text-[11px] font-medium text-fg-3 uppercase tracking-wide">
+                {itemState === 'factory:gate-pending'
+                  ? 'Human review required'
+                  : 'Ready to proceed'}
+              </h4>
+              {itemState === 'factory:gate-pending' && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/15 text-yellow-400 font-medium">
+                  low confidence
+                </span>
+              )}
+            </div>
+            {itemState === 'factory:gate-pending' && (
+              <p className="text-[12px] text-fg-3">
+                Investigation confidence is low. Review the open questions above before proceeding.
+              </p>
+            )}
+            <textarea
+              data-testid="investigation-notes-input"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional notes or answers to open questions…"
+              rows={3}
+              className="w-full rounded border border-line bg-bg px-3 py-2 text-[12px] text-fg placeholder:text-fg-2 focus:outline-none focus:border-[color:var(--accent)] resize-none"
+            />
+            {proceedError != null && (
+              <p className="text-[11px] text-[color:var(--danger)]">{proceedError}</p>
+            )}
+            <button
+              type="button"
+              data-testid="investigation-proceed-button"
+              onClick={handleProceed}
+              disabled={proceeding}
+              className="px-3 py-1.5 rounded text-[11px] font-medium bg-[color:var(--accent)]/15 text-[color:var(--accent)] border border-[color:var(--accent)]/30 hover:bg-[color:var(--accent)]/25 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {proceeding ? 'Proceeding…' : 'Proceed to dev-ready'}
+            </button>
+          </div>
+        </InvestigationAccordionSection>
       )}
     </div>
   );

--- a/apps/web/src/components/detail/components/InvestigationSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.tsx
@@ -25,6 +25,7 @@ import {
   extractInvestigationPayload,
   latestInvestigationEvent,
 } from '../lib/investigation';
+import { hasPlaywrightRepro } from '../lib/playwright-capture';
 import { AcceptanceContractDetails } from './AcceptanceContractDetails';
 import { ConfidenceBadge } from './ConfidenceBadge';
 import { CostBadge } from './CostBadge';
@@ -165,6 +166,7 @@ export function InvestigationSection({
   const hasKeyFiles = investigate.keyFiles.length > 0;
   const findingsAccordionContent = hasFindingsSummary || hasKeyFiles;
   const accordionResetKey = `${projectSlug}:${id}:${latest.runId ?? latest.id}`;
+  const hasBugReproCapture = itemType === 'bug' && hasPlaywrightRepro(events);
 
   function renderKeyFileCards() {
     return investigate.keyFiles.map((f) => {
@@ -396,7 +398,7 @@ export function InvestigationSection({
       )}
 
       {/* Playwright captures (bug items only) */}
-      {itemType === 'bug' && (
+      {hasBugReproCapture && (
         <InvestigationAccordionSection title="Bug Repro Capture" resetKey={accordionResetKey}>
           <PlaywrightCaptureSection projectSlug={projectSlug} id={id} itemType={itemType} />
         </InvestigationAccordionSection>
@@ -410,7 +412,7 @@ export function InvestigationSection({
             itemState === 'factory:gate-pending' ? 'Human review required' : 'Ready to proceed'
           }
           defaultOpen={itemState === 'factory:gate-pending'}
-          resetKey={accordionResetKey}
+          resetKey={`${accordionResetKey}:${itemState ?? 'unknown-state'}`}
           testId="investigation-proceed-gate"
           contentTestId="investigation-proceed-gate-content"
         >

--- a/apps/web/src/components/detail/components/InvestigationSection.tsx
+++ b/apps/web/src/components/detail/components/InvestigationSection.tsx
@@ -29,6 +29,7 @@ import { AcceptanceContractDetails } from './AcceptanceContractDetails';
 import { ConfidenceBadge } from './ConfidenceBadge';
 import { CostBadge } from './CostBadge';
 import { FindingCard } from './FindingCard';
+import { InvestigationAccordionSection } from './InvestigationAccordionSection';
 import { PlaywrightCaptureSection } from './PlaywrightCaptureSection';
 import { SectionEmptyState } from './SectionEmptyState';
 import { SpecDetails } from './SpecDetails';
@@ -232,43 +233,50 @@ export function InvestigationSection({
 
       {/* Root-cause finding card */}
       {investigate.findings.trim().length > 0 && (
-        <FindingCard
-          severity={investigate.confidence}
-          title="Root cause hypothesis"
-          body={
-            <div
-              data-testid="findings-content"
-              className="prose prose-sm prose-invert max-w-none text-[13px] text-fg-2 [&_p]:mb-2 [&_ul]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_code]:font-mono [&_code]:text-[12px]"
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by renderMarkdownToHtml
-              dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(investigate.findings) }}
-            />
-          }
-          conf={conf}
-          personaInitials={initials}
-          personaName={personaLabel}
-        />
+        <InvestigationAccordionSection title="Findings" defaultOpen>
+          <FindingCard
+            severity={investigate.confidence}
+            title="Root cause hypothesis"
+            body={
+              <div
+                data-testid="findings-content"
+                className="prose prose-sm prose-invert max-w-none text-[13px] text-fg-2 [&_p]:mb-2 [&_ul]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_code]:font-mono [&_code]:text-[12px]"
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by renderMarkdownToHtml
+                dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(investigate.findings) }}
+              />
+            }
+            conf={conf}
+            personaInitials={initials}
+            personaName={personaLabel}
+          />
+        </InvestigationAccordionSection>
       )}
 
       {/* Key files as long finding cards */}
       {investigate.keyFiles.length > 0 && (
-        <div data-testid="key-files-list" className="flex flex-col gap-3">
-          {investigate.keyFiles.map((f) => {
-            const basename = f.path.split('/').pop() ?? f.path;
-            return (
-              <FindingCard
-                key={f.path}
-                severity={investigate.confidence}
-                title={basename}
-                body={f.reason ? <span>{f.reason}</span> : <span className="text-fg-2">—</span>}
-                filePath={f.path}
-                viewUrl={githubBase != null ? `${githubBase}/${f.path}` : undefined}
-                conf={conf}
-                personaInitials={initials}
-                personaName={personaLabel}
-              />
-            );
-          })}
-        </div>
+        <InvestigationAccordionSection
+          title="Key Files"
+          badge={`${investigate.keyFiles.length} file${investigate.keyFiles.length !== 1 ? 's' : ''}`}
+        >
+          <div data-testid="key-files-list" className="flex flex-col gap-3">
+            {investigate.keyFiles.map((f) => {
+              const basename = f.path.split('/').pop() ?? f.path;
+              return (
+                <FindingCard
+                  key={f.path}
+                  severity={investigate.confidence}
+                  title={basename}
+                  body={f.reason ? <span>{f.reason}</span> : <span className="text-fg-2">—</span>}
+                  filePath={f.path}
+                  viewUrl={githubBase != null ? `${githubBase}/${f.path}` : undefined}
+                  conf={conf}
+                  personaInitials={initials}
+                  personaName={personaLabel}
+                />
+              );
+            })}
+          </div>
+        </InvestigationAccordionSection>
       )}
 
       <AcceptanceContractDetails contract={acceptanceContract} />
@@ -278,10 +286,10 @@ export function InvestigationSection({
 
       {/* Open questions */}
       {investigate.openQuestions.length > 0 && (
-        <div className="rounded-lg border border-line bg-bg-elev px-4 py-4">
-          <div className="text-[10.5px] uppercase tracking-wider text-fg-2 mb-2">
-            Open questions
-          </div>
+        <InvestigationAccordionSection
+          title="Open Questions"
+          badge={`${investigate.openQuestions.length} unresolved`}
+        >
           <ul data-testid="open-questions-list" className="space-y-1 list-disc list-inside">
             {investigate.openQuestions.map((q) => (
               <li key={q} className="text-[12.5px] text-fg-2">
@@ -289,19 +297,16 @@ export function InvestigationSection({
               </li>
             ))}
           </ul>
-        </div>
+        </InvestigationAccordionSection>
       )}
 
       {/* Investigation trail */}
       {investigate.decisionSummaries.length > 0 && (
-        <div className="rounded-lg border border-line bg-bg-elev overflow-hidden">
-          <div className="px-4 py-3 border-b border-line bg-bg-elev-2 flex items-baseline gap-2">
-            <div className="text-[10.5px] uppercase tracking-wider text-fg-2">
-              Investigation trail
-            </div>
-            <div className="text-[12px] text-fg-3">What was looked at, in order</div>
-          </div>
-          <ol data-testid="investigation-trail" className="px-4 py-3 flex flex-col gap-2">
+        <InvestigationAccordionSection
+          title="Investigation Trail"
+          badge="What was looked at, in order"
+        >
+          <ol data-testid="investigation-trail" className="flex flex-col gap-2">
             {investigate.decisionSummaries.map((s, i) => (
               <li
                 // biome-ignore lint/suspicious/noArrayIndexKey: trail is append-only and indices are stable for a given event payload
@@ -333,16 +338,16 @@ export function InvestigationSection({
               </li>
             ))}
           </ol>
-        </div>
+        </InvestigationAccordionSection>
       )}
 
       {/* Human review notes posted via the investigation gate */}
       {humanNotes.length > 0 && (
-        <div data-testid="investigation-human-notes">
-          <h4 className="text-[11px] font-medium text-fg-3 mb-2 uppercase tracking-wide">
-            Human review notes
-          </h4>
-          <div className="space-y-2">
+        <InvestigationAccordionSection
+          title="Human Review Notes"
+          badge={`${humanNotes.length} note${humanNotes.length !== 1 ? 's' : ''}`}
+        >
+          <div data-testid="investigation-human-notes" className="space-y-2">
             {humanNotes.map((note) => (
               <div
                 key={note.id}
@@ -361,12 +366,14 @@ export function InvestigationSection({
               </div>
             ))}
           </div>
-        </div>
+        </InvestigationAccordionSection>
       )}
 
       {/* Playwright captures (bug items only) */}
       {itemType === 'bug' && (
-        <PlaywrightCaptureSection projectSlug={projectSlug} id={id} itemType={itemType} />
+        <InvestigationAccordionSection title="Bug Repro Capture">
+          <PlaywrightCaptureSection projectSlug={projectSlug} id={id} itemType={itemType} />
+        </InvestigationAccordionSection>
       )}
 
       {/* Human proceed gate */}

--- a/apps/web/src/components/detail/components/SpecDetails.test.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.test.tsx
@@ -100,21 +100,35 @@ const SPEC: EngineeringSpecDto = {
 describe('SpecDetails', () => {
   it('renders collapsed header regardless of lifecycle state', () => {
     render(<SpecDetails spec={SPEC} itemState="factory:investigation-complete" />);
-    expect(screen.getByText('Engineering Spec')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /Engineering Spec/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
     expect(screen.getByText('2 work packages · 5 AC')).toBeTruthy();
     expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
+    expect(screen.queryByText('Update login and token refresh flow.')).toBeNull();
   });
 
   it('renders collapsed header when state is factory:dev-ready', () => {
     render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
-    expect(screen.getByText('Engineering Spec')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /Engineering Spec/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
     expect(screen.getByText('2 work packages · 5 AC')).toBeTruthy();
     expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
   });
 
+  it('honors defaultOpen when requested', () => {
+    render(<SpecDetails spec={SPEC} defaultOpen itemState="factory:dev-ready" />);
+    expect(
+      screen.getByRole('button', { name: /Engineering Spec/i }).getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(screen.getByText('Build the authentication flow with token refresh.')).toBeTruthy();
+    expect(screen.getByText('Update login and token refresh flow.')).toBeTruthy();
+  });
+
   it('expands to show all populated engineering spec sections', async () => {
     render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
-    await userEvent.click(screen.getByText('Engineering Spec'));
+    await userEvent.click(screen.getByRole('button', { name: /Engineering Spec/i }));
     expect(screen.getByText('Build the authentication flow with token refresh.')).toBeTruthy();
     expect(screen.getByText('Move refresh validation into session middleware.')).toBeTruthy();
     expect(screen.getAllByText('WP1').length).toBeGreaterThan(1);
@@ -141,9 +155,22 @@ describe('SpecDetails', () => {
 
   it('does not render legacy verifyCommand text for canonical criteria without executable checks', async () => {
     render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
-    await userEvent.click(screen.getByText('Engineering Spec'));
+    await userEvent.click(screen.getByRole('button', { name: /Engineering Spec/i }));
     expect(screen.getByText('Expired tokens are rejected.')).toBeTruthy();
     expect(screen.queryByText(/verifyCommand/i)).toBeNull();
     expect(screen.queryByText(/missing/i)).toBeNull();
+  });
+
+  it('collapses the engineering spec content after a second toggle', async () => {
+    render(<SpecDetails spec={SPEC} itemState="factory:dev-ready" />);
+    const toggle = screen.getByRole('button', { name: /Engineering Spec/i });
+
+    await userEvent.click(toggle);
+    expect(screen.getByText('Build the authentication flow with token refresh.')).toBeTruthy();
+
+    await userEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Build the authentication flow with token refresh.')).toBeNull();
+    expect(screen.queryByText('Update login and token refresh flow.')).toBeNull();
   });
 });

--- a/apps/web/src/components/detail/components/SpecDetails.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.tsx
@@ -1,7 +1,5 @@
 import type { EngineeringSpecDto } from '@/lib/types';
 import {
-  ChevronDown,
-  ChevronRight,
   ClipboardCheck,
   Database,
   FileCode2,
@@ -10,7 +8,8 @@ import {
   ShieldAlert,
   Terminal,
 } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import type { ReactNode } from 'react';
+import { InvestigationAccordionSection } from './InvestigationAccordionSection';
 
 function hasText(value: string | null | undefined): value is string {
   return value != null && value.trim().length > 0;
@@ -40,11 +39,12 @@ function MonoList({ values }: { values: string[] }) {
 
 export function SpecDetails({
   spec,
+  defaultOpen = false,
 }: {
   spec: EngineeringSpecDto;
   itemState?: string;
+  defaultOpen?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
   const wpCount = spec.workPackages.length;
   const hasArchitecture =
     spec.architecture != null &&
@@ -56,293 +56,269 @@ export function SpecDetails({
     (spec.schemaChanges.ddl.length > 0 || spec.schemaChanges.migrations.length > 0);
 
   return (
-    <div className="rounded-lg border border-[color:var(--accent)]/20 bg-bg-elev overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between px-4 py-3 bg-bg-elev-2 text-left cursor-pointer"
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          <Package size={12} className="shrink-0 text-[color:var(--accent)]" />
-          <span className="text-[10.5px] uppercase tracking-wider text-fg-2 shrink-0">
-            Engineering Spec
-          </span>
-          <span className="text-[11px] text-fg-4 truncate">
-            {wpCount} work package{wpCount !== 1 ? 's' : ''} · {spec.acceptanceCriteriaCount} AC
-          </span>
-        </div>
-        <span className="shrink-0 text-fg-4">
-          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </span>
-      </button>
+    <InvestigationAccordionSection
+      title="Engineering Spec"
+      icon={Package}
+      defaultOpen={defaultOpen}
+      badge={`${wpCount} work package${wpCount !== 1 ? 's' : ''} · ${spec.acceptanceCriteriaCount} AC`}
+    >
+      <Section title="Objective">
+        <p className="text-[12.5px] text-fg-2 leading-relaxed">{spec.objective}</p>
+      </Section>
 
-      {open && (
-        <div className="px-4 py-4 flex flex-col gap-4 border-t border-line">
-          <Section title="Objective">
-            <p className="text-[12.5px] text-fg-2 leading-relaxed">{spec.objective}</p>
-          </Section>
-
-          {hasArchitecture && spec.architecture != null && (
-            <Section title="Architecture">
-              <div className="grid gap-2 text-[12px] text-fg-2">
-                {hasText(spec.architecture.current) && (
-                  <div>
-                    <span className="text-fg-4">Current: </span>
-                    {spec.architecture.current}
-                  </div>
-                )}
-                {hasText(spec.architecture.new) && (
-                  <div>
-                    <span className="text-fg-4">New: </span>
-                    {spec.architecture.new}
-                  </div>
-                )}
-                {hasText(spec.architecture.decisionRationale) && (
-                  <div>
-                    <span className="text-fg-4">Rationale: </span>
-                    {spec.architecture.decisionRationale}
-                  </div>
-                )}
+      {hasArchitecture && spec.architecture != null && (
+        <Section title="Architecture">
+          <div className="grid gap-2 text-[12px] text-fg-2">
+            {hasText(spec.architecture.current) && (
+              <div>
+                <span className="text-fg-4">Current: </span>
+                {spec.architecture.current}
               </div>
-            </Section>
-          )}
-
-          {spec.workPackages.length > 0 && (
-            <Section title="Work Packages">
-              <div className="rounded border border-line overflow-hidden">
-                <table className="w-full text-[11.5px]">
-                  <thead>
-                    <tr className="border-b border-line bg-bg-elev-2">
-                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">ID</th>
-                      <th className="px-3 py-2 text-left text-fg-3 font-medium">Changes</th>
-                      <th className="px-3 py-2 text-left text-fg-3 font-medium">Files</th>
-                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-28">Depends</th>
-                      <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">Tier</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {spec.workPackages.map((wp) => (
-                      <tr key={wp.id} className="border-b border-line last:border-0 align-top">
-                        <td className="px-3 py-2 font-mono text-fg-2 whitespace-nowrap">{wp.id}</td>
-                        <td className="px-3 py-2 text-fg-2 leading-relaxed">{wp.changes}</td>
-                        <td className="px-3 py-2">
-                          <MonoList values={wp.filesOwned} />
-                        </td>
-                        <td className="px-3 py-2 font-mono text-[10.5px] text-fg-4">
-                          {wp.dependsOn.length > 0 ? wp.dependsOn.join(', ') : 'None'}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-fg-4 whitespace-nowrap">
-                          {wp.builderTier}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </Section>
-          )}
-
-          {spec.executionOrder.length > 0 && (
-            <Section title="Execution Order">
-              <div className="flex flex-col gap-2">
-                {spec.executionOrder.map((batch) => (
-                  <div
-                    key={`${batch.batch}:${batch.wpIds.join(',')}`}
-                    className="flex items-center gap-2 text-[12px] text-fg-2"
-                  >
-                    <GitBranch size={12} className="shrink-0 text-fg-4" />
-                    <span className="font-mono text-fg-4">Batch {batch.batch}</span>
-                    <span>{batch.wpIds.join(', ')}</span>
-                  </div>
-                ))}
-              </div>
-            </Section>
-          )}
-
-          <Section title="Acceptance Criteria">
-            <div className="flex items-center gap-2 text-[11.5px] text-fg-3 mb-2">
-              <ClipboardCheck size={12} className="text-fg-4 shrink-0" />
-              <span>{spec.acceptanceCriteriaCount} acceptance criteria</span>
-            </div>
-            {spec.acceptanceCriteria.length > 0 && (
-              <ol className="flex flex-col gap-2">
-                {spec.acceptanceCriteria.map((ac) => (
-                  <li
-                    key={ac.id}
-                    className="grid grid-cols-[3.5rem_1fr] gap-3 text-[12px] text-fg-2"
-                  >
-                    <span className="font-mono text-[11px] text-fg-4">{ac.id}</span>
-                    <div className="min-w-0">
-                      <div className="leading-relaxed">{ac.statement}</div>
-                      {(ac.executableChecks?.length ?? 0) > 0 && (
-                        <div className="mt-2 flex flex-col gap-1">
-                          {ac.executableChecks?.map((check) => (
-                            <div
-                              key={check.id}
-                              className="flex items-start gap-2 rounded border border-line bg-bg-elev-2 px-2 py-1.5"
-                            >
-                              <Terminal size={10} className="mt-0.5 shrink-0 text-fg-4" />
-                              <div className="min-w-0">
-                                <div className="font-mono text-[10.5px] text-fg-4 break-words">
-                                  {check.command}
-                                </div>
-                                <div className="text-[10px] text-fg-5">
-                                  {(check.kind ?? 'custom').toUpperCase()} · exit{' '}
-                                  {(check.expectedExitCodes ?? [0]).join(', ')}
-                                </div>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ol>
             )}
-          </Section>
-
-          {spec.verificationTooling.length > 0 && (
-            <Section title="Verification">
-              <div className="flex flex-col gap-2">
-                {spec.verificationTooling.map((tool) => (
-                  <div
-                    key={tool.name}
-                    className="rounded border border-line bg-bg-elev-2 px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 text-[12px] text-fg-2">
-                      <Terminal size={12} className="shrink-0 text-fg-4" />
-                      <span className="font-medium">{tool.name}</span>
-                      <span className="text-[10px] text-fg-5">
-                        exit {tool.expectedExitCodes.join(', ')}
-                      </span>
-                    </div>
-                    <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
-                      {tool.command}
-                    </div>
-                    {hasText(tool.inputSpec) && (
-                      <div className="mt-1 text-[11px] text-fg-4">{tool.inputSpec}</div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </Section>
-          )}
-
-          {spec.interfaceContracts.length > 0 && (
-            <Section title="Interfaces">
-              <div className="flex flex-col gap-2">
-                {spec.interfaceContracts.map((contract) => (
-                  <div
-                    key={`${contract.file}:${contract.name}`}
-                    className="rounded border border-line bg-bg-elev-2 px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 text-[12px] text-fg-2">
-                      <FileCode2 size={12} className="shrink-0 text-fg-4" />
-                      <span className="font-medium">{contract.name}</span>
-                    </div>
-                    <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
-                      {contract.file}
-                      {contract.lineRange != null ? `:${contract.lineRange}` : ''}
-                    </div>
-                    {contract.requiredExports != null && contract.requiredExports.length > 0 && (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {contract.requiredExports.map((requiredExport) => (
-                          <span
-                            key={`${requiredExport.file ?? contract.file}:${requiredExport.name}`}
-                            className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-fg-3"
-                          >
-                            export {requiredExport.name}
-                            {requiredExport.file != null ? ` @ ${requiredExport.file}` : ''}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-bg px-2 py-2 text-[10.5px] text-fg-3">
-                      {contract.signature}
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </Section>
-          )}
-
-          {hasSchemaChanges && spec.schemaChanges != null && (
-            <Section title="Schema">
-              <div className="flex flex-col gap-2 text-[12px] text-fg-2">
-                {spec.schemaChanges.ddl.length > 0 && (
-                  <div>
-                    <div className="flex items-center gap-2 text-fg-4 mb-1">
-                      <Database size={12} />
-                      <span>DDL</span>
-                    </div>
-                    <MonoList values={spec.schemaChanges.ddl} />
-                  </div>
-                )}
-                {spec.schemaChanges.migrations.length > 0 && (
-                  <div>
-                    <div className="text-fg-4 mb-1">Migrations</div>
-                    <MonoList values={spec.schemaChanges.migrations} />
-                  </div>
-                )}
-              </div>
-            </Section>
-          )}
-
-          {spec.constraints.length > 0 && (
-            <Section title="Constraints">
-              <div className="flex flex-col gap-1">
-                {spec.constraints.map((constraint) => (
-                  <div
-                    key={`${constraint.kind}:${constraint.name}:${constraint.source}`}
-                    className="grid grid-cols-[5.5rem_1fr] gap-2 text-[12px]"
-                  >
-                    <span className="font-mono text-[10.5px] text-fg-4">{constraint.kind}</span>
-                    <span className="text-fg-2">
-                      {constraint.name}{' '}
-                      <span className="font-mono text-[10.5px] text-fg-4 break-words">
-                        {constraint.source}
-                      </span>
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </Section>
-          )}
-
-          {spec.riskRegister.length > 0 && (
-            <Section title="Risks">
-              <div className="flex flex-col gap-2">
-                {spec.riskRegister.map((risk) => (
-                  <div key={`${risk.severity}:${risk.risk}`} className="text-[12px] text-fg-2">
-                    <div className="flex items-center gap-2">
-                      <ShieldAlert size={12} className="shrink-0 text-fg-4" />
-                      <span className="font-mono text-[10.5px] uppercase text-fg-4">
-                        {risk.severity}
-                      </span>
-                      <span>{risk.risk}</span>
-                    </div>
-                    <div className="ml-5 mt-1 text-fg-4">{risk.mitigation}</div>
-                  </div>
-                ))}
-              </div>
-            </Section>
-          )}
-
-          <Section title="Metadata">
-            <div className="grid gap-1 text-[11px] text-fg-4">
+            {hasText(spec.architecture.new) && (
               <div>
-                <span className="text-fg-5">Pipeline: </span>
-                <span className="font-mono break-words">{spec.pipelineRunId}</span>
+                <span className="text-fg-4">New: </span>
+                {spec.architecture.new}
               </div>
+            )}
+            {hasText(spec.architecture.decisionRationale) && (
               <div>
-                <span className="text-fg-5">Updated: </span>
-                <span className="font-mono">{spec.updatedAt}</span>
+                <span className="text-fg-4">Rationale: </span>
+                {spec.architecture.decisionRationale}
               </div>
-            </div>
-          </Section>
-        </div>
+            )}
+          </div>
+        </Section>
       )}
-    </div>
+
+      {spec.workPackages.length > 0 && (
+        <Section title="Work Packages">
+          <div className="rounded border border-line overflow-hidden">
+            <table className="w-full text-[11.5px]">
+              <thead>
+                <tr className="border-b border-line bg-bg-elev-2">
+                  <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">ID</th>
+                  <th className="px-3 py-2 text-left text-fg-3 font-medium">Changes</th>
+                  <th className="px-3 py-2 text-left text-fg-3 font-medium">Files</th>
+                  <th className="px-3 py-2 text-left text-fg-3 font-medium w-28">Depends</th>
+                  <th className="px-3 py-2 text-left text-fg-3 font-medium w-20">Tier</th>
+                </tr>
+              </thead>
+              <tbody>
+                {spec.workPackages.map((wp) => (
+                  <tr key={wp.id} className="border-b border-line last:border-0 align-top">
+                    <td className="px-3 py-2 font-mono text-fg-2 whitespace-nowrap">{wp.id}</td>
+                    <td className="px-3 py-2 text-fg-2 leading-relaxed">{wp.changes}</td>
+                    <td className="px-3 py-2">
+                      <MonoList values={wp.filesOwned} />
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[10.5px] text-fg-4">
+                      {wp.dependsOn.length > 0 ? wp.dependsOn.join(', ') : 'None'}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-fg-4 whitespace-nowrap">
+                      {wp.builderTier}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+      )}
+
+      {spec.executionOrder.length > 0 && (
+        <Section title="Execution Order">
+          <div className="flex flex-col gap-2">
+            {spec.executionOrder.map((batch) => (
+              <div
+                key={`${batch.batch}:${batch.wpIds.join(',')}`}
+                className="flex items-center gap-2 text-[12px] text-fg-2"
+              >
+                <GitBranch size={12} className="shrink-0 text-fg-4" />
+                <span className="font-mono text-fg-4">Batch {batch.batch}</span>
+                <span>{batch.wpIds.join(', ')}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      <Section title="Acceptance Criteria">
+        <div className="flex items-center gap-2 text-[11.5px] text-fg-3 mb-2">
+          <ClipboardCheck size={12} className="text-fg-4 shrink-0" />
+          <span>{spec.acceptanceCriteriaCount} acceptance criteria</span>
+        </div>
+        {spec.acceptanceCriteria.length > 0 && (
+          <ol className="flex flex-col gap-2">
+            {spec.acceptanceCriteria.map((ac) => (
+              <li key={ac.id} className="grid grid-cols-[3.5rem_1fr] gap-3 text-[12px] text-fg-2">
+                <span className="font-mono text-[11px] text-fg-4">{ac.id}</span>
+                <div className="min-w-0">
+                  <div className="leading-relaxed">{ac.statement}</div>
+                  {(ac.executableChecks?.length ?? 0) > 0 && (
+                    <div className="mt-2 flex flex-col gap-1">
+                      {ac.executableChecks?.map((check) => (
+                        <div
+                          key={check.id}
+                          className="flex items-start gap-2 rounded border border-line bg-bg-elev-2 px-2 py-1.5"
+                        >
+                          <Terminal size={10} className="mt-0.5 shrink-0 text-fg-4" />
+                          <div className="min-w-0">
+                            <div className="font-mono text-[10.5px] text-fg-4 break-words">
+                              {check.command}
+                            </div>
+                            <div className="text-[10px] text-fg-5">
+                              {(check.kind ?? 'custom').toUpperCase()} · exit{' '}
+                              {(check.expectedExitCodes ?? [0]).join(', ')}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </Section>
+
+      {spec.verificationTooling.length > 0 && (
+        <Section title="Verification">
+          <div className="flex flex-col gap-2">
+            {spec.verificationTooling.map((tool) => (
+              <div key={tool.name} className="rounded border border-line bg-bg-elev-2 px-3 py-2">
+                <div className="flex items-center gap-2 text-[12px] text-fg-2">
+                  <Terminal size={12} className="shrink-0 text-fg-4" />
+                  <span className="font-medium">{tool.name}</span>
+                  <span className="text-[10px] text-fg-5">
+                    exit {tool.expectedExitCodes.join(', ')}
+                  </span>
+                </div>
+                <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
+                  {tool.command}
+                </div>
+                {hasText(tool.inputSpec) && (
+                  <div className="mt-1 text-[11px] text-fg-4">{tool.inputSpec}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {spec.interfaceContracts.length > 0 && (
+        <Section title="Interfaces">
+          <div className="flex flex-col gap-2">
+            {spec.interfaceContracts.map((contract) => (
+              <div
+                key={`${contract.file}:${contract.name}`}
+                className="rounded border border-line bg-bg-elev-2 px-3 py-2"
+              >
+                <div className="flex items-center gap-2 text-[12px] text-fg-2">
+                  <FileCode2 size={12} className="shrink-0 text-fg-4" />
+                  <span className="font-medium">{contract.name}</span>
+                </div>
+                <div className="mt-1 font-mono text-[10.5px] text-fg-4 break-words">
+                  {contract.file}
+                  {contract.lineRange != null ? `:${contract.lineRange}` : ''}
+                </div>
+                {contract.requiredExports != null && contract.requiredExports.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {contract.requiredExports.map((requiredExport) => (
+                      <span
+                        key={`${requiredExport.file ?? contract.file}:${requiredExport.name}`}
+                        className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-fg-3"
+                      >
+                        export {requiredExport.name}
+                        {requiredExport.file != null ? ` @ ${requiredExport.file}` : ''}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-bg px-2 py-2 text-[10.5px] text-fg-3">
+                  {contract.signature}
+                </pre>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {hasSchemaChanges && spec.schemaChanges != null && (
+        <Section title="Schema">
+          <div className="flex flex-col gap-2 text-[12px] text-fg-2">
+            {spec.schemaChanges.ddl.length > 0 && (
+              <div>
+                <div className="flex items-center gap-2 text-fg-4 mb-1">
+                  <Database size={12} />
+                  <span>DDL</span>
+                </div>
+                <MonoList values={spec.schemaChanges.ddl} />
+              </div>
+            )}
+            {spec.schemaChanges.migrations.length > 0 && (
+              <div>
+                <div className="text-fg-4 mb-1">Migrations</div>
+                <MonoList values={spec.schemaChanges.migrations} />
+              </div>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {spec.constraints.length > 0 && (
+        <Section title="Constraints">
+          <div className="flex flex-col gap-1">
+            {spec.constraints.map((constraint) => (
+              <div
+                key={`${constraint.kind}:${constraint.name}:${constraint.source}`}
+                className="grid grid-cols-[5.5rem_1fr] gap-2 text-[12px]"
+              >
+                <span className="font-mono text-[10.5px] text-fg-4">{constraint.kind}</span>
+                <span className="text-fg-2">
+                  {constraint.name}{' '}
+                  <span className="font-mono text-[10.5px] text-fg-4 break-words">
+                    {constraint.source}
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {spec.riskRegister.length > 0 && (
+        <Section title="Risks">
+          <div className="flex flex-col gap-2">
+            {spec.riskRegister.map((risk) => (
+              <div key={`${risk.severity}:${risk.risk}`} className="text-[12px] text-fg-2">
+                <div className="flex items-center gap-2">
+                  <ShieldAlert size={12} className="shrink-0 text-fg-4" />
+                  <span className="font-mono text-[10.5px] uppercase text-fg-4">
+                    {risk.severity}
+                  </span>
+                  <span>{risk.risk}</span>
+                </div>
+                <div className="ml-5 mt-1 text-fg-4">{risk.mitigation}</div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      <Section title="Metadata">
+        <div className="grid gap-1 text-[11px] text-fg-4">
+          <div>
+            <span className="text-fg-5">Pipeline: </span>
+            <span className="font-mono break-words">{spec.pipelineRunId}</span>
+          </div>
+          <div>
+            <span className="text-fg-5">Updated: </span>
+            <span className="font-mono">{spec.updatedAt}</span>
+          </div>
+        </div>
+      </Section>
+    </InvestigationAccordionSection>
   );
 }

--- a/apps/web/src/components/detail/components/SpecDetails.tsx
+++ b/apps/web/src/components/detail/components/SpecDetails.tsx
@@ -40,10 +40,12 @@ function MonoList({ values }: { values: string[] }) {
 export function SpecDetails({
   spec,
   defaultOpen = false,
+  resetKey,
 }: {
   spec: EngineeringSpecDto;
   itemState?: string;
   defaultOpen?: boolean;
+  resetKey?: string;
 }) {
   const wpCount = spec.workPackages.length;
   const hasArchitecture =
@@ -60,6 +62,7 @@ export function SpecDetails({
       title="Engineering Spec"
       icon={Package}
       defaultOpen={defaultOpen}
+      resetKey={resetKey}
       badge={`${wpCount} work package${wpCount !== 1 ? 's' : ''} · ${spec.acceptanceCriteriaCount} AC`}
     >
       <Section title="Objective">

--- a/apps/web/src/components/detail/lib/playwright-capture.ts
+++ b/apps/web/src/components/detail/lib/playwright-capture.ts
@@ -83,3 +83,7 @@ export function extractPlaywrightRepro(events: AgentEventDto[]): PlaywrightRepro
   }
   return null;
 }
+
+export function hasPlaywrightRepro(events: AgentEventDto[]): boolean {
+  return extractPlaywrightRepro(events) != null;
+}


### PR DESCRIPTION
## Summary

investigation bug ui 10

## Work Packages

- ✓ **WP1**: Create a reusable local accordion section component matching the existing SpecDetails header style from apps/web/src/com
- ✓ **WP3**: Replace SpecDetails local accordion state at apps/web/src/components/detail/components/SpecDetails.tsx:41 and header mar
- ✓ **WP2**: Replace the static card root at apps/web/src/components/detail/components/AcceptanceContractDetails.tsx:17 with Investig
- ✓ **WP4**: Use InvestigationAccordionSection around the InvestigationSection content that is currently not consistently disclosed: 

Closes #1152
