### PR TITLE
Show task header cost metrics

### DIFF
--- a/apps/web/src/components/detail/components/TaskHeader.test.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.test.tsx
@@ -1,0 +1,127 @@
+/** @vitest-environment jsdom */
+import { fetchIssueCosts, fetchMilestones } from '@/lib/api';
+import type { WorkItemCostsDto, WorkItemDto } from '@/lib/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskHeader } from './TaskHeader';
+
+vi.mock('@/lib/api', () => ({
+  fetchIssueCosts: vi.fn(),
+  fetchMilestones: vi.fn(),
+  fetchPersonaNames: vi.fn().mockResolvedValue([]),
+  fetchLegalTargets: vi.fn().mockResolvedValue({ from: 'factory:in-progress', legalTargets: [] }),
+  setLabel: vi.fn(),
+  setMilestone: vi.fn(),
+  transitionState: vi.fn(),
+}));
+
+vi.mock('./TransitionButton', () => ({
+  TransitionButton: () => <button type="button">Transition</button>,
+}));
+
+let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+function item(partial: Partial<WorkItemDto> = {}): WorkItemDto {
+  return {
+    id: 'wi-1',
+    externalId: '42',
+    repoRef: 'owner/repo',
+    title: 'Fix task header metrics',
+    body: '',
+    type: 'bug',
+    priority: 'high',
+    mode: 'supervised',
+    state: 'factory:in-progress',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: '2026-05-01T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('TaskHeader', () => {
+  beforeEach(() => {
+    dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-01T02:15:00Z').getTime());
+    vi.mocked(fetchMilestones).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    dateNowSpy.mockRestore();
+    vi.mocked(fetchIssueCosts).mockReset();
+    vi.mocked(fetchMilestones).mockReset();
+  });
+
+  it('renders cost, token, cache, and fix duration metrics', async () => {
+    const costs: WorkItemCostsDto = {
+      workItemId: 'wi-1',
+      totalUsd: 0.42,
+      hasEstimated: false,
+      rows: [
+        {
+          runId: 'run-1',
+          workItemId: 'wi-1',
+          stage: 'dev',
+          skill: 'implement',
+          modelId: 'claude-sonnet-4-6',
+          provider: 'claude',
+          inputTokens: 1200,
+          cachedInputTokens: 600,
+          outputTokens: 300,
+          reasoningOutputTokens: 0,
+          costUsd: 0.42,
+          costLabel: 'exact',
+          cacheHitRatio: 0.5,
+          personaId: null,
+          createdAt: '2026-05-01T01:00:00Z',
+        },
+      ],
+    };
+    vi.mocked(fetchIssueCosts).mockResolvedValue(costs);
+
+    renderWithQueryClient(<TaskHeader item={item()} projectSlug="proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-header-cost').textContent).toContain('cost $0.42');
+    });
+    expect(screen.getByTestId('task-header-tokens').textContent).toContain('tokens 1.5k');
+    expect(screen.getByTestId('task-header-cached-tokens').textContent).toContain('cached 600');
+    expect(screen.getByTestId('task-header-cache-hit').textContent).toContain('cache hit 50%');
+    expect(screen.getByTestId('task-header-fix-duration').textContent).toContain(
+      'fix duration 2h 15m',
+    );
+  });
+
+  it('freezes fix duration at closedAt for completed work', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValue({
+      workItemId: 'wi-1',
+      totalUsd: 0,
+      hasEstimated: false,
+      rows: [],
+    });
+
+    renderWithQueryClient(
+      <TaskHeader
+        item={item({
+          state: 'factory:done',
+          createdAt: '2026-05-01T00:00:00Z',
+          closedAt: '2026-05-01T00:45:00Z',
+        })}
+        projectSlug="proj"
+      />,
+    );
+
+    expect(screen.getByTestId('task-header-fix-duration').textContent).toContain(
+      'fix duration 45m',
+    );
+  });
+});

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -18,6 +18,31 @@ interface TaskHeaderProps {
   hasOpenDep?: boolean;
 }
 
