### PR TITLE
Fix legacy implement repo root fallback

### DIFF
--- a/apps/server/src/shared/dispatch-dev.ts
+++ b/apps/server/src/shared/dispatch-dev.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
 import { getUseMultiAgentPipeline } from '@goose-hub/core/db/repositories/project-settings.js';
 import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
@@ -140,6 +141,92 @@ async function readRoutingLabels(input: {
       error: String(err),
     });
     return [];
+  }
+}
+
+async function recordLegacyFixIssueStartupFailure(input: {
+  source: StateSource;
+  item: WorkItem;
+  slug: string;
+  issueNumber: number;
+  error: Error;
+}): Promise<void> {
+  logger.error('dispatchFixIssue: legacy fix-issue failed before in-progress transition', {
+    slug: input.slug,
+    issueNumber: input.issueNumber,
+    itemId: input.item.id,
+    error: input.error.message,
+  });
+  eventStore.appendEvent({
+    projectId: input.slug,
+    workItemId: input.item.id,
+    kind: 'agent.run-failed',
+    payload: {
+      skill: 'implement',
+      workflowSkill: 'fix-issue',
+      error: input.error.message,
+      reason: 'legacy fix-issue failed before in-progress transition',
+    },
+  });
+
+  try {
+    await input.source.comment(
+      input.item.externalId,
+      buildAgentComment(
+        'Dev',
+        'Failed',
+        'Fix-issue failed before implementation could start — escalating to needs-human',
+        [`Error: ${input.error.message}`],
+      ),
+    );
+  } catch (commentErr) {
+    logger.warn('dispatchFixIssue: failed to comment on pre-start failure', {
+      slug: input.slug,
+      issueNumber: input.issueNumber,
+      error: String(commentErr),
+    });
+  }
+
+  let current: WorkItem;
+  try {
+    current = await input.source.getItem(input.issueNumber.toString());
+  } catch (readErr) {
+    logger.warn('dispatchFixIssue: failed to re-read issue after pre-start failure', {
+      slug: input.slug,
+      issueNumber: input.issueNumber,
+      error: String(readErr),
+    });
+    return;
+  }
+
+  if (current.state !== 'factory:dev-ready') {
+    logger.info('dispatchFixIssue: pre-start failure left state unchanged by dispatcher', {
+      slug: input.slug,
+      issueNumber: input.issueNumber,
+      state: current.state,
+    });
+    return;
+  }
+
+  try {
+    await input.source.transitionState(
+      current.externalId,
+      'factory:dev-ready',
+      'factory:needs-human',
+    );
+    emitStateTransitionEvent({
+      projectId: input.slug,
+      workItemId: current.id,
+      from: 'factory:dev-ready',
+      to: 'factory:needs-human',
+      by: 'fix-issue',
+    });
+  } catch (transitionErr) {
+    logger.warn('dispatchFixIssue: failed to transition pre-start failure to needs-human', {
+      slug: input.slug,
+      issueNumber: input.issueNumber,
+      error: String(transitionErr),
+    });
   }
 }
 
@@ -325,6 +412,21 @@ export async function dispatchInvestigationComplete(
         issueNumber,
         targetState,
       });
+
+      if (targetState === 'factory:dev-ready' && usesLegacyImplementation) {
+        return async () => {
+          const current = await source.getItem(issueNumber.toString());
+          if (current.state !== 'factory:dev-ready') {
+            logger.info('dispatchInvestigationComplete: post-lock implement fallback no-op', {
+              slug,
+              issueNumber,
+              state: current.state,
+            });
+            return;
+          }
+          await dispatchFixIssue(slug, issueNumber);
+        };
+      }
     },
   );
 }
@@ -474,7 +576,18 @@ export async function dispatchFixIssue(slug: string, issueNumber: number): Promi
           }
         : undefined;
 
