### PR TITLE
Add local project creation wizard

### DIFF
--- a/apps/server/src/domains/bootstrap/router.test.ts
+++ b/apps/server/src/domains/bootstrap/router.test.ts
@@ -1,15 +1,21 @@
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockActivate, mockPreview, mockRun } = vi.hoisted(() => ({
-  mockActivate: vi.fn(),
-  mockPreview: vi.fn(),
-  mockRun: vi.fn(),
-}));
+const { mockActivate, mockCreateLocal, mockPreview, mockPreviewLocal, mockRun } = vi.hoisted(
+  () => ({
+    mockActivate: vi.fn(),
+    mockCreateLocal: vi.fn(),
+    mockPreview: vi.fn(),
+    mockPreviewLocal: vi.fn(),
+    mockRun: vi.fn(),
+  }),
+);
 
 vi.mock('./service.js', () => ({
   activateLocalDbProject: mockActivate,
+  createLocalProjectService: mockCreateLocal,
   previewBootstrapService: mockPreview,
+  previewLocalProjectCreationService: mockPreviewLocal,
   runBootstrapService: mockRun,
 }));
 
@@ -144,6 +150,94 @@ describe('POST /projects/bootstrap/run', () => {
     expect(res.status).toBe(500);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('workflow exploded');
+  });
+});
+
+describe('POST /projects/bootstrap/local-project/preview', () => {
+  it('returns 200 with the generated config preview', async () => {
+    mockPreviewLocal.mockResolvedValue({
+      ok: true,
+      data: {
+        slug: 'widgets',
+        name: 'widgets',
+        configPath: 'target-projects/widgets/project.config.ts',
+        config: 'const config = {}',
+        requiredEnvVars: [],
+        repositories: [],
+        integrations: ['github'],
+      },
+    });
+
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/local-project/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: { kind: 'github-code', repoRefs: ['octo/widgets'] } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ slug: 'widgets' });
+    expect(mockPreviewLocal).toHaveBeenCalledWith({
+      source: { kind: 'github-code', repoRefs: ['octo/widgets'] },
+    });
+  });
+
+  it('returns the service status code on failure', async () => {
+    mockPreviewLocal.mockResolvedValue({ ok: false, error: 'bad source', status: 400 });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/local-project/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: { kind: 'advanced' } }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'bad source' });
+  });
+});
+
+describe('POST /projects/bootstrap/local-project/create', () => {
+  it('returns 200 with the local write result', async () => {
+    mockCreateLocal.mockResolvedValue({
+      ok: true,
+      data: {
+        status: 'created',
+        slug: 'widgets',
+        name: 'widgets',
+        configPath: 'target-projects/widgets/project.config.ts',
+        writtenPath: '/repo/target-projects/widgets/project.config.ts',
+        config: 'const config = {}',
+        requiredEnvVars: [],
+        repositories: [],
+        integrations: [],
+      },
+    });
+
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/local-project/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'widgets', source: { kind: 'local-only' } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: 'created', slug: 'widgets' });
+    expect(mockCreateLocal).toHaveBeenCalledWith({
+      slug: 'widgets',
+      source: { kind: 'local-only' },
+    });
+  });
+
+  it('supports conflict responses', async () => {
+    mockCreateLocal.mockResolvedValue({ ok: false, error: 'exists', status: 409 });
+    const app = makeApp();
+    const res = await app.request('/projects/bootstrap/local-project/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'widgets', source: { kind: 'local-only' } }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'exists' });
   });
 });
 

--- a/apps/server/src/domains/bootstrap/router.ts
+++ b/apps/server/src/domains/bootstrap/router.ts
@@ -13,7 +13,14 @@
 
 import { Hono } from 'hono';
 import { parseBody } from '#shared/middleware.js';
-import { activateLocalDbProject, previewBootstrapService, runBootstrapService } from './service.js';
+import {
+  type LocalProjectCreationRequestDto,
+  activateLocalDbProject,
+  createLocalProjectService,
+  previewBootstrapService,
+  previewLocalProjectCreationService,
+  runBootstrapService,
+} from './service.js';
 
 const router = new Hono();
 
