### PR TITLE
Ground feature PRDs and specs in code context

### DIFF
--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -192,7 +192,7 @@ function projectEngineeringSpec(record: NonNullable<ReturnType<typeof getEnginee
 }
 
 const TYPE_EXCLUDED_LEGAL_TARGETS: Readonly<Record<string, readonly StateName[]>> = {
-  bug: ['factory:framing', 'factory:grilling', 'factory:research-pending'],
+  bug: ['factory:framing', 'factory:grounding', 'factory:grilling', 'factory:research-pending'],
   feature: ['factory:investigating', 'factory:research-pending'],
 };
 

--- a/apps/server/src/domains/workflows/triage-batch.test.ts
+++ b/apps/server/src/domains/workflows/triage-batch.test.ts
@@ -806,7 +806,7 @@ describe('runTriageBatch onward routing after accept', () => {
     );
   });
 
-  it('routes fresh type:feature (no factory:from-prd) to factory:grilling after accepting', async () => {
+  it('routes fresh type:feature (no factory:from-prd) to factory:grounding after accepting', async () => {
     const source = makeMockSource([
       makeWorkItem({
         title: 'Show active milestone filter on board',
@@ -838,7 +838,7 @@ describe('runTriageBatch onward routing after accept', () => {
     expect(source.transitionState).toHaveBeenCalledWith(
       '42',
       'factory:accepted',
-      'factory:grilling',
+      'factory:grounding',
     );
   });
 

--- a/apps/server/src/shared/dispatch-discover.ts
+++ b/apps/server/src/shared/dispatch-discover.ts
@@ -5,6 +5,7 @@ import { parallelLock } from '@goose-hub/core/projects/parallel-lock.js';
 import { runDecomposePrdWorkflow } from '@goose-hub/core/workflows/decompose-prd.js';
 import { runGrillAndPrdWorkflow } from '@goose-hub/core/workflows/grill-and-prd.js';
 import type { PRDOutput } from '@goose-hub/skills/write-prd/schema.js';
+import { runFeatureGroundingWorkflow } from '../../../../slices/feature-grounding/workflow.js';
 import { runFramingWorkflow } from '../../../../slices/framing/workflow.js';
 import { getMaxParallelAgents, withParallelLock } from './dispatch-lock.js';
 import { getProject } from './projects.js';
@@ -74,6 +75,47 @@ export async function dispatchFraming(slug: string, issueNumber: number): Promis
       deps: { projectConfig, ...(mockGrillDeps ?? {}) },
     });
   });
+}
+
+/** Run feature code-grounding for a fresh feature before grill/PRD discovery. */
+export async function dispatchFeatureGrounding(slug: string, issueNumber: number): Promise<void> {
+  await withParallelLock(
+    slug,
+    issueNumber,
+    'dispatchFeatureGrounding',
+    dispatchFeatureGrounding,
+    async () => {
+      const source = await getSourceForSlug(slug);
+      if (source == null) {
+        logger.error('dispatchFeatureGrounding: no source for slug', { slug });
+        return;
+      }
+      const item = await source.getItem(issueNumber.toString());
+      if (item.state !== 'factory:grounding') {
+        logger.info('dispatchFeatureGrounding: state already advanced, skipping', {
+          slug,
+          issueNumber,
+          state: item.state,
+        });
+        return;
+      }
+      const mockDeps =
+        process.env.MOCK_AGENTS === 'true'
+          ? {
+              createWorktreeImpl: (_repo: string, _runId: string) => '/mock/worktree',
+              cleanupWorktreeImpl: (_runId: string) => undefined,
+            }
+          : undefined;
+      const result = await runFeatureGroundingWorkflow(item, source, slug, REPO_ROOT, mockDeps);
+
+      if (result.nextState === 'factory:prd-drafting') {
+        return () => dispatchRetryWritePrd(slug, issueNumber);
+      }
+      if (result.nextState === 'factory:grilling') {
+        return () => dispatchGrillAndPrd(slug, issueNumber);
+      }
+    },
+  );
 }
 
 /**

--- a/apps/server/src/shared/dispatch-discover.ts
+++ b/apps/server/src/shared/dispatch-discover.ts
@@ -67,13 +67,16 @@ export async function dispatchFraming(slug: string, issueNumber: number): Promis
             cleanupWorktreeImpl: (_runId: string) => undefined,
           }
         : undefined;
-    await runFramingWorkflow({
+    const result = await runFramingWorkflow({
       workItem: item,
       stateSource: source,
       projectId: slug,
       priorReplies,
       deps: { projectConfig, ...(mockGrillDeps ?? {}) },
     });
+    if (result?.phase !== 'needs-human') {
+      return () => dispatchFeatureGrounding(slug, issueNumber);
+    }
   });
 }
 

--- a/apps/server/src/shared/dispatch-routing.ts
+++ b/apps/server/src/shared/dispatch-routing.ts
@@ -438,6 +438,24 @@ export async function dispatchResumeIssue(
       return;
     }
 
+    if (failedSkill === 'feature-grounding') {
+      logger.info(
+        'dispatchResumeIssue: needs-human from feature-grounding failure, resuming to grounding',
+        { slug, issueNumber },
+      );
+      await source.forceState(workItemId, 'factory:grounding');
+      emitStateTransitionEvent({
+        projectId: slug,
+        workItemId,
+        from: fromState,
+        to: 'factory:grounding',
+        by: 'resume',
+        extraPayload: interventionEventPayload(options.intervention),
+      });
+      await dispatchFeatureGrounding(slug, issueNumber);
+      return;
+    }
+
     if (failedSkill === 'investigate') {
       logger.info(
         'dispatchResumeIssue: needs-human from investigate failure, resuming to investigating',

--- a/apps/server/src/shared/dispatch-routing.ts
+++ b/apps/server/src/shared/dispatch-routing.ts
@@ -13,6 +13,7 @@ import {
 } from './dispatch-dev.js';
 import {
   dispatchDecomposePrd,
+  dispatchFeatureGrounding,
   dispatchFraming,
   dispatchGrillAndPrd,
   dispatchRetryWritePrd,
@@ -111,6 +112,10 @@ export async function dispatchForLabel(
     await dispatchGrillAndPrd(slug, issueNumber);
     return;
   }
+  if (labelName === 'factory:grounding') {
+    await dispatchFeatureGrounding(slug, issueNumber);
+    return;
+  }
   if (labelName === 'factory:framing') {
     await dispatchFraming(slug, issueNumber);
     return;
@@ -191,6 +196,7 @@ const RESUME_WORKFLOWS: Partial<Record<StateName, ResumeEntry>> = {
   'factory:needs-fix': { targetState: 'factory:needs-fix', dispatch: dispatchNeedsFix },
   // Discover lane
   'factory:framing': { targetState: 'factory:framing', dispatch: dispatchFraming },
+  'factory:grounding': { targetState: 'factory:grounding', dispatch: dispatchFeatureGrounding },
   'factory:grilling': { targetState: 'factory:grilling', dispatch: dispatchGrillAndPrd },
   // factory:gate-pending is handled above with lane-origin inspection; it is
   // intentionally absent from this table so the special-case runs first.

--- a/apps/web/src/components/detail/components/PRDSection.tsx
+++ b/apps/web/src/components/detail/components/PRDSection.tsx
@@ -53,13 +53,19 @@ export interface ParsedPRDView {
   implementationDecisions?: Array<{
     decision: string;
     rationale?: string;
-    moduleRef?: string;
+    moduleRef?: string | { path: string; status?: string; confidence?: string; evidence?: string };
   }>;
   testingDecisions?: {
     approach: string;
-    modulesToTest: string[];
+    modulesToTest: Array<string | { path: string; status?: string }>;
     priorArt?: string;
   };
+}
+
+function moduleRefToString(ref: string | { path: string; status?: string } | undefined): string | undefined {
+  if (ref == null) return undefined;
+  if (typeof ref === 'string') return ref;
+  return ref.status != null ? `${ref.path} (${ref.status})` : ref.path;
 }
 
 const COMPLEXITY_COLORS: Record<string, string> = {
@@ -648,8 +654,8 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
               >
                 <p className="text-fg font-medium">{d.decision}</p>
                 {d.rationale != null && <p className="text-fg-2 mt-0.5">{d.rationale}</p>}
-                {d.moduleRef != null && (
-                  <p className="font-mono text-[11px] text-fg-3 mt-0.5">{d.moduleRef}</p>
+                {moduleRefToString(d.moduleRef) != null && (
+                  <p className="font-mono text-[11px] text-fg-3 mt-0.5">{moduleRefToString(d.moduleRef)}</p>
                 )}
               </div>
             ))}
@@ -663,9 +669,10 @@ export function PRDSection({ projectSlug, id, state }: PRDSectionProps) {
             <p className="text-fg">{prd.testingDecisions.approach}</p>
             {prd.testingDecisions.modulesToTest.length > 0 && (
               <ul className="list-disc pl-5 space-y-0.5">
-                {prd.testingDecisions.modulesToTest.map((m) => (
-                  <li key={m} className="font-mono text-[11.5px] text-fg-2">
-                    {m}
+                {prd.testingDecisions.modulesToTest.map((m, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: modules have no stable id
+                  <li key={i} className="font-mono text-[11.5px] text-fg-2">
+                    {moduleRefToString(m)}
                   </li>
                 ))}
               </ul>

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -34,6 +34,8 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'agent.triage-complete': 'Triage complete',
   'agent.repo-override': 'Repository override',
   'agent.investigation-complete': 'Investigation complete',
+  'feature.framed': 'Feature framed',
+  'feature.grounding-complete': 'Feature grounding complete',
   'agent.investigation-seed-built': 'Investigation seed built',
   'agent.investigation-seed-empty': 'Investigation seed empty',
   'agent.bug-enhance-lazy': 'Bug grounding seed',

--- a/apps/web/src/components/office/lib/state-indicators.ts
+++ b/apps/web/src/components/office/lib/state-indicators.ts
@@ -15,6 +15,7 @@ export type IndicatorKind = 'speech' | 'thought' | 'question' | 'coffee' | 'bang
 const STATE_TO_INDICATOR: Readonly<Record<string, IndicatorKind>> = {
   'factory:triaging': 'speech',
   'factory:accepted': 'thought',
+  'factory:grounding': 'thought',
   'factory:grilling': 'speech',
   'factory:prd-drafting': 'speech',
   'factory:prd-review': 'thought',

--- a/apps/web/src/components/office/lib/state-to-role.ts
+++ b/apps/web/src/components/office/lib/state-to-role.ts
@@ -40,6 +40,7 @@ export const OFFICE_ROLES: readonly OfficeRole[] = [
 const STATE_TO_ROLE: Readonly<Record<string, OfficeRole | null>> = {
   'factory:triaging': 'triager',
   'factory:accepted': 'triager',
+  'factory:grounding': 'investigator',
   'factory:grilling': 'griller',
   'factory:prd-drafting': 'prd-writer',
   'factory:prd-review': 'prd-writer',

--- a/apps/web/src/components/office/lib/state-to-room.ts
+++ b/apps/web/src/components/office/lib/state-to-room.ts
@@ -14,6 +14,7 @@ const STATE_TO_ROOM: Readonly<Record<string, RoomId | null>> = {
   // Triage cluster — intake + early reasoning lives in triage
   'factory:triaging': 'triage',
   'factory:accepted': 'triage',
+  'factory:grounding': 'investigation',
   'factory:grilling': 'triage',
   'factory:prd-drafting': 'triage',
   'factory:prd-review': 'triage',

--- a/apps/web/src/components/office/slice.test.ts
+++ b/apps/web/src/components/office/slice.test.ts
@@ -77,6 +77,7 @@ describe('state → desk role mapping', () => {
     const states = [
       'factory:triaging',
       'factory:accepted',
+      'factory:grounding',
       'factory:grilling',
       'factory:prd-drafting',
       'factory:prd-review',
@@ -139,6 +140,7 @@ describe('state → indicator mapping', () => {
 
   it('uses thought for investigating / pre-thinking states', () => {
     expect(indicatorForState('factory:investigating')).toBe('thought');
+    expect(indicatorForState('factory:grounding')).toBe('thought');
     expect(indicatorForState('factory:research-pending')).toBe('thought');
     expect(indicatorForState('factory:dev-ready')).toBe('thought');
   });

--- a/apps/web/src/lib/constants.test.ts
+++ b/apps/web/src/lib/constants.test.ts
@@ -13,6 +13,7 @@ const ALL_FACTORY_STATES = [
   'factory:accepted',
   'factory:rejected',
   'factory:framing',
+  'factory:grounding',
   'factory:grilling',
   'factory:prd-drafting',
   'factory:prd-review',

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -6,6 +6,7 @@ export const STATE_LABEL: Record<string, string> = {
   'factory:accepted': 'accepted',
   'factory:rejected': 'rejected',
   'factory:framing': 'framing',
+  'factory:grounding': 'grounding',
   'factory:grilling': 'grilling',
   'factory:prd-drafting': 'prd-drafting',
   'factory:prd-review': 'prd-review',
@@ -68,6 +69,7 @@ export const PRD_ACTIVE_STATES = new Set([
 // the discover lane. Hidden entirely on issues that never went through grill,
 // so triage / dev-ready / coding etc. don't see a Grill tab.
 export const GRILL_ACTIVE_STATES = new Set([
+  'factory:grounding',
   'factory:grilling',
   'factory:gate-pending',
   'factory:prd-drafting',
@@ -94,6 +96,7 @@ export const GATE_STATES: Record<string, string> = {
 
 export const PENDING_NEXT_RUN_STATES: Record<string, string> = {
   'factory:triaging': 'triage',
+  'factory:grounding': 'feature-grounding',
   'factory:grilling': 'grill-me',
   'factory:prd-drafting': 'write-prd',
   'factory:decomposing': 'decompose-issues',

--- a/apps/web/src/lib/lanes.config.ts
+++ b/apps/web/src/lib/lanes.config.ts
@@ -23,6 +23,7 @@ export const LANES: readonly LaneConfig[] = [
     label: 'Discover',
     states: [
       'factory:framing',
+      'factory:grounding',
       'factory:grilling',
       'factory:prd-drafting',
       'factory:prd-review',

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -763,6 +763,7 @@ export type WorkflowKind = 'bug' | 'feature' | 'chore' | 'research';
 export type WorkflowEdgeKind = 'primary' | 'optional' | 'retry' | 'summary';
 export type WorkflowGroup =
   | 'triage'
+  | 'grounding'
   | 'investigation'
   | 'grill'
   | 'prd'

--- a/core/agent-runtime/budgets.ts
+++ b/core/agent-runtime/budgets.ts
@@ -57,6 +57,12 @@ export const SKILL_BUDGETS: Record<string, SkillBudget> = {
     timeoutMs: 180_000,
     modelTier: 'sonnet',
   },
+  'feature-grounding': {
+    maxTurns: 20,
+    maxBudgetUsd: 2.0,
+    timeoutMs: 300_000,
+    modelTier: 'haiku',
+  },
   'evidence-post': { maxTurns: 60, maxBudgetUsd: 2.0, timeoutMs: 300_000, modelTier: 'haiku' },
   implement: {
     maxTurns: 150,

--- a/core/agent-runtime/schema-bridge.test.ts
+++ b/core/agent-runtime/schema-bridge.test.ts
@@ -152,7 +152,8 @@ describe('toJsonSchema', () => {
     expect(implementationDecision.properties).toHaveProperty('rationale');
     expect(implementationDecision.properties).toHaveProperty('moduleRef');
     expect(implementationDecision.properties?.rationale).toEqual({ type: ['string', 'null'] });
-    expect(implementationDecision.properties?.moduleRef).toEqual({ type: ['string', 'null'] });
+    expect(schemaAllowsNull(implementationDecision.properties?.moduleRef)).toBe(true);
+    expect(schemaAllowsModuleRefObject(implementationDecision.properties?.moduleRef)).toBe(true);
     expect(implementationDecision.required).toEqual(['decision', 'rationale', 'moduleRef']);
 
     const testingDecisions = properties.testingDecisions as {
@@ -340,4 +341,24 @@ function schemaAllowsNull(value: unknown): boolean {
       ? value.oneOf
       : [];
   return variants.some(schemaAllowsNull);
+}
+
+function schemaAllowsModuleRefObject(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const variants = Array.isArray(value.anyOf)
+    ? value.anyOf
+    : Array.isArray(value.oneOf)
+      ? value.oneOf
+      : null;
+  if (variants != null) return variants.some(schemaAllowsModuleRefObject);
+  const properties = isRecord(value.properties) ? value.properties : {};
+  const status = properties.status;
+  return (
+    value.type === 'object' &&
+    isRecord(properties.path) &&
+    isRecord(status) &&
+    Array.isArray(status.enum) &&
+    status.enum.includes('existing') &&
+    status.enum.includes('planned')
+  );
 }

--- a/core/bootstrap/labels.ts
+++ b/core/bootstrap/labels.ts
@@ -16,6 +16,7 @@ export const FACTORY_LABELS: Label[] = [
   { name: 'factory:triaging', color: 'fbca04', description: 'Awaiting triage decision' },
   { name: 'factory:accepted', color: '0e8a16', description: 'Accepted by triage' },
   { name: 'factory:rejected', color: 'e6e6e6', description: 'Rejected by triage' },
+  { name: 'factory:grounding', color: '14b8a6', description: 'Feature code-grounding preflight' },
   {
     name: 'factory:framing',
     color: '8b5cf6',

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -26,6 +26,8 @@ export const EVENT_KINDS = [
   'github.label.changed',
   'github.label-mirror-warning',
   'agent.investigation-complete',
+  'feature.framed',
+  'feature.grounding-complete',
   'agent.investigation-context-injected',
   'agent.investigation-seed-built',
   'investigation.digest-applied',

--- a/core/scout-reports/repository.ts
+++ b/core/scout-reports/repository.ts
@@ -107,6 +107,16 @@ export function persistScoutReport(
   return storedReport;
 }
 
+export function persistScoutReportForRun(
+  projectId: string,
+  workItemId: string,
+  scoutRunId: string,
+  scoutSkill: string,
+  report: unknown,
+): unknown {
+  return persistScoutReport(projectId, workItemId, scoutRunId, scoutSkill, report);
+}
+
 export function listScoutReportsForInvestigation(
   projectId: string,
   workItemId: string,
@@ -128,4 +138,12 @@ export function listScoutReportsForInvestigation(
     ...r,
     report: JSON.parse(r.report) as unknown,
   }));
+}
+
+export function listScoutReportsForRun(
+  projectId: string,
+  workItemId: string,
+  scoutRunId: string,
+): ScoutReport[] {
+  return listScoutReportsForInvestigation(projectId, workItemId, scoutRunId);
 }

--- a/core/state-machine/states.test.ts
+++ b/core/state-machine/states.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { STATES } from './states.js';
 
 describe('STATES', () => {
-  it('has exactly 27 canonical states', () => {
-    expect(STATES).toHaveLength(27);
+  it('has exactly 28 canonical states', () => {
+    expect(STATES).toHaveLength(28);
   });
 
   it('contains all canonical factory:* states in order', () => {
@@ -12,6 +12,7 @@ describe('STATES', () => {
       'factory:accepted',
       'factory:rejected',
       'factory:framing',
+      'factory:grounding',
       'factory:grilling',
       'factory:prd-drafting',
       'factory:prd-review',

--- a/core/state-machine/states.ts
+++ b/core/state-machine/states.ts
@@ -3,6 +3,7 @@ export const STATES = Object.freeze([
   'factory:accepted',
   'factory:rejected',
   'factory:framing',
+  'factory:grounding',
   'factory:grilling',
   'factory:prd-drafting',
   'factory:prd-review',

--- a/core/state-machine/transitions.test.ts
+++ b/core/state-machine/transitions.test.ts
@@ -11,14 +11,22 @@ describe('isLegalTransition — section 9.1 happy paths', () => {
     expect(isLegalTransition('factory:rejected', 'factory:archived')).toBe(true));
 
   // feature path
-  it('accepted → grilling', () =>
-    expect(isLegalTransition('factory:accepted', 'factory:grilling')).toBe(true));
+  it('accepted → grounding', () =>
+    expect(isLegalTransition('factory:accepted', 'factory:grounding')).toBe(true));
   it('accepted → framing', () =>
     expect(isLegalTransition('factory:accepted', 'factory:framing')).toBe(true));
-  it('framing can route to grill or PRD drafting', () =>
+  it('framing can route to grounding, grill, or PRD drafting', () =>
     expect(legalTargets('factory:framing')).toStrictEqual([
+      'factory:grounding',
       'factory:grilling',
       'factory:prd-drafting',
+      'factory:archived',
+    ]));
+  it('grounding can route to grill or PRD drafting', () =>
+    expect(legalTargets('factory:grounding')).toStrictEqual([
+      'factory:grilling',
+      'factory:prd-drafting',
+      'factory:needs-human',
       'factory:archived',
     ]));
   it('grilling → prd-drafting', () =>
@@ -171,7 +179,8 @@ describe('legalTargets', () => {
       'factory:archived',
     ]));
 
-  it('accepted yields six targets', () => expect(legalTargets('factory:accepted')).toHaveLength(6));
+  it('accepted yields seven targets', () =>
+    expect(legalTargets('factory:accepted')).toHaveLength(7));
 
   it('dev-ready yields spec-ready, in-progress, needs-human, and archived', () =>
     expect(legalTargets('factory:dev-ready')).toStrictEqual([

--- a/core/state-machine/transitions.ts
+++ b/core/state-machine/transitions.ts
@@ -4,6 +4,7 @@ const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
   'factory:triaging': ['factory:accepted', 'factory:rejected', 'factory:archived'],
   'factory:accepted': [
     'factory:framing',
+    'factory:grounding',
     'factory:grilling',
     'factory:investigating',
     'factory:dev-ready',
@@ -11,7 +12,18 @@ const TRANSITIONS: Readonly<Record<StateName, readonly StateName[]>> = {
     'factory:archived',
   ],
   'factory:rejected': ['factory:archived'],
-  'factory:framing': ['factory:grilling', 'factory:prd-drafting', 'factory:archived'],
+  'factory:framing': [
+    'factory:grounding',
+    'factory:grilling',
+    'factory:prd-drafting',
+    'factory:archived',
+  ],
+  'factory:grounding': [
+    'factory:grilling',
+    'factory:prd-drafting',
+    'factory:needs-human',
+    'factory:archived',
+  ],
   'factory:grilling': ['factory:prd-drafting', 'factory:archived'],
   'factory:prd-drafting': ['factory:prd-review', 'factory:archived'],
   'factory:prd-review': ['factory:dev-ready', 'factory:decomposing', 'factory:archived'],

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -39,6 +39,36 @@ export interface ProjectContextBundle {
   claudeMd: string;
 }
 
+function latestFeatureGroundingContext(
+  projectId: string,
+  workItemId: string,
+): {
+  codeGrounding?: unknown;
+  scoutDigest?: unknown;
+} {
+  const [latest] = eventStore.replay({
+    projectId,
+    workItemId,
+    kind: 'feature.grounding-complete',
+    order: 'desc',
+    limit: 1,
+  });
+  if (latest == null) return {};
+  const payload = latest.payload as Record<string, unknown>;
+  return {
+    codeGrounding: {
+      groundingRunId: payload.groundingRunId,
+      existingSurfaces: payload.existingSurfaces,
+      confirmedExports: payload.confirmedExports,
+      plannedFiles: payload.plannedFiles,
+      testSurfaces: payload.testSurfaces,
+      reusablePatterns: payload.reusablePatterns,
+      openQuestions: payload.openQuestions,
+    },
+    scoutDigest: payload.scoutDigest,
+  };
+}
+
 function serializeStack(stack: StackConfig | undefined): string {
   if (stack == null) return '';
   const parts: string[] = [];
@@ -308,14 +338,21 @@ export async function runGrillAndPrdWorkflow(
   // Merge stackSummary from config into the bundle
   const stackSummary = serializeStack((projectConfig as ProjectConfig | null)?.stack);
   const fullProjectContext = { ...projectContext, stackSummary };
+  const groundingContext = latestFeatureGroundingContext(projectId, workItem.id);
 
   // ─── Skip-grill mode: jump directly to write-prd ─────────────────────────
   if (skipGrill) {
     const allEvents = eventStore.replay({ projectId, workItemId: workItem.id });
     const grillCompleted = [...allEvents].reverse().find((e) => e.kind === 'grill.completed');
+    const featureFramed = [...allEvents].reverse().find((e) => e.kind === 'feature.framed');
+    const featureGrounding = [...allEvents]
+      .reverse()
+      .find((e) => e.kind === 'feature.grounding-complete');
     const refinedIntent =
       input.refinedIntent ??
       (grillCompleted?.payload as { refinedIntent?: string } | null)?.refinedIntent ??
+      (featureGrounding?.payload as { refinedIntent?: string } | null)?.refinedIntent ??
+      (featureFramed?.payload as { refinedIntent?: string } | null)?.refinedIntent ??
       workItem.title;
     return runWritePrdStep({
       workItem,
@@ -327,6 +364,7 @@ export async function runGrillAndPrdWorkflow(
       projectConfig,
       totalSpendForSkill,
       fullProjectContext,
+      ...groundingContext,
       refinedIntent,
       priorReplies: augmentPriorRepliesWithCrystallizations(priorReplies, projectId, workItem.id),
     });
@@ -344,6 +382,7 @@ export async function runGrillAndPrdWorkflow(
       projectConfig,
       totalSpendForSkill,
       fullProjectContext,
+      ...groundingContext,
       refinedIntent: priorPrd?.title ?? workItem.title,
       priorPrd,
       humanConcerns,
@@ -424,6 +463,7 @@ export async function runGrillAndPrdWorkflow(
           worktreePath,
           priorReplies: augmentedPriorReplies,
           projectContext: fullProjectContext,
+          ...groundingContext,
           projectConfig,
           deps: { runtime },
         });
@@ -598,6 +638,7 @@ export async function runGrillAndPrdWorkflow(
     projectConfig,
     totalSpendForSkill,
     fullProjectContext,
+    ...groundingContext,
     refinedIntent: refinedIntentForPrd ?? workItem.title,
     priorReplies: augmentPriorRepliesWithCrystallizations(
       augmentedPriorReplies,
@@ -617,6 +658,8 @@ interface WritePrdStepInput {
   projectConfig: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null | undefined;
   totalSpendForSkill: (projectId: string, skill: string) => number;
   fullProjectContext: ProjectContextBundle;
+  codeGrounding?: unknown;
+  scoutDigest?: unknown;
   refinedIntent: string;
   priorPrd?: PRDOutput;
   humanConcerns?: string[];
@@ -634,6 +677,8 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     projectConfig,
     totalSpendForSkill,
     fullProjectContext,
+    codeGrounding,
+    scoutDigest,
     refinedIntent,
     priorPrd,
     humanConcerns,
@@ -693,6 +738,8 @@ async function runWritePrdStep(input: WritePrdStepInput): Promise<GrillAndPrdRes
     discoverSessionId,
     refinedIntent,
     fullProjectContext,
+    codeGrounding,
+    scoutDigest,
     projectConfig,
     priorReplies,
     priorPrd,

--- a/core/workflows/grill-and-prd.ts
+++ b/core/workflows/grill-and-prd.ts
@@ -340,6 +340,20 @@ export async function runGrillAndPrdWorkflow(
   const fullProjectContext = { ...projectContext, stackSummary };
   const groundingContext = latestFeatureGroundingContext(projectId, workItem.id);
 
+  // Restore framed body for grill and write-prd: the state source re-fetches the
+  // original GitHub issue body, which is unframed. Use the framedBody stored in
+  // the feature.framed event so grill-me sees the enriched description.
+  const [framedEvent] = eventStore.replay({
+    projectId,
+    workItemId: workItem.id,
+    kind: 'feature.framed',
+    order: 'desc',
+    limit: 1,
+  });
+  const framedBody = (framedEvent?.payload as { framedBody?: string } | undefined)?.framedBody;
+  const effectiveWorkItem =
+    framedBody != null && !isReviseMode ? { ...workItem, body: framedBody } : workItem;
+
   // ─── Skip-grill mode: jump directly to write-prd ─────────────────────────
   if (skipGrill) {
     const allEvents = eventStore.replay({ projectId, workItemId: workItem.id });
@@ -355,7 +369,7 @@ export async function runGrillAndPrdWorkflow(
       (featureFramed?.payload as { refinedIntent?: string } | null)?.refinedIntent ??
       workItem.title;
     return runWritePrdStep({
-      workItem,
+      workItem: effectiveWorkItem,
       stateSource,
       projectId,
       workflowRunId,
@@ -450,10 +464,10 @@ export async function runGrillAndPrdWorkflow(
 
         const outcome = await runGrillRound({
           workItem: {
-            id: workItem.id,
-            title: workItem.title,
-            body: workItem.body,
-            externalId: workItem.externalId,
+            id: effectiveWorkItem.id,
+            title: effectiveWorkItem.title,
+            body: effectiveWorkItem.body,
+            externalId: effectiveWorkItem.externalId,
           },
           projectId,
           workItemId: workItem.id,

--- a/core/workflows/grill-and-prd/grill-and-prd.test.ts
+++ b/core/workflows/grill-and-prd/grill-and-prd.test.ts
@@ -357,6 +357,30 @@ describe('runGrillRound', () => {
     }
   });
 
+  it('passes feature grounding digest into grill-me context', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(
+      makeAgentResult(minimalGrillOutput({ readyForPRD: true, refinedIntent: 'Final intent.' })),
+    );
+
+    await runGrillRound({
+      ...baseInput(),
+      codeGrounding: {
+        groundingRunId: 'grounding-run',
+        existingSurfaces: ['core/workflows/grill-and-prd.ts'],
+      },
+      scoutDigest: { reports: [{ scoutName: 'scout-code-path' }] },
+    });
+
+    expect(mockInvokeSkill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          codeGrounding: expect.objectContaining({ groundingRunId: 'grounding-run' }),
+          scoutDigest: { reports: [{ scoutName: 'scout-code-path' }] },
+        }),
+      }),
+    );
+  });
+
   it('returns invalid when output has readyForPRD:false with no questions', async () => {
     mockInvokeSkill.mockResolvedValueOnce(
       makeAgentResult(minimalGrillOutput({ readyForPRD: false, questions: [] })),
@@ -451,6 +475,28 @@ describe('runPrdDraft', () => {
     if (result.status === 'ok') {
       expect(result.prdOutput.title).toBe('Test PRD');
     }
+  });
+
+  it('passes feature grounding digest into write-prd context', async () => {
+    mockInvokeSkill.mockResolvedValueOnce(makeAgentResult(minimalPrdOutput()));
+
+    await runPrdDraft({
+      ...baseInput(),
+      codeGrounding: {
+        groundingRunId: 'grounding-run',
+        plannedFiles: ['apps/web/src/features/new-flow/view.tsx'],
+      },
+      scoutDigest: { reports: [{ scoutName: 'scout-pattern' }] },
+    });
+
+    expect(mockInvokeSkill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          codeGrounding: expect.objectContaining({ groundingRunId: 'grounding-run' }),
+          scoutDigest: { reports: [{ scoutName: 'scout-pattern' }] },
+        }),
+      }),
+    );
   });
 
   it('returns invalid when output parse fails', async () => {

--- a/core/workflows/grill-and-prd/grill-round.ts
+++ b/core/workflows/grill-and-prd/grill-round.ts
@@ -22,6 +22,8 @@ export interface RunGrillRoundInput {
   worktreePath: string;
   priorReplies: Array<{ role: 'user' | 'agent'; content: string; crystallized?: string }>;
   projectContext: ProjectContextBundle;
+  codeGrounding?: unknown;
+  scoutDigest?: unknown;
   projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
   deps?: { runtime?: AgentRuntime };
 }
@@ -37,6 +39,8 @@ export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRou
     worktreePath,
     priorReplies,
     projectContext,
+    codeGrounding,
+    scoutDigest,
     projectConfig,
     deps,
   } = input;
@@ -62,6 +66,8 @@ export async function runGrillRound(input: RunGrillRoundInput): Promise<GrillRou
         priorReplies,
         roundNumber,
         projectContext,
+        ...(codeGrounding != null ? { codeGrounding } : {}),
+        ...(scoutDigest != null ? { scoutDigest } : {}),
       },
       overrides: {
         workspaceDir: worktreePath,

--- a/core/workflows/grill-and-prd/prd-draft.ts
+++ b/core/workflows/grill-and-prd/prd-draft.ts
@@ -33,6 +33,8 @@ export interface RunPrdDraftInput {
   discoverSessionId: string;
   refinedIntent: string;
   fullProjectContext: ProjectContextBundle;
+  codeGrounding?: unknown;
+  scoutDigest?: unknown;
   projectConfig?: Pick<ProjectConfig, 'budgets' | 'stack' | 'targetRepo'> | null;
   priorReplies?: Array<{ role: 'user' | 'agent'; content: string; crystallized?: string }>;
   priorPrd?: PRDOutput;
@@ -50,6 +52,8 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
     discoverSessionId,
     refinedIntent,
     fullProjectContext,
+    codeGrounding,
+    scoutDigest,
     priorReplies,
     priorPrd,
     humanConcerns,
@@ -75,6 +79,8 @@ export async function runPrdDraft(input: RunPrdDraftInput): Promise<PrdDraftOutc
         refinedIntent,
         priority: workItem.priority,
         projectContext: fullProjectContext,
+        ...(codeGrounding != null ? { codeGrounding } : {}),
+        ...(scoutDigest != null ? { scoutDigest } : {}),
         ...(priorReplies != null ? { priorReplies } : {}),
         ...(priorPrd != null ? { priorPrd } : {}),
         ...(humanConcerns != null ? { humanConcerns } : {}),

--- a/core/workflows/timeline-sections.test.ts
+++ b/core/workflows/timeline-sections.test.ts
@@ -13,6 +13,7 @@ describe('timeline sections', () => {
   it('defines the canonical operator-facing section order', () => {
     expect(TIMELINE_SECTION_DEFINITIONS.map((section) => section.id)).toEqual([
       'triage',
+      'grounding',
       'investigation',
       'grill',
       'prd',

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -3,6 +3,7 @@ import { WORKFLOW_CATALOG, type WorkflowGroup } from './workflow-catalog.js';
 
 export const TIMELINE_SECTION_DEFINITIONS = [
   { id: 'triage', title: 'Triage' },
+  { id: 'grounding', title: 'Grounding' },
   { id: 'investigation', title: 'Investigation' },
   { id: 'grill', title: 'Grill' },
   { id: 'prd', title: 'PRD' },
@@ -40,6 +41,7 @@ const SECTION_IDS = new Set<TimelineSectionId>(
 
 const WORKFLOW_GROUP_TO_TIMELINE_SECTION: Record<WorkflowGroup, TimelineSectionId> = {
   triage: 'triage',
+  grounding: 'grounding',
   investigation: 'investigation',
   grill: 'grill',
   prd: 'prd',
@@ -60,6 +62,8 @@ const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
   'agent.triage-complete': 'triage',
   'agent.repo-override': 'triage',
   'agent.investigation-complete': 'investigation',
+  'feature.framed': 'grounding',
+  'feature.grounding-complete': 'grounding',
   'agent.investigation-context-injected': 'investigation',
   'agent.investigation-seed-built': 'investigation',
   'agent.investigation-seed-empty': 'investigation',

--- a/core/workflows/triage-routing.test.ts
+++ b/core/workflows/triage-routing.test.ts
@@ -22,10 +22,10 @@ describe('targetStateForTriage', () => {
       expected: 'factory:framing',
     },
     {
-      name: 'clean fresh feature keeps grilling',
+      name: 'clean fresh feature routes through feature grounding',
       type: 'feature' as const,
       labels: ['vague:low'],
-      expected: 'factory:grilling',
+      expected: 'factory:grounding',
     },
   ])('$name', ({ type, labels, expected }) => {
     expect(targetStateForTriage(type, labels)).toBe(expected);

--- a/core/workflows/triage-routing.ts
+++ b/core/workflows/triage-routing.ts
@@ -5,7 +5,7 @@ export const TRIAGE_ROUTE_TARGETS = Object.freeze({
   bug: 'factory:investigating',
   vagueBug: 'factory:investigating',
   research: 'factory:research-pending',
-  freshFeature: 'factory:grilling',
+  freshFeature: 'factory:grounding',
   vagueFeature: 'factory:framing',
   chore: 'factory:dev-ready',
   prdFeature: 'factory:dev-ready',

--- a/core/workflows/workflow-catalog.test.ts
+++ b/core/workflows/workflow-catalog.test.ts
@@ -59,7 +59,7 @@ describe('workflow catalog', () => {
   it('keeps triage routing assumptions aligned with the runtime route helper', () => {
     expect(targetStateForTriage('bug')).toBe('factory:investigating');
     expect(targetStateForTriage('research')).toBe('factory:research-pending');
-    expect(targetStateForTriage('feature')).toBe('factory:grilling');
+    expect(targetStateForTriage('feature')).toBe('factory:grounding');
     expect(targetStateForTriage('feature', ['vague:high'])).toBe('factory:framing');
     expect(targetStateForTriage('chore')).toBe('factory:dev-ready');
 

--- a/core/workflows/workflow-catalog.ts
+++ b/core/workflows/workflow-catalog.ts
@@ -6,6 +6,7 @@ export type WorkflowKind = 'bug' | 'feature' | 'chore' | 'research';
 export type WorkflowEdgeKind = 'primary' | 'optional' | 'retry' | 'summary';
 export type WorkflowGroup =
   | 'triage'
+  | 'grounding'
   | 'investigation'
   | 'grill'
   | 'prd'
@@ -880,6 +881,11 @@ const featureEntry: WorkflowCatalogEntry = {
       notes:
         'Vague fresh features run feature-frame, then either continue to grill-me or skip directly to PRD drafting.',
     }),
+    stateNode('grounding', 'Grounding', 'factory:grounding', {
+      group: 'grounding',
+      notes:
+        'Feature preflight scout swarm grounds existing files, exports, tests, and planned files.',
+    }),
     stateNode('grilling', 'Grilling', 'factory:grilling', { group: 'grill' }),
     stateNode('prd-drafting', 'PRD draft', 'factory:prd-drafting', { group: 'prd' }),
     stateNode('prd-review', 'PRD review', 'factory:prd-review', { group: 'prd' }),
@@ -897,6 +903,14 @@ const featureEntry: WorkflowCatalogEntry = {
       'triager',
       'factory:framing',
       { group: 'grill' },
+    ),
+    skillNode(
+      'feature-grounding-skill',
+      'feature-grounding',
+      'feature-grounding',
+      'investigator',
+      'factory:grounding',
+      { group: 'grounding', mode: 'swarm', visual: 'fanout' },
     ),
     skillNode('write-prd-skill', 'write-prd', 'write-prd', 'prd-writer', 'factory:prd-drafting', {
       group: 'prd',
@@ -922,10 +936,11 @@ const featureEntry: WorkflowCatalogEntry = {
   edges: [
     summary('triage-skill', 'repo-match-skill'),
     primary('triaging', 'accepted'),
-    primary('accepted', 'grilling'),
+    primary('accepted', 'grounding'),
     optional('accepted', 'framing', 'Vague fresh feature'),
-    optional('framing', 'grilling', 'Still needs grilling'),
-    optional('framing', 'prd-drafting', 'Framed enough for PRD'),
+    optional('framing', 'grounding', 'Framed feature needs code grounding'),
+    primary('grounding', 'grilling'),
+    optional('grounding', 'prd-drafting', 'Framed enough for PRD'),
     primary('grilling', 'prd-drafting'),
     primary('prd-drafting', 'prd-review'),
     primary('prd-review', 'dev-ready'),
@@ -934,6 +949,7 @@ const featureEntry: WorkflowCatalogEntry = {
     optional('issues-created', 'dev-ready', 'Legacy child delivery'),
     optional('issues-created', 'done', 'Parent complete'),
     summary('framing', 'feature-frame-skill'),
+    summary('grounding', 'feature-grounding-skill', 'code-grounding preflight'),
     summary('grilling', 'grill-me-skill'),
     summary('prd-drafting', 'write-prd-skill'),
     summary('prd-review', 'advise-on-prd-skill'),
@@ -943,6 +959,7 @@ const featureEntry: WorkflowCatalogEntry = {
   normalPath: [
     'triaging',
     'accepted',
+    'grounding',
     'grilling',
     'prd-drafting',
     'prd-review',
@@ -961,9 +978,16 @@ const featureEntry: WorkflowCatalogEntry = {
       id: 'grill',
       title: 'Grill',
       description:
-        'Clean fresh feature work enters grill-me; vague fresh feature work first runs feature-frame and either continues to grill-me or skips to PRD drafting.',
+        'Clean fresh feature work enters feature code-grounding before grill-me; vague fresh feature work first runs feature-frame, then grounding, then either grill-me or PRD drafting.',
       group: 'grill',
-      nodes: ['framing', 'feature-frame-skill', 'grilling', 'grill-me-skill'],
+      nodes: [
+        'framing',
+        'feature-frame-skill',
+        'grounding',
+        'feature-grounding-skill',
+        'grilling',
+        'grill-me-skill',
+      ],
     },
     {
       id: 'prd',

--- a/scripts/install-labels.mjs
+++ b/scripts/install-labels.mjs
@@ -31,6 +31,7 @@ const LABELS = [
   { name: 'factory:triaging',              color: 'fbca04', description: 'Awaiting triage decision' },
   { name: 'factory:accepted',              color: '0e8a16', description: 'Accepted by triage' },
   { name: 'factory:rejected',              color: 'e6e6e6', description: 'Rejected by triage' },
+  { name: 'factory:grounding',             color: '14b8a6', description: 'Feature code-grounding preflight' },
   { name: 'factory:grilling',              color: '8b5cf6', description: 'Grill-me chat in progress' },
   { name: 'factory:prd-drafting',          color: '8b5cf6', description: 'PRD being written' },
   { name: 'factory:prd-review',            color: '8b5cf6', description: 'Awaiting human PRD approval' },

--- a/skills/grill-me/prompt.md
+++ b/skills/grill-me/prompt.md
@@ -14,13 +14,14 @@ Your context contains:
 - `<priorReplies>` — JSON array for the conversation so far (`{ role, content, crystallized? }`). May be empty for round 1. An `agent` entry's `crystallized` field holds the decision distilled from that question and the following user reply. An agent entry starting with `<!-- factory:prd -->` is a previously drafted PRD that the user declined.
 - `<roundNumber>` — which round you are on **right now** (1-based). Authoritative.
 - `<projectContext>` — JSON payload containing `stackSummary`, `contextMd`, `adrSummaries`, `claudeMd`.
+- `<codeGrounding>` / `<scoutDigest>` (optional) — feature code-grounding from a preflight scout swarm. Use it to avoid asking questions already answered by the codebase. Treat it as evidence first and ask the user only about remaining product uncertainty. If it conflicts with a crystallized user decision, the user decision wins.
 - Tools are rooted at a detached-HEAD workspace for the target repo. Use `read`, `search`, and `work-item-read` to ground questions and recommended answers in actual code rather than asking the user.
 
 ## Your job this invocation
 
 1. Read the work item title and body carefully.
 2. Read the `priorReplies` transcript to understand what has already been asked and answered.
-3. Read `projectContext` — if the codebase already answers a potential question, skip it and ask about something genuinely unknown.
+3. Read `projectContext` and any `<codeGrounding>` / `<scoutDigest>` — if the codebase already answers a potential question, skip it and ask about something genuinely unknown.
 4. **Code-first rule.** Before asking the user, attempt to answer your candidate question yourself by exploring the rooted workspace. You have `read`, `search`, and `work-item-read` tools rooted there. If the answer is in the codebase, an ADR, CONTEXT.md, or a sibling work item — use it as the basis for `recommendedAnswer` and only ask the user to confirm or override. Only escalate to a fresh question when no source-of-truth artefact answers it.
 5. Identify the single most important unknown that, if answered, would most advance clarity.
 6. Formulate ONE clear, specific, answerable question. Do not ask compound questions.

--- a/skills/grill-me/skill.config.ts
+++ b/skills/grill-me/skill.config.ts
@@ -31,6 +31,8 @@ export const GrillMeContextSchema = z.object({
   priorReplies: z.array(GrillPriorReplyEntrySchema),
   roundNumber: z.number().int().min(1),
   projectContext: ProjectContextSchema,
+  codeGrounding: z.unknown().optional(),
+  scoutDigest: z.unknown().optional(),
 });
 
 const config: SkillConfig = {
@@ -40,7 +42,14 @@ const config: SkillConfig = {
   modelPin: 'sonnet',
   freshContext: false,
   role: 'griller',
-  contextAllowlist: ['workItem', 'priorReplies', 'roundNumber', 'projectContext'],
+  contextAllowlist: [
+    'workItem',
+    'priorReplies',
+    'roundNumber',
+    'projectContext',
+    'codeGrounding',
+    'scoutDigest',
+  ],
 };
 
 export default config;

--- a/skills/spec-author/prompt.md
+++ b/skills/spec-author/prompt.md
@@ -11,11 +11,12 @@ The `<task>` block contains:
 - `<workItem>` — JSON payload for the work item, with `title`, `body`, and `number`
 - `<issueType>` — `feature` or `bug` (drives strictness of AC→Journey mapping)
 - `<prdContext>` (optional) — canonical compact PRD planning context from the approved parent PRD. Treat this as authoritative for journeys, requirements, acceptance criteria, slice boundaries, implementation decisions, testing decisions, and out-of-scope constraints. If it includes `artifactRef`, the full raw PRD was stored outside prompt context; use the inline fields as the planning contract and targeted repo reads for implementation details.
-  PRD module references may name planned files, not current files. Verify them against `<existingFileManifest>` or targeted reads before citing them as existing code.
+  PRD module references are hints, not proof. They may be existing files, planned files, guesses, or stale paths. Verify them against `<existingFileManifest>`, actual reads/searches, or symbol-index output before citing them as existing code. Planned PRD refs must become `{ "path": "...", "status": "new" }` if owned by a WP.
 - `<prd>` (optional) — legacy compact PRD context string. Prefer `<prdContext>` when both are present. When absent and `issueType: feature`, derive minimal journeys from the work item.
 - `<investigationSynthesis>` (optional) — JSON-stringified `InvestigateOutput` (`findings`, `keyFiles`, `confidence`, `openQuestions`) produced by the synthesis step of the investigate workflow. **Read this first.** It is the distilled signal: use `findings` to understand the root cause or intent, `keyFiles` to orient your architecture section, and `openQuestions` to flag risks. When present, treat it as authoritative; use scout reports only for file:line citations.
 - `<scoutReports>` (optional) — JSON-stringified Wave-1 scout report digest metadata (M19.01). This is `scout-report-digest-v1`, not the raw scout report JSON. It includes top findings, high-confidence facts, files referenced, risks, contradictions, and artifact keys for full reports when they were offloaded.
 - `<wave2Reports>` (optional) — JSON-stringified Wave-2 deep-agent report digest metadata (interface-designer artefacts, risk-analyst register). This is also digest-first and may include artifact keys for full reports.
+- `<featureGrounding>` (optional) — feature code-grounding payload from `feature.grounding-complete`. It may include `existingSurfaces`, `confirmedExports`, `plannedFiles`, `testSurfaces`, and `openQuestions`. Existing surfaces are still citation targets only after verification; planned files must be owned as `{ "path": "...", "status": "new" }`.
 - `<repairFeedback>` (optional) — validator errors from a prior attempt. When present, return a complete corrected JSON object and address every listed error.
 - `<existingFileManifest>` (optional) — JSON array `[{path, kind: 'file' | 'dir'}]` listing files and directories that already exist under the spec scopeRoots. Every WP `filesOwned[].path` that points to a non-test, non-`*.config.ts` production file under `apps/`, `core/`, `slices/`, or `skills/` MUST either appear in this manifest OR be annotated as `{ "path": "…", "status": "new" }`. The validator hard-rejects unannotated missing paths.
 
@@ -42,6 +43,7 @@ A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/
   - Good: `apps/server/README.md:5`
   - Bad: `core/agent-runtime/event-types.ts:SYMBOL:EventLike`
   - Bad: `apps/server/README.md:5-20`
+- A `constraints[].source` using `path:symbol` may only cite a symbol you observed in an actual read/search result or symbol-index output. If no stable symbol exists, use `path:line` instead.
 - Optional fields should be omitted when they do not apply. Do not emit `null`.
 
 ### Required sections (Steve `01-planning-phase.md:287-300`)
@@ -65,10 +67,10 @@ A single JSON object conforming to `EngineeringSpecSchema` (`skills/spec-author/
 
 Each WP `filesOwned` entry is one of:
 
-- A bare string path: `"apps/web/src/components/detail/TaskHeader.tsx"` — must exist in `<existingFileManifest>`.
+- A bare string path: `"apps/web/src/components/detail/TaskHeader.tsx"` — must be a verified existing file. It must exist in `<existingFileManifest>` or have been confirmed by a targeted read/search.
 - An object `{ "path": "apps/web/src/components/detail/NewSection.tsx", "status": "new" }` — declares a file to be created. Validator skips the existence check.
 
-Do not invent paths. If `<existingFileManifest>` is absent, fall back to the manual investigation path and read the directory with `list_dir` before authoring `filesOwned`.
+Do not invent paths. `filesOwned` bare strings must be verified existing files. New files must use `{ "path": "...", "status": "new" }`; do not emit unannotated planned paths. If `<existingFileManifest>` is absent, fall back to the manual investigation path and read the directory with `list_dir` before authoring `filesOwned`.
 
 #### File ownership (full-stop, not per-batch)
 
@@ -99,6 +101,7 @@ Every entry in `constraints` must have `source` in the form `path/to/file.ts:LIN
 Do not use line ranges and do not write `SYMBOL:`. For symbols, put the symbol
 name after the final colon: `path/to/file.ts:EventLike`, not
 `path/to/file.ts:SYMBOL:EventLike`.
+Only cite symbols you actually observed in real code reads, searches, or symbol-index output. If you only know the file but not a stable symbol, cite a line number from the read/search result.
 
 You must run constraint inventory for every:
 - State-machine phase referenced (read the enum)
@@ -154,6 +157,7 @@ If it says a constraint cites a file that does not exist, do not cite that
 planned file again. Move planned paths to `filesOwned` or `interfaceContracts`
 and cite an existing host file, exported symbol, or current integration point in
 `constraints`.
+If repair feedback says a symbol is missing, do not introduce new unverified symbols. Use an available export listed in the feedback, or switch that constraint to a `path:line` citation.
 
 Emit: `[decision] READ: Issue #<n> — <one-sentence summary>`
 

--- a/skills/spec-author/skill.config.ts
+++ b/skills/spec-author/skill.config.ts
@@ -72,6 +72,8 @@ export const SpecAuthorContextSchema = z.object({
     .array(z.object({ path: z.string(), kind: z.enum(['file', 'dir']) }))
     .optional()
     .describe('Capped list of files+dirs under the spec scopeRoots. Use to ground WP filesOwned.'),
+  /** Feature code-grounding payload from the grounding scouts, when available. */
+  featureGrounding: z.unknown().optional(),
 });
 
 const config: SkillConfig = {
@@ -89,6 +91,7 @@ const config: SkillConfig = {
     'investigationSynthesis',
     'repairFeedback',
     'existingFileManifest',
+    'featureGrounding',
   ],
   /**
    * Read bundle: spec-author authors a JSON artefact in its terminal

--- a/skills/write-prd/prompt.md
+++ b/skills/write-prd/prompt.md
@@ -20,6 +20,7 @@ You run in **fresh context**. The only inputs you can see are:
 - `<priority>` — one of `low | medium | high | critical`.
 - `<projectContext>` — JSON payload containing `stackSummary`, `contextMd`, `adrSummaries`, and `claudeMd`.
 - `<priorReplies>` (optional) — the grilling transcript that produced the refined intent. Each `agent` entry may carry a `crystallized` field: a single-sentence decision distilled from that question and its reply. **Treat the crystallized decisions as the authoritative record of what was agreed.** Use the raw Q+A only as supporting detail when a crystallization is ambiguous or absent.
+- `<codeGrounding>` / `<scoutDigest>` (optional) — feature code-grounding produced before discovery. Treat it as evidence and orientation, not as product intent. It may identify existing surfaces, confirmed exports, planned/new file candidates, relevant tests, reusable patterns, and open questions. Verify exact citations before relying on them, and let crystallized user decisions win when product intent conflicts with grounding.
 - `<priorPrd>` (optional) — JSON payload for the previous PRD draft when revising.
 - `<humanConcerns>` (optional) — JSON array of human-raised concerns to address in revision mode.
 
@@ -76,13 +77,17 @@ Slices should be vertical cuts through the stack (UI + API + DB together), not h
 `implementationDecisions[]` is required (min 1). For each significant architectural choice:
 - Use `decision` to name what was decided (e.g. "Use Drizzle ORM for the new table").
 - Use `rationale` to explain why, referencing `projectContext.adrSummaries` or `projectContext.contextMd` where applicable. If a decision extends or contradicts an existing ADR, call it out explicitly.
-- Use `moduleRef` to identify the primary file/module affected (e.g. `core/state-source/interface.ts`).
+- Use `moduleRef` to identify the primary file/module affected. Prefer the object form:
+  - `{ "path": "core/state-source/interface.ts", "status": "existing", "confidence": "high", "evidence": "codeGrounding existingSurfaces" }` only when the current repo evidence says the path exists.
+  - `{ "path": "apps/web/src/features/new-flow/view.tsx", "status": "planned", "confidence": "medium", "evidence": "new file candidate from PRD plan" }` for files expected to be created.
+  - Bare string refs are legacy hints only; avoid them in new output.
+- Do not mark a path `existing` because it sounds plausible. If the path is uncertain, either omit `moduleRef`, mark it `planned`, or add an `UNCERTAINTY` decision summary instead of inventing a current file.
 
 ## Testing decisions
 
 `testingDecisions` is required. Describe the testing strategy at a behaviour level:
 - `approach`: describe **what external behaviour to test**, not implementation details. Reference the functional spec's when/given/then triples as the source of truth.
-- `modulesToTest`: list the modules that need coverage (e.g. `slices/my-slice/slice.test.ts`).
+- `modulesToTest`: list the modules that need coverage. Prefer `{ "path": "...", "status": "existing" | "planned", "confidence": "...", "evidence": "..." }`. Use `existing` only for known current files; use `planned` for tests that should be created.
 - `priorArt`: if similar tests exist in the codebase (from `projectContext.contextMd` or ADRs), name them so implementors can reference them. Omit if nothing relevant exists.
 
 ## Decision summaries
@@ -158,11 +163,15 @@ Exact field names (use these verbatim):
   ],
   "estimatedComplexity": "medium",
   "implementationDecisions": [
-    { "decision": "<string>", "rationale": "<optional — cite ADR or CONTEXT.md>", "moduleRef": "<optional — primary file affected>" }
+    {
+      "decision": "<string>",
+      "rationale": "<optional — cite ADR or CONTEXT.md>",
+      "moduleRef": { "path": "<repo-root path>", "status": "existing", "confidence": "high", "evidence": "<grounding evidence>" }
+    }
   ],
   "testingDecisions": {
     "approach": "<what external behaviour to verify, not how>",
-    "modulesToTest": ["<e.g. slices/my-slice/slice.test.ts>"],
+    "modulesToTest": [{ "path": "<e.g. slices/my-slice/slice.test.ts>", "status": "planned", "confidence": "medium", "evidence": "<why this test path is planned/existing>" }],
     "priorArt": "<optional — similar tests in the codebase>"
   },
   "decisionSummaries": [

--- a/skills/write-prd/schema.ts
+++ b/skills/write-prd/schema.ts
@@ -76,15 +76,24 @@ export const SliceOutlineSchema = z.object({
   journeyRefs: z.array(z.string()),
 });
 
+export const ModuleReferenceSchema = z.object({
+  path: z.string(),
+  status: z.enum(['existing', 'planned']),
+  confidence: z.enum(['high', 'medium', 'low']).optional(),
+  evidence: z.string().optional(),
+});
+
+export const ModuleRefFieldSchema = z.union([z.string(), ModuleReferenceSchema]);
+
 export const ImplementationDecisionSchema = z.object({
   decision: z.string(),
   rationale: z.string().optional(),
-  moduleRef: z.string().optional(),
+  moduleRef: ModuleRefFieldSchema.optional(),
 });
 
 export const TestingDecisionsSchema = z.object({
   approach: z.string(),
-  modulesToTest: z.array(z.string()),
+  modulesToTest: z.array(ModuleRefFieldSchema),
   priorArt: z.string().optional(),
 });
 
@@ -133,5 +142,7 @@ export type Journey = z.infer<typeof JourneySchema>;
 export type AcceptanceCriterion = z.infer<typeof AcceptanceCriterionSchema>;
 export type FunctionalSpec = z.infer<typeof FunctionalSpecSchema>;
 export type SliceOutline = z.infer<typeof SliceOutlineSchema>;
+export type ModuleReference = z.infer<typeof ModuleReferenceSchema>;
+export type ModuleRefField = z.infer<typeof ModuleRefFieldSchema>;
 export type ImplementationDecision = z.infer<typeof ImplementationDecisionSchema>;
 export type TestingDecisions = z.infer<typeof TestingDecisionsSchema>;

--- a/skills/write-prd/skill.config.ts
+++ b/skills/write-prd/skill.config.ts
@@ -5,6 +5,25 @@ import { PRDOutputSchema } from './schema.js';
 
 export { ProjectContextSchema };
 
+export const CodeGroundingContextSchema = z.object({
+  groundingRunId: z.string(),
+  existingSurfaces: z.array(z.string()).optional(),
+  confirmedExports: z
+    .array(
+      z.object({
+        path: z.string(),
+        symbol: z.string(),
+        evidence: z.string().optional(),
+      }),
+    )
+    .optional(),
+  plannedFiles: z.array(z.string()).optional(),
+  testSurfaces: z.array(z.string()).optional(),
+  reusablePatterns: z.array(z.string()).optional(),
+  openQuestions: z.array(z.string()).optional(),
+  scoutDigest: z.unknown().optional(),
+});
+
 export const WritePRDContextSchema = z.object({
   workItem: z.object({
     title: z.string(),
@@ -17,6 +36,8 @@ export const WritePRDContextSchema = z.object({
   priorReplies: z.array(GrillPriorReplyEntrySchema).optional(),
   priorPrd: PRDOutputSchema.optional(),
   humanConcerns: z.array(z.string()).optional(),
+  codeGrounding: CodeGroundingContextSchema.optional(),
+  scoutDigest: z.unknown().optional(),
 });
 
 const config: SkillConfig = {
@@ -36,6 +57,8 @@ const config: SkillConfig = {
     'priorReplies',
     'priorPrd',
     'humanConcerns',
+    'codeGrounding',
+    'scoutDigest',
   ],
 };
 

--- a/skills/write-prd/slice.test.ts
+++ b/skills/write-prd/slice.test.ts
@@ -85,12 +85,24 @@ const validPRD = {
     {
       decision: 'Stream CSV via existing admin route',
       rationale: 'Follows admin gateway pattern in CONTEXT.md',
-      moduleRef: 'apps/server/src/domains/admin/',
+      moduleRef: {
+        path: 'apps/server/src/domains/admin/',
+        status: 'existing' as const,
+        confidence: 'high' as const,
+        evidence: 'project context',
+      },
     },
   ],
   testingDecisions: {
     approach: 'Verify admin endpoint returns correct CSV rows for date range',
-    modulesToTest: ['slices/admin-csv-export/slice.test.ts'],
+    modulesToTest: [
+      {
+        path: 'slices/admin-csv-export/slice.test.ts',
+        status: 'planned' as const,
+        confidence: 'medium' as const,
+        evidence: 'new feature coverage',
+      },
+    ],
   },
   decisionSummaries: [baseDecisionSummary],
 };
@@ -187,6 +199,25 @@ describe('PRD schema', () => {
     const result = PRDOutputSchema.safeParse({
       ...validPRD,
       engineeringSpecRef: 'docs/eng-specs/audit-export.md',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts existing and planned module refs with evidence', () => {
+    const result = PRDOutputSchema.safeParse(validPRD);
+    expect(result.success).toBe(true);
+  });
+
+  it('keeps legacy bare string module refs backward compatible', () => {
+    const result = PRDOutputSchema.safeParse({
+      ...validPRD,
+      implementationDecisions: [
+        { decision: 'Use legacy ref shape', moduleRef: 'core/state-source/interface.ts' },
+      ],
+      testingDecisions: {
+        approach: 'Existing tests',
+        modulesToTest: ['slices/write-prd/slice.test.ts'],
+      },
     });
     expect(result.success).toBe(true);
   });

--- a/slices/dogfood/checklist.ts
+++ b/slices/dogfood/checklist.ts
@@ -36,7 +36,8 @@ export const CHECKLISTS: Record<WorkflowKind, ChecklistItem[]> = {
     { label: 'Done', state: 'factory:done' },
   ],
   feature: [
-    { label: 'Issue triaged → grilling', state: 'factory:grilling' },
+    { label: 'Issue triaged → grounding', state: 'factory:grounding' },
+    { label: 'Feature grounding complete', state: 'factory:grilling' },
     { label: 'PRD drafting', state: 'factory:prd-drafting' },
     { label: 'PRD review (human gate)', state: 'factory:prd-review' },
     { label: 'Decomposing into child issues', state: 'factory:decomposing' },

--- a/slices/feature-grounding/slice.test.ts
+++ b/slices/feature-grounding/slice.test.ts
@@ -1,0 +1,232 @@
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDispatchWave = vi.fn();
+const mockPersistScoutReportForRun = vi.fn();
+const mockAppendEvent = vi.fn();
+const mockReplay = vi.fn();
+const mockTransitionAndEmitState = vi.fn();
+
+vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
+  dispatchWave: (...args: unknown[]) => mockDispatchWave(...args),
+}));
+
+vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
+  persistScoutReportForRun: (...args: unknown[]) => mockPersistScoutReportForRun(...args),
+}));
+
+vi.mock('@goose-hub/core/event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: (...args: unknown[]) => mockAppendEvent(...args),
+    replay: (...args: unknown[]) => mockReplay(...args),
+  },
+}));
+
+vi.mock('@goose-hub/core/event-stream/state-transition.js', () => ({
+  transitionAndEmitState: (...args: unknown[]) => mockTransitionAndEmitState(...args),
+}));
+
+vi.mock('@goose-hub/core/projects/loader.js', () => ({
+  getProjectBySlug: vi.fn().mockResolvedValue({
+    id: 'goose-hub-self',
+    targetRepo: { defaultBranch: 'main' },
+    budgets: { maxParallelAgents: 4 },
+    investigationSwarm: { enabled: true },
+    agentConfig: { runtime: 'auto' },
+  }),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue({ personaId: 'investigator-test' }),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/select-runtime.js', () => ({
+  selectRuntime: vi.fn().mockReturnValue({ run: vi.fn() }),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/read-prompt.js', () => ({
+  readPromptWithContext: vi.fn().mockReturnValue('# scout prompt'),
+}));
+
+vi.mock('@goose-hub/core/db/repositories/project-settings.js', () => ({
+  getUseInvestigationSwarm: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@goose-hub/core/agent-runtime/skill-runtime-resolver.js', () => ({
+  resolveSkillRuntimeForProject: vi.fn().mockReturnValue({
+    modelOverride: 'claude-3-5-sonnet-latest',
+    provider: 'claude',
+    budgets: { timeoutMs: 30_000 },
+  }),
+}));
+
+vi.mock('@goose-hub/core/workspaces/workflow-base.js', () => ({
+  resolveWorkflowBaseForWorkItem: vi.fn().mockReturnValue({
+    branch: 'main',
+    ref: 'origin/main',
+    source: 'configured-default',
+  }),
+}));
+
+function makeWorkItem(): WorkItem {
+  return {
+    id: 'github:shaunnez/goose-hub#1176',
+    externalId: '1176',
+    repoRef: 'shaunnez/goose-hub',
+    title: 'Add workflow snapshot costs',
+    body: 'Show cost cards on the detail page.',
+    type: 'feature',
+    priority: 'medium',
+    mode: 'supervised',
+    state: 'factory:grounding',
+    authorIsOwner: true,
+    schedule: 'current',
+    exec: 'serial',
+    dependsOn: [],
+    blocks: [],
+    createdAt: new Date(),
+  };
+}
+
+function makeSource(): StateSource {
+  return {
+    projectId: 'goose-hub-self',
+    repoRef: 'shaunnez/goose-hub',
+    transitionState: vi.fn(),
+    forceState: vi.fn(),
+    comment: vi.fn(),
+  } as unknown as StateSource;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReplay.mockReturnValue([]);
+  mockDispatchWave.mockResolvedValue({
+    status: 'ok',
+    shouldAdvance: true,
+    shouldEscalate: false,
+    failedScouts: [],
+    skippedScouts: [],
+    okCount: 2,
+    applicableCount: 2,
+    requiredOkCount: 2,
+    summary: 'completed',
+    reports: [
+      {
+        scoutName: 'scout-code-path',
+        status: 'ok',
+        outcome: 'ok',
+        findings: [
+          {
+            file: 'apps/web/src/components/detail/lib/costs.ts',
+            fact: 'costs.ts exports useIssueCostsBreakdown.',
+            confidence: 'high',
+          },
+        ],
+        decisionSummaries: [],
+        runId: 'run:scout-code-path',
+      },
+      {
+        scoutName: 'scout-test-inventory',
+        status: 'ok',
+        outcome: 'ok',
+        findings: [
+          {
+            file: 'apps/web/src/components/detail/lib/costs.test.ts',
+            fact: 'Existing test surface covers costs.',
+            confidence: 'high',
+          },
+        ],
+        decisionSummaries: [{ kind: 'UNCERTAINTY', summary: 'Product card ordering is unclear.' }],
+        runId: 'run:scout-test',
+      },
+    ],
+  });
+  mockPersistScoutReportForRun.mockImplementation(
+    (_projectId, _workItemId, _runId, _skill, report) => report,
+  );
+});
+
+describe('feature-grounding workflow', () => {
+  it('dispatches a scout wave, persists scout reports, emits grounding complete, and routes to grilling', async () => {
+    const { runFeatureGroundingWorkflow } = await import('./workflow.js');
+    await runFeatureGroundingWorkflow(makeWorkItem(), makeSource(), 'goose-hub-self', '/repo', {
+      createWorktreeImpl: () => '/tmp/grounding-worktree',
+      cleanupWorktreeImpl: vi.fn(),
+    });
+
+    expect(mockDispatchWave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentRunId: expect.any(String),
+        worktreePath: '/tmp/grounding-worktree',
+        minSuccessfulScouts: 2,
+      }),
+    );
+    expect(mockPersistScoutReportForRun).toHaveBeenCalledTimes(2);
+    const groundingEvent = mockAppendEvent.mock.calls.find(
+      ([event]) => event.kind === 'feature.grounding-complete',
+    )?.[0];
+    expect(groundingEvent.payload).toMatchObject({
+      groundingRunId: expect.any(String),
+      existingSurfaces: ['apps/web/src/components/detail/lib/costs.ts'],
+      testSurfaces: ['apps/web/src/components/detail/lib/costs.test.ts'],
+      confirmedExports: [
+        expect.objectContaining({
+          path: 'apps/web/src/components/detail/lib/costs.ts',
+          symbol: 'useIssueCostsBreakdown',
+        }),
+      ],
+      openQuestions: ['Product card ordering is unclear.'],
+    });
+    expect(mockTransitionAndEmitState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'factory:grounding',
+        to: 'factory:grilling',
+        by: 'feature-grounding',
+      }),
+    );
+  });
+
+  it('uses framed context and routes skip-grill features to PRD drafting', async () => {
+    mockReplay.mockReturnValue([
+      {
+        kind: 'feature.framed',
+        payload: {
+          framedBody: 'Original\n\nFramed details',
+          refinedIntent: 'Add grounded feature',
+          stillNeedsGrilling: false,
+        },
+      },
+    ]);
+    const { runFeatureGroundingWorkflow } = await import('./workflow.js');
+    const result = await runFeatureGroundingWorkflow(
+      makeWorkItem(),
+      makeSource(),
+      'goose-hub-self',
+      '/repo',
+      {
+        createWorktreeImpl: () => '/tmp/grounding-worktree',
+        cleanupWorktreeImpl: vi.fn(),
+      },
+    );
+
+    expect(result.nextState).toBe('factory:prd-drafting');
+    expect(mockDispatchWave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workItem: expect.objectContaining({ body: 'Original\n\nFramed details' }),
+      }),
+    );
+    const groundingEvent = mockAppendEvent.mock.calls.find(
+      ([event]) => event.kind === 'feature.grounding-complete',
+    )?.[0];
+    expect(groundingEvent.payload).toMatchObject({
+      refinedIntent: 'Add grounded feature',
+    });
+    expect(mockTransitionAndEmitState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'factory:grounding',
+        to: 'factory:prd-drafting',
+      }),
+    );
+  });
+});

--- a/slices/feature-grounding/workflow.ts
+++ b/slices/feature-grounding/workflow.ts
@@ -1,0 +1,357 @@
+import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
+import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
+import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
+import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
+import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
+import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
+import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
+import {
+  type ScoutBudgetResolver,
+  type ScoutReport,
+  dispatchWave,
+} from '@goose-hub/core/agent-runtime/swarm.js';
+import { getUseInvestigationSwarm } from '@goose-hub/core/db/repositories/project-settings.js';
+import { transitionAndEmitState } from '@goose-hub/core/event-stream/state-transition.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
+import { buildScoutReportDigestBundle } from '@goose-hub/core/scout-reports/digest.js';
+import { persistScoutReportForRun } from '@goose-hub/core/scout-reports/repository.js';
+import type { StateName } from '@goose-hub/core/state-machine/states.js';
+import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { extractIdentifiers } from '@goose-hub/core/symbol-index/lookup.js';
+import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
+import { cleanupWorktree, createWorktree } from '@goose-hub/core/workspaces/worktree.js';
+
+export interface FeatureGroundingWorkflowDeps {
+  createWorktreeImpl?: typeof createWorktree;
+  cleanupWorktreeImpl?: typeof cleanupWorktree;
+  resolveWorkflowBaseImpl?: typeof resolveWorkflowBaseForWorkItem;
+  runtime?: AgentRuntime;
+}
+
+export type FeatureGroundingPayload = {
+  groundingRunId: string;
+  existingSurfaces: string[];
+  confirmedExports: Array<{ path: string; symbol: string; evidence?: string }>;
+  plannedFiles: string[];
+  testSurfaces: string[];
+  reusablePatterns: string[];
+  openQuestions: string[];
+};
+
+export type FeatureGroundingWorkflowResult = {
+  nextState: Extract<
+    StateName,
+    'factory:grilling' | 'factory:prd-drafting' | 'factory:needs-human'
+  >;
+};
+
+type FramedFeaturePayload = {
+  framedBody?: string;
+  refinedIntent?: string;
+  stillNeedsGrilling?: boolean;
+};
+
+const FEATURE_SCOUTS = [
+  {
+    scoutName: 'scout-code-path',
+    scoutFocus:
+      'Feature code grounding: find existing implementation surfaces, public entry points, and current files this feature likely extends. Do not diagnose a bug or claim root cause.',
+  },
+  {
+    scoutName: 'scout-dependency',
+    scoutFocus:
+      'Feature code grounding: map dependencies and reusable integration seams for this feature. Report confirmed exports and imports only when observed in code.',
+  },
+  {
+    scoutName: 'scout-pattern',
+    scoutFocus:
+      'Feature code grounding: find reusable patterns and sibling implementations this feature should follow.',
+  },
+  {
+    scoutName: 'scout-test-inventory',
+    scoutFocus:
+      'Feature code grounding: find relevant existing tests and planned test candidates for the feature.',
+  },
+];
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter((value) => value.trim() !== ''))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+function fileFromFinding(finding: { file?: string | null }): string | null {
+  return typeof finding.file === 'string' && finding.file.trim() !== '' ? finding.file : null;
+}
+
+function extractConfirmedExports(
+  reports: ScoutReport[],
+): FeatureGroundingPayload['confirmedExports'] {
+  const exports: FeatureGroundingPayload['confirmedExports'] = [];
+  const exportPattern =
+    /\bexport(?:s|ed)?\s+(?:symbol\s+)?`?([A-Za-z_$][\w$]*)`?|\b`([A-Za-z_$][\w$]*)`\s+is exported/gi;
+  for (const report of reports) {
+    for (const finding of report.findings) {
+      const path = fileFromFinding(finding);
+      if (path == null) continue;
+      for (const match of finding.fact.matchAll(exportPattern)) {
+        const symbol = match[1] ?? match[2];
+        if (symbol != null) {
+          exports.push({ path, symbol, evidence: `${report.scoutName}: ${finding.fact}` });
+        }
+      }
+    }
+  }
+  const seen = new Set<string>();
+  return exports.filter((entry) => {
+    const key = `${entry.path}:${entry.symbol}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function summarizeGrounding(
+  reports: ScoutReport[],
+): Omit<FeatureGroundingPayload, 'groundingRunId'> {
+  const okReports = reports.filter(
+    (report) => report.status === 'ok' && report.outcome !== 'skipped',
+  );
+  const findings = okReports.flatMap((report) =>
+    report.findings.map((finding) => ({ ...finding, scoutName: report.scoutName })),
+  );
+  const existingSurfaces = uniqueSorted(
+    findings.flatMap((finding) => {
+      const file = fileFromFinding(finding);
+      return file != null && !/\.(test|spec)\.[jt]sx?$/.test(file) ? [file] : [];
+    }),
+  );
+  const testSurfaces = uniqueSorted(
+    findings.flatMap((finding) => {
+      const file = fileFromFinding(finding);
+      return file != null && /\.(test|spec)\.[jt]sx?$/.test(file) ? [file] : [];
+    }),
+  );
+  const plannedFiles = uniqueSorted(
+    findings.flatMap((finding) => {
+      const text = finding.fact.toLowerCase();
+      const file = fileFromFinding(finding);
+      return file != null && /\b(planned|new file|create|candidate)\b/.test(text) ? [file] : [];
+    }),
+  );
+  const reusablePatterns = uniqueSorted(
+    findings
+      .filter((finding) => finding.scoutName === 'scout-pattern')
+      .map((finding) => finding.fact),
+  ).slice(0, 8);
+  const openQuestions = uniqueSorted(
+    reports.flatMap((report) =>
+      report.decisionSummaries.flatMap((summary) =>
+        summary.kind === 'UNCERTAINTY' ? [summary.summary] : [],
+      ),
+    ),
+  ).slice(0, 8);
+
+  return {
+    existingSurfaces,
+    confirmedExports: extractConfirmedExports(okReports),
+    plannedFiles,
+    testSurfaces,
+    reusablePatterns,
+    openQuestions,
+  };
+}
+
+function latestFramedFeature(projectId: string, workItemId: string): FramedFeaturePayload | null {
+  const [latest] = eventStore.replay({
+    projectId,
+    workItemId,
+    kind: 'feature.framed',
+    order: 'desc',
+    limit: 1,
+  });
+  return (latest?.payload as FramedFeaturePayload | undefined) ?? null;
+}
+
+function workItemContextNumber(externalId: string): number {
+  const trimmed = externalId.trim();
+  return /^\d+$/.test(trimmed) ? Number(trimmed) : 0;
+}
+
+export async function runFeatureGroundingWorkflow(
+  workItem: WorkItem,
+  stateSource: StateSource,
+  projectId: string,
+  targetRepo: string,
+  deps: FeatureGroundingWorkflowDeps = {},
+): Promise<FeatureGroundingWorkflowResult> {
+  const runId = crypto.randomUUID();
+  const { personaId } = selectPersona(projectId, 'investigator');
+  const createWtFn = deps.createWorktreeImpl ?? createWorktree;
+  const cleanupWtFn = deps.cleanupWorktreeImpl ?? cleanupWorktree;
+  const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBaseForWorkItem;
+  const projectConfig = await getProjectBySlug(projectId);
+  const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
+  const groundingBudget = resolveSkillRuntimeForProject({
+    skill: 'scout-code-path',
+    projectBudgets: projectConfig?.budgets,
+    projectId,
+    configRuntime,
+    role: 'investigator',
+  });
+  const runtime =
+    deps.runtime ??
+    selectRuntime({
+      configRuntime,
+      model: groundingBudget.modelOverride,
+      skillProvider: groundingBudget.provider,
+    });
+  const workflowBase = resolveWorkflowBaseFn(
+    projectId,
+    workItem.id,
+    targetRepo,
+    projectConfig?.targetRepo?.defaultBranch,
+  );
+  const worktreePath = createWtFn(targetRepo, runId, workflowBase.ref);
+
+  const resolveScoutBudget: ScoutBudgetResolver = (skill, projectBudgets, currentProjectId) =>
+    resolveSkillRuntimeForProject({
+      skill,
+      projectBudgets,
+      projectId: currentProjectId,
+      configRuntime,
+      role: 'investigator',
+    });
+
+  try {
+    const swarmEnabled = getUseInvestigationSwarm(
+      projectConfig?.id ?? projectId,
+      projectConfig?.investigationSwarm?.enabled ?? true,
+    );
+    const scoutJsonSchema = toJsonSchema(ScoutOutputSchema);
+    const framedFeature = latestFramedFeature(projectId, workItem.id);
+    const groundedBody = framedFeature?.framedBody ?? workItem.body;
+    const nextState: FeatureGroundingWorkflowResult['nextState'] =
+      framedFeature?.stillNeedsGrilling === false ? 'factory:prd-drafting' : 'factory:grilling';
+    const workItemCtx = {
+      number: workItemContextNumber(workItem.externalId),
+      title: workItem.title,
+      body: groundedBody,
+    };
+    const symbolIdentifiers = extractIdentifiers(`${workItem.title} ${groundedBody}`);
+    const scoutSpecs = FEATURE_SCOUTS.map((spec) => ({
+      ...spec,
+      extraContext:
+        symbolIdentifiers.length > 0
+          ? { symbolIndexHints: symbolIdentifiers.slice(0, 12).map((name) => ({ name })) }
+          : undefined,
+    }));
+
+    const wave = await dispatchWave({
+      parentRunId: runId,
+      scoutSpecs,
+      workItem: workItemCtx,
+      worktreePath,
+      projectId,
+      workItemId: workItem.id,
+      runtime,
+      personaId,
+      maxScoutAgents: projectConfig?.budgets?.maxParallelAgents,
+      projectBudgets: projectConfig?.budgets,
+      minSuccessfulScouts: swarmEnabled ? 2 : 1,
+      resolveScoutBudget,
+      loadSkillAssets: (scoutName) => ({
+        appendSystemPrompt: `${readPromptWithContext(scoutName, projectId)}
+
+Feature-grounding mode:
+- This is not bug investigation. Do not return root cause, repro steps, or fix diagnosis.
+- Return code-grounding facts: existing surfaces, confirmed exports, relevant tests, reusable patterns, planned/new file candidates, and open questions.
+- Treat digest/report facts as evidence pointers. Exact citations must be verified before downstream agents rely on them.`,
+        outputJsonSchema: scoutJsonSchema,
+      }),
+    });
+
+    const persistedReports = wave.reports.flatMap((report) => {
+      if (report.status !== 'ok' || report.outcome === 'skipped') return [];
+      const persisted = persistScoutReportForRun(projectId, workItem.id, runId, report.scoutName, {
+        findings: report.findings,
+        decisionSummaries: report.decisionSummaries,
+      });
+      return [{ ...report, report: persisted }];
+    });
+    const digest = buildScoutReportDigestBundle(
+      persistedReports.map((report, index) => ({
+        id: index + 1,
+        projectId,
+        workItemId: workItem.id,
+        investigationRunId: runId,
+        scoutSkill: report.scoutName,
+        report: report.report,
+        createdAt: new Date(0).toISOString(),
+      })),
+    );
+    const grounding = summarizeGrounding(wave.reports);
+
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'feature.grounding-complete',
+      payload: {
+        groundingRunId: runId,
+        ...grounding,
+        refinedIntent: framedFeature?.refinedIntent,
+        scoutDigest: digest,
+        baseBranch: workflowBase.branch,
+      },
+      runId,
+      personaId,
+    });
+
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:grounding',
+      to: nextState,
+      by: 'feature-grounding',
+      runId,
+    });
+    return { nextState };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    eventStore.appendEvent({
+      projectId,
+      workItemId: workItem.id,
+      kind: 'agent.run-failed',
+      payload: { skill: 'feature-grounding', runId, error: error.message },
+      runId,
+    });
+    await stateSource.comment(
+      workItem.externalId,
+      buildAgentComment(
+        'Feature Grounding',
+        'Failed',
+        'Feature code-grounding failed — escalating to needs-human',
+        [`Error: ${error.message}`],
+      ),
+    );
+    await transitionAndEmitState({
+      mode: 'legal',
+      source: stateSource,
+      itemId: workItem.externalId,
+      projectId,
+      workItemId: workItem.id,
+      from: 'factory:grounding',
+      to: 'factory:needs-human',
+      by: 'feature-grounding',
+      runId,
+    });
+    return { nextState: 'factory:needs-human' };
+  } finally {
+    cleanupWtFn(runId);
+  }
+}

--- a/slices/feature-grounding/workflow.ts
+++ b/slices/feature-grounding/workflow.ts
@@ -122,10 +122,19 @@ function summarizeGrounding(
   const findings = okReports.flatMap((report) =>
     report.findings.map((finding) => ({ ...finding, scoutName: report.scoutName })),
   );
+  const plannedSet = new Set(
+    findings.flatMap((finding) => {
+      const text = finding.fact.toLowerCase();
+      const file = fileFromFinding(finding);
+      return file != null && /\b(planned|new file|create|candidate)\b/.test(text) ? [file] : [];
+    }),
+  );
   const existingSurfaces = uniqueSorted(
     findings.flatMap((finding) => {
       const file = fileFromFinding(finding);
-      return file != null && !/\.(test|spec)\.[jt]sx?$/.test(file) ? [file] : [];
+      return file != null && !plannedSet.has(file) && !/\.(test|spec)\.[jt]sx?$/.test(file)
+        ? [file]
+        : [];
     }),
   );
   const testSurfaces = uniqueSorted(
@@ -134,13 +143,7 @@ function summarizeGrounding(
       return file != null && /\.(test|spec)\.[jt]sx?$/.test(file) ? [file] : [];
     }),
   );
-  const plannedFiles = uniqueSorted(
-    findings.flatMap((finding) => {
-      const text = finding.fact.toLowerCase();
-      const file = fileFromFinding(finding);
-      return file != null && /\b(planned|new file|create|candidate)\b/.test(text) ? [file] : [];
-    }),
-  );
+  const plannedFiles = uniqueSorted(plannedSet);
   const reusablePatterns = uniqueSorted(
     findings
       .filter((finding) => finding.scoutName === 'scout-pattern')
@@ -258,7 +261,7 @@ export async function runFeatureGroundingWorkflow(
       workItemId: workItem.id,
       runtime,
       personaId,
-      maxScoutAgents: projectConfig?.budgets?.maxParallelAgents,
+      maxScoutAgents: projectConfig?.budgets?.maxScoutAgents,
       projectBudgets: projectConfig?.budgets,
       minSuccessfulScouts: swarmEnabled ? 2 : 1,
       resolveScoutBudget,
@@ -272,6 +275,76 @@ Feature-grounding mode:
         outputJsonSchema: scoutJsonSchema,
       }),
     });
+
+    if (wave.shouldEscalate) {
+      const failedList = wave.failedScouts.join(', ') || 'unknown';
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-failed',
+        payload: { skill: 'feature-grounding', runId, error: `Wave halted: ${failedList} failed` },
+        runId,
+        personaId,
+      });
+      await stateSource.comment(
+        workItem.externalId,
+        buildAgentComment(
+          'Feature Grounding',
+          'Failed',
+          `Feature code-grounding halted: scouts ${failedList} failed — escalating to needs-human`,
+          [],
+        ),
+      );
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:grounding',
+        to: 'factory:needs-human',
+        by: 'feature-grounding',
+        runId,
+      });
+      return { nextState: 'factory:needs-human' };
+    }
+
+    if (!wave.shouldAdvance) {
+      const summary = `ok=${wave.okCount}/${wave.requiredOkCount}`;
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-failed',
+        payload: {
+          skill: 'feature-grounding',
+          runId,
+          error: `Wave incomplete: ${summary}, insufficient successful scouts`,
+        },
+        runId,
+        personaId,
+      });
+      await stateSource.comment(
+        workItem.externalId,
+        buildAgentComment(
+          'Feature Grounding',
+          'Failed',
+          `Feature code-grounding incomplete (${summary}) — escalating to needs-human`,
+          [],
+        ),
+      );
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:grounding',
+        to: 'factory:needs-human',
+        by: 'feature-grounding',
+        runId,
+      });
+      return { nextState: 'factory:needs-human' };
+    }
 
     const persistedReports = wave.reports.flatMap((report) => {
       if (report.status !== 'ok' || report.outcome === 'skipped') return [];

--- a/slices/framing/slice.test.ts
+++ b/slices/framing/slice.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentRuntime,
   AgentSpec,
 } from '@goose-hub/core/agent-runtime/interface.js';
+import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { InMemoryLabelsSource } from '@goose-hub/core/state-source/in-memory-labels.js';
 import type { StateSource } from '@goose-hub/core/state-source/interface.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -89,116 +90,12 @@ function featureFrameOutput(stillNeedsGrilling: boolean) {
   };
 }
 
-function validGrillQuestion() {
-  return {
-    questions: [
-      {
-        text: 'Who can see another user saved report?',
-        recommendedAnswer: 'Saved reports are private to the creator for the first version.',
-      },
-    ],
-    refinedIntent: 'Add named saved report filters.',
-    readyForPRD: false,
-    decisionSummaries: [
-      {
-        kind: 'PLAN',
-        summary: 'Asked about saved report visibility before PRD drafting.',
-        evidence: 'The framed content does not define sharing behavior.',
-      },
-    ],
-  };
-}
-
-function validPrdOutput() {
-  return {
-    title: 'Saved report filters',
-    problem: 'Users repeat report filter setup because saved filtered views do not exist.',
-    proposedSolution: 'Allow users to save, reopen, and manage named report filter sets.',
-    outOfScope: ['Sharing saved reports between users'],
-    successCriteria: ['Users can reopen a saved report without rebuilding filters.'],
-    acceptanceCriteria: [
-      {
-        id: 'AC-1',
-        statement: 'A user can save current report filters with a readable name.',
-        journeyId: 'J-1',
-        stepIdx: 1,
-      },
-    ],
-    journeys: [
-      {
-        id: 'J-1',
-        persona: 'Operator',
-        trigger: 'Needs to reuse a filtered report',
-        steps: [
-          {
-            userAction: 'Saves current filters',
-            systemResponse: 'Stores the named report',
-            dataShown: 'Saved report name',
-            stateChange: 'Saved report exists',
-          },
-        ],
-        successState: 'The report can be reopened later.',
-        errorStates: [{ error: 'Duplicate name', recovery: 'Ask for a different name.' }],
-        edgeCases: ['Deleted filter values are ignored when reopening.'],
-      },
-    ],
-    functionalSpec: {
-      behaviors: [
-        {
-          when: 'saving filters',
-          given: 'the report has active filters',
-          // biome-ignore lint/suspicious/noThenProperty: schema mirrors when/given/then doctrine from #313
-          then: 'Factory stores a named saved report for the user',
-        },
-      ],
-      stateModel: [
-        {
-          state: 'editing-report-filters',
-          entryCondition: 'User is on the reports page',
-          behaviorsAvailable: ['save filters'],
-          exitTransitions: ['saved-report-created'],
-        },
-      ],
-      invalidTransitions: [
-        { from: 'empty-name', to: 'saved-report-created', reason: 'Name is required.' },
-      ],
-      dataConstraints: [{ type: 'name', validation: 'Required and unique per user.' }],
-    },
-    verticalSlices: [
-      {
-        title: 'Saved report creation',
-        goal: 'Store named filter sets from the reports page.',
-        estimatedSize: 'M',
-        journeyRefs: ['J-1'],
-      },
-    ],
-    estimatedComplexity: 'medium',
-    implementationDecisions: [
-      {
-        decision: 'Keep saved reports private in the first version.',
-        rationale: 'Sharing is out of scope.',
-      },
-    ],
-    testingDecisions: {
-      approach: 'Cover save and reopen behavior through workflow-facing tests.',
-      modulesToTest: ['slices/framing/slice.test.ts'],
-    },
-    decisionSummaries: [
-      {
-        kind: 'PLAN',
-        summary: 'Drafted the PRD from the framed saved reports intent.',
-        evidence: 'feature-frame returned stillNeedsGrilling false.',
-      },
-    ],
-  };
-}
-
 describe('framing workflow', () => {
-  it('routes framed work straight through the existing skip-grill PRD path when grilling is not needed', async () => {
+  it('persists framed context and routes through grounding when grilling is not needed', async () => {
     const projectId = uniqueProjectId('skip-grill');
     const source = new InMemoryLabelsSource(projectId, REPO_REF);
     const item = await seedFramingIssue(source);
-    const runtime = makeQueuedRuntime([featureFrameOutput(false), validPrdOutput()]);
+    const runtime = makeQueuedRuntime([featureFrameOutput(false)]);
 
     const result = await runFramingWorkflow({
       workItem: item,
@@ -207,33 +104,35 @@ describe('framing workflow', () => {
       deps: {
         runtime,
         projectConfig: { budgets: TEST_BUDGETS, stack: TEST_STACK, targetRepo: testTargetRepo('') },
-        buildContext: async () => ({
-          stackSummary: '',
-          contextMd: '',
-          adrSummaries: [],
-          claudeMd: '',
-        }),
       },
     });
 
     const specs = vi.mocked(runtime.run).mock.calls.map(([spec]) => spec as AgentSpec);
-    expect(specs.map((spec) => spec.skill)).toEqual(['feature-frame', 'write-prd']);
-    expect(specs[1]?.context.refinedIntent).toBe('Add named saved report filters.');
-    expect((specs[1]?.context.workItem as { body: string }).body).toBe(
-      `${item.body}\n\n${featureFrameOutput(false).framedContent}`,
-    );
+    expect(specs.map((spec) => spec.skill)).toEqual(['feature-frame']);
+    const [framedEvent] = eventStore.replay({
+      projectId,
+      workItemId: item.id,
+      kind: 'feature.framed',
+      order: 'desc',
+      limit: 1,
+    });
+    expect(framedEvent?.payload).toMatchObject({
+      refinedIntent: 'Add named saved report filters.',
+      stillNeedsGrilling: false,
+      framedBody: `${item.body}\n\n${featureFrameOutput(false).framedContent}`,
+    });
     expect(await source.getItem(item.externalId)).toMatchObject({
-      state: 'factory:prd-review',
+      state: 'factory:grounding',
       body: item.body,
     });
     expect(result.phase).toBe('prd-review');
   });
 
-  it('routes to grill-me with the augmented in-memory body when grilling is still needed', async () => {
+  it('routes framed work to grounding before grill-me when grilling is still needed', async () => {
     const projectId = uniqueProjectId('needs-grill');
     const source = new InMemoryLabelsSource(projectId, REPO_REF);
     const item = await seedFramingIssue(source);
-    const runtime = makeQueuedRuntime([featureFrameOutput(true), validGrillQuestion()]);
+    const runtime = makeQueuedRuntime([featureFrameOutput(true)]);
 
     const result = await runFramingWorkflow({
       workItem: item,
@@ -246,25 +145,25 @@ describe('framing workflow', () => {
           stack: TEST_STACK,
           targetRepo: testTargetRepo('/repo'),
         },
-        buildContext: async () => ({
-          stackSummary: '',
-          contextMd: '',
-          adrSummaries: [],
-          claudeMd: '',
-        }),
-        createWorktreeImpl: () => '/mock/worktree',
-        cleanupWorktreeImpl: () => undefined,
       },
     });
 
     const specs = vi.mocked(runtime.run).mock.calls.map(([spec]) => spec as AgentSpec);
-    expect(specs.map((spec) => spec.skill)).toEqual(['feature-frame', 'grill-me']);
+    expect(specs.map((spec) => spec.skill)).toEqual(['feature-frame']);
     expect(specs[0]?.workspaceDir).toBe('/repo');
-    expect((specs[1]?.context.workItem as { body: string }).body).toBe(
-      `${item.body}\n\n${featureFrameOutput(true).framedContent}`,
-    );
+    const [framedEvent] = eventStore.replay({
+      projectId,
+      workItemId: item.id,
+      kind: 'feature.framed',
+      order: 'desc',
+      limit: 1,
+    });
+    expect(framedEvent?.payload).toMatchObject({
+      stillNeedsGrilling: true,
+      framedBody: `${item.body}\n\n${featureFrameOutput(true).framedContent}`,
+    });
     expect(await source.getItem(item.externalId)).toMatchObject({
-      state: 'factory:gate-pending',
+      state: 'factory:grounding',
       body: item.body,
     });
     expect(result.phase).toBe('grilling');
@@ -289,7 +188,7 @@ describe('framing workflow', () => {
       blocks: [],
       createdAt: new Date('2026-05-25T00:00:00Z'),
     };
-    const runtime = makeQueuedRuntime([featureFrameOutput(false), validPrdOutput()]);
+    const runtime = makeQueuedRuntime([featureFrameOutput(false)]);
 
     await runFramingWorkflow({
       workItem: item,
@@ -302,12 +201,6 @@ describe('framing workflow', () => {
           stack: TEST_STACK,
           targetRepo: testTargetRepo('/repo'),
         },
-        buildContext: async () => ({
-          stackSummary: '',
-          contextMd: '',
-          adrSummaries: [],
-          claudeMd: '',
-        }),
       },
     });
 

--- a/slices/framing/workflow.ts
+++ b/slices/framing/workflow.ts
@@ -8,10 +8,9 @@ import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import type { ProjectConfig } from '@goose-hub/core/types.js';
-import {
-  type GrillAndPrdResult,
-  type ProjectContextBundle,
-  runGrillAndPrdWorkflow,
+import type {
+  GrillAndPrdResult,
+  ProjectContextBundle,
 } from '@goose-hub/core/workflows/grill-and-prd.js';
 import type { FeatureFrameOutput } from '@goose-hub/skills/feature-frame/schema.js';
 
@@ -157,36 +156,28 @@ export async function runFramingWorkflow(
   );
 
   const framedBody = appendFramedContent(workItem.body, featureFrame.framedContent);
-  const nextState = featureFrame.stillNeedsGrilling ? 'factory:grilling' : 'factory:prd-drafting';
+  eventStore.appendEvent({
+    kind: 'feature.framed',
+    projectId,
+    workItemId: workItem.id,
+    runId: frameRunId,
+    payload: {
+      workflowRunId,
+      framedContent: featureFrame.framedContent,
+      framedBody,
+      refinedIntent: featureFrame.refinedIntent,
+      proposedAcceptanceCriteria: featureFrame.proposedAcceptanceCriteria,
+      stillNeedsGrilling: featureFrame.stillNeedsGrilling,
+    },
+  });
+
   await transitionFromFraming({
     source: stateSource,
     workItem,
     projectId,
     runId: frameRunId,
-    to: nextState,
+    to: 'factory:grounding',
   });
 
-  const framedWorkItem: WorkItem = {
-    ...workItem,
-    body: framedBody,
-    state: nextState,
-  };
-
-  return runGrillAndPrdWorkflow({
-    workItem: framedWorkItem,
-    stateSource,
-    projectId,
-    priorReplies: input.priorReplies ?? [],
-    skipGrill: !featureFrame.stillNeedsGrilling,
-    refinedIntent: featureFrame.refinedIntent,
-    deps: {
-      runtime: deps.runtime,
-      projectConfig,
-      totalSpendForSkill: deps.totalSpendForSkill,
-      buildContext: deps.buildContext,
-      createWorktreeImpl: deps.createWorktreeImpl,
-      cleanupWorktreeImpl: deps.cleanupWorktreeImpl,
-      repoRoot: deps.repoRoot,
-    },
-  });
+  return { phase: featureFrame.stillNeedsGrilling ? 'grilling' : 'prd-review' };
 }

--- a/slices/parallel-implement/slice.test.ts
+++ b/slices/parallel-implement/slice.test.ts
@@ -2365,6 +2365,7 @@ describe('implement-wp ownership gate', () => {
         verticalSlices: [{ title: 'Slice 1' }],
         implementationDecisions: [{ decision: 'Use existing dispatch.' }],
         testingDecisions: { approach: 'unit' },
+        moduleRefs: [],
       },
     });
 

--- a/slices/spec-author/prd-planning-context.ts
+++ b/slices/spec-author/prd-planning-context.ts
@@ -21,6 +21,13 @@ export type PrdPlanningContext = {
   verticalSlices: unknown[];
   implementationDecisions: unknown[];
   testingDecisions: unknown | null;
+  moduleRefs: Array<{
+    path: string;
+    status: 'existing' | 'planned' | 'unknown';
+    source: 'implementationDecision' | 'testingDecision';
+    confidence?: 'high' | 'medium' | 'low';
+    evidence?: string;
+  }>;
   artifactRef?: ArtifactRef;
 };
 
@@ -53,6 +60,52 @@ function stringArrayField(record: Record<string, unknown>, key: string): string[
 function arrayField(record: Record<string, unknown>, key: string): unknown[] {
   const value = record[key];
   return Array.isArray(value) ? value : [];
+}
+
+function normalizeModuleRef(
+  value: unknown,
+  source: 'implementationDecision' | 'testingDecision',
+): PrdPlanningContext['moduleRefs'][number] | null {
+  if (typeof value === 'string' && value.trim() !== '') {
+    return { path: value.trim(), status: 'unknown', source };
+  }
+  const record = asRecord(value);
+  const path = stringField(record, 'path').trim();
+  if (path === '') return null;
+  const rawStatus = record.status;
+  const status =
+    rawStatus === 'existing' || rawStatus === 'planned' ? rawStatus : ('unknown' as const);
+  const rawConfidence = record.confidence;
+  const confidence =
+    rawConfidence === 'high' || rawConfidence === 'medium' || rawConfidence === 'low'
+      ? rawConfidence
+      : undefined;
+  const evidence = stringField(record, 'evidence');
+  return {
+    path,
+    status,
+    source,
+    ...(confidence != null ? { confidence } : {}),
+    ...(evidence !== '' ? { evidence } : {}),
+  };
+}
+
+function collectModuleRefs(prd: Record<string, unknown>): PrdPlanningContext['moduleRefs'] {
+  const refs: PrdPlanningContext['moduleRefs'] = [];
+  for (const decision of arrayField(prd, 'implementationDecisions')) {
+    const record = asRecord(decision);
+    const ref = normalizeModuleRef(record.moduleRef, 'implementationDecision');
+    if (ref != null) refs.push(ref);
+  }
+  const testing = asRecord(prd.testingDecisions);
+  const modulesToTest = testing.modulesToTest;
+  if (Array.isArray(modulesToTest)) {
+    for (const moduleRef of modulesToTest) {
+      const ref = normalizeModuleRef(moduleRef, 'testingDecision');
+      if (ref != null) refs.push(ref);
+    }
+  }
+  return refs;
 }
 
 export function buildPrdPlanningContext(
@@ -93,6 +146,7 @@ export function buildPrdPlanningContext(
     verticalSlices: arrayField(prd, 'verticalSlices'),
     implementationDecisions: arrayField(prd, 'implementationDecisions'),
     testingDecisions: prd.testingDecisions ?? null,
+    moduleRefs: collectModuleRefs(prd),
     ...(stored.stored ? { artifactRef: stored } : {}),
   };
 }

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -47,6 +47,7 @@ vi.mock('@goose-hub/core/projects/loader.js', () => ({
 
 vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
   listScoutReportsForInvestigation: vi.fn().mockReturnValue([]),
+  listScoutReportsForRun: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock('@goose-hub/core/event-stream/store.js', () => ({
@@ -777,6 +778,113 @@ describe('runSpecAuthorWorkflow', () => {
       );
     });
 
+    it('includes nearby manifest candidates in missing filesOwned repair feedback', async () => {
+      const { collectScopeManifest } = await import('@goose-hub/core/workspaces/scope-manifest.js');
+      vi.mocked(collectScopeManifest).mockReturnValueOnce([
+        { path: 'apps/web/src/components/detail', kind: 'dir' },
+        { path: 'apps/web/src/components/detail/lib/costs.ts', kind: 'file' },
+        { path: 'apps/web/src/components/detail/components/OverviewSection.tsx', kind: 'file' },
+      ]);
+      mockValidateEngineeringSpec
+        .mockReturnValueOnce({
+          ok: false,
+          errors: [
+            {
+              rule: 'self-check-grounded-in-code',
+              message:
+                "WP 'WP1' filesOwned path 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts' does not exist in worktree and is not annotated status:'new'. Either fix the path or declare it as a new file.",
+              ref: 'WP1',
+            },
+          ],
+        })
+        .mockReturnValueOnce({ ok: true });
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const retryInput = mockInvokeSkill.mock.calls[1]?.[0] as {
+        overrides?: { appendContext?: { repairFeedback?: string } };
+      };
+      expect(retryInput.overrides?.appendContext?.repairFeedback).toContain(
+        "Nearby existing manifest candidates for 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts'",
+      );
+      expect(retryInput.overrides?.appendContext?.repairFeedback).toContain(
+        'apps/web/src/components/detail/lib/costs.ts',
+      );
+    });
+
+    it('includes available exports and line-citation guidance in missing symbol repair feedback', async () => {
+      const fs = await import('node:fs');
+      vi.mocked(fs.readFileSync).mockReturnValueOnce(
+        'export function dispatchWave() {}\nexport const runScout = true;\n',
+      );
+      mockValidateEngineeringSpec
+        .mockReturnValueOnce({
+          ok: false,
+          errors: [
+            {
+              rule: 'constraint-source-symbol-missing',
+              message:
+                "constraint 'Wave dispatch' cites symbol 'dispatchWav' in 'core/agent-runtime/swarm.ts' which is not present",
+              ref: 'Wave dispatch',
+            },
+          ],
+        })
+        .mockReturnValueOnce({ ok: true });
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
+
+      const retryInput = mockInvokeSkill.mock.calls[1]?.[0] as {
+        overrides?: { appendContext?: { repairFeedback?: string } };
+      };
+      expect(retryInput.overrides?.appendContext?.repairFeedback).toContain(
+        "Available exports in 'core/agent-runtime/swarm.ts': dispatchWave, runScout",
+      );
+      expect(retryInput.overrides?.appendContext?.repairFeedback).toContain(
+        'Do not introduce new unverified symbols',
+      );
+      expect(retryInput.overrides?.appendContext?.repairFeedback).toContain(
+        'switch to a path:line citation',
+      );
+    });
+
+    it('does not persist when the repair still cites nonexistent symbols', async () => {
+      mockValidateEngineeringSpec
+        .mockReturnValueOnce({
+          ok: false,
+          errors: [
+            {
+              rule: 'constraint-source-symbol-missing',
+              message:
+                "constraint 'Wave dispatch' cites symbol 'dispatchWav' in 'core/agent-runtime/swarm.ts' which is not present",
+            },
+          ],
+        })
+        .mockReturnValueOnce({
+          ok: false,
+          errors: [
+            {
+              rule: 'constraint-source-symbol-missing',
+              message:
+                "constraint 'Wave dispatch' cites symbol 'newUnverifiedSymbol' in 'core/agent-runtime/swarm.ts' which is not present",
+            },
+          ],
+        });
+
+      const source = makeMockSource();
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(makeWorkItem(), source, 'goose-hub-self', '/repo');
+
+      expect(mockInvokeSkill).toHaveBeenCalledTimes(2);
+      expect(mockPersistEngineeringSpec).not.toHaveBeenCalled();
+      expect(source.transitionState).toHaveBeenCalledWith(
+        '55',
+        'factory:dev-ready',
+        'factory:needs-human',
+      );
+    });
+
     it('retries once with repair feedback when output schema validation fails', async () => {
       const outputError = Object.assign(
         new Error("invokeSkill: output validation failed for 'spec-author'"),
@@ -1180,6 +1288,81 @@ describe('runSpecAuthorWorkflow', () => {
       );
     });
 
+    it('preserves planned PRD module refs so spec-author can mark them status:new', async () => {
+      vi.mocked(eventStore.replay).mockImplementation((query?: { kind?: string }) => {
+        if (query?.kind === 'prd.drafted') {
+          return [
+            {
+              id: 10,
+              projectId: 'goose-hub-self',
+              workItemId: 'github:shaunnez/goose-hub#55',
+              kind: 'prd.drafted',
+              payload: {
+                prd: {
+                  title: 'Workflow Snapshot Grid',
+                  problem: 'Operators need compact workflow summaries.',
+                  proposedSolution: 'Render overview workflow cards.',
+                  successCriteria: [],
+                  acceptanceCriteria: [],
+                  journeys: [],
+                  functionalSpec: null,
+                  verticalSlices: [],
+                  implementationDecisions: [
+                    {
+                      decision: 'Add planned hook',
+                      moduleRef: {
+                        path: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts',
+                        status: 'planned',
+                        confidence: 'medium',
+                        evidence: 'feature plan says create hook',
+                      },
+                    },
+                  ],
+                  testingDecisions: {
+                    approach: 'Cover planned hook',
+                    modulesToTest: [
+                      {
+                        path: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.test.ts',
+                        status: 'planned',
+                      },
+                    ],
+                  },
+                },
+              },
+              runId: 'prd-run',
+              personaId: null,
+              createdAt: '2026-05-22T00:00:00.000Z',
+            },
+          ] as never;
+        }
+        return [];
+      });
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(
+        makeWorkItem({ type: 'feature' }),
+        makeMockSource(),
+        'goose-hub-self',
+        '/repo',
+      );
+
+      const context = mockInvokeSkill.mock.calls[0]?.[0]?.context as {
+        prdContext?: { moduleRefs?: Array<{ path: string; status: string }> };
+      };
+      expect(context.prdContext?.moduleRefs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts',
+            status: 'planned',
+          }),
+          expect.objectContaining({
+            path: 'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.test.ts',
+            status: 'planned',
+          }),
+        ]),
+      );
+    });
+
     it('derives scopeRoots from scout report digest files when investigation synthesis has no keyFiles', async () => {
       const { collectScopeManifest } = await import('@goose-hub/core/workspaces/scope-manifest.js');
       const scoutRepo = await import('@goose-hub/core/scout-reports/repository.js');
@@ -1231,6 +1414,68 @@ describe('runSpecAuthorWorkflow', () => {
         '/tmp/test-spec-worktree',
         expect.arrayContaining(['apps/web/src/components/detail', 'core/workflows']),
       );
+    });
+
+    it('passes feature grounding scout digest into spec-author when no bug investigation exists', async () => {
+      const scoutRepo = await import('@goose-hub/core/scout-reports/repository.js');
+      vi.mocked(eventStore.replay).mockImplementation((query?: { kind?: string }) => {
+        if (query?.kind === 'feature.grounding-complete') {
+          return [
+            {
+              id: 1,
+              projectId: 'goose-hub-self',
+              workItemId: 'github:shaunnez/goose-hub#55',
+              kind: 'feature.grounding-complete',
+              payload: {
+                groundingRunId: 'grounding-run',
+                existingSurfaces: ['apps/web/src/components/detail/lib/costs.ts'],
+                plannedFiles: ['apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts'],
+                testSurfaces: ['apps/web/src/components/detail/lib/costs.test.ts'],
+              },
+              runId: 'grounding-run',
+              createdAt: '2026-05-28T00:00:00Z',
+            },
+          ] as never;
+        }
+        return [];
+      });
+      vi.mocked(scoutRepo.listScoutReportsForRun).mockReturnValueOnce([
+        {
+          id: 1,
+          projectId: 'goose-hub-self',
+          workItemId: 'github:shaunnez/goose-hub#55',
+          investigationRunId: 'grounding-run',
+          scoutSkill: 'scout-code-path',
+          report: {
+            findings: [
+              {
+                file: 'apps/web/src/components/detail/lib/costs.ts',
+                fact: 'costs.ts exports useIssueCostsBreakdown.',
+                confidence: 'high',
+              },
+            ],
+          },
+          createdAt: '2026-05-28T00:00:00Z',
+        },
+      ]);
+
+      const { runSpecAuthorWorkflow } = await import('./workflow.js');
+      await runSpecAuthorWorkflow(
+        makeWorkItem({ type: 'feature' }),
+        makeMockSource(),
+        'goose-hub-self',
+        '/repo',
+      );
+
+      const context = mockInvokeSkill.mock.calls[0]?.[0]?.context as {
+        scoutReports?: string;
+        featureGrounding?: { plannedFiles?: string[] };
+      };
+      expect(context.scoutReports).toContain('scout-report-digest-v1');
+      expect(context.scoutReports).toContain('apps/web/src/components/detail/lib/costs.ts');
+      expect(context.featureGrounding?.plannedFiles).toEqual([
+        'apps/web/src/components/detail/hooks/useIssueCostsBreakdown.ts',
+      ]);
     });
 
     it('omits existingFileManifest from context when collectScopeManifest returns []', async () => {

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import { persistEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
@@ -6,7 +7,10 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { resolveLatestPrd } from '@goose-hub/core/prd/read-model.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import { buildScoutReportDigestBundle } from '@goose-hub/core/scout-reports/digest.js';
-import { listScoutReportsForInvestigation } from '@goose-hub/core/scout-reports/repository.js';
+import {
+  listScoutReportsForInvestigation,
+  listScoutReportsForRun,
+} from '@goose-hub/core/scout-reports/repository.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { collectScopeManifest } from '@goose-hub/core/workspaces/scope-manifest.js';
 import {
@@ -67,6 +71,7 @@ type SpecAuthorContext = {
   scoutReports?: string;
   wave2Reports?: string;
   investigationSynthesis?: string;
+  featureGrounding?: unknown;
   existingFileManifest?: Array<{ path: string; kind: 'file' | 'dir' }>;
 };
 
@@ -85,12 +90,129 @@ function formatValidationErrors(validation: Exclude<ValidationResult, { ok: true
   return validation.errors.map((e) => e.message);
 }
 
-function buildRepairFeedback(kind: 'schema' | 'structural', errors: string[]): string {
+function moduleRefPath(value: unknown): string | null {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (value != null && typeof value === 'object') {
+    const path = (value as { path?: unknown }).path;
+    if (typeof path === 'string' && path.length > 0) return path;
+  }
+  return null;
+}
+
+function nearbyManifestCandidates(
+  missingPath: string,
+  manifest: Array<{ path: string; kind: 'file' | 'dir' }> = [],
+): string[] {
+  const dirname = dirOf(missingPath);
+  const basename = missingPath.slice(missingPath.lastIndexOf('/') + 1).toLowerCase();
+  const basenameStem = basename.replace(/\.[^.]+$/, '');
+  const filePaths = manifest.filter((entry) => entry.kind === 'file').map((entry) => entry.path);
+  const sameDir = filePaths.filter((path) => dirOf(path) === dirname);
+  const sameStem = filePaths.filter((path) =>
+    path
+      .slice(path.lastIndexOf('/') + 1)
+      .toLowerCase()
+      .includes(basenameStem),
+  );
+  const parentDir = dirOf(dirname);
+  const ancestor = filePaths.filter(
+    (path) =>
+      dirname !== '' &&
+      (path.startsWith(`${dirname}/`) ||
+        dirname.startsWith(`${dirOf(path)}/`) ||
+        (parentDir !== '' && dirOf(path).startsWith(`${parentDir}/`))),
+  );
+  return [...new Set([...sameDir, ...sameStem, ...ancestor])].slice(0, 8);
+}
+
+function availableExportsForFile(worktreePath: string | undefined, filePath: string): string[] {
+  if (worktreePath == null) return [];
+  let contents = '';
+  try {
+    contents = readFileSync(`${worktreePath}/${filePath}`, 'utf8');
+  } catch {
+    return [];
+  }
+  const exports = new Set<string>();
+  const declarationRe =
+    /export\s+(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/g;
+  for (const match of contents.matchAll(declarationRe)) {
+    if (match[1] != null) exports.add(match[1]);
+  }
+  const namedRe = /export\s*\{([^}]+)\}/g;
+  for (const match of contents.matchAll(namedRe)) {
+    const names = match[1] ?? '';
+    for (const raw of names.split(',')) {
+      const name = raw
+        .trim()
+        .replace(/\s+as\s+.+$/i, '')
+        .trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) exports.add(name);
+    }
+  }
+  return [...exports].sort();
+}
+
+function enrichRepairErrors(
+  errors: string[],
+  options: {
+    existingFileManifest?: Array<{ path: string; kind: 'file' | 'dir' }>;
+    worktreePath?: string;
+  } = {},
+): string[] {
+  const enriched: string[] = [];
+  for (const error of errors) {
+    enriched.push(error);
+    const missingOwned = error.match(/filesOwned path '([^']+)' does not exist/);
+    const missingConstraintFile = error.match(/cites '([^']+)' which does not exist/);
+    const missingPath = missingOwned?.[1] ?? missingConstraintFile?.[1];
+    if (missingPath != null) {
+      const candidates = nearbyManifestCandidates(missingPath, options.existingFileManifest);
+      if (candidates.length > 0) {
+        enriched.push(
+          `Nearby existing manifest candidates for '${missingPath}': ${candidates.join(', ')}`,
+        );
+      } else {
+        enriched.push(
+          `No nearby existing manifest candidates for '${missingPath}'. If this is a new file, mark it with status:"new"; otherwise switch to a verified existing path.`,
+        );
+      }
+    }
+
+    const missingSymbol = error.match(/cites symbol '([^']+)' in '([^']+)' which is not present/);
+    if (missingSymbol != null) {
+      const [, symbol, filePath] = missingSymbol;
+      const exports = availableExportsForFile(options.worktreePath, filePath);
+      if (exports.length > 0) {
+        enriched.push(
+          `Available exports in '${filePath}': ${exports.join(', ')}. Use one of these only if it matches the constraint, otherwise switch to a path:line citation.`,
+        );
+      } else {
+        enriched.push(
+          `No available exports were found for '${filePath}'. Switch this constraint to a path:line citation from an actual read/search result.`,
+        );
+      }
+      enriched.push(`Do not introduce new unverified symbols while repairing '${symbol}'.`);
+    }
+  }
+  return enriched;
+}
+
+function buildRepairFeedback(
+  kind: 'schema' | 'structural',
+  errors: string[],
+  options: {
+    existingFileManifest?: Array<{ path: string; kind: 'file' | 'dir' }>;
+    worktreePath?: string;
+  } = {},
+): string {
+  const enrichedErrors = enrichRepairErrors(errors, options);
   return [
     `Previous spec-author attempt failed ${kind} validation.`,
     'Return a complete corrected EngineeringSpecSchema JSON object only.',
+    'Do not introduce new unverified symbols.',
     'Address every error below:',
-    ...errors.map((error) => `- ${error}`),
+    ...enrichedErrors.map((error) => `- ${error}`),
   ].join('\n');
 }
 
@@ -244,23 +366,29 @@ function addDirWithAncestors(roots: Set<string>, path: unknown): void {
 }
 
 function prdModuleRefPaths(prdContext: {
+  moduleRefs?: Array<{ path?: unknown }>;
   implementationDecisions?: unknown[];
   testingDecisions?: unknown;
 }): string[] {
   const paths: string[] = [];
 
+  for (const ref of prdContext.moduleRefs ?? []) {
+    if (typeof ref.path === 'string' && ref.path.length > 0) paths.push(ref.path);
+  }
+
   for (const decision of prdContext.implementationDecisions ?? []) {
     if (decision == null || typeof decision !== 'object') continue;
-    const moduleRef = (decision as { moduleRef?: unknown }).moduleRef;
-    if (typeof moduleRef === 'string' && moduleRef.length > 0) paths.push(moduleRef);
+    const path = moduleRefPath((decision as { moduleRef?: unknown }).moduleRef);
+    if (path != null) paths.push(path);
   }
 
   const testing = prdContext.testingDecisions;
   if (testing != null && typeof testing === 'object') {
     const modulesToTest = (testing as { modulesToTest?: unknown }).modulesToTest;
     if (Array.isArray(modulesToTest)) {
-      for (const path of modulesToTest) {
-        if (typeof path === 'string' && path.length > 0) paths.push(path);
+      for (const moduleRef of modulesToTest) {
+        const path = moduleRefPath(moduleRef);
+        if (path != null) paths.push(path);
       }
     }
   }
@@ -277,6 +405,7 @@ function deriveSpecScopeRoots(input: {
   investigationSynthesis?: string;
   scoutReports?: string;
   wave2Reports?: string;
+  featureGrounding?: unknown;
 }): string[] {
   const roots = new Set<string>();
   const addPath = (path: unknown) => {
@@ -336,6 +465,22 @@ function deriveSpecScopeRoots(input: {
           }
         }
       }
+    }
+  }
+
+  if (input.featureGrounding != null && typeof input.featureGrounding === 'object') {
+    const grounding = input.featureGrounding as {
+      existingSurfaces?: unknown;
+      plannedFiles?: unknown;
+      testSurfaces?: unknown;
+    };
+    for (const list of [
+      grounding.existingSurfaces,
+      grounding.plannedFiles,
+      grounding.testSurfaces,
+    ]) {
+      if (!Array.isArray(list)) continue;
+      for (const path of list) addDirWithAncestors(roots, path);
     }
   }
 
@@ -401,6 +546,7 @@ export async function runSpecAuthorWorkflow(
     let scoutReports: string | undefined;
     let wave2Reports: string | undefined;
     let investigationSynthesis: string | undefined;
+    let featureGrounding: unknown;
 
     if (latestInv != null) {
       const payload = latestInv.payload as { investigationRunId?: string; investigate?: unknown };
@@ -448,6 +594,25 @@ export async function runSpecAuthorWorkflow(
       if (payload.investigate != null) {
         investigationSynthesis = JSON.stringify(payload.investigate);
       }
+    } else {
+      const [latestGrounding] = eventStore.replay({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'feature.grounding-complete',
+        order: 'desc',
+        limit: 1,
+      });
+      if (latestGrounding != null) {
+        const payload = latestGrounding.payload as { groundingRunId?: string };
+        featureGrounding = latestGrounding.payload;
+        if (payload.groundingRunId != null) {
+          const reports = listScoutReportsForRun(projectId, workItem.id, payload.groundingRunId);
+          if (reports.length > 0) {
+            const bundle = buildScoutReportDigestBundle(reports);
+            scoutReports = stringifyScoutDigestForContext(bundle.reports);
+          }
+        }
+      }
     }
 
     const workItemCtx = {
@@ -477,6 +642,7 @@ export async function runSpecAuthorWorkflow(
     const scopeRoots = deriveSpecScopeRoots({
       prdContext,
       investigationSynthesis,
+      featureGrounding,
       scoutReports,
       wave2Reports,
     });
@@ -492,6 +658,7 @@ export async function runSpecAuthorWorkflow(
       scoutReports,
       wave2Reports,
       investigationSynthesis,
+      ...(featureGrounding != null && { featureGrounding }),
       // Omit when empty so the prompt's fallback behaviour (keyed on field absence) fires correctly.
       ...(existingFileManifest.length > 0 && { existingFileManifest }),
     };
@@ -607,7 +774,11 @@ export async function runSpecAuthorWorkflow(
       const failedRunId = errorRunId(error, pipelineRunId);
       const retryRunId = crypto.randomUUID();
       appendRepairRetryEvent(projectId, workItem.id, failedRunId, 'schema', issues);
-      attempt = await runAttempt(retryRunId, buildRepairFeedback('schema', issues), failedRunId);
+      attempt = await runAttempt(
+        retryRunId,
+        buildRepairFeedback('schema', issues, { existingFileManifest, worktreePath }),
+        failedRunId,
+      );
     }
 
     if (!attempt.validation.ok && !didRepair) {
@@ -617,7 +788,7 @@ export async function runSpecAuthorWorkflow(
       appendRepairRetryEvent(projectId, workItem.id, attempt.runId, 'structural', errors);
       attempt = await runAttempt(
         retryRunId,
-        buildRepairFeedback('structural', errors),
+        buildRepairFeedback('structural', errors, { existingFileManifest, worktreePath }),
         attempt.runId,
       );
     }


### PR DESCRIPTION
## Summary
- Harden spec-author prompts and repair feedback so file ownership and constraint citations must be backed by verified files, exports, or line citations.
- Add existing/planned PRD module references and pass grounding context through grill, PRD drafting, and spec-author.
- Add a feature-grounding scout workflow/state, routing, timeline/catalog/checklist support, and framed-feature handoff before grill or PRD drafting.

## Verification
- pnpm exec biome check .
- pnpm typecheck
- pnpm test