+function formatCacheHit(ratio: number): string {
+  if (!Number.isFinite(ratio)) return '—';
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function formatFixDuration(item?: WorkItemDto): string {
+  if (item == null || item.createdAt === '') return '—';
+  const startMs = new Date(item.createdAt).getTime();
+  if (!Number.isFinite(startMs)) return '—';
+
+  const closedAt = item.closedAt;
+  const closedMs = closedAt != null ? new Date(closedAt).getTime() : Number.NaN;
+  const endMs = Number.isFinite(closedMs) ? closedMs : Date.now();
+  const minutes = Math.max(0, Math.floor((endMs - startMs) / 60000));
+  if (minutes < 60) return `${minutes}m`;
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 48) return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
+}
+
 export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeaderProps) {
   const queryClient = useQueryClient();
   const [savingPriority, setSavingPriority] = useState(false);
@@ -36,6 +61,20 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
 
   const lane = item?.state ? (laneForState(item.state) ?? item.state.replace('factory:', '')) : '—';
   const lastPersonaLabel = getPersonaLabel(personaMap, item?.lastPersonaId) ?? '—';
+  const costTitle =
+    costs.runCount === 0
+      ? 'No agent runs recorded yet'
+      : [
+          `${formatTokens(costs.totalTokens)} tokens`,
+          `${formatTokens(costs.totalCachedInputTokens)} cached input tokens`,
+          `${formatCacheHit(costs.totalCacheHitRatio)} cache hit`,
+          `${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`,
+        ].join(' · ');
+  const costValue = costs.runCount === 0 ? '$—' : formatCost(costs.total, costs.totalLabel);
+  const tokenValue = costs.runCount === 0 ? '—' : formatTokens(costs.totalTokens);
+  const cachedTokenValue = costs.runCount === 0 ? '—' : formatTokens(costs.totalCachedInputTokens);
+  const cacheHitValue = costs.runCount === 0 ? '—' : formatCacheHit(costs.totalCacheHitRatio);
+  const fixDuration = formatFixDuration(item);
 
   const externalId = item?.externalId;
   const invalidate = useCallback(() => {
@@ -123,20 +162,37 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
           <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
           <span data-testid="task-header-cost">
             cost{' '}
-            <span
-              className="font-mono"
-              title={
-                costs.runCount === 0
-                  ? 'No agent runs recorded yet'
-                  : `${formatTokens(costs.totalTokens)} tokens across ${costs.runCount} run${costs.runCount === 1 ? '' : 's'}`
-              }
-            >
-              {costs.runCount === 0 ? '$—' : formatCost(costs.total, costs.totalLabel)}
+            <span className="font-mono" title={costTitle}>
+              {costValue}
             </span>
           </span>
           <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
-          <span title="Duration tracking available in M9" data-testid="duration-placeholder">
-            duration <span className="font-mono">—</span>
+          <span data-testid="task-header-tokens">
+            tokens{' '}
+            <span className="font-mono" title={costTitle}>
+              {tokenValue}
+            </span>
+          </span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span data-testid="task-header-cached-tokens">
+            cached{' '}
+            <span className="font-mono" title={costTitle}>
+              {cachedTokenValue}
+            </span>
+          </span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span data-testid="task-header-cache-hit">
+            cache hit{' '}
+            <span className="font-mono" title={costTitle}>
+              {cacheHitValue}
+            </span>
+          </span>
+          <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
+          <span
+            title="Elapsed time since this work item opened"
+            data-testid="task-header-fix-duration"
+          >
+            fix duration <span className="font-mono">{fixDuration}</span>
           </span>
           {/* Type — static, leftmost */}
           <span className="inline-flex items-center h-6 px-2.5 rounded-full text-[11.5px] bg-bg-elev border border-line text-fg-2 capitalize">

--- a/apps/web/src/components/detail/lib/costs.test.ts
+++ b/apps/web/src/components/detail/lib/costs.test.ts
@@ -89,6 +89,10 @@ describe('useIssueCostsBreakdown', () => {
 
     expect(result.current.total).toBeCloseTo(0.36, 5);
     expect(result.current.totalTokens).toBe(200 + 100 + 300 + 100 + 800 + 400);
+    expect(result.current.totalInputTokens).toBe(200 + 300 + 800);
+    expect(result.current.totalCachedInputTokens).toBe(200);
+    expect(result.current.totalReasoningOutputTokens).toBe(20);
+    expect(result.current.totalCacheHitRatio).toBeCloseTo(200 / 1300, 5);
     expect(result.current.byRun.get('r-dev-1')?.costUsd).toBe(0.25);
 
     const qa = result.current.byStage.get('qa');

--- a/apps/web/src/components/detail/lib/costs.ts
+++ b/apps/web/src/components/detail/lib/costs.ts
@@ -20,6 +20,10 @@ export interface IssueCostsBreakdown {
   byStage: Map<CostRowDto['stage'], StageBreakdown>;
   total: number;
   totalTokens: number;
+  totalInputTokens: number;
+  totalCachedInputTokens: number;
+  totalReasoningOutputTokens: number;
+  totalCacheHitRatio: number;
   hasEstimated: boolean;
   totalLabel: 'estimated' | 'exact';
   runCount: number;
@@ -31,6 +35,10 @@ const EMPTY: Omit<IssueCostsBreakdown, 'isLoading'> = {
   byStage: new Map(),
   total: 0,
   totalTokens: 0,
+  totalInputTokens: 0,
+  totalCachedInputTokens: 0,
+  totalReasoningOutputTokens: 0,
+  totalCacheHitRatio: 0,
   hasEstimated: false,
   totalLabel: 'exact',
   runCount: 0,
@@ -56,11 +64,17 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
     const byRun = new Map<string, CostRowDto>();
     const byStage = new Map<CostRowDto['stage'], StageBreakdown>();
     let totalTokens = 0;
+    let totalInputTokens = 0;
+    let totalCachedInputTokens = 0;
+    let totalReasoningOutputTokens = 0;
 
     for (const row of data.rows) {
       byRun.set(row.runId, row);
       const tokens = row.inputTokens + row.outputTokens;
       totalTokens += tokens;
+      totalInputTokens += row.inputTokens;
+      totalCachedInputTokens += row.cachedInputTokens;
+      totalReasoningOutputTokens += row.reasoningOutputTokens;
 
       const existing = byStage.get(row.stage);
       if (existing) {
@@ -92,6 +106,10 @@ export function useIssueCostsBreakdown(projectSlug: string, id: string): IssueCo
       byStage,
       total: data.totalUsd,
       totalTokens,
+      totalInputTokens,
+      totalCachedInputTokens,
+      totalReasoningOutputTokens,
+      totalCacheHitRatio: totalCachedInputTokens / Math.max(totalInputTokens, 1),
       hasEstimated: data.hasEstimated,
       totalLabel: data.hasEstimated ? 'estimated' : 'exact',
       runCount: data.rows.length,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface WorkItemDto {
   prdChildren?: string[];
   prdParent?: string;
   createdAt: string;
+  closedAt?: string | null;
   lastPersonaId?: string | null;
 }
 

--- a/core/state-source/github-issue-mapper.ts
+++ b/core/state-source/github-issue-mapper.ts
@@ -33,6 +33,7 @@ export interface GithubIssue {
   milestone: GithubMilestone | null;
   user: { login: string } | null;
   created_at: string;
+  closed_at?: string | null;
   pull_request?: unknown;
 }
 
@@ -105,6 +106,7 @@ export function mapIssueToWorkItem(
     dependsOn: parseDependsOn(body),
     blocks: parseBlocks(body),
     createdAt: new Date(issue.created_at),
+    closedAt: issue.closed_at == null ? undefined : new Date(issue.closed_at),
   };
 }
 

--- a/core/state-source/in-memory-labels.ts
+++ b/core/state-source/in-memory-labels.ts
@@ -2,7 +2,7 @@ import { deleteEngineeringSpec } from '../engineering-specs/repository.js';
 import { eventStore } from '../event-stream/store.js';
 import { deleteInterventionsForWorkItem } from '../interventions/repository.js';
 import { resolveState } from '../state-machine/conflict-resolver.js';
-import { STATES } from '../state-machine/states.js';
+import { STATES, TERMINAL_STATES } from '../state-machine/states.js';
 import type { StateName } from '../state-machine/states.js';
 import { isLegalTransition } from '../state-machine/transitions.js';
 import type {
@@ -51,6 +51,7 @@ interface MockIssueStore {
   blocks: string[];
   comments: IssueComment[];
   createdAt: Date;
+  closedAt?: Date;
   prDiff?: string;
   /** Arbitrary extra labels not tracked by the enum fields above. */
   extraLabels: Set<string>;
@@ -109,6 +110,7 @@ export class InMemoryLabelsSource implements StateSource {
       dependsOn: issue.dependsOn,
       blocks: issue.blocks,
       createdAt: issue.createdAt,
+      closedAt: issue.closedAt,
     };
   }
 
@@ -174,6 +176,7 @@ export class InMemoryLabelsSource implements StateSource {
       );
     }
     issue.state = to;
+    issue.closedAt = TERMINAL_STATES.has(to) ? new Date() : undefined;
   }
 
   async forceState(itemId: string, to: StateName): Promise<void> {
@@ -181,6 +184,7 @@ export class InMemoryLabelsSource implements StateSource {
     const issue = this.getByExternalId(number);
     if (issue == null) throw new Error(`InMemoryLabelsSource: issue #${number} not found`);
     issue.state = to;
+    issue.closedAt = TERMINAL_STATES.has(to) ? new Date() : undefined;
   }
 
   async comment(itemId: string, body: string): Promise<void> {
@@ -328,6 +332,7 @@ export class InMemoryLabelsSource implements StateSource {
     if (issue == null) throw new Error('InMemoryLabelsSource: created issue not found');
     if (opts.state != null && opts.state !== 'factory:triaging') {
       issue.state = opts.state;
+      issue.closedAt = TERMINAL_STATES.has(opts.state) ? new Date() : undefined;
     }
     if (opts.schedule != null) issue.schedule = opts.schedule;
     if (opts.dependsOn != null) issue.dependsOn = opts.dependsOn;

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -37,6 +37,7 @@ export interface WorkItem {
   dependsOn: string[]; // repo-qualified refs parsed from body
   blocks: string[];
   createdAt: Date;
+  closedAt?: Date;
 }
 
 export interface Milestone {

--- a/core/state-source/local-db.ts
+++ b/core/state-source/local-db.ts
@@ -100,6 +100,7 @@ export class LocalDbStateSource implements StateSource {
       dependsOn: mapDependencyRefs(row.body, 'depends-on', repoRef),
       blocks: mapDependencyRefs(row.body, 'blocks', repoRef),
       createdAt: new Date(row.createdAt),
+      closedAt: row.closedAt == null ? undefined : new Date(row.closedAt),
     };
   }
 


### PR DESCRIPTION
## Summary
- add aggregate cached-token and cache-hit rollups to the detail cost hook
- show cost, tokens, cached tokens, cache hit, and fix duration in the task header
- add focused coverage for the new header metrics and cost rollups

## Tests
- pnpm exec biome check apps/web/src/components/detail/lib/costs.ts apps/web/src/components/detail/lib/costs.test.ts apps/web/src/components/detail/components/TaskHeader.tsx apps/web/src/components/detail/components/TaskHeader.test.tsx
- pnpm vitest apps/web/src/components/detail/lib/costs.test.ts apps/web/src/components/detail/components/TaskHeader.test.tsx
- pnpm typecheck
- pnpm test