### PR TITLE
M7.XX: capture chore

### DIFF
--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -19,6 +19,10 @@ export function TopBar({ breadcrumb }: TopBarProps) {
         e.preventDefault();
         setShowSearch((prev) => !prev);
       }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setShowCapture((prev) => !prev);
+      }
     }
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
@@ -46,11 +50,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -53,3 +53,16 @@ describe('chrome slice — deferred surfaces config', () => {
     expect(collapsed).toBe(false);
   });
 });
+
+describe('chrome slice — capture shortcut (issue #26)', () => {
+  const topBarSource = readFileSync(join(import.meta.dirname, 'TopBar.tsx'), 'utf-8');
+
+  it('TopBar capture button shows the ⌘J keyboard shortcut label', () => {
+    expect(topBarSource).toContain('capture-button');
+    expect(topBarSource).toContain('⌘J');
+  });
+
+  it('TopBar binds the ⌘J / Ctrl+J keyboard shortcut to open capture', () => {
+    expect(topBarSource).toContain("'j'");
+  });
+});


### PR DESCRIPTION
## Summary

capture chore

## Files
- `apps/web/src/components/chrome/TopBar.tsx` — observed modified change
- `apps/web/src/components/chrome/slice.test.ts` — observed modified change

## Tests
- `apps/web/src/components/chrome/slice.test.ts` (2 cases)

Local Work Item: local:goose-hub-self-claude#26
