### PR TITLE
Make prewarm selected-repo aware

### DIFF
--- a/apps/server/src/domains/workflows/router.ts
+++ b/apps/server/src/domains/workflows/router.ts
@@ -72,6 +72,13 @@ async function seedFixtureIssue(
   });
   if (item.id.startsWith(`local:${source.projectId}#`)) {
     if (!source.repoRef.startsWith('local:')) {
+      await source.createRepoLink?.({
+        itemId: item.id,
+        repoRef: source.repoRef,
+        role: 'primary',
+        confidence: 1,
+        source: 'mock-seed',
+      });
       localDbTestRefs.upsertExternalRef({
         projectId: source.projectId,
         itemId: item.id,

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -18,6 +18,7 @@ export const EVENT_KINDS = [
   'agent.run-started',
   'agent.run-completed',
   'agent.run-failed',
+  'agent.checkout-readiness',
   'agent.budget-exceeded',
   'agent.fallback-triggered',
   'agent.triage-complete',

--- a/core/projects/restart-issue.ts
+++ b/core/projects/restart-issue.ts
@@ -66,6 +66,19 @@ export async function restartIssue(input: RestartIssueInput): Promise<RestartIss
     initialState: targetState,
     extraLabels,
   });
+  const repoLinks =
+    input.source.listRepoLinks != null ? await input.source.listRepoLinks(oldItem.id) : [];
+  if (input.source.createRepoLink != null) {
+    for (const link of repoLinks) {
+      await input.source.createRepoLink({
+        itemId: newItem.id,
+        repoRef: link.repoRef,
+        role: link.role,
+        confidence: link.confidence ?? null,
+        source: link.source ?? 'restart',
+      });
+    }
+  }
 
   if (schedule !== 'current') {
     await input.source.setLabelInGroup(newItem.id, 'schedule', schedule);

--- a/core/state-source/interface.ts
+++ b/core/state-source/interface.ts
@@ -18,6 +18,13 @@ export interface WorkItemExternalRef {
   createdAt: string;
 }
 
+export interface WorkItemRepoLink {
+  repoRef: string;
+  role: string;
+  confidence?: number | null;
+  source?: string | null;
+}
+
 /**
  * Default values applied when a work item has no label in the corresponding
  * group. Used by the ingress parsers in `github-labels.ts` so the fallback
@@ -125,6 +132,8 @@ export interface StateSource {
   removeLabel(itemId: string, name: string): Promise<void>;
   /** Return all labels currently on the item (state labels + extra labels). */
   listLabels?(itemId: string): Promise<string[]>;
+  listRepoLinks?(itemId: string): Promise<WorkItemRepoLink[]> | WorkItemRepoLink[];
+  createRepoLink?(input: { itemId: string } & WorkItemRepoLink): Promise<void> | void;
   attach(itemId: string, artifact: Artifact): Promise<void>;
   createIssue(input: CreateIssueInput): Promise<WorkItem>;
   createMilestone(title: string): Promise<Milestone>;

--- a/core/state-source/local-db.ts
+++ b/core/state-source/local-db.ts
@@ -16,6 +16,7 @@ import type {
   StateSource,
   Subscription,
   WorkItem,
+  WorkItemRepoLink,
   WorkItemType,
 } from './interface.js';
 import { LocalDbWorkItemRepository, parseExternalRefMetadata } from './local-db-repository.js';
@@ -254,6 +255,26 @@ export class LocalDbStateSource implements StateSource {
       `exec:${item.exec}`,
       ...this.repository.listLabels(this.projectId, itemId),
     ];
+  }
+
+  listRepoLinks(itemId: string): WorkItemRepoLink[] {
+    return this.repository.listRepoLinks(this.projectId, itemId).map((link) => ({
+      repoRef: link.repoRef,
+      role: link.role,
+      confidence: link.confidence,
+      source: link.source,
+    }));
+  }
+
+  createRepoLink(input: { itemId: string } & WorkItemRepoLink): void {
+    this.repository.createRepoLink({
+      projectId: this.projectId,
+      itemId: input.itemId,
+      repoRef: input.repoRef,
+      role: input.role,
+      confidence: input.confidence ?? null,
+      source: input.source ?? 'restart',
+    });
   }
 
   async attach(_itemId: string, _artifact: Artifact): Promise<void> {

--- a/core/tool-layer/mcp/tools/context.ts
+++ b/core/tool-layer/mcp/tools/context.ts
@@ -3,6 +3,7 @@ import { eventStore } from '../../../event-stream/store.js';
 import { getProjectBySlug } from '../../../projects/loader.js';
 import type { WorkItem } from '../../../state-source/interface.js';
 import { listLocalDbRepoLinks } from '../../../workspaces/repo-affinity.js';
+import { stackCommandsForWorktree } from '../../../workspaces/stack-commands.js';
 import { recordDecision } from '../../tools/record-decision.js';
 import { emitToolCall } from '../audit.js';
 import type { FactoryContext } from '../context.js';
@@ -119,7 +120,7 @@ export async function getStackCommands(
     );
   }
 
-  const stack = project.stack;
+  const stack = await stackCommandsForWorktree(ctx.workspaceRoot, project.stack);
   const result: GetStackCommandsResult = {
     runtime: stack.runtime,
     packageManager: stack.packageManager,

--- a/core/tool-layer/mcp/tools/verify.ts
+++ b/core/tool-layer/mcp/tools/verify.ts
@@ -4,6 +4,7 @@ import type { z } from 'zod';
 import { eventStore } from '../../../event-stream/store.js';
 import { getProjectBySlug } from '../../../projects/loader.js';
 import type { ProjectConfig, StackConfig } from '../../../types.js';
+import { stackCommandsForWorktree } from '../../../workspaces/stack-commands.js';
 import type { RepoRelativePath } from '../../path-contract.js';
 import { type ParsedTestFailures, parseTestFailures } from '../../test-failure-parser.js';
 import { emitBlockedToolCall, emitToolCall } from '../audit.js';
@@ -109,7 +110,7 @@ async function loadStack(
   if (project == null) {
     throw new StackCommandMissingError('test', ctx.projectId);
   }
-  return { project, stack: project.stack };
+  return { project, stack: await stackCommandsForWorktree(ctx.workspaceRoot, project.stack) };
 }
 
 function handleBlocked(

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -60,6 +60,7 @@ const WORKFLOW_GROUP_TO_TIMELINE_SECTION: Record<WorkflowGroup, TimelineSectionI
 
 const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
   'dogfood.seed-applied': 'system',
+  'agent.checkout-readiness': 'system',
   'agent.triage-complete': 'triage',
   'agent.repo-override': 'triage',
   'agent.investigation-complete': 'investigation',

--- a/core/workspaces/checkout-readiness.test.ts
+++ b/core/workspaces/checkout-readiness.test.ts
@@ -69,6 +69,8 @@ describe('checkout readiness', () => {
       clonePath: repositoryClonePath('proj', 'workspace/repo'),
       baseBranch: 'main',
       baseRef: 'origin/main',
+      checkoutSource: 'managed-clone',
+      configuredLocalPath: null,
     });
     expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
       'git',
@@ -124,12 +126,21 @@ describe('checkout readiness', () => {
           defaultBranch: 'develop',
           role: 'code',
           selectedBy: 'repo-link-primary',
+          checkoutSource: 'fallback-path',
+          configuredLocalPath: '/missing/configured/path',
         },
       ),
     ).toMatchObject({
       repoRef: 'workspace/repo',
       localPath: '/mock-home/.factory/repos/proj/workspace/repo',
       defaultBranch: 'main',
+      checkoutSource: 'managed-clone',
+      readiness: {
+        checkoutSource: 'managed-clone',
+        selectionSource: 'fallback-path',
+        checkoutPath: '/mock-home/.factory/repos/proj/workspace/repo',
+        managedClonePath: '/mock-home/.factory/repos/proj/workspace/repo',
+      },
       workflowBase: { branch: 'main', ref: 'origin/main' },
     });
   });

--- a/core/workspaces/checkout-readiness.ts
+++ b/core/workspaces/checkout-readiness.ts
@@ -16,10 +16,23 @@ export interface CheckoutReadinessResult {
   baseBranch: string;
   baseRef: string;
   selectionReason: string;
+  checkoutSource: 'managed-clone';
+  configuredLocalPath?: string | null;
 }
 
 export interface PreparedWorkItemRepository extends SelectedWorkItemRepository {
   workflowBase?: WorkflowBase;
+  readiness?: {
+    checkoutSource:
+      | 'configured-local-path'
+      | 'project-target-path'
+      | 'fallback-path'
+      | 'managed-clone';
+    selectionSource?: SelectedWorkItemRepository['checkoutSource'];
+    checkoutPath: string;
+    configuredLocalPath?: string | null;
+    managedClonePath?: string;
+  };
 }
 
 export interface EnsureRepositoryCheckoutOptions {
@@ -176,6 +189,8 @@ export function ensureRepositoryCheckout(
     baseBranch: base.branch,
     baseRef: base.ref,
     selectionReason: options.selectionReason ?? 'repo-link-primary',
+    checkoutSource: 'managed-clone',
+    configuredLocalPath: repoConfig.localPath.length > 0 ? repoConfig.localPath : null,
   };
 }
 
@@ -197,6 +212,14 @@ export function ensureSelectedRepositoryCheckout(
     ...selected,
     localPath: checkout.clonePath,
     defaultBranch: checkout.baseBranch,
+    checkoutSource: 'managed-clone',
+    readiness: {
+      checkoutSource: 'managed-clone',
+      selectionSource: selected.checkoutSource,
+      checkoutPath: checkout.clonePath,
+      configuredLocalPath: checkout.configuredLocalPath,
+      managedClonePath: checkout.clonePath,
+    },
     workflowBase: {
       branch: checkout.baseBranch,
       ref: checkout.baseRef,

--- a/core/workspaces/prewarm-package-manager.test.ts
+++ b/core/workspaces/prewarm-package-manager.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type WorktreeDependencyPreflightError, prewarmWorktree } from './worktree.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+function repo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'prewarm-pm-'));
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  return dir;
+}
+
+const packageJson = (packageManager?: string) =>
+  JSON.stringify({
+    ...(packageManager != null ? { packageManager } : {}),
+    scripts: { test: 'vitest' },
+  });
+
+describe('prewarmWorktree package manager selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+  });
+
+  it('runs npm ci for npm lockfile repos', async () => {
+    const dir = repo({ 'package.json': packageJson(), 'package-lock.json': '{}' });
+
+    await prewarmWorktree(dir);
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'npm',
+      ['ci'],
+      expect.objectContaining({ cwd: dir, stdio: 'pipe' }),
+    );
+  });
+
+  it('runs pnpm install --frozen-lockfile for pnpm repos', async () => {
+    const dir = repo({ 'package.json': packageJson(), 'pnpm-lock.yaml': 'lockfileVersion: 9\n' });
+
+    await prewarmWorktree(dir);
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'pnpm',
+      ['install', '--frozen-lockfile'],
+      expect.objectContaining({ cwd: dir, stdio: 'pipe' }),
+    );
+  });
+
+  it('runs yarn install for yarn repos', async () => {
+    const dir = repo({ 'package.json': packageJson(), 'yarn.lock': '' });
+
+    await prewarmWorktree(dir);
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'yarn',
+      ['install', '--frozen-lockfile'],
+      expect.objectContaining({ cwd: dir, stdio: 'pipe' }),
+    );
+  });
+
+  it('wraps failed installs with command, cwd, exit code, package manager, and stderr', async () => {
+    const dir = repo({ 'package.json': packageJson(), 'package-lock.json': '{}' });
+    vi.mocked(execFileSync).mockImplementation(() => {
+      const err = new Error('npm failed') as Error & { status: number; stderr: Buffer };
+      err.status = 1;
+      err.stderr = Buffer.from('first line\nlast line\n');
+      throw err;
+    });
+
+    await expect(prewarmWorktree(dir)).rejects.toMatchObject({
+      name: 'WorktreeDependencyPreflightError',
+      command: ['npm', 'ci'],
+      cwd: dir,
+      packageManager: 'npm',
+      exitCode: 1,
+      stderrTail: 'first line\nlast line',
+    } satisfies Partial<WorktreeDependencyPreflightError>);
+  });
+});

