### PR TITLE
Add feature-enhance grounding diagnostics

### DIFF
--- a/apps/web/src/components/detail/components/TimelineEvents.tsx
+++ b/apps/web/src/components/detail/components/TimelineEvents.tsx
@@ -261,6 +261,7 @@ export function renderTimelineItem(item: RenderItem, idx: number, context?: Time
     case 'audit.failed':
     case 'audit.autonomy-gate-fired':
     case 'agent.investigation-seed-empty':
+    case 'agent.feature-enhance-empty':
     case 'state.transition-deferred':
     case 'agent.bug-enhance-empty':
     case 'agent.bug-enhance-hallucinated':

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx
@@ -294,6 +294,18 @@ describe('Misc timeline events', () => {
         },
       },
       {
+        kind: 'agent.feature-enhance-empty',
+        title: 'Feature grounding empty',
+        payload: {
+          enhanceRunId: 'grounding-run:feature-enhance',
+          reasons: ['tool-call-blocked', 'no-grounded-output'],
+          repoIntelCallCount: 1,
+          blockedToolCallCount: 1,
+          blockedToolNames: ['search_text'],
+          validationIssues: [{ path: 'candidateFiles.0.source', message: 'Invalid source' }],
+        },
+      },
+      {
         kind: 'agent.bug-enhance-workspace-empty',
         title: 'Bug grounding workspace missing',
         payload: { workspaceDir: '/tmp/missing', runId: 'bug-run' },
@@ -391,6 +403,12 @@ describe('Misc timeline events', () => {
     expect(rendered).toContain('$0.80 cap');
     expect(rendered).toContain('stages triage → investigate → implement → qa → review → retro');
     expect(rendered).toContain('bug with no seed - fail-safe up to T2');
+    expect(rendered).toContain('grounding-run:feature-enhance');
+    expect(rendered).toContain('1 repo-intel calls');
+    expect(rendered).toContain('search_text');
+    expect(rendered).toContain('1 blocked tools');
+    expect(rendered).toContain('1 validation issues');
+    expect(rendered).toContain('tool-call-blocked, no-grounded-output');
     expect(rendered).not.toContain('"rawProbeKey"');
     expect(rendered).not.toContain('raw-value');
     expect(rendered).not.toContain('"selectedStages"');

--- a/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/MiscEvents.tsx
@@ -237,6 +237,11 @@ function payloadStringArray(payload: CompactOperationalPayload | null, key: stri
     : [];
 }
 
+function payloadArrayLength(payload: CompactOperationalPayload | null, key: string): number | null {
+  const value = payload?.[key];
+  return Array.isArray(value) ? value.length : null;
+}
+
 function formatBudgetCaps(value: unknown): string | null {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) return null;
   const caps = value as RouteBudgetCaps;
@@ -916,6 +921,21 @@ function compactOperationalEventDetails(event: AgentEventDto): {
       detail =
         payloadStringArray(p, 'reasons')?.join(', ') ??
         'Bug enhancement completed without useful content or grounding.';
+      break;
+    case 'agent.feature-enhance-empty':
+      tone = 'warning';
+      icon = 'warning';
+      push(payloadString(p, 'enhanceRunId') ?? formatShortId(event.runId ?? undefined));
+      pushNumber('repoIntelCallCount', 'repo-intel calls');
+      push(payloadStringArray(p, 'blockedToolNames').join(', '));
+      pushNumber('blockedToolCallCount', 'blocked tools');
+      facts.push(
+        `${payloadNumber(p, 'validationIssueCount') ?? payloadArrayLength(p, 'validationIssues') ?? 0} validation issues`,
+      );
+      detail =
+        payloadStringArray(p, 'reasons')?.join(', ') ??
+        payloadString(p, 'reason') ??
+        'Feature enhancement completed without valid grounded output.';
       break;
     case 'agent.bug-enhance-workspace-empty':
       tone = 'warning';

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -2424,6 +2424,7 @@ describe('EVENT_KIND_LABEL — QA and fix-feedback kinds', () => {
 
 describe('EVENT_KIND_LABEL — workflow routing kinds', () => {
   const KINDS = [
+    'agent.feature-enhance-empty',
     'workflow.route-selected',
     'workflow.route-confirmed',
     'workflow.route-escalation-proposed',

--- a/apps/web/src/components/detail/lib/timeline/labels.ts
+++ b/apps/web/src/components/detail/lib/timeline/labels.ts
@@ -37,6 +37,7 @@ export const EVENT_KIND_LABEL: Record<string, string> = {
   'feature.framed': 'Feature framed',
   'feature.grounding-enhanced': 'Feature grounding enhanced',
   'feature.grounding-complete': 'Feature grounding complete',
+  'agent.feature-enhance-empty': 'Feature grounding empty',
   'agent.investigation-seed-built': 'Investigation seed built',
   'agent.investigation-seed-empty': 'Investigation seed empty',
   'agent.bug-enhance-lazy': 'Bug grounding seed',

--- a/core/agent-runtime/feature-enhance-runner.test.ts
+++ b/core/agent-runtime/feature-enhance-runner.test.ts
@@ -1,0 +1,332 @@
+import type { AgentEvent } from '../event-stream/store.js';
+import type { FeatureEnhanceOutput } from '@goose-hub/skills/feature-enhance/schema.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResolvedSkillRuntime } from './skill-runtime-resolver.js';
+
+const mockAppendEvent = vi.fn();
+const mockReplay = vi.fn();
+const mockRunFn = vi.fn();
+
+vi.mock('../event-stream/store.js', () => ({
+  eventStore: {
+    appendEvent: (...args: unknown[]) => mockAppendEvent(...args),
+    replay: (...args: unknown[]) => mockReplay(...args),
+  },
+}));
+
+vi.mock('../projects/loader.js', () => ({
+  getProjectBySlug: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('./skill-runtime-resolver.js', () => ({
+  resolveSkillRuntimeForProject: vi.fn().mockReturnValue({
+    budgets: { maxTurns: 5, maxBudgetUsd: 0.2, timeoutMs: 30_000 },
+    modelOverride: 'claude-3-5-haiku-latest',
+    tier: 'haiku',
+    provider: 'claude',
+    source: 'skill-default',
+    selectionReason: 'test',
+    runtimeTrace: {
+      tier: { value: 'haiku', source: 'skill-default', reason: 'test' },
+      provider: { value: 'claude', source: 'skill-default', reason: 'test' },
+    },
+    resolvedPrimary: { tier: 'haiku', provider: 'claude', modelId: 'claude-3-5-haiku-latest' },
+    resolvedFallback: null,
+    resolvedAdvisor: null,
+  }),
+}));
+
+vi.mock('./select-persona.js', () => ({
+  selectPersona: vi.fn().mockReturnValue({ personaId: 'goose-hub-self/triager/0' }),
+}));
+
+vi.mock('./select-runtime.js', () => ({
+  selectRuntime: vi.fn().mockReturnValue({ run: mockRunFn }),
+}));
+
+vi.mock('./read-prompt.js', () => ({
+  readPromptWithContext: vi.fn().mockReturnValue('# mock feature-enhance prompt'),
+}));
+
+vi.mock('./schema-bridge.js', () => ({
+  toJsonSchema: vi.fn().mockReturnValue({ type: 'object', title: 'FeatureEnhanceOutput' }),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+const { runFeatureEnhance } = await import('./feature-enhance-runner.js');
+const { resolveSkillRuntimeForProject } = await import('./skill-runtime-resolver.js');
+
+function makeToolEvent(toolName: string, overrides: Record<string, unknown> = {}): AgentEvent {
+  return {
+    id: 1,
+    projectId: 'goose-hub-self',
+    workItemId: 'github:owner/repo#42',
+    kind: 'agent.tool-call',
+    payload: {
+      tool_name: toolName,
+      status: 'ok',
+      blocked: false,
+      ...overrides,
+    },
+    runId: 'grounding-run:feature-enhance',
+    personaId: null,
+    createdAt: '2026-06-05T00:00:00.000Z',
+  };
+}
+
+function makeOutput(overrides: Partial<FeatureEnhanceOutput> = {}): FeatureEnhanceOutput {
+  return {
+    candidateFiles: [
+      {
+        path: 'slices/feature-grounding/workflow.ts',
+        confidence: 'high',
+        source: 'tool-verified',
+        reason: 'Existing feature grounding workflow.',
+      },
+    ],
+    existingSurfaces: ['slices/feature-grounding/workflow.ts'],
+    similarPatterns: ['Feature grounding emits grounding events.'],
+    testSurfaces: ['slices/feature-grounding/slice.test.ts'],
+    acceptanceHints: ['Grounding emits a complete event before implementation.'],
+    openQuestions: [],
+    confidence: 'high',
+    escalationSignals: [],
+    ...overrides,
+  };
+}
+
+function makeInput() {
+  return {
+    projectId: 'goose-hub-self',
+    workItemId: 'github:owner/repo#42',
+    enhanceRunId: 'grounding-run:feature-enhance',
+    parentRunId: 'grounding-run',
+    workspaceDir: '/repo',
+    context: {
+      workItem: {
+        number: 42,
+        title: 'Add feature grounding diagnostics',
+        body: 'Make feature-enhance failures visible.',
+      },
+      projectContext: {
+        projectId: 'goose-hub-self',
+        targetRepo: '/repo',
+        defaultBranch: 'main',
+      },
+    },
+  };
+}
+
+function makeResolvedRuntime(provider: 'claude' | 'codex'): ResolvedSkillRuntime {
+  const tier = provider === 'codex' ? 'sonnet' : 'haiku';
+  const modelOverride = provider === 'codex' ? 'gpt-5-codex' : 'claude-3-5-haiku-latest';
+  return {
+    budgets: { maxTurns: 5, maxBudgetUsd: 0.2, timeoutMs: 30_000 },
+    modelOverride,
+    tier,
+    provider,
+    source: 'skill-default',
+    selectionReason: 'test runtime',
+    runtimeTrace: {
+      tier: { value: tier, source: 'skill-default', reason: 'test runtime' },
+      provider: { value: provider, source: 'skill-default', reason: 'test runtime' },
+    },
+    resolvedPrimary: { tier, provider, modelId: modelOverride },
+    resolvedFallback: null,
+    resolvedAdvisor: null,
+  };
+}
+
+describe('runFeatureEnhance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReplay.mockReturnValue([]);
+    vi.mocked(resolveSkillRuntimeForProject).mockReturnValue(makeResolvedRuntime('claude'));
+  });
+
+  it('returns ok:true for valid grounded output', async () => {
+    mockRunFn.mockResolvedValue({
+      output: makeOutput(),
+      decisionSummaries: [],
+      events: [makeToolEvent('mcp__factory-tools__repo_intel.query')],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({
+      ok: true,
+      enhanceRunId: 'grounding-run:feature-enhance',
+      output: expect.objectContaining({ confidence: 'high' }),
+    });
+    expect(mockAppendEvent).not.toHaveBeenCalled();
+    expect(mockRunFn).toHaveBeenCalledWith(expect.objectContaining({ toolBundles: ['read'] }));
+  });
+
+  it('emits agent.feature-enhance-empty when output validation fails', async () => {
+    mockRunFn.mockResolvedValue({
+      output: { confidence: 'maybe' },
+      decisionSummaries: [],
+      events: [makeToolEvent('repo_intel.query')],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({ ok: false, reason: 'output-validation-failed' });
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'agent.feature-enhance-empty',
+        payload: expect.objectContaining({
+          parentRunId: 'grounding-run',
+          enhanceRunId: 'grounding-run:feature-enhance',
+          reasons: ['output-validation-failed'],
+          repoIntelCallCount: 1,
+          validationIssues: expect.any(Array),
+          outputPreview: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it('captures blocked tool calls as blocked tool names', async () => {
+    mockRunFn.mockResolvedValue({
+      output: makeOutput(),
+      decisionSummaries: [],
+      events: [
+        makeToolEvent('mcp__factory-tools__search_text', {
+          blocked: true,
+          status: 'failed',
+        }),
+      ],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({ ok: false, reason: 'tool-call-blocked' });
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          blockedToolCallCount: 1,
+          blockedToolNames: ['search_text'],
+        }),
+      }),
+    );
+  });
+
+  it('emits empty/no-grounding telemetry for valid low-confidence empty output', async () => {
+    mockRunFn.mockResolvedValue({
+      output: makeOutput({
+        candidateFiles: [],
+        existingSurfaces: [],
+        similarPatterns: [],
+        testSurfaces: [],
+        acceptanceHints: [],
+        openQuestions: ['No matching repo surface found.'],
+        confidence: 'low',
+        escalationSignals: ['needs product clarification'],
+      }),
+      decisionSummaries: [],
+      events: [makeToolEvent('repo_intel.query')],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({ ok: false, reason: 'no-grounded-output' });
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          reasons: ['no-grounded-output'],
+          toolCallCount: 1,
+          repoIntelCallCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it('replays events and emits telemetry for runtime max-turn failures', async () => {
+    mockRunFn.mockRejectedValue(new Error('tool-call budget exceeded: 6 > 5'));
+    mockReplay.mockReturnValue([
+      makeToolEvent('repo_intel.query'),
+      makeToolEvent('mcp__factory-tools__read_file'),
+    ]);
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(mockReplay).toHaveBeenCalledWith({ runId: 'grounding-run:feature-enhance' });
+    expect(result).toMatchObject({ ok: false, reason: 'runtime-max-turn-failed' });
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          reasons: ['runtime-max-turn-failed'],
+          toolCallCount: 2,
+          repoIntelCallCount: 1,
+          error: expect.stringContaining('tool-call budget exceeded'),
+        }),
+      }),
+    );
+  });
+
+  it('counts both Claude-prefixed and Codex repo-intel calls', async () => {
+    vi.mocked(resolveSkillRuntimeForProject).mockReturnValue(makeResolvedRuntime('codex'));
+    mockRunFn.mockResolvedValue({
+      output: makeOutput({
+        candidateFiles: [],
+        existingSurfaces: [],
+        similarPatterns: [],
+        testSurfaces: [],
+        acceptanceHints: [],
+        confidence: 'low',
+      }),
+      decisionSummaries: [],
+      events: [
+        makeToolEvent('mcp__factory-tools__repo_intel.query'),
+        makeToolEvent('repo_intel.query'),
+      ],
+    });
+
+    await runFeatureEnhance(makeInput());
+
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          repoIntelCallCount: 2,
+          runtime: 'codex-cli',
+          modelId: 'gpt-5-codex',
+        }),
+      }),
+    );
+  });
+
+  it('rejects candidate files without tool-verified evidence', async () => {
+    mockRunFn.mockResolvedValue({
+      output: makeOutput({
+        candidateFiles: [
+          {
+            path: 'apps/web/src/components/detail/IssueDetailPage.tsx',
+            confidence: 'medium',
+            source: 'inferred',
+            reason: 'Looks related from product wording.',
+          },
+        ],
+      }),
+      decisionSummaries: [],
+      events: [makeToolEvent('repo_intel.query')],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'candidate-files-without-tool-verified-evidence',
+    });
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          reasons: ['candidate-files-without-tool-verified-evidence'],
+        }),
+      }),
+    );
+  });
+});

--- a/core/agent-runtime/feature-enhance-runner.test.ts
+++ b/core/agent-runtime/feature-enhance-runner.test.ts
@@ -329,4 +329,40 @@ describe('runFeatureEnhance', () => {
       }),
     );
   });
+
+  it('accepts mixed candidate sources when at least one candidate is tool-verified', async () => {
+    mockRunFn.mockResolvedValue({
+      output: makeOutput({
+        candidateFiles: [
+          {
+            path: 'slices/feature-grounding/workflow.ts',
+            confidence: 'high',
+            source: 'tool-verified',
+            reason: 'Existing feature grounding workflow.',
+          },
+          {
+            path: 'apps/web/src/components/detail/IssueDetailPage.tsx',
+            confidence: 'medium',
+            source: 'body-mention',
+            reason: 'Issue body mentions the detail page.',
+          },
+        ],
+      }),
+      decisionSummaries: [],
+      events: [makeToolEvent('repo_intel.query')],
+    });
+
+    const result = await runFeatureEnhance(makeInput());
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: expect.objectContaining({
+        candidateFiles: expect.arrayContaining([
+          expect.objectContaining({ source: 'tool-verified' }),
+          expect.objectContaining({ source: 'body-mention' }),
+        ]),
+      }),
+    });
+    expect(mockAppendEvent).not.toHaveBeenCalled();
+  });
 });

--- a/core/agent-runtime/feature-enhance-runner.ts
+++ b/core/agent-runtime/feature-enhance-runner.ts
@@ -1,0 +1,383 @@
+import { createHash } from 'node:crypto';
+import {
+  FeatureEnhanceOutputSchema,
+  type FeatureEnhanceOutput,
+} from '@goose-hub/skills/feature-enhance/schema.js';
+import featureEnhanceConfig, {
+  FeatureEnhanceContextSchema,
+} from '@goose-hub/skills/feature-enhance/skill.config.js';
+import type { z } from 'zod';
+import type { ProjectConfig } from '../types.js';
+import type { AgentEvent } from '../event-stream/store.js';
+import { eventStore } from '../event-stream/store.js';
+import { logger } from '../logger.js';
+import { getProjectBySlug } from '../projects/loader.js';
+import type { AgentRuntime } from './interface.js';
+import { safeParseOutputForSchema } from './output-normalization.js';
+import { readPromptWithContext } from './read-prompt.js';
+import { toJsonSchema } from './schema-bridge.js';
+import { selectPersona } from './select-persona.js';
+import { selectRuntime } from './select-runtime.js';
+import { resolveSkillRuntimeForProject } from './skill-runtime-resolver.js';
+
+const FEATURE_ENHANCE_SKILL = 'feature-enhance';
+
+type FeatureEnhanceContext = z.infer<typeof FeatureEnhanceContextSchema>;
+
+export type FeatureEnhanceEmptyReason =
+  | 'no-tool-call-made'
+  | 'tool-call-blocked'
+  | 'output-validation-failed'
+  | 'runtime-failed'
+  | 'runtime-max-turn-failed'
+  | 'no-grounded-output'
+  | 'candidate-files-without-tool-verified-evidence';
+
+export type FeatureEnhanceEmptyPayload = {
+  parentRunId?: string;
+  enhanceRunId: string;
+  reason: FeatureEnhanceEmptyReason;
+  reasons: FeatureEnhanceEmptyReason[];
+  validationIssues?: Array<{ path: string; message: string }>;
+  outputPreview?: string;
+  blockedToolNames: string[];
+  toolCallCount: number;
+  repoIntelCallCount: number;
+  blockedToolCallCount: number;
+  runtime?: string;
+  modelId?: string;
+  outputSchemaHash?: string;
+  error?: string;
+};
+
+export type FeatureEnhanceRunResult =
+  | { ok: true; output: FeatureEnhanceOutput; enhanceRunId: string; personaId: string }
+  | {
+      ok: false;
+      enhanceRunId: string;
+      reason: string;
+      telemetry: FeatureEnhanceEmptyPayload;
+    };
+
+export type RunFeatureEnhanceInput = {
+  projectId: string;
+  workItemId: string;
+  enhanceRunId: string;
+  parentRunId?: string;
+  context: FeatureEnhanceContext;
+  workspaceDir?: string;
+  runtimeOverride?: AgentRuntime;
+  projectConfigOverride?: Partial<ProjectConfig> | null;
+  extraEventPayload?: Record<string, unknown>;
+};
+
+type ToolEventAnalysis = {
+  toolCallCount: number;
+  repoIntelCallCount: number;
+  blockedToolCallCount: number;
+  blockedToolNames: string[];
+};
+
+type RuntimeDiagnostics = {
+  runtime?: string;
+  modelId?: string;
+  outputSchemaHash?: string;
+};
+
+function stableJson(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value == null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(',')}}`;
+}
+
+function schemaHash(schema: Record<string, unknown> | undefined): string | undefined {
+  if (schema == null) return undefined;
+  return createHash('sha256').update(stableJson(schema)).digest('hex').slice(0, 16);
+}
+
+function outputPreview(output: unknown): string {
+  const serialized = typeof output === 'string' ? output : JSON.stringify(output);
+  return serialized.slice(0, 2_000);
+}
+
+function payloadRecord(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizedToolName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (value.startsWith('mcp__factory-tools__')) {
+    return value.slice('mcp__factory-tools__'.length);
+  }
+  return value;
+}
+
+function analyzeToolEvents(events: readonly AgentEvent[]): ToolEventAnalysis {
+  let toolCallCount = 0;
+  let repoIntelCallCount = 0;
+  let blockedToolCallCount = 0;
+  const blockedToolNames = new Set<string>();
+
+  for (const event of events) {
+    if (event.kind !== 'agent.tool-call') continue;
+    toolCallCount++;
+    const payload = payloadRecord(event.payload);
+    const toolName = normalizedToolName(payload?.tool_name ?? payload?.toolName ?? payload?.tool);
+    if (toolName === 'repo_intel.query') repoIntelCallCount++;
+    if (payload?.blocked === true || payload?.status === 'failed') {
+      blockedToolCallCount++;
+      if (toolName != null) blockedToolNames.add(toolName);
+    }
+  }
+
+  return {
+    toolCallCount,
+    repoIntelCallCount,
+    blockedToolCallCount,
+    blockedToolNames: Array.from(blockedToolNames),
+  };
+}
+
+function isGrounded(output: FeatureEnhanceOutput): boolean {
+  return (
+    output.candidateFiles.length > 0 ||
+    output.existingSurfaces.length > 0 ||
+    output.testSurfaces.length > 0 ||
+    output.similarPatterns.length > 0 ||
+    output.acceptanceHints.length > 0
+  );
+}
+
+function buildEmptyReasons(input: {
+  output: FeatureEnhanceOutput;
+  toolAnalysis: ToolEventAnalysis;
+}): FeatureEnhanceEmptyReason[] {
+  const reasons = new Set<FeatureEnhanceEmptyReason>();
+  if (input.toolAnalysis.toolCallCount === 0) reasons.add('no-tool-call-made');
+  if (input.toolAnalysis.blockedToolCallCount > 0) reasons.add('tool-call-blocked');
+  if (!isGrounded(input.output)) reasons.add('no-grounded-output');
+  if (
+    input.output.candidateFiles.some((candidate) => candidate.source !== 'tool-verified')
+  ) {
+    reasons.add('candidate-files-without-tool-verified-evidence');
+  }
+  return Array.from(reasons);
+}
+
+function appendEmptyEvent(input: {
+  runInput: RunFeatureEnhanceInput;
+  reasons: FeatureEnhanceEmptyReason[];
+  analysis: ToolEventAnalysis;
+  diagnostics: RuntimeDiagnostics;
+  personaId?: string;
+  details?: Partial<
+    Pick<FeatureEnhanceEmptyPayload, 'validationIssues' | 'outputPreview' | 'error'>
+  >;
+}): FeatureEnhanceEmptyPayload {
+  const [reason = 'no-grounded-output'] = input.reasons;
+  const payload: FeatureEnhanceEmptyPayload = {
+    ...(input.runInput.parentRunId != null ? { parentRunId: input.runInput.parentRunId } : {}),
+    enhanceRunId: input.runInput.enhanceRunId,
+    reason,
+    reasons: input.reasons.length > 0 ? input.reasons : [reason],
+    blockedToolNames: input.analysis.blockedToolNames,
+    toolCallCount: input.analysis.toolCallCount,
+    repoIntelCallCount: input.analysis.repoIntelCallCount,
+    blockedToolCallCount: input.analysis.blockedToolCallCount,
+    ...(input.diagnostics.runtime != null ? { runtime: input.diagnostics.runtime } : {}),
+    ...(input.diagnostics.modelId != null ? { modelId: input.diagnostics.modelId } : {}),
+    ...(input.diagnostics.outputSchemaHash != null
+      ? { outputSchemaHash: input.diagnostics.outputSchemaHash }
+      : {}),
+    ...input.details,
+  };
+
+  eventStore.appendEvent({
+    projectId: input.runInput.projectId,
+    workItemId: input.runInput.workItemId,
+    kind: 'agent.feature-enhance-empty',
+    payload,
+    runId: input.runInput.enhanceRunId,
+    personaId: input.personaId,
+  });
+
+  return payload;
+}
+
+function runtimeName(provider: string): string {
+  return provider === 'codex' ? 'codex-cli' : 'claude-cli';
+}
+
+function runtimeFailureReason(error: unknown): FeatureEnhanceEmptyReason {
+  const message = String(error);
+  return /\b(max[- ]?turn|tool-call budget exceeded|budget exceeded)\b/i.test(message)
+    ? 'runtime-max-turn-failed'
+    : 'runtime-failed';
+}
+
+export async function runFeatureEnhance(
+  input: RunFeatureEnhanceInput,
+): Promise<FeatureEnhanceRunResult> {
+  const projectConfig =
+    input.projectConfigOverride !== undefined
+      ? input.projectConfigOverride
+      : await getProjectBySlug(input.projectId);
+  const resolved = resolveSkillRuntimeForProject({
+    skill: FEATURE_ENHANCE_SKILL,
+    projectBudgets: projectConfig?.budgets,
+    projectId: input.projectId,
+    configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+    skillProvider: featureEnhanceConfig.provider,
+    fallbackTier: featureEnhanceConfig.modelPin,
+    fallbackProvider: featureEnhanceConfig.provider,
+    role: featureEnhanceConfig.role ?? 'developer',
+    allowHoldoutOverride: projectConfig?.agentConfig?.allowHoldoutOverride,
+    ignoreProviderOverride: input.runtimeOverride != null,
+  });
+  const runtime =
+    input.runtimeOverride ??
+    selectRuntime({
+      configRuntime: projectConfig?.agentConfig?.runtime ?? 'auto',
+      model: resolved.modelOverride,
+      skillProvider: featureEnhanceConfig.provider,
+    });
+  const outputJsonSchema = toJsonSchema(FeatureEnhanceOutputSchema) as Record<string, unknown>;
+  const diagnostics: RuntimeDiagnostics = {
+    runtime: runtimeName(resolved.provider),
+    modelId: resolved.modelOverride,
+    outputSchemaHash: schemaHash(outputJsonSchema),
+  };
+  const role = featureEnhanceConfig.role ?? 'developer';
+  const { personaId } = selectPersona(input.projectId, role);
+  const appendSystemPrompt = readPromptWithContext(FEATURE_ENHANCE_SKILL, input.projectId);
+
+  const contextResult = FeatureEnhanceContextSchema.safeParse(input.context);
+  if (!contextResult.success) {
+    const telemetry = appendEmptyEvent({
+      runInput: input,
+      reasons: ['output-validation-failed'],
+      analysis: {
+        toolCallCount: 0,
+        repoIntelCallCount: 0,
+        blockedToolCallCount: 0,
+        blockedToolNames: [],
+      },
+      diagnostics,
+      personaId,
+      details: {
+        validationIssues: contextResult.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      },
+    });
+    return {
+      ok: false,
+      enhanceRunId: input.enhanceRunId,
+      reason: telemetry.reason,
+      telemetry,
+    };
+  }
+
+  try {
+    const result = await runtime.run({
+      runId: input.enhanceRunId,
+      role,
+      skill: FEATURE_ENHANCE_SKILL,
+      ...(input.workspaceDir != null ? { workspaceDir: input.workspaceDir } : {}),
+      context: {
+        ...contextResult.data,
+        projectId: input.projectId,
+        workItemId: input.workItemId,
+      },
+      contextAllowlist: featureEnhanceConfig.contextAllowlist,
+      freshContext: featureEnhanceConfig.freshContext,
+      toolBundles: ['read'],
+      toolExtras: [],
+      budgets: resolved.budgets,
+      effort: resolved.effort,
+      personaId,
+      workItemId: input.workItemId,
+      modelOverride: resolved.modelOverride,
+      outputJsonSchema,
+      appendSystemPrompt,
+      extraEventPayload: {
+        ...input.extraEventPayload,
+        ...(input.parentRunId != null ? { parentRunId: input.parentRunId } : {}),
+      },
+    });
+
+    const analysis = analyzeToolEvents(result.events);
+    const parsed = safeParseOutputForSchema(FeatureEnhanceOutputSchema, result.output);
+    if (!parsed.success) {
+      logger.warn('feature-enhance: output validation failed', {
+        runId: input.enhanceRunId,
+        errors: parsed.error.issues,
+        raw: JSON.stringify(result.output),
+      });
+      const telemetry = appendEmptyEvent({
+        runInput: input,
+        reasons: ['output-validation-failed'],
+        analysis,
+        diagnostics,
+        personaId,
+        details: {
+          validationIssues: parsed.error.issues.map((issue) => ({
+            path: issue.path.join('.'),
+            message: issue.message,
+          })),
+          outputPreview: outputPreview(result.output),
+        },
+      });
+      return {
+        ok: false,
+        enhanceRunId: input.enhanceRunId,
+        reason: telemetry.reason,
+        telemetry,
+      };
+    }
+
+    const emptyReasons = buildEmptyReasons({ output: parsed.data, toolAnalysis: analysis });
+    if (emptyReasons.length > 0) {
+      const telemetry = appendEmptyEvent({
+        runInput: input,
+        reasons: emptyReasons,
+        analysis,
+        diagnostics,
+        personaId,
+        details: { outputPreview: outputPreview(parsed.data) },
+      });
+      return {
+        ok: false,
+        enhanceRunId: input.enhanceRunId,
+        reason: telemetry.reason,
+        telemetry,
+      };
+    }
+
+    return { ok: true, output: parsed.data, enhanceRunId: input.enhanceRunId, personaId };
+  } catch (err) {
+    logger.error('feature-enhance: agent run failed', { runId: input.enhanceRunId, err: String(err) });
+    const analysis = analyzeToolEvents(eventStore.replay({ runId: input.enhanceRunId }));
+    const telemetry = appendEmptyEvent({
+      runInput: input,
+      reasons: [runtimeFailureReason(err)],
+      analysis,
+      diagnostics,
+      personaId,
+      details: { error: String(err) },
+    });
+    return {
+      ok: false,
+      enhanceRunId: input.enhanceRunId,
+      reason: telemetry.reason,
+      telemetry,
+    };
+  }
+}

--- a/core/agent-runtime/feature-enhance-runner.ts
+++ b/core/agent-runtime/feature-enhance-runner.ts
@@ -163,7 +163,8 @@ function buildEmptyReasons(input: {
   if (input.toolAnalysis.blockedToolCallCount > 0) reasons.add('tool-call-blocked');
   if (!isGrounded(input.output)) reasons.add('no-grounded-output');
   if (
-    input.output.candidateFiles.some((candidate) => candidate.source !== 'tool-verified')
+    input.output.candidateFiles.length > 0 &&
+    !input.output.candidateFiles.some((candidate) => candidate.source === 'tool-verified')
   ) {
     reasons.add('candidate-files-without-tool-verified-evidence');
   }

--- a/core/agent-runtime/mock-outputs.test.ts
+++ b/core/agent-runtime/mock-outputs.test.ts
@@ -60,6 +60,39 @@ describe('resolveMockOutput — repo-match', () => {
   });
 });
 
+describe('resolveMockOutput — feature-enhance', () => {
+  it('returns tool-verified grounding with a matching repo-intel tool event', () => {
+    const r = resolveMockOutput(
+      makeSpec({
+        skill: 'feature-enhance',
+        runId: 'grounding-run:feature-enhance',
+        context: { projectId: 'goose-hub-self', workItemId: 'github:owner/repo#42' },
+        workItemId: 'github:owner/repo#42',
+      }),
+    );
+    const out = r.output as {
+      candidateFiles: Array<{ source?: string }>;
+    };
+
+    expect(out.candidateFiles).toEqual([
+      expect.objectContaining({ source: 'tool-verified' }),
+    ]);
+    expect(r.events).toEqual([
+      expect.objectContaining({
+        kind: 'agent.tool-call',
+        projectId: 'goose-hub-self',
+        workItemId: 'github:owner/repo#42',
+        runId: 'grounding-run:feature-enhance',
+        payload: expect.objectContaining({
+          tool_name: 'repo_intel.query',
+          status: 'ok',
+          blocked: false,
+        }),
+      }),
+    ]);
+  });
+});
+
 describe('resolveMockOutput — implement', () => {
   it('returns a deterministic implement plan with a mock PR url', () => {
     const r = resolveMockOutput(makeSpec({ skill: 'implement' }));

--- a/core/agent-runtime/mock-outputs.ts
+++ b/core/agent-runtime/mock-outputs.ts
@@ -637,7 +637,7 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
             {
               path: 'apps/web/src/components/detail/IssueDetailPage.tsx',
               confidence: 'medium',
-              source: 'inferred',
+              source: 'tool-verified',
               reason: 'Mock feature-enhance anchors detail-page feature work.',
             },
           ],
@@ -650,7 +650,22 @@ export function resolveMockOutput(spec: AgentSpec): AgentResult {
           escalationSignals: [],
         },
         decisionSummaries: [{ kind: 'INSIGHT', summary: 'Mock feature-enhance for e2e test' }],
-        events: [],
+        events: [
+          {
+            id: 1,
+            projectId: (spec.context.projectId as string | undefined) ?? 'mock-project',
+            workItemId: workItemId ?? null,
+            kind: 'agent.tool-call',
+            payload: {
+              tool_name: 'repo_intel.query',
+              status: 'ok',
+              blocked: false,
+            },
+            runId: spec.runId,
+            personaId: spec.personaId,
+            createdAt: new Date(0).toISOString(),
+          },
+        ],
       };
 
     // retrospective-cross-run — triggered by the nightly playbook service.

--- a/core/event-stream/kinds.ts
+++ b/core/event-stream/kinds.ts
@@ -29,6 +29,7 @@ export const EVENT_KINDS = [
   'feature.framed',
   'feature.grounding-enhanced',
   'feature.grounding-complete',
+  'agent.feature-enhance-empty',
   'agent.investigation-context-injected',
   'agent.investigation-seed-built',
   'investigation.digest-applied',

--- a/core/workflows/timeline-sections.test.ts
+++ b/core/workflows/timeline-sections.test.ts
@@ -59,6 +59,9 @@ describe('timeline sections', () => {
     expect(
       resolveTimelineSection({ kind: 'agent.run-started', payload: { skill: 'bug-enhance' } }),
     ).toBe('investigation');
+    expect(
+      resolveTimelineSection({ kind: 'agent.run-started', payload: { skill: 'feature-enhance' } }),
+    ).toBe('grounding');
   });
 
   it('falls through display aliases to the durable runtime skill for section ownership', () => {
@@ -132,6 +135,12 @@ describe('timeline sections', () => {
     ).toBe('investigation');
   });
 
+  it('routes feature-enhance child runtime events to grounding', () => {
+    expect(
+      resolveTimelineSection({ kind: 'agent.tool-call', runId: 'grounding-1:feature-enhance' }),
+    ).toBe('grounding');
+  });
+
   it('maps control flow to transitions and unknown telemetry to system', () => {
     expect(resolveTimelineSection({ kind: 'state.transitioned' })).toBe('transitions');
     expect(resolveTimelineSection({ kind: 'manual.action' })).toBe('transitions');
@@ -140,6 +149,11 @@ describe('timeline sections', () => {
 
   it('routes investigation digest events to the investigation section', () => {
     expect(resolveTimelineSection({ kind: 'investigation.digest-applied' })).toBe('investigation');
+  });
+
+  it('routes feature-enhance empty diagnostics to grounding', () => {
+    expect(resolveTimelineSection({ kind: 'agent.feature-enhance-empty' })).toBe('grounding');
+    expect(TIMELINE_EVENT_CLASSIFICATION['agent.feature-enhance-empty']).toBe('direct');
   });
 
   it('routes post-implementation evidence events to Evidence instead of Dev Review', () => {
@@ -193,6 +207,7 @@ describe('timeline sections', () => {
   it('keeps skill identity separate from timeline section identity', () => {
     expect(timelineSectionForSkill('write-prd')).toBe('prd');
     expect(timelineSectionForSkill('advise-on-prd')).toBe('prd');
+    expect(timelineSectionForSkill('feature-enhance')).toBe('grounding');
     expect(timelineSectionForSkill('bug-enhance')).toBe('investigation');
     expect(timelineSectionForSkill('parallel-implement')).toBe('implementation');
     expect(timelineSectionForSkill('evidence-post')).toBe('evidence');

--- a/core/workflows/timeline-sections.ts
+++ b/core/workflows/timeline-sections.ts
@@ -66,6 +66,7 @@ const DIRECT_EVENT_KIND_SECTION: Record<string, TimelineSectionId> = {
   'feature.framed': 'grounding',
   'feature.grounding-enhanced': 'grounding',
   'feature.grounding-complete': 'grounding',
+  'agent.feature-enhance-empty': 'grounding',
   'agent.investigation-context-injected': 'investigation',
   'agent.investigation-seed-built': 'investigation',
   'agent.investigation-seed-empty': 'investigation',
@@ -264,6 +265,7 @@ export const TIMELINE_EVENT_CLASSIFICATION = Object.freeze(
 const skillToSection = buildSkillSectionMap();
 const stateToSection = buildStateSectionMap();
 const SKILL_SECTION_ALIASES = new Map<string, TimelineSectionId>([
+  ['feature-enhance', 'grounding'],
   ['parallel-implement', 'implementation'],
   ['evidence-post', 'evidence'],
 ]);
@@ -437,6 +439,7 @@ function timelineSectionFromHistoricalRunId(
 ): TimelineSectionId | null {
   if (runId == null) return null;
   if (runId.includes(':scout:')) return 'investigation';
+  if (runId.includes(':feature-enhance')) return 'grounding';
   if (runId.includes(':bug-enhance')) return 'investigation';
   if (runId.endsWith(':grill-me')) return 'grill';
   if (runId.endsWith(':write-prd') || runId.endsWith(':advise-on-prd')) return 'prd';

--- a/skills/feature-enhance/prompt.md
+++ b/skills/feature-enhance/prompt.md
@@ -8,9 +8,26 @@ You ground a fresh feature request against the repository before spec or impleme
 `<framedFeature>` may contain a framed feature body from feature-frame.
 `<projectContext>` may contain project and repo metadata.
 
+## Tool Boundary
+
+Use only these runtime-visible read-only repository tools:
+
+- Claude: `mcp__factory-tools__repo_intel.query`, `mcp__factory-tools__search_text`, `mcp__factory-tools__list_dir`, `mcp__factory-tools__list_files`, `mcp__factory-tools__read_file`
+- Codex: `repo_intel.query`, `search_text`, `list_dir`, `list_files`, `read_file`
+
+Forbidden tools and behaviours:
+
+- Do not use ToolSearch, native Read, Bash, Agent, Skill, AskUserQuestion, MCP resources, `file://`, delegation, or user questions.
+- Do not ask the user.
+- Do not keep exploring after you have 1-3 grounded candidates.
+
 ## Tool budget
 