-    await runFixIssueWorkflow(item, source, slug, REPO_ROOT, mockDeps);
+    try {
+      await runFixIssueWorkflow(item, source, slug, REPO_ROOT, mockDeps);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      await recordLegacyFixIssueStartupFailure({
+        source,
+        item,
+        slug,
+        issueNumber,
+        error,
+      });
+    }
   });
 }
 

--- a/apps/server/src/shared/dispatch.test.ts
+++ b/apps/server/src/shared/dispatch.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -11,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockRunTriageBatch = vi.fn();
 const mockRunInvestigateWorkflow = vi.fn();
 const mockRunAcceptanceContractWorkflow = vi.fn();
+const mockRunFixIssueWorkflow = vi.fn();
 const mockRunQaWorkflow = vi.fn();
 const mockRunFixFeedbackWorkflow = vi.fn();
 const mockRunReviewWorkflow = vi.fn();
@@ -67,6 +69,10 @@ vi.mock('../../../../slices/investigate/workflow.js', () => ({
 
 vi.mock('../../../../slices/acceptance-contract/workflow.js', () => ({
   runAcceptanceContractWorkflow: mockRunAcceptanceContractWorkflow,
+}));
+
+vi.mock('../../../../slices/fix-issue/workflow.js', () => ({
+  runFixIssueWorkflow: mockRunFixIssueWorkflow,
 }));
 
 vi.mock('../../../../slices/qa/workflow.js', () => ({
@@ -140,6 +146,7 @@ beforeEach(() => {
   mockRunTriageBatch.mockResolvedValue(undefined);
   mockRunInvestigateWorkflow.mockResolvedValue(undefined);
   mockRunAcceptanceContractWorkflow.mockResolvedValue(undefined);
+  mockRunFixIssueWorkflow.mockResolvedValue(undefined);
   mockRunQaWorkflow.mockResolvedValue(undefined);
   mockRunFixFeedbackWorkflow.mockResolvedValue(undefined);
   mockRunReviewWorkflow.mockResolvedValue(undefined);
@@ -568,6 +575,51 @@ describe('dispatchInvestigationComplete', () => {
       'factory:gate-pending',
     );
   });
+
+  it('starts legacy implement after investigation-complete fallback if the issue remains dev-ready', async () => {
+    const source = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'github:shaunnez/goose-hub#42',
+          externalId: '42',
+          state: 'factory:investigation-complete',
+          type: 'bug',
+        })
+        .mockResolvedValueOnce({
+          id: 'github:shaunnez/goose-hub#42',
+          externalId: '42',
+          state: 'factory:dev-ready',
+          type: 'bug',
+        })
+        .mockResolvedValueOnce({
+          id: 'github:shaunnez/goose-hub#42',
+          externalId: '42',
+          state: 'factory:dev-ready',
+          type: 'bug',
+        }),
+      comment: vi.fn().mockResolvedValue(undefined),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+    };
+    mockGetSourceForSlug.mockResolvedValue(source);
+    mockEventStoreReplay.mockReturnValue([
+      {
+        kind: 'agent.investigation-complete',
+        payload: { investigate: { confidence: 'high' } },
+      },
+    ]);
+
+    const { dispatchInvestigationComplete } = await import('./dispatch.js');
+    await dispatchInvestigationComplete('goose-hub-self', 42);
+
+    expect(source.transitionState).toHaveBeenCalledWith(
+      'github:shaunnez/goose-hub#42',
+      'factory:investigation-complete',
+      'factory:dev-ready',
+    );
+    expect(mockRunFixIssueWorkflow).toHaveBeenCalledOnce();
+  });
 });
 
 // ─── dispatchFixIssue ─────────────────────────────────────────────────────
@@ -701,6 +753,95 @@ describe('dispatchFixIssue', () => {
     expect(mockLoggerInfo).not.toHaveBeenCalledWith(
       'dispatchFixIssue: item blocked by deps, skipping',
       expect.anything(),
+    );
+  });
+
+  it('passes the real repo root to legacy fix-issue when project targetRepo is stale', async () => {
+    const mockItem = {
+      id: 'github:shaunnez/goose-hub#44',
+      externalId: '44',
+      title: 'stale target repo',
+      body: '',
+      repoRef: 'shaunnez/goose-hub',
+      state: 'factory:dev-ready',
+      schedule: 'current',
+      type: 'bug',
+    };
+    const mockSource = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi.fn().mockResolvedValue(mockItem),
+      comment: vi.fn().mockResolvedValue(undefined),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+    };
+    mockGetSourceForSlug.mockResolvedValue(mockSource);
+    mockGetProject.mockResolvedValue({
+      id: 'slug',
+      budgets: { maxParallelAgents: 1 },
+      source: { repo: 'shaunnez/goose-hub', type: 'github' },
+      targetRepo: {
+        localPath: '/definitely/missing/goose-hub',
+        defaultBranch: 'main',
+        cloneUrl: '',
+      },
+    });
+    mockFilterEligibleByDependencies.mockResolvedValue({
+      eligible: [mockItem],
+      blocked: [],
+      unregistered: [],
+    });
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    await dispatchFixIssue('slug', 44);
+
+    expect(mockRunFixIssueWorkflow).toHaveBeenCalledOnce();
+    const repoRoot = mockRunFixIssueWorkflow.mock.calls[0][3] as string;
+    expect(existsSync(repoRoot)).toBe(true);
+    expect(repoRoot).toContain('goose-hub');
+  });
+
+  it('records pre-in-progress legacy fix-issue failures and escalates only from dev-ready', async () => {
+    const mockItem = {
+      id: 'github:shaunnez/goose-hub#45',
+      externalId: '45',
+      title: 'pre worktree failure',
+      body: '',
+      repoRef: 'shaunnez/goose-hub',
+      state: 'factory:dev-ready',
+      schedule: 'current',
+      type: 'bug',
+    };
+    const mockSource = {
+      repoRef: 'shaunnez/goose-hub',
+      getItem: vi.fn().mockResolvedValue(mockItem),
+      comment: vi.fn().mockResolvedValue(undefined),
+      transitionState: vi.fn().mockResolvedValue(undefined),
+    };
+    mockGetSourceForSlug.mockResolvedValue(mockSource);
+    mockRunFixIssueWorkflow.mockRejectedValue(new Error('git worktree add failed'));
+
+    const { dispatchFixIssue } = await import('./dispatch.js');
+    await expect(dispatchFixIssue('slug', 45)).resolves.toBeUndefined();
+
+    expect(mockEventStoreAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'slug',
+        workItemId: 'github:shaunnez/goose-hub#45',
+        kind: 'agent.run-failed',
+        payload: expect.objectContaining({
+          skill: 'implement',
+          workflowSkill: 'fix-issue',
+          error: 'git worktree add failed',
+        }),
+      }),
+    );
+    expect(mockSource.comment).toHaveBeenCalledWith(
+      '45',
+      expect.stringContaining('Fix-issue failed before implementation could start'),
+    );
+    expect(mockSource.transitionState).toHaveBeenCalledWith(
+      '45',
+      'factory:dev-ready',
+      'factory:needs-human',
     );
   });
 });