--- a/core/workspaces/prewarm-package-manager.test.ts
+++ b/core/workspaces/prewarm-package-manager.test.ts
@@ -41,6 +41,18 @@ describe('prewarmWorktree package manager selection', () => {
     );
   });
 
+  it('runs npm install for npm repos without lockfiles', async () => {
+    const dir = repo({ 'package.json': packageJson() });
+
+    await prewarmWorktree(dir);
+
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      'npm',
+      ['install'],
+      expect.objectContaining({ cwd: dir, stdio: 'pipe' }),
+    );
+  });
+
   it('runs pnpm install --frozen-lockfile for pnpm repos', async () => {
     const dir = repo({ 'package.json': packageJson(), 'pnpm-lock.yaml': 'lockfileVersion: 9\n' });
 

--- a/core/workspaces/repo-affinity.test.ts
+++ b/core/workspaces/repo-affinity.test.ts
@@ -136,6 +136,7 @@ describe('repo affinity', () => {
       repoRef: 'owner/docs',
       localPath: docsRepoPath,
       defaultBranch: 'trunk',
+      checkoutSource: 'configured-local-path',
       selectedBy: 'repo-link-primary',
     });
   });
@@ -177,6 +178,7 @@ describe('repo affinity', () => {
       repoRef: 'owner/docs',
       localPath: docsRepoPath,
       defaultBranch: 'trunk',
+      checkoutSource: 'configured-local-path',
       selectedBy: 'repo-override',
     });
   });
@@ -192,6 +194,7 @@ describe('repo affinity', () => {
       repoRef: 'owner/app',
       localPath: appRepoPath,
       defaultBranch: 'main',
+      checkoutSource: 'configured-local-path',
       selectedBy: 'work-item',
     });
   });
