### PR TITLE
Harden sparse grounding scout retries

### DIFF
--- a/core/agent-runtime/bug-enhance-runner.test.ts
+++ b/core/agent-runtime/bug-enhance-runner.test.ts
@@ -425,4 +425,46 @@ describe('runBugEnhance — repo-intel grounding contract', () => {
       }),
     );
   });
+
+  it('retries sparse UI-web bugs that returned unknown without making a tool call', async () => {
+    const hints = makeHints(['apps/web/src/components/header/CaptureHeader.tsx']);
+    mockRunFn
+      .mockResolvedValueOnce(
+        makeAgentResult(undefined, {
+          enhancedContent: '',
+          category: 'unknown',
+          events: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAgentResult(hints, {
+          enhancedContent:
+            '**Repro steps**\n1. Open the header.\n\n**Location**\napps/web/src/components/header/CaptureHeader.tsx',
+          category: 'ui-web',
+          events: [makeToolEvent('repo_intel.query')],
+        }),
+      );
+
+    const result = await runBugEnhance({
+      ...BASE_INPUT,
+      title: 'capture bug 2',
+      body: 'Capture key in the header should open with apple J key. And the button should show that label just like search does',
+    });
+
+    expect(mockRunFn).toHaveBeenCalledTimes(2);
+    expect(mockRunFn.mock.calls[1][0]).toMatchObject({
+      runId: expect.stringMatching(/:grounding-retry$/),
+      skill: 'bug-enhance',
+    });
+    expect(mockRunFn.mock.calls[1][0].appendSystemPrompt).toContain(
+      'Grounding retry: this bug report has UI-web signals',
+    );
+    expect(result.markdown).toContain('CaptureHeader.tsx');
+    expect(result.groundedHints?.candidateFiles).toEqual([
+      expect.objectContaining({ path: 'apps/web/src/components/header/CaptureHeader.tsx' }),
+    ]);
+    expect(eventStore.appendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent.bug-enhance-empty' }),
+    );
+  });
 });

--- a/core/agent-runtime/bug-enhance-runner.ts
+++ b/core/agent-runtime/bug-enhance-runner.ts
@@ -10,6 +10,7 @@ import type { AgentEvent } from '../event-stream/store.js';
 import { eventStore } from '../event-stream/store.js';
 import { logger } from '../logger.js';
 import { getProjectBySlug } from '../projects/loader.js';
+import type { AgentSpec } from './interface.js';
 import { safeParseOutputForSchema } from './output-normalization.js';
 import { readPromptWithContext } from './read-prompt.js';
 import { recordAgentRun } from './run-record.js';
@@ -20,6 +21,8 @@ import { selectRuntime } from './select-runtime.js';
 import { resolveSkillRuntimeForProject } from './skill-runtime-resolver.js';
 
 const jsonSchema = toJsonSchema(BugEnhanceOutputSchema);
+const UI_WEB_BUG_SIGNAL_RE =
+  /\b(ui|browser|frontend|page|route|screen|modal|dialog|button|header|search|shortcut|keyboard|key|click|label|capture|cmd|command|apple)\b|⌘/i;
 
 export interface BugEnhanceResult {
   /** Markdown sections to append after the original bug body, if any. */
@@ -84,7 +87,7 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
     const appendSystemPrompt =
       pathGroundingPrompt.length > 0 ? `${prompt}\n\n${pathGroundingPrompt}` : prompt;
 
-    const result = await runtime.run({
+    const baseSpec: AgentSpec = {
       runId,
       role: 'triager',
       skill: 'bug-enhance',
@@ -111,7 +114,9 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
             },
           }
         : {}),
-    });
+    };
+
+    let result = await runtime.run(baseSpec);
 
     const parsed = safeParseOutputForSchema(BugEnhanceOutputSchema, result.output);
     if (!parsed.success) {
@@ -146,18 +151,35 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
       return { markdown: null, groundedHints: null };
     }
 
-    const content = parsed.data.enhancedContent.trim();
+    let parsedData = parsed.data;
+    let toolAnalysis = analyzeToolEvents(result.events);
+    if (shouldRetryUiWebGrounding(input, parsedData, toolAnalysis)) {
+      const retrySpec = buildGroundingRetrySpec(baseSpec);
+      const retryResult = await runtime.run(retrySpec);
+      const retryParsed = safeParseOutputForSchema(BugEnhanceOutputSchema, retryResult.output);
+      if (retryParsed.success) {
+        result = retryResult;
+        parsedData = retryParsed.data;
+        toolAnalysis = analyzeToolEvents(result.events);
+      } else {
+        logger.warn('bug-enhance: grounding retry output validation failed', {
+          errors: retryParsed.error.issues,
+          raw: JSON.stringify(retryResult.output),
+        });
+      }
+    }
+
+    const content = parsedData.enhancedContent.trim();
     if (content.length === 0) {
       logger.warn('bug-enhance: enhancedContent empty after trim', {
         runId,
-        decisions: parsed.data.decisionSummaries,
+        decisions: parsedData.decisionSummaries,
       });
     }