--- a/core/workspaces/repo-affinity.test.ts
+++ b/core/workspaces/repo-affinity.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { WorkItem } from '../state-source/interface.js';
 import type {
@@ -20,22 +23,31 @@ function repoLink(repoRef: string, role: string): LocalDbRepoLinkRow {
   };
 }
 
+const appRepoPath = mkdtempSync(join(tmpdir(), 'repo-affinity-app-'));
+const docsRepoPath = mkdtempSync(join(tmpdir(), 'repo-affinity-docs-'));
+const fallbackRepoPath = mkdtempSync(join(tmpdir(), 'repo-affinity-fallback-'));
+const targetRepoPath = mkdtempSync(join(tmpdir(), 'repo-affinity-target-'));
+
+function missingPath(label: string): string {
+  return join(tmpdir(), `repo-affinity-missing-${label}-${Date.now()}`);
+}
+
 const project = {
   id: 'proj',
   repos: ['owner/app', 'owner/docs'],
-  targetRepo: { localPath: '/fallback', defaultBranch: 'main', cloneUrl: '' },
+  targetRepo: { localPath: targetRepoPath, defaultBranch: 'main', cloneUrl: '' },
   repositories: [
     {
       id: 'app',
       repoRef: 'owner/app',
-      localPath: '/repos/app',
+      localPath: appRepoPath,
       defaultBranch: 'main',
       cloneUrl: '',
     },
     {
       id: 'docs',
       repoRef: 'owner/docs',
-      localPath: '/repos/docs',
+      localPath: docsRepoPath,
       defaultBranch: 'trunk',
       cloneUrl: '',
     },
@@ -46,6 +58,11 @@ const workItem = {
   id: 'local:proj#1',
   externalId: '1',
   repoRef: 'owner/app',
+} as WorkItem;
+
+const githubWorkItem = {
+  ...workItem,
+  id: 'github:owner/app#1',
 } as WorkItem;
 
 describe('repo affinity', () => {
@@ -70,14 +87,76 @@ describe('repo affinity', () => {
       resolveRepositoryForWorkItem({
         project,
         workItem,
-        fallbackLocalPath: '/repo',
+        fallbackLocalPath: fallbackRepoPath,
         repository,
       }),
     ).toMatchObject({
       repoRef: 'owner/docs',
-      localPath: '/repos/docs',
+      localPath: docsRepoPath,
       defaultBranch: 'trunk',
       selectedBy: 'repo-link-primary',
     });
   });
+
+  it('uses a valid configured repository path before project targetRepo and fallback', () => {
+    expect(
+      resolveRepositoryForWorkItem({
+        project,
+        workItem: githubWorkItem,
+        fallbackLocalPath: fallbackRepoPath,
+      }),
+    ).toMatchObject({
+      repoRef: 'owner/app',
+      localPath: appRepoPath,
+      defaultBranch: 'main',
+      selectedBy: 'work-item',
+    });
+  });
+
+  it('falls back to input fallbackLocalPath when configured path is a missing home path', () => {
+    const missingHomeProject = {
+      ...project,
+      targetRepo: { ...project.targetRepo, localPath: `~/missing-${Date.now()}` },
+      repositories: [
+        {
+          ...project.repositories[0],
+          localPath: `~/missing-${Date.now()}`,
+        },
+      ],
+    } as ProjectConfig;
+
+    expect(
+      resolveRepositoryForWorkItem({
+        project: missingHomeProject,
+        workItem: githubWorkItem,
+        fallbackLocalPath: fallbackRepoPath,
+      }),
+    ).toMatchObject({
+      localPath: fallbackRepoPath,
+    });
+  });
+
+  it('falls back when configured and targetRepo absolute paths are missing', () => {
+    const missingAbsoluteProject = {
+      ...project,
+      targetRepo: { ...project.targetRepo, localPath: missingPath('target') },
+      repositories: [
+        {
+          ...project.repositories[0],
+          localPath: missingPath('configured'),
+        },
+      ],
+    } as ProjectConfig;
+
+    expect(
+      resolveRepositoryForWorkItem({
+        project: missingAbsoluteProject,
+        workItem: githubWorkItem,
+        fallbackLocalPath: fallbackRepoPath,
+      }),
+    ).toMatchObject({
+      localPath: fallbackRepoPath,
+    });
+  });
+
 });

--- a/core/workspaces/repo-affinity.test.ts
+++ b/core/workspaces/repo-affinity.test.ts
@@ -136,6 +136,31 @@ describe('repo affinity', () => {
     });
   });
 