-Use read-only repository tools only: `repo_intel.query`, `search_text`, `list_dir`, and `read_file`. Keep this pass cheap. Prefer targeted repo-intel and search calls over broad exploration.
+- Maximum 5 tool calls total.
+- Prefer `repo_intel.query` / `mcp__factory-tools__repo_intel.query`.
+- Stop once 1-3 grounded candidates are found.
+- Keep this pass cheap. Prefer targeted repo-intel and search calls over broad exploration.
+- If tools are blocked or evidence is missing, return valid low-confidence JSON.
 
 ## Intent
 
@@ -19,6 +36,8 @@ Use read-only repository tools only: `repo_intel.query`, `search_text`, `list_di
 - Do not diagnose bugs, root causes, or repro steps.
 - Do not invent files. Only emit file paths that are explicit in the work item or supported by read-only repository inspection.
 - If no files are found, return empty file arrays, `confidence: "low"`, and explain the miss in `openQuestions` or `escalationSignals`.
+- Non-empty `candidateFiles` must include at least one tool-verified candidate from the allowed tools.
+- Every emitted candidate file must be backed by tool evidence or omitted.
 
 ## Output contract
 

--- a/skills/feature-enhance/slice.test.ts
+++ b/skills/feature-enhance/slice.test.ts
@@ -82,4 +82,55 @@ describe('feature-enhance prompt', () => {
     expect(prompt).toContain('Do not invent files');
     expect(prompt).toContain('If no files are found');
   });
+
+  it('declares Claude and Codex runtime-visible read tools', () => {
+    const prompt = readPrompt();
+    for (const toolName of [
+      'mcp__factory-tools__repo_intel.query',
+      'mcp__factory-tools__search_text',
+      'mcp__factory-tools__list_dir',
+      'mcp__factory-tools__list_files',
+      'mcp__factory-tools__read_file',
+      'repo_intel.query',
+      'search_text',
+      'list_dir',
+      'list_files',
+      'read_file',
+    ]) {
+      expect(prompt).toContain(toolName);
+    }
+  });
+
+  it('explicitly forbids blocked native and delegation tools', () => {
+    const prompt = readPrompt();
+    for (const forbidden of [
+      'ToolSearch',
+      'native Read',
+      'Bash',
+      'Agent',
+      'Skill',
+      'AskUserQuestion',
+      'MCP resources',
+      'file://',
+      'delegation',
+      'user questions',
+    ]) {
+      expect(prompt).toContain(forbidden);
+    }
+  });
+
+  it('caps exploration and requires valid low-confidence JSON on grounding failure', () => {
+    const prompt = readPrompt();
+    expect(prompt).toContain('Maximum 5 tool calls total');
+    expect(prompt).toContain('return valid low-confidence JSON');
+    expect(prompt).toContain('Stop once 1-3 grounded candidates are found');
+  });
+
+  it('requires tool-backed evidence for emitted candidate files', () => {
+    const prompt = readPrompt();
+    expect(prompt).toContain(
+      'Non-empty `candidateFiles` must include at least one tool-verified candidate',
+    );
+    expect(prompt).toContain('Every emitted candidate file must be backed by tool evidence');
+  });
 });

--- a/slices/feature-grounding/slice.test.ts
+++ b/slices/feature-grounding/slice.test.ts
@@ -4,7 +4,7 @@ import type { FeatureEnhanceOutput } from '@goose-hub/skills/feature-enhance/sch
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDispatchWave = vi.fn();
-const mockInvokeSkill = vi.fn();
+const mockRunFeatureEnhance = vi.fn();
 const mockPersistScoutReportForRun = vi.fn();
 const mockAppendEvent = vi.fn();
 const mockReplay = vi.fn();
@@ -14,8 +14,8 @@ vi.mock('@goose-hub/core/agent-runtime/swarm.js', () => ({
   dispatchWave: (...args: unknown[]) => mockDispatchWave(...args),
 }));
 
-vi.mock('@goose-hub/core/agent-runtime/invoke-skill.js', () => ({
-  invokeSkill: (...args: unknown[]) => mockInvokeSkill(...args),
+vi.mock('@goose-hub/core/agent-runtime/feature-enhance-runner.js', () => ({
+  runFeatureEnhance: (...args: unknown[]) => mockRunFeatureEnhance(...args),
 }));
 
 vi.mock('@goose-hub/core/scout-reports/repository.js', () => ({
@@ -175,12 +175,11 @@ function replayWith(input: { framed?: unknown; selectedRoute?: WorkflowRouteDeci
 
 async function runWith(routeDecision: WorkflowRouteDecision, output: FeatureEnhanceOutput) {
   replayWith({ selectedRoute: routeDecision });
-  mockInvokeSkill.mockResolvedValueOnce({
+  mockRunFeatureEnhance.mockResolvedValueOnce({
+    ok: true,
     output,
-    decisionSummaries: [],
-    events: [],
+    enhanceRunId: 'grounding-run:feature-enhance',
     personaId: 'triager-test',
-    role: 'triager',
   });
   const { runFeatureGroundingWorkflow } = await import('./workflow.js');
   return runFeatureGroundingWorkflow(
@@ -249,8 +248,8 @@ describe('feature-grounding workflow', () => {
     const result = await runWith(route('T0'), enhancement());
 
     expect(result.nextState).toBe('factory:dev-ready');
-    expect(mockInvokeSkill).toHaveBeenCalledWith(
-      expect.objectContaining({ skillName: 'feature-enhance' }),
+    expect(mockRunFeatureEnhance).toHaveBeenCalledWith(
+      expect.objectContaining({ enhanceRunId: expect.stringContaining(':feature-enhance') }),
     );
     expect(mockDispatchWave).not.toHaveBeenCalled();
     const enhancedEvent = mockAppendEvent.mock.calls.find(
@@ -330,25 +329,60 @@ describe('feature-grounding workflow', () => {
     ]);
   });
 
-  it('empty feature-enhance output asks for product clarification instead of implementation guessing', async () => {
-    const result = await runWith(
-      route('T0'),
-      enhancement({
-        candidateFiles: [],
-        existingSurfaces: [],
-        similarPatterns: [],
-        testSurfaces: [],
-        acceptanceHints: [],
-        openQuestions: ['No matching repo surface found.'],
-        confidence: 'low',
-        escalationSignals: ['needs product clarification'],
-      }),
+  it('runner failure emits parent failure, transitions to needs-human, and does not launch scouts', async () => {
+    replayWith({ selectedRoute: route('T2') });
+    mockRunFeatureEnhance.mockResolvedValueOnce({
+      ok: false,
+      enhanceRunId: 'grounding-run:feature-enhance',
+      reason: 'no-grounded-output',
+      telemetry: {
+        parentRunId: 'grounding-run',
+        enhanceRunId: 'grounding-run:feature-enhance',
+        reason: 'no-grounded-output',
+        reasons: ['no-grounded-output'],
+        blockedToolNames: [],
+        toolCallCount: 1,
+        repoIntelCallCount: 1,
+        blockedToolCallCount: 0,
+        runtime: 'claude-cli',
+        modelId: 'claude-3-5-haiku-latest',
+        outputSchemaHash: 'abc123',
+      },
+    });
+    const { runFeatureGroundingWorkflow } = await import('./workflow.js');
+
+    const result = await runFeatureGroundingWorkflow(
+      makeWorkItem(),
+      makeSource(),
+      'goose-hub-self',
+      process.cwd(),
+      {
+        createWorktreeImpl: () => process.cwd(),
+        cleanupWorktreeImpl: vi.fn(),
+      },
     );
 
-    expect(result.nextState).toBe('factory:grilling');
+    expect(result.nextState).toBe('factory:needs-human');
     expect(mockDispatchWave).not.toHaveBeenCalled();
+    const failedEvent = mockAppendEvent.mock.calls.find(
+      ([event]) => event.kind === 'agent.run-failed',
+    )?.[0];
+    expect(failedEvent.payload).toMatchObject({
+      error: 'feature-enhance produced no valid grounded output',
+      enhanceRunId: 'grounding-run:feature-enhance',
+      reason: 'no-grounded-output',
+      failureDetails: {
+        reasons: ['no-grounded-output'],
+        toolCallCount: 1,
+        repoIntelCallCount: 1,
+      },
+    });
     expect(mockTransitionAndEmitState).toHaveBeenCalledWith(
-      expect.objectContaining({ to: 'factory:grilling' }),
+      expect.objectContaining({
+        from: 'factory:grounding',
+        to: 'factory:needs-human',
+        by: 'feature-grounding',
+      }),
     );
   });
 
@@ -364,7 +398,8 @@ describe('feature-grounding workflow', () => {
         },
       },
     });
-    mockInvokeSkill.mockResolvedValueOnce({
+    mockRunFeatureEnhance.mockResolvedValueOnce({
+      ok: true,
       output: enhancement({
         candidateFiles: [],
         existingSurfaces: [],
@@ -373,10 +408,8 @@ describe('feature-grounding workflow', () => {
         confidence: 'low',
         escalationSignals: ['needs PRD clarification'],
       }),
-      decisionSummaries: [],
-      events: [],
+      enhanceRunId: 'grounding-run:feature-enhance',
       personaId: 'triager-test',
-      role: 'triager',
     });
     const { runFeatureGroundingWorkflow } = await import('./workflow.js');
     const result = await runFeatureGroundingWorkflow(
@@ -391,7 +424,7 @@ describe('feature-grounding workflow', () => {
     );
 
     expect(result.nextState).toBe('factory:prd-drafting');
-    expect(mockInvokeSkill).toHaveBeenCalledWith(
+    expect(mockRunFeatureEnhance).toHaveBeenCalledWith(
       expect.objectContaining({
         context: expect.objectContaining({
           workItem: expect.objectContaining({ body: 'Original\n\nFramed details' }),

--- a/slices/feature-grounding/workflow.ts
+++ b/slices/feature-grounding/workflow.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildAgentComment } from '@goose-hub/core/agent-comment/index.js';
+import { runFeatureEnhance } from '@goose-hub/core/agent-runtime/feature-enhance-runner.js';
 import type { AgentRuntime } from '@goose-hub/core/agent-runtime/interface.js';
-import { invokeSkill } from '@goose-hub/core/agent-runtime/invoke-skill.js';
 import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { ScoutOutputSchema } from '@goose-hub/core/agent-runtime/scout-output.js';
@@ -41,6 +41,7 @@ export interface FeatureGroundingWorkflowDeps {
   createWorktreeImpl?: typeof createWorktree;
   cleanupWorktreeImpl?: typeof cleanupWorktree;
   resolveWorkflowBaseImpl?: typeof resolveWorkflowBaseForWorkItem;
+  runFeatureEnhanceImpl?: typeof runFeatureEnhance;
   runtime?: AgentRuntime;
 }
 
@@ -357,6 +358,7 @@ export async function runFeatureGroundingWorkflow(
   const createWtFn = deps.createWorktreeImpl ?? createWorktree;
   const cleanupWtFn = deps.cleanupWorktreeImpl ?? cleanupWorktree;
   const resolveWorkflowBaseFn = deps.resolveWorkflowBaseImpl ?? resolveWorkflowBaseForWorkItem;
+  const runFeatureEnhanceFn = deps.runFeatureEnhanceImpl ?? runFeatureEnhance;
   const projectConfig = await getProjectBySlug(projectId);
   const configRuntime = projectConfig?.agentConfig?.runtime ?? 'auto';
   const groundingBudget = resolveSkillRuntimeForProject({
@@ -420,11 +422,11 @@ export async function runFeatureGroundingWorkflow(
       body: groundedBody,
     };
     const enhanceRunId = `${runId}:feature-enhance`;
-    const enhanceResult = await invokeSkill({
-      skillName: 'feature-enhance',
+    const enhanceResult = await runFeatureEnhanceFn({
       projectId,
       workItemId: workItem.id,
-      runId: enhanceRunId,
+      enhanceRunId,
+      parentRunId: runId,
       context: {
         workItem: workItemCtx,
         ...(framedFeature != null
@@ -441,20 +443,51 @@ export async function runFeatureGroundingWorkflow(
           defaultBranch: workflowBase.branch,
         },
       },
-      overrides: {
-        workspaceDir: worktreePath,
-        runtimeOverride: deps.runtime,
-        projectConfigOverride: projectConfig,
-        extraEventPayload: {
-          parentRunId: runId,
-          workflowSkill: 'feature-grounding',
-        },
+      workspaceDir: worktreePath,
+      runtimeOverride: deps.runtime,
+      projectConfigOverride: projectConfig,
+      extraEventPayload: {
+        workflowSkill: 'feature-grounding',
       },
     });
-    const enhanced = pruneFeatureEnhanceOutput(
-      enhanceResult.output as FeatureEnhanceOutput,
-      worktreePath,
-    );
+
+    if (!enhanceResult.ok) {
+      eventStore.appendEvent({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'agent.run-failed',
+        payload: {
+          skill: 'feature-grounding',
+          runId,
+          error: 'feature-enhance produced no valid grounded output',
+          enhanceRunId: enhanceResult.enhanceRunId,
+          reason: enhanceResult.reason,
+          failureDetails: {
+            reasons: enhanceResult.telemetry.reasons,
+            toolCallCount: enhanceResult.telemetry.toolCallCount,
+            repoIntelCallCount: enhanceResult.telemetry.repoIntelCallCount,
+            blockedToolNames: enhanceResult.telemetry.blockedToolNames,
+            validationIssueCount: enhanceResult.telemetry.validationIssues?.length ?? 0,
+          },
+        },
+        runId,
+        personaId,
+      });
+      await transitionAndEmitState({
+        mode: 'legal',
+        source: stateSource,
+        itemId: workItem.externalId,
+        projectId,
+        workItemId: workItem.id,
+        from: 'factory:grounding',
+        to: 'factory:needs-human',
+        by: 'feature-grounding',
+        runId,
+      });
+      return { nextState: 'factory:needs-human' };
+    }
+
+    const enhanced = pruneFeatureEnhanceOutput(enhanceResult.output, worktreePath);
     const investigationSeed = toInvestigationSeed(enhanced);
     const route = routeForFeatureGrounding({
       projectId,


### PR DESCRIPTION
## Summary
- tighten feature-enhance prompt tool boundary and add prompt contract tests
- add feature-enhance runner with structured empty telemetry and workflow fail-fast handling
- render agent.feature-enhance-empty as a visible Grounding timeline diagnostic

## Verification
- pnpm vitest --run skills/feature-enhance/slice.test.ts
- pnpm vitest --run core/agent-runtime/feature-enhance-runner.test.ts
- pnpm vitest --run slices/feature-grounding/slice.test.ts
- pnpm vitest --run apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/timeline/MiscEvents.test.tsx core/workflows/timeline-sections.test.ts
- pnpm typecheck
- git diff --check