### PR TITLE
Fix spec-author retry grouping and PRD path context

### DIFF
--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -1496,6 +1496,46 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     });
   });
 
+  it('keeps spec-author structural repair retries in the same delivery-router section', () => {
+    const items = groupTimelineEventsByCanonicalSection([
+      makeEvent(1, 'agent.run-started', 'spec-original', {
+        payload: { skill: 'spec-author' },
+      }),
+      makeEvent(2, 'agent.run-completed', 'spec-original', {
+        payload: { skill: 'spec-author' },
+      }),
+      makeEvent(3, 'agent.log', 'spec-original', {
+        payload: {
+          skill: 'spec-author',
+          stream: 'validation',
+          text: 'Spec author structural validation failed; retrying once.',
+        },
+      }),
+      makeEvent(4, 'agent.run-started', 'spec-repair', {
+        payload: {
+          skill: 'spec-author',
+          attempt: 'repair',
+          repairOf: 'spec-original',
+        },
+      }),
+      makeEvent(5, 'agent.run-completed', 'spec-repair', {
+        payload: { skill: 'spec-author' },
+      }),
+      makeEvent(6, 'agent.run-failed', 'spec-repair', {
+        payload: { skill: 'spec-author', error: 'Validation failed' },
+      }),
+    ]);
+
+    const deliverySections = items.filter(
+      (item) => item.kind === 'timeline-section' && item.section === 'delivery-router',
+    );
+
+    expect(deliverySections).toHaveLength(1);
+    expect(collectRunIdsForTimelineSection(deliverySections[0]?.items ?? [])).toEqual(
+      new Set(['spec-original', 'spec-repair']),
+    );
+  });
+
   it('uses run-started metadata before grouping sparse runtime events', () => {
     const items = groupTimelineEventsByCanonicalSection([
       makeEvent(1, 'agent.run-completed', 'run-prd-sparse'),

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -1521,8 +1521,8 @@ describe('groupTimelineEventsByCanonicalSection', () => {
       makeEvent(5, 'agent.run-completed', 'spec-repair', {
         payload: { skill: 'spec-author' },
       }),
-      makeEvent(6, 'agent.run-failed', 'spec-repair', {
-        payload: { skill: 'spec-author', error: 'Validation failed' },
+      makeEvent(6, 'spec.completed', 'spec-repair', {
+        payload: { pipelineRunId: 'spec-repair' },
       }),
     ]);
 

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -401,7 +401,7 @@ function timelineSegmentExplicitKey(
     case 'decompose':
       return workflowRunId ?? runId;
     case 'delivery-router':
-      return pipelineRunId ?? workflowRunId ?? specAuthorRepairByRunId.get(runId ?? '') ?? runId;
+      return specAuthorRepairByRunId.get(runId ?? '') ?? pipelineRunId ?? workflowRunId ?? runId;
     case 'implementation':
       return (
         fixFeedbackSegmentIdForEvent(event, fixFeedbackAttemptByRunId) ??

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -241,6 +241,7 @@ export function groupTimelineEventsByCanonicalSection(
   const discoverSessionByWorkflowOrRunId = buildDiscoverSessionRunIndex(normalizedEvents);
   const fixFeedbackAttemptByRunId = buildFixFeedbackAttemptRunIndex(normalizedEvents);
   const prdWorkflowByRevisionEventId = buildPrdRevisionWorkflowIndex(normalizedEvents);
+  const specAuthorRepairByRunId = buildSpecAuthorRepairRunIndex(normalizedEvents);
   const segments = buildTimelineSegments(
     normalizedEvents,
     runMetadata,
@@ -249,6 +250,7 @@ export function groupTimelineEventsByCanonicalSection(
     discoverSessionByWorkflowOrRunId,
     fixFeedbackAttemptByRunId,
     prdWorkflowByRevisionEventId,
+    specAuthorRepairByRunId,
   );
   const standaloneItems: RenderItem[] = [
     ...normalizedEvents
@@ -302,6 +304,7 @@ function buildTimelineSegments(
   discoverSessionByWorkflowOrRunId: DiscoverSessionRunIndex,
   fixFeedbackAttemptByRunId: ReadonlyMap<string, string>,
   prdWorkflowByRevisionEventId: ReadonlyMap<number, string>,
+  specAuthorRepairByRunId: ReadonlyMap<string, string>,
 ): TimelineSegmentAccumulator[] {
   const segments = new Map<string, TimelineSegmentAccumulator>();
   const orderedEvents = [...events].sort(
@@ -323,6 +326,7 @@ function buildTimelineSegments(
       discoverSessionByWorkflowOrRunId,
       fixFeedbackAttemptByRunId,
       prdWorkflowByRevisionEventId,
+      specAuthorRepairByRunId,
     );
     let segment: TimelineSegmentAccumulator | undefined;
 
@@ -367,6 +371,7 @@ function timelineSegmentExplicitKey(
   discoverSessionByWorkflowOrRunId: DiscoverSessionRunIndex,
   fixFeedbackAttemptByRunId: ReadonlyMap<string, string>,
   prdWorkflowByRevisionEventId: ReadonlyMap<number, string>,
+  specAuthorRepairByRunId: ReadonlyMap<string, string>,
 ): string | null {
   const payload = event.payload as Record<string, unknown> | null;
   const stringPayload = (key: string): string | null => {
@@ -396,7 +401,7 @@ function timelineSegmentExplicitKey(
     case 'decompose':
       return workflowRunId ?? runId;
     case 'delivery-router':
-      return pipelineRunId ?? workflowRunId ?? runId;
+      return pipelineRunId ?? workflowRunId ?? specAuthorRepairByRunId.get(runId ?? '') ?? runId;
     case 'implementation':
       return (
         fixFeedbackSegmentIdForEvent(event, fixFeedbackAttemptByRunId) ??
@@ -593,6 +598,22 @@ function isFixFeedbackRelatedEvent(event: AgentEventDto): boolean {
     eventHasWorkflowIdentity(event, 'fix-feedback') ||
     eventPayloadString(event, 'by') === 'fix-feedback'
   );
+}
+
+function buildSpecAuthorRepairRunIndex(events: AgentEventDto[]): Map<string, string> {
+  const repairByRunId = new Map<string, string>();
+
+  for (const event of events) {
+    if (event.kind !== 'agent.run-started') continue;
+    if (eventSkill(event) !== 'spec-author') continue;
+    if (eventPayloadString(event, 'attempt') !== 'repair') continue;
+    const runId = event.runId;
+    const repairOf = eventPayloadString(event, 'repairOf');
+    if (runId == null || runId.trim() === '' || repairOf == null) continue;
+    repairByRunId.set(runId, repairOf);
+  }
+
+  return repairByRunId;
 }
 
 function buildFixFeedbackAttemptRunIndex(events: AgentEventDto[]): Map<string, string> {

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -11,6 +11,7 @@ The `<task>` block contains:
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`
 - `<issueType>` — `feature` or `bug` (drives strictness of AC→Journey mapping)
 - `<prdContext>` (optional) — canonical compact PRD planning context from the approved parent PRD. Treat this as authoritative for journeys, requirements, acceptance criteria, slice boundaries, implementation decisions, testing decisions, and out-of-scope constraints. If it includes `artifactRef`, the full raw PRD was stored outside prompt context; use the inline fields as the planning contract and targeted repo reads for implementation details.
+  PRD module references may name planned files, not current files. Verify them against `<existingFileManifest>` or targeted reads before citing them as existing code.
 - `<prd>` (optional) — legacy compact PRD context string. Prefer `<prdContext>` when both are present. When absent and `issueType: feature`, derive minimal journeys from the work item.
 - `<investigationSynthesis>` (optional) — JSON-stringified `InvestigateOutput` (`findings`, `keyFiles`, `confidence`, `openQuestions`) produced by the synthesis step of the investigate workflow. **Read this first.** It is the distilled signal: use `findings` to understand the root cause or intent, `keyFiles` to orient your architecture section, and `openQuestions` to flag risks. When present, treat it as authoritative; use scout reports only for file:line citations.
 - `<scoutReports>` (optional) — JSON-stringified Wave-1 scout report digest metadata (M19.01). This is `scout-report-digest-v1`, not the raw scout report JSON. It includes top findings, high-confidence facts, files referenced, risks, contradictions, and artifact keys for full reports when they were offloaded.
@@ -149,6 +150,10 @@ Identify the change being requested. Pull `userJourneys` and `functionalRequirem
 If `<repairFeedback>` is present, read it first. Treat it as mandatory
 feedback from the validator and make the smallest correction needed while still
 returning a complete `EngineeringSpecSchema` JSON object.
+If it says a constraint cites a file that does not exist, do not cite that
+planned file again. Move planned paths to `filesOwned` or `interfaceContracts`
+and cite an existing host file, exported symbol, or current integration point in
+`constraints`.
 
 Emit: `[decision] READ: Issue #<n> — <one-sentence summary>`
 

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -1137,6 +1137,10 @@ describe('runSpecAuthorWorkflow', () => {
                       decision: 'Extend issue costs',
                       moduleRef: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts',
                     },
+                    {
+                      decision: 'Create a deeper planned feature view',
+                      moduleRef: 'apps/web/src/features/new-flow/view.tsx',
+                    },
                   ],
                   testingDecisions: {
                     modulesToTest: [
@@ -1169,6 +1173,9 @@ describe('runSpecAuthorWorkflow', () => {
           'apps/web/src/components/detail/hooks',
           'apps/web/src/components/detail',
           'apps/web/src/components/detail/components',
+          'apps/web/src/features/new-flow',
+          'apps/web/src/features',
+          'apps/web/src',
         ]),
       );
     });

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -1105,6 +1105,74 @@ describe('runSpecAuthorWorkflow', () => {
       expect(roots).not.toContain('Slice A');
     });
 
+    it('derives scopeRoots from PRD module refs and includes the nearest parent for planned dirs', async () => {
+      const { collectScopeManifest } = await import('@goose-hub/core/workspaces/scope-manifest.js');
+
+      vi.mocked(eventStore.replay).mockImplementation((query?: { kind?: string }) => {
+        if (query?.kind === 'prd.drafted') {
+          return [
+            {
+              id: 10,
+              projectId: 'goose-hub-self',
+              workItemId: 'github:shaunnez/goose-hub#55',
+              kind: 'prd.drafted',
+              payload: {
+                prd: {
+                  title: 'Workflow Snapshot Grid',
+                  problem: 'Operators need compact workflow summaries.',
+                  proposedSolution: 'Render overview workflow cards.',
+                  successCriteria: [],
+                  acceptanceCriteria: [],
+                  journeys: [],
+                  functionalSpec: null,
+                  verticalSlices: [
+                    { title: 'Slice A', goal: 'Do A', estimatedSize: 'S', journeyRefs: [] },
+                  ],
+                  implementationDecisions: [
+                    {
+                      decision: 'Add a pure summary builder',
+                      moduleRef: 'apps/web/src/components/detail/lib/overview-workflow-summary.ts',
+                    },
+                    {
+                      decision: 'Extend issue costs',
+                      moduleRef: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts',
+                    },
+                  ],
+                  testingDecisions: {
+                    modulesToTest: [
+                      'apps/web/src/components/detail/components/OverviewSection.test.tsx',
+                    ],
+                  },
+                },
+              },
+              runId: 'prd-run',
+              personaId: null,
+              createdAt: '2026-05-22T00:00:00.000Z',
+            },
+          ] as never;
+        }
+        return [];
+      });
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(
+        makeWorkItem({ type: 'feature' }),
+        makeMockSource(),
+        'goose-hub-self',
+        '/repo',
+      );
+
+      expect(collectScopeManifest).toHaveBeenCalledWith(
+        '/tmp/test-spec-worktree',
+        expect.arrayContaining([
+          'apps/web/src/components/detail/lib',
+          'apps/web/src/components/detail/hooks',
+          'apps/web/src/components/detail',
+          'apps/web/src/components/detail/components',
+        ]),
+      );
+    });
+
     it('derives scopeRoots from scout report digest files when investigation synthesis has no keyFiles', async () => {
       const { collectScopeManifest } = await import('@goose-hub/core/workspaces/scope-manifest.js');
       const scoutRepo = await import('@goose-hub/core/scout-reports/repository.js');

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -225,8 +225,46 @@ function dirOf(p: string): string {
   return slash === -1 ? '' : p.slice(0, slash);
 }
 
+function addDirWithParent(roots: Set<string>, path: unknown): void {
+  if (typeof path !== 'string' || path.length === 0) return;
+  const d = dirOf(path);
+  if (d.length === 0) return;
+  roots.add(d);
+  const parent = dirOf(d);
+  if (parent.length > 0) roots.add(parent);
+}
+
+function prdModuleRefPaths(prdContext: {
+  implementationDecisions?: unknown[];
+  testingDecisions?: unknown;
+}): string[] {
+  const paths: string[] = [];
+
+  for (const decision of prdContext.implementationDecisions ?? []) {
+    if (decision == null || typeof decision !== 'object') continue;
+    const moduleRef = (decision as { moduleRef?: unknown }).moduleRef;
+    if (typeof moduleRef === 'string' && moduleRef.length > 0) paths.push(moduleRef);
+  }
+
+  const testing = prdContext.testingDecisions;
+  if (testing != null && typeof testing === 'object') {
+    const modulesToTest = (testing as { modulesToTest?: unknown }).modulesToTest;
+    if (Array.isArray(modulesToTest)) {
+      for (const path of modulesToTest) {
+        if (typeof path === 'string' && path.length > 0) paths.push(path);
+      }
+    }
+  }
+
+  return paths;
+}
+
 function deriveSpecScopeRoots(input: {
-  prdContext?: { verticalSlices?: Array<unknown> };
+  prdContext?: {
+    verticalSlices?: Array<unknown>;
+    implementationDecisions?: Array<unknown>;
+    testingDecisions?: unknown;
+  };
   investigationSynthesis?: string;
   scoutReports?: string;
   wave2Reports?: string;
@@ -237,6 +275,12 @@ function deriveSpecScopeRoots(input: {
     const d = dirOf(path);
     if (d.length > 0) roots.add(d);
   };
+
+  if (input.prdContext != null) {
+    for (const path of prdModuleRefPaths(input.prdContext)) {
+      addDirWithParent(roots, path);
+    }
+  }
 
   if (input.investigationSynthesis != null) {
     let parsed: unknown;

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -225,13 +225,22 @@ function dirOf(p: string): string {
   return slash === -1 ? '' : p.slice(0, slash);
 }
 
-function addDirWithParent(roots: Set<string>, path: unknown): void {
+function isStableScopeAncestor(path: string): boolean {
+  if (path === 'core') return true;
+  if (path.endsWith('/src')) return true;
+  if (/^(slices|skills)\/[^/]+$/.test(path)) return true;
+  if (/^apps\/[^/]+$/.test(path)) return true;
+  return false;
+}
+
+function addDirWithAncestors(roots: Set<string>, path: unknown): void {
   if (typeof path !== 'string' || path.length === 0) return;
-  const d = dirOf(path);
-  if (d.length === 0) return;
-  roots.add(d);
-  const parent = dirOf(d);
-  if (parent.length > 0) roots.add(parent);
+  let dir = dirOf(path);
+  while (dir.length > 0) {
+    roots.add(dir);
+    if (isStableScopeAncestor(dir)) return;
+    dir = dirOf(dir);
+  }
 }
 
 function prdModuleRefPaths(prdContext: {
@@ -278,7 +287,7 @@ function deriveSpecScopeRoots(input: {
 
   if (input.prdContext != null) {
     for (const path of prdModuleRefPaths(input.prdContext)) {
-      addDirWithParent(roots, path);
+      addDirWithAncestors(roots, path);
     }
   }
 


### PR DESCRIPTION
## Summary
- collapse spec-author structural repair retries into the original Delivery Router timeline segment
- seed spec-author scope manifests from PRD module/test refs, including nearest parents for planned dirs
- clarify spec-author repair guidance so planned files are not reused as current-code constraints

## Verification
- pnpm vitest run apps/web/src/components/detail/lib/timeline.test.ts slices/spec-author/slice.test.ts
- pnpm exec biome check apps/web/src/components/detail/lib/timeline/index.ts apps/web/src/components/detail/lib/timeline.test.ts slices/spec-author/workflow.ts slices/spec-author/slice.test.ts skills/spec-author/prompt.md
- pnpm typecheck