@@ -43,6 +50,24 @@ router.post('/bootstrap/run', async (c) => {
   return result.ok
     ? c.json(result.data)
     : c.json({ error: result.error }, result.status as 400 | 404 | 500 | 502);
+});
+
+router.post('/bootstrap/local-project/preview', async (c) => {
+  const body = await parseBody<LocalProjectCreationRequestDto>(c);
+  if (!body.ok) return body.error;
+  const result = await previewLocalProjectCreationService(body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 404 | 409 | 500 | 502);
+});
+
+router.post('/bootstrap/local-project/create', async (c) => {
+  const body = await parseBody<LocalProjectCreationRequestDto>(c);
+  if (!body.ok) return body.error;
+  const result = await createLocalProjectService(body.data);
+  return result.ok
+    ? c.json(result.data)
+    : c.json({ error: result.error }, result.status as 400 | 404 | 409 | 500 | 502);
 });
 
 router.post('/bootstrap/activate', async (c) => {

--- a/apps/server/src/domains/bootstrap/service.test.ts
+++ b/apps/server/src/domains/bootstrap/service.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockBootstrapProject, mockGetProject, mockImportIssues, mockInspectGithubRepo } =
@@ -30,10 +33,17 @@ vi.mock('#shared/projects.js', () => ({
   getProject: mockGetProject,
 }));
 
-import { activateLocalDbProject, previewBootstrapService, runBootstrapService } from './service.js';
+import {
+  activateLocalDbProject,
+  createLocalProjectService,
+  previewBootstrapService,
+  previewLocalProjectCreationService,
+  runBootstrapService,
+} from './service.js';
 
 const ORIGINAL_TOKEN = process.env.GITHUB_TOKEN;
 const ORIGINAL_MOCK = process.env.MOCK_BOOTSTRAP;
+const ORIGINAL_TARGET_PROJECTS_ROOT = process.env.BOOTSTRAP_TARGET_PROJECTS_ROOT;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,6 +58,11 @@ afterEach(() => {
   else process.env.GITHUB_TOKEN = ORIGINAL_TOKEN;
   if (ORIGINAL_MOCK === undefined) Reflect.deleteProperty(process.env, 'MOCK_BOOTSTRAP');
   else process.env.MOCK_BOOTSTRAP = ORIGINAL_MOCK;
+  if (ORIGINAL_TARGET_PROJECTS_ROOT === undefined) {
+    Reflect.deleteProperty(process.env, 'BOOTSTRAP_TARGET_PROJECTS_ROOT');
+  } else {
+    process.env.BOOTSTRAP_TARGET_PROJECTS_ROOT = ORIGINAL_TARGET_PROJECTS_ROOT;
+  }
   vi.unstubAllGlobals();
 });
 
@@ -296,6 +311,92 @@ describe('runBootstrapService', () => {
       expect(result.data.registrationPrUrl).toContain('pull/');
       expect(result.data.slug).toBe('widgets');
     }
+    expect(mockBootstrapProject).not.toHaveBeenCalled();
+  });
+});
+
+describe('local project creation', () => {
+  it('previews local-only config without GitHub inspection or imports', async () => {
+    const result = await previewLocalProjectCreationService({
+      slug: 'local-ops',
+      name: 'Local Ops',
+      source: { kind: 'local-only' },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.configPath).toBe('target-projects/local-ops/project.config.ts');
+      expect(result.data.config).toContain("kind: 'local-db'");
+      expect(result.data.config).not.toContain('integrations:');
+      expect(result.data.repositories).toEqual([]);
+    }
+    expect(mockInspectGithubRepo).not.toHaveBeenCalled();
+    expect(mockBootstrapProject).not.toHaveBeenCalled();
+    expect(mockImportIssues).not.toHaveBeenCalled();
+  });
+
+  it('previews GitHub code repos with imports off', async () => {
+    const result = await previewLocalProjectCreationService({
+      source: { kind: 'github-code', repoRefs: ['octo/widgets'] },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.slug).toBe('widgets');
+      expect(result.data.integrations).toEqual(['github']);
+      expect(result.data.config).toContain('mirrorLabels: false');
+      expect(result.data.config).toContain('importIssues: false');
+    }
+    expect(mockInspectGithubRepo).not.toHaveBeenCalled();
+  });
+
+  it('previews Jira assigned-to-me config with credential env names', async () => {
+    const result = await previewLocalProjectCreationService({
+      source: {
+        kind: 'jira',
+        baseUrl: 'https://example.atlassian.net',
+        projectKeys: ['ENG'],
+        importMode: 'assigned-to-me',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.slug).toBe('eng');
+      expect(result.data.requiredEnvVars).toContain('JIRA_EMAIL or ATLASSIAN_EMAIL');
+      expect(result.data.config).toContain('importMode: "assigned-to-me"');
+    }
+  });
+
+  it('previews Bitbucket PR integration as metadata/post-back only', async () => {
+    const result = await previewLocalProjectCreationService({
+      source: { kind: 'bitbucket', workspace: 'acme', repos: ['api'] },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.integrations).toEqual(['bitbucket']);
+      expect(result.data.config).toContain('bitbucket: {');
+      expect(result.data.config).not.toContain('kind: "bitbucket"');
+    }
+  });
+
+  it('writes project.config.ts locally without activating imports', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'goose-hub-target-projects-'));
+    process.env.BOOTSTRAP_TARGET_PROJECTS_ROOT = root;
+
+    const result = await createLocalProjectService({
+      slug: 'widgets',
+      source: { kind: 'github-code', repoRefs: ['octo/widgets'] },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const written = await readFile(result.data.writtenPath, 'utf-8');
+      expect(written).toBe(result.data.config);
+      expect(written).toContain('importIssues: false');
+    }
+    expect(mockImportIssues).not.toHaveBeenCalled();
     expect(mockBootstrapProject).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/domains/bootstrap/service.ts
+++ b/apps/server/src/domains/bootstrap/service.ts
@@ -18,6 +18,7 @@
  * walk through the wizard without hitting GitHub or running the workflow.
  */
 
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import * as nodeOs from 'node:os';
 import * as nodePath from 'node:path';
 import type { AuditResult } from '@goose-hub/core/bootstrap/claude-md-auditor.js';
@@ -28,6 +29,11 @@ import {
 import { FACTORY_LABELS } from '@goose-hub/core/bootstrap/labels.js';
 import { importGitHubIssuesToLocalDb } from '@goose-hub/core/integrations/github/import-issues.js';
 import { logger } from '@goose-hub/core/logger.js';
+import type {
+  LocalDbSourceConfig,
+  ProjectRepositoryConfig,
+  TargetRepoConfig,
+} from '@goose-hub/core/types.js';
 import {
   type BootstrapResult,
   bootstrapProject,
@@ -35,6 +41,8 @@ import {
   sanitiseSlug,
   summariseStack,
 } from '@goose-hub/core/workflows/bootstrap-project.js';
+import { renderProjectConfig } from '@goose-hub/core/workflows/bootstrap-renderers.js';
+import { targetProjectsRoot } from '@goose-hub/target-projects';
 import type { Result } from '#shared/middleware.js';
 import { getProject } from '#shared/projects.js';
 
@@ -92,6 +100,48 @@ export interface BootstrapRequestDto {
   repoRefs?: string[];
   slug?: string;
   name?: string;
+}
+
+export type ProjectCreationSourceDto =
+  | { kind: 'local-only' }
+  | { kind: 'github-code'; repoRefs: string[]; defaultBranch?: string; localPath?: string }
+  | {
+      kind: 'jira';
+      baseUrl: string;
+      projectKeys: string[];
+      importMode: 'manual' | 'assigned-to-me';
+    }
+  | { kind: 'bitbucket'; workspace: string; repos: string[]; defaultBranch?: string }
+  | {
+      kind: 'advanced';
+      github?: { repoRefs: string[]; defaultBranch?: string; localPath?: string };
+      jira?: {
+        baseUrl: string;
+        projectKeys: string[];
+        importMode: 'manual' | 'assigned-to-me';
+      };
+      bitbucket?: { workspace: string; repos: string[]; defaultBranch?: string };
+    };
+
+export interface LocalProjectCreationRequestDto {
+  slug?: string;
+  name?: string;
+  source: ProjectCreationSourceDto;
+}
+
+export interface LocalProjectCreationPreviewDto {
+  slug: string;
+  name: string;
+  configPath: string;
+  config: string;
+  requiredEnvVars: string[];
+  repositories: ProjectRepositoryConfig[];
+  integrations: Array<'github' | 'jira' | 'bitbucket'>;
+}
+
+export interface LocalProjectCreationRunDto extends LocalProjectCreationPreviewDto {
+  status: 'created';
+  writtenPath: string;
 }
 
 const MOCK_FIXTURE_PREVIEW: BootstrapPreviewDto = {
@@ -326,6 +376,62 @@ export async function runBootstrapService(
   };
 }
 
+export async function previewLocalProjectCreationService(
+  input: LocalProjectCreationRequestDto,
+): Promise<Result<LocalProjectCreationPreviewDto>> {
+  try {
+    return { ok: true, data: buildLocalProjectCreationPreview(input) };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'invalid project creation request',
+      status: 400,
+    };
+  }
+}
+
+export async function createLocalProjectService(
+  input: LocalProjectCreationRequestDto,
+): Promise<Result<LocalProjectCreationRunDto>> {
+  let preview: LocalProjectCreationPreviewDto;
+  try {
+    preview = buildLocalProjectCreationPreview(input);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'invalid project creation request',
+      status: 400,
+    };
+  }
+
+  const root = getTargetProjectsRoot();
+  const dir = nodePath.join(root, preview.slug);
+  const writtenPath = nodePath.join(dir, 'project.config.ts');
+  try {
+    await stat(writtenPath);
+    return {
+      ok: false,
+      error: `project config already exists for slug "${preview.slug}"`,
+      status: 409,
+    };
+  } catch {
+    // Missing is expected for a new local project.
+  }
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(writtenPath, preview.config, 'utf-8');
+  } catch (err) {
+    logger.error('local project creation failed to write config', {
+      slug: preview.slug,
+      error: String(err),
+    });
+    return { ok: false, error: String(err), status: 500 };
+  }
+
+  return { ok: true, data: { ...preview, status: 'created', writtenPath } };
+}
+
 export async function activateLocalDbProject(slug: string): Promise<Result<LocalDbActivationDto>> {
   const cfg = await getProject(slug);
   if (cfg == null) return { ok: false, error: 'project not found', status: 404 };
@@ -359,4 +465,230 @@ function deriveSlugForRequest(request: BootstrapRequestDto, repoRefs: string[]):
   if (request.slug != null) return sanitiseSlug(request.slug);
   const firstRepoName = repoRefs[0].split('/')[1] ?? repoRefs[0];
   return sanitiseSlug(firstRepoName);
+}
+
+function buildLocalProjectCreationPreview(
+  input: LocalProjectCreationRequestDto,
+): LocalProjectCreationPreviewDto {
+  if (input == null || typeof input !== 'object') throw new Error('request body is required');
+  const source = input.source;
+  if (source == null || typeof source !== 'object') throw new Error('source is required');
+
+  const slug = sanitiseSlug(input.slug ?? defaultSlugForCreationSource(source));
+  const name = input.name?.trim() || slug;
+  const normalized = normalizeProjectCreationSource(source, slug);
+  const config = renderProjectConfig({
+    slug,
+    name,
+    source: normalized.source,
+    repositories: normalized.repositories,
+    targetRepo: normalized.targetRepo,
+    stack: {
+      type: 'unknown',
+    },
+    detectedAt: new Date().toISOString(),
+    activeMilestone: undefined,
+  });
+
+  return {
+    slug,
+    name,
+    configPath: `target-projects/${slug}/project.config.ts`,
+    config,
+    requiredEnvVars: normalized.requiredEnvVars,
+    repositories: normalized.repositories,
+    integrations: normalized.integrations,
+  };
+}
+
+function normalizeProjectCreationSource(
+  source: ProjectCreationSourceDto,
+  slug: string,
+): {
+  source: LocalDbSourceConfig;
+  repositories: ProjectRepositoryConfig[];
+  targetRepo: TargetRepoConfig;
+  requiredEnvVars: string[];
+  integrations: Array<'github' | 'jira' | 'bitbucket'>;
+} {
+  const integrations: NonNullable<LocalDbSourceConfig['integrations']> = {};
+  const repositories: ProjectRepositoryConfig[] = [];
+  const requiredEnvVars = new Set<string>();
+  const enabledIntegrations: Array<'github' | 'jira' | 'bitbucket'> = [];
+
+  const addGithub = (github: {
+    repoRefs: string[];
+    defaultBranch?: string;
+    localPath?: string;
+  }) => {
+    const repoRefs = normalizeRepoRefs({ repoRefs: github.repoRefs });
+    integrations.github = {
+      repos: repoRefs,
+      mirrorLabels: false,
+      importIssues: false,
+    };
+    enabledIntegrations.push('github');
+    for (const repoRef of repoRefs) {
+      repositories.push(
+        githubRepository(repoRef, github.defaultBranch ?? 'main', github.localPath),
+      );
+    }
+  };
+
+  const addJira = (jira: {
+    baseUrl: string;
+    projectKeys: string[];
+    importMode: 'manual' | 'assigned-to-me';
+  }) => {
+    const baseUrl = requireNonEmpty(jira.baseUrl, 'jira.baseUrl');
+    const projectKeys = normalizeStringList(jira.projectKeys, 'jira.projectKeys');
+    integrations.jira = {
+      enabled: true,
+      baseUrl,
+      projectKeys,
+      importMode: jira.importMode,
+      postBack: { comments: true, transitions: false },
+    };
+    requiredEnvVars.add('JIRA_EMAIL or ATLASSIAN_EMAIL');
+    requiredEnvVars.add('JIRA_API_TOKEN or ATLASSIAN_API_TOKEN');
+    enabledIntegrations.push('jira');
+  };
+
+  const addBitbucket = (bitbucket: {
+    workspace: string;
+    repos: string[];
+    defaultBranch?: string;
+  }) => {
+    const workspace = requireNonEmpty(bitbucket.workspace, 'bitbucket.workspace');
+    const repos = normalizeStringList(bitbucket.repos, 'bitbucket.repos');
+    integrations.bitbucket = {
+      enabled: true,
+      workspace,
+      repos,
+      postBack: { pullRequests: true, comments: true },
+    };
+    requiredEnvVars.add('BITBUCKET_TOKEN or BITBUCKET_USERNAME + BITBUCKET_APP_PASSWORD');
+    enabledIntegrations.push('bitbucket');
+    for (const repo of repos) {
+      const repoRef = `${workspace}/${repo}`;
+      repositories.push(bitbucketRepository(repoRef, bitbucket.defaultBranch ?? 'main'));
+    }
+  };
+
+  switch (source.kind) {
+    case 'local-only':
+      break;
+    case 'github-code':
+      addGithub(source);
+      break;
+    case 'jira':
+      addJira(source);
+      break;
+    case 'bitbucket':
+      addBitbucket(source);
+      break;
+    case 'advanced':
+      if (source.github != null) addGithub(source.github);
+      if (source.jira != null) addJira(source.jira);
+      if (source.bitbucket != null) addBitbucket(source.bitbucket);
+      break;
+    default:
+      throw new Error('unsupported project creation source');
+  }
+
+  const targetRepo = repositories[0] ?? {
+    cloneUrl: '',
+    defaultBranch: 'main',
+    localPath: `~/code/${slug}`,
+  };
+
+  return {
+    source: {
+      kind: 'local-db',
+      stateMachine: 'db',
+      ...(Object.keys(integrations).length > 0 ? { integrations } : {}),
+    },
+    repositories,
+    targetRepo,
+    requiredEnvVars: [...requiredEnvVars],
+    integrations: enabledIntegrations,
+  };
+}
+
+function defaultSlugForCreationSource(source: ProjectCreationSourceDto): string {
+  switch (source.kind) {
+    case 'github-code': {
+      const first = normalizeRepoRefs({ repoRefs: source.repoRefs })[0];
+      return first.split('/')[1] ?? first;
+    }
+    case 'bitbucket':
+      return normalizeStringList(source.repos, 'bitbucket.repos')[0];
+    case 'jira':
+      return normalizeStringList(source.projectKeys, 'jira.projectKeys')[0].toLowerCase();
+    case 'advanced':
+      if (source.github?.repoRefs?.length)
+        return defaultSlugForCreationSource({ kind: 'github-code', ...source.github });
+      if (source.bitbucket?.repos?.length) {
+        return defaultSlugForCreationSource({ kind: 'bitbucket', ...source.bitbucket });
+      }
+      if (source.jira?.projectKeys?.length)
+        return defaultSlugForCreationSource({ kind: 'jira', ...source.jira });
+      throw new Error('advanced source must configure at least one integration');
+    case 'local-only':
+      throw new Error('slug is required for local-only projects');
+  }
+}
+
+function githubRepository(
+  repoRef: string,
+  defaultBranch: string,
+  localPath?: string,
+): ProjectRepositoryConfig {
+  return {
+    id: repoId(repoRef),
+    repoRef,
+    cloneUrl: `git@github.com:${repoRef}.git`,
+    defaultBranch,
+    localPath: localPath?.trim() || `~/code/${repoRef}`,
+    role: 'code',
+  };
+}
+
+function bitbucketRepository(repoRef: string, defaultBranch: string): ProjectRepositoryConfig {
+  return {
+    id: repoId(repoRef),
+    repoRef,
+    cloneUrl: `git@bitbucket.org:${repoRef}.git`,
+    defaultBranch,
+    localPath: `~/code/${repoRef}`,
+    role: 'code',
+  };
+}
+
+function repoId(repoRef: string): string {
+  return repoRef
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function requireNonEmpty(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value.trim();
+}
+
+function normalizeStringList(values: unknown, field: string): string[] {
+  if (!Array.isArray(values)) throw new Error(`${field} must be an array`);
+  const normalized = values
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter(Boolean);
+  if (normalized.length === 0) throw new Error(`${field} must contain at least one value`);
+  return normalized;
+}
+
+function getTargetProjectsRoot(): string {
+  return process.env.BOOTSTRAP_TARGET_PROJECTS_ROOT ?? targetProjectsRoot;
 }

--- a/apps/web/src/components/bootstrap/README.md
+++ b/apps/web/src/components/bootstrap/README.md
@@ -1,6 +1,6 @@
 # bootstrap
 
-Bootstrap wizard UI for adding a new project to Factory's roster. Closes #308 (M12.07).
+Bootstrap wizard UI for adding a local-db project to Factory's roster.
 
 ## Structure
 
@@ -22,53 +22,39 @@ The "Add Project" button on the **Settings** page opens the wizard
 
 ## Steps
 
-1. **Repository** — user types `owner/repo`. The wizard validates the format
-   client-side and calls `POST /api/projects/bootstrap/preview` to confirm
-   the server can reach the repo with its configured token. The browser
-   never collects or sends a GitHub token.
-2. **Stack** — server-detected stack summary (runtime, package manager,
-   commands). Read-only.
-3. **CLAUDE.md** — preview (`action: 'create'`) or unified diff
-   (`action: 'update'`) shown in a read-only textarea. When the existing
-   CLAUDE.md already has every required section (`action: 'ok'`), the wizard
-   shows a confirmation message instead of an empty editor.
-4. **Labels** — list of canonical Factory labels that will be installed on
-   the target repo (colour swatch + name + description per label).
-5. **Webhook** — copy-pasteable instructions for configuring a GitHub
-   webhook at `https://github.com/<owner/repo>/settings/hooks/new`. Mentions
-   `ngrok` for local development.
-6. **Open Registration PR** — single button calls
-   `POST /api/projects/bootstrap/run`, displays the resulting PR URL on
-   success.
+1. **Source** — user chooses local-only, GitHub code, Jira import,
+   Bitbucket PR integration, or an advanced combination.
+2. **Config** — server renders the exact `project.config.ts` that will be
+   written, including local-db source integrations and required env var names.
+3. **Create** — single button calls
+   `POST /api/projects/bootstrap/local-project/create` and writes
+   `target-projects/<slug>/project.config.ts` locally.
 
 ## Server contract
 
-Two endpoints under the `bootstrap` server domain
+The local creation flow uses two endpoints under the `bootstrap` server domain
 (`apps/server/src/domains/bootstrap/`):
 
-- `POST /projects/bootstrap/preview { repoRef }` — returns
-  `BootstrapPreviewDto { slug, defaultBranch, stack, audit, labelsToInstall }`.
-  The preview endpoint is **read-only**: it runs stack detection +
-  CLAUDE.md audit + reports the canonical label set, but does NOT mutate
-  GitHub state, install labels, or open a PR.
-- `POST /projects/bootstrap/run { repoRef, slug? }` — invokes the
-  `bootstrapProject` workflow end-to-end. Returns `BootstrapRunDto` with
-  the registration PR URL.
+- `POST /projects/bootstrap/local-project/preview` — returns
+  `LocalProjectCreationPreviewDto { slug, configPath, config, requiredEnvVars }`.
+  The preview endpoint is read-only and does not inspect GitHub or import
+  provider issues.
+- `POST /projects/bootstrap/local-project/create` — writes the previewed
+  config locally and returns `LocalProjectCreationRunDto`.
 
-The split keeps the destructive `/run` step deliberate: the wizard's
-"Open Registration PR" button is the only call site.
+The older GitHub PR bootstrap endpoints still exist for PR-based registration,
+but the Settings wizard no longer forces GitHub inspection as the only way to
+create a project.
 
 ## Mocking the workflow
 
-The Playwright e2e (`apps/web/e2e/pipeline/bootstrap-wizard.spec.ts`)
-drives the wizard through every step in the pipeline lane. The pipeline
-config (`playwright-e2e-pipeline.config.ts`) boots the server with
-`MOCK_BOOTSTRAP=true`, so both endpoints short-circuit to deterministic
-fixtures — no GitHub calls, no real labels installed, no PR opened.
+Component tests mock `previewLocalProjectCreation` and `createLocalProject` so
+the wizard can exercise each source mode without touching provider APIs or the
+filesystem.
 
 ## State machine
 
-`lib/wizard-state.ts` exports a pure 6-step state machine
+`lib/wizard-state.ts` exports a pure 3-step state machine
 (`WIZARD_STEPS`, `nextStep`, `prevStep`, `stepIndex`, `stepLabel`) plus
 `isValidRepoRef(...)`. Tests in `slice.test.ts` cover every transition.
 

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
@@ -4,10 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BootstrapWizard } from './BootstrapWizard';
 
-// API is mocked at the module level; each test injects fresh mock impls.
 vi.mock('@/lib/api', () => ({
-  previewBootstrap: vi.fn(),
-  runBootstrap: vi.fn(),
+  createLocalProject: vi.fn(),
+  previewLocalProjectCreation: vi.fn(),
 }));
 
 afterEach(() => {
@@ -18,36 +17,17 @@ afterEach(() => {
 const FIXTURE_PREVIEW = {
   slug: 'widgets',
   name: 'widgets',
-  defaultBranch: 'main',
-  repos: [
-    {
-      repoRef: 'octo/widgets',
-      defaultBranch: 'main',
-      description: 'Widgets',
-      stackSummary: 'node (pnpm) — scripts: build, test',
-      auditAction: 'create' as const,
-      auditPath: 'CLAUDE.md',
-    },
-  ],
-  stack: { type: 'node', summary: 'node (pnpm) — scripts: build, test', raw: {} },
-  audit: {
-    action: 'create' as const,
-    content: '# CLAUDE.md\n\n## What this repo is\n\n…\n',
-    rationale: 'No CLAUDE.md found.',
-  },
-  labelsToInstall: [
-    { name: 'factory:done', color: 'd1d5db', description: 'Done' },
-    { name: 'factory:in-progress', color: '1d76db', description: 'In progress' },
-  ],
+  configPath: 'target-projects/widgets/project.config.ts',
+  config: "source: {\n  kind: 'local-db',\n}",
+  requiredEnvVars: [] as string[],
+  repositories: [],
+  integrations: [] as Array<'github' | 'jira' | 'bitbucket'>,
 };
 
 const FIXTURE_RESULT = {
+  ...FIXTURE_PREVIEW,
   status: 'created' as const,
-  registrationPrUrl: 'https://github.com/shaunnez/goose-hub/pull/123',
-  slug: 'widgets',
-  stackSummary: 'node (pnpm)',
-  auditAction: 'create' as const,
-  labelCounts: { created: 5, updated: 0, skipped: 23 },
+  writtenPath: '/repo/target-projects/widgets/project.config.ts',
 };
 
 function renderWizard(open = true) {
@@ -62,137 +42,161 @@ describe('BootstrapWizard', () => {
     expect(screen.queryByTestId('bootstrap-wizard')).toBeNull();
   });
 
-  it('starts on the repo step', () => {
+  it('starts on the source step', () => {
     renderWizard();
-    expect(screen.getByTestId('step-repo')).toBeTruthy();
-    expect(screen.getByTestId('bootstrap-repo-input')).toBeTruthy();
+    expect(screen.getByTestId('step-source')).toBeTruthy();
+    expect(screen.getByTestId('bootstrap-mode-local-only')).toBeTruthy();
   });
 
-  it('disables the Next button when the repo ref is invalid', async () => {
-    const user = userEvent.setup();
-    renderWizard();
-    const next = screen.getByTestId('wizard-next') as HTMLButtonElement;
-    expect(next.disabled).toBe(true);
-
-    const input = screen.getByTestId('bootstrap-repo-input');
-    await user.type(input, 'not-a-valid-ref');
-    expect((screen.getByTestId('wizard-next') as HTMLButtonElement).disabled).toBe(true);
-  });
-
-  it('walks all five preview steps and shows the PR URL on completion', async () => {
-    const { previewBootstrap, runBootstrap } = await import('@/lib/api');
-    vi.mocked(previewBootstrap).mockResolvedValue(FIXTURE_PREVIEW);
-    vi.mocked(runBootstrap).mockResolvedValue(FIXTURE_RESULT);
+  it('previews and creates a local-only project', async () => {
+    const { createLocalProject, previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockResolvedValue(FIXTURE_PREVIEW);
+    vi.mocked(createLocalProject).mockResolvedValue(FIXTURE_RESULT);
 
     const user = userEvent.setup();
     renderWizard();
-
-    // Step 1 — enter repo + click Next.
-    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.type(screen.getByTestId('bootstrap-slug-input'), 'widgets');
     await user.click(screen.getByTestId('wizard-next'));
 
-    // Step 2 — stack summary.
-    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
-    expect(screen.getByTestId('stack-summary').textContent).toContain('node');
-    await user.click(screen.getByTestId('wizard-next'));
-
-    // Step 3 — CLAUDE.md preview.
-    await waitFor(() => expect(screen.getByTestId('step-claudemd')).toBeTruthy());
-    expect((screen.getByTestId('claudemd-preview') as HTMLTextAreaElement).value).toContain(
-      'CLAUDE.md',
+    await waitFor(() => expect(screen.getByTestId('project-config-preview')).toBeTruthy());
+    expect((screen.getByTestId('project-config-preview') as HTMLTextAreaElement).value).toContain(
+      "kind: 'local-db'",
     );
-    await user.click(screen.getByTestId('wizard-next'));
+    expect(previewLocalProjectCreation).toHaveBeenCalledWith({
+      slug: 'widgets',
+      name: undefined,
+      source: { kind: 'local-only' },
+    });
 
-    // Step 4 — label install confirmation.
-    await waitFor(() => expect(screen.getByTestId('step-labels')).toBeTruthy());
-    expect(screen.getAllByTestId('labels-list-item').length).toBe(2);
     await user.click(screen.getByTestId('wizard-next'));
-
-    // Step 5 — webhook setup.
-    await waitFor(() => expect(screen.getByTestId('step-webhook')).toBeTruthy());
-    // Must match the actual server route in apps/server/src/server.ts (`/webhooks/github`),
-    // not the singular `/webhook/github` that previously shipped here.
-    expect(screen.getByTestId('webhook-payload-url').textContent).toContain('/webhooks/github');
-    await user.click(screen.getByTestId('wizard-next'));
-
-    // Final step — Open PR + result render.
     await waitFor(() => expect(screen.getByTestId('step-submit')).toBeTruthy());
     await user.click(screen.getByTestId('bootstrap-submit'));
     await waitFor(() => expect(screen.getByTestId('bootstrap-result')).toBeTruthy());
-    const link = screen.getByTestId('bootstrap-pr-link') as HTMLAnchorElement;
-    expect(link.href).toBe('https://github.com/shaunnez/goose-hub/pull/123');
-    expect(runBootstrap).toHaveBeenCalledWith({
-      repoRefs: ['octo/widgets'],
-      name: undefined,
+    expect(createLocalProject).toHaveBeenCalledWith({
       slug: 'widgets',
+      name: undefined,
+      source: { kind: 'local-only' },
     });
   });
 
-  it('shows update-mode CLAUDE.md as a diff when audit.action="update"', async () => {
-    const { previewBootstrap } = await import('@/lib/api');
-    vi.mocked(previewBootstrap).mockResolvedValue({
+  it('previews GitHub code mode with imports left to the server config', async () => {
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockResolvedValue({
       ...FIXTURE_PREVIEW,
-      audit: {
-        action: 'update',
-        content: '--- existing\n+++ proposed\n+## Hard rules\n+...',
-        rationale: 'Existing CLAUDE.md missing required sections.',
+      integrations: ['github'],
+      config: 'github: { mirrorLabels: false, importIssues: false }',
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.click(screen.getByTestId('bootstrap-mode-github-code'));
+    await user.type(screen.getByTestId('bootstrap-github-repos-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() => expect(screen.getByTestId('step-preview')).toBeTruthy());
+    expect(previewLocalProjectCreation).toHaveBeenCalledWith({
+      slug: undefined,
+      name: undefined,
+      source: { kind: 'github-code', repoRefs: ['octo/widgets'] },
+    });
+  });
+
+  it('previews Jira manual import mode', async () => {
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockResolvedValue({
+      ...FIXTURE_PREVIEW,
+      integrations: ['jira'],
+      requiredEnvVars: ['JIRA_EMAIL or ATLASSIAN_EMAIL'],
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.click(screen.getByTestId('bootstrap-mode-jira'));
+    await user.type(screen.getByTestId('bootstrap-jira-base-url-input'), 'https://example.net');
+    await user.type(screen.getByTestId('bootstrap-jira-keys-input'), 'ENG');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('required-env-vars').textContent).toContain('JIRA'),
+    );
+    expect(previewLocalProjectCreation).toHaveBeenCalledWith({
+      slug: undefined,
+      name: undefined,
+      source: {
+        kind: 'jira',
+        baseUrl: 'https://example.net',
+        projectKeys: ['ENG'],
+        importMode: 'manual',
       },
     });
-
-    const user = userEvent.setup();
-    renderWizard();
-    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
-    await user.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
-    await user.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => expect(screen.getByTestId('step-claudemd')).toBeTruthy());
-    expect(screen.getByText(/diff \(update\)/i)).toBeTruthy();
-    expect((screen.getByTestId('claudemd-preview') as HTMLTextAreaElement).value).toContain(
-      '+## Hard rules',
-    );
   });
 
-  it('hides the textarea when audit.action="ok"', async () => {
-    const { previewBootstrap } = await import('@/lib/api');
-    vi.mocked(previewBootstrap).mockResolvedValue({
+  it('previews Bitbucket PR integration mode', async () => {
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockResolvedValue({
       ...FIXTURE_PREVIEW,
-      audit: { action: 'ok', content: '', rationale: 'Already complete.' },
+      integrations: ['bitbucket'],
     });
 
     const user = userEvent.setup();
     renderWizard();
-    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
+    await user.click(screen.getByTestId('bootstrap-mode-bitbucket'));
+    await user.type(screen.getByTestId('bootstrap-bitbucket-workspace-input'), 'acme');
+    await user.type(screen.getByTestId('bootstrap-bitbucket-repos-input'), 'api,web');
     await user.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
+
+    await waitFor(() => expect(screen.getByTestId('step-preview')).toBeTruthy());
+    expect(previewLocalProjectCreation).toHaveBeenCalledWith({
+      slug: undefined,
+      name: undefined,
+      source: { kind: 'bitbucket', workspace: 'acme', repos: ['api', 'web'] },
+    });
+  });
+
+  it('previews advanced combinations', async () => {
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockResolvedValue({
+      ...FIXTURE_PREVIEW,
+      integrations: ['github', 'jira', 'bitbucket'],
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await user.click(screen.getByTestId('bootstrap-mode-advanced'));
+    await user.type(screen.getByTestId('bootstrap-github-repos-input'), 'octo/widgets');
+    await user.type(screen.getByTestId('bootstrap-jira-base-url-input'), 'https://example.net');
+    await user.type(screen.getByTestId('bootstrap-jira-keys-input'), 'ENG');
+    await user.type(screen.getByTestId('bootstrap-bitbucket-workspace-input'), 'acme');
+    await user.type(screen.getByTestId('bootstrap-bitbucket-repos-input'), 'api');
     await user.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => expect(screen.getByTestId('claudemd-ok')).toBeTruthy());
-    expect(screen.queryByTestId('claudemd-preview')).toBeNull();
+
+    await waitFor(() => expect(screen.getByTestId('step-preview')).toBeTruthy());
+    expect(previewLocalProjectCreation).toHaveBeenCalledWith({
+      slug: undefined,
+      name: undefined,
+      source: {
+        kind: 'advanced',
+        github: { repoRefs: ['octo/widgets'] },
+        jira: {
+          baseUrl: 'https://example.net',
+          projectKeys: ['ENG'],
+          importMode: 'manual',
+        },
+        bitbucket: { workspace: 'acme', repos: ['api'] },
+      },
+    });
   });
 
   it('surfaces preview errors in a banner', async () => {
-    const { previewBootstrap } = await import('@/lib/api');
-    vi.mocked(previewBootstrap).mockRejectedValue(new Error('repo not found'));
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    vi.mocked(previewLocalProjectCreation).mockRejectedValue(new Error('bad source'));
 
     const user = userEvent.setup();
     renderWizard();
-    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/missing');
+    await user.type(screen.getByTestId('bootstrap-slug-input'), 'widgets');
     await user.click(screen.getByTestId('wizard-next'));
     await waitFor(() => expect(screen.getByTestId('wizard-error')).toBeTruthy());
-    expect(screen.getByTestId('wizard-error').textContent).toContain('repo not found');
-    // We stayed on the repo step.
-    expect(screen.getByTestId('step-repo')).toBeTruthy();
-  });
-
-  it('lets the user step backwards', async () => {
-    const { previewBootstrap } = await import('@/lib/api');
-    vi.mocked(previewBootstrap).mockResolvedValue(FIXTURE_PREVIEW);
-
-    const user = userEvent.setup();
-    renderWizard();
-    await user.type(screen.getByTestId('bootstrap-repo-input'), 'octo/widgets');
-    await user.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => expect(screen.getByTestId('step-stack')).toBeTruthy());
-    await user.click(screen.getByTestId('wizard-prev'));
-    await waitFor(() => expect(screen.getByTestId('step-repo')).toBeTruthy());
+    expect(screen.getByTestId('wizard-error').textContent).toContain('bad source');
+    expect(screen.getByTestId('step-source')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
@@ -187,6 +187,24 @@ describe('BootstrapWizard', () => {
     });
   });
 
+  it('rejects invalid advanced GitHub refs instead of dropping them', async () => {
+    const { previewLocalProjectCreation } = await import('@/lib/api');
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByTestId('bootstrap-mode-advanced'));
+    await user.type(screen.getByTestId('bootstrap-github-repos-input'), 'not-a-ref');
+    await user.type(screen.getByTestId('bootstrap-jira-base-url-input'), 'https://example.net');
+    await user.type(screen.getByTestId('bootstrap-jira-keys-input'), 'ENG');
+    await user.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() => expect(screen.getByTestId('wizard-error')).toBeTruthy());
+    expect(screen.getByTestId('wizard-error').textContent).toContain(
+      'GitHub repositories must look like "owner/repo"',
+    );
+    expect(previewLocalProjectCreation).not.toHaveBeenCalled();
+  });
+
   it('surfaces preview errors in a banner', async () => {
     const { previewLocalProjectCreation } = await import('@/lib/api');
     vi.mocked(previewLocalProjectCreation).mockRejectedValue(new Error('bad source'));

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
@@ -1,18 +1,18 @@
-/**
- * BootstrapWizard — multi-step modal that walks the human through registering
- * a new project under Factory's roster (M12.07, issue #308).
- *
- * The wizard hits two server endpoints:
- *   - POST /projects/bootstrap/preview { repoRef }  → BootstrapPreviewDto
- *   - POST /projects/bootstrap/run     { repoRef, slug? } → BootstrapRunDto
- *
- * Tokens are server-held (env GITHUB_TOKEN); the browser never collects
- * tokens. The "Open Registration PR" button on the final step calls /run.
- */
-
-import { previewBootstrap, runBootstrap } from '@/lib/api';
-import type { BootstrapPreviewDto, BootstrapRunDto } from '@/lib/types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { createLocalProject, previewLocalProjectCreation } from '@/lib/api';
+import type {
+  LocalProjectCreationPreviewDto,
+  LocalProjectCreationRequestDto,
+  LocalProjectCreationRunDto,
+  ProjectCreationSourceDto,
+} from '@/lib/types';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   WIZARD_STEPS,
   type WizardStep,
@@ -24,6 +24,8 @@ import {
   stepLabel,
 } from '../lib/wizard-state';
 
+type CreationMode = ProjectCreationSourceDto['kind'];
+
 interface BootstrapWizardProps {
   open: boolean;
   onClose: () => void;
@@ -31,41 +33,55 @@ interface BootstrapWizardProps {
 
 interface WizardState {
   step: WizardStep;
-  repoRef: string;
-  repoRefsText: string;
+  mode: CreationMode;
   projectName: string;
   slug: string;
-  preview: BootstrapPreviewDto | null;
-  result: BootstrapRunDto | null;
+  githubReposText: string;
+  jiraBaseUrl: string;
+  jiraKeysText: string;
+  jiraImportMode: 'manual' | 'assigned-to-me';
+  bitbucketWorkspace: string;
+  bitbucketReposText: string;
+  preview: LocalProjectCreationPreviewDto | null;
+  lastRequest: LocalProjectCreationRequestDto | null;
+  result: LocalProjectCreationRunDto | null;
   loading: boolean;
   error: string | null;
 }
 
 const INITIAL_STATE: WizardState = {
-  step: 'repo',
-  repoRef: '',
-  repoRefsText: '',
+  step: 'source',
+  mode: 'local-only',
   projectName: '',
   slug: '',
+  githubReposText: '',
+  jiraBaseUrl: '',
+  jiraKeysText: '',
+  jiraImportMode: 'manual',
+  bitbucketWorkspace: '',
+  bitbucketReposText: '',
   preview: null,
+  lastRequest: null,
   result: null,
   loading: false,
   error: null,
 };
 
+const MODE_LABELS: Record<CreationMode, string> = {
+  'local-only': 'Local only',
+  'github-code': 'Local + GitHub code repo',
+  jira: 'Local + Jira import',
+  bitbucket: 'Local + Bitbucket PR integration',
+  advanced: 'Advanced: multiple repos/integrations',
+};
+
 export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
-  // Tracks whether the modal is still mounted/open by the time an in-flight
-  // preview/run request resolves. Without this guard, a late response can
-  // re-populate state after the user has closed the wizard, leaving stale
-  // step/preview data visible on the next open.
   const openRef = useRef(open);
-
   const reset = useCallback(() => setState(INITIAL_STATE), []);
 
   useEffect(() => {
     openRef.current = open;
-    // Reset whenever the modal closes so the next open starts fresh.
     if (!open) reset();
   }, [open, reset]);
 
@@ -75,136 +91,90 @@ export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
     setState((s) => ({ ...s, error, loading: false }));
   }
 
-  async function handleValidateRepo() {
-    if (!isValidRepoRefs(state.repoRefsText || state.repoRef)) {
-      setError('Each repository ref must look like "owner/repo"');
+  async function handlePreview() {
+    let request: LocalProjectCreationRequestDto;
+    try {
+      request = buildRequest(state);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid project source');
       return;
     }
-    const repoRefs = parseRepoRefs(state.repoRefsText || state.repoRef);
+
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
-      const preview = await previewBootstrap({
-        repoRefs,
-        name: state.projectName.trim() || undefined,
-        slug: state.slug.trim() || undefined,
-      });
+      const preview = await previewLocalProjectCreation(request);
       if (!openRef.current) return;
       setState((s) => ({
         ...s,
-        repoRef: repoRefs[0] ?? '',
         preview,
+        lastRequest: request,
         loading: false,
         step: nextStep(s.step),
       }));
     } catch (err) {
       if (!openRef.current) return;
-      setError(err instanceof Error ? err.message : 'Failed to validate repo');
+      setError(err instanceof Error ? err.message : 'Failed to preview project config');
     }
   }
 
-  async function handleOpenPr() {
+  async function handleCreate() {
+    const request = state.lastRequest ?? buildRequest(state);
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
-      const result = await runBootstrap({
-        repoRefs: parseRepoRefs(state.repoRefsText || state.repoRef),
-        name: state.projectName.trim() || undefined,
-        slug: state.slug.trim() || state.preview?.slug,
-      });
+      const result = await createLocalProject(request);
       if (!openRef.current) return;
       setState((s) => ({ ...s, result, loading: false }));
     } catch (err) {
       if (!openRef.current) return;
-      setError(err instanceof Error ? err.message : 'Failed to open registration PR');
+      setError(err instanceof Error ? err.message : 'Failed to create project config');
     }
   }
 
   function handleNext() {
     setState((s) => ({ ...s, step: nextStep(s.step), error: null }));
   }
+
   function handlePrev() {
     setState((s) => ({ ...s, step: prevStep(s.step), error: null }));
-  }
-
-  function handleClose() {
-    onClose();
   }
 
   return (
     <div
       data-testid="bootstrap-wizard"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 50,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'rgba(0,0,0,0.45)',
-      }}
-      onClick={handleClose}
-      onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+      style={overlayStyle}
+      onClick={onClose}
+      onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
       <div
-        // biome-ignore lint/a11y/useSemanticElements: native <dialog> requires open/showModal lifecycle that conflicts with the existing CSS-overlay pattern used elsewhere in the app; aria-label + role="dialog" is the documented React-modal fallback.
+        // biome-ignore lint/a11y/useSemanticElements: this follows the existing modal overlay pattern; native dialog lifecycle would be a broader component rewrite.
         role="dialog"
-        aria-label="Add Project bootstrap wizard"
-        style={{
-          background: 'var(--bg-elev)',
-          border: '1px solid var(--line)',
-          borderRadius: 8,
-          padding: '24px',
-          width: '100%',
-          maxWidth: 720,
-          maxHeight: '90vh',
-          overflowY: 'auto',
-          color: 'var(--fg)',
-        }}
+        aria-label="Add project wizard"
+        style={dialogStyle}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
       >
-        <h2
-          style={{
-            margin: '0 0 12px',
-            fontSize: 15,
-            fontWeight: 600,
-          }}
-        >
-          Add project
-        </h2>
-
+        <h2 style={{ margin: '0 0 12px', fontSize: 15, fontWeight: 600 }}>Add project</h2>
         <StepIndicator current={state.step} />
 
         <div style={{ marginTop: 16 }}>
-          {state.step === 'repo' && (
-            <StepRepo
-              repoRefsText={state.repoRefsText}
-              projectName={state.projectName}
-              slug={state.slug}
-              onRepoRefsChange={(repoRefsText) =>
-                setState((s) => ({ ...s, repoRefsText, repoRef: repoRefsText, error: null }))
+          {state.step === 'source' && (
+            <StepSource
+              state={state}
+              onChange={(patch) =>
+                setState((s) => ({
+                  ...s,
+                  ...patch,
+                  preview: null,
+                  result: null,
+                  lastRequest: null,
+                  error: null,
+                }))
               }
-              onProjectNameChange={(projectName) =>
-                setState((s) => ({ ...s, projectName, error: null }))
-              }
-              onSlugChange={(slug) => setState((s) => ({ ...s, slug, error: null }))}
-              loading={state.loading}
-              onSubmit={handleValidateRepo}
             />
           )}
-          {state.step === 'stack' && state.preview && <StepStack preview={state.preview} />}
-          {state.step === 'claudeMd' && state.preview && <StepClaudeMd preview={state.preview} />}
-          {state.step === 'labels' && state.preview && <StepLabels preview={state.preview} />}
-          {state.step === 'webhook' && state.preview && (
-            <StepWebhook preview={state.preview} repoRef={state.repoRef} />
-          )}
+          {state.step === 'preview' && state.preview && <StepPreview preview={state.preview} />}
           {state.step === 'submit' && (
-            <StepSubmit
-              repoRef={state.repoRef}
-              preview={state.preview}
-              result={state.result}
-              loading={state.loading}
-              onOpenPr={handleOpenPr}
-            />
+            <StepSubmit result={state.result} loading={state.loading} onCreate={handleCreate} />
           )}
         </div>
 
@@ -223,41 +193,101 @@ export function BootstrapWizard({ open, onClose }: BootstrapWizardProps) {
           hasResult={state.result != null}
           canAdvance={canAdvance(state)}
           onPrev={handlePrev}
-          onNext={state.step === 'repo' ? handleValidateRepo : handleNext}
-          onClose={handleClose}
+          onNext={state.step === 'source' ? handlePreview : handleNext}
+          onClose={onClose}
         />
       </div>
     </div>
   );
 }
 
+function buildRequest(state: WizardState): LocalProjectCreationRequestDto {
+  const base = {
+    name: state.projectName.trim() || undefined,
+    slug: state.slug.trim() || undefined,
+  };
+  return {
+    ...base,
+    source: buildSource(state),
+  };
+}
+
+function buildSource(state: WizardState): ProjectCreationSourceDto {
+  switch (state.mode) {
+    case 'local-only':
+      return { kind: 'local-only' };
+    case 'github-code':
+      return { kind: 'github-code', repoRefs: parseRepoRefs(state.githubReposText) };
+    case 'jira':
+      return {
+        kind: 'jira',
+        baseUrl: state.jiraBaseUrl.trim(),
+        projectKeys: parseList(state.jiraKeysText),
+        importMode: state.jiraImportMode,
+      };
+    case 'bitbucket':
+      return {
+        kind: 'bitbucket',
+        workspace: state.bitbucketWorkspace.trim(),
+        repos: parseList(state.bitbucketReposText),
+      };
+    case 'advanced': {
+      const source: Extract<ProjectCreationSourceDto, { kind: 'advanced' }> = { kind: 'advanced' };
+      if (isValidRepoRefs(state.githubReposText)) {
+        source.github = { repoRefs: parseRepoRefs(state.githubReposText) };
+      }
+      if (state.jiraBaseUrl.trim() && parseList(state.jiraKeysText).length > 0) {
+        source.jira = {
+          baseUrl: state.jiraBaseUrl.trim(),
+          projectKeys: parseList(state.jiraKeysText),
+          importMode: state.jiraImportMode,
+        };
+      }
+      if (state.bitbucketWorkspace.trim() && parseList(state.bitbucketReposText).length > 0) {
+        source.bitbucket = {
+          workspace: state.bitbucketWorkspace.trim(),
+          repos: parseList(state.bitbucketReposText),
+        };
+      }
+      return source;
+    }
+  }
+}
+
 function canAdvance(state: WizardState): boolean {
   if (state.loading) return false;
-  if (state.step === 'repo') {
-    return isValidRepoRefs(state.repoRefsText || state.repoRef);
+  if (state.step === 'source') {
+    if (state.mode === 'local-only') return state.slug.trim().length > 0;
+    if (state.mode === 'github-code') return isValidRepoRefs(state.githubReposText);
+    if (state.mode === 'jira') {
+      return state.jiraBaseUrl.trim().length > 0 && parseList(state.jiraKeysText).length > 0;
+    }
+    if (state.mode === 'bitbucket') {
+      return (
+        state.bitbucketWorkspace.trim().length > 0 && parseList(state.bitbucketReposText).length > 0
+      );
+    }
+    return (
+      isValidRepoRefs(state.githubReposText) ||
+      (state.jiraBaseUrl.trim().length > 0 && parseList(state.jiraKeysText).length > 0) ||
+      (state.bitbucketWorkspace.trim().length > 0 && parseList(state.bitbucketReposText).length > 0)
+    );
   }
-  if (state.step === 'submit') {
-    return state.result != null;
-  }
+  if (state.step === 'submit') return state.result != null;
   return state.preview != null;
+}
+
+function parseList(raw: string): string[] {
+  return raw
+    .split(/[\n,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
 }
 
 function StepIndicator({ current }: { current: WizardStep }) {
   const currentIdx = stepIndex(current);
   return (
-    <ol
-      data-testid="wizard-steps"
-      style={{
-        display: 'flex',
-        gap: 4,
-        listStyle: 'none',
-        padding: 0,
-        margin: 0,
-        fontSize: 11,
-        color: 'var(--fg-2)',
-        flexWrap: 'wrap',
-      }}
-    >
+    <ol data-testid="wizard-steps" style={stepListStyle}>
       {WIZARD_STEPS.map((step, idx) => {
         const isActive = step === current;
         const isComplete = idx < currentIdx;
@@ -286,41 +316,23 @@ function StepIndicator({ current }: { current: WizardStep }) {
   );
 }
 
-function StepRepo({
-  repoRefsText,
-  projectName,
-  slug,
-  onRepoRefsChange,
-  onProjectNameChange,
-  onSlugChange,
-  loading,
-  onSubmit,
+function StepSource({
+  state,
+  onChange,
 }: {
-  repoRefsText: string;
-  projectName: string;
-  slug: string;
-  onRepoRefsChange: (v: string) => void;
-  onProjectNameChange: (v: string) => void;
-  onSlugChange: (v: string) => void;
-  loading: boolean;
-  onSubmit: () => void;
+  state: WizardState;
+  onChange: (patch: Partial<WizardState>) => void;
 }) {
   return (
-    <form
-      data-testid="step-repo"
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (!loading) onSubmit();
-      }}
-    >
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 180px', gap: 10, marginBottom: 10 }}>
+    <div data-testid="step-source">
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 180px', gap: 10, marginBottom: 12 }}>
         <Field label="Project alias" htmlFor="bootstrap-project-name">
           <input
             id="bootstrap-project-name"
             data-testid="bootstrap-project-name-input"
             type="text"
-            value={projectName}
-            onChange={(e) => onProjectNameChange(e.target.value)}
+            value={state.projectName}
+            onChange={(e) => onChange({ projectName: e.target.value })}
             placeholder="Goose Hub"
             autoComplete="off"
             style={textInputStyle}
@@ -331,56 +343,190 @@ function StepRepo({
             id="bootstrap-project-slug"
             data-testid="bootstrap-slug-input"
             type="text"
-            value={slug}
-            onChange={(e) => onSlugChange(e.target.value)}
+            value={state.slug}
+            onChange={(e) => onChange({ slug: e.target.value })}
             placeholder="goose-hub"
             autoComplete="off"
             style={textInputStyle}
           />
         </Field>
       </div>
-      <label
-        htmlFor="bootstrap-repo-ref"
-        style={{ display: 'block', fontSize: 12, color: 'var(--fg-2)', marginBottom: 4 }}
-      >
-        GitHub repositories (owner/repo, one per line)
-      </label>
-      <textarea
-        id="bootstrap-repo-ref"
-        data-testid="bootstrap-repo-input"
-        value={repoRefsText}
-        onChange={(e) => onRepoRefsChange(e.target.value)}
-        placeholder={'octo/widgets\nocto/docs'}
-        autoComplete="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        style={{
-          ...textInputStyle,
-          minHeight: 72,
-          resize: 'vertical',
-        }}
-      />
-      <p style={{ marginTop: 6, fontSize: 11, color: 'var(--fg-3)' }}>
-        The server checks accessibility with its configured GITHUB_TOKEN. The browser never sees a
-        token.
-      </p>
-    </form>
+
+      <fieldset style={fieldsetStyle}>
+        <legend style={legendStyle}>Mode</legend>
+        {Object.entries(MODE_LABELS).map(([mode, label]) => (
+          <label key={mode} style={radioLabelStyle}>
+            <input
+              data-testid={`bootstrap-mode-${mode}`}
+              type="radio"
+              checked={state.mode === mode}
+              onChange={() => onChange({ mode: mode as CreationMode })}
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </fieldset>
+
+      {(state.mode === 'github-code' || state.mode === 'advanced') && (
+        <Field label="GitHub repositories" htmlFor="bootstrap-github-repos">
+          <textarea
+            id="bootstrap-github-repos"
+            data-testid="bootstrap-github-repos-input"
+            value={state.githubReposText}
+            onChange={(e) => onChange({ githubReposText: e.target.value })}
+            placeholder={'octo/widgets\nocto/docs'}
+            style={textareaStyle}
+          />
+        </Field>
+      )}
+
+      {(state.mode === 'jira' || state.mode === 'advanced') && (
+        <div style={sectionGridStyle}>
+          <Field label="Jira base URL" htmlFor="bootstrap-jira-base-url">
+            <input
+              id="bootstrap-jira-base-url"
+              data-testid="bootstrap-jira-base-url-input"
+              value={state.jiraBaseUrl}
+              onChange={(e) => onChange({ jiraBaseUrl: e.target.value })}
+              placeholder="https://example.atlassian.net"
+              style={textInputStyle}
+            />
+          </Field>
+          <Field label="Jira project keys" htmlFor="bootstrap-jira-keys">
+            <input
+              id="bootstrap-jira-keys"
+              data-testid="bootstrap-jira-keys-input"
+              value={state.jiraKeysText}
+              onChange={(e) => onChange({ jiraKeysText: e.target.value })}
+              placeholder="ENG,OPS"
+              style={textInputStyle}
+            />
+          </Field>
+          <Field label="Jira import mode" htmlFor="bootstrap-jira-import-mode">
+            <select
+              id="bootstrap-jira-import-mode"
+              data-testid="bootstrap-jira-import-mode-select"
+              value={state.jiraImportMode}
+              onChange={(e) =>
+                onChange({ jiraImportMode: e.target.value as 'manual' | 'assigned-to-me' })
+              }
+              style={textInputStyle}
+            >
+              <option value="manual">Manual</option>
+              <option value="assigned-to-me">Assigned to me</option>
+            </select>
+          </Field>
+        </div>
+      )}
+
+      {(state.mode === 'bitbucket' || state.mode === 'advanced') && (
+        <div style={sectionGridStyle}>
+          <Field label="Bitbucket workspace" htmlFor="bootstrap-bitbucket-workspace">
+            <input
+              id="bootstrap-bitbucket-workspace"
+              data-testid="bootstrap-bitbucket-workspace-input"
+              value={state.bitbucketWorkspace}
+              onChange={(e) => onChange({ bitbucketWorkspace: e.target.value })}
+              placeholder="workspace"
+              style={textInputStyle}
+            />
+          </Field>
+          <Field label="Bitbucket repositories" htmlFor="bootstrap-bitbucket-repos">
+            <input
+              id="bootstrap-bitbucket-repos"
+              data-testid="bootstrap-bitbucket-repos-input"
+              value={state.bitbucketReposText}
+              onChange={(e) => onChange({ bitbucketReposText: e.target.value })}
+              placeholder="api,web"
+              style={textInputStyle}
+            />
+          </Field>
+        </div>
+      )}
+    </div>
   );
 }
 
-const textInputStyle: React.CSSProperties = {
-  display: 'block',
-  width: '100%',
-  boxSizing: 'border-box',
-  padding: '6px 10px',
-  borderRadius: 6,
-  border: '1px solid var(--line)',
-  background: 'var(--bg)',
-  color: 'var(--fg)',
-  fontSize: 13,
-  fontFamily: 'monospace',
-  outline: 'none',
-};
+function StepPreview({ preview }: { preview: LocalProjectCreationPreviewDto }) {
+  return (
+    <div data-testid="step-preview">
+      <h3 style={headingStyle}>Generated config</h3>
+      <p style={metaTextStyle}>
+        <code>{preview.configPath}</code>
+      </p>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '8px 0' }}>
+        <Badge>local-db</Badge>
+        {preview.integrations.map((integration) => (
+          <Badge key={integration}>{integration}</Badge>
+        ))}
+      </div>
+      {preview.requiredEnvVars.length > 0 && (
+        <div data-testid="required-env-vars" style={{ margin: '8px 0 12px', fontSize: 12 }}>
+          <strong>Env:</strong>{' '}
+          {preview.requiredEnvVars.map((envVar) => (
+            <code key={envVar} style={{ marginRight: 8 }}>
+              {envVar}
+            </code>
+          ))}
+        </div>
+      )}
+      <textarea
+        data-testid="project-config-preview"
+        readOnly
+        value={preview.config}
+        rows={18}
+        style={{ ...textareaStyle, minHeight: 320 }}
+      />
+    </div>
+  );
+}
+
+function StepSubmit({
+  result,
+  loading,
+  onCreate,
+}: {
+  result: LocalProjectCreationRunDto | null;
+  loading: boolean;
+  onCreate: () => void;
+}) {
+  return (
+    <div data-testid="step-submit">
+      <h3 style={headingStyle}>Create project config</h3>
+      {result == null && (
+        <button
+          type="button"
+          data-testid="bootstrap-submit"
+          disabled={loading}
+          onClick={onCreate}
+          style={primaryButtonStyle}
+        >
+          {loading ? 'Creating...' : 'Create Project'}
+        </button>
+      )}
+      {result != null && (
+        <div data-testid="bootstrap-result">
+          <p style={{ margin: '0 0 8px', fontSize: 12 }}>
+            <strong>Status:</strong> {result.status}
+          </p>
+          <p style={{ margin: 0, fontSize: 12 }}>
+            <strong>Path:</strong> <code>{result.configPath}</code>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Badge({ children }: { children: string }) {
+  return (
+    <span
+      style={{ border: '1px solid var(--line)', borderRadius: 4, padding: '2px 6px', fontSize: 11 }}
+    >
+      {children}
+    </span>
+  );
+}
 
 function Field({
   label,
@@ -389,274 +535,13 @@ function Field({
 }: {
   label: string;
   htmlFor: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <label htmlFor={htmlFor} style={{ display: 'block', fontSize: 12, color: 'var(--fg-2)' }}>
       <span style={{ display: 'block', marginBottom: 4 }}>{label}</span>
       {children}
     </label>
-  );
-}
-
-function StepStack({ preview }: { preview: BootstrapPreviewDto }) {
-  return (
-    <div data-testid="step-stack">
-      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Detected stack</h3>
-      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
-        <strong>Type:</strong> {preview.stack.type}
-      </p>
-      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
-        <strong>Default branch:</strong>{' '}
-        <code style={{ fontFamily: 'monospace' }}>{preview.defaultBranch}</code>
-      </p>
-      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
-        <strong>Slug:</strong> <code style={{ fontFamily: 'monospace' }}>{preview.slug}</code>
-      </p>
-      <p style={{ margin: '0 0 4px', fontSize: 12 }}>
-        <strong>Repos:</strong> {preview.repos.length}
-      </p>
-      <ul style={{ margin: '8px 0 0 18px', padding: 0, fontSize: 12, color: 'var(--fg-2)' }}>
-        {preview.repos.map((repo) => (
-          <li key={repo.repoRef}>
-            <code style={{ fontFamily: 'monospace' }}>{repo.repoRef}</code> — {repo.stackSummary}
-          </li>
-        ))}
-      </ul>
-      <pre
-        data-testid="stack-summary"
-        style={{
-          marginTop: 12,
-          background: 'var(--bg)',
-          border: '1px solid var(--line)',
-          borderRadius: 6,
-          padding: 12,
-          fontSize: 11,
-          fontFamily: 'monospace',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-all',
-        }}
-      >
-        {preview.stack.summary}
-      </pre>
-    </div>
-  );
-}
-
-function StepClaudeMd({ preview }: { preview: BootstrapPreviewDto }) {
-  const isCreate = preview.audit.action === 'create';
-  const isUpdate = preview.audit.action === 'update';
-  const isOk = preview.audit.action === 'ok';
-  return (
-    <div data-testid="step-claudemd">
-      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>
-        CLAUDE.md {isCreate ? 'preview (create)' : isUpdate ? 'diff (update)' : 'audit'}
-      </h3>
-      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
-        {preview.audit.rationale}
-      </p>
-      {!isOk && (
-        <textarea
-          data-testid="claudemd-preview"
-          readOnly
-          value={preview.audit.content}
-          rows={12}
-          style={{
-            display: 'block',
-            width: '100%',
-            boxSizing: 'border-box',
-            background: 'var(--bg)',
-            border: '1px solid var(--line)',
-            borderRadius: 6,
-            color: 'var(--fg)',
-            fontFamily: 'monospace',
-            fontSize: 11,
-            padding: 8,
-            resize: 'vertical',
-          }}
-        />
-      )}
-      {isOk && (
-        <p data-testid="claudemd-ok" style={{ margin: 0, fontSize: 12, color: 'var(--fg-2)' }}>
-          The target repo's CLAUDE.md already contains every required section. No changes proposed.
-        </p>
-      )}
-    </div>
-  );
-}
-
-function StepLabels({ preview }: { preview: BootstrapPreviewDto }) {
-  return (
-    <div data-testid="step-labels">
-      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>
-        Labels to install ({preview.labelsToInstall.length})
-      </h3>
-      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
-        These are the canonical Factory labels that will be created or updated on{' '}
-        <code style={{ fontFamily: 'monospace' }}>{preview.slug}</code>'s GitHub repo.
-      </p>
-      <ul
-        data-testid="labels-list"
-        style={{
-          listStyle: 'none',
-          padding: 0,
-          margin: 0,
-          maxHeight: 240,
-          overflowY: 'auto',
-          border: '1px solid var(--line)',
-          borderRadius: 6,
-        }}
-      >
-        {preview.labelsToInstall.map((label) => (
-          <li
-            key={label.name}
-            data-testid="labels-list-item"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '5px 10px',
-              borderBottom: '1px solid var(--line)',
-              fontSize: 12,
-            }}
-          >
-            <span
-              style={{
-                display: 'inline-block',
-                width: 12,
-                height: 12,
-                borderRadius: 3,
-                background: `#${label.color}`,
-                flexShrink: 0,
-              }}
-            />
-            <code style={{ fontFamily: 'monospace', flexShrink: 0 }}>{label.name}</code>
-            <span style={{ color: 'var(--fg-3)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-              {label.description}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function StepWebhook({ preview, repoRef }: { preview: BootstrapPreviewDto; repoRef: string }) {
-  const payloadUrl = '<your-goose-hub-host>/webhooks/github';
-  return (
-    <div data-testid="step-webhook">
-      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Webhook setup</h3>
-      <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
-        After this PR merges, configure a GitHub webhook on{' '}
-        <code style={{ fontFamily: 'monospace' }}>{repoRef || preview.slug}</code> so factory ticks
-        react to label changes.
-      </p>
-      <ol style={{ margin: '0 0 8px 18px', padding: 0, fontSize: 12, lineHeight: 1.7 }}>
-        <li>
-          Go to{' '}
-          <code style={{ fontFamily: 'monospace' }}>
-            https://github.com/{repoRef || preview.slug}/settings/hooks/new
-          </code>
-          .
-        </li>
-        <li>
-          Payload URL:{' '}
-          <code data-testid="webhook-payload-url" style={{ fontFamily: 'monospace' }}>
-            {payloadUrl}
-          </code>
-        </li>
-        <li>
-          Content type: <code style={{ fontFamily: 'monospace' }}>application/json</code>
-        </li>
-        <li>
-          Secret: the value of{' '}
-          <code style={{ fontFamily: 'monospace' }}>GITHUB_WEBHOOK_SECRET</code> from your goose-hub
-          server env.
-        </li>
-        <li>Events: select Issues, Pull requests, and Issue comments.</li>
-        <li>Active: yes.</li>
-      </ol>
-      <p style={{ margin: 0, fontSize: 11, color: 'var(--fg-3)' }}>
-        Local development: tunnel <code style={{ fontFamily: 'monospace' }}>localhost:3001</code>{' '}
-        with <code style={{ fontFamily: 'monospace' }}>ngrok http 3001</code> and use the ngrok URL
-        above instead.
-      </p>
-    </div>
-  );
-}
-
-function StepSubmit({
-  repoRef,
-  preview,
-  result,
-  loading,
-  onOpenPr,
-}: {
-  repoRef: string;
-  preview: BootstrapPreviewDto | null;
-  result: BootstrapRunDto | null;
-  loading: boolean;
-  onOpenPr: () => void;
-}) {
-  return (
-    <div data-testid="step-submit">
-      <h3 style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Open registration PR</h3>
-      {result == null && (
-        <>
-          <p style={{ margin: '0 0 12px', fontSize: 12, color: 'var(--fg-2)' }}>
-            Clicking the button below will install the canonical labels on{' '}
-            <code style={{ fontFamily: 'monospace' }}>{repoRef}</code> and open a registration PR on{' '}
-            <code style={{ fontFamily: 'monospace' }}>shaunnez/goose-hub</code> with slug{' '}
-            <code style={{ fontFamily: 'monospace' }}>{preview?.slug}</code>.
-          </p>
-          <button
-            type="button"
-            data-testid="bootstrap-submit"
-            disabled={loading}
-            onClick={onOpenPr}
-            style={{
-              padding: '6px 16px',
-              borderRadius: 6,
-              border: 'none',
-              background: 'var(--accent, #6366f1)',
-              color: '#fff',
-              fontSize: 13,
-              cursor: loading ? 'not-allowed' : 'pointer',
-              opacity: loading ? 0.7 : 1,
-            }}
-          >
-            {loading ? 'Opening PR…' : 'Open Registration PR'}
-          </button>
-        </>
-      )}
-      {result != null && (
-        <div data-testid="bootstrap-result">
-          <p style={{ margin: '0 0 8px', fontSize: 12 }}>
-            <strong>Status:</strong> {result.status}
-          </p>
-          {result.registrationPrUrl && (
-            <p style={{ margin: '0 0 8px', fontSize: 12 }}>
-              <strong>PR:</strong>{' '}
-              <a
-                data-testid="bootstrap-pr-link"
-                href={result.registrationPrUrl}
-                target="_blank"
-                rel="noreferrer"
-                style={{ color: 'var(--accent, #6366f1)' }}
-              >
-                {result.registrationPrUrl}
-              </a>
-            </p>
-          )}
-          {result.labelCounts && (
-            <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--fg-2)' }}>
-              Labels — created {result.labelCounts.created}, updated {result.labelCounts.updated},
-              skipped {result.labelCounts.skipped}.
-            </p>
-          )}
-        </div>
-      )}
-    </div>
   );
 }
 
@@ -677,31 +562,11 @@ function WizardFooter({
   onNext: () => void;
   onClose: () => void;
 }) {
-  const isFirst = step === 'repo';
+  const isFirst = step === 'source';
   const isFinal = step === 'submit';
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        marginTop: 24,
-        paddingTop: 12,
-        borderTop: '1px solid var(--line)',
-      }}
-    >
-      <button
-        type="button"
-        onClick={onClose}
-        style={{
-          padding: '5px 14px',
-          borderRadius: 6,
-          border: '1px solid var(--line)',
-          background: 'var(--bg)',
-          color: 'var(--fg-2)',
-          fontSize: 13,
-          cursor: 'pointer',
-        }}
-      >
+    <div style={footerStyle}>
+      <button type="button" onClick={onClose} style={secondaryButtonStyle}>
         {hasResult ? 'Close' : 'Cancel'}
       </button>
       <div style={{ display: 'flex', gap: 8 }}>
@@ -711,15 +576,7 @@ function WizardFooter({
             data-testid="wizard-prev"
             onClick={onPrev}
             disabled={loading}
-            style={{
-              padding: '5px 14px',
-              borderRadius: 6,
-              border: '1px solid var(--line)',
-              background: 'var(--bg)',
-              color: 'var(--fg-2)',
-              fontSize: 13,
-              cursor: loading ? 'not-allowed' : 'pointer',
-            }}
+            style={secondaryButtonStyle}
           >
             Back
           </button>
@@ -730,21 +587,133 @@ function WizardFooter({
             data-testid="wizard-next"
             onClick={onNext}
             disabled={!canAdvance || loading}
-            style={{
-              padding: '5px 14px',
-              borderRadius: 6,
-              border: 'none',
-              background: 'var(--accent, #6366f1)',
-              color: '#fff',
-              fontSize: 13,
-              cursor: !canAdvance || loading ? 'not-allowed' : 'pointer',
-              opacity: !canAdvance || loading ? 0.7 : 1,
-            }}
+            style={primaryButtonStyle}
           >
-            {loading ? 'Loading…' : 'Next'}
+            {loading ? 'Loading...' : 'Next'}
           </button>
         )}
       </div>
     </div>
   );
 }
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 50,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,0,0,0.45)',
+};
+
+const dialogStyle: CSSProperties = {
+  background: 'var(--bg-elev)',
+  border: '1px solid var(--line)',
+  borderRadius: 8,
+  padding: 24,
+  width: '100%',
+  maxWidth: 760,
+  maxHeight: '90vh',
+  overflowY: 'auto',
+  color: 'var(--fg)',
+};
+
+const stepListStyle: CSSProperties = {
+  display: 'flex',
+  gap: 4,
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  fontSize: 11,
+  color: 'var(--fg-2)',
+  flexWrap: 'wrap',
+};
+
+const textInputStyle: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  boxSizing: 'border-box',
+  padding: '6px 10px',
+  borderRadius: 6,
+  border: '1px solid var(--line)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  fontFamily: 'monospace',
+  outline: 'none',
+};
+
+const textareaStyle: CSSProperties = {
+  ...textInputStyle,
+  minHeight: 72,
+  resize: 'vertical',
+};
+
+const fieldsetStyle: CSSProperties = {
+  border: '1px solid var(--line)',
+  borderRadius: 6,
+  padding: 10,
+  margin: '0 0 12px',
+};
+
+const legendStyle: CSSProperties = {
+  padding: '0 4px',
+  fontSize: 12,
+  color: 'var(--fg-2)',
+};
+
+const radioLabelStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  margin: '6px 0',
+  fontSize: 13,
+};
+
+const sectionGridStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: 10,
+  marginTop: 12,
+};
+
+const headingStyle: CSSProperties = {
+  margin: '0 0 8px',
+  fontSize: 13,
+  fontWeight: 600,
+};
+
+const metaTextStyle: CSSProperties = {
+  margin: '0 0 4px',
+  fontSize: 12,
+  color: 'var(--fg-2)',
+};
+
+const footerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: 24,
+  paddingTop: 12,
+  borderTop: '1px solid var(--line)',
+};
+
+const primaryButtonStyle: CSSProperties = {
+  padding: '5px 14px',
+  borderRadius: 6,
+  border: 'none',
+  background: 'var(--accent, #6366f1)',
+  color: '#fff',
+  fontSize: 13,
+  cursor: 'pointer',
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  padding: '5px 14px',
+  borderRadius: 6,
+  border: '1px solid var(--line)',
+  background: 'var(--bg)',
+  color: 'var(--fg-2)',
+  fontSize: 13,
+  cursor: 'pointer',
+};

--- a/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
+++ b/apps/web/src/components/bootstrap/components/BootstrapWizard.tsx
@@ -233,7 +233,10 @@ function buildSource(state: WizardState): ProjectCreationSourceDto {
       };
     case 'advanced': {
       const source: Extract<ProjectCreationSourceDto, { kind: 'advanced' }> = { kind: 'advanced' };
-      if (isValidRepoRefs(state.githubReposText)) {
+      if (state.githubReposText.trim().length > 0 && !isValidRepoRefs(state.githubReposText)) {
+        throw new Error('GitHub repositories must look like "owner/repo"');
+      }
+      if (state.githubReposText.trim().length > 0) {
         source.github = { repoRefs: parseRepoRefs(state.githubReposText) };
       }
       if (state.jiraBaseUrl.trim() && parseList(state.jiraKeysText).length > 0) {

--- a/apps/web/src/components/bootstrap/lib/wizard-state.ts
+++ b/apps/web/src/components/bootstrap/lib/wizard-state.ts
@@ -2,35 +2,22 @@
  * Wizard step state machine for the bootstrap wizard (M12.07).
  *
  * Steps:
- *   1. repo        — enter `owner/repo`, server validates accessibility
- *   2. stack       — show detected stack summary, user reviews
- *   3. claudeMd    — show CLAUDE.md preview/diff (read-only), user confirms
- *   4. labels      — show labels-to-install list, user confirms
- *   5. webhook     — show webhook setup instructions, user confirms
- *   6. submit      — show "Open Registration PR" button + final result
+ *   1. source   — choose local project source and integrations
+ *   2. preview  — show exact generated project.config.ts
+ *   3. submit   — create target-projects/<slug>/project.config.ts locally
  *
  * The state machine is intentionally pure: the wizard component holds the
  * `WizardState` in `useState` and calls `next()` / `prev()` on each step.
  */
 
-export type WizardStep = 'repo' | 'stack' | 'claudeMd' | 'labels' | 'webhook' | 'submit';
+export type WizardStep = 'source' | 'preview' | 'submit';
 
-export const WIZARD_STEPS: ReadonlyArray<WizardStep> = [
-  'repo',
-  'stack',
-  'claudeMd',
-  'labels',
-  'webhook',
-  'submit',
-] as const;
+export const WIZARD_STEPS: ReadonlyArray<WizardStep> = ['source', 'preview', 'submit'] as const;
 
 const STEP_LABELS: Record<WizardStep, string> = {
-  repo: 'Repository',
-  stack: 'Stack',
-  claudeMd: 'CLAUDE.md',
-  labels: 'Labels',
-  webhook: 'Webhook',
-  submit: 'Open PR',
+  source: 'Source',
+  preview: 'Config',
+  submit: 'Create',
 };
 
 export function stepLabel(step: WizardStep): string {

--- a/apps/web/src/components/bootstrap/slice.test.ts
+++ b/apps/web/src/components/bootstrap/slice.test.ts
@@ -18,8 +18,8 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('wizard-state — WIZARD_STEPS', () => {
-  it('lists all 6 steps in order', () => {
-    expect(WIZARD_STEPS).toEqual(['repo', 'stack', 'claudeMd', 'labels', 'webhook', 'submit']);
+  it('lists all 3 steps in order', () => {
+    expect(WIZARD_STEPS).toEqual(['source', 'preview', 'submit']);
   });
 
   it('has a label for every step', () => {
@@ -29,34 +29,28 @@ describe('wizard-state — WIZARD_STEPS', () => {
   });
 
   it('returns a stable index per step', () => {
-    expect(stepIndex('repo')).toBe(0);
+    expect(stepIndex('source')).toBe(0);
     expect(stepIndex('submit')).toBe(WIZARD_STEPS.length - 1);
   });
 });
 
 describe('wizard-state — nextStep / prevStep', () => {
-  it('advances repo → stack → claudeMd → labels → webhook → submit', () => {
-    expect(nextStep('repo')).toBe('stack');
-    expect(nextStep('stack')).toBe('claudeMd');
-    expect(nextStep('claudeMd')).toBe('labels');
-    expect(nextStep('labels')).toBe('webhook');
-    expect(nextStep('webhook')).toBe('submit');
+  it('advances source → preview → submit', () => {
+    expect(nextStep('source')).toBe('preview');
+    expect(nextStep('preview')).toBe('submit');
   });
 
   it('clamps at the final step', () => {
     expect(nextStep('submit')).toBe('submit');
   });
 
-  it('walks back submit → webhook → … → repo', () => {
-    expect(prevStep('submit')).toBe('webhook');
-    expect(prevStep('webhook')).toBe('labels');
-    expect(prevStep('labels')).toBe('claudeMd');
-    expect(prevStep('claudeMd')).toBe('stack');
-    expect(prevStep('stack')).toBe('repo');
+  it('walks back submit → preview → source', () => {
+    expect(prevStep('submit')).toBe('preview');
+    expect(prevStep('preview')).toBe('source');
   });
 
   it('clamps at the first step', () => {
-    expect(prevStep('repo')).toBe('repo');
+    expect(prevStep('source')).toBe('source');
   });
 });
 

--- a/apps/web/src/lib/api/bootstrap.ts
+++ b/apps/web/src/lib/api/bootstrap.ts
@@ -1,6 +1,9 @@
 import type {
   BootstrapPreviewDto,
   BootstrapRunDto,
+  LocalProjectCreationPreviewDto,
+  LocalProjectCreationRequestDto,
+  LocalProjectCreationRunDto,
   ProjectConfigDto,
   ProjectSummary,
 } from '../types.js';
@@ -54,4 +57,34 @@ export async function runBootstrap(
     throw new Error(`POST /projects/bootstrap/run failed: ${res.status} ${text}`);
   }
   return (await res.json()) as BootstrapRunDto;
+}
+
+export async function previewLocalProjectCreation(
+  input: LocalProjectCreationRequestDto,
+): Promise<LocalProjectCreationPreviewDto> {
+  const res = await fetch('/api/projects/bootstrap/local-project/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST /projects/bootstrap/local-project/preview failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as LocalProjectCreationPreviewDto;
+}
+
+export async function createLocalProject(
+  input: LocalProjectCreationRequestDto,
+): Promise<LocalProjectCreationRunDto> {
+  const res = await fetch('/api/projects/bootstrap/local-project/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST /projects/bootstrap/local-project/create failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as LocalProjectCreationRunDto;
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -599,6 +599,55 @@ export interface BootstrapRunDto {
   labelCounts?: { created: number; updated: number; skipped: number };
 }
 
+export type ProjectCreationSourceDto =
+  | { kind: 'local-only' }
+  | { kind: 'github-code'; repoRefs: string[]; defaultBranch?: string; localPath?: string }
+  | {
+      kind: 'jira';
+      baseUrl: string;
+      projectKeys: string[];
+      importMode: 'manual' | 'assigned-to-me';
+    }
+  | { kind: 'bitbucket'; workspace: string; repos: string[]; defaultBranch?: string }
+  | {
+      kind: 'advanced';
+      github?: { repoRefs: string[]; defaultBranch?: string; localPath?: string };
+      jira?: {
+        baseUrl: string;
+        projectKeys: string[];
+        importMode: 'manual' | 'assigned-to-me';
+      };
+      bitbucket?: { workspace: string; repos: string[]; defaultBranch?: string };
+    };
+
+export interface LocalProjectCreationRequestDto {
+  slug?: string;
+  name?: string;
+  source: ProjectCreationSourceDto;
+}
+
+export interface LocalProjectCreationPreviewDto {
+  slug: string;
+  name: string;
+  configPath: string;
+  config: string;
+  requiredEnvVars: string[];
+  repositories: Array<{
+    id: string;
+    repoRef: string;
+    cloneUrl: string;
+    defaultBranch: string;
+    localPath: string;
+    role?: 'code' | 'docs' | 'infra' | 'unknown';
+  }>;
+  integrations: Array<'github' | 'jira' | 'bitbucket'>;
+}
+
+export interface LocalProjectCreationRunDto extends LocalProjectCreationPreviewDto {
+  status: 'created';
+  writtenPath: string;
+}
+
 export interface ProjectSettingsDto {
   projectId: string;
   configBudgets: Record<string, unknown>;

--- a/core/workflows/bootstrap-renderers.test.ts
+++ b/core/workflows/bootstrap-renderers.test.ts
@@ -43,5 +43,155 @@ describe('renderProjectConfig', () => {
     expect(rendered).toContain('repoRef: "workspace/widgets-web"');
     expect(rendered).toContain('repos: ["workspace/widgets-api","workspace/widgets-web"]');
     expect(rendered).toContain('targetRepo: {');
+    expect(rendered).toContain('mirrorLabels: false');
+    expect(rendered).toContain('importIssues: false');
+  });
+
+  it('renders local-only projects with no integrations', () => {
+    const rendered = renderProjectConfig({
+      slug: 'local-ops',
+      name: 'Local Ops',
+      source: { kind: 'local-db', stateMachine: 'db' },
+      repositories: [],
+      targetRepo: { cloneUrl: '', defaultBranch: 'main', localPath: '~/code/local-ops' },
+      detectedAt: '2026-05-28T00:00:00.000Z',
+      stack: { type: 'unknown' },
+      activeMilestone: undefined,
+    });
+
+    expect(rendered).toContain("kind: 'local-db'");
+    expect(rendered).not.toContain('integrations:');
+    expect(rendered).toContain('repositories: []');
+    expect(rendered).toContain('repos: []');
+  });
+
+  it('renders GitHub code repositories with imports off', () => {
+    const rendered = renderProjectConfig({
+      slug: 'widgets',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          github: { repos: ['octo/widgets'], mirrorLabels: false, importIssues: false },
+        },
+      },
+      repositories: [
+        {
+          id: 'octo-widgets',
+          repoRef: 'octo/widgets',
+          cloneUrl: 'git@github.com:octo/widgets.git',
+          defaultBranch: 'main',
+          localPath: '~/code/octo/widgets',
+          role: 'code',
+        },
+      ],
+      targetRepo: {
+        cloneUrl: 'git@github.com:octo/widgets.git',
+        defaultBranch: 'main',
+        localPath: '~/code/octo/widgets',
+      },
+      detectedAt: '2026-05-28T00:00:00.000Z',
+      stack: { type: 'unknown' },
+      activeMilestone: undefined,
+    });
+
+    expect(rendered).toContain('github: {');
+    expect(rendered).toContain('repos: ["octo/widgets"]');
+    expect(rendered).toContain('mirrorLabels: false');
+    expect(rendered).toContain('importIssues: false');
+  });
+
+  it('renders Jira manual import config', () => {
+    const rendered = renderProjectConfig({
+      slug: 'jira-manual',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          jira: {
+            enabled: true,
+            baseUrl: 'https://example.atlassian.net',
+            projectKeys: ['ENG'],
+            importMode: 'manual',
+          },
+        },
+      },
+      repositories: [],
+      targetRepo: { cloneUrl: '', defaultBranch: 'main', localPath: '~/code/jira-manual' },
+      detectedAt: '2026-05-28T00:00:00.000Z',
+      stack: { type: 'unknown' },
+      activeMilestone: undefined,
+    });
+
+    expect(rendered).toContain('jira: {');
+    expect(rendered).toContain('baseUrl: "https://example.atlassian.net"');
+    expect(rendered).toContain('projectKeys: ["ENG"]');
+    expect(rendered).toContain('importMode: "manual"');
+  });
+
+  it('renders Jira assigned-to-me config', () => {
+    const rendered = renderProjectConfig({
+      slug: 'jira-mine',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          jira: {
+            enabled: true,
+            baseUrl: 'https://example.atlassian.net',
+            projectKeys: ['ENG'],
+            importMode: 'assigned-to-me',
+          },
+        },
+      },
+      repositories: [],
+      targetRepo: { cloneUrl: '', defaultBranch: 'main', localPath: '~/code/jira-mine' },
+      detectedAt: '2026-05-28T00:00:00.000Z',
+      stack: { type: 'unknown' },
+      activeMilestone: undefined,
+    });
+
+    expect(rendered).toContain('importMode: "assigned-to-me"');
+  });
+
+  it('renders Bitbucket PR integration config', () => {
+    const rendered = renderProjectConfig({
+      slug: 'bb-prs',
+      source: {
+        kind: 'local-db',
+        stateMachine: 'db',
+        integrations: {
+          bitbucket: {
+            enabled: true,
+            workspace: 'acme',
+            repos: ['api'],
+            postBack: { pullRequests: true, comments: true },
+          },
+        },
+      },
+      repositories: [
+        {
+          id: 'acme-api',
+          repoRef: 'acme/api',
+          cloneUrl: 'git@bitbucket.org:acme/api.git',
+          defaultBranch: 'main',
+          localPath: '~/code/acme/api',
+          role: 'code',
+        },
+      ],
+      targetRepo: {
+        cloneUrl: 'git@bitbucket.org:acme/api.git',
+        defaultBranch: 'main',
+        localPath: '~/code/acme/api',
+      },
+      detectedAt: '2026-05-28T00:00:00.000Z',
+      stack: { type: 'unknown' },
+      activeMilestone: undefined,
+    });
+
+    expect(rendered).toContain('bitbucket: {');
+    expect(rendered).toContain('workspace: "acme"');
+    expect(rendered).toContain('repos: ["api"]');
+    expect(rendered).toContain('postBack: { pullRequests: true, comments: true }');
   });
 });

--- a/core/workflows/bootstrap-renderers.test.ts
+++ b/core/workflows/bootstrap-renderers.test.ts
@@ -43,8 +43,8 @@ describe('renderProjectConfig', () => {
     expect(rendered).toContain('repoRef: "workspace/widgets-web"');
     expect(rendered).toContain('repos: ["workspace/widgets-api","workspace/widgets-web"]');
     expect(rendered).toContain('targetRepo: {');
-    expect(rendered).toContain('mirrorLabels: false');
-    expect(rendered).toContain('importIssues: false');
+    expect(rendered).toContain('mirrorLabels: true');
+    expect(rendered).toContain('importIssues: true');
   });
 
   it('renders local-only projects with no integrations', () => {

--- a/core/workflows/bootstrap-renderers.ts
+++ b/core/workflows/bootstrap-renderers.ts
@@ -8,6 +8,7 @@ import * as nodePath from 'node:path';
 import type { AuditResult } from '../bootstrap/claude-md-auditor.js';
 import type { InstallResult } from '../bootstrap/label-installer.js';
 import type { StackInfo } from '../bootstrap/stack-detector.js';
+import type { LocalDbSourceConfig, ProjectRepositoryConfig, TargetRepoConfig } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // PrBodyInput
@@ -28,6 +29,30 @@ export interface BootstrapRepoRenderInput {
   defaultBranch: string;
   description: string;
   cloneUrl?: string;
+  localPath?: string;
+  role?: ProjectRepositoryConfig['role'];
+}
+
+export interface ProviderNeutralProjectConfigInput {
+  slug: string;
+  name?: string;
+  source: LocalDbSourceConfig;
+  repositories?: ProjectRepositoryConfig[];
+  targetRepo: TargetRepoConfig;
+  stack: StackInfo;
+  detectedAt: string;
+  activeMilestone?: undefined;
+}
+
+export interface GithubBootstrapProjectConfigInput {
+  slug: string;
+  name?: string;
+  repoRef: string;
+  repos?: BootstrapRepoRenderInput[];
+  defaultBranch: string;
+  cloneRoot: string;
+  stack: StackInfo;
+  detectedAt: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,16 +91,11 @@ export function summariseStack(stack: StackInfo): string {
  * detected stack baked in. Budgets/personas are intentionally minimal — the
  * human is expected to edit before merging the bootstrap PR.
  */
-export function renderProjectConfig(input: {
-  slug: string;
-  name?: string;
-  repoRef: string;
-  repos?: BootstrapRepoRenderInput[];
-  defaultBranch: string;
-  cloneRoot: string;
-  stack: StackInfo;
-  detectedAt: string;
-}): string {
+export function renderProjectConfig(
+  input: GithubBootstrapProjectConfigInput | ProviderNeutralProjectConfigInput,
+): string {
+  if ('source' in input) return renderProviderNeutralProjectConfig(input);
+
   const { slug, repoRef, defaultBranch, cloneRoot, stack, detectedAt } = input;
   const name = input.name ?? slug;
   const repos = input.repos ?? [{ repoRef, defaultBranch, description: '' }];
@@ -98,8 +118,8 @@ const config: ProjectConfig = {
     integrations: {
       github: {
         repos: ${JSON.stringify(repoRefs)},
-        mirrorLabels: true,
-        importIssues: true,
+        mirrorLabels: false,
+        importIssues: false,
       },
     },
   },
@@ -174,14 +194,161 @@ export default config;
 `;
 }
 
+function renderProviderNeutralProjectConfig(input: ProviderNeutralProjectConfigInput): string {
+  const { slug, source, stack, detectedAt } = input;
+  const name = input.name ?? slug;
+  const repositories = input.repositories ?? [];
+  const repoRefs = repositories.map((repo) => repo.repoRef);
+  const stackBlock = renderStackBlock(stack, detectedAt);
+  const sourceBlock = renderLocalDbSourceBlock(source);
+  const targetRepoBlock = renderTargetRepoBlock(input.targetRepo);
+  const repositoriesBlock = renderProjectRepositoriesBlock(repositories);
+
+  return `import type { ProjectConfig } from '../../core/types.js';
+
+const config: ProjectConfig = {
+  id: ${JSON.stringify(slug)},
+  name: ${JSON.stringify(name)},
+  slug: ${JSON.stringify(slug)},
+  source: ${sourceBlock},
+  targetRepo: ${targetRepoBlock},
+  repositories: ${repositoriesBlock},
+  stack: ${stackBlock},
+  mode: 'supervised',
+  storage: { kind: 'local', path: ${JSON.stringify(`~/.factory/data/${slug}`)} },
+  repos: ${JSON.stringify(repoRefs)},
+  agentConfig: {
+    runtime: 'claude-cli',
+    rolesModels: {
+      triager: { primary: 'haiku', fallback: 'haiku', advisor: null },
+      griller: { primary: 'sonnet', fallback: 'haiku', advisor: null },
+      'prd-writer': { primary: 'sonnet', fallback: 'haiku', advisor: null },
+      decomposer: { primary: 'sonnet', fallback: 'haiku', advisor: null },
+      investigator: { primary: 'sonnet', fallback: 'haiku', advisor: null },
+      developer: { primary: 'haiku', fallback: 'sonnet', advisor: null },
+      qa: { primary: 'sonnet', fallback: null, advisor: null },
+      reviewer: { primary: 'sonnet', fallback: null, advisor: null },
+      retrospector: { primary: 'sonnet', fallback: 'haiku', advisor: null },
+      researcher: { primary: 'sonnet', fallback: 'haiku', advisor: null },
+    },
+    fallbackPolicy: {
+      critical: 'same-tier-only',
+      high: 'same-tier-only',
+      medium: 'allow-down-tier',
+      low: 'allow-down-tier',
+    },
+    advisorMode: {
+      enabled: false,
+      triggerOn: { priorities: [] },
+      maxAdvisorBudgetUsd: 0,
+      disableInAutonomous: true,
+    },
+    retrospectivePolicy: {
+      defaultTier: 'light',
+      deepTriggers: [],
+    },
+  },
+  budgets: {
+    dailyTokens: 0,
+    maxParallelAgents: 0,
+    maxRetries: 0,
+    perBashCommandMaxSeconds: 0,
+    perWorkflowMaxUsd: 0,
+    perAgentMaxUsd: 0,
+    perAdvisorMaxUsd: 0,
+  },
+  governance: {
+    immutablePaths: [
+      'MISSION.md',
+      'FACTORY_RULES.md',
+      'CLAUDE.md',
+      'target-projects/**/MISSION.md',
+      'target-projects/**/FACTORY_RULES.md',
+      'target-projects/**/project.config.ts',
+      'target-projects/**/personas/**',
+    ],
+  },
+  isolation: { mode: 'native' },
+  archiveAfterDays: 7,
+  visibility: 'always_visible',
+  colorStripe: '#6366f1',
+};
+
+export default config;
+`;
+}
+
+function renderTargetRepoBlock(targetRepo: TargetRepoConfig): string {
+  return `{
+    cloneUrl: ${JSON.stringify(targetRepo.cloneUrl)},
+    defaultBranch: ${JSON.stringify(targetRepo.defaultBranch)},
+    localPath: ${JSON.stringify(targetRepo.localPath)},
+  }`;
+}
+
+function renderProjectRepositoriesBlock(repositories: ProjectRepositoryConfig[]): string {
+  if (repositories.length === 0) return '[]';
+  return JSON.stringify(repositories, null, 4)
+    .replace(/"([^"]+)":/g, '$1:')
+    .replace(/"unknown"/g, "'unknown'")
+    .replace(/"code"/g, "'code'")
+    .replace(/"docs"/g, "'docs'")
+    .replace(/"infra"/g, "'infra'");
+}
+
+function renderLocalDbSourceBlock(source: LocalDbSourceConfig): string {
+  const integrations = source.integrations;
+  const lines = [`    kind: 'local-db',`, `    stateMachine: 'db',`];
+  const integrationLines: string[] = [];
+
+  if (integrations?.github != null) {
+    integrationLines.push(
+      '      github: {',
+      `        repos: ${JSON.stringify(integrations.github.repos)},`,
+      `        mirrorLabels: ${integrations.github.mirrorLabels === true ? 'true' : 'false'},`,
+      `        importIssues: ${integrations.github.importIssues === true ? 'true' : 'false'},`,
+      '      },',
+    );
+  }
+
+  if (integrations?.jira != null) {
+    integrationLines.push(
+      '      jira: {',
+      `        enabled: ${integrations.jira.enabled ? 'true' : 'false'},`,
+      `        baseUrl: ${JSON.stringify(integrations.jira.baseUrl)},`,
+      `        projectKeys: ${JSON.stringify(integrations.jira.projectKeys)},`,
+      `        importMode: ${JSON.stringify(integrations.jira.importMode)},`,
+      `        postBack: { comments: ${integrations.jira.postBack?.comments === true ? 'true' : 'false'}, transitions: false },`,
+      '      },',
+    );
+  }
+
+  if (integrations?.bitbucket != null) {
+    integrationLines.push(
+      '      bitbucket: {',
+      `        enabled: ${integrations.bitbucket.enabled ? 'true' : 'false'},`,
+      `        workspace: ${JSON.stringify(integrations.bitbucket.workspace)},`,
+      `        repos: ${JSON.stringify(integrations.bitbucket.repos)},`,
+      `        postBack: { pullRequests: ${integrations.bitbucket.postBack?.pullRequests === true ? 'true' : 'false'}, comments: ${integrations.bitbucket.postBack?.comments === true ? 'true' : 'false'} },`,
+      '      },',
+    );
+  }
+
+  if (integrationLines.length > 0) {
+    lines.push('    integrations: {', ...integrationLines, '    },');
+  }
+
+  return `{\n${lines.join('\n')}\n  }`;
+}
+
 function renderRepositoriesBlock(repos: BootstrapRepoRenderInput[], cloneRoot: string): string {
   const entries = repos.map((repo) => ({
     id: repoId(repo.repoRef),
     repoRef: repo.repoRef,
     cloneUrl: repo.cloneUrl ?? `git@github.com:${repo.repoRef}.git`,
     defaultBranch: repo.defaultBranch,
-    localPath: localRepoPath(cloneRoot, repo.repoRef),
-    role: 'unknown',
+    localPath: repo.localPath ?? localRepoPath(cloneRoot, repo.repoRef),
+    role: repo.role ?? 'unknown',
   }));
   return JSON.stringify(entries, null, 4)
     .replace(/"([^"]+)":/g, '$1:')

--- a/core/workflows/bootstrap-renderers.ts
+++ b/core/workflows/bootstrap-renderers.ts
@@ -118,8 +118,8 @@ const config: ProjectConfig = {
     integrations: {
       github: {
         repos: ${JSON.stringify(repoRefs)},
-        mirrorLabels: false,
-        importIssues: false,
+        mirrorLabels: true,
+        importIssues: true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- add provider-neutral local-db project config rendering with GitHub imports and label mirroring defaulting off
- add local project preview/create endpoints that render and write target-projects/<slug>/project.config.ts without GitHub inspection or provider imports
- rework the Settings Add project wizard around local-only, GitHub code, Jira, Bitbucket, and advanced source modes with exact config preview and env var display

## Verification
- pnpm test core/workflows/bootstrap-renderers.test.ts apps/server/src/domains/bootstrap/service.test.ts apps/server/src/domains/bootstrap/router.test.ts apps/web/src/components/bootstrap/slice.test.ts apps/web/src/components/bootstrap/components/BootstrapWizard.test.tsx
- pnpm typecheck
- local Playwright smoke against http://localhost:5173/settings for Jira config preview