### PR TITLE
M7.XX: Capture button should work with hotkey 2

### DIFF
--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TopBar } from './TopBar';
+
+vi.mock('@/components/search/components/SearchModal', () => ({
+  SearchModal: ({ open }: { open: boolean }) => (open ? <div data-testid="search-modal" /> : null),
+}));
+
+vi.mock('@/components/ui/CaptureModal', () => ({
+  CaptureModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="capture-modal" /> : null,
+}));
+
+vi.mock('./ChangelogModal', () => ({
+  ChangelogModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="changelog-modal" /> : null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TopBar', () => {
+  it('shows the capture shortcut label on the header button', () => {
+    render(<TopBar />);
+
+    const button = screen.getByTestId('capture-button');
+    expect(button.getAttribute('title')).toBe('Capture an idea or task (⌘J)');
+    expect(button.textContent).toContain('Capture');
+    expect(button.textContent).toContain('⌘J');
+  });
+
+  it('opens the capture modal when the capture button is clicked', () => {
+    render(<TopBar />);
+
+    const button = screen.getByTestId('capture-button');
+    fireEvent.click(button);
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+
+  it('opens the capture modal on Cmd+J', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+
+  it('opens the capture modal on Ctrl+J', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -8,6 +8,9 @@ interface TopBarProps {
   breadcrumb?: React.ReactNode;
 }
 
+const SEARCH_SHORTCUT = '⌘K';
+const CAPTURE_SHORTCUT = '⌘J';
+
 export function TopBar({ breadcrumb }: TopBarProps) {
   const [showCapture, setShowCapture] = useState(false);
   const [showChangelog, setShowChangelog] = useState(false);
@@ -58,26 +61,26 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task (⌘J)"
+          title={`Capture an idea or task (${CAPTURE_SHORTCUT})`}
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
           <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
-            ⌘J
+            {CAPTURE_SHORTCUT}
           </kbd>
         </button>
         <button
           type="button"
           data-testid="search-button"
           onClick={() => setShowSearch(true)}
-          title="Search work items (⌘K)"
+          title={`Search work items (${SEARCH_SHORTCUT})`}
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Search size={13} />
           <span>Search</span>
           <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
-            ⌘K
+            {SEARCH_SHORTCUT}
           </kbd>
         </button>
       </header>

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -15,9 +15,21 @@ export function TopBar({ breadcrumb }: TopBarProps) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if (!(e.metaKey || e.ctrlKey)) {
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+
+      if (key === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
+        return;
+      }
+
+      if (key === 'j') {
+        e.preventDefault();
+        setShowCapture(true);
       }
     }
     document.addEventListener('keydown', onKey);
@@ -46,11 +58,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

Capture button should work with hotkey 2

## Files
- `apps/web/src/components/chrome/TopBar.tsx` — observed modified change
- `apps/web/src/components/chrome/TopBar.test.tsx` — observed untracked change

## Tests
- `apps/web/src/components/chrome/TopBar.test.tsx` (4 cases)

Local Work Item: local:goose-hub-self#5