@@ -216,6 +219,8 @@ describe('repo affinity', () => {
       }),
     ).toMatchObject({
       localPath: fallbackRepoPath,
+      checkoutSource: 'fallback-path',
+      configuredLocalPath: expect.stringContaining('~/missing-'),
     });
   });
 
@@ -241,6 +246,8 @@ describe('repo affinity', () => {
     ).toMatchObject({
       localPath: targetRepoPath,
       defaultBranch: 'develop',
+      checkoutSource: 'project-target-path',
+      configuredLocalPath: expect.stringContaining('repo-affinity-missing-configured-'),
     });
   });
 
@@ -264,6 +271,8 @@ describe('repo affinity', () => {
       }),
     ).toMatchObject({
       localPath: fallbackRepoPath,
+      checkoutSource: 'fallback-path',
+      configuredLocalPath: expect.stringContaining('repo-affinity-missing-configured-'),
     });
   });
 });

--- a/core/workspaces/repo-affinity.ts
+++ b/core/workspaces/repo-affinity.ts
@@ -17,6 +17,12 @@ export interface SelectedWorkItemRepository {
   localPath: string;
   defaultBranch: string;
   role: string;
+  checkoutSource?:
+    | 'configured-local-path'
+    | 'project-target-path'
+    | 'fallback-path'
+    | 'managed-clone';
+  configuredLocalPath?: string;
   selectedBy: 'repo-link-primary' | 'repo-override' | 'work-item' | 'project';
 }
 
@@ -147,14 +153,24 @@ export function resolveRepositoryForWorkItem(input: {
   }
   const configuredLocalPath = normalizeExistingLocalPath(configuredRepo?.localPath);
   const targetLocalPath = normalizeExistingLocalPath(project?.targetRepo?.localPath);
+  const selectedLocalPath = configuredLocalPath ?? targetLocalPath ?? input.fallbackLocalPath;
   return {
     repoRef,
-    localPath: configuredLocalPath ?? targetLocalPath ?? input.fallbackLocalPath,
+    localPath: selectedLocalPath,
     defaultBranch:
       (configuredLocalPath != null ? configuredRepo?.defaultBranch : null) ??
       project?.targetRepo?.defaultBranch ??
       'main',
     role: repoLink?.role ?? configuredRepo?.role ?? 'unknown',
+    checkoutSource:
+      configuredLocalPath != null
+        ? 'configured-local-path'
+        : targetLocalPath != null
+          ? 'project-target-path'
+          : 'fallback-path',
+    ...(configuredRepo?.localPath != null && configuredRepo.localPath.length > 0
+      ? { configuredLocalPath: configuredRepo.localPath }
+      : {}),
     selectedBy:
       repoLink?.role === 'primary'
         ? 'repo-link-primary'

--- a/core/workspaces/stack-commands.test.ts
+++ b/core/workspaces/stack-commands.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { stackCommandsForWorktree } from './stack-commands.js';
+
+function repo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'stack-commands-'));
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  return dir;
+}
+
+describe('selected repo stack commands', () => {
+  it('derives commands from the selected npm repo instead of broad project pnpm defaults', async () => {
+    const dir = repo({
+      'package.json': JSON.stringify({
+        scripts: {
+          test: 'jest',
+          lint: 'eslint .',
+        },
+      }),
+      'package-lock.json': '{}',
+    });
+
+    await expect(
+      stackCommandsForWorktree(dir, {
+        runtime: 'node',
+        packageManager: 'pnpm',
+        testCommand: 'pnpm --filter broad-project test',
+        lintCommand: 'pnpm biome check .',
+        typecheckCommand: 'pnpm typecheck',
+        e2eCommand: 'pnpm test:e2e',
+        detectedAt: '2026-06-05T00:00:00.000Z',
+      }),
+    ).resolves.toMatchObject({
+      runtime: 'node',
+      packageManager: 'npm',
+      installCommand: ['npm', 'ci'],
+      testCommand: 'npm test',
+      lintCommand: 'npm run lint',
+    });
+  });
+
+  it('only exposes optional commands when package scripts exist', async () => {
+    const dir = repo({
+      'package.json': JSON.stringify({
+        scripts: {
+          test: 'vitest',
+        },
+      }),
+      'pnpm-lock.yaml': 'lockfileVersion: 9\n',
+    });
+
+    await expect(stackCommandsForWorktree(dir)).resolves.toEqual(
+      expect.not.objectContaining({
+        lintCommand: expect.any(String),
+        typecheckCommand: expect.any(String),
+        e2eCommand: expect.any(String),
+      }),
+    );
+  });
+});

--- a/core/workspaces/stack-commands.test.ts
+++ b/core/workspaces/stack-commands.test.ts
@@ -40,6 +40,39 @@ describe('selected repo stack commands', () => {
       installCommand: ['npm', 'ci'],
       testCommand: 'npm test',
       lintCommand: 'npm run lint',
+      typecheckCommand: 'pnpm typecheck',
+      e2eCommand: 'pnpm test:e2e',
+    });
+  });
+
+  it('preserves configured commands when the selected repo omits matching scripts', async () => {
+    const dir = repo({
+      'package.json': JSON.stringify({
+        scripts: {
+          test: 'vitest',
+          'test:e2e:pipeline': 'playwright test',
+        },
+      }),
+      'pnpm-lock.yaml': 'lockfileVersion: 9\n',
+    });
+
+    await expect(
+      stackCommandsForWorktree(dir, {
+        runtime: 'node',
+        packageManager: 'pnpm',
+        testCommand: 'pnpm test --reporter=json',
+        lintCommand: 'pnpm lint',
+        typecheckCommand: 'pnpm typecheck',
+        e2eCommand: 'pnpm test:e2e:pipeline',
+        detectedAt: '2026-06-05T00:00:00.000Z',
+      }),
+    ).resolves.toMatchObject({
+      runtime: 'node',
+      packageManager: 'pnpm',
+      testCommand: 'pnpm test',
+      lintCommand: 'pnpm lint',
+      typecheckCommand: 'pnpm typecheck',
+      e2eCommand: 'pnpm test:e2e:pipeline',
     });
   });
 

--- a/core/workspaces/stack-commands.ts
+++ b/core/workspaces/stack-commands.ts
@@ -42,7 +42,12 @@ export async function installCommandForPackageManager(
       ? ['pnpm', 'install', '--frozen-lockfile', '--filter', filter]
       : ['pnpm', 'install', '--frozen-lockfile'];
   }
-  if (packageManager === 'npm') return ['npm', 'ci'];
+  if (packageManager === 'npm') {
+    return (await exists(join(repoPath, 'package-lock.json'))) ||
+      (await exists(join(repoPath, 'npm-shrinkwrap.json')))
+      ? ['npm', 'ci']
+      : ['npm', 'install'];
+  }
   return (await isYarnBerry(repoPath))
     ? ['yarn', 'install', '--immutable']
     : ['yarn', 'install', '--frozen-lockfile'];
