### PR TITLE
Make project config authoritative for repo allowlists

### DIFF
--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -82,7 +82,7 @@ vi.mock('../workflows/sprint-review-trigger.js', () => ({
 }));
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { getArtifact, getArtifactSlice } from '@goose-hub/core/agent-artifacts/repository.js';
 import { getEngineeringSpec } from '@goose-hub/core/engineering-specs/repository.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
@@ -2123,7 +2123,7 @@ describe('approveIssue — edge cases', () => {
   });
 });
 
-describe('overrideIssueRepo — body (requires repos.md mock)', () => {
+describe('overrideIssueRepo — body', () => {
   it('returns 404 when source not found after valid slug', async () => {
     vi.mocked(getSourceForSlug).mockResolvedValueOnce(null);
     const result = await overrideIssueRepo('valid-slug', '1', 'owner/repo');
@@ -2132,7 +2132,11 @@ describe('overrideIssueRepo — body (requires repos.md mock)', () => {
   });
 
   it('returns 400 when repo is not in the allowlist', async () => {
-    vi.mocked(readFileSync).mockReturnValueOnce('### [owner/allowed-repo]\n' as never);
+    mockGetProject.mockResolvedValueOnce({
+      id: 'test-proj',
+      source: { kind: 'github', repo: 'owner/allowed-repo', stateMachine: 'labels' },
+      repos: ['owner/allowed-repo'],
+    } as never);
     const result = await overrideIssueRepo('proj', '1', 'owner/not-allowed');
     expect(result).toMatchObject({
       ok: false,
@@ -2142,14 +2146,12 @@ describe('overrideIssueRepo — body (requires repos.md mock)', () => {
   });
 
   it('returns triage null when repo is allowed but no triage event exists', async () => {
-    vi.mocked(readFileSync).mockReturnValueOnce('### [owner/repo]\n' as never);
     vi.mocked(eventStore.replay).mockReturnValueOnce([]);
     const result = await overrideIssueRepo('proj', '1', 'owner/repo');
     expect(result).toMatchObject({ ok: true, data: { triage: null } });
   });
 
   it('returns triage dto when repo is allowed and triage event exists', async () => {
-    vi.mocked(readFileSync).mockReturnValueOnce('### [owner/repo]\n' as never);
     vi.mocked(eventStore.replay).mockReturnValueOnce([
       {
         id: 1,
@@ -2169,6 +2171,7 @@ describe('overrideIssueRepo — body (requires repos.md mock)', () => {
       const triage = result.data.triage as Record<string, unknown>;
       expect(triage.type).toBe('bug');
       expect(triage.overrideRepo).toBe('owner/repo');
+      expect(triage.repositories).toEqual(['owner/repo']);
     }
   });
 });

--- a/apps/server/src/domains/issues/triage.ts
+++ b/apps/server/src/domains/issues/triage.ts
@@ -1,8 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
-import { targetProjectsRoot } from '@goose-hub/target-projects';
+import { listProjectRepoRefs } from '@goose-hub/core/projects/repositories.js';
 import type { Result } from '#shared/middleware.js';
+import { getProject } from '#shared/projects.js';
 import { getSourceForSlug, isValidSlug } from '#shared/source.js';
 import { resolveCanonicalWorkItemForRoute } from '#shared/work-item-resolution.js';
 
@@ -18,6 +17,7 @@ interface TriageDto {
   priority: string;
   candidates: Array<{ repo: string; confidence: number; evidence: string; tier: number }>;
   overrideRepo: string | null;
+  repositories: string[];
 }
 
 /**
@@ -26,13 +26,18 @@ interface TriageDto {
  * payloads from the latest `agent.triage-complete` event; this helper keeps
  * them in sync as the triage schema evolves.
  */
-function buildTriageDto(payload: unknown, overrideRepo: string | null): TriageDto {
+function buildTriageDto(
+  payload: unknown,
+  overrideRepo: string | null,
+  repositories: string[],
+): TriageDto {
   const p = payload as TriageEventPayload;
   return {
     type: p.triage.type,
     priority: p.triage.priority,
     candidates: p.repoMatch.candidates ?? [],
     overrideRepo,
+    repositories,
   };
 }
 
@@ -51,11 +56,13 @@ export async function getIssueTriage(
 
   const overrideEvent = allEvents.filter((e) => e.kind === 'agent.repo-override').at(-1);
   const overridePayload = overrideEvent?.payload as { repo?: string } | undefined;
+  const project = await getProject(slug);
+  const repositories = project == null ? [] : listProjectRepoRefs(project);
 
   return {
     ok: true,
     data: {
-      triage: buildTriageDto(triageEvent.payload, overridePayload?.repo ?? null),
+      triage: buildTriageDto(triageEvent.payload, overridePayload?.repo ?? null, repositories),
     },
   };
 }
@@ -72,12 +79,9 @@ export async function overrideIssueRepo(
     return { ok: false, error: 'project not found', status: 404 };
   }
 
-  const reposMdPath = join(targetProjectsRoot, slug, 'repos.md');
-  const reposMd = readFileSync(reposMdPath, 'utf8');
-  const allowedRepos =
-    reposMd
-      .match(/^###\s+\[([^\]]+)\]/gm)
-      ?.map((m) => m.replace(/^###\s+\[/, '').replace(/\]$/, '')) ?? [];
+  const project = await getProject(slug);
+  if (project == null) return { ok: false, error: 'project not found', status: 404 };
+  const allowedRepos = listProjectRepoRefs(project);
 
   if (!allowedRepos.includes(repo)) {
     return { ok: false, error: `repo '${repo}' not in allowlist`, status: 400 };
@@ -97,7 +101,7 @@ export async function overrideIssueRepo(
   return {
     ok: true,
     data: {
-      triage: buildTriageDto(triageEvent.payload, repo),
+      triage: buildTriageDto(triageEvent.payload, repo, allowedRepos),
     },
   };
 }

--- a/apps/server/src/domains/workflows/triage-batch.test.ts
+++ b/apps/server/src/domains/workflows/triage-batch.test.ts
@@ -201,6 +201,34 @@ describe('runTriageBatch', () => {
   });
 
   it('passes repos context to repo-match skill', async () => {
+    const { getProject } = await import('#shared/projects.js');
+    vi.mocked(getProject).mockResolvedValue({
+      id: 'goose-hub-self',
+      slug: 'goose-hub-self',
+      name: 'Goose Hub',
+      source: { kind: 'github', repo: 'shaunnez/goose-hub', stateMachine: 'labels' },
+      targetRepo: {
+        cloneUrl: 'https://github.com/shaunnez/goose-hub.git',
+        defaultBranch: 'main',
+        localPath: '../goose-hub',
+      },
+      repositories: [
+        {
+          id: 'goose-hub',
+          repoRef: 'shaunnez/goose-hub',
+          cloneUrl: 'https://github.com/shaunnez/goose-hub.git',
+          defaultBranch: 'main',
+          localPath: '../goose-hub',
+          role: 'code',
+        },
+      ],
+      activeMilestone: null,
+      colorStripe: '#000',
+      budgets: { perWorkflowMaxUsd: 1, dailyTokens: 500_000, perAdvisorMaxUsd: 0.5 },
+      agentConfig: { runtime: 'auto' },
+      mode: 'supervised',
+    } as never);
+
     const item = makeWorkItem();
     const source = makeMockSource([item]);
 
@@ -225,6 +253,12 @@ describe('runTriageBatch', () => {
     };
     expect(repoMatchCall.context).toHaveProperty('repos');
     expect(repoMatchCall.contextAllowlist).toContain('repos');
+    expect(repoMatchCall.context.repos).toContain(
+      '### [shaunnez/goose-hub](https://github.com/shaunnez/goose-hub)',
+    );
+    expect(repoMatchCall.context.repos).toContain(
+      '**Description:** shaunnez/goose-hub managed by Factory.',
+    );
   });
 
   it('applies type and priority labels', async () => {

--- a/apps/server/src/domains/workflows/triage-batch.ts
+++ b/apps/server/src/domains/workflows/triage-batch.ts
@@ -11,6 +11,7 @@ import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-tra
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { logger } from '@goose-hub/core/logger.js';
 import { accumulatePersonaStats } from '@goose-hub/core/persona/accumulate.js';
+import { buildRepoRegistryContext } from '@goose-hub/core/projects/repo-registry-context.js';
 import type { StateSource, WorkItemType } from '@goose-hub/core/state-source/interface.js';
 import { targetStateForTriage } from '@goose-hub/core/workflows/triage-routing.js';
 import { type VaguenessScore, scoreVagueness } from '@goose-hub/core/workflows/vagueness-gate.js';
@@ -46,7 +47,7 @@ function typeFromLabels(labels: readonly string[]): WorkItemType | null {
   return null;
 }
 
-function readReposContext(slug: string): string {
+function readReposMd(slug: string): string {
   if (!isValidSlug(slug)) {
     // Defence-in-depth (#201). Caller's getSourceForSlug already filtered
     // unknowns, but never touch the filesystem with a slug containing path
@@ -125,7 +126,8 @@ export async function runTriageBatch(slug: string, source?: StateSource): Promis
     }
   }
 
-  const reposContext = readReposContext(slug);
+  const reposContext =
+    projectConfig != null ? buildRepoRegistryContext(projectConfig, readReposMd(slug)) : '';
   const triagePrompt = readPromptWithContext('triage', slug);
   const repoMatchPrompt = readPromptWithContext('repo-match', slug);
   const triageJsonSchema = toJsonSchema(TriageOutputSchema);

--- a/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.test.tsx
@@ -25,6 +25,7 @@ const TRIAGE_DATA: TriageResultDto = {
     },
   ],
   overrideRepo: null,
+  repositories: ['shaunnez/goose-hub', 'shaunnez/target-projects'],
 };
 
 function renderSection(slug = 'proj', id = '42') {

--- a/apps/web/src/components/detail/components/TriageResultsSection.tsx
+++ b/apps/web/src/components/detail/components/TriageResultsSection.tsx
@@ -10,9 +10,6 @@ interface TriageResultsSectionProps {
   id: string;
 }
 
-// Static allowlist — mirrors target-projects/goose-hub-self/repos.md
-const ALLOWLISTED_REPOS = ['shaunnez/goose-hub'];
-
 function ScoreBar({ value }: { value: number }) {
   const pct = Math.max(0, Math.min(100, value));
   const color = pct >= 70 ? 'var(--accent)' : pct >= 40 ? 'oklch(0.74 0.15 200)' : 'var(--fg-4)';
@@ -86,6 +83,7 @@ export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionPr
 
   const triage: TriageResultDto = data;
   const pickedRepo = triage.overrideRepo ?? triage.candidates[0]?.repo;
+  const overrideRepos = triage.repositories ?? [];
 
   const priorityColor = PRIORITY_COLOR[triage.priority];
   const priorityBg = PRIORITY_BG[triage.priority];
@@ -199,7 +197,7 @@ export function TriageResultsSection({ projectSlug, id }: TriageResultsSectionPr
               className="text-[12px] bg-bg-elev border border-line rounded-md px-2 py-1.5 text-fg-2 focus:outline-none focus:border-accent"
             >
               <option value="">Select repo to override…</option>
-              {ALLOWLISTED_REPOS.map((r) => (
+              {overrideRepos.map((r) => (
                 <option key={r} value={r}>
                   {r}
                 </option>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -301,6 +301,7 @@ export interface TriageResultDto {
   priority: string;
   candidates: TriageRepoCandidate[];
   overrideRepo: string | null;
+  repositories: string[];
 }
 
 export interface InboxItemDto {

--- a/core/projects/repo-registry-context.test.ts
+++ b/core/projects/repo-registry-context.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectConfig } from '../types.js';
+import { buildRepoRegistryContext, parseRepoDescriptions } from './repo-registry-context.js';
+
+function project(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    id: 'widgets',
+    name: 'Widgets',
+    slug: 'widgets',
+    source: { kind: 'local-db', stateMachine: 'db' },
+    targetRepo: {
+      cloneUrl: 'https://github.com/acme/widgets.git',
+      defaultBranch: 'main',
+      localPath: '../widgets',
+    },
+    repositories: [
+      {
+        id: 'widgets',
+        repoRef: 'acme/widgets',
+        cloneUrl: 'https://github.com/acme/widgets.git',
+        defaultBranch: 'trunk',
+        localPath: '../widgets',
+        role: 'code',
+      },
+      {
+        id: 'docs',
+        repoRef: 'acme/docs',
+        cloneUrl: 'https://github.com/acme/docs.git',
+        defaultBranch: 'main',
+        localPath: '../docs',
+        role: 'docs',
+      },
+    ],
+    stack: {
+      runtime: 'node',
+      packageManager: 'pnpm',
+      testCommand: 'pnpm test',
+      detectedAt: '2026-01-01T00:00:00.000Z',
+    },
+    mode: 'supervised',
+    storage: { kind: 'local', path: '.factory/widgets.db' },
+    repos: ['acme/widgets', 'acme/docs'],
+    agentConfig: { runtime: 'auto' },
+    budgets: { perWorkflowMaxUsd: 1, dailyTokens: 1000, perAdvisorMaxUsd: 0.5 },
+    governance: { owner: 'team', escalation: 'ask' },
+    isolation: { mode: 'worktree' },
+    archiveAfterDays: 30,
+    visibility: 'always_visible',
+    ...overrides,
+  } as ProjectConfig;
+}
+
+describe('parseRepoDescriptions', () => {
+  it('extracts descriptions keyed by repo ref', () => {
+    const descriptions = parseRepoDescriptions(
+      '### [acme/widgets](https://github.com/acme/widgets)\n**Description:** Widget app.\n',
+    );
+
+    expect(descriptions.get('acme/widgets')).toBe('Widget app.');
+  });
+});
+
+describe('buildRepoRegistryContext', () => {
+  it('uses project.config.ts repositories as the allowlist authority', () => {
+    const context = buildRepoRegistryContext(project());
+
+    expect(context).toContain('### [acme/widgets](https://github.com/acme/widgets)');
+    expect(context).toContain('**Default branch:** `trunk`');
+    expect(context).toContain('**Description:** acme/docs managed by Factory.');
+  });
+
+  it('uses repos.md only to enrich descriptions', () => {
+    const context = buildRepoRegistryContext(
+      project(),
+      '### [acme/widgets](https://github.com/acme/widgets)\n**Description:** Widget app.\n',
+    );
+
+    expect(context).toContain('**Description:** Widget app.');
+    expect(context).toContain('**Description:** acme/docs managed by Factory.');
+  });
+});

--- a/core/projects/repo-registry-context.ts
+++ b/core/projects/repo-registry-context.ts
@@ -1,0 +1,41 @@
+import type { ProjectConfig } from '../types.js';
+import { listProjectRepositories } from './repositories.js';
+
+const DESCRIPTION_PREFIX = '**Description:**';
+
+export function parseRepoDescriptions(markdown: string): Map<string, string> {
+  const descriptions = new Map<string, string>();
+  let currentRepoRef: string | null = null;
+
+  for (const line of markdown.split('\n')) {
+    const heading = line.match(/^###\s+\[([^\]]+)\]/);
+    if (heading) {
+      currentRepoRef = heading[1].trim();
+      continue;
+    }
+
+    if (currentRepoRef != null && line.startsWith(DESCRIPTION_PREFIX)) {
+      const description = line.slice(DESCRIPTION_PREFIX.length).trim();
+      if (description.length > 0) descriptions.set(currentRepoRef, description);
+      currentRepoRef = null;
+    }
+  }
+
+  return descriptions;
+}
+
+export function buildRepoRegistryContext(project: ProjectConfig, reposMd = ''): string {
+  const descriptions = parseRepoDescriptions(reposMd);
+  const repositories = listProjectRepositories(project);
+
+  return repositories
+    .map((repo) => {
+      const description = descriptions.get(repo.repoRef) ?? `${repo.repoRef} managed by Factory.`;
+      return [
+        `### [${repo.repoRef}](https://github.com/${repo.repoRef})`,
+        `**Default branch:** \`${repo.defaultBranch}\``,
+        `**Description:** ${description}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+}

--- a/skills/repo-match/README.md
+++ b/skills/repo-match/README.md
@@ -34,7 +34,8 @@ Matches a work item to the most likely target repository using a three-tier thre
 
 ## Allowlist config
 
-Repo allowlist lives in `target-projects/<project-slug>/repos.md`. Format:
+Repo allowlist lives in `target-projects/<project-slug>/project.config.ts`.
+`repos.md` is optional human/LLM context and may provide descriptions using this format:
 
 ```markdown
 ### [owner/slug](url)


### PR DESCRIPTION
## Summary
- add a shared config-backed repo registry context builder that uses repos.md only for optional descriptions
- update triage-batch repo-match context and repo override validation to use ProjectConfig repository helpers
- expose triage repository refs to the detail UI and remove the hardcoded override allowlist
- update repo-match docs/tests for the new authority model

## Verification
- pnpm test core/projects/repo-registry-context.test.ts apps/server/src/domains/workflows/triage-batch.test.ts apps/server/src/domains/issues/service.test.ts skills/repo-match/slice.test.ts apps/web/src/components/detail/components/TriageResultsSection.test.tsx
- pnpm test core/projects/repo-registry-context.test.ts apps/server/src/domains/workflows/triage-batch.test.ts apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/components/TriageResultsSection.test.tsx
- pnpm typecheck
- pnpm exec biome check core/projects/repo-registry-context.ts core/projects/repo-registry-context.test.ts apps/server/src/domains/workflows/triage-batch.ts apps/server/src/domains/workflows/triage-batch.test.ts apps/server/src/domains/issues/triage.ts apps/server/src/domains/issues/service.test.ts apps/web/src/components/detail/components/TriageResultsSection.tsx apps/web/src/components/detail/components/TriageResultsSection.test.tsx apps/web/src/lib/types.ts skills/repo-match/README.md

## Notes
- pnpm --filter @goose-hub/web build currently fails on unrelated pre-existing web type errors in InvestigationAccordionSection.tsx, TaskHeader.test.tsx, and timeline files; no failures reference this change.