### PR TITLE
M7.XX: capture chore

### DIFF
--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -19,6 +19,10 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         e.preventDefault();
         setShowSearch((prev) => !prev);
       }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setShowCapture((prev) => !prev);
+      }
     }
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
@@ -51,6 +55,9 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -6,6 +6,18 @@ import { describe, expect, it } from 'vitest';
 // exist and the milestone-stub configuration stays honest with the M2 plan.
 // Component rendering tests are exercised by the Playwright happy-path (#36).
 
+describe('chrome slice — TopBar capture shortcut', () => {
+  const topBarSource = readFileSync(join(import.meta.dirname, 'TopBar.tsx'), 'utf-8');
+
+  it('TopBar binds ⌘J / Ctrl+J to open capture', () => {
+    expect(topBarSource).toContain("e.key.toLowerCase() === 'j'");
+  });
+
+  it('capture button shows ⌘J kbd label', () => {
+    expect(topBarSource).toContain('⌘J');
+  });
+});
+
 const DEFERRED_SURFACES = [
   { label: 'Inbox', milestone: 'M3' },
   { label: 'Roster', milestone: 'M5' },


### PR DESCRIPTION
## Summary

capture chore

## Files
- `apps/web/src/components/chrome/TopBar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)

Local Work Item: local:goose-hub-self-claude#22
