### PR TITLE
Fix task header pipeline duration

### DIFF
--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -833,6 +833,128 @@ describe('getIssue', () => {
       workItemId: 'github:owner/repo#1',
     });
   });
+
+  it('excludes hidden runtime skill runs from pipelineStartedAt', async () => {
+    vi.mocked(eventStore.replay)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        {
+          id: 1,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-started',
+          payload: { skill: 'intervention-proposer' },
+          runId: 'intervention-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:00:00Z',
+        },
+        {
+          id: 2,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-started',
+          payload: { skill: 'triage' },
+          runId: 'triage-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:10:59Z',
+        },
+        {
+          id: 3,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'review.completed',
+          payload: {},
+          runId: 'review-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:28:10Z',
+        },
+      ]);
+
+    const result = await getIssue('proj', '1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: { item: { pipelineStartedAt: '2026-05-28T08:10:59Z' } },
+    });
+  });
+
+  it('sets pipelineCompletedAt from agent.run-failed when no review completes', async () => {
+    vi.mocked(eventStore.replay)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        {
+          id: 1,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-started',
+          payload: { skill: 'triage' },
+          runId: 'triage-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:10:59Z',
+        },
+        {
+          id: 2,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-failed',
+          payload: { error: 'timeout' },
+          runId: 'triage-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:20:00Z',
+        },
+      ]);
+
+    const result = await getIssue('proj', '1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          pipelineStartedAt: '2026-05-28T08:10:59Z',
+          pipelineCompletedAt: '2026-05-28T08:20:00Z',
+        },
+      },
+    });
+  });
+
+  it('does not set pipelineCompletedAt from a needs-fix review', async () => {
+    vi.mocked(eventStore.replay)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        {
+          id: 1,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-started',
+          payload: { skill: 'triage' },
+          runId: 'triage-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:10:59Z',
+        },
+        {
+          id: 2,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'review.completed',
+          payload: { verdict: 'needs-fix' },
+          runId: 'review-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:28:10Z',
+        },
+      ]);
+
+    const result = await getIssue('proj', '1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          pipelineStartedAt: '2026-05-28T08:10:59Z',
+          pipelineCompletedAt: null,
+        },
+      },
+    });
+  });
 });
 
 describe('getIssueWorktreeDiff (#185)', () => {

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -780,6 +780,59 @@ describe('getIssue', () => {
     const result = await getIssue('unknown', '1');
     expect(result).toMatchObject({ ok: false, status: 404 });
   });
+
+  it('enriches the issue with durable agent pipeline timestamps', async () => {
+    vi.mocked(eventStore.replay)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        {
+          id: 1,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'agent.run-started',
+          payload: { skill: 'triage' },
+          runId: 'triage-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:10:59Z',
+        },
+        {
+          id: 2,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'review.completed',
+          payload: {},
+          runId: 'review-run',
+          personaId: null,
+          createdAt: '2026-05-28T08:28:10Z',
+        },
+        {
+          id: 3,
+          projectId: 'proj',
+          workItemId: 'github:owner/repo#1',
+          kind: 'retrospective.completed',
+          payload: {},
+          runId: 'retro-run',
+          personaId: null,
+          createdAt: '2026-05-28T10:43:26Z',
+        },
+      ]);
+
+    const result = await getIssue('proj', '1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        item: {
+          pipelineStartedAt: '2026-05-28T08:10:59Z',
+          pipelineCompletedAt: '2026-05-28T08:28:10Z',
+        },
+      },
+    });
+    expect(eventStore.replay).toHaveBeenLastCalledWith({
+      projectId: 'proj',
+      workItemId: 'github:owner/repo#1',
+    });
+  });
 });
 
 describe('getIssueWorktreeDiff (#185)', () => {

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -196,6 +196,53 @@ const TYPE_EXCLUDED_LEGAL_TARGETS: Readonly<Record<string, readonly StateName[]>
   feature: ['factory:investigating', 'factory:research-pending'],
 };
 
+const PIPELINE_FALLBACK_TERMINAL_KINDS = new Set([
+  'qa.completed',
+  'qa.verification-blocked',
+  'dev-review.completed',
+  'dev-review.failed',
+  'parallel-implement.exhausted',
+  'parallel-implement.wp-terminal-blocked',
+  'pr.opened',
+]);
+
+function eventDateMs(event: AgentEvent): number {
+  const ms = new Date(event.createdAt).getTime();
+  return Number.isFinite(ms) ? ms : Number.NaN;
+}
+
+function latestEventTimestamp(events: AgentEvent[], predicate: (event: AgentEvent) => boolean) {
+  return events
+    .filter(predicate)
+    .map((event) => ({ createdAt: event.createdAt, ms: eventDateMs(event) }))
+    .filter((event) => Number.isFinite(event.ms))
+    .sort((a, b) => a.ms - b.ms)
+    .at(-1)?.createdAt;
+}
+
+function resolvePipelineTimes(projectId: string, workItemId: string) {
+  const events = eventStore.replay({ projectId, workItemId });
+  const pipelineStartedAt = events
+    .filter((event) => event.kind === 'agent.run-started')
+    .map((event) => ({ createdAt: event.createdAt, ms: eventDateMs(event) }))
+    .filter((event) => Number.isFinite(event.ms))
+    .sort((a, b) => a.ms - b.ms)
+    .at(0)?.createdAt;
+
+  const reviewCompletedAt = latestEventTimestamp(
+    events,
+    (event) => event.kind === 'review.completed',
+  );
+  const fallbackCompletedAt = latestEventTimestamp(events, (event) =>
+    PIPELINE_FALLBACK_TERMINAL_KINDS.has(event.kind),
+  );
+
+  return {
+    pipelineStartedAt: pipelineStartedAt ?? null,
+    pipelineCompletedAt: reviewCompletedAt ?? fallbackCompletedAt ?? null,
+  };
+}
+
 function buildPrdRelationships(projectId: string): {
   byParent: Map<string, string[]>;
   byChild: Map<string, string>;
@@ -263,6 +310,7 @@ export async function getIssue(slug: string, id: string): Promise<Result<{ item:
   const enriched = {
     ...(item as object),
     lastPersonaId: lastPersonaMap.get(workItemId) ?? null,
+    ...resolvePipelineTimes(slug, workItemId),
     prdChildren: byParent.get(externalId),
     prdParent: byChild.get(externalId),
   };

--- a/apps/server/src/domains/issues/service.ts
+++ b/apps/server/src/domains/issues/service.ts
@@ -204,6 +204,7 @@ const PIPELINE_FALLBACK_TERMINAL_KINDS = new Set([
   'parallel-implement.exhausted',
   'parallel-implement.wp-terminal-blocked',
   'pr.opened',
+  'agent.run-failed',
 ]);
 
 function eventDateMs(event: AgentEvent): number {
@@ -223,16 +224,17 @@ function latestEventTimestamp(events: AgentEvent[], predicate: (event: AgentEven
 function resolvePipelineTimes(projectId: string, workItemId: string) {
   const events = eventStore.replay({ projectId, workItemId });
   const pipelineStartedAt = events
-    .filter((event) => event.kind === 'agent.run-started')
+    .filter((event) => event.kind === 'agent.run-started' && isIssueTimelineEvent(event))
     .map((event) => ({ createdAt: event.createdAt, ms: eventDateMs(event) }))
     .filter((event) => Number.isFinite(event.ms))
     .sort((a, b) => a.ms - b.ms)
     .at(0)?.createdAt;
 
-  const reviewCompletedAt = latestEventTimestamp(
-    events,
-    (event) => event.kind === 'review.completed',
-  );
+  const reviewCompletedAt = latestEventTimestamp(events, (event) => {
+    if (event.kind !== 'review.completed') return false;
+    const verdict = (event.payload as { verdict?: string } | null)?.verdict;
+    return verdict !== 'needs-fix';
+  });
   const fallbackCompletedAt = latestEventTimestamp(events, (event) =>
     PIPELINE_FALLBACK_TERMINAL_KINDS.has(event.kind),
   );

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -295,7 +295,12 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
           </button>
         </div>
 
-        <TaskHeader item={item} projectSlug={slug} hasOpenDep={hasOpenDep} />
+        <TaskHeader
+          item={item}
+          projectSlug={slug}
+          hasOpenDep={hasOpenDep}
+          events={eventsQuery.data ?? []}
+        />
         <ProjectBudgetBanner status={budgetStatus} />
 
         <GatePendingBanner

--- a/apps/web/src/components/detail/components/TaskHeader.test.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fetchIssueCosts, fetchMilestones } from '@/lib/api';
-import type { WorkItemCostsDto, WorkItemDto } from '@/lib/types';
+import type { AgentEventDto, WorkItemCostsDto, WorkItemDto } from '@/lib/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -48,6 +48,18 @@ function item(partial: Partial<WorkItemDto> = {}): WorkItemDto {
   };
 }
 
+function event(id: number, kind: string, createdAt: string, payload: unknown = {}): AgentEventDto {
+  return {
+    id,
+    projectId: 'proj',
+    workItemId: 'github:owner/repo#42',
+    kind,
+    payload,
+    runId: `run-${id}`,
+    createdAt,
+  };
+}
+
 describe('TaskHeader', () => {
   beforeEach(() => {
     dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-01T02:15:00Z').getTime());
@@ -61,7 +73,7 @@ describe('TaskHeader', () => {
     vi.mocked(fetchMilestones).mockReset();
   });
 
-  it('renders cost, token, cache, and fix duration metrics', async () => {
+  it('renders cost, token, cache, and pipeline fix duration metrics', async () => {
     const costs: WorkItemCostsDto = {
       workItemId: 'wi-1',
       totalUsd: 0.42,
@@ -88,7 +100,18 @@ describe('TaskHeader', () => {
     };
     vi.mocked(fetchIssueCosts).mockResolvedValue(costs);
 
-    renderWithQueryClient(<TaskHeader item={item()} projectSlug="proj" />);
+    renderWithQueryClient(
+      <TaskHeader
+        item={item()}
+        projectSlug="proj"
+        events={[
+          event(1, 'agent.run-started', '2026-05-01T00:00:00Z', { skill: 'triage' }),
+          event(2, 'agent.run-started', '2026-05-01T00:02:00Z', { skill: 'investigate' }),
+          event(3, 'review.completed', '2026-05-01T00:17:11Z'),
+          event(4, 'retrospective.completed', '2026-05-01T02:15:00Z'),
+        ]}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('task-header-cost').textContent).toContain('cost $0.42');
@@ -97,11 +120,11 @@ describe('TaskHeader', () => {
     expect(screen.getByTestId('task-header-cached-tokens').textContent).toContain('cached 600');
     expect(screen.getByTestId('task-header-cache-hit').textContent).toContain('cache hit 50%');
     expect(screen.getByTestId('task-header-fix-duration').textContent).toContain(
-      'fix duration 2h 15m',
+      'fix duration 17m',
     );
   });
 
-  it('freezes fix duration at closedAt for completed work', async () => {
+  it('does not derive fix duration from work item age or closedAt', async () => {
     vi.mocked(fetchIssueCosts).mockResolvedValue({
       workItemId: 'wi-1',
       totalUsd: 0,
@@ -115,13 +138,29 @@ describe('TaskHeader', () => {
           state: 'factory:done',
           createdAt: '2026-05-01T00:00:00Z',
           closedAt: '2026-05-01T00:45:00Z',
+          pipelineStartedAt: '2026-05-01T00:10:00Z',
+          pipelineCompletedAt: '2026-05-01T00:27:00Z',
         })}
         projectSlug="proj"
+        events={[event(4, 'retrospective.completed', '2026-05-01T02:15:00Z')]}
       />,
     );
 
     expect(screen.getByTestId('task-header-fix-duration').textContent).toContain(
-      'fix duration 45m',
+      'fix duration 17m',
     );
+  });
+
+  it('shows an empty fix duration before the agent pipeline starts', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValue({
+      workItemId: 'wi-1',
+      totalUsd: 0,
+      hasEstimated: false,
+      rows: [],
+    });
+
+    renderWithQueryClient(<TaskHeader item={item()} projectSlug="proj" events={[]} />);
+
+    expect(screen.getByTestId('task-header-fix-duration').textContent).toContain('fix duration —');
   });
 });

--- a/apps/web/src/components/detail/components/TaskHeader.test.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.test.tsx
@@ -151,6 +151,54 @@ describe('TaskHeader', () => {
     );
   });
 
+  it('keeps fix duration live during rework after a needs-fix review', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValue({
+      workItemId: 'wi-1',
+      totalUsd: 0,
+      hasEstimated: false,
+      rows: [],
+    });
+
+    renderWithQueryClient(
+      <TaskHeader
+        item={item()}
+        projectSlug="proj"
+        events={[
+          event(1, 'agent.run-started', '2026-05-01T00:00:00Z', { skill: 'triage' }),
+          event(2, 'review.completed', '2026-05-01T00:17:00Z', { verdict: 'needs-fix' }),
+          event(3, 'agent.run-started', '2026-05-01T00:20:00Z', { skill: 'implement' }),
+        ]}
+      />,
+    );
+
+    // Date.now() mocked to 2026-05-01T02:15:00Z → 2h 15m since first run started
+    expect(screen.getByTestId('task-header-fix-duration').textContent).toContain(
+      'fix duration 2h 15m',
+    );
+  });
+
+  it('freezes fix duration at agent.run-failed for failed pipelines', async () => {
+    vi.mocked(fetchIssueCosts).mockResolvedValue({
+      workItemId: 'wi-1',
+      totalUsd: 0,
+      hasEstimated: false,
+      rows: [],
+    });
+
+    renderWithQueryClient(
+      <TaskHeader
+        item={item()}
+        projectSlug="proj"
+        events={[
+          event(1, 'agent.run-started', '2026-05-01T00:00:00Z', { skill: 'triage' }),
+          event(2, 'agent.run-failed', '2026-05-01T00:10:00Z', { error: 'timeout' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('task-header-fix-duration').textContent).toContain('fix duration 10m');
+  });
+
   it('shows an empty fix duration before the agent pipeline starts', async () => {
     vi.mocked(fetchIssueCosts).mockResolvedValue({
       workItemId: 'wi-1',

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -2,7 +2,7 @@ import { fetchMilestones, setLabel, setMilestone } from '@/lib/api';
 import { PRIORITY_BG, PRIORITY_BORDER, PRIORITY_COLOR, STATE_LABEL } from '@/lib/constants';
 import { parseDependencies } from '@/lib/dependency-parser';
 import { laneForState } from '@/lib/lanes.config';
-import type { MilestoneDto, WorkItemDto } from '@/lib/types';
+import type { AgentEventDto, MilestoneDto, WorkItemDto } from '@/lib/types';
 import { getPersonaLabel, usePersonaMap } from '@/lib/usePersonaMap';
 import { formatCost, formatTokens } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -16,6 +16,7 @@ interface TaskHeaderProps {
   item?: WorkItemDto;
   projectSlug: string;
   hasOpenDep?: boolean;
+  events?: AgentEventDto[];
 }
 
 function formatCacheHit(ratio: number): string {
@@ -23,14 +24,68 @@ function formatCacheHit(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
 }
 
-function formatFixDuration(item?: WorkItemDto): string {
-  if (item == null || item.createdAt === '') return '—';
-  const startMs = new Date(item.createdAt).getTime();
-  if (!Number.isFinite(startMs)) return '—';
+function eventTimeMs(event: AgentEventDto): number {
+  const ms = new Date(event.createdAt).getTime();
+  return Number.isFinite(ms) ? ms : Number.NaN;
+}
 
-  const closedAt = item.closedAt;
-  const closedMs = closedAt != null ? new Date(closedAt).getTime() : Number.NaN;
-  const endMs = Number.isFinite(closedMs) ? closedMs : Date.now();
+function timestampMs(value?: string | null): number {
+  if (value == null || value === '') return Number.NaN;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : Number.NaN;
+}
+
+function eventPipelineCompletedMs(events: AgentEventDto[]): number | null {
+  const reviewCompletedMs = events
+    .filter((event) => event.kind === 'review.completed')
+    .map(eventTimeMs)
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b)
+    .at(-1);
+  if (reviewCompletedMs != null) return reviewCompletedMs;
+
+  const fallbackTerminalMs = events
+    .filter((event) =>
+      [
+        'qa.completed',
+        'qa.verification-blocked',
+        'dev-review.completed',
+        'dev-review.failed',
+        'parallel-implement.exhausted',
+        'parallel-implement.wp-terminal-blocked',
+        'pr.opened',
+      ].includes(event.kind),
+    )
+    .map(eventTimeMs)
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b)
+    .at(-1);
+  return fallbackTerminalMs ?? null;
+}
+
+function formatFixDuration(item: WorkItemDto | undefined, events: AgentEventDto[]): string {
+  const itemCompletedMs = timestampMs(item?.pipelineCompletedAt);
+  const eventCompletedMs = eventPipelineCompletedMs(events);
+  const endMs =
+    Number.isFinite(itemCompletedMs) || eventCompletedMs != null
+      ? Math.max(Number.isFinite(itemCompletedMs) ? itemCompletedMs : 0, eventCompletedMs ?? 0)
+      : Date.now();
+
+  const itemStartedMs = timestampMs(item?.pipelineStartedAt);
+  const eventStartedMs = events
+    .filter((event) => event.kind === 'agent.run-started')
+    .map(eventTimeMs)
+    .filter((ms) => Number.isFinite(ms) && ms <= endMs)
+    .sort((a, b) => a - b)
+    .at(0);
+  const startMs =
+    Number.isFinite(itemStartedMs) && eventStartedMs != null
+      ? Math.min(itemStartedMs, eventStartedMs)
+      : Number.isFinite(itemStartedMs)
+        ? itemStartedMs
+        : eventStartedMs;
+  if (startMs == null) return '—';
+
   const minutes = Math.max(0, Math.floor((endMs - startMs) / 60000));
   if (minutes < 60) return `${minutes}m`;
 
@@ -43,7 +98,12 @@ function formatFixDuration(item?: WorkItemDto): string {
   return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
 }
 
-export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeaderProps) {
+export function TaskHeader({
+  item,
+  projectSlug,
+  hasOpenDep = false,
+  events = [],
+}: TaskHeaderProps) {
   const queryClient = useQueryClient();
   const [savingPriority, setSavingPriority] = useState(false);
   const [savingSchedule, setSavingSchedule] = useState(false);
@@ -74,7 +134,7 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
   const tokenValue = costs.runCount === 0 ? '—' : formatTokens(costs.totalTokens);
   const cachedTokenValue = costs.runCount === 0 ? '—' : formatTokens(costs.totalCachedInputTokens);
   const cacheHitValue = costs.runCount === 0 ? '—' : formatCacheHit(costs.totalCacheHitRatio);
-  const fixDuration = formatFixDuration(item);
+  const fixDuration = formatFixDuration(item, events);
 
   const externalId = item?.externalId;
   const invalidate = useCallback(() => {
@@ -189,7 +249,7 @@ export function TaskHeader({ item, projectSlug, hasOpenDep = false }: TaskHeader
           </span>
           <span aria-hidden className="w-[3px] h-[3px] rounded-full bg-fg-4" />
           <span
-            title="Elapsed time since this work item opened"
+            title="Elapsed time from the first agent run to review completion or the current pipeline point"
             data-testid="task-header-fix-duration"
           >
             fix duration <span className="font-mono">{fixDuration}</span>

--- a/apps/web/src/components/detail/components/TaskHeader.tsx
+++ b/apps/web/src/components/detail/components/TaskHeader.tsx
@@ -37,7 +37,11 @@ function timestampMs(value?: string | null): number {
 
 function eventPipelineCompletedMs(events: AgentEventDto[]): number | null {
   const reviewCompletedMs = events
-    .filter((event) => event.kind === 'review.completed')
+    .filter((event) => {
+      if (event.kind !== 'review.completed') return false;
+      const verdict = (event.payload as { verdict?: string } | null)?.verdict;
+      return verdict !== 'needs-fix';
+    })
     .map(eventTimeMs)
     .filter(Number.isFinite)
     .sort((a, b) => a - b)
@@ -54,6 +58,7 @@ function eventPipelineCompletedMs(events: AgentEventDto[]): number | null {
         'parallel-implement.exhausted',
         'parallel-implement.wp-terminal-blocked',
         'pr.opened',
+        'agent.run-failed',
       ].includes(event.kind),
     )
     .map(eventTimeMs)

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface WorkItemDto {
   prdParent?: string;
   createdAt: string;
   closedAt?: string | null;
+  pipelineStartedAt?: string | null;
+  pipelineCompletedAt?: string | null;
   lastPersonaId?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- derive task header fix duration from full issue pipeline timestamps instead of work item age
- enrich issue detail DTOs with durable pipeline start/completion bounds from the event store
- overlay live detail-page events so in-progress pipelines can still update the header

## Verification
- pnpm vitest apps/web/src/components/detail/components/TaskHeader.test.tsx apps/server/src/domains/issues/service.test.ts --run
- pnpm exec biome check apps/web/src/components/detail/components/TaskHeader.tsx apps/web/src/components/detail/components/TaskHeader.test.tsx apps/web/src/components/detail/components/DetailPage.tsx apps/web/src/lib/types.ts apps/server/src/domains/issues/service.ts apps/server/src/domains/issues/service.test.ts
- pnpm typecheck