@@ -80,7 +85,7 @@ export function stackCommandsFromDetectedStack(
 ): SelectedRepoStack {
   if (stack.type === 'node') {
     const pm = stack.packageManager;
-    return {
+    const detected: SelectedRepoStack = {
       runtime: 'node',
       packageManager: pm,
       detectedAt,
@@ -89,6 +94,24 @@ export function stackCommandsFromDetectedStack(
       ...(stack.scripts.lint ? { lintCommand: nodeScriptCommand(pm, 'lint') } : {}),
       ...(stack.scripts.typecheck ? { typecheckCommand: nodeScriptCommand(pm, 'typecheck') } : {}),
       ...(stack.scripts.e2e ? { e2eCommand: nodeScriptCommand(pm, 'e2e') } : {}),
+    };
+    return {
+      ...detected,
+      ...(detected.testCommand.length === 0 && fallback?.testCommand != null
+        ? { testCommand: fallback.testCommand }
+        : {}),
+      ...(detected.buildCommand == null && fallback?.buildCommand != null
+        ? { buildCommand: fallback.buildCommand }
+        : {}),
+      ...(detected.lintCommand == null && fallback?.lintCommand != null
+        ? { lintCommand: fallback.lintCommand }
+        : {}),
+      ...(detected.typecheckCommand == null && fallback?.typecheckCommand != null
+        ? { typecheckCommand: fallback.typecheckCommand }
+        : {}),
+      ...(detected.e2eCommand == null && fallback?.e2eCommand != null
+        ? { e2eCommand: fallback.e2eCommand }
+        : {}),
     };
   }
   if (stack.type === 'go') {

--- a/core/workspaces/stack-commands.ts
+++ b/core/workspaces/stack-commands.ts
@@ -1,0 +1,137 @@
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type StackInfo, detectStack } from '../bootstrap/stack-detector.js';
+import type { StackConfig } from '../types.js';
+
+export type PackageManager = 'pnpm' | 'npm' | 'yarn';
+
+export interface SelectedRepoStack extends StackConfig {
+  installCommand?: string[];
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isYarnBerry(repoPath: string): Promise<boolean> {
+  if (await exists(join(repoPath, '.yarnrc.yml'))) return true;
+  try {
+    const pkg = JSON.parse(await readFile(join(repoPath, 'package.json'), 'utf8')) as {
+      packageManager?: unknown;
+    };
+    const packageManager = typeof pkg.packageManager === 'string' ? pkg.packageManager : '';
+    const match = packageManager.match(/^yarn@(\d+)/);
+    return match != null && Number(match[1]) >= 2;
+  } catch {
+    return false;
+  }
+}
+
+export async function installCommandForPackageManager(
+  repoPath: string,
+  packageManager: PackageManager,
+  filter?: string,
+): Promise<string[]> {
+  if (packageManager === 'pnpm') {
+    return filter
+      ? ['pnpm', 'install', '--frozen-lockfile', '--filter', filter]
+      : ['pnpm', 'install', '--frozen-lockfile'];
+  }
+  if (packageManager === 'npm') return ['npm', 'ci'];
+  return (await isYarnBerry(repoPath))
+    ? ['yarn', 'install', '--immutable']
+    : ['yarn', 'install', '--frozen-lockfile'];
+}
+
+function nodeScriptCommand(pm: PackageManager, script: string): string {
+  if (script === 'test') return pm === 'npm' ? 'npm test' : `${pm} test`;
+  return `${pm} run ${script}`;
+}
+
+export async function stackCommandsForWorktree(
+  worktreePath: string,
+  fallback?: StackConfig,
+): Promise<SelectedRepoStack> {
+  const detectedAt = new Date().toISOString();
+  const stack = await detectStack(worktreePath);
+  const commands = stackCommandsFromDetectedStack(stack, detectedAt, fallback);
+  if (
+    commands.packageManager === 'pnpm' ||
+    commands.packageManager === 'npm' ||
+    commands.packageManager === 'yarn'
+  ) {
+    return {
+      ...commands,
+      installCommand: await installCommandForPackageManager(worktreePath, commands.packageManager),
+    };
+  }
+  return commands;
+}
+
+export function stackCommandsFromDetectedStack(
+  stack: StackInfo,
+  detectedAt: string,
+  fallback?: StackConfig,
+): SelectedRepoStack {
+  if (stack.type === 'node') {
+    const pm = stack.packageManager;
+    return {
+      runtime: 'node',
+      packageManager: pm,
+      detectedAt,
+      testCommand: stack.scripts.test ? nodeScriptCommand(pm, 'test') : '',
+      ...(stack.scripts.build ? { buildCommand: nodeScriptCommand(pm, 'build') } : {}),
+      ...(stack.scripts.lint ? { lintCommand: nodeScriptCommand(pm, 'lint') } : {}),
+      ...(stack.scripts.typecheck ? { typecheckCommand: nodeScriptCommand(pm, 'typecheck') } : {}),
+      ...(stack.scripts.e2e ? { e2eCommand: nodeScriptCommand(pm, 'e2e') } : {}),
+    };
+  }
+  if (stack.type === 'go') {
+    return {
+      runtime: 'go',
+      packageManager: 'go',
+      detectedAt,
+      buildCommand: stack.buildCommand,
+      testCommand: stack.testCommand,
+    };
+  }
+  if (stack.type === 'rust') {
+    return {
+      runtime: 'rust',
+      packageManager: 'cargo',
+      detectedAt,
+      buildCommand: stack.buildCommand,
+      testCommand: stack.testCommand,
+    };
+  }
+  if (stack.type === 'python') {
+    return {
+      runtime: 'python',
+      packageManager: 'pip',
+      detectedAt,
+      testCommand: stack.testRunner === 'pytest' ? 'pytest' : 'python -m unittest',
+      ...(stack.lintTool != null ? { lintCommand: stack.lintTool } : {}),
+    };
+  }
+  if (stack.type === 'ruby') {
+    return {
+      runtime: 'ruby',
+      packageManager: 'bundle',
+      detectedAt,
+      testCommand: stack.testRunner === 'rspec' ? 'bundle exec rspec' : 'ruby -Itest',
+    };
+  }
+  return (
+    fallback ?? {
+      runtime: 'unknown',
+      packageManager: 'unknown',
+      detectedAt,
+      testCommand: '',
+    }
+  );
+}

--- a/core/workspaces/worktree.ts
+++ b/core/workspaces/worktree.ts
@@ -3,6 +3,11 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import { GIT_ENV } from './git-env.js';
+import {
+  type PackageManager,
+  installCommandForPackageManager,
+  stackCommandsForWorktree,
+} from './stack-commands.js';
 
 const WORKSPACES_DIR = join(homedir(), '.factory', 'workspaces');
 
@@ -24,12 +29,28 @@ export type IntegrationWorktree = {
 export class WorktreeDependencyPreflightError extends Error {
   readonly command: readonly string[];
   readonly cwd: string;
+  readonly packageManager?: string;
+  readonly exitCode?: number | null;
+  readonly stderrTail?: string;
 
-  constructor(message: string, opts: { command: readonly string[]; cwd: string; cause?: unknown }) {
+  constructor(
+    message: string,
+    opts: {
+      command: readonly string[];
+      cwd: string;
+      cause?: unknown;
+      packageManager?: string;
+      exitCode?: number | null;
+      stderrTail?: string;
+    },
+  ) {
     super(message);
     this.name = 'WorktreeDependencyPreflightError';
     this.command = opts.command;
     this.cwd = opts.cwd;
+    this.packageManager = opts.packageManager;
+    this.exitCode = opts.exitCode;
+    this.stderrTail = opts.stderrTail;
     this.cause = opts.cause;
   }
 }
@@ -272,21 +293,62 @@ export function reattachIntegrationWorktreeAtRemoteTip(
 }
 
 /**
- * Runs `pnpm install --frozen-lockfile` in the worktree to warm node_modules before the agent
- * starts. Eliminates the first wasted turn where the agent discovers and installs dependencies.
+ * Runs the selected package manager's install command in the worktree before the
+ * agent starts. Eliminates the first wasted turn where the agent discovers and
+ * installs dependencies.
  *
  * @param worktreePath - Absolute path to the worktree directory.
  * @param filter - Optional pnpm workspace filter (e.g. `"./apps/web"`). When provided, only that
  *   package and its dependencies are installed.
  */
-export function prewarmWorktree(worktreePath: string, filter?: string): void {
-  const args = filter
-    ? ['install', '--frozen-lockfile', '--filter', filter]
-    : ['install', '--frozen-lockfile'];
-  execFileSync('pnpm', args, {
-    cwd: worktreePath,
-    stdio: 'pipe',
-  });
+export async function prewarmWorktree(worktreePath: string, filter?: string): Promise<void> {
+  const stack = await stackCommandsForWorktree(worktreePath);
+  const packageManager = stack.packageManager;
+  if (packageManager !== 'pnpm' && packageManager !== 'npm' && packageManager !== 'yarn') {
+    return;
+  }
+  const command = await installCommandForPackageManager(
+    worktreePath,
+    packageManager as PackageManager,
+    filter,
+  );
+  try {
+    execFileSync(command[0], command.slice(1), {
+      cwd: worktreePath,
+      stdio: 'pipe',
+    });
+  } catch (err) {
+    const details = dependencyPreflightErrorDetails(err);
+    throw new WorktreeDependencyPreflightError(
+      `worktree dependency preflight failed: ${command.join(' ')}`,
+      {
+        command,
+        cwd: worktreePath,
+        packageManager,
+        cause: err,
+        ...details,
+      },
+    );
+  }
+}
+
+function dependencyPreflightErrorDetails(err: unknown): {
+  exitCode?: number | null;
+  stderrTail?: string;
+} {
+  if (err == null || typeof err !== 'object') return {};
+  const record = err as { status?: unknown; stderr?: unknown };
+  const exitCode = typeof record.status === 'number' ? record.status : null;
+  const rawStderr = Buffer.isBuffer(record.stderr)
+    ? record.stderr.toString('utf8')
+    : typeof record.stderr === 'string'
+      ? record.stderr
+      : '';
+  const stderrTail = rawStderr.trim().split('\n').slice(-20).join('\n');
+  return {
+    exitCode,
+    ...(stderrTail.length > 0 ? { stderrTail } : {}),
+  };
 }
 
 export function assertPnpmPackageExecutableAvailable(
@@ -303,7 +365,7 @@ export function assertPnpmPackageExecutableAvailable(
   } catch (err) {
     throw new WorktreeDependencyPreflightError(
       `worktree dependencies unavailable: ${packageFilter} ${executable} binary not resolvable`,
-      { command: ['pnpm', ...args], cwd: worktreePath, cause: err },
+      { command: ['pnpm', ...args], cwd: worktreePath, packageManager: 'pnpm', cause: err },
     );
   }
 }

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -104,7 +104,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `stack-detector` | yes | Stack detector for target project repositories. Closes M12.01 (#304). |
 | `webhook-runbook` | yes | **Status:** Documentation slice for M12 project bootstrap. |
 
-## skills/ (39 entries, 0 missing README)
+## skills/ (40 entries, 0 missing README)
 
 | Name | README | Summary |
 |---|---|---|
@@ -119,6 +119,7 @@ A flat, machine-readable map of every package and slice in this repo. The point:
 | `echo-test` | yes | Trivial echo-back skill used to prove the M4 runtime pipeline end-to-end. |
 | `echo-test-holdout` | yes | Holdout variant of echo-test that verifies context allowlist enforcement. |
 | `evidence-post` | yes | Runs the slice's Playwright spec on the PR commit, captures screenshots and a continuous WebM walkthrough to `evidence/issue-<N>/`, commits those artefacts to the PR branch, and posts a comment on the linked issue with the screenshots embedded inline via `raw.githubusercontent.com` URLs **pinned to the PR head commit SHA**. |
+| `feature-enhance` | yes | Read-only feature grounding pass for fresh feature work. It turns product-language intent into candidate repository surfaces before the `factory:grounding` workflow decides whether scouts are needed. |
 | `feature-frame` | yes | Frames vague feature work items before grill-me. It adds append-only scaffold content, required refined intent, proposed acceptance criteria, optional grounded hints, and a boolean gate for whether grilling is still needed. |
 | `grill-me` | yes | Runs a structured discovery session on a vague work item. Asks ONE focused question per round (Mat Pocock interrogation pattern) until the intent is precise enough to hand off to a PRD writer. |
 | `hub-chat` | yes | The default assistant the user (Shaun) talks to inside the Goose Hub web UI. Interactive multi-turn skill, invoked once per round. Conversation history lives in the `chat_messages` table (M20). The orchestrator slice that drives the loop is `slices/chat-orchestrator/`. |

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -53,7 +53,14 @@ export interface RunImplementInput {
   projectId: string;
   workItem: WorkItem;
   worktreePath: string;
-  stack: { testCommand: string; lintCommand?: string; typecheckCommand?: string };
+  stack: {
+    packageManager?: string;
+    installCommand?: string[];
+    testCommand: string;
+    lintCommand?: string;
+    typecheckCommand?: string;
+    e2eCommand?: string;
+  };
   appendSystemPrompt: string;
   outputJsonSchema: Record<string, unknown>;
   personaId: string;
@@ -636,9 +643,12 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
         'workItem.body',
         'workItem.number',
         'workItem.priority',
+        'stack.packageManager',
+        'stack.installCommand',
         'stack.testCommand',
         'stack.lintCommand',
         'stack.typecheckCommand',
+        'stack.e2eCommand',
         'investigation',
         'codeContext',
         'relatedSurface',

--- a/slices/fix-issue/pr-helpers.ts
+++ b/slices/fix-issue/pr-helpers.ts
@@ -10,6 +10,7 @@ import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { WorkItem } from '@goose-hub/core/state-source/interface.js';
 import type { ObservedChangedFilesPacket } from '@goose-hub/core/workspaces/observed-changes.js';
+import { stackCommandsForWorktree } from '@goose-hub/core/workspaces/stack-commands.js';
 import {
   EvidencePostPlanSchema,
   EvidencePostSchema,
@@ -276,12 +277,29 @@ export function resolveWorktreeHeadSha(worktreePath: string): string {
   }
 }
 
-export async function deriveStack(projectId: string): Promise<{
+export async function deriveStack(
+  projectId: string,
+  worktreePath?: string,
+): Promise<{
+  packageManager?: string;
+  installCommand?: string[];
   testCommand: string;
   lintCommand?: string;
   typecheckCommand?: string;
+  e2eCommand?: string;
 }> {
   const config = await getProjectBySlug(projectId);
+  if (worktreePath != null) {
+    const stack = await stackCommandsForWorktree(worktreePath, config?.stack);
+    return {
+      packageManager: stack.packageManager,
+      installCommand: stack.installCommand,
+      testCommand: stack.testCommand,
+      lintCommand: stack.lintCommand,
+      typecheckCommand: stack.typecheckCommand,
+      e2eCommand: stack.e2eCommand,
+    };
+  }
   if (config?.stack) {
     return {
       testCommand: config.stack.testCommand,

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -98,6 +98,32 @@ const mockResolveWorkflowBase = vi.fn().mockReturnValue({
   source: 'configured-default',
 });
 vi.mock('@goose-hub/core/workspaces/worktree.js', () => ({
+  WorktreeDependencyPreflightError: class WorktreeDependencyPreflightError extends Error {
+    readonly command: readonly string[];
+    readonly cwd: string;
+    readonly packageManager?: string;
+    readonly exitCode?: number | null;
+    readonly stderrTail?: string;
+
+    constructor(
+      message: string,
+      opts: {
+        command: readonly string[];
+        cwd: string;
+        packageManager?: string;
+        exitCode?: number | null;
+        stderrTail?: string;
+      },
+    ) {
+      super(message);
+      this.name = 'WorktreeDependencyPreflightError';
+      this.command = opts.command;
+      this.cwd = opts.cwd;
+      this.packageManager = opts.packageManager;
+      this.exitCode = opts.exitCode;
+      this.stderrTail = opts.stderrTail;
+    }
+  },
   createWorktree: (...args: unknown[]) => mockCreateWorktree(...args),
   cleanupWorktree: (...args: unknown[]) => mockCleanupWorktree(...args),
   prewarmWorktree: (...args: unknown[]) => mockPrewarmWorktree(...args),
@@ -112,6 +138,7 @@ vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
 import { GIT_ENV } from '@goose-hub/core/workspaces/git-env.js';
+import { WorktreeDependencyPreflightError } from '@goose-hub/core/workspaces/worktree.js';
 
 function resetEventStoreMocks(): void {
   vi.mocked(eventStore.replay).mockReturnValue([]);
@@ -2051,6 +2078,45 @@ describe('runFixIssueWorkflow (#183)', () => {
       personaName: 'proj/developer/0',
       role: 'developer',
       outcome: 'failure',
+    });
+  });
+
+  it('on prewarm failure: emits package manager and command metadata', async () => {
+    const item = makeWorkItem({ priority: 'medium', repoRef: 'owner/repo' });
+    const source = makeStateSource();
+    const prewarmError = new WorktreeDependencyPreflightError(
+      'worktree dependency preflight failed: npm ci',
+      {
+        command: ['npm', 'ci'],
+        cwd: '/work/wt',
+        packageManager: 'npm',
+        exitCode: 1,
+        stderrTail: 'npm ERR! lockfile out of date',
+      },
+    );
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', {
+      runtime: { run: vi.fn() },
+      openPRImpl: vi.fn(),
+      adviseOnPlanImpl: vi.fn(),
+      createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
+      cleanupWorktreeImpl: vi.fn(),
+      prewarmWorktreeImpl: vi.fn().mockRejectedValue(prewarmError),
+    });
+
+    const failed = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failed?.[0].payload).toMatchObject({
+      phase: 'prewarm',
+      repoRef: 'owner/repo',
+      checkoutPath: '/repo',
+      worktreePath: '/work/wt',
+      packageManager: 'npm',
+      command: 'npm ci',
+      exitCode: 1,
+      stderrTail: 'npm ERR! lockfile out of date',
     });
   });
 

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -22,6 +22,7 @@ import { orchestratorCommitAll } from '@goose-hub/core/workspaces/orchestrator-g
 import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import {
+  WorktreeDependencyPreflightError,
   cleanupWorktree,
   createWorktree,
   prewarmWorktree,
@@ -57,8 +58,8 @@ export interface FixIssueDeps {
   createWorktreeImpl?: typeof createWorktree;
   /** Override cleanupWorktree (used by tests). */
   cleanupWorktreeImpl?: typeof cleanupWorktree;
-  /** Override prewarmWorktree (used by tests to skip pnpm install). */
-  prewarmWorktreeImpl?: typeof prewarmWorktree;
+  /** Override prewarmWorktree (used by tests to skip dependency install). */
+  prewarmWorktreeImpl?: (worktreePath: string, filter?: string) => void | Promise<void>;
   /** Override resolveWorktreeHeadSha (used by tests to avoid real git subprocess). */
   resolveWorktreeHeadShaImpl?: typeof resolveWorktreeHeadSha;
   /** Override resolveWorkflowBase (used by tests to avoid real git subprocess). */
@@ -126,6 +127,22 @@ export async function runFixIssueWorkflow(
       fallbackLocalPath: targetRepo,
     }),
   );
+  eventStore.appendEvent({
+    projectId,
+    workItemId: workItem.id,
+    kind: 'agent.checkout-readiness',
+    payload: {
+      runId,
+      repoRef: selectedRepository.repoRef,
+      checkoutPath: selectedRepository.localPath,
+      defaultBranch: selectedRepository.defaultBranch,
+      selectedBy: selectedRepository.selectedBy,
+      checkoutSource: selectedRepository.checkoutSource,
+      readiness: selectedRepository.readiness ?? null,
+    },
+    runId,
+    personaId: implementPersonaId,
+  });
   const workflowWorkItem =
     selectedRepository.repoRef === workItem.repoRef
       ? workItem
@@ -221,7 +238,7 @@ export async function runFixIssueWorkflow(
 
     // Pre-warm: install dependencies before spawning the agent so it doesn't
     // waste its first turn running pnpm install.
-    prewarmWtFn(worktreePath);
+    await prewarmWtFn(worktreePath);
 
     const codeContext = buildCodeContextBundle({
       worktreePath,
@@ -244,7 +261,7 @@ export async function runFixIssueWorkflow(
         projectId,
         workItem,
         worktreePath,
-        stack: await deriveStack(projectId),
+        stack: await deriveStack(projectId, worktreePath),
         appendSystemPrompt: implementPrompt,
         outputJsonSchema: implementJsonSchema,
         personaId: implementPersonaId,
@@ -339,7 +356,7 @@ export async function runFixIssueWorkflow(
       projectId,
       workItem: workflowWorkItem,
       worktreePath,
-      stack: await deriveStack(projectId),
+      stack: await deriveStack(projectId, worktreePath),
       appendSystemPrompt: implementPrompt,
       outputJsonSchema: implementJsonSchema,
       personaId: implementPersonaId,
@@ -394,7 +411,21 @@ export async function runFixIssueWorkflow(
       projectId,
       workItemId: workItem.id,
       kind: 'agent.run-failed',
-      payload: { runId, error: error.message },
+      payload:
+        err instanceof WorktreeDependencyPreflightError
+          ? {
+              runId,
+              error: error.message,
+              phase: 'prewarm',
+              repoRef: selectedRepository.repoRef,
+              checkoutPath: selectedRepository.localPath,
+              worktreePath,
+              packageManager: err.packageManager,
+              command: err.command.join(' '),
+              exitCode: err.exitCode ?? null,
+              stderrTail: err.stderrTail ?? null,
+            }
+          : { runId, error: error.message },
       runId,
     });
     await stateSource.comment(

--- a/slices/investigate/workflow.ts
+++ b/slices/investigate/workflow.ts
@@ -71,6 +71,7 @@ import { ensureSelectedRepositoryCheckout } from '@goose-hub/core/workspaces/che
 import { resolveRepositoryForWorkItem } from '@goose-hub/core/workspaces/repo-affinity.js';
 import { resolveWorkflowBaseForWorkItem } from '@goose-hub/core/workspaces/workflow-base.js';
 import {
+  WorktreeDependencyPreflightError,
   cleanupWorktree,
   createWorktree,
   prewarmWorktree,
@@ -304,7 +305,7 @@ function runtimeNameForModel(modelId: string): 'codex-cli' | 'claude-cli' {
  */
 export interface InvestigateWorkflowDeps {
   createWorktreeImpl?: typeof createWorktree;
-  prewarmWorktreeImpl?: typeof prewarmWorktree;
+  prewarmWorktreeImpl?: (worktreePath: string, filter?: string) => void | Promise<void>;
   resolveWorkflowBaseImpl?: typeof resolveWorkflowBaseForWorkItem;
   runtime?: AgentRuntime;
   playwrightEvidenceRunner?: typeof runPlaywrightReproPlan;
@@ -388,6 +389,22 @@ export async function runInvestigateWorkflow(
       fallbackLocalPath: targetRepo,
     }),
   );
+  eventStore.appendEvent({
+    projectId,
+    workItemId: workItem.id,
+    kind: 'agent.checkout-readiness',
+    payload: {
+      runId,
+      repoRef: selectedRepository.repoRef,
+      checkoutPath: selectedRepository.localPath,
+      defaultBranch: selectedRepository.defaultBranch,
+      selectedBy: selectedRepository.selectedBy,
+      checkoutSource: selectedRepository.checkoutSource,
+      readiness: selectedRepository.readiness ?? null,
+    },
+    runId,
+    personaId,
+  });
   const workflowBase =
     selectedRepository.workflowBase ??
     resolveWorkflowBaseFn(
@@ -404,7 +421,34 @@ export async function runInvestigateWorkflow(
   );
 
   if (workItem.type === 'bug') {
-    prewarmWtFn(worktreePath, '@goose-hub/web');
+    try {
+      await prewarmWtFn(worktreePath, '@goose-hub/web');
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-failed',
+        payload:
+          err instanceof WorktreeDependencyPreflightError
+            ? {
+                runId,
+                error: error.message,
+                phase: 'prewarm',
+                repoRef: selectedRepository.repoRef,
+                checkoutPath: selectedRepository.localPath,
+                worktreePath,
+                packageManager: err.packageManager,
+                command: err.command.join(' '),
+                exitCode: err.exitCode ?? null,
+                stderrTail: err.stderrTail ?? null,
+              }
+            : { runId, error: error.message, phase: 'prewarm' },
+        runId,
+        personaId,
+      });
+      throw err;
+    }
   }
 
   const workItemCtx = {

--- a/slices/issue-restart/slice.test.ts
+++ b/slices/issue-restart/slice.test.ts
@@ -1,6 +1,14 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { describe, expect, it } from 'vitest';
+import * as schema from '../../core/db/schema.js';
 import { filterRestartAuxiliaryLabels, restartIssue } from '../../core/projects/restart-issue.js';
 import { InMemoryLabelsSource } from '../../core/state-source/in-memory-labels.js';
+import { LocalDbWorkItemRepository } from '../../core/state-source/local-db-repository.js';
+import { LocalDbStateSource } from '../../core/state-source/local-db.js';
 
 describe('issue restart', () => {
   it('filters lifecycle-owned labels but preserves auxiliary labels', () => {
@@ -86,5 +94,63 @@ describe('issue restart', () => {
     const fresh = await source.getItem(result.newItem.id);
     expect(fresh.state).toBe('factory:triaging');
     expect(fresh.schedule).toBe('later');
+  });
+
+  it('copies local-db primary and related repo links with metadata', async () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema });
+    const migrationsFolder = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'core',
+      'db',
+      'migrations',
+    );
+    migrate(db, { migrationsFolder });
+    const repository = new LocalDbWorkItemRepository({
+      db,
+      now: () => new Date('2026-06-05T00:00:00.000Z'),
+    });
+    const source = new LocalDbStateSource('proj', 'owner/app', repository);
+    const oldItem = await source.createIssue({ title: 'Restart with repos', body: '' });
+    repository.createRepoLink({
+      projectId: 'proj',
+      itemId: oldItem.id,
+      repoRef: 'owner/app',
+      role: 'primary',
+      confidence: 0.95,
+      source: 'affinity',
+    });
+    repository.createRepoLink({
+      projectId: 'proj',
+      itemId: oldItem.id,
+      repoRef: 'owner/docs',
+      role: 'related',
+      confidence: 0.5,
+      source: 'manual',
+    });
+
+    const result = await restartIssue({
+      source,
+      projectId: 'proj',
+      itemId: oldItem.id,
+    });
+
+    expect(repository.listRepoLinks('proj', result.newItem.id)).toMatchObject([
+      {
+        repoRef: 'owner/app',
+        role: 'primary',
+        confidence: 0.95,
+        source: 'affinity',
+      },
+      {
+        repoRef: 'owner/docs',
+        role: 'related',
+        confidence: 0.5,
+        source: 'manual',
+      },
+    ]);
+    sqlite.close();
   });
 });

--- a/slices/parallel-implement/workflow.ts
+++ b/slices/parallel-implement/workflow.ts
@@ -43,7 +43,9 @@ import {
   resolveRemoteBranchHead,
   revertWpChanges,
 } from '@goose-hub/core/workspaces/orchestrator-git.js';
+import { stackCommandsForWorktree } from '@goose-hub/core/workspaces/stack-commands.js';
 import {
+  WorktreeDependencyPreflightError,
   assertGooseHubWebPlaywrightReady,
   type cleanupWorktree,
   createIntegrationWorktree,
@@ -94,7 +96,7 @@ export interface ParallelImplementDeps {
   createWpWorktreeImpl?: typeof createWpScratchWorktree;
   createIssueWorktreeImpl?: typeof createWorktree;
   /** Override dependency prewarm for tests or alternate package managers. */
-  prewarmWorktreeImpl?: typeof prewarmWorktree;
+  prewarmWorktreeImpl?: (worktreePath: string, filter?: string) => void | Promise<void>;
   /** Override post-prewarm dependency verification for tests or alternate package managers. */
   verifyWorktreeDependenciesImpl?: (worktreePath: string) => void;
   resolveWorkflowBaseImpl?: typeof resolveWorkflowBase;
@@ -692,13 +694,7 @@ export async function runParallelImplementWorkflow(
   }
   const specForRun = normalizedSpec.spec;
 
-  const stack = projectConfig?.stack
-    ? {
-        testCommand: projectConfig.stack.testCommand,
-        lintCommand: projectConfig.stack.lintCommand,
-        typecheckCommand: projectConfig.stack.typecheckCommand,
-      }
-    : { testCommand: 'pnpm test' };
+  const stack = await stackCommandsForWorktree(targetRepo, projectConfig?.stack);
 
   const allWpIds = specForRun.workPackages.map((wp) => wp.id);
   const scratchWorktrees = new Map<string, string>(); // wpId → path
@@ -803,7 +799,7 @@ export async function runParallelImplementWorkflow(
     }
     issueWorktreePath = integrationWorktree.worktreePath;
     integrationHeadSha = latestPersisted?.pushedSha ?? integrationWorktree.previousHeadSha;
-    prewarmWtFn(issueWorktreePath);
+    await prewarmWtFn(issueWorktreePath);
     try {
       verifyWorktreeDepsFn(issueWorktreePath);
     } catch (err) {
@@ -857,7 +853,7 @@ export async function runParallelImplementWorkflow(
         for (const wp of batchWps) {
           if (scratchWorktrees.has(wp.id)) continue;
           const wtPath = createWpFn(targetRepo, runId, wp.id, scratchBaseRef);
-          prewarmWtFn(wtPath);
+          await prewarmWtFn(wtPath);
           scratchWorktrees.set(wp.id, wtPath);
         }
 
@@ -1614,6 +1610,18 @@ export async function runParallelImplementWorkflow(
         runId,
         skill: 'parallel-implement',
         error: error.message,
+        ...(err instanceof WorktreeDependencyPreflightError
+          ? {
+              phase: 'prewarm',
+              repoRef: workItem.repoRef ?? null,
+              checkoutPath: targetRepo,
+              worktreePath: err.cwd,
+              packageManager: err.packageManager,
+              command: err.command.join(' '),
+              exitCode: err.exitCode ?? null,
+              stderrTail: err.stderrTail ?? null,
+            }
+          : {}),
         ...(persistenceFailure ?? {}),
         ...(blockedGate ?? {}),
       },

--- a/slices/parallel-implement/wp-builder.ts
+++ b/slices/parallel-implement/wp-builder.ts
@@ -82,7 +82,14 @@ export interface RunOneWpBuilderOptions {
   workItemId?: string;
   workItem: WorkItem;
   scratchWorktreePath: string;
-  stack: { testCommand: string; lintCommand?: string; typecheckCommand?: string };
+  stack: {
+    packageManager?: string;
+    installCommand?: string[];
+    testCommand: string;
+    lintCommand?: string;
+    typecheckCommand?: string;
+    e2eCommand?: string;
+  };
   runtime: AgentRuntime;
   budgets: AgentBudgets;
   modelOverride: string;
@@ -633,9 +640,12 @@ export async function runOneWpBuilder(opts: RunOneWpBuilderOptions): Promise<WpB
       'investigation',
       'acceptanceContract',
       'parentPrdContext',
+      'stack.packageManager',
+      'stack.installCommand',
       'stack.testCommand',
       'stack.lintCommand',
       'stack.typecheckCommand',
+      'stack.e2eCommand',
     ],
     freshContext: false,
     toolBundles: ['dev-tools'],

--- a/slices/qa/workflow.ts
+++ b/slices/qa/workflow.ts
@@ -31,6 +31,7 @@ import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interfa
 import { parseVitestJson } from '@goose-hub/core/test-runner/parse-vitest-json.js';
 import type { RegressionPolicy, TierResult } from '@goose-hub/core/verify/tiers.js';
 import { runTier as defaultRunTier } from '@goose-hub/core/verify/tiers.js';
+import { stackCommandsForWorktree } from '@goose-hub/core/workspaces/stack-commands.js';
 import {
   type CriteriaResult,
   CriteriaResultSchema,
@@ -654,11 +655,15 @@ export async function runQaWorkflow(
   const { personaId } = selectPersona(projectSlug, 'qa');
   const prHints = findPrOpenedHints(workItem.id);
   const workspaceDir = prHints.worktreePath;
+  const qaStack =
+    workspaceDir != null
+      ? await stackCommandsForWorktree(workspaceDir, projectConfig?.stack)
+      : projectConfig?.stack;
   const prDiff = getPrDiff(workItem, workspaceDir, prHints.baseBranch);
   const regressionPolicy: RegressionPolicy = projectConfig?.regressionPolicy ?? 'escalate';
   const settingsProjectId = projectConfig?.id ?? projectSlug;
   const e2eConfigDefault: QaE2eMode =
-    projectConfig?.qaE2eMode ?? (projectConfig?.stack?.e2eCommand != null ? 'ui-changed' : 'off');
+    projectConfig?.qaE2eMode ?? (qaStack?.e2eCommand != null ? 'ui-changed' : 'off');
   const qaE2eMode = getQaE2eMode(settingsProjectId, e2eConfigDefault);
 
   // Snapshot prior events BEFORE this run's outcome is appended.
@@ -851,13 +856,13 @@ export async function runQaWorkflow(
       payload: { runId, status: 'running' },
       runId,
     });
-    const testCommand = projectConfig?.stack?.testCommand ?? DEFAULT_TEST_COMMAND;
-    const lintCommand = projectConfig?.stack?.lintCommand ?? 'pnpm biome check .';
-    const typecheckCommand = projectConfig?.stack?.typecheckCommand;
-    const configuredE2eCommand = projectConfig?.stack?.e2eCommand;
+    const testCommand = qaStack?.testCommand ?? DEFAULT_TEST_COMMAND;
+    const lintCommand = qaStack?.lintCommand;
+    const typecheckCommand = qaStack?.typecheckCommand;
+    const configuredE2eCommand = qaStack?.e2eCommand;
     const testCapture = resolveVitestJsonCapture({
       workspaceDir,
-      runtime: projectConfig?.stack?.runtime,
+      runtime: qaStack?.runtime,
       testCommand,
     });
     const [webPort, apiPort] =


### PR DESCRIPTION
## Summary
- make worktree dependency prewarm detect npm/pnpm/yarn from the selected repo and emit typed failure metadata
- derive implement, QA, and factory-tool stack commands from the selected repo/worktree instead of broad project stack defaults
- preserve local-db repo links across issue restart and emit checkout readiness metadata

## Verification
- pnpm vitest run core/workspaces/prewarm-package-manager.test.ts core/workspaces/stack-commands.test.ts core/workspaces/repo-affinity.test.ts core/workspaces/checkout-readiness.test.ts slices/issue-restart/slice.test.ts slices/fix-issue/slice.test.ts
- pnpm vitest run core/event-stream/store.test.ts core/workflows/timeline-sections.test.ts apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
- pnpm typecheck
- pnpm lint