### PR TITLE
Implement local-db repo checkout readiness

### DIFF
--- a/apps/server/src/domains/issues/diff.ts
+++ b/apps/server/src/domains/issues/diff.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { type AgentEvent, eventStore } from '@goose-hub/core/event-stream/store.js';
+import { existingWorktreePath } from '@goose-hub/core/workspaces/worktree.js';
 import type { Result } from '#shared/middleware.js';
 import { isValidSlug } from '#shared/source.js';
 import { resolveCanonicalWorkItemForRoute } from '#shared/work-item-resolution.js';
@@ -78,9 +79,11 @@ export async function getIssueWorktreeDiff(
     };
   }
 
-  const worktreePath = join(homedir(), '.factory', 'workspaces', runId);
+  const worktreePath =
+    existingWorktreePath(runId, repoRef ?? undefined) ??
+    join(homedir(), '.factory', 'workspaces', runId);
   if (!existsSync(worktreePath)) {
-    const prResult = await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
+    const prResult = repoRef == null ? null : await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
     if (prResult != null)
       return { ok: true, data: { diff: prResult.diff, runId: prResult.prRunId } };
     return {
@@ -90,7 +93,7 @@ export async function getIssueWorktreeDiff(
   }
 
   if (!existsSync(join(worktreePath, '.git'))) {
-    const prResult = await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
+    const prResult = repoRef == null ? null : await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
     if (prResult != null)
       return { ok: true, data: { diff: prResult.diff, runId: prResult.prRunId } };
     return {
@@ -118,7 +121,7 @@ export async function getIssueWorktreeDiff(
     if (diff.length > 0) return { ok: true, data: { diff, runId } };
     // Worktree exists but all changes are committed (e.g. PR already opened).
     // Fall through to the GitHub PR diff.
-    const prResult = await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
+    const prResult = repoRef == null ? null : await tryGitHubPrDiff(ascending, repoRef, fetchImpl);
     if (prResult != null)
       return { ok: true, data: { diff: prResult.diff, runId: prResult.prRunId } };
     return {

--- a/apps/server/src/domains/issues/service.test.ts
+++ b/apps/server/src/domains/issues/service.test.ts
@@ -35,6 +35,7 @@ vi.mock('@goose-hub/core/engineering-specs/repository.js', () => ({
 }));
 vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
   cleanupWorktree: vi.fn(),
+  existingWorktreePath: vi.fn().mockReturnValue(null),
 }));
 vi.mock('@goose-hub/core/state-machine/states.js', () => ({
   STATES: [
@@ -1488,7 +1489,7 @@ describe('approveIssue / rejectIssue (#186)', () => {
     const result = await approveIssue('proj', '1', { mergePRImpl });
 
     expect(result).toMatchObject({ ok: true });
-    expect(cleanupWorktree).toHaveBeenCalledWith('dev-run-123');
+    expect(cleanupWorktree).toHaveBeenCalledWith('/wt/dev-run-123');
   });
 
   it('approveIssue runs merge-decision and emits its result for a legacy pipelineRunId', async () => {

--- a/apps/server/src/domains/issues/transitions.ts
+++ b/apps/server/src/domains/issues/transitions.ts
@@ -152,6 +152,13 @@ export async function approveIssue(
   if (typeof prNumber !== 'number') {
     return { ok: false, error: 'pr.opened event missing prNumber', status: 500 };
   }
+  if (repoRef == null) {
+    return {
+      ok: false,
+      error: 'Work Item has no repository assigned for PR approval',
+      status: 400,
+    };
+  }
   const pipelineRunId =
     typeof prPayload.pipelineRunId === 'string' ? prPayload.pipelineRunId : undefined;
 
@@ -312,8 +319,12 @@ export async function approveIssue(
     .reverse()
     .find((e) => e.kind === 'pr.opened');
   if (prOpenedEvent != null) {
-    const { devRunId } = prOpenedEvent.payload as { devRunId?: string };
-    if (typeof devRunId === 'string') cleanupWorktree(devRunId);
+    const { devRunId, worktreePath } = prOpenedEvent.payload as {
+      devRunId?: string;
+      worktreePath?: string;
+    };
+    if (typeof worktreePath === 'string' && worktreePath.length > 0) cleanupWorktree(worktreePath);
+    else if (typeof devRunId === 'string') cleanupWorktree(devRunId, repoRef);
   }
 
   await transitionAndEmitState({

--- a/apps/server/src/domains/issues/triage.ts
+++ b/apps/server/src/domains/issues/triage.ts
@@ -1,5 +1,6 @@
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { listProjectRepoRefs } from '@goose-hub/core/projects/repositories.js';
+import { LocalDbWorkItemRepository } from '@goose-hub/core/state-source/local-db-repository.js';
 import type { Result } from '#shared/middleware.js';
 import { getProject } from '#shared/projects.js';
 import { getSourceForSlug, isValidSlug } from '#shared/source.js';
@@ -91,6 +92,16 @@ export async function overrideIssueRepo(
   if (!resolved.ok) return resolved;
   const { canonicalWorkItemId: workItemId } = resolved.data;
   const projectId = resolved.data.projectId;
+
+  if (resolved.data.isLocalDb) {
+    new LocalDbWorkItemRepository().createRepoLink({
+      projectId,
+      itemId: workItemId,
+      repoRef: repo,
+      role: 'primary',
+      source: 'manual',
+    });
+  }
 
   eventStore.appendEvent({ projectId, workItemId, kind: 'agent.repo-override', payload: { repo } });
 

--- a/apps/server/src/domains/search/service.ts
+++ b/apps/server/src/domains/search/service.ts
@@ -16,7 +16,7 @@ export interface SearchHit {
   type: string;
   priority: string;
   milestoneTitle: string | null;
-  repoRef: string;
+  repoRef: string | null;
   confidence: number;
 }
 

--- a/apps/server/src/shared/work-item-resolution.test.ts
+++ b/apps/server/src/shared/work-item-resolution.test.ts
@@ -25,7 +25,7 @@ import {
 function makeSource(item: WorkItem): StateSource {
   return {
     projectId: 'proj',
-    repoRef: item.repoRef,
+    repoRef: item.repoRef ?? 'local:proj',
     listOpenWork: vi.fn(),
     listClosedWorkByMilestone: vi.fn(),
     listWorkByMilestone: vi.fn(),

--- a/apps/server/src/shared/work-item-resolution.ts
+++ b/apps/server/src/shared/work-item-resolution.ts
@@ -9,7 +9,7 @@ export interface ResolvedCanonicalWorkItemForRoute {
   routeId: string;
   canonicalWorkItemId: string;
   externalId: string;
-  repoRef: string;
+  repoRef: string | null;
   projectId: string;
   isLocalDb: boolean;
 }
@@ -20,7 +20,7 @@ export interface ResolvedWorkItemForRoute {
   routeId: string;
   canonicalWorkItemId: string;
   externalId: string;
-  repoRef: string;
+  repoRef: string | null;
   isLocalDb: boolean;
 }
 

--- a/apps/web/src/components/board/components/IssueCard.tsx
+++ b/apps/web/src/components/board/components/IssueCard.tsx
@@ -10,7 +10,8 @@ import { Ban, Database, GitFork } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 /** Shorten a repo-qualified dep ref to issue-number-only when it's in the same repo. */
-function shortRef(ref: string, repoRef: string): string {
+function shortRef(ref: string, repoRef: string | null): string {
+  if (repoRef == null) return ref;
   const prefix = `${repoRef}#`;
   if (ref.startsWith(prefix)) return `#${ref.split('#').pop()}`;
   // Already short (e.g. "#292" from same-repo shorthand in body)

--- a/apps/web/src/components/detail/components/DependenciesSection.tsx
+++ b/apps/web/src/components/detail/components/DependenciesSection.tsx
@@ -14,7 +14,7 @@ interface DependenciesSectionProps {
 function resolveDepTarget(
   ref: DependencyRef,
   currentSlug: string,
-  currentRepoRef: string,
+  currentRepoRef: string | null,
   projects: ProjectSummary[],
 ): { slug: string; id: string } | 'unregistered' {
   if (ref.repoRef === null || ref.repoRef === currentRepoRef) {

--- a/apps/web/src/components/detail/components/DetailPage.tsx
+++ b/apps/web/src/components/detail/components/DetailPage.tsx
@@ -261,7 +261,7 @@ export function DetailPage({ section = 'overview' }: DetailPageProps) {
           <span className="font-mono text-[12px] text-fg-3 truncate">
             <span className="text-fg-3">{slug}</span>
             <span className="mx-1.5 text-fg-2">/</span>
-            <span className="text-fg-3">{item?.repoRef}</span>
+            <span className="text-fg-3">{item?.repoRef ?? 'unassigned'}</span>
             <span className="mx-1.5 text-fg-2">/</span>
             <span className="text-fg font-semibold">#{item?.externalId}</span>
           </span>

--- a/apps/web/src/components/detail/lib/useHasOpenDep.ts
+++ b/apps/web/src/components/detail/lib/useHasOpenDep.ts
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
 function resolveDepTarget(
   ref: DependencyRef,
   currentSlug: string,
-  currentRepoRef: string,
+  currentRepoRef: string | null,
   projects: ProjectSummary[],
 ): { slug: string; id: string } | 'unregistered' {
   if (ref.repoRef === null || ref.repoRef === currentRepoRef) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -22,7 +22,7 @@ export interface WorkItemDto {
   id: string;
   canonicalWorkItemId: string;
   externalId: string;
-  repoRef: string;
+  repoRef: string | null;
   title: string;
   body: string;
   type: string;

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -32,7 +32,7 @@ export const DEFAULT_EXEC: ExecMode = 'parallel';
 export interface WorkItem {
   id: string; // global: "github:shaunnez/goose-hub#42"
   externalId: string; // "42" or "PROJ-123"
-  repoRef: string; // "shaunnez/goose-hub"
+  repoRef: string | null; // "shaunnez/goose-hub", or null until local-db repo assignment is explicit
   title: string;
   body: string;
   type: WorkItemType;

--- a/core/state-source/local-db.test.ts
+++ b/core/state-source/local-db.test.ts
@@ -45,7 +45,7 @@ describe('LocalDbStateSource', () => {
   }
 
   it('creates, gets, lists, comments, labels, and transitions without GitHub', async () => {
-    const { source } = trackedSource();
+    const { source, repository } = trackedSource();
     const created = await source.createIssue({
       title: 'Local source',
       body: 'Depends on: owner/repo#7\nBlocks: #9',
@@ -57,14 +57,31 @@ describe('LocalDbStateSource', () => {
     expect(created).toMatchObject({
       id: 'local:proj#1',
       externalId: '1',
-      repoRef: 'owner/repo',
+      repoRef: null,
       type: 'bug',
       priority: 'high',
       state: 'factory:triaging',
-      dependsOn: ['7'],
+      dependsOn: ['owner/repo#7'],
       blocks: ['9'],
       externalRefs: [],
     });
+    expect(repository.listRepoLinks('proj', created.id)).toEqual([]);
+    repository.createRepoLink({
+      projectId: 'proj',
+      itemId: created.id,
+      repoRef: 'owner/related',
+      role: 'related',
+      source: 'test',
+    });
+    await expect(source.getItem(created.id)).resolves.toMatchObject({ repoRef: null });
+    repository.createRepoLink({
+      projectId: 'proj',
+      itemId: created.id,
+      repoRef: 'owner/repo',
+      role: 'primary',
+      source: 'test',
+    });
+    await expect(source.getItem(created.id)).resolves.toMatchObject({ repoRef: 'owner/repo' });
     expect((await source.getItem('1')).id).toBe(created.id);
     expect((await source.listOpenWork()).map((item) => item.id)).toEqual([created.id]);
     expect(await source.listLabels(created.id)).toEqual([
@@ -161,6 +178,26 @@ describe('LocalDbStateSource', () => {
         ],
       },
     ]);
+  });
+
+  it('uses explicit primary repo links when present', async () => {
+    const { source, repository } = trackedSource();
+    const created = await source.createIssue({
+      title: 'Repo-assigned work',
+      body: 'Depends on: owner/repo#7',
+    });
+    repository.createRepoLink({
+      projectId: 'proj',
+      itemId: created.id,
+      repoRef: 'owner/repo',
+      role: 'primary',
+      source: 'manual',
+    });
+
+    await expect(source.getItem(created.id)).resolves.toMatchObject({
+      repoRef: 'owner/repo',
+      dependsOn: ['7'],
+    });
   });
 
   it('omits open Work Items whose Jira issue ref is hidden', async () => {

--- a/core/state-source/local-db.ts
+++ b/core/state-source/local-db.ts
@@ -43,7 +43,11 @@ function parseStateLabel(label: string): StateName | null {
   return STATE_LABELS.has(label) ? (label as StateName) : null;
 }
 
-function mapDependencyRefs(body: string, type: 'depends-on' | 'blocks', repoRef: string): string[] {
+function mapDependencyRefs(
+  body: string,
+  type: 'depends-on' | 'blocks',
+  repoRef: string | null,
+): string[] {
   return parseDependencies(body)
     .filter((ref) => ref.type === type)
     .map((ref) =>
@@ -94,8 +98,7 @@ export class LocalDbStateSource implements StateSource {
 
   private toWorkItem(row: LocalDbWorkItemRow): WorkItem {
     const repoLinks = this.repository.listRepoLinks(this.projectId, row.id);
-    const repoRef =
-      (repoLinks.find((link) => link.role === 'primary') ?? repoLinks[0])?.repoRef ?? this.repoRef;
+    const repoRef = repoLinks.find((link) => link.role === 'primary')?.repoRef ?? null;
     return {
       id: row.id,
       externalId: row.externalId,
@@ -268,15 +271,6 @@ export class LocalDbStateSource implements StateSource {
       priority: input.priority,
       milestoneId: input.milestoneId ?? null,
     });
-    if (!this.repoRef.startsWith('local:')) {
-      this.repository.createRepoLink({
-        projectId: this.projectId,
-        itemId: row.id,
-        repoRef: this.repoRef,
-        role: 'primary',
-        source: 'bootstrap',
-      });
-    }
     if (input.extraLabels != null) await this.addLabels(row.id, input.extraLabels);
     return this.toWorkItem(this.repository.requireWorkItem(this.projectId, row.id));
   }

--- a/core/tool-layer/mcp/tools/context.ts
+++ b/core/tool-layer/mcp/tools/context.ts
@@ -137,7 +137,7 @@ export async function getStackCommands(
 export interface GetWorkItemResult {
   id: string;
   externalId: string;
-  repoRef: string;
+  repoRef: string | null;
   title: string;
   body: string;
   type: WorkItem['type'];

--- a/core/types.ts
+++ b/core/types.ts
@@ -55,6 +55,18 @@ export interface ProjectRepositoryConfig extends TargetRepoConfig {
   id: string;
   repoRef: string;
   role?: 'code' | 'docs' | 'infra' | 'unknown';
+  branchStrategy?: BranchStrategyConfig;
+}
+
+export interface BranchPreferenceConfig {
+  repoNamePattern: string;
+  branches: string[];
+}
+
+export interface BranchStrategyConfig {
+  preferredBranches?: BranchPreferenceConfig[];
+  fallbackBranches?: string[];
+  useRemoteHeadFallback?: boolean;
 }
 
 export interface StackConfig {
@@ -235,6 +247,8 @@ export interface ProjectConfig {
   targetRepo: TargetRepoConfig;
   /** Canonical registry of code/doc/infra repositories a Work Item may target. */
   repositories?: ProjectRepositoryConfig[];
+  /** Project-level branch policy used when preparing repository checkouts. */
+  branchStrategy?: BranchStrategyConfig;
   stack: StackConfig;
   mode: 'interactive' | 'supervised' | 'autonomous';
   storage: { kind: 'local'; path: string };

--- a/core/workspaces/checkout-readiness.test.ts
+++ b/core/workspaces/checkout-readiness.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectRepositoryConfig } from '../types.js';
+import {
+  ensureRepositoryCheckout,
+  ensureSelectedRepositoryCheckout,
+  normalizeRepoRemote,
+  repositoryClonePath,
+} from './checkout-readiness.js';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+vi.mock('node:os', () => ({ homedir: vi.fn().mockReturnValue('/mock-home') }));
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, statSync } from 'node:fs';
+
+const repoConfig: ProjectRepositoryConfig = {
+  id: 'repo',
+  repoRef: 'workspace/repo',
+  cloneUrl: 'git@bitbucket.org:workspace/repo.git',
+  defaultBranch: 'main',
+  localPath: '',
+};
+
+describe('checkout readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as never);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args.join(' ') === 'remote get-url origin') {
+        return 'https://bitbucket.org/workspace/repo.git\n';
+      }
+      if (
+        cmd === 'git' &&
+        Array.isArray(args) &&
+        args.join(' ') === 'symbolic-ref --quiet --short refs/remotes/origin/HEAD'
+      ) {
+        return 'origin/main\n';
+      }
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') {
+        return 'true\n';
+      }
+      return '';
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes SSH and HTTPS remotes to the same host/path', () => {
+    expect(normalizeRepoRemote('git@bitbucket.org:Workspace/Repo.git')).toBe(
+      'bitbucket.org/workspace/repo',
+    );
+    expect(normalizeRepoRemote('https://bitbucket.org/workspace/repo.git')).toBe(
+      'bitbucket.org/workspace/repo',
+    );
+  });
+
+  it('clones missing repositories under the canonical project repo root', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(ensureRepositoryCheckout('proj', repoConfig)).toMatchObject({
+      repoRef: 'workspace/repo',
+      clonePath: repositoryClonePath('proj', 'workspace/repo'),
+      baseBranch: 'main',
+      baseRef: 'origin/main',
+    });
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['clone', repoConfig.cloneUrl, '/mock-home/.factory/repos/proj/workspace/repo'],
+      expect.any(Object),
+    );
+    expect(vi.mocked(mkdirSync)).toHaveBeenCalledWith('/mock-home/.factory/repos/proj/workspace', {
+      recursive: true,
+    });
+  });
+
+  it('fails existing non-git paths before workflow start', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse') {
+        throw new Error('not git');
+      }
+      return '';
+    });
+
+    expect(() => ensureRepositoryCheckout('proj', repoConfig)).toThrow(
+      'repository checkout path is not a git repository',
+    );
+  });
+
+  it('fails when the existing clone remote does not match the registered repo', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args.join(' ') === 'remote get-url origin') {
+        return 'https://bitbucket.org/workspace/other.git\n';
+      }
+      return 'true\n';
+    });
+
+    expect(() => ensureRepositoryCheckout('proj', repoConfig)).toThrow(
+      'repository checkout remote mismatch',
+    );
+  });
+
+  it('prepares a selected linked repository with the ensured clone path and base ref', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(
+      ensureSelectedRepositoryCheckout(
+        {
+          id: 'proj',
+          source: { kind: 'local-db', stateMachine: 'db' },
+          repositories: [repoConfig],
+        } as never,
+        {
+          repoRef: 'workspace/repo',
+          localPath: '/fallback',
+          defaultBranch: 'develop',
+          role: 'code',
+          selectedBy: 'repo-link-primary',
+        },
+      ),
+    ).toMatchObject({
+      repoRef: 'workspace/repo',
+      localPath: '/mock-home/.factory/repos/proj/workspace/repo',
+      defaultBranch: 'main',
+      workflowBase: { branch: 'main', ref: 'origin/main' },
+    });
+  });
+});

--- a/core/workspaces/checkout-readiness.ts
+++ b/core/workspaces/checkout-readiness.ts
@@ -1,0 +1,206 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { listProjectRepositories } from '../projects/repositories.js';
+import type { BranchStrategyConfig, ProjectConfig, ProjectRepositoryConfig } from '../types.js';
+import { GIT_ENV } from './git-env.js';
+import type { SelectedWorkItemRepository } from './repo-affinity.js';
+import type { WorkflowBase } from './worktree.js';
+
+const REPOS_DIR = join(homedir(), '.factory', 'repos');
+
+export interface CheckoutReadinessResult {
+  repoRef: string;
+  clonePath: string;
+  baseBranch: string;
+  baseRef: string;
+  selectionReason: string;
+}
+
+export interface PreparedWorkItemRepository extends SelectedWorkItemRepository {
+  workflowBase?: WorkflowBase;
+}
+
+export interface EnsureRepositoryCheckoutOptions {
+  cloneRoot?: string;
+  branchStrategy?: BranchStrategyConfig;
+  selectionReason?: string;
+}
+
+export function repositoryClonePath(
+  projectId: string,
+  repoRef: string,
+  cloneRoot = REPOS_DIR,
+): string {
+  return join(cloneRoot, projectId, repoRef);
+}
+
+export function normalizeRepoRemote(value: string): string {
+  const trimmed = value.trim();
+  const scp = trimmed.includes('://') ? null : trimmed.match(/^([^@/:]+@)?([^:]+):(.+)$/);
+  const urlish = scp == null ? trimmed : `ssh://${scp[1] ?? ''}${scp[2]}/${scp[3]}`;
+  try {
+    const url = new URL(urlish);
+    const repoPath = url.pathname
+      .replace(/^\/+/, '')
+      .replace(/\.git$/i, '')
+      .toLowerCase();
+    return `${url.hostname.toLowerCase()}/${repoPath}`;
+  } catch {
+    return trimmed.replace(/\.git$/i, '').toLowerCase();
+  }
+}
+
+function remoteMatches(actual: string, expected: string): boolean {
+  return normalizeRepoRemote(actual) === normalizeRepoRemote(expected);
+}
+
+function repoName(repoRef: string): string {
+  return repoRef.split('/').filter(Boolean).at(-1) ?? repoRef;
+}
+
+function remoteHeadBranch(repoPath: string): string | null {
+  try {
+    const output = execFileSync(
+      'git',
+      ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'],
+      {
+        cwd: repoPath,
+        encoding: 'utf8',
+        env: GIT_ENV,
+      },
+    ).trim();
+    return output.startsWith('origin/') ? output.slice('origin/'.length) : output;
+  } catch {
+    return null;
+  }
+}
+
+function remoteBranchExists(repoPath: string, branch: string): boolean {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `origin/${branch}`], {
+      cwd: repoPath,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveConfiguredBase(
+  repoPath: string,
+  repoConfig: ProjectRepositoryConfig,
+  branchStrategy?: BranchStrategyConfig,
+): WorkflowBase {
+  const strategy = repoConfig.branchStrategy ?? branchStrategy;
+  const candidates: string[] = [];
+  const name = repoName(repoConfig.repoRef);
+  for (const preference of strategy?.preferredBranches ?? []) {
+    let pattern: RegExp;
+    try {
+      pattern = new RegExp(preference.repoNamePattern);
+    } catch {
+      continue;
+    }
+    if (pattern.test(name)) candidates.push(...preference.branches);
+  }
+  if (repoConfig.defaultBranch.trim().length > 0) candidates.push(repoConfig.defaultBranch);
+  if (strategy?.useRemoteHeadFallback !== false) {
+    const head = remoteHeadBranch(repoPath);
+    if (head != null) candidates.push(head);
+  }
+  candidates.push(...(strategy?.fallbackBranches ?? ['main', 'master']));
+  for (const branch of [...new Set(candidates.map((value) => value.trim()).filter(Boolean))]) {
+    const branchName = branch.startsWith('origin/') ? branch.slice('origin/'.length) : branch;
+    if (remoteBranchExists(repoPath, branchName)) {
+      return { branch: branchName, ref: `origin/${branchName}`, source: 'configured-default' };
+    }
+  }
+  throw new Error(`no checkout base branch found for ${repoConfig.repoRef}`);
+}
+
+export function ensureRepositoryCheckout(
+  projectId: string,
+  repoConfig: ProjectRepositoryConfig,
+  options: EnsureRepositoryCheckoutOptions = {},
+): CheckoutReadinessResult {
+  const clonePath = repositoryClonePath(projectId, repoConfig.repoRef, options.cloneRoot);
+  if (!existsSync(clonePath)) {
+    mkdirSync(dirname(clonePath), { recursive: true });
+    execFileSync('git', ['clone', repoConfig.cloneUrl, clonePath], {
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+  } else {
+    const stat = statSync(clonePath);
+    if (!stat.isDirectory()) {
+      throw new Error(`repository checkout path exists but is not a directory: ${clonePath}`);
+    }
+    try {
+      execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+        cwd: clonePath,
+        stdio: 'pipe',
+        env: GIT_ENV,
+      });
+    } catch {
+      throw new Error(`repository checkout path is not a git repository: ${clonePath}`);
+    }
+  }
+
+  const actualRemote = execFileSync('git', ['remote', 'get-url', 'origin'], {
+    cwd: clonePath,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim();
+  if (!remoteMatches(actualRemote, repoConfig.cloneUrl)) {
+    throw new Error(
+      `repository checkout remote mismatch for ${repoConfig.repoRef}: expected ${normalizeRepoRemote(
+        repoConfig.cloneUrl,
+      )}, got ${normalizeRepoRemote(actualRemote)}`,
+    );
+  }
+
+  execFileSync('git', ['fetch', 'origin', '--prune'], {
+    cwd: clonePath,
+    stdio: 'pipe',
+    env: GIT_ENV,
+  });
+
+  const base = resolveConfiguredBase(clonePath, repoConfig, options.branchStrategy);
+  return {
+    repoRef: repoConfig.repoRef,
+    clonePath,
+    baseBranch: base.branch,
+    baseRef: base.ref,
+    selectionReason: options.selectionReason ?? 'repo-link-primary',
+  };
+}
+
+export function ensureSelectedRepositoryCheckout(
+  project: ProjectConfig | null | undefined,
+  selected: SelectedWorkItemRepository,
+): PreparedWorkItemRepository {
+  if (project == null) return selected;
+  const repoConfig = listProjectRepositories(project).find(
+    (repo) => repo.repoRef === selected.repoRef,
+  );
+  if (repoConfig == null || repoConfig.cloneUrl.trim().length === 0) return selected;
+
+  const checkout = ensureRepositoryCheckout(project.id, repoConfig, {
+    branchStrategy: project.branchStrategy,
+    selectionReason: selected.selectedBy,
+  });
+  return {
+    ...selected,
+    localPath: checkout.clonePath,
+    defaultBranch: checkout.baseBranch,
+    workflowBase: {
+      branch: checkout.baseBranch,
+      ref: checkout.baseRef,
+      source: 'configured-default',
+    },
+  };
+}

--- a/core/workspaces/repo-affinity.test.ts
+++ b/core/workspaces/repo-affinity.test.ts
@@ -1,14 +1,28 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkItem } from '../state-source/interface.js';
 import type {
   LocalDbRepoLinkRow,
   LocalDbWorkItemRepository,
 } from '../state-source/local-db-repository.js';
 import type { ProjectConfig } from '../types.js';
-import { resolveRepositoryForWorkItem, selectRepoLink } from './repo-affinity.js';
+import {
+  resolveRepositoryForWorkItem,
+  selectCheckoutRepoLink,
+  selectRepoLink,
+} from './repo-affinity.js';
+
+const { mockReplayEvents } = vi.hoisted(() => ({
+  mockReplayEvents: vi.fn(),
+}));
+
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: {
+    replay: mockReplayEvents,
+  },
+}));
 
 function repoLink(repoRef: string, role: string): LocalDbRepoLinkRow {
   return {
@@ -74,16 +88,36 @@ const githubWorkItem = {
 } as WorkItem;
 
 describe('repo affinity', () => {
+  beforeEach(() => {
+    mockReplayEvents.mockReset().mockReturnValue([]);
+  });
+
   it('selects a primary repo link over other linked repos', () => {
     expect(
-      selectRepoLink([repoLink('owner/app', 'context'), repoLink('owner/docs', 'primary')]),
+      selectRepoLink([repoLink('owner/app', 'related'), repoLink('owner/docs', 'primary')]),
     ).toMatchObject({ repoRef: 'owner/docs' });
   });
 
-  it('rejects ambiguous local-db repo links with no primary', () => {
+  it('does not treat a lone related repo link as checkout-eligible', () => {
+    expect(selectCheckoutRepoLink([repoLink('owner/app', 'related')])).toEqual({
+      kind: 'repo-unassigned',
+      reason: 'no-primary',
+    });
+  });
+
+  it('returns typed unassigned for multiple related links with no primary', () => {
+    expect(
+      selectCheckoutRepoLink([repoLink('owner/app', 'related'), repoLink('owner/docs', 'related')]),
+    ).toEqual({
+      kind: 'repo-unassigned',
+      reason: 'no-primary',
+    });
+  });
+
+  it('keeps compatibility throws for no-primary repo links', () => {
     expect(() =>
-      selectRepoLink([repoLink('owner/app', 'context'), repoLink('owner/docs', 'context')]),
-    ).toThrow('multiple repo links and no primary');
+      selectRepoLink([repoLink('owner/app', 'related'), repoLink('owner/docs', 'related')]),
+    ).toThrow('no primary repo link');
   });
 
   it('resolves implementation localPath and defaultBranch from the selected repo link', () => {
@@ -118,7 +152,33 @@ describe('repo affinity', () => {
         fallbackLocalPath: '/repo',
         repository,
       }),
-    ).toThrow("repo link 'workspace/bitbucket-repo' is not registered");
+    ).toThrow("repo 'workspace/bitbucket-repo' is not registered");
+  });
+
+  it('uses the latest manual repo override when a local-db item has no primary link yet', () => {
+    mockReplayEvents.mockReturnValue([
+      {
+        kind: 'agent.repo-override',
+        payload: { repo: 'owner/docs' },
+      },
+    ]);
+    const repository = {
+      listRepoLinks: () => [repoLink('owner/app', 'related')],
+    } as unknown as LocalDbWorkItemRepository;
+
+    expect(
+      resolveRepositoryForWorkItem({
+        project,
+        workItem: { ...workItem, repoRef: null } as WorkItem,
+        fallbackLocalPath: fallbackRepoPath,
+        repository,
+      }),
+    ).toMatchObject({
+      repoRef: 'owner/docs',
+      localPath: docsRepoPath,
+      defaultBranch: 'trunk',
+      selectedBy: 'repo-override',
+    });
   });
 
   it('uses a valid configured repository path before project targetRepo and fallback', () => {

--- a/core/workspaces/repo-affinity.ts
+++ b/core/workspaces/repo-affinity.ts
@@ -1,28 +1,47 @@
 import { existsSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { eventStore } from '../event-stream/store.js';
 import { firstProjectRepository, listProjectRepositories } from '../projects/repositories.js';
 import type { WorkItem } from '../state-source/interface.js';
 import { LocalDbWorkItemRepository } from '../state-source/local-db-repository.js';
 import type { LocalDbRepoLinkRow } from '../state-source/local-db-repository.js';
 import type { ProjectConfig } from '../types.js';
 
+export type RepoLinkSelectionResult =
+  | { kind: 'selected'; link: LocalDbRepoLinkRow; selectedBy: 'repo-link-primary' }
+  | { kind: 'repo-unassigned'; reason: 'no-primary' | 'no-links' }
+  | { kind: 'repo-ambiguous'; links: LocalDbRepoLinkRow[] };
+
 export interface SelectedWorkItemRepository {
   repoRef: string;
   localPath: string;
   defaultBranch: string;
   role: string;
-  selectedBy: 'repo-link-primary' | 'repo-link-single' | 'work-item' | 'project';
+  selectedBy: 'repo-link-primary' | 'repo-override' | 'work-item' | 'project';
+}
+
+export function selectCheckoutRepoLink(links: LocalDbRepoLinkRow[]): RepoLinkSelectionResult {
+  if (links.length === 0) return { kind: 'repo-unassigned', reason: 'no-links' };
+  const primaryLinks = links.filter((link) => link.role === 'primary');
+  if (primaryLinks.length === 1) {
+    return { kind: 'selected', link: primaryLinks[0], selectedBy: 'repo-link-primary' };
+  }
+  if (primaryLinks.length > 1) {
+    return { kind: 'repo-ambiguous', links: primaryLinks };
+  }
+  return { kind: 'repo-unassigned', reason: 'no-primary' };
 }
 
 export function selectRepoLink(links: LocalDbRepoLinkRow[]): LocalDbRepoLinkRow | null {
-  if (links.length === 0) return null;
-  const primaryLinks = links.filter((link) => link.role === 'primary');
-  if (primaryLinks.length === 1) return primaryLinks[0];
-  if (primaryLinks.length > 1) {
+  const selection = selectCheckoutRepoLink(links);
+  if (selection.kind === 'selected') return selection.link;
+  if (selection.kind === 'repo-ambiguous') {
     throw new Error('local-db Work Item has multiple primary repo links');
   }
-  if (links.length === 1) return links[0];
-  throw new Error('local-db Work Item has multiple repo links and no primary repo link');
+  if (selection.reason === 'no-primary' && links.length > 0) {
+    throw new Error('local-db Work Item has no primary repo link');
+  }
+  return null;
 }
 
 export function listLocalDbRepoLinks(
@@ -54,6 +73,26 @@ function normalizeExistingLocalPath(localPath: string | null | undefined): strin
   }
 }
 
+function latestRepoOverride(projectId: string, workItemId: string): string | null {
+  try {
+    const event = eventStore
+      .replay({
+        projectId,
+        workItemId,
+        kind: 'agent.repo-override',
+        order: 'desc',
+        limit: 1,
+      })
+      .at(0);
+    const payload = event?.payload as { repo?: unknown } | undefined;
+    return typeof payload?.repo === 'string' && payload.repo.trim().length > 0
+      ? payload.repo.trim()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveRepositoryForWorkItem(input: {
   project: ProjectConfig | null | undefined;
   workItem: WorkItem;
@@ -61,17 +100,37 @@ export function resolveRepositoryForWorkItem(input: {
   repository?: LocalDbWorkItemRepository;
 }): SelectedWorkItemRepository {
   const project = input.project;
-  const repoLink =
+  const repoSelection =
     project == null
-      ? null
-      : selectRepoLink(listLocalDbRepoLinks(project.id, input.workItem.id, input.repository));
+      ? ({ kind: 'repo-unassigned', reason: 'no-links' } as const)
+      : selectCheckoutRepoLink(
+          listLocalDbRepoLinks(project.id, input.workItem.id, input.repository),
+        );
+  const repoLink = repoSelection.kind === 'selected' ? repoSelection.link : null;
+  const overrideRepoRef =
+    input.workItem.id.startsWith('local:') && project != null
+      ? latestRepoOverride(project.id, input.workItem.id)
+      : null;
 
-  if (input.workItem.id.startsWith('local:') && project != null && repoLink == null) {
+  if (
+    input.workItem.id.startsWith('local:') &&
+    project != null &&
+    repoSelection.kind === 'repo-ambiguous'
+  ) {
+    throw new Error('local-db Work Item has multiple primary repo links');
+  }
+  if (
+    input.workItem.id.startsWith('local:') &&
+    project != null &&
+    repoSelection.kind === 'repo-unassigned' &&
+    overrideRepoRef == null
+  ) {
     throw new Error('local-db Work Item has no repo link for implementation');
   }
 
   const repoRef =
     repoLink?.repoRef ??
+    overrideRepoRef ??
     input.workItem.repoRef ??
     (project == null ? null : firstProjectRepository(project)?.repoRef) ??
     '';
@@ -83,8 +142,8 @@ export function resolveRepositoryForWorkItem(input: {
     project == null
       ? undefined
       : listProjectRepositories(project).find((repo) => repo.repoRef === repoRef);
-  if (repoLink != null && project != null && configuredRepo == null) {
-    throw new Error(`local-db Work Item repo link '${repoRef}' is not registered in repositories`);
+  if (input.workItem.id.startsWith('local:') && project != null && configuredRepo == null) {
+    throw new Error(`local-db Work Item repo '${repoRef}' is not registered in repositories`);
   }
   const configuredLocalPath = normalizeExistingLocalPath(configuredRepo?.localPath);
   const targetLocalPath = normalizeExistingLocalPath(project?.targetRepo?.localPath);
@@ -99,8 +158,8 @@ export function resolveRepositoryForWorkItem(input: {
     selectedBy:
       repoLink?.role === 'primary'
         ? 'repo-link-primary'
-        : repoLink != null
-          ? 'repo-link-single'
+        : overrideRepoRef != null
+          ? 'repo-override'
           : input.workItem.repoRef != null
             ? 'work-item'
             : 'project',

--- a/core/workspaces/slice.test.ts
+++ b/core/workspaces/slice.test.ts
@@ -67,6 +67,19 @@ describe('createWorktree', () => {
     );
   });
 
+  it('uses a repo-aware path when repoRef is provided', () => {
+    createWorktree('/repo/path', 'run-abc-123', 'origin/main', 'owner/repo');
+
+    expect(vi.mocked(mkdirSync)).toHaveBeenCalledWith(WT('run-abc-123'), {
+      recursive: true,
+    });
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'add', '--detach', join(WT('run-abc-123'), 'owner-repo'), 'origin/main'],
+      expect.objectContaining({ cwd: '/repo/path' }),
+    );
+  });
+
   it('returns the worktree path', () => {
     const result = createWorktree('/repo/path', 'run-abc-123');
     expect(result).toBe(WT('run-abc-123'));

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { GIT_ENV } from './git-env.js';
 
 const WORKSPACES_DIR = join(homedir(), '.factory', 'workspaces');
@@ -35,11 +35,21 @@ export class WorktreeDependencyPreflightError extends Error {
 }
 
 /**
- * Resolves the worktree path for a given runId.
- * Pattern: ~/.factory/workspaces/<runId>/
+ * Resolves the worktree path for a given runId and optional repoRef.
+ * Legacy pattern: ~/.factory/workspaces/<runId>/
+ * Repo-aware pattern: ~/.factory/workspaces/<runId>/<repoId>/
  */
-function worktreePath(runId: string): string {
-  return join(WORKSPACES_DIR, runId);
+function worktreePath(runId: string, repoRef?: string): string {
+  if (repoRef == null || repoRef.length === 0) return join(WORKSPACES_DIR, runId);
+  return join(WORKSPACES_DIR, runId, repoId(repoRef));
+}
+
+export function repoId(repoRef: string): string {
+  return repoRef
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /**
@@ -47,9 +57,13 @@ function worktreePath(runId: string): string {
  * Used by tail workflows (audit, retro) that want to attach to the dev
  * worktree opportunistically without recreating it.
  */
-export function existingWorktreePath(runId: string): string | null {
-  const wtPath = worktreePath(runId);
-  return existsSync(wtPath) ? wtPath : null;
+export function existingWorktreePath(runId: string, repoRef?: string): string | null {
+  if (repoRef != null && repoRef.length > 0) {
+    const repoAwarePath = worktreePath(runId, repoRef);
+    if (existsSync(repoAwarePath)) return repoAwarePath;
+  }
+  const legacyPath = worktreePath(runId);
+  return existsSync(legacyPath) ? legacyPath : null;
 }
 
 function currentBranch(repo: string): string | null {
@@ -102,11 +116,16 @@ export function resolveWorkflowBase(repo: string, configuredDefaultBranch?: stri
  * @param runId - Canonical workflow isolation key (ULID/UUID).
  * @returns The absolute path to the created worktree.
  */
-export function createWorktree(repo: string, runId: string, baseRef?: string): string {
-  const wtPath = worktreePath(runId);
+export function createWorktree(
+  repo: string,
+  runId: string,
+  baseRef?: string,
+  repoRef?: string,
+): string {
+  const wtPath = worktreePath(runId, repoRef);
 
-  // Ensure the parent workspaces directory exists
-  mkdirSync(WORKSPACES_DIR, { recursive: true });
+  // Ensure the parent directory exists for both legacy and repo-aware paths.
+  mkdirSync(dirname(wtPath), { recursive: true });
 
   const args = ['worktree', 'add', '--detach', wtPath];
   if (baseRef != null && baseRef.length > 0) {
@@ -147,9 +166,10 @@ export function createIntegrationWorktree(
   pipelineRunId: string,
   branchName: string,
   baseRef?: string,
+  repoRef?: string,
 ): IntegrationWorktree {
-  const wtPath = worktreePath(pipelineRunId);
-  mkdirSync(WORKSPACES_DIR, { recursive: true });
+  const wtPath = worktreePath(pipelineRunId, repoRef);
+  mkdirSync(dirname(wtPath), { recursive: true });
 
   if (!existsSync(wtPath)) {
     const args = ['worktree', 'add', '--detach', wtPath];
@@ -293,16 +313,16 @@ export function assertGooseHubWebPlaywrightReady(worktreePath: string): void {
 }
 
 /**
- * Removes the git worktree for the given runId.
+ * Removes the git worktree for the given runId or explicit worktree path.
  *
  * Idempotent: if the worktree path does not exist, this is a no-op.
  * If `git worktree remove` fails (e.g. repo already gone), the directory
  * is still removed via rmSync with force.
  *
- * @param runId - Canonical workflow isolation key (ULID/UUID).
+ * @param runIdOrPath - Canonical workflow isolation key (ULID/UUID), or an absolute worktree path.
  */
-export function cleanupWorktree(runId: string): void {
-  const wtPath = worktreePath(runId);
+export function cleanupWorktree(runIdOrPath: string, repoRef?: string): void {
+  const wtPath = isAbsolute(runIdOrPath) ? runIdOrPath : worktreePath(runIdOrPath, repoRef);
 
   if (!existsSync(wtPath)) {
     return;

--- a/slices/feature-grounding/workflow.ts
+++ b/slices/feature-grounding/workflow.ts
@@ -20,6 +20,8 @@ import { persistScoutReportForRun } from '@goose-hub/core/scout-reports/reposito
 import type { StateName } from '@goose-hub/core/state-machine/states.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
 import { extractIdentifiers } from '@goose-hub/core/symbol-index/lookup.js';
+import { ensureSelectedRepositoryCheckout } from '@goose-hub/core/workspaces/checkout-readiness.js';
+import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import { cleanupWorktree, createWorktree } from '@goose-hub/core/workspaces/worktree.js';
 
@@ -211,13 +213,28 @@ export async function runFeatureGroundingWorkflow(
       model: groundingBudget.modelOverride,
       skillProvider: groundingBudget.provider,
     });
-  const workflowBase = resolveWorkflowBaseFn(
-    projectId,
-    workItem.id,
-    targetRepo,
-    projectConfig?.targetRepo?.defaultBranch,
+  const selectedRepository = ensureSelectedRepositoryCheckout(
+    workItem.id.startsWith('local:') ? projectConfig : null,
+    resolveRepositoryForWorkItem({
+      project: workItem.id.startsWith('local:') ? projectConfig : null,
+      workItem,
+      fallbackLocalPath: targetRepo,
+    }),
   );
-  const worktreePath = createWtFn(targetRepo, runId, workflowBase.ref);
+  const workflowBase =
+    selectedRepository.workflowBase ??
+    resolveWorkflowBaseFn(
+      projectId,
+      workItem.id,
+      selectedRepository.localPath,
+      selectedRepository.defaultBranch,
+    );
+  const worktreePath = createWtFn(
+    selectedRepository.localPath,
+    runId,
+    workflowBase.ref,
+    selectedRepository.repoRef,
+  );
 
   const resolveScoutBudget: ScoutBudgetResolver = (skill, projectBudgets, currentProjectId) =>
     resolveSkillRuntimeForProject({
@@ -425,6 +442,6 @@ Feature-grounding mode:
     });
     return { nextState: 'factory:needs-human' };
   } finally {
-    cleanupWtFn(runId);
+    cleanupWtFn(worktreePath);
   }
 }

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -280,7 +280,12 @@ describe('runFixIssueWorkflow — default deps (lines 68-73 ?? fallbacks)', () =
     // ClaudeCliRuntime was used (default runtime dep)
     expect(mockClaudeCliRun).toHaveBeenCalledTimes(1);
     // createWorktree was called (default worktree dep)
-    expect(mockCreateWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'origin/main');
+    expect(mockCreateWorktree).toHaveBeenCalledWith(
+      '/repo',
+      expect.any(String),
+      'origin/main',
+      'owner/repo',
+    );
     // openPR was called (default openPR dep)
     expect(mockOpenPR).toHaveBeenCalled();
     // worktree persists until merge — NOT cleaned up after PR open
@@ -309,7 +314,12 @@ describe('runFixIssueWorkflow — default deps (lines 68-73 ?? fallbacks)', () =
       '/repo',
       'main',
     );
-    expect(mockCreateWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'seed-commit-sha');
+    expect(mockCreateWorktree).toHaveBeenCalledWith(
+      '/repo',
+      expect.any(String),
+      'seed-commit-sha',
+      'owner/repo',
+    );
     expect(mockOpenPR).toHaveBeenCalledWith(
       expect.objectContaining({ baseBranch: 'dogfood/run/logger-001-drop-meta' }),
     );
@@ -526,7 +536,12 @@ describe('runFixIssueWorkflow (#183)', () => {
       resolveWorktreeHeadShaImpl,
     });
 
-    expect(createWorktreeImpl).toHaveBeenCalledWith('/repo', expect.any(String), 'origin/main');
+    expect(createWorktreeImpl).toHaveBeenCalledWith(
+      '/repo',
+      expect.any(String),
+      'origin/main',
+      'owner/repo',
+    );
     expect(source.transitionState).toHaveBeenNthCalledWith(
       1,
       '42',

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -17,6 +17,7 @@ import {
   lookupWorkItemSymbols,
   symbolHintsToKeyFiles,
 } from '@goose-hub/core/symbol-index/lookup.js';
+import { ensureSelectedRepositoryCheckout } from '@goose-hub/core/workspaces/checkout-readiness.js';
 import { orchestratorCommitAll } from '@goose-hub/core/workspaces/orchestrator-git.js';
 import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
@@ -117,23 +118,33 @@ export async function runFixIssueWorkflow(
     workItem,
     injectedRuntime: deps.runtime,
   });
-  const selectedRepository = resolveRepositoryForWorkItem({
-    project: implementExecution.projectConfig,
-    workItem,
-    fallbackLocalPath: targetRepo,
-  });
+  const selectedRepository = ensureSelectedRepositoryCheckout(
+    workItem.id.startsWith('local:') ? implementExecution.projectConfig : null,
+    resolveRepositoryForWorkItem({
+      project: implementExecution.projectConfig,
+      workItem,
+      fallbackLocalPath: targetRepo,
+    }),
+  );
   const workflowWorkItem =
     selectedRepository.repoRef === workItem.repoRef
       ? workItem
       : { ...workItem, repoRef: selectedRepository.repoRef };
-  const workflowBase = resolveWorkflowBaseFn(
-    projectId,
-    workItem.id,
-    selectedRepository.localPath,
-    selectedRepository.defaultBranch,
-  );
+  const workflowBase =
+    selectedRepository.workflowBase ??
+    resolveWorkflowBaseFn(
+      projectId,
+      workItem.id,
+      selectedRepository.localPath,
+      selectedRepository.defaultBranch,
+    );
   const baseBranch = workflowBase.branch;
-  const worktreePath = createWtFn(selectedRepository.localPath, runId, workflowBase.ref);
+  const worktreePath = createWtFn(
+    selectedRepository.localPath,
+    runId,
+    workflowBase.ref,
+    selectedRepository.repoRef,
+  );
   const investigation = latestInvestigationContext({
     projectId,
     workItemId: workItem.id,
@@ -406,7 +417,7 @@ export async function runFixIssueWorkflow(
       runId,
     });
     // Error path: no PR was opened, no merge is coming — clean up now.
-    cleanupWtFn(runId);
+    cleanupWtFn(worktreePath);
   }
   // Success path: worktree persists until PR merge so QA can run in the same environment.
   // Cleanup happens in approveIssue() when the PR is merged.

--- a/slices/investigate/slice.test.ts
+++ b/slices/investigate/slice.test.ts
@@ -650,7 +650,12 @@ describe('runInvestigateWorkflow', () => {
       const { runInvestigateWorkflow } = await import('./workflow.js');
       await runInvestigateWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'origin/main');
+      expect(createWorktree).toHaveBeenCalledWith(
+        '/repo',
+        expect.any(String),
+        'origin/main',
+        'shaunnez/goose-hub',
+      );
       expect(cleanupWorktree).toHaveBeenCalledOnce();
     });
 
@@ -675,7 +680,12 @@ describe('runInvestigateWorkflow', () => {
         '/repo',
         expect.any(String),
       );
-      expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'seed-commit-sha');
+      expect(createWorktree).toHaveBeenCalledWith(
+        '/repo',
+        expect.any(String),
+        'seed-commit-sha',
+        'shaunnez/goose-hub',
+      );
     });
 
     it('emits only one parent run-started event and suppresses the synthesis duplicate', async () => {

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -67,6 +67,8 @@ import {
 } from '@goose-hub/core/workflow-routing/events.js';
 import { selectWorkflowRoute } from '@goose-hub/core/workflow-routing/select-route.js';
 import { buildRouteSignals } from '@goose-hub/core/workflow-routing/signals.js';
+import { ensureSelectedRepositoryCheckout } from '@goose-hub/core/workspaces/checkout-readiness.js';
+import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import {
   cleanupWorktree,
@@ -378,13 +380,28 @@ export async function runInvestigateWorkflow(
       model: investigatorModelOverride,
       skillProvider: forcedRuntimeProvider ?? investigateBudget.provider,
     });
-  const workflowBase = resolveWorkflowBaseFn(
-    projectId,
-    workItem.id,
-    targetRepo,
-    projectConfig?.targetRepo?.defaultBranch,
+  const selectedRepository = ensureSelectedRepositoryCheckout(
+    workItem.id.startsWith('local:') ? projectConfig : null,
+    resolveRepositoryForWorkItem({
+      project: workItem.id.startsWith('local:') ? projectConfig : null,
+      workItem,
+      fallbackLocalPath: targetRepo,
+    }),
   );
-  const worktreePath = createWtFn(targetRepo, runId, workflowBase.ref);
+  const workflowBase =
+    selectedRepository.workflowBase ??
+    resolveWorkflowBaseFn(
+      projectId,
+      workItem.id,
+      selectedRepository.localPath,
+      selectedRepository.defaultBranch,
+    );
+  const worktreePath = createWtFn(
+    selectedRepository.localPath,
+    runId,
+    workflowBase.ref,
+    selectedRepository.repoRef,
+  );
 
   if (workItem.type === 'bug') {
     prewarmWtFn(worktreePath, '@goose-hub/web');
@@ -1046,7 +1063,7 @@ export async function runInvestigateWorkflow(
               plan: planParsed.data,
               workspaceDir: worktreePath,
               issueNumber: Number(workItem.externalId),
-              repo: workItem.repoRef,
+              repo: selectedRepository.repoRef,
             });
           } else if (finalParsed.success) {
             // Backward-compatible while older agents still return the final payload.
@@ -1213,7 +1230,7 @@ export async function runInvestigateWorkflow(
       });
     }
   } finally {
-    cleanupWorktree(runId);
+    cleanupWorktree(worktreePath);
   }
 }
 

--- a/slices/spec-author/slice.test.ts
+++ b/slices/spec-author/slice.test.ts
@@ -694,7 +694,12 @@ describe('runSpecAuthorWorkflow', () => {
       const { runSpecAuthorWorkflow } = await import('./workflow.js');
       await runSpecAuthorWorkflow(makeWorkItem(), makeMockSource(), 'goose-hub-self', '/repo');
 
-      expect(createWorktree).toHaveBeenCalledWith('/repo', expect.any(String), 'origin/main');
+      expect(createWorktree).toHaveBeenCalledWith(
+        '/repo',
+        expect.any(String),
+        'origin/main',
+        'shaunnez/goose-hub',
+      );
       expect(cleanupWorktree).toHaveBeenCalledOnce();
     });
   });

--- a/slices/spec-author/workflow.ts
+++ b/slices/spec-author/workflow.ts
@@ -12,6 +12,8 @@ import {
   listScoutReportsForRun,
 } from '@goose-hub/core/scout-reports/repository.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
+import { ensureSelectedRepositoryCheckout } from '@goose-hub/core/workspaces/checkout-readiness.js';
+import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { collectScopeManifest } from '@goose-hub/core/workspaces/scope-manifest.js';
 import {
   cleanupWorktree,
@@ -531,8 +533,23 @@ export async function runSpecAuthorWorkflow(
 
   const pipelineRunId = crypto.randomUUID();
   const projectConfig = await getProjectBySlug(projectId);
-  const workflowBase = resolveWorkflowBaseFn(targetRepo, projectConfig?.targetRepo?.defaultBranch);
-  const worktreePath = createWtFn(targetRepo, pipelineRunId, workflowBase.ref);
+  const selectedRepository = ensureSelectedRepositoryCheckout(
+    workItem.id.startsWith('local:') ? projectConfig : null,
+    resolveRepositoryForWorkItem({
+      project: workItem.id.startsWith('local:') ? projectConfig : null,
+      workItem,
+      fallbackLocalPath: targetRepo,
+    }),
+  );
+  const workflowBase =
+    selectedRepository.workflowBase ??
+    resolveWorkflowBaseFn(selectedRepository.localPath, selectedRepository.defaultBranch);
+  const worktreePath = createWtFn(
+    selectedRepository.localPath,
+    pipelineRunId,
+    workflowBase.ref,
+    selectedRepository.repoRef,
+  );
 
   try {
     // Load scout reports from the most recent investigation for this work item.
@@ -938,6 +955,6 @@ export async function runSpecAuthorWorkflow(
       by: 'spec-author',
     });
   } finally {
-    cleanupWorktree(pipelineRunId);
+    cleanupWorktree(worktreePath);
   }
 }


### PR DESCRIPTION
## Summary
- Stop assigning local-db work items to a bootstrap repo until an explicit primary repo link exists.
- Add primary-only repo affinity selection plus checkout readiness helpers for canonical clones, remote validation, fetch, and base branch resolution.
- Make disposable worktrees repo-aware and update local-db workflows, server diff/approval handling, and UI types for nullable repo refs.

## Verification
- pnpm lint: passed before rebasing onto latest origin/main; after rebase, fails in unrelated current-main files apps/server/src/domains/inbox/service.test.ts and core/agent-runtime/bug-enhance-runner.* import/format checks.
- pnpm typecheck: passed after rebase.
- pnpm test: passed before rebase, 398 files / 5425 passed / 3 skipped. After rebase, 397 files passed and 1 unrelated current-main failure in core/workflows/timeline-sections.test.ts for missing agent.bug-enhance-empty classification.