### PR TITLE
M19.XX: remove text in sidebar

### DIFF
--- a/apps/web/src/components/chrome/Sidebar.tsx
+++ b/apps/web/src/components/chrome/Sidebar.tsx
@@ -192,12 +192,9 @@ export function Sidebar({ activeSlug }: SidebarProps) {
       <div
         className={cn(
           'border-t border-line',
-          collapsed ? 'flex justify-center py-2' : 'flex items-center px-3 py-2',
+          collapsed ? 'flex justify-center py-2' : 'flex justify-end px-3 py-2',
         )}
       >
-        {!collapsed && (
-          <span className="text-[11px] text-fg-2 flex-1 whitespace-nowrap">Local-first</span>
-        )}
         <button
           type="button"
           onClick={toggle}

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -25,6 +25,11 @@ describe('chrome slice — sidebar brand label', () => {
     const labelMatch = sidebarSource.match(/<span[^>]*text-\[14px\][^>]*>[\s\S]*?<\/span>/);
     expect(labelMatch?.[0]).not.toContain('Agentic OS');
   });
+
+  it('sidebar footer omits the removed Local-first copy and keeps toggle titles', () => {
+    expect(sidebarSource).not.toContain('Local-first');
+    expect(sidebarSource).toContain("collapsed ? 'Expand sidebar' : 'Collapse sidebar'");
+  });
 });
 
 describe('chrome slice — deferred surfaces config', () => {


### PR DESCRIPTION
## Summary

remove text in sidebar

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chrome/Sidebar.tsx:191`-`apps/web/src/components/chrome/Sidebar.tsx:206` to remove the c

Local Work Item: local:goose-hub-self#2
