### PR TITLE
Harden scout-pattern tool availability handling

### DIFF
--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -329,6 +329,7 @@ export async function runOneScout(
     scoutOutput.status === 'skipped' &&
     isUnsupportedToolAvailabilitySkip(decisionSummaries) &&
     !hasFactoryEvidenceAttempt(result.events);
+  if (unsupportedToolSkipWithoutAttempt) findings = [];
   if (scoutOutput.status === 'skipped' && !unsupportedToolSkipWithoutAttempt) {
     return emitSkippedScout({
       append,
@@ -340,7 +341,10 @@ export async function runOneScout(
     });
   }
 
-  if (findings.length === 0 && !hasSuccessfulFactoryEvidenceCall(result.events)) {
+  if (
+    (findings.length === 0 || unsupportedToolSkipWithoutAttempt) &&
+    !hasSuccessfulFactoryEvidenceCall(result.events)
+  ) {
     const seedEvidence = await readSeedEvidenceSnippets(ctx.worktreePath, fullContext);
     if (seedEvidence.length > 0) {
       const retryTimeoutMs = remainingTimeoutMs(start, budgets.timeoutMs);
@@ -378,13 +382,17 @@ export async function runOneScout(
           }
           const retryOutput = normalizeScoutOutput(retryParsed.data);
           const retryFindings = retryOutput.findings;
+          let retryUnsupportedToolSkipWithoutAttempt = false;
           if (retryOutput.status === 'skipped') {
             const retryDecisionSummaries =
               retryResult.decisionSummaries.length > 0
                 ? retryResult.decisionSummaries
                 : retryOutput.decisionSummaries;
+            retryUnsupportedToolSkipWithoutAttempt =
+              isUnsupportedToolAvailabilitySkip(retryDecisionSummaries) &&
+              !hasFactoryEvidenceAttempt(retryResult.events);
             if (
-              !isUnsupportedToolAvailabilitySkip(retryDecisionSummaries) ||
+              !retryUnsupportedToolSkipWithoutAttempt ||
               hasFactoryEvidenceAttempt(retryResult.events)
             ) {
               return emitSkippedScout({
@@ -399,9 +407,10 @@ export async function runOneScout(
             decisionSummaries = retryDecisionSummaries;
           }
           if (
-            retryFindings.length > 0 ||
-            hasSuccessfulFactoryEvidenceCall(retryResult.events) ||
-            retryOutput.status === 'ok'
+            !retryUnsupportedToolSkipWithoutAttempt &&
+            (retryFindings.length > 0 ||
+              hasSuccessfulFactoryEvidenceCall(retryResult.events) ||
+              retryOutput.status === 'ok')
           ) {
             result = retryResult;
             findings = retryFindings;

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -135,6 +135,28 @@ function hasSuccessfulFactoryEvidenceCall(events: readonly AgentEvent[]): boolea
   });
 }
 
+function hasFactoryEvidenceAttempt(events: readonly AgentEvent[]): boolean {
+  return events.some((event) => {
+    if (event.kind !== 'agent.tool-call') return false;
+    const payload = payloadRecord(event.payload);
+    if (payload == null) return false;
+    const toolName = normalizedToolName(payload.tool_name ?? payload.toolName ?? payload.tool);
+    return toolName != null && FACTORY_EVIDENCE_TOOL_NAMES.has(toolName);
+  });
+}
+
+function isUnsupportedToolAvailabilitySkip(decisionSummaries: readonly DecisionSummary[]): boolean {
+  const text = decisionSummaries
+    .map((summary) => `${summary.summary} ${summary.evidence ?? ''}`)
+    .join('\n')
+    .toLowerCase();
+  if (!/\btool/.test(text)) return false;
+  if (!/(read|search|workspace|factory|file)/.test(text)) return false;
+  return /not available|unavailable|not exposed|no .*tool|missing .*tool|required .*tool/.test(
+    text,
+  );
+}
+
 export async function runOneScout(
   spec: ScoutSpec,
   idx: number,
@@ -303,7 +325,11 @@ export async function runOneScout(
     result.decisionSummaries.length > 0 ? result.decisionSummaries : scoutOutput.decisionSummaries;
   let effectiveRunId = runId;
   let evidenceBackedEmptyResult = false;
-  if (scoutOutput.status === 'skipped') {
+  const unsupportedToolSkipWithoutAttempt =
+    scoutOutput.status === 'skipped' &&
+    isUnsupportedToolAvailabilitySkip(decisionSummaries) &&
+    !hasFactoryEvidenceAttempt(result.events);
+  if (scoutOutput.status === 'skipped' && !unsupportedToolSkipWithoutAttempt) {
     return emitSkippedScout({
       append,
       ctx,
@@ -353,17 +379,24 @@ export async function runOneScout(
           const retryOutput = normalizeScoutOutput(retryParsed.data);
           const retryFindings = retryOutput.findings;
           if (retryOutput.status === 'skipped') {
-            return emitSkippedScout({
-              append,
-              ctx,
-              runId: retrySpec.runId,
-              scoutName: spec.scoutName,
-              findings: retryFindings,
-              decisionSummaries:
-                retryResult.decisionSummaries.length > 0
-                  ? retryResult.decisionSummaries
-                  : retryOutput.decisionSummaries,
-            });
+            const retryDecisionSummaries =
+              retryResult.decisionSummaries.length > 0
+                ? retryResult.decisionSummaries
+                : retryOutput.decisionSummaries;
+            if (
+              !isUnsupportedToolAvailabilitySkip(retryDecisionSummaries) ||
+              hasFactoryEvidenceAttempt(retryResult.events)
+            ) {
+              return emitSkippedScout({
+                append,
+                ctx,
+                runId: retrySpec.runId,
+                scoutName: spec.scoutName,
+                findings: retryFindings,
+                decisionSummaries: retryDecisionSummaries,
+              });
+            }
+            decisionSummaries = retryDecisionSummaries;
           }
           if (
             retryFindings.length > 0 ||

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -668,6 +668,65 @@ describe('swarm.dispatchWave', () => {
     expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
   });
 
+  it('fails a tool-unavailable skip even when the scout returned findings', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-pattern': () =>
+        Promise.resolve({
+          output: {
+            findings: [
+              {
+                file: 'src/fake.ts',
+                line: 1,
+                fact: 'This finding was returned without using read/search tools.',
+                confidence: 'low',
+              },
+            ],
+            decisionSummaries: [
+              {
+                kind: 'UNCERTAINTY',
+                summary:
+                  'Could not inspect the workspace because the required Factory read/search tools (`read_file` and `search_text`) are not available in this run.',
+              },
+            ],
+            status: 'skipped',
+          },
+          decisionSummaries: [
+            {
+              kind: 'UNCERTAINTY',
+              summary:
+                'Could not inspect the workspace because the required Factory read/search tools (`read_file` and `search_text`) are not available in this run.',
+            },
+          ],
+          events: [],
+        }),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-tool-skip-with-findings',
+      scoutSpecs: [makeScoutSpec('scout-pattern')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      outcome: 'failed',
+      findings: [],
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-skipped')).toBe(false);
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+  });
+
   it('retries a tool-unavailable skip with deterministic seed evidence', async () => {
     const { fn: appendEvent } = makeFakeAppendEvent();
     const worktreePath = await makeSeedWorktree();

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -633,6 +633,89 @@ describe('swarm.dispatchWave', () => {
     expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
   });
 
+  it('fails a tool-unavailable skip when the scout made no Factory read/search attempt', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const runtime = makeRuntime({
+      'scout-pattern': () =>
+        Promise.resolve(
+          skippedResult(
+            'Could not inspect the workspace because the required Factory read/search tools (`read_file` and `search_text`) are not available in this run.',
+          ),
+        ),
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-tool-skip-no-attempt',
+      scoutSpecs: [makeScoutSpec('scout-pattern')],
+      workItem: makeWorkItem(),
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(result.reports[0]).toMatchObject({
+      status: 'error',
+      outcome: 'failed',
+      errorReason:
+        'scout returned no findings and made no successful Factory read/search/file tool calls',
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-skipped')).toBe(false);
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(true);
+  });
+
+  it('retries a tool-unavailable skip with deterministic seed evidence', async () => {
+    const { fn: appendEvent } = makeFakeAppendEvent();
+    const worktreePath = await makeSeedWorktree();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-pattern': (spec) => {
+        seenSpecs.push(spec);
+        if (seenSpecs.length === 1) {
+          return Promise.resolve(
+            skippedResult(
+              'Could not inspect the workspace because the required Factory read/search tools (`read_file` and `search_text`) are not available in this run.',
+            ),
+          );
+        }
+        return Promise.resolve(emptyResult([toolCallEvent(spec.runId, 'read_file', 'ok')]));
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-tool-skip-seeded-retry',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-pattern'),
+          extraContext: { investigationSeed: makeInvestigationSeed() },
+        },
+      ],
+      workItem: makeWorkItem(),
+      worktreePath,
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+    });
+
+    expect(seenSpecs).toHaveLength(2);
+    expect(seenSpecs[1].runId).toBe(
+      'parent-tool-skip-seeded-retry:scout:scout-pattern:0:evidence-retry',
+    );
+    expect(result.reports[0]).toMatchObject({
+      status: 'ok',
+      outcome: 'ok',
+      runId: 'parent-tool-skip-seeded-retry:scout:scout-pattern:0:evidence-retry',
+    });
+  });
+
   it('does not halt when two scouts skip and enough useful evidence remains', async () => {
     const { fn: appendEvent, events } = makeFakeAppendEvent();
     const runtime = makeRuntime({

--- a/skills/scout-code-path/prompt.md
+++ b/skills/scout-code-path/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/skills/scout-dependency/prompt.md
+++ b/skills/scout-dependency/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/skills/scout-pattern/prompt.md
+++ b/skills/scout-pattern/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/skills/scout-schema/prompt.md
+++ b/skills/scout-schema/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**. Any write attempt will be rejected.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/skills/scout-test-inventory/prompt.md
+++ b/skills/scout-test-inventory/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/skills/scout-tool-boundary.test.ts
+++ b/skills/scout-tool-boundary.test.ts
@@ -28,9 +28,8 @@ function expectToolBoundary(prompt: string): void {
 function expectFactoryReadDiscipline(prompt: string): void {
   expect(prompt).toContain('Use `list_dir`, `list_files`, `search_text`, or `read_file`');
   expect(prompt).toContain('Do not use `resources/list`, `resources/read`, or file resources');
-  expect(prompt).toContain(
-    'If a required Factory tool is unavailable, name the exact missing tool',
-  );
+  expect(prompt).toContain('Do not assume Factory tools are unavailable');
+  expect(prompt).toContain('If a required Factory tool call returns an error');
   expect(prompt).toContain('return explicit irrelevance');
 }
 

--- a/skills/scout-user-journey/prompt.md
+++ b/skills/scout-user-journey/prompt.md
@@ -9,7 +9,7 @@ You have **read and search access only**.
 - Allowed read tools: factory-tools read/search/git-read tools exposed to this run, including `read_file`, `list_dir`, `list_files`, `repo_intel.query`, and `search_text`.
 - Forbidden: MCP resources (`resources/list`, `resources/read`), `file://` URIs/resource handles, native shell, and any agent spawning, subagent delegation, collab, fork, or full-history fork.
 - Use `list_dir`, `list_files`, `search_text`, or `read_file` for workspace inspection. Do not use `resources/list`, `resources/read`, or file resources.
-- If a required Factory tool is unavailable, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
+- Do not assume Factory tools are unavailable. If a required Factory tool call returns an error that says the tool does not exist, name the exact missing tool in an `UNCERTAINTY` decision summary and return valid JSON; do not say "factory resources unavailable".
 - Start from any issue-provided path, `<investigationSeed>` candidate file, or `<symbolIndexHints>` location before broad search.
 - When you need to locate a symbol, call `repo_intel.query` with `intent: 'find-symbol'`. Use `search_text` only when `repo_intel` returns `not-found` or `index-stale`.
 - If this scout domain does not apply, return explicit irrelevance: `status: "skipped"` with `findings: []` and a decision summary. Do not ask the user for input.

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -356,6 +356,85 @@ describe('runInvestigateWorkflow', () => {
     });
   });
 
+  describe('buildPatternScoutFocus', () => {
+    it('anchors prose bugs to seed files when symbol identifiers are weak', async () => {
+      const { buildPatternScoutFocus } = await import('./workflow.js');
+
+      const focus = buildPatternScoutFocus({
+        workItem: {
+          title: 'Grill timeline stays live',
+          body: 'When a question is answered, mark it as completed like other agents do on the timeline.',
+        },
+        symbolIdentifiers: [],
+        investigationSeed: {
+          candidateFiles: [
+            { path: 'core/workflows/grill-and-prd.ts', root: 'worktree' },
+            { path: 'apps/server/src/domains/issues/prd-actions.ts', root: 'worktree' },
+            {
+              path: 'apps/web/src/components/detail/lib/timeline/phases/discover.ts',
+              root: 'worktree',
+            },
+          ],
+          candidateSymbols: [],
+          testFiles: [],
+          recentlyChangedFiles: [],
+          priorInvestigationRunIds: [],
+          builtAt: '2026-05-28T00:00:00.000Z',
+        },
+      });
+
+      expect(focus).toContain('completion/status pattern');
+      expect(focus).toContain('core/workflows/grill-and-prd.ts');
+      expect(focus).toContain('apps/server/src/domains/issues/prd-actions.ts');
+      expect(focus).not.toBe('Identify existing patterns the fix should follow');
+    });
+
+    it('keeps explicit code/event terms ahead of seed-file fallback', async () => {
+      const { buildPatternScoutFocus } = await import('./workflow.js');
+
+      const focus = buildPatternScoutFocus({
+        workItem: {
+          title: 'Fix timeline after `grill.completed`',
+          body: 'The badge should switch from "live" to "completed".',
+        },
+        symbolIdentifiers: [],
+        investigationSeed: {
+          candidateFiles: [{ path: 'apps/web/src/timeline.ts', root: 'worktree' }],
+          candidateSymbols: [],
+          testFiles: [],
+          recentlyChangedFiles: [],
+          priorInvestigationRunIds: [],
+          builtAt: '2026-05-28T00:00:00.000Z',
+        },
+      });
+
+      expect(focus).toContain('grill.completed');
+      expect(focus).toContain('live');
+      expect(focus).toContain('completed');
+    });
+
+    it('preserves symbol-based focus when identifiers are available', async () => {
+      const { buildPatternScoutFocus } = await import('./workflow.js');
+
+      const focus = buildPatternScoutFocus({
+        workItem: { title: 'Fix AuthService', body: 'Crashes on login' },
+        symbolIdentifiers: ['AuthService', 'SessionStore'],
+        investigationSeed: {
+          candidateFiles: [{ path: 'apps/web/src/timeline.ts', root: 'worktree' }],
+          candidateSymbols: [],
+          testFiles: [],
+          recentlyChangedFiles: [],
+          priorInvestigationRunIds: [],
+          builtAt: '2026-05-28T00:00:00.000Z',
+        },
+      });
+
+      expect(focus).toBe(
+        'Find existing usages of: AuthService, SessionStore — patterns this fix must follow',
+      );
+    });
+  });
+
   describe('swarm dispatch — acceptance criterion 1', () => {
     it('calls dispatchWave exactly twice (Wave 1 then Wave 2)', async () => {
       const { runInvestigateWorkflow } = await import('./workflow.js');

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -21,6 +21,7 @@ import { resolveGlobalSettingsForProject } from '@goose-hub/core/agent-runtime/r
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
 import {
+  type InvestigationSeed,
   buildInvestigationSeed,
   emitInvestigationSeedBuilt,
 } from '@goose-hub/core/agent-runtime/scout-prefetch.js';
@@ -142,6 +143,70 @@ function buildSchemaScoutFocus(workItem: { title: string; body: string }): strin
       : 'DB schemas, Zod schemas, event payload types, state enums, and API contracts relevant to this work item';
 
   return `Schema/type contracts only for ${target}. Do not trace runtime, retry, scheduler, or workflow control flow; return UNCERTAINTY if no schema surface exists after the first targeted reads.`;
+}
+
+export function buildPatternScoutFocus(input: {
+  workItem: { title: string; body: string };
+  symbolIdentifiers: string[];
+  investigationSeed: InvestigationSeed;
+}): string {
+  const text = `${input.workItem.title}\n${input.workItem.body}`;
+  const explicitTerms = extractPatternTerms(text).slice(0, 4);
+  const seedFiles = input.investigationSeed.candidateFiles.map((file) => file.path).slice(0, 3);
+
+  if (explicitTerms.length > 0) {
+    const seedHint =
+      seedFiles.length > 0 ? ` Start from ${formatInlineList(seedFiles)} before broad search.` : '';
+    return `Find existing usages of: ${explicitTerms.join(', ')} — patterns this fix must follow.${seedHint}`;
+  }
+
+  const patternTokens = input.symbolIdentifiers.slice(0, 4);
+  if (patternTokens.length > 0) {
+    return `Find existing usages of: ${patternTokens.join(', ')} — patterns this fix must follow`;
+  }
+
+  if (seedFiles.length > 0) {
+    return `Find the ${patternThemeForWorkItem(text)} used in ${formatInlineList(seedFiles)} and nearby sibling code; identify what this fix must replicate.`;
+  }
+
+  return 'Identify existing patterns the fix should follow';
+}
+
+function extractPatternTerms(text: string): string[] {
+  const terms: string[] = [];
+  const add = (value: string | undefined) => {
+    const trimmed = value?.trim();
+    if (trimmed == null || trimmed.length < 2 || trimmed.length > 64) return;
+    if (terms.includes(trimmed)) return;
+    terms.push(trimmed);
+  };
+
+  for (const match of text.matchAll(/\b[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+\b/g)) {
+    add(match[0]);
+  }
+  for (const [, inner] of text.matchAll(/`([^`]+)`/g)) add(inner);
+  for (const [, inner] of text.matchAll(/"([^"]+)"/g)) add(inner);
+  for (const [, inner] of text.matchAll(/'([^']+)'/g)) add(inner);
+
+  return terms;
+}
+
+function patternThemeForWorkItem(text: string): string {
+  const lower = text.toLowerCase();
+  if (
+    /\btimeline\b|\bbadge\b|\bphase\b|\bstate\b|\bstatus\b/.test(lower) &&
+    /\blive\b|\bcompleted?\b|\banswered?\b|\bfinished?\b/.test(lower)
+  ) {
+    return 'completion/status pattern';
+  }
+  if (/\bevent\b|\bemits?\b|\bappend(?:s|ed)?\b/.test(lower)) {
+    return 'event emission pattern';
+  }
+  return 'code pattern';
+}
+
+function formatInlineList(values: string[]): string {
+  return values.map((value) => `\`${value}\``).join(', ');
 }
 
 function runtimeNameForModel(modelId: string): 'codex-cli' | 'claude-cli' {
@@ -447,11 +512,11 @@ export async function runInvestigateWorkflow(
         builtMs: Date.now() - seedStartedAt,
       });
 
-      const patternTokens = symbolIdentifiers.slice(0, 4);
-      const patternFocus =
-        patternTokens.length > 0
-          ? `Find existing usages of: ${patternTokens.join(', ')} — patterns this fix must follow`
-          : 'Identify existing patterns the fix should follow';
+      const patternFocus = buildPatternScoutFocus({
+        workItem: workItemCtx,
+        symbolIdentifiers,
+        investigationSeed,
+      });
 
       const wave1Scouts = initialPlan.selectedWave1Scouts.map((spec) => {
         const shapedHints =


### PR DESCRIPTION
## Summary
- build scout-pattern focus from explicit issue terms, existing symbols, or investigation seed files instead of falling back to vague prose when symbols are weak
- reject zero-attempt tool-unavailable scout skips so they retry with seed evidence or fail as no-evidence instead of becoming graceful skips
- clarify scout-pattern prompt so tools can only be reported unavailable after an attempted missing-tool error

## Tests
- pnpm test core/agent-runtime/swarm.test.ts -- --runInBand
- pnpm test slices/investigate/slice.test.ts -- --runInBand
- pnpm exec biome check core/agent-runtime/scout-runner.ts core/agent-runtime/swarm.test.ts slices/investigate/workflow.ts slices/investigate/slice.test.ts skills/scout-pattern/prompt.md
- pnpm typecheck