### PR TITLE
M19.XX: capture chore 2

### DIFF
--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TopBar } from './TopBar';
+
+vi.mock('@/components/ui/CaptureModal', () => ({
+  CaptureModal: ({
+    open,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  }) => (open ? <div data-testid="capture-modal">Capture modal</div> : null),
+}));
+
+vi.mock('@/components/search/components/SearchModal', () => ({
+  SearchModal: ({
+    open,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  }) => (open ? <div data-testid="search-modal">Search modal</div> : null),
+}));
+
+vi.mock('./ChangelogModal', () => ({
+  ChangelogModal: ({
+    open,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  }) => (open ? <div data-testid="changelog-modal">Changelog modal</div> : null),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TopBar', () => {
+  it('shows the Capture shortcut badge in the header', () => {
+    render(<TopBar />);
+
+    expect(screen.getByTestId('capture-button').textContent).toContain('Capture');
+    expect(screen.getByText('⌘J')).toBeTruthy();
+  });
+
+  it('opens the capture modal on meta+j', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+
+  it('keeps the search shortcut wired on ctrl+k', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+
+    expect(screen.getByTestId('search-modal')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -18,6 +18,12 @@ export function TopBar({ breadcrumb }: TopBarProps) {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
+        return;
+      }
+
+      if (e.metaKey && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setShowCapture(true);
       }
     }
     document.addEventListener('keydown', onKey);
@@ -46,11 +52,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

capture chore 2

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chrome/TopBar.tsx:16` so the document keydown handler continues to toggle search on `⌘K`

Local Work Item: local:goose-hub-self#23
