### PR TITLE
Summarize QA preflight steps in timeline

### DIFF
--- a/apps/web/src/components/detail/components/timeline/QaEvents.tsx
+++ b/apps/web/src/components/detail/components/timeline/QaEvents.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/cn';
 import type { AgentEventDto } from '@/lib/types';
 import { AlertTriangle, CheckCircle, Circle, LoaderCircle, XCircle } from 'lucide-react';
+import type { QaPreflightStepStatus, QaPreflightSummary } from '../../lib/timeline/qa-preflight';
 
 type TierResult = {
   passed: boolean;
@@ -110,13 +111,19 @@ function formatBytes(value: number | undefined): string {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-function statusTone(status: VerificationStatus | undefined): string {
+function statusTone(status: VerificationStatus | QaPreflightStepStatus | undefined): string {
   if (status === 'running') return 'border-blue-500/20 bg-blue-500/10 text-blue-300';
   if (status === 'passed' || status === 'posted') {
     return 'border-green-500/20 bg-green-500/10 text-green-400';
   }
   if (status === 'failed') return 'border-red-500/20 bg-red-500/10 text-[color:var(--danger)]';
-  if (status === 'skipped' || status === 'absent') return 'border-fg-5/20 bg-fg-5/10 text-fg-3';
+  if (status === 'superseded' || status === 'aborted' || status === 'interrupted') {
+    return 'border-yellow-500/20 bg-yellow-500/10 text-yellow-400';
+  }
+  if (status === 'skipped' || status === 'absent' || status === 'not-started') {
+    return 'border-fg-5/20 bg-fg-5/10 text-fg-3';
+  }
+  if (status === 'incomplete') return 'border-yellow-500/20 bg-yellow-500/10 text-yellow-400';
   return 'border-yellow-500/20 bg-yellow-500/10 text-yellow-400';
 }
 
@@ -318,6 +325,85 @@ export function QaPreflightStepEvent({ event }: { event: AgentEventDto }) {
       {p?.reason != null && (
         <div className="mt-1 text-[11.5px] leading-snug text-fg-3">{p.reason}</div>
       )}
+    </li>
+  );
+}
+
+export function QaPreflightSummaryEvent({ summary }: { summary: QaPreflightSummary }) {
+  if (!summary.hasPreflightEvents) return null;
+  return (
+    <li
+      data-event-kind="qa.preflight-summary"
+      className="rounded-md border border-line bg-bg-elev/60 px-4 py-3"
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-fg-3">
+            {summary.status === 'running' ? (
+              <LoaderCircle size={13} className="shrink-0 animate-spin text-blue-300" />
+            ) : summary.status === 'passed' ? (
+              <CheckCircle size={13} className="shrink-0 text-green-400" />
+            ) : summary.status === 'failed' ? (
+              <XCircle size={13} className="shrink-0 text-[color:var(--danger)]" />
+            ) : (
+              <AlertTriangle size={13} className="shrink-0 text-yellow-400" />
+            )}
+            <span className="font-mono uppercase tracking-wider">{summary.title}</span>
+            <span
+              className={cn(
+                'rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase',
+                statusTone(summary.status === 'superseded' ? 'superseded' : summary.status),
+              )}
+            >
+              {summary.status}
+            </span>
+          </div>
+          {summary.description != null && (
+            <div className="mt-1 text-[11.5px] leading-snug text-fg-3">{summary.description}</div>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {summary.steps.map((step) => {
+          const duration = formatDurationMs(step.durationMs ?? undefined);
+          return (
+            <div
+              key={step.key}
+              className="grid grid-cols-[minmax(86px,1fr)_auto] items-start gap-x-3 gap-y-1 rounded border border-line bg-bg/40 px-2.5 py-2 text-[11px] md:grid-cols-[minmax(96px,1fr)_92px_64px_54px]"
+            >
+              <div className="min-w-0">
+                <div className="truncate font-mono text-fg-3">{step.label}</div>
+                {step.command != null && (
+                  <div className="mt-1 truncate font-mono text-[10.5px] text-fg-4">
+                    {step.command}
+                  </div>
+                )}
+                {step.reason != null && (
+                  <div className="mt-1 text-[11px] leading-snug text-fg-3">{step.reason}</div>
+                )}
+              </div>
+              <span
+                className={cn(
+                  'justify-self-end rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase md:justify-self-start',
+                  statusTone(step.status),
+                )}
+              >
+                {step.status}
+              </span>
+              <span className="hidden font-mono text-fg-4 md:block">{duration ?? ''}</span>
+              <span className="hidden font-mono text-fg-4 md:block">
+                {step.exitCode != null ? `exit ${step.exitCode}` : ''}
+              </span>
+              {(duration != null || step.exitCode != null) && (
+                <div className="col-span-2 flex flex-wrap gap-2 font-mono text-fg-4 md:hidden">
+                  {duration != null && <span>{duration}</span>}
+                  {step.exitCode != null && <span>exit {step.exitCode}</span>}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </li>
   );
 }

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.test.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.test.tsx
@@ -24,7 +24,93 @@ function makeEvent(id: number, kind: string, payload: unknown, runId = 'qa-run')
   } as AgentEventDto;
 }
 
+function makeRecentEvent(
+  id: number,
+  kind: string,
+  payload: unknown,
+  runId = 'qa-run',
+): AgentEventDto {
+  return {
+    ...makeEvent(id, kind, payload, runId),
+    createdAt: new Date(Date.now() - (10 - id) * 1000).toISOString(),
+  };
+}
+
 describe('RunGroupWrapper', () => {
+  it('shows QA preflight running banner for live preflight-only QA groups', () => {
+    const events = [
+      makeRecentEvent(1, 'qa.preflight-started', {
+        runId: 'qa-run',
+        qaAttemptId: 'qa-attempt',
+        status: 'running',
+      }),
+      makeRecentEvent(2, 'qa.preflight-step-started', {
+        runId: 'qa-run',
+        qaAttemptId: 'qa-attempt',
+        step: 'test',
+        command: 'pnpm test',
+      }),
+    ];
+    const items: RenderItem[] = events.map((event) => ({ kind: 'event', event }));
+
+    render(
+      <ul>
+        <RunGroupWrapper
+          runId="qa-attempt"
+          items={items}
+          idx={0}
+          skill="qa"
+          startedAt={events[0].createdAt}
+          endedAt={null}
+          lastEventAt={events[1].createdAt}
+          personaId={null}
+          modelId={null}
+          runtime={null}
+          renderItem={(_item, idx) => <li key={idx}>child</li>}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('QA preflight running...')).toBeTruthy();
+    expect(screen.queryByText('Agent running...')).toBeNull();
+  });
+
+  it('shows Agent running banner after a live QA agent has started', () => {
+    const events = [
+      makeRecentEvent(1, 'qa.preflight-started', {
+        runId: 'qa-run',
+        qaAttemptId: 'qa-attempt',
+        status: 'running',
+      }),
+      makeRecentEvent(2, 'agent.run-started', {
+        skill: 'qa',
+        qaAttemptId: 'qa-attempt',
+      }),
+    ];
+    const items: RenderItem[] = events.map((event) => ({ kind: 'event', event }));
+
+    render(
+      <ul>
+        <RunGroupWrapper
+          runId="qa-attempt"
+          items={items}
+          idx={0}
+          skill="qa"
+          startedAt={events[0].createdAt}
+          endedAt={null}
+          lastEventAt={events[1].createdAt}
+          personaId={null}
+          modelId={null}
+          runtime={null}
+          renderItem={(_item, idx) => <li key={idx}>child</li>}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText('Agent running...')).toBeTruthy();
+    expect(screen.queryByText('QA preflight running...')).toBeNull();
+  });
+
   it('shows superseded QA preflight status even after the QA agent started', () => {
     const events = [
       makeEvent(1, 'qa.preflight-started', {
@@ -62,7 +148,54 @@ describe('RunGroupWrapper', () => {
       </ul>,
     );
 
-    expect(screen.getByText('Preflight superseded')).toBeTruthy();
+    expect(screen.getAllByText('Preflight superseded').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Complete')).toBeNull();
+  });
+
+  it('does not synthesize tool calls for QA preflight rows and keeps real tool calls', () => {
+    const events = [
+      makeRecentEvent(1, 'qa.preflight-step-started', {
+        runId: 'qa-run',
+        qaAttemptId: 'qa-attempt',
+        step: 'lint',
+        command: 'pnpm lint',
+      }),
+      makeRecentEvent(2, 'agent.run-started', {
+        skill: 'qa',
+        qaAttemptId: 'qa-attempt',
+      }),
+      makeRecentEvent(3, 'agent.tool-call', {
+        skill: 'qa',
+        qaAttemptId: 'qa-attempt',
+        tool_name: 'Bash',
+      }),
+    ];
+    const items: RenderItem[] = events.map((event) => ({ kind: 'event', event }));
+    const renderedKinds: string[] = [];
+
+    render(
+      <ul>
+        <RunGroupWrapper
+          runId="qa-attempt"
+          items={items}
+          idx={0}
+          skill="qa"
+          startedAt={events[0].createdAt}
+          endedAt={null}
+          lastEventAt={events[2].createdAt}
+          personaId={null}
+          modelId={null}
+          runtime={null}
+          renderItem={(item, idx) => {
+            if (item.kind === 'event') renderedKinds.push(item.event.kind);
+            return <li key={idx}>{item.kind === 'event' ? item.event.kind : item.kind}</li>;
+          }}
+        />
+      </ul>,
+    );
+
+    expect(renderedKinds).toContain('agent.tool-call');
+    expect(renderedKinds).not.toContain('qa.preflight-step-started');
+    expect(renderedKinds.filter((kind) => kind === 'agent.tool-call')).toHaveLength(1);
   });
 });

--- a/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
+++ b/apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx
@@ -11,8 +11,10 @@ import {
   formatSkillName,
   getAgentLogDisplayText,
   isCodexTransportWarningLog,
+  summarizeQaPreflightSteps,
 } from '../../lib/timeline';
 import { CostBadge } from '../CostBadge';
+import { QaPreflightSummaryEvent } from './QaEvents';
 
 const STALL_MS = 15 * 60 * 1000; // 15 minutes with no new events → stalled
 
@@ -93,6 +95,15 @@ export function RunGroupWrapper({
   const codexTransportWarnings = groupEventList.filter(isCodexTransportWarningLog);
   const codexTransportWarning = codexTransportWarnings[0] ?? null;
   const warningRecovered = codexTransportWarning != null && endedAt != null && !isFailed;
+  const qaPreflightSummary = useMemo(
+    () => summarizeQaPreflightSteps(groupEventList),
+    [groupEventList],
+  );
+  const hasQaAgentStarted = groupEventList.some(
+    (event) =>
+      event.kind === 'agent.run-started' &&
+      (event.payload as { skill?: string } | null)?.skill === 'qa',
+  );
 
   const displayItems = items
     .filter(
@@ -100,6 +111,11 @@ export function RunGroupWrapper({
         !(
           item.kind === 'event' &&
           codexTransportWarnings.some((event) => event.id === item.event.id)
+        ) &&
+        !(
+          item.kind === 'event' &&
+          qaPreflightSummary.hasPreflightStepEvents &&
+          item.event.kind.startsWith('qa.preflight-step-')
         ),
     )
     .map((item) => {
@@ -130,6 +146,12 @@ export function RunGroupWrapper({
   const endMs = endedAt != null ? new Date(endedAt).getTime() : null;
   const lastMs = lastEventAt != null ? new Date(lastEventAt).getTime() : null;
   const isStalled = isLive && lastMs != null && now - lastMs > STALL_MS;
+  const liveBannerText =
+    isLive && !isStalled
+      ? qaPreflightSummary.hasPreflightEvents && !hasQaAgentStarted
+        ? 'QA preflight running...'
+        : 'Agent running...'
+      : null;
   const liveDuration = startMs != null ? formatDuration(now - startMs) : null;
   const completeDuration =
     startMs != null && endMs != null ? formatDuration((lastMs ?? endMs) - startMs) : null;
@@ -297,6 +319,9 @@ export function RunGroupWrapper({
           <span className="ml-auto shrink-0 text-fg-5">{items.length} events</span>
         </summary>
         <ol className="flex flex-col gap-2 px-3 pb-3">
+          {qaPreflightSummary.hasPreflightEvents && (
+            <QaPreflightSummaryEvent summary={qaPreflightSummary} />
+          )}
           {isStalled && (
             <li className="rounded-md border border-dashed border-yellow-500/30 bg-yellow-500/5 px-3 py-2 flex items-center gap-2 text-[10.5px] text-yellow-400">
               <span className="font-mono uppercase tracking-wider">
@@ -305,10 +330,10 @@ export function RunGroupWrapper({
               </span>
             </li>
           )}
-          {isLive && !isStalled && (
+          {liveBannerText != null && (
             <li className="rounded-md border border-dashed border-[color:var(--accent)]/30 bg-[color:var(--accent)]/5 px-3 py-2 flex items-center gap-2 text-[10.5px] text-[color:var(--accent)]">
               <Loader2 size={12} className="shrink-0 animate-spin" />
-              <span className="font-mono uppercase tracking-wider">Agent running…</span>
+              <span className="font-mono uppercase tracking-wider">{liveBannerText}</span>
             </li>
           )}
           {codexTransportWarning != null && (

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -1509,6 +1509,49 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     });
   });
 
+  it('preserves passed preflight status when the QA workflow fails after preflight completed', () => {
+    const QA_ATTEMPT = 'qa-attempt-agent-failed';
+    const summary = summarizeQaPreflightSteps([
+      makeEvent(1, 'qa.preflight-step-started', 'qa-runtime-agent-failed', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'lint',
+          command: 'pnpm lint',
+          status: 'running',
+        },
+      }),
+      makeEvent(2, 'qa.preflight-step-completed', 'qa-runtime-agent-failed', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'lint',
+          command: 'pnpm lint',
+          status: 'passed',
+          exitCode: 0,
+        },
+      }),
+      makeEvent(3, 'qa.preflight-completed', 'qa-runtime-agent-failed', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          status: 'passed',
+        },
+      }),
+      makeEvent(4, 'qa.workflow-failed', 'qa-runtime-agent-failed', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          status: 'failed',
+          reason: 'qa-agent-failed',
+        },
+      }),
+    ]);
+
+    expect(summary.status).toBe('passed');
+    expect(summary.title).toBe('Preflight passed');
+    expect(summary.steps.find((step) => step.step === 'lint')).toMatchObject({
+      status: 'passed',
+      exitCode: 0,
+    });
+  });
+
   it('renders started-only QA preflight steps as running for live attempts', () => {
     const summary = summarizeQaPreflightSteps([
       makeEvent(1, 'qa.preflight-step-started', 'qa-live-preflight', {

--- a/apps/web/src/components/detail/lib/timeline.test.ts
+++ b/apps/web/src/components/detail/lib/timeline.test.ts
@@ -11,6 +11,7 @@ import {
   groupByReviewWorkflow,
   groupEvents,
   groupTimelineEventsByCanonicalSection,
+  summarizeQaPreflightSteps,
 } from './timeline';
 import {
   compareTimelineChildrenForReading,
@@ -1437,6 +1438,120 @@ describe('groupTimelineEventsByCanonicalSection', () => {
     expect(qaSections[0].items).toHaveLength(1);
     expect(qaSections[0].items[0]).toMatchObject({ kind: 'run-group', runId: QA_RUN });
     expect(collectRunIdsForTimelineSection(qaSections[0].items)).toEqual(new Set([QA_RUN]));
+  });
+
+  it('collapses started and completed QA preflight steps into one passed row', () => {
+    const QA_ATTEMPT = 'qa-attempt-preflight-pass';
+    const summary = summarizeQaPreflightSteps([
+      makeEvent(1, 'qa.preflight-step-started', 'qa-runtime-pass', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'lint',
+          command: 'pnpm lint',
+          status: 'running',
+        },
+      }),
+      makeEvent(2, 'qa.preflight-step-completed', 'qa-runtime-pass', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'lint',
+          command: 'pnpm lint',
+          status: 'passed',
+          durationMs: 1500,
+          exitCode: 0,
+        },
+      }),
+    ]);
+
+    const lintRows = summary.steps.filter((step) => step.step === 'lint');
+    expect(lintRows).toHaveLength(1);
+    expect(lintRows[0]).toMatchObject({
+      label: 'Lint',
+      status: 'passed',
+      durationMs: 1500,
+      exitCode: 0,
+      command: 'pnpm lint',
+    });
+  });
+
+  it('collapses started and failed QA preflight steps into one failed row', () => {
+    const QA_ATTEMPT = 'qa-attempt-preflight-fail';
+    const summary = summarizeQaPreflightSteps([
+      makeEvent(1, 'qa.preflight-step-started', 'qa-runtime-fail', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'test',
+          command: 'pnpm test',
+          status: 'running',
+        },
+      }),
+      makeEvent(2, 'qa.preflight-step-failed', 'qa-runtime-fail', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'test',
+          command: 'pnpm test',
+          status: 'failed',
+          durationMs: 7500,
+          exitCode: 1,
+          reason: 'vitest failed',
+        },
+      }),
+    ]);
+
+    const testRows = summary.steps.filter((step) => step.step === 'test');
+    expect(testRows).toHaveLength(1);
+    expect(testRows[0]).toMatchObject({
+      label: 'Tests',
+      status: 'failed',
+      durationMs: 7500,
+      exitCode: 1,
+      reason: 'vitest failed',
+    });
+  });
+
+  it('renders started-only QA preflight steps as running for live attempts', () => {
+    const summary = summarizeQaPreflightSteps([
+      makeEvent(1, 'qa.preflight-step-started', 'qa-live-preflight', {
+        payload: {
+          qaAttemptId: 'qa-live-preflight',
+          step: 'test',
+          command: 'pnpm test',
+          status: 'running',
+        },
+      }),
+    ]);
+
+    expect(summary.status).toBe('running');
+    expect(summary.steps.find((step) => step.step === 'test')).toMatchObject({
+      status: 'running',
+      command: 'pnpm test',
+    });
+  });
+
+  it('renders started-only QA preflight steps as superseded for superseded attempts', () => {
+    const QA_ATTEMPT = 'qa-superseded-preflight';
+    const summary = summarizeQaPreflightSteps([
+      makeEvent(1, 'qa.preflight-step-started', 'qa-runtime-superseded', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          step: 'test',
+          command: 'pnpm test',
+          status: 'running',
+        },
+      }),
+      makeEvent(2, 'qa.workflow-aborted', 'qa-runtime-superseded', {
+        payload: {
+          qaAttemptId: QA_ATTEMPT,
+          reason: 'superseded',
+        },
+      }),
+    ]);
+
+    expect(summary.status).toBe('superseded');
+    expect(summary.steps.find((step) => step.step === 'test')).toMatchObject({
+      status: 'superseded',
+      command: 'pnpm test',
+    });
   });
 
   it('groups QA preflight events before agent runtime metadata arrives', () => {

--- a/apps/web/src/components/detail/lib/timeline/index.ts
+++ b/apps/web/src/components/detail/lib/timeline/index.ts
@@ -42,6 +42,8 @@ export { VISIBLE_INTERVENTION_EVENT_TYPES } from './interventions';
 export { groupByContractPhase } from './phases/contract';
 export { groupByDiscoverPhase } from './phases/discover';
 export { groupByInvestigationPhase } from './phases/investigation';
+export { summarizeQaPreflightSteps } from './qa-preflight';
+export type { QaPreflightStepStatus, QaPreflightSummary } from './qa-preflight';
 export {
   collectBillableRunIdsForTimelineSection,
   collectRunIdsForTimelineSection,

--- a/apps/web/src/components/detail/lib/timeline/qa-preflight.ts
+++ b/apps/web/src/components/detail/lib/timeline/qa-preflight.ts
@@ -1,0 +1,282 @@
+import type { AgentEventDto } from '@/lib/types';
+
+export type QaPreflightStepKey =
+  | 'lint'
+  | 'typecheck'
+  | 'test'
+  | 'e2e'
+  | 'evidence'
+  | 'executable-checks'
+  | string;
+
+export type QaPreflightStepStatus =
+  | 'running'
+  | 'passed'
+  | 'failed'
+  | 'skipped'
+  | 'superseded'
+  | 'aborted'
+  | 'interrupted'
+  | 'incomplete'
+  | 'not-started'
+  | 'unknown';
+
+export type QaPreflightSummaryStatus =
+  | 'running'
+  | 'passed'
+  | 'failed'
+  | 'superseded'
+  | 'aborted'
+  | 'incomplete'
+  | 'unknown';
+
+export type QaPreflightStepSummary = {
+  key: string;
+  qaAttemptId: string | null;
+  step: QaPreflightStepKey;
+  label: string;
+  command: string | null;
+  status: QaPreflightStepStatus;
+  durationMs: number | null;
+  exitCode: number | null;
+  reason: string | null;
+  lastEventAt: string | null;
+};
+
+export type QaPreflightSummary = {
+  hasPreflightEvents: boolean;
+  hasPreflightStepEvents: boolean;
+  status: QaPreflightSummaryStatus;
+  title: string;
+  description: string | null;
+  steps: QaPreflightStepSummary[];
+};
+
+type QaPreflightPayload = {
+  qaAttemptId?: string;
+  runId?: string;
+  step?: string;
+  command?: string;
+  status?: string;
+  durationMs?: number;
+  exitCode?: number;
+  reason?: string;
+};
+
+const STANDARD_STEP_ORDER: QaPreflightStepKey[] = ['lint', 'typecheck', 'test', 'e2e'];
+const EXTRA_STEP_ORDER: QaPreflightStepKey[] = ['evidence', 'executable-checks'];
+
+export function summarizeQaPreflightSteps(events: AgentEventDto[]): QaPreflightSummary {
+  const preflightEvents = events.filter((event) => event.kind.startsWith('qa.preflight-'));
+  const stepEvents = preflightEvents.filter((event) => event.kind.startsWith('qa.preflight-step-'));
+  const terminal = latestQaWorkflowTerminal(events);
+  const hasPreflightCompleted = preflightEvents.some(
+    (event) => event.kind === 'qa.preflight-completed',
+  );
+  const groups = new Map<string, AgentEventDto[]>();
+
+  for (const event of stepEvents) {
+    const payload = event.payload as QaPreflightPayload | null;
+    const step = normalizeStep(payload?.step);
+    const command = stringOrNull(payload?.command);
+    const qaAttemptId =
+      stringOrNull(payload?.qaAttemptId) ?? stringOrNull(payload?.runId) ?? event.runId ?? null;
+    const key = `${qaAttemptId ?? 'unknown'}:${step}:${command ?? ''}`;
+    const group = groups.get(key) ?? [];
+    group.push(event);
+    groups.set(key, group);
+  }
+
+  const groupedSteps = [...groups.entries()].map(([key, group]) => {
+    const sorted = [...group].sort(compareEvents);
+    return stepSummaryFromGroup(key, sorted, terminal);
+  });
+
+  const groupedStandardSteps = new Set(
+    groupedSteps.filter((step) => STANDARD_STEP_ORDER.includes(step.step)).map((step) => step.step),
+  );
+  const missingStandardSteps = STANDARD_STEP_ORDER.filter(
+    (step) => !groupedStandardSteps.has(step),
+  ).map((step) => emptyStepSummary(step));
+
+  const steps = [...groupedSteps, ...missingStandardSteps].sort(compareStepSummaries);
+  const status = resolveSummaryStatus(steps, terminal, hasPreflightCompleted);
+
+  return {
+    hasPreflightEvents: preflightEvents.length > 0,
+    hasPreflightStepEvents: stepEvents.length > 0,
+    status,
+    title: summaryTitle(status),
+    description: summaryDescription(status),
+    steps,
+  };
+}
+
+function stepSummaryFromGroup(
+  key: string,
+  events: AgentEventDto[],
+  terminal: AgentEventDto | null,
+): QaPreflightStepSummary {
+  const latest = events.at(-1);
+  const payload = latest?.payload as QaPreflightPayload | null;
+  const step = normalizeStep(payload?.step);
+  const status = terminalizeStepStatus(statusFromEvent(latest), terminal);
+  return {
+    key,
+    qaAttemptId:
+      stringOrNull(payload?.qaAttemptId) ?? stringOrNull(payload?.runId) ?? latest?.runId ?? null,
+    step,
+    label: qaPreflightStepLabel(step),
+    command: stringOrNull(payload?.command),
+    status,
+    durationMs: numberOrNull(payload?.durationMs),
+    exitCode: numberOrNull(payload?.exitCode),
+    reason: stringOrNull(payload?.reason),
+    lastEventAt: latest?.createdAt ?? null,
+  };
+}
+
+function emptyStepSummary(step: QaPreflightStepKey): QaPreflightStepSummary {
+  return {
+    key: `not-started:${step}`,
+    qaAttemptId: null,
+    step,
+    label: qaPreflightStepLabel(step),
+    command: null,
+    status: 'not-started',
+    durationMs: null,
+    exitCode: null,
+    reason: null,
+    lastEventAt: null,
+  };
+}
+
+function statusFromEvent(event: AgentEventDto | undefined): QaPreflightStepStatus {
+  if (event == null) return 'unknown';
+  const payload = event.payload as QaPreflightPayload | null;
+  if (event.kind === 'qa.preflight-step-started') return 'running';
+  if (event.kind === 'qa.preflight-step-failed') return 'failed';
+  if (event.kind === 'qa.preflight-step-completed') {
+    return payload?.status === 'skipped' ? 'skipped' : 'passed';
+  }
+  return 'unknown';
+}
+
+function terminalizeStepStatus(
+  status: QaPreflightStepStatus,
+  terminal: AgentEventDto | null,
+): QaPreflightStepStatus {
+  if (status !== 'running' || terminal == null) return status;
+  if (terminal.kind === 'qa.workflow-aborted') {
+    const reason = (terminal.payload as QaPreflightPayload | null)?.reason;
+    return reason === 'superseded' ? 'superseded' : 'aborted';
+  }
+  if (terminal.kind === 'qa.workflow-failed') return 'interrupted';
+  if (terminal.kind === 'qa.workflow-completed') return 'incomplete';
+  return status;
+}
+
+function resolveSummaryStatus(
+  steps: QaPreflightStepSummary[],
+  terminal: AgentEventDto | null,
+  hasPreflightCompleted: boolean,
+): QaPreflightSummaryStatus {
+  if (terminal?.kind === 'qa.workflow-aborted') {
+    const reason = (terminal.payload as QaPreflightPayload | null)?.reason;
+    return reason === 'superseded' ? 'superseded' : 'aborted';
+  }
+  if (terminal?.kind === 'qa.workflow-failed') return 'failed';
+  if (
+    terminal?.kind === 'qa.workflow-completed' &&
+    steps.some((step) => step.status === 'running' || step.status === 'incomplete')
+  ) {
+    return 'incomplete';
+  }
+  if (steps.some((step) => step.status === 'failed' || step.status === 'interrupted')) {
+    return 'failed';
+  }
+  if (steps.some((step) => step.status === 'running')) return 'running';
+  if (hasPreflightCompleted) return 'passed';
+  return steps.some((step) => step.status !== 'not-started') ? 'running' : 'unknown';
+}
+
+function summaryTitle(status: QaPreflightSummaryStatus): string {
+  if (status === 'superseded') return 'Preflight superseded';
+  if (status === 'aborted') return 'Preflight abandoned';
+  if (status === 'failed') return 'Preflight failed';
+  if (status === 'incomplete') return 'Preflight incomplete';
+  if (status === 'passed') return 'Preflight passed';
+  if (status === 'running') return 'Preflight running';
+  return 'Preflight status unknown';
+}
+
+function summaryDescription(status: QaPreflightSummaryStatus): string | null {
+  if (status === 'superseded')
+    return 'A newer QA attempt replaced this one before preflight finished.';
+  if (status === 'aborted') return 'QA stopped before preflight finished.';
+  if (status === 'failed') return 'QA preflight did not finish cleanly.';
+  if (status === 'incomplete') return 'QA completed with incomplete preflight results.';
+  return null;
+}
+
+function latestQaWorkflowTerminal(events: AgentEventDto[]): AgentEventDto | null {
+  return (
+    [...events]
+      .filter((event) =>
+        ['qa.workflow-aborted', 'qa.workflow-failed', 'qa.workflow-completed'].includes(event.kind),
+      )
+      .sort(compareEvents)
+      .at(-1) ?? null
+  );
+}
+
+function compareStepSummaries(a: QaPreflightStepSummary, b: QaPreflightStepSummary): number {
+  const orderDelta = stepOrder(a.step) - stepOrder(b.step);
+  if (orderDelta !== 0) return orderDelta;
+  return (a.command ?? '').localeCompare(b.command ?? '');
+}
+
+function stepOrder(step: QaPreflightStepKey): number {
+  const standardIndex = STANDARD_STEP_ORDER.indexOf(step);
+  if (standardIndex !== -1) return standardIndex;
+  const extraIndex = EXTRA_STEP_ORDER.indexOf(step);
+  if (extraIndex !== -1) return STANDARD_STEP_ORDER.length + extraIndex;
+  return STANDARD_STEP_ORDER.length + EXTRA_STEP_ORDER.length;
+}
+
+function compareEvents(a: AgentEventDto, b: AgentEventDto): number {
+  const timeDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  if (timeDelta !== 0) return timeDelta;
+  return a.id - b.id;
+}
+
+function normalizeStep(step: string | undefined): QaPreflightStepKey {
+  return stringOrNull(step) ?? 'unknown';
+}
+
+export function qaPreflightStepLabel(step: QaPreflightStepKey): string {
+  switch (step) {
+    case 'lint':
+      return 'Lint';
+    case 'typecheck':
+      return 'Typecheck';
+    case 'test':
+      return 'Tests';
+    case 'e2e':
+      return 'E2E';
+    case 'evidence':
+      return 'Evidence';
+    case 'executable-checks':
+      return 'Executable checks';
+    default:
+      return 'Preflight step';
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}

--- a/apps/web/src/components/detail/lib/timeline/qa-preflight.ts
+++ b/apps/web/src/components/detail/lib/timeline/qa-preflight.ts
@@ -185,7 +185,6 @@ function resolveSummaryStatus(
     const reason = (terminal.payload as QaPreflightPayload | null)?.reason;
     return reason === 'superseded' ? 'superseded' : 'aborted';
   }
-  if (terminal?.kind === 'qa.workflow-failed') return 'failed';
   if (
     terminal?.kind === 'qa.workflow-completed' &&
     steps.some((step) => step.status === 'running' || step.status === 'incomplete')
@@ -197,6 +196,7 @@ function resolveSummaryStatus(
   }
   if (steps.some((step) => step.status === 'running')) return 'running';
   if (hasPreflightCompleted) return 'passed';
+  if (terminal?.kind === 'qa.workflow-failed') return 'failed';
   return steps.some((step) => step.status !== 'not-started') ? 'running' : 'unknown';
 }
 


### PR DESCRIPTION
## Summary
- collapse QA preflight step lifecycle events into one compact row per step within each QA attempt
- terminalize open preflight steps when a QA attempt is superseded, aborted, failed, or completed
- distinguish live QA preflight banner copy from active QA agent runtime copy while preserving real tool-call rows

## Verification
- pnpm test apps/web/src/components/detail/lib/timeline.test.ts
- pnpm test apps/web/src/components/detail/components/timeline
- pnpm typecheck
- pnpm exec biome check apps/web/src/components/detail/lib/timeline/qa-preflight.ts apps/web/src/components/detail/components/timeline/QaEvents.tsx apps/web/src/components/detail/components/timeline/RunGroupWrapper.tsx apps/web/src/components/detail/lib/timeline.test.ts apps/web/src/components/detail/components/timeline/RunGroupWrapper.test.tsx apps/web/src/components/detail/lib/timeline/index.ts