### PR TITLE
Fix implementation pipeline timeline grouping

### DIFF
--- a/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
@@ -60,8 +60,19 @@ export function PhaseGroupWrapper({
         ? 'PRD Phase'
         : phase === 'contract'
           ? 'Contract Phase'
-          : 'Dev Phase';
+          : idKind === 'pipeline'
+            ? 'Implementation Pipeline'
+            : 'Dev Phase';
   const idLabel = idKind;
+  const countLabel = items.some(
+    (item) =>
+      item.kind === 'run-group' ||
+      item.kind === 'phase-group' ||
+      item.kind === 'review-group' ||
+      item.kind === 'investigation-phase',
+  )
+    ? 'groups'
+    : 'events';
 
   const statusBadge = isStalled ? (
     <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">
@@ -131,7 +142,9 @@ export function PhaseGroupWrapper({
           <span aria-hidden className="w-[3px] h-[3px] shrink-0 rounded-full bg-fg-4" />
           <span className="w-[72px] shrink-0 flex justify-start">{statusBadge}</span>
           <span className="flex-1 min-w-0 truncate">{metaLine}</span>
-          <span className="ml-auto shrink-0 text-fg-5">{items.length} events</span>
+          <span className="ml-auto shrink-0 text-fg-5">
+            {items.length} {countLabel}
+          </span>
         </summary>
         <ol className="flex flex-col gap-2 px-3 pb-3">
           {items.map((item, i) => renderItem(item, i, context))}

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -2,6 +2,7 @@ import type { AgentEventDto, InterventionDto, InterventionEventDto } from '@/lib
 import { describe, expect, it } from 'vitest';
 import {
   EVENT_KIND_LABEL,
+  type RenderItem,
   collectRunIdsForTimelineSection,
   computeIsLive,
   computeIsWritePrdStuck,
@@ -10,6 +11,12 @@ import {
   groupEvents,
   groupTimelineEventsByCanonicalSection,
 } from './timeline';
+import {
+  compareTimelineChildrenForReading,
+  effectiveTimestamp,
+  itemLastEventAt,
+  itemStartedAt,
+} from './timeline/render-items';
 
 function makeEvent(
   id: number,
@@ -855,7 +862,7 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     );
   });
 
-  it('sorts children inside a timeline segment by start time descending', () => {
+  it('sorts children inside a timeline segment by latest activity with earlier starts as ties', () => {
     const items = groupTimelineEventsByCanonicalSection([
       makeEvent(1, 'agent.run-started', 'triage-run', {
         createdAt: '2026-05-22T21:07:39Z',
@@ -876,7 +883,37 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     const triage = section(items, 'triage');
     expect(
       triage?.items.map((item) => (item.kind === 'run-group' ? item.runId : item.kind)),
-    ).toEqual(['repo-run', 'triage-run']);
+    ).toEqual(['triage-run', 'repo-run']);
+  });
+
+  it('uses the latest log-group entry for timeline child activity ordering', () => {
+    const logGroup: RenderItem = {
+      kind: 'log-group',
+      events: [
+        makeEvent(1, 'agent.log', null, { createdAt: '2026-05-22T21:07:39Z' }),
+        makeEvent(2, 'agent.log', null, { createdAt: '2026-05-22T21:08:09Z' }),
+      ],
+    };
+    const runGroup: RenderItem = {
+      kind: 'run-group',
+      runId: 'completed-run',
+      items: [],
+      skill: 'triage',
+      startedAt: '2026-05-22T21:07:50Z',
+      endedAt: '2026-05-22T21:08:04Z',
+      lastEventAt: '2026-05-22T21:08:04Z',
+      personaId: null,
+      modelId: null,
+      runtime: null,
+    };
+
+    expect(effectiveTimestamp(logGroup)).toBe(new Date('2026-05-22T21:08:09Z').getTime());
+    expect(itemStartedAt(logGroup)).toBe('2026-05-22T21:07:39Z');
+    expect(itemLastEventAt(logGroup)).toBe('2026-05-22T21:08:09Z');
+    expect([runGroup, logGroup].sort(compareTimelineChildrenForReading)).toEqual([
+      logGroup,
+      runGroup,
+    ]);
   });
 
   it('keeps repeated Grill rounds together but splits PRD revisions by workflow run', () => {
@@ -1074,30 +1111,45 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     ).toBe(true);
   });
 
-  it('keeps parallel implement parent and WP runs in the spec pipeline implementation segment', () => {
+  it('keeps parallel implement parent and WP runs in one implementation pipeline accordion', () => {
     const PIPELINE_RUN = 'pipeline-implementation-123';
     const PARALLEL_RUN = 'parallel-implement-run-456';
     const WP_RUN = `${PARALLEL_RUN}:wp:WP1:iter:1`;
+    const pipelineEvent = (
+      id: number,
+      kind: string,
+      runId: string | null,
+      payload: Record<string, unknown>,
+    ) =>
+      makeEvent(id, kind, runId, {
+        payload: { ...payload, pipelineRunId: PIPELINE_RUN },
+      });
     const items = groupTimelineEventsByCanonicalSection([
-      makeEvent(1, 'parallel-implement.iteration-started', PIPELINE_RUN, {
-        payload: { pipelineRunId: PIPELINE_RUN, iteration: 1, wpCount: 1, wpIds: ['WP1'] },
-      }),
-      makeEvent(2, 'agent.run-started', PARALLEL_RUN, {
-        payload: { skill: 'implement-wp' },
+      pipelineEvent(1, 'parallel-implement.iteration-started', PARALLEL_RUN, {
+        iteration: 1,
+        wpCount: 1,
+        wpIds: ['WP1'],
       }),
       makeEvent(3, 'agent.run-started', WP_RUN, {
         payload: { skill: 'implement-wp' },
       }),
-      makeEvent(4, 'parallel-implement.wp-started', WP_RUN, {
-        payload: { wpId: 'WP1', wpRunId: WP_RUN },
+      pipelineEvent(4, 'parallel-implement.wp-started', WP_RUN, {
+        wpId: 'WP1',
+        wpRunId: WP_RUN,
       }),
       makeEvent(5, 'agent.run-completed', WP_RUN),
-      makeEvent(6, 'parallel-implement.wp-committed', WP_RUN, {
-        payload: { wpId: 'WP1', wpRunId: WP_RUN, commitSha: 'abc1234' },
+      pipelineEvent(6, 'parallel-implement.wp-committed', WP_RUN, {
+        wpId: 'WP1',
+        wpRunId: WP_RUN,
+        commitSha: 'abc1234',
       }),
-      makeEvent(7, 'agent.run-completed', PARALLEL_RUN),
-      makeEvent(8, 'pr.opened', PIPELINE_RUN, {
-        payload: { pipelineRunId: PIPELINE_RUN, number: 968 },
+      pipelineEvent(7, 'pr.opened', PARALLEL_RUN, {
+        devRunId: PARALLEL_RUN,
+        prNumber: 968,
+      }),
+      pipelineEvent(8, 'agent.run-completed', PARALLEL_RUN, {
+        skill: 'parallel-implement',
+        prNumber: 968,
       }),
     ]);
 
@@ -1108,19 +1160,25 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     expect(implementationSections).toHaveLength(1);
     expect(implementationSections[0].segmentId).toBe(`implementation:${PIPELINE_RUN}`);
 
-    expect(implementationSections[0].items.some((item) => item.kind === 'phase-group')).toBe(false);
+    expect(implementationSections[0].items).toHaveLength(1);
+    expect(implementationSections[0].items[0]).toMatchObject({
+      kind: 'phase-group',
+      phase: 'dev',
+      pipelineRunId: PIPELINE_RUN,
+    });
+    const pipelineGroup = implementationSections[0].items[0];
+    if (pipelineGroup.kind !== 'phase-group') return;
+
     expect(
-      implementationSections[0].items.some(
-        (item) => item.kind === 'run-group' && item.runId === PIPELINE_RUN,
-      ),
-    ).toBe(false);
+      pipelineGroup.items.map((item) => (item.kind === 'run-group' ? item.runId : item.kind)),
+    ).toEqual([PARALLEL_RUN, WP_RUN]);
     expect(
-      implementationSections[0].items.some(
-        (item) => item.kind === 'event' && item.event.kind === 'pr.opened',
-      ),
+      pipelineGroup.items
+        .flatMap((item) => (item.kind === 'run-group' ? item.items : [item]))
+        .some((item) => item.kind === 'event' && item.event.kind === 'pr.opened'),
     ).toBe(true);
     expect(collectRunIdsForTimelineSection(implementationSections[0].items)).toEqual(
-      new Set([PIPELINE_RUN, PARALLEL_RUN, WP_RUN]),
+      new Set([PARALLEL_RUN, WP_RUN]),
     );
   });
 

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -826,7 +826,12 @@ function flattenRedundantSectionPhase(
   if (section === 'delivery-router' && item.kind === 'phase-group' && item.phase === 'contract') {
     return item.items;
   }
-  if (section === 'implementation' && item.kind === 'phase-group' && item.phase === 'dev') {
+  if (
+    section === 'implementation' &&
+    item.kind === 'phase-group' &&
+    item.phase === 'dev' &&
+    item.items.length <= 1
+  ) {
     return item.items;
   }
   if (section === 'review' && item.kind === 'review-group') return item.items;

--- a/apps/web/src/components/detail/lib/timeline/render-items.ts
+++ b/apps/web/src/components/detail/lib/timeline/render-items.ts
@@ -19,7 +19,7 @@ export function effectiveTimestamp(item: RenderItem): number {
   if (item.kind === 'review-group') {
     return new Date(item.lastEventAt ?? item.startedAt ?? 0).getTime();
   }
-  return new Date(item.events[0]?.createdAt ?? 0).getTime();
+  return maxEventTimestamp(item.events);
 }
 
 export function optionalTimestamp(value: string | null): number {
@@ -46,11 +46,11 @@ export function compareTopLevelTimelineItems(a: RenderItem, b: RenderItem): numb
 }
 
 export function compareTimelineChildrenForReading(a: RenderItem, b: RenderItem): number {
-  const startDelta = optionalTimestamp(itemStartedAt(b)) - optionalTimestamp(itemStartedAt(a));
-  if (startDelta !== 0) return startDelta;
-
   const activityDelta = effectiveTimestamp(b) - effectiveTimestamp(a);
   if (activityDelta !== 0) return activityDelta;
+
+  const startDelta = optionalTimestamp(itemStartedAt(a)) - optionalTimestamp(itemStartedAt(b));
+  if (startDelta !== 0) return startDelta;
 
   if (a.kind === 'run-group' && b.kind === 'run-group') return a.runId.localeCompare(b.runId);
   if (a.kind === 'event' && b.kind === 'event') return a.event.id - b.event.id;
@@ -110,7 +110,7 @@ export function eventFromRenderItem(item: RenderItem): AgentEventDto[] {
 
 export function itemStartedAt(item: RenderItem): string | null {
   if (item.kind === 'event') return item.event.createdAt;
-  if (item.kind === 'log-group') return item.events.at(-1)?.createdAt ?? null;
+  if (item.kind === 'log-group') return minEventTimestampIso(item.events);
   if (
     item.kind === 'timeline-section' ||
     item.kind === 'run-group' ||
@@ -140,7 +140,7 @@ export function itemEndedAt(item: RenderItem): string | null {
 
 export function itemLastEventAt(item: RenderItem): string | null {
   if (item.kind === 'event') return item.event.createdAt;
-  if (item.kind === 'log-group') return item.events[0]?.createdAt ?? null;
+  if (item.kind === 'log-group') return maxEventTimestampIso(item.events);
   if (
     item.kind === 'timeline-section' ||
     item.kind === 'run-group' ||
@@ -152,6 +152,41 @@ export function itemLastEventAt(item: RenderItem): string | null {
     return item.lastEventAt;
   }
   return null;
+}
+
+function minEventTimestampIso(events: AgentEventDto[]): string | null {
+  let minMs = Number.POSITIVE_INFINITY;
+  let iso: string | null = null;
+  for (const event of events) {
+    const ms = new Date(event.createdAt).getTime();
+    if (ms < minMs) {
+      minMs = ms;
+      iso = event.createdAt;
+    }
+  }
+  return iso;
+}
+
+function maxEventTimestamp(events: AgentEventDto[]): number {
+  let maxMs = Number.NEGATIVE_INFINITY;
+  for (const event of events) {
+    const ms = new Date(event.createdAt).getTime();
+    if (ms > maxMs) maxMs = ms;
+  }
+  return maxMs === Number.NEGATIVE_INFINITY ? 0 : maxMs;
+}
+
+function maxEventTimestampIso(events: AgentEventDto[]): string | null {
+  let maxMs = Number.NEGATIVE_INFINITY;
+  let iso: string | null = null;
+  for (const event of events) {
+    const ms = new Date(event.createdAt).getTime();
+    if (ms > maxMs) {
+      maxMs = ms;
+      iso = event.createdAt;
+    }
+  }
+  return iso;
 }
 
 export function extractTimelineSectionTimes(items: RenderItem[]): {


### PR DESCRIPTION
## Summary
- keep multi-run parallel implementation pipelines inside one nested implementation accordion
- order timeline children by latest activity, then earlier start time for ties
- label nested implementation pipeline groups and show group counts when they contain run groups

## Verification
- pnpm vitest run apps/web/src/components/detail/lib/timeline.test.ts
- pnpm vitest run apps/web/src/components/detail/components/TimelineSection.test.ts
- pnpm exec biome check apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/lib/timeline/index.ts apps/web/src/components/detail/lib/timeline/render-items.ts apps/web/src/components/detail/components/timeline/PhaseGroupWrapper.tsx
- pnpm typecheck
- git diff --check