+  it('uses targetRepo defaultBranch when configured repo path is stale', () => {
+    const staleConfiguredProject = {
+      ...project,
+      targetRepo: { localPath: targetRepoPath, defaultBranch: 'develop', cloneUrl: '' },
+      repositories: [
+        {
+          ...project.repositories[0],
+          localPath: missingPath('configured'),
+          defaultBranch: 'feature-branch',
+        },
+      ],
+    } as ProjectConfig;
+
+    expect(
+      resolveRepositoryForWorkItem({
+        project: staleConfiguredProject,
+        workItem: githubWorkItem,
+        fallbackLocalPath: fallbackRepoPath,
+      }),
+    ).toMatchObject({
+      localPath: targetRepoPath,
+      defaultBranch: 'develop',
+    });
+  });
+
   it('falls back when configured and targetRepo absolute paths are missing', () => {
     const missingAbsoluteProject = {
       ...project,

--- a/core/workspaces/repo-affinity.ts
+++ b/core/workspaces/repo-affinity.ts
@@ -80,7 +80,10 @@ export function resolveRepositoryForWorkItem(input: {
   return {
     repoRef,
     localPath: configuredLocalPath ?? targetLocalPath ?? input.fallbackLocalPath,
-    defaultBranch: configuredRepo?.defaultBranch ?? project?.targetRepo?.defaultBranch ?? 'main',
+    defaultBranch:
+      (configuredLocalPath != null ? configuredRepo?.defaultBranch : null) ??
+      project?.targetRepo?.defaultBranch ??
+      'main',
     role: repoLink?.role ?? configuredRepo?.role ?? 'unknown',
     selectedBy:
       repoLink?.role === 'primary'

--- a/core/workspaces/repo-affinity.ts
+++ b/core/workspaces/repo-affinity.ts
@@ -1,3 +1,5 @@
+import { existsSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
 import type { WorkItem } from '../state-source/interface.js';
 import { LocalDbWorkItemRepository } from '../state-source/local-db-repository.js';
 import type { LocalDbRepoLinkRow } from '../state-source/local-db-repository.js';
@@ -35,6 +37,22 @@ export function listLocalDbRepoLinks(
   }
 }
 
+function normalizeExistingLocalPath(localPath: string | null | undefined): string | null {
+  if (localPath == null || localPath.length === 0) return null;
+  const expanded =
+    localPath === '~'
+      ? homedir()
+      : localPath.startsWith('~/')
+        ? `${homedir()}${localPath.slice(1)}`
+        : localPath;
+  if (!existsSync(expanded)) return null;
+  try {
+    return statSync(expanded).isDirectory() ? expanded : null;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveRepositoryForWorkItem(input: {
   project: ProjectConfig | null | undefined;
   workItem: WorkItem;
@@ -57,10 +75,11 @@ export function resolveRepositoryForWorkItem(input: {
   }
 
   const configuredRepo = project?.repositories?.find((repo) => repo.repoRef === repoRef);
+  const configuredLocalPath = normalizeExistingLocalPath(configuredRepo?.localPath);
+  const targetLocalPath = normalizeExistingLocalPath(project?.targetRepo?.localPath);
   return {
     repoRef,
-    localPath:
-      configuredRepo?.localPath ?? project?.targetRepo?.localPath ?? input.fallbackLocalPath,
+    localPath: configuredLocalPath ?? targetLocalPath ?? input.fallbackLocalPath,
     defaultBranch: configuredRepo?.defaultBranch ?? project?.targetRepo?.defaultBranch ?? 'main',
     role: repoLink?.role ?? configuredRepo?.role ?? 'unknown',
     selectedBy:


### PR DESCRIPTION
## Summary
- validate configured repository paths before legacy implement uses them
- fall back to the dispatch repo root when configured paths are stale
- surface pre-in-progress legacy implement failures with run-failed events, issue comments, and guarded needs-human transitions
- add post-lock legacy implement pickup after investigation-complete -> dev-ready

## Verification
- pnpm test -- --run apps/server/src/shared/dispatch.test.ts core/workspaces/repo-affinity.test.ts
  - wrapper ran full suite: 369 passed, 5187 passed, 3 skipped