-    const toolAnalysis = analyzeToolEvents(result.events);
-    const rawHints = hasUsableHints(parsed.data.groundedHints) ? parsed.data.groundedHints : null;
+    const rawHints = hasUsableHints(parsedData.groundedHints) ? parsedData.groundedHints : null;
     const groundedHints = rawHints != null ? pruneNonExistentPaths(rawHints, input, runId) : null;
     const emptyReasons = buildEmptyReasons({
-      category: parsed.data.category,
+      category: parsedData.category,
       enhancedContentLength: content.length,
       hasGroundedHints: groundedHints != null,
       toolAnalysis,
@@ -168,7 +190,7 @@ export async function runBugEnhance(input: RunBugEnhanceInput): Promise<BugEnhan
         runId,
         reasons: emptyReasons,
         analysis: toolAnalysis,
-        category: parsed.data.category ?? null,
+        category: parsedData.category ?? null,
         enhancedContentLength: content.length,
         hasGroundedHints: groundedHints != null,
       });
@@ -264,6 +286,35 @@ function buildEmptyReasons(input: {
   if (input.enhancedContentLength === 0) reasons.add('empty-enhanced-content');
   if (!input.hasGroundedHints) reasons.add('no-grounded-hints');
   return Array.from(reasons);
+}
+
+function shouldRetryUiWebGrounding(
+  input: RunBugEnhanceInput,
+  output: { category?: BugCategory; groundedHints?: GroundedHints },
+  analysis: ToolEventAnalysis,
+): boolean {
+  if (analysis.toolCallCount > 0) return false;
+  if (output.category != null && output.category !== 'unknown') return false;
+  if (hasUsableHints(output.groundedHints)) return false;
+  return UI_WEB_BUG_SIGNAL_RE.test(`${input.title}\n${input.body}`);
+}
+
+function buildGroundingRetrySpec(baseSpec: AgentSpec): AgentSpec {
+  const instruction = [
+    'Grounding retry: this bug report has UI-web signals but the first pass returned unknown without making a Factory read/search/file tool call.',
+    'Classify it as ui-web unless a Factory evidence call proves a different surface.',
+    'Before returning, call at least one Factory evidence tool: repo_intel.query, search_text, list_files, or read_file.',
+    'Start from visible terms in the work item such as header, button, search, capture, shortcut, label, and key.',
+  ].join('\n');
+
+  return {
+    ...baseSpec,
+    runId: `${baseSpec.runId}:grounding-retry`,
+    appendSystemPrompt:
+      baseSpec.appendSystemPrompt != null && baseSpec.appendSystemPrompt.length > 0
+        ? `${baseSpec.appendSystemPrompt}\n\n${instruction}`
+        : instruction,
+  };
 }
 
 function emitBugEnhanceEmpty(input: {

--- a/core/agent-runtime/scout-runner.ts
+++ b/core/agent-runtime/scout-runner.ts
@@ -22,6 +22,8 @@ const FACTORY_EVIDENCE_TOOL_NAMES = new Set([
   'repo_intel.query',
   'search_text',
 ]);
+const USER_JOURNEY_UI_SIGNAL_RE =
+  /\b(ui|browser|frontend|page|route|screen|modal|dialog|button|header|search|shortcut|keyboard|key|click|label|capture|cmd|command|apple|user journey)\b|⌘/i;
 
 /** Per-scout findings. Mirrors `ScoutOutputSchema` in each scout's schema.ts. */
 export interface ScoutFinding {
@@ -431,6 +433,100 @@ export async function runOneScout(
           }
         }
       }
+    } else if (
+      runtime != null &&
+      shouldRetryUserJourneyWithoutSeed({
+        spec,
+        ctx,
+        fullContext,
+        outputStatus: scoutOutput.status,
+        unsupportedToolSkipWithoutAttempt,
+      })
+    ) {
+      const retryTimeoutMs = remainingTimeoutMs(start, budgets.timeoutMs);
+      if (retryTimeoutMs <= 0) {
+        timedOut = true;
+      } else {
+        const retrySpec = buildNoSeedEvidenceRetrySpec(spawnSpec, retryTimeoutMs);
+        assembleSpawnContext(retrySpec);
+        try {
+          const retryResult = await runtime.run(retrySpec);
+          const retryParsed = safeParseOutputForSchema(ScoutOutputSchema, retryResult.output);
+          if (!retryParsed.success) {
+            const reason = `scout output failed schema validation: ${retryParsed.error.issues
+              .map((i) => `${i.path.join('.')}: ${i.message}`)
+              .join('; ')}`;
+            append({
+              projectId: ctx.projectId,
+              workItemId: ctx.workItemId ?? null,
+              kind: 'swarm.scout-failed',
+              payload: { runId, scoutName: spec.scoutName, errorReason: reason },
+              runId,
+            });
+            return {
+              scoutName: spec.scoutName,
+              status: 'error',
+              outcome: 'failed',
+              findings: [],
+              decisionSummaries:
+                retryResult.decisionSummaries.length > 0
+                  ? retryResult.decisionSummaries
+                  : decisionSummaries,
+              errorReason: reason,
+              runId,
+            };
+          }
+          const retryOutput = normalizeScoutOutput(retryParsed.data);
+          const retryFindings = retryOutput.findings;
+          let retryUnsupportedToolSkipWithoutAttempt = false;
+          if (retryOutput.status === 'skipped') {
+            const retryDecisionSummaries =
+              retryResult.decisionSummaries.length > 0
+                ? retryResult.decisionSummaries
+                : retryOutput.decisionSummaries;
+            retryUnsupportedToolSkipWithoutAttempt =
+              isUnsupportedToolAvailabilitySkip(retryDecisionSummaries) &&
+              !hasFactoryEvidenceAttempt(retryResult.events);
+            if (
+              !retryUnsupportedToolSkipWithoutAttempt ||
+              hasFactoryEvidenceAttempt(retryResult.events)
+            ) {
+              return emitSkippedScout({
+                append,
+                ctx,
+                runId: retrySpec.runId,
+                scoutName: spec.scoutName,
+                findings: retryFindings,
+                decisionSummaries: retryDecisionSummaries,
+              });
+            }
+            decisionSummaries = retryDecisionSummaries;
+          }
+          if (
+            !retryUnsupportedToolSkipWithoutAttempt &&
+            (retryFindings.length > 0 ||
+              hasSuccessfulFactoryEvidenceCall(retryResult.events) ||
+              retryOutput.status === 'ok')
+          ) {
+            result = retryResult;
+            findings = retryFindings;
+            evidenceBackedEmptyResult = retryFindings.length === 0 && retryOutput.status === 'ok';
+            effectiveRunId = retrySpec.runId;
+            decisionSummaries =
+              retryResult.decisionSummaries.length > 0
+                ? retryResult.decisionSummaries
+                : retryOutput.decisionSummaries;
+          } else {
+            retrySkippedReason = 'no-seed-evidence-retry-unbacked';
+          }
+        } catch (err) {
+          if (isTimeoutError(err, retryTimeoutMs)) {
+            timedOut = true;
+          } else {
+            errorReason = err instanceof Error ? err.message : String(err);
+          }
+        }
+      }
     } else {
       retrySkippedReason =
         seedCandidateFileCount === 0 ? 'no-seed-evidence' : 'seed-evidence-unavailable';
@@ -603,6 +699,22 @@ function countSeedCandidateFiles(context: Record<string, unknown>): number {
   return candidates.length;
 }
 
+function shouldRetryUserJourneyWithoutSeed(input: {
+  spec: ScoutSpec;
+  ctx: RunOneScoutContext;
+  fullContext: Record<string, unknown>;
+  outputStatus: string;
+  unsupportedToolSkipWithoutAttempt: boolean;
+}): boolean {
+  if (input.spec.scoutName !== 'scout-user-journey') return false;
+  if (countSeedCandidateFiles(input.fullContext) !== 0) return false;
+  if (input.outputStatus !== 'skipped' && input.outputStatus !== 'ok') return false;
+  if (!input.unsupportedToolSkipWithoutAttempt && input.outputStatus !== 'ok') return false;
+  return USER_JOURNEY_UI_SIGNAL_RE.test(
+    `${input.ctx.workItem.title}\n${input.ctx.workItem.body}\n${input.spec.scoutFocus}`,
+  );
+}
+
 async function readBoundedSeedFile(
   worktreePath: string,
   filePath: string,
@@ -668,6 +780,25 @@ function buildEvidenceRetrySpec(
     ...spawnSpec,
     runId: `${spawnSpec.runId}:evidence-retry`,
     context,
+    budgets: { ...spawnSpec.budgets, timeoutMs },
+    appendSystemPrompt:
+      spawnSpec.appendSystemPrompt != null && spawnSpec.appendSystemPrompt.length > 0
+        ? `${spawnSpec.appendSystemPrompt}\n\n${instruction}`
+        : instruction,
+  };
+}
+
+function buildNoSeedEvidenceRetrySpec(spawnSpec: AgentSpec, timeoutMs: number): AgentSpec {
+  const instruction = [
+    'No-seed evidence retry: this selected scout must make at least one Factory evidence call before returning.',
+    'Ignore MCP resources/list or resources/read advisories; those are not the Factory read/search/file tools.',
+    'Use one of repo_intel.query, search_text, list_files, or read_file, starting from visible terms in <workItem> and <scoutFocus>.',
+    'If a successful Factory evidence call proves this scout domain does not apply, return status "skipped" with a decision summary.',
+  ].join('\n');
+
+  return {
+    ...spawnSpec,
+    runId: `${spawnSpec.runId}:no-seed-evidence-retry`,
     budgets: { ...spawnSpec.budgets, timeoutMs },
     appendSystemPrompt:
       spawnSpec.appendSystemPrompt != null && spawnSpec.appendSystemPrompt.length > 0

--- a/core/agent-runtime/swarm.test.ts
+++ b/core/agent-runtime/swarm.test.ts
@@ -775,6 +775,88 @@ describe('swarm.dispatchWave', () => {
     });
   });
 
+  it('retries a selected user-journey scout skip with no seed evidence', async () => {
+    const { fn: appendEvent, events } = makeFakeAppendEvent();
+    const seenSpecs: AgentSpec[] = [];
+    const runtime = makeRuntime({
+      'scout-user-journey': (spec) => {
+        seenSpecs.push(spec);
+        if (seenSpecs.length === 1) {
+          return Promise.resolve(
+            skippedResult(
+              'Could not inspect the workspace because the required Factory read/search tools are not available in this run.',
+            ),
+          );
+        }
+        return Promise.resolve({
+          output: {
+            findings: [
+              {
+                file: 'apps/web/src/components/chrome/TopBar.tsx',
+                line: 47,
+                fact: 'Capture button is rendered in the header.',
+                confidence: 'high',
+              },
+            ],
+            decisionSummaries: [{ kind: 'READ', summary: 'Read TopBar header button flow.' }],
+            status: 'ok',
+          },
+          decisionSummaries: [{ kind: 'READ', summary: 'Read TopBar header button flow.' }],
+          events: [toolCallEvent(spec.runId, 'search_text', 'ok')],
+        });
+      },
+    });
+
+    const result = await dispatchWave({
+      parentRunId: 'parent-user-journey-no-seed-retry',
+      scoutSpecs: [
+        {
+          ...makeScoutSpec('scout-user-journey'),
+          scoutFocus: 'Walk the header capture button shortcut flow.',
+          extraContext: {
+            investigationSeed: {
+              candidateFiles: [],
+              candidateSymbols: [],
+              testFiles: [],
+              recentlyChangedFiles: [],
+              priorInvestigationRunIds: [],
+              builtAt: '2026-06-08T00:00:00.000Z',
+            },
+          },
+        },
+      ],
+      workItem: {
+        number: 21,
+        title: 'capture bug 2',
+        body: 'Capture key in the header should open with apple J key. And the button should show that label just like search does',
+      },
+      worktreePath: '/tmp/wt',
+      projectId: 'goose-hub-self',
+      personaId: 'goose-hub-self/investigator/0',
+      runtime,
+      appendEvent,
+      scoutTimeoutMs: 1_000,
+      heartbeatIntervalMs: 60_000,
+      resolveScoutBudget: testBudgetResolver,
+      minSuccessfulScouts: 1,
+    });
+
+    expect(seenSpecs).toHaveLength(2);
+    expect(seenSpecs[1].runId).toBe(
+      'parent-user-journey-no-seed-retry:scout:scout-user-journey:0:no-seed-evidence-retry',
+    );
+    expect(seenSpecs[1].appendSystemPrompt).toContain(
+      'No-seed evidence retry: this selected scout must make at least one Factory evidence call',
+    );
+    expect(result.status).toBe('ok');
+    expect(result.reports[0]).toMatchObject({
+      status: 'ok',
+      outcome: 'ok',
+      findings: [expect.objectContaining({ file: 'apps/web/src/components/chrome/TopBar.tsx' })],
+    });
+    expect(events.some((e) => e.kind === 'swarm.scout-failed')).toBe(false);
+  });
+
   it('does not halt when two scouts skip and enough useful evidence remains', async () => {
     const { fn: appendEvent, events } = makeFakeAppendEvent();
     const runtime = makeRuntime({


### PR DESCRIPTION
## Summary
- retry lazy bug grounding once when a sparse UI bug returns unknown without making Factory evidence calls
- retry selected user-journey scouts once when they skip with no seed evidence and no Factory read/search/file call
- add regressions for the header capture shortcut failure shape

## Verification
- pnpm vitest core/agent-runtime/bug-enhance-runner.test.ts core/agent-runtime/swarm.test.ts
- pnpm typecheck
- git diff --check
- pnpm test *(fails in unrelated core/agent-runtime/slice.test.ts: db.update is not a function in existing mocked DB path)*