### PR TITLE
M19.XX: api bug

### DIFF
--- a/apps/server/src/domains/inbox/router.test.ts
+++ b/apps/server/src/domains/inbox/router.test.ts
@@ -77,6 +77,19 @@ describe('POST /inbox', () => {
     expect(res.status).toBe(400);
     expect(mockCreateInboxItem).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for null JSON body', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid request body' });
+    expect(mockCreateInboxItem).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /inbox', () => {
@@ -199,6 +212,19 @@ describe('POST /inbox/:id/promote', () => {
       body: 'not-json',
     });
     expect(res.status).toBe(400);
+    expect(mockPromoteInboxItem).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for null JSON body', async () => {
+    const app = makeApp();
+    const res = await app.request('/inbox/5/promote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid request body' });
     expect(mockPromoteInboxItem).not.toHaveBeenCalled();
   });
 

--- a/apps/server/src/shared/middleware.test.ts
+++ b/apps/server/src/shared/middleware.test.ts
@@ -2,34 +2,51 @@ import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 import { parseBody } from './middleware.js';
 
+async function parseRequestBody(body: string) {
+  const app = new Hono();
+  let result: unknown;
+
+  app.post('/test', async (c) => {
+    result = await parseBody<{ name?: string }>(c);
+    return c.json({});
+  });
+
+  await app.request('/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+
+  return result;
+}
+
 describe('parseBody', () => {
   it('returns ok:true with parsed data for valid JSON', async () => {
-    const app = new Hono();
-    let result: unknown;
-    app.post('/test', async (c) => {
-      result = await parseBody<{ name: string }>(c);
-      return c.json({});
-    });
-    await app.request('/test', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'hello' }),
-    });
+    const result = await parseRequestBody(JSON.stringify({ name: 'hello' }));
+
     expect(result).toEqual({ ok: true, data: { name: 'hello' } });
   });
 
   it('returns ok:false with 400 response for invalid JSON', async () => {
-    const app = new Hono();
-    let result: unknown;
-    app.post('/test', async (c) => {
-      result = await parseBody<{ name: string }>(c);
-      return c.json({});
-    });
-    await app.request('/test', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: 'not-json',
-    });
+    const result = await parseRequestBody('not-json');
+
     expect(result).toMatchObject({ ok: false });
+  });
+
+  it.each(['null', '[]', '"hello"', '123', 'true'])(
+    'returns ok:false with 400 response for non-object JSON body %s',
+    async (body) => {
+      const result = await parseRequestBody(body);
+
+      expect(result).toMatchObject({ ok: false });
+    },
+  );
+
+  it('returns invalid request body response for non-object JSON values', async () => {
+    const result = (await parseRequestBody('null')) as { ok: false; error: Response };
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error.status).toBe(400);
+    await expect(result.error.json()).resolves.toEqual({ error: 'invalid request body' });
   });
 });

--- a/apps/server/src/shared/middleware.ts
+++ b/apps/server/src/shared/middleware.ts
@@ -5,12 +5,21 @@ export type Result<T> = { ok: true; data: T } | { ok: false; error: string; stat
 
 export type ParsedBody<T> = { ok: true; data: T } | { ok: false; error: Response };
 
+function invalidRequestBody(c: Context) {
+  return { ok: false, error: c.json({ error: 'invalid request body' }, 400) } as const;
+}
+
 export async function parseBody<T>(c: Context): Promise<ParsedBody<T>> {
   try {
-    const data = (await c.req.json()) as T;
-    return { ok: true, data };
+    const data = await c.req.json();
+
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+      return invalidRequestBody(c);
+    }
+
+    return { ok: true, data: data as T };
   } catch (err) {
     logger.warn('request body parse failed', { err: String(err) });
-    return { ok: false, error: c.json({ error: 'invalid request body' }, 400) };
+    return invalidRequestBody(c);
   }
 }


### PR DESCRIPTION
## Summary

api bug

## Work Packages

- ✓ **WP1**: In apps/server/src/shared/middleware.ts:8-17, tighten parseBody<T>() so c.req.json() results that are null, arrays, or n

Closes #1178
