### PR TITLE
feat: Bitbucket PR delivery + runtime artifact leak guard

### DIFF
--- a/core/connectors/bitbucket/open-pr.ts
+++ b/core/connectors/bitbucket/open-pr.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process';
+import { createBitbucketPullRequest } from '../../integrations/bitbucket/rest.js';
+import type { OpenPrResult } from '../github/open-pr.js';
+
+export interface OpenBitbucketPrInput {
+  worktreePath: string;
+  workspace: string;
+  repo: string;
+  title: string;
+  body: string;
+  branchName: string;
+  baseBranch?: string;
+  fetchImpl?: typeof fetch;
+  gitExec?: (args: string[], cwd: string) => string;
+  skipPush?: boolean;
+}
+
+/**
+ * Pushes the current worktree HEAD to a feature branch and opens a PR via
+ * the Bitbucket REST API. Returns the PR number and web URL.
+ *
+ * Requires pullrequest:write scope on the app password or access token.
+ * Credentials are read from BITBUCKET_USERNAME+BITBUCKET_APP_PASSWORD or BITBUCKET_TOKEN.
+ */
+export async function openBitbucketPR(input: OpenBitbucketPrInput): Promise<OpenPrResult> {
+  if (process.env.MOCK_SOURCE === 'true') {
+    return {
+      prNumber: 999,
+      prUrl: `https://bitbucket.org/${input.workspace}/${input.repo}/pull-requests/999`,
+      branch: input.branchName,
+      base: input.baseBranch ?? 'main',
+    };
+  }
+
+  const {
+    worktreePath,
+    workspace,
+    repo,
+    title,
+    body,
+    branchName,
+    baseBranch = 'main',
+    fetchImpl = fetch,
+    gitExec = defaultGitExec,
+    skipPush = false,
+  } = input;
+
+  if (!skipPush) {
+    gitExec(
+      ['push', '--force-with-lease', 'origin', `HEAD:refs/heads/${branchName}`],
+      worktreePath,
+    );
+  }
+
+  const { prNumber, prUrl } = await createBitbucketPullRequest({
+    workspace,
+    repo,
+    title,
+    description: body,
+    sourceBranch: branchName,
+    targetBranch: baseBranch,
+    fetchImpl,
+  });
+
+  return { prNumber, prUrl, branch: branchName, base: baseBranch };
+}
+
+function defaultGitExec(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}

--- a/core/connectors/bitbucket/open-pr.ts
+++ b/core/connectors/bitbucket/open-pr.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { createBitbucketPullRequest } from '../../integrations/bitbucket/rest.js';
+import { GIT_ENV } from '../../workspaces/git-env.js';
 import type { OpenPrResult } from '../github/open-pr.js';
 
 export interface OpenBitbucketPrInput {
@@ -66,5 +67,5 @@ export async function openBitbucketPR(input: OpenBitbucketPrInput): Promise<Open
 }
 
 function defaultGitExec(args: string[], cwd: string): string {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: GIT_ENV });
 }

--- a/core/integrations/bitbucket/external-refs.ts
+++ b/core/integrations/bitbucket/external-refs.ts
@@ -42,6 +42,31 @@ export function upsertBitbucketPullRequestRef(
   });
 }
 
+export interface BitbucketBranchExternalRefInput {
+  projectId: string;
+  workItemId: string;
+  workspace: string;
+  repo: string;
+  branchName: string;
+  repository?: LocalDbWorkItemRepository;
+}
+
+export function upsertBitbucketBranchRef(
+  input: BitbucketBranchExternalRefInput,
+): LocalDbExternalRefRow {
+  const repository = input.repository ?? new LocalDbWorkItemRepository();
+  return repository.upsertExternalRef({
+    projectId: input.projectId,
+    itemId: input.workItemId,
+    provider: 'bitbucket',
+    kind: 'branch',
+    repoRef: bitbucketRepoRef(input),
+    externalId: input.branchName,
+    url: null,
+    metadata: null,
+  });
+}
+
 export function latestBitbucketPullRequestRef(input: {
   projectId: string;
   workItemId: string;

--- a/core/integrations/bitbucket/rest.test.ts
+++ b/core/integrations/bitbucket/rest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createBitbucketRestAdapter } from './rest.js';
+import { createBitbucketPullRequest, createBitbucketRestAdapter } from './rest.js';
 
 function response(status: number, body: unknown, statusText = 'OK') {
   return {
@@ -121,5 +121,109 @@ describe('Bitbucket REST adapter', () => {
       ok: false,
       error: { kind: 'not_found', status: 404 },
     });
+  });
+});
+
+describe('createBitbucketPullRequest', () => {
+  it('posts correct payload and maps id/url from response', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response(201, {
+        id: 77,
+        title: 'Factory: add capitalize helper',
+        links: { html: { href: 'https://bitbucket.org/ws/repo/pull-requests/77' } },
+      }),
+    );
+
+    const result = await createBitbucketPullRequest({
+      workspace: 'ws',
+      repo: 'repo',
+      title: 'Factory: add capitalize helper',
+      description: 'Closes #42',
+      sourceBranch: 'factory/run-1',
+      targetBranch: 'main',
+      username: 'ada',
+      appPassword: 'secret',
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      prNumber: 77,
+      prUrl: 'https://bitbucket.org/ws/repo/pull-requests/77',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.bitbucket.org/2.0/repositories/ws/repo/pullrequests');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      title: 'Factory: add capitalize helper',
+      description: 'Closes #42',
+      source: { branch: { name: 'factory/run-1' } },
+      destination: { branch: { name: 'main' } },
+    });
+  });
+
+  it('falls back to constructed URL when response omits links', async () => {
+    const fetchImpl = vi.fn(async () => response(201, { id: 12 }));
+
+    const result = await createBitbucketPullRequest({
+      workspace: 'ws',
+      repo: 'repo',
+      title: 'T',
+      sourceBranch: 'factory/x',
+      targetBranch: 'main',
+      username: 'ada',
+      appPassword: 'secret',
+      fetchImpl,
+    });
+
+    expect(result.prUrl).toBe('https://bitbucket.org/ws/repo/pull-requests/12');
+  });
+
+  it('throws on 4xx response with body detail', async () => {
+    const fetchImpl = vi.fn(async () => response(401, 'Unauthorized', 'Unauthorized'));
+
+    await expect(
+      createBitbucketPullRequest({
+        workspace: 'ws',
+        repo: 'repo',
+        title: 'T',
+        sourceBranch: 'factory/x',
+        targetBranch: 'main',
+        username: 'ada',
+        appPassword: 'secret',
+        fetchImpl,
+      }),
+    ).rejects.toThrow('Bitbucket PR creation failed: 401');
+  });
+
+  it('throws when no credentials are provided', async () => {
+    const fetchImpl = vi.fn();
+    const prev = {
+      user: process.env.BITBUCKET_USERNAME,
+      pass: process.env.BITBUCKET_APP_PASSWORD,
+      token: process.env.BITBUCKET_TOKEN,
+    };
+    process.env.BITBUCKET_USERNAME = '';
+    process.env.BITBUCKET_APP_PASSWORD = '';
+    process.env.BITBUCKET_TOKEN = '';
+
+    try {
+      await expect(
+        createBitbucketPullRequest({
+          workspace: 'ws',
+          repo: 'repo',
+          title: 'T',
+          sourceBranch: 'factory/x',
+          targetBranch: 'main',
+          fetchImpl,
+        }),
+      ).rejects.toThrow('credentials required');
+    } finally {
+      if (prev.user !== undefined) process.env.BITBUCKET_USERNAME = prev.user;
+      if (prev.pass !== undefined) process.env.BITBUCKET_APP_PASSWORD = prev.pass;
+      if (prev.token !== undefined) process.env.BITBUCKET_TOKEN = prev.token;
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/core/integrations/bitbucket/rest.ts
+++ b/core/integrations/bitbucket/rest.ts
@@ -353,3 +353,86 @@ function stringValue(value: unknown): string {
 function numberValue(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
+
+export interface BitbucketCreatePrInput {
+  workspace: string;
+  repo: string;
+  title: string;
+  description?: string;
+  sourceBranch: string;
+  targetBranch: string;
+  username?: string;
+  appPassword?: string;
+  accessToken?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface BitbucketCreatePrResult {
+  prNumber: number;
+  prUrl: string;
+}
+
+/**
+ * Creates a pull request in Bitbucket via the REST API.
+ * Auth reads from explicit options first, then env vars (BITBUCKET_TOKEN or
+ * BITBUCKET_USERNAME + BITBUCKET_APP_PASSWORD). Requires pullrequest:write scope.
+ */
+export async function createBitbucketPullRequest(
+  input: BitbucketCreatePrInput,
+): Promise<BitbucketCreatePrResult> {
+  const auth = authorizationHeader({
+    username: input.username ?? process.env.BITBUCKET_USERNAME,
+    appPassword: input.appPassword ?? process.env.BITBUCKET_APP_PASSWORD,
+    accessToken: input.accessToken ?? process.env.BITBUCKET_TOKEN,
+  });
+  if (auth == null) {
+    throw new Error(
+      'Bitbucket credentials required: set BITBUCKET_USERNAME+BITBUCKET_APP_PASSWORD or BITBUCKET_TOKEN',
+    );
+  }
+
+  const baseUrl = (input.baseUrl ?? 'https://api.bitbucket.org/2.0').replace(/\/+$/, '');
+  const url = `${baseUrl}/repositories/${encodeURIComponent(input.workspace)}/${encodeURIComponent(input.repo)}/pullrequests`;
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: auth,
+      },
+      body: JSON.stringify({
+        title: input.title,
+        description: input.description ?? '',
+        source: { branch: { name: input.sourceBranch } },
+        destination: { branch: { name: input.targetBranch } },
+        close_source_branch: false,
+      }),
+    });
+  } catch (err) {
+    throw new Error(`Failed to connect to Bitbucket: ${String(err)}`);
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '<no body>');
+    throw new Error(
+      `Bitbucket PR creation failed: ${response.status} ${response.statusText} — ${detail}`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    id?: unknown;
+    links?: { html?: { href?: unknown } };
+  };
+  const prNumber = typeof json.id === 'number' ? json.id : Number(json.id);
+  const prUrl =
+    typeof json.links?.html?.href === 'string'
+      ? json.links.html.href
+      : `https://bitbucket.org/${encodeURIComponent(input.workspace)}/${encodeURIComponent(input.repo)}/pull-requests/${prNumber}`;
+
+  return { prNumber, prUrl };
+}

--- a/core/workspaces/orchestrator-git.test.ts
+++ b/core/workspaces/orchestrator-git.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -53,5 +53,24 @@ describe('orchestratorCommitAll', () => {
     if (result.status !== 'committed') return;
     expect(result.sha).toMatch(/^[a-f0-9]{40}$/);
     expect(git(['show', '--format=%s', '--no-patch', 'HEAD'])).toBe('repair');
+  });
+
+  it('does not commit .factory or .claude runtime artifacts', () => {
+    writeFileSync(join(repo, 'README.md'), 'changed\n');
+    mkdirSync(join(repo, '.factory'), { recursive: true });
+    writeFileSync(join(repo, '.factory', 'symbol-index.db'), 'binary\n');
+    mkdirSync(join(repo, '.claude'), { recursive: true });
+    writeFileSync(join(repo, '.claude', 'session.json'), '{}');
+
+    const result = orchestratorCommitAll(repo, 'no-runtime-artifacts');
+
+    expect(result.status).toBe('committed');
+    if (result.status !== 'committed') return;
+    const committedFiles = git(['show', '--name-only', '--format=', 'HEAD'])
+      .split('\n')
+      .filter(Boolean);
+    expect(committedFiles).not.toContain('.factory/symbol-index.db');
+    expect(committedFiles).not.toContain('.claude/session.json');
+    expect(committedFiles).toContain('README.md');
   });
 });

--- a/core/workspaces/orchestrator-git.ts
+++ b/core/workspaces/orchestrator-git.ts
@@ -143,6 +143,15 @@ export function orchestratorCommitAll(
   commitMsg: string,
 ): OrchestratorCommitAllResult {
   execFileSync('git', ['add', '-A'], { cwd: worktreePath, stdio: 'pipe', env: GIT_ENV });
+  // Unstage runtime-artifact dirs that must never appear in target-repo commits.
+  // spawnSync is intentional: non-zero exit (dir absent or nothing staged) is expected and fine.
+  for (const dir of ['.factory', '.claude']) {
+    spawnSync('git', ['restore', '--staged', dir], {
+      cwd: worktreePath,
+      stdio: 'pipe',
+      env: GIT_ENV,
+    });
+  }
   const stagedDiff = spawnSync('git', ['diff', '--cached', '--quiet'], {
     cwd: worktreePath,
     stdio: 'pipe',

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -23,10 +23,15 @@ import { recordAgentRun } from '@goose-hub/core/agent-runtime/run-record.js';
 import { selectRuntime } from '@goose-hub/core/agent-runtime/select-runtime.js';
 import { resolveSkillRuntimeForProject } from '@goose-hub/core/agent-runtime/skill-runtime-resolver.js';
 import { runWithEscalation } from '@goose-hub/core/agent-runtime/with-escalation.js';
+import { openBitbucketPR } from '@goose-hub/core/connectors/bitbucket/open-pr.js';
 import { openLocalDbPR, type openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { getEvidencePostEnabled } from '@goose-hub/core/db/repositories/project-settings.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import {
+  upsertBitbucketBranchRef,
+  upsertBitbucketPullRequestRef,
+} from '@goose-hub/core/integrations/bitbucket/external-refs.js';
 import { upsertGithubExternalRef } from '@goose-hub/core/integrations/github/external-refs.js';
 import { getProjectBySlug } from '@goose-hub/core/projects/loader.js';
 import type { StateSource, WorkItem } from '@goose-hub/core/state-source/interface.js';
@@ -37,7 +42,11 @@ import {
 } from '@goose-hub/core/symbol-index/hints-used.js';
 import type { SymbolKeyFileHint } from '@goose-hub/core/symbol-index/lookup.js';
 import { canonicalPathStringFromAuditPayload } from '@goose-hub/core/tool-layer/tool-call-audit.js';
-import { deriveObservedChangedFiles } from '@goose-hub/core/workspaces/observed-changes.js';
+import type { LocalDbSourceConfig, SourceConfig } from '@goose-hub/core/types.js';
+import {
+  type ObservedChangedFilesPacket,
+  deriveObservedChangedFiles,
+} from '@goose-hub/core/workspaces/observed-changes.js';
 import type { orchestratorCommitAll } from '@goose-hub/core/workspaces/orchestrator-git.js';
 import {
   type RepoRelativePathNormalization,
@@ -96,6 +105,9 @@ export interface AfterImplementInput {
   worktreePath: string;
   baseBranch: string;
   openPRFn: typeof openPR;
+  openBitbucketPRFn?: typeof openBitbucketPR;
+  /** Source config from the project — drives PR provider routing. */
+  sourceConfig?: SourceConfig | null;
   evidenceRuntime?: AgentRuntime;
   evidencePostPrompt: string;
   evidencePostJsonSchema: Record<string, unknown>;
@@ -113,6 +125,22 @@ type NormalizedPathField = {
   source: RepoRelativePathNormalization['source'];
   ambiguous?: string[];
 };
+
+const RUNTIME_ARTIFACT_DIRS = ['.factory', '.claude'];
+
+function filterRuntimeArtifacts(packet: ObservedChangedFilesPacket): ObservedChangedFilesPacket {
+  const files = packet.files.filter(
+    (f) =>
+      !RUNTIME_ARTIFACT_DIRS.some(
+        (dir) =>
+          f.rawPath === dir ||
+          f.rawPath.startsWith(`${dir}/`) ||
+          f.path === dir ||
+          f.path.startsWith(`${dir}/`),
+      ),
+  );
+  return { ...packet, files, paths: files.map((f) => f.path), count: files.length };
+}
 
 const WRITE_TOOL_NAMES = new Set([
   'Write',
@@ -944,7 +972,7 @@ export async function runImplement(input: RunImplementInput): Promise<ImplementO
 export async function afterImplement(input: AfterImplementInput): Promise<void> {
   const { implementOutput, workItem, stateSource, projectId, runId, worktreePath } = input;
   const stateSourceItemId = workItem.id.startsWith('local:') ? workItem.id : workItem.externalId;
-  const observedChangedFiles = deriveObservedChangedFiles(worktreePath);
+  const observedChangedFiles = filterRuntimeArtifacts(deriveObservedChangedFiles(worktreePath));
 
   // Orchestrator commits the builder's work before opening the PR (ADR 0031).
   // The implement skill writes files but no longer commits; this call stages
@@ -986,10 +1014,6 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
   });
 
   // Step 5: open PR.
-  const token = process.env.GITHUB_TOKEN ?? '';
-  if (token.length === 0 && process.env.MOCK_OPEN_PR !== 'true') {
-    throw new Error('GITHUB_TOKEN env var is required to open PR');
-  }
   const linkedIssueRef = workItem.id.startsWith('local:')
     ? latestLinkedGithubIssue(projectId, workItem.id)
     : null;
@@ -1001,6 +1025,12 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
   const shouldCloseGithubIssue =
     Number.isFinite(closesIssueNumber) &&
     (linkedIssueRef != null || !workItem.id.startsWith('local:'));
+
+  const isBitbucketProject =
+    input.sourceConfig?.kind === 'local-db' &&
+    (input.sourceConfig as LocalDbSourceConfig).integrations?.bitbucket?.postBack?.pullRequests ===
+      true;
+
   const body = buildPrBody({
     workItem,
     implementOutput,
@@ -1008,43 +1038,85 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
     closesIssueNumber: shouldCloseGithubIssue ? closesIssueNumber : null,
   });
 
-  const prResult = shouldCloseGithubIssue
-    ? await input.openPRFn({
-        worktreePath,
-        repo: repoRef,
-        issueNumber: closesIssueNumber,
-        title,
-        body,
-        branchName,
-        baseBranch: input.baseBranch,
-        token,
-      })
-    : await openLocalDbPR({
-        worktreePath,
-        repo: repoRef,
-        title,
-        body,
-        branchName,
-        baseBranch: input.baseBranch,
-        token,
-      });
+  let prResult: Awaited<ReturnType<typeof openBitbucketPR>>;
+  let prProvider: 'github' | 'bitbucket';
 
-  if (workItem.id.startsWith('local:')) {
-    upsertGithubExternalRef({
+  if (isBitbucketProject) {
+    const [workspace, repo, ...rest] = (repoRef ?? '').split('/');
+    if (!workspace || !repo || rest.length > 0) {
+      throw new Error(
+        `Cannot derive Bitbucket workspace/repo from repoRef: "${repoRef ?? '(null)'}". Expected "workspace/repo".`,
+      );
+    }
+    const openBitbucketPRFn = input.openBitbucketPRFn ?? openBitbucketPR;
+    prResult = await openBitbucketPRFn({
+      worktreePath,
+      workspace,
+      repo,
+      title,
+      body,
+      branchName,
+      baseBranch: input.baseBranch,
+    });
+    upsertBitbucketPullRequestRef({
       projectId,
       workItemId: workItem.id,
-      kind: 'pull_request',
-      repoRef,
-      externalId: String(prResult.prNumber),
+      workspace,
+      repo,
+      pullRequestId: prResult.prNumber,
       url: prResult.prUrl,
     });
-    upsertGithubExternalRef({
+    upsertBitbucketBranchRef({
       projectId,
       workItemId: workItem.id,
-      kind: 'branch',
-      repoRef,
-      externalId: prResult.branch,
+      workspace,
+      repo,
+      branchName: prResult.branch,
     });
+    prProvider = 'bitbucket';
+  } else {
+    const token = process.env.GITHUB_TOKEN ?? '';
+    if (token.length === 0 && process.env.MOCK_OPEN_PR !== 'true') {
+      throw new Error('GITHUB_TOKEN env var is required to open PR');
+    }
+    prResult = shouldCloseGithubIssue
+      ? await input.openPRFn({
+          worktreePath,
+          repo: repoRef,
+          issueNumber: closesIssueNumber,
+          title,
+          body,
+          branchName,
+          baseBranch: input.baseBranch,
+          token,
+        })
+      : await openLocalDbPR({
+          worktreePath,
+          repo: repoRef,
+          title,
+          body,
+          branchName,
+          baseBranch: input.baseBranch,
+          token,
+        });
+    if (workItem.id.startsWith('local:')) {
+      upsertGithubExternalRef({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'pull_request',
+        repoRef,
+        externalId: String(prResult.prNumber),
+        url: prResult.prUrl,
+      });
+      upsertGithubExternalRef({
+        projectId,
+        workItemId: workItem.id,
+        kind: 'branch',
+        repoRef,
+        externalId: prResult.branch,
+      });
+    }
+    prProvider = 'github';
   }
 
   eventStore.appendEvent({
@@ -1061,6 +1133,8 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
       // Legacy fix-issue has a single developer run, so the delivery
       // lifecycle intentionally aliases the dev run id for M19 scoring.
       pipelineRunId: runId,
+      provider: prProvider,
+      repoRef,
     },
     runId,
   });

--- a/slices/fix-issue/implement-phase.ts
+++ b/slices/fix-issue/implement-phase.ts
@@ -42,7 +42,11 @@ import {
 } from '@goose-hub/core/symbol-index/hints-used.js';
 import type { SymbolKeyFileHint } from '@goose-hub/core/symbol-index/lookup.js';
 import { canonicalPathStringFromAuditPayload } from '@goose-hub/core/tool-layer/tool-call-audit.js';
-import type { LocalDbSourceConfig, SourceConfig } from '@goose-hub/core/types.js';
+import type {
+  LocalDbBitbucketIntegrationConfig,
+  LocalDbSourceConfig,
+  SourceConfig,
+} from '@goose-hub/core/types.js';
 import {
   type ObservedChangedFilesPacket,
   deriveObservedChangedFiles,
@@ -127,6 +131,19 @@ type NormalizedPathField = {
 };
 
 const RUNTIME_ARTIFACT_DIRS = ['.factory', '.claude'];
+
+function isBitbucketRepoRef(repoRef: string, config: LocalDbBitbucketIntegrationConfig): boolean {
+  // Multi-workspace config: check explicit list first
+  if (config.workspaces != null && config.workspaces.length > 0) {
+    return config.workspaces.some((w) => w.repos.some((r) => `${w.workspace}/${r}` === repoRef));
+  }
+  // Single-workspace + explicit repo list
+  if (config.workspace != null && config.repos != null && config.repos.length > 0) {
+    return config.repos.some((r) => `${config.workspace}/${r}` === repoRef);
+  }
+  // Fallback: workspace prefix only (no explicit repo list configured)
+  return config.workspace != null && repoRef.startsWith(`${config.workspace}/`);
+}
 
 function filterRuntimeArtifacts(packet: ObservedChangedFilesPacket): ObservedChangedFilesPacket {
   const files = packet.files.filter(
@@ -1026,10 +1043,15 @@ export async function afterImplement(input: AfterImplementInput): Promise<void> 
     Number.isFinite(closesIssueNumber) &&
     (linkedIssueRef != null || !workItem.id.startsWith('local:'));
 
+  const bitbucketIntegration =
+    input.sourceConfig?.kind === 'local-db'
+      ? (input.sourceConfig as LocalDbSourceConfig).integrations?.bitbucket
+      : undefined;
   const isBitbucketProject =
-    input.sourceConfig?.kind === 'local-db' &&
-    (input.sourceConfig as LocalDbSourceConfig).integrations?.bitbucket?.postBack?.pullRequests ===
-      true;
+    bitbucketIntegration != null &&
+    bitbucketIntegration.postBack?.pullRequests === true &&
+    repoRef != null &&
+    isBitbucketRepoRef(repoRef, bitbucketIntegration);
 
   const body = buildPrBody({
     workItem,

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -84,6 +84,7 @@ const mockOpenPR = vi
   .mockResolvedValue({ prNumber: 1, prUrl: 'u', branch: 'b', base: 'main' });
 vi.mock('@goose-hub/core/connectors/github/open-pr.js', () => ({
   openPR: (...args: unknown[]) => mockOpenPR(...args),
+  openLocalDbPR: (...args: unknown[]) => mockOpenPR(...args),
 }));
 const mockAdviseOnPlan = vi.fn();
 vi.mock('@goose-hub/core/agent-runtime/advisor.js', () => ({
@@ -135,8 +136,40 @@ vi.mock('@goose-hub/core/workspaces/workflow-base.js', () => ({
 vi.mock('@goose-hub/core/workspaces/orchestrator-git.js', () => ({
   orchestratorCommitAll: vi.fn().mockReturnValue({ status: 'committed', sha: 'fake-sha' }),
 }));
+vi.mock('@goose-hub/core/state-source/local-db-repository.js', () => ({
+  LocalDbWorkItemRepository: vi.fn().mockImplementation(() => ({
+    listExternalRefs: vi.fn().mockReturnValue([]),
+    upsertExternalRef: vi.fn().mockReturnValue({
+      id: 1,
+      provider: '',
+      kind: '',
+      repoRef: '',
+      externalId: '',
+      url: null,
+      metadata: null,
+      metadataJson: null,
+      createdAt: '',
+    }),
+    // repo-affinity uses this to resolve the checkout repository for local: items
+    listRepoLinks: vi
+      .fn()
+      .mockReturnValue([
+        { repoRef: 'workspace/repo', role: 'primary', confidence: 1, source: 'explicit' },
+      ]),
+  })),
+}));
+const mockOpenBitbucketPR = vi.fn().mockResolvedValue({
+  prNumber: 200,
+  prUrl: 'https://bitbucket.org/workspace/repo/pull-requests/200',
+  branch: 'factory/run-bb',
+  base: 'main',
+});
+vi.mock('@goose-hub/core/connectors/bitbucket/open-pr.js', () => ({
+  openBitbucketPR: (...args: unknown[]) => mockOpenBitbucketPR(...args),
+}));
 
 import { eventStore } from '@goose-hub/core/event-stream/store.js';
+import { LocalDbWorkItemRepository } from '@goose-hub/core/state-source/local-db-repository.js';
 import { GIT_ENV } from '@goose-hub/core/workspaces/git-env.js';
 import { WorktreeDependencyPreflightError } from '@goose-hub/core/workspaces/worktree.js';
 
@@ -2820,5 +2853,175 @@ describe('resolveWorktreeHeadSha (M7.bug fix — #233 SHA pinning)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+function makeBitbucketProjectConfig(postBackPullRequests = true): Record<string, unknown> {
+  return makeProjectConfig({
+    source: {
+      kind: 'local-db',
+      stateMachine: 'db',
+      integrations: {
+        bitbucket: {
+          enabled: true,
+          postBack: { pullRequests: postBackPullRequests, comments: false },
+        },
+      },
+    },
+    repos: ['workspace/repo'],
+  });
+}
+
+describe('runFixIssueWorkflow — Bitbucket PR delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEventStoreMocks();
+    mockAccumulatePersonaStats.mockClear();
+    resetRuntimeRoutingMocks();
+    mockProjectConfig = makeBitbucketProjectConfig();
+  });
+
+  function makeBitbucketDeps(overrides: Record<string, unknown> = {}) {
+    return {
+      runtime: {
+        run: vi.fn().mockResolvedValueOnce({
+          output: makeImplementOutput(),
+          decisionSummaries: [],
+          events: [],
+        } satisfies AgentResult),
+      } as AgentRuntime,
+      openBitbucketPRImpl: vi.fn().mockResolvedValue({
+        prNumber: 200,
+        prUrl: 'https://bitbucket.org/workspace/repo/pull-requests/200',
+        branch: 'factory/run-bb',
+        base: 'main',
+      }),
+      adviseOnPlanImpl: vi.fn(),
+      createWorktreeImpl: vi.fn().mockReturnValue('/work/wt'),
+      cleanupWorktreeImpl: vi.fn(),
+      resolveWorktreeHeadShaImpl: vi
+        .fn()
+        .mockReturnValue('abc1234567890abcdef1234567890abcdef1234'),
+      ...overrides,
+    };
+  }
+
+  it('calls openBitbucketPRFn with workspace/repo, not openPRFn', async () => {
+    const item = makeWorkItem({
+      id: 'local:proj/42',
+      externalId: '42',
+      repoRef: 'workspace/repo',
+    });
+    const source = makeStateSource();
+    const deps = makeBitbucketDeps();
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', deps);
+
+    expect(deps.openBitbucketPRImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: 'workspace',
+        repo: 'repo',
+        branchName: expect.stringContaining('factory/'),
+      }),
+    );
+    expect(mockOpenPR).not.toHaveBeenCalled();
+  });
+
+  it('pr.opened event has provider: bitbucket', async () => {
+    const item = makeWorkItem({
+      id: 'local:proj/42',
+      externalId: '42',
+      repoRef: 'workspace/repo',
+    });
+    const source = makeStateSource();
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', makeBitbucketDeps());
+
+    const opened = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'pr.opened');
+    expect(opened).toBeDefined();
+    const payload = opened?.[0].payload as Record<string, unknown>;
+    expect(payload).toHaveProperty('provider', 'bitbucket');
+    expect(payload).toHaveProperty('prNumber', 200);
+    expect(payload).toHaveProperty(
+      'prUrl',
+      'https://bitbucket.org/workspace/repo/pull-requests/200',
+    );
+  });
+
+  it('local-db without postBack.pullRequests falls back to GitHub connector', async () => {
+    mockProjectConfig = makeBitbucketProjectConfig(false);
+    process.env.GITHUB_TOKEN = 'ghp_test';
+    const item = makeWorkItem({
+      id: 'local:proj/42',
+      externalId: '42',
+      repoRef: 'workspace/repo',
+    });
+    const source = makeStateSource();
+    const deps = makeBitbucketDeps();
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', deps);
+
+    // GitHub path uses openLocalDbPR (mocked via mockOpenPR module-level mock)
+    expect(mockOpenPR).toHaveBeenCalled();
+    expect(deps.openBitbucketPRImpl).not.toHaveBeenCalled();
+
+    const opened = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'pr.opened');
+    const payload = opened?.[0].payload as Record<string, unknown>;
+    expect(payload).toHaveProperty('provider', 'github');
+  });
+
+  it('emits needs-human and transitions if repoRef cannot become workspace/repo', async () => {
+    // Build a project config that accepts 'org/sub/repo' as a known repository
+    // so repo-affinity passes, but the 3-segment repoRef reaches afterImplement
+    // and triggers the "Cannot derive" guard.
+    const threePartRef = 'org/sub/repo';
+    mockProjectConfig = {
+      ...makeBitbucketProjectConfig(),
+      repos: [threePartRef],
+      repositories: [
+        {
+          id: 'r1',
+          repoRef: threePartRef,
+          cloneUrl: '',
+          defaultBranch: 'main',
+          localPath: '/repo',
+          role: 'code',
+        },
+      ],
+    };
+    vi.mocked(LocalDbWorkItemRepository).mockImplementationOnce(
+      () =>
+        ({
+          listExternalRefs: vi.fn().mockReturnValue([]),
+          upsertExternalRef: vi.fn().mockReturnValue({ id: 1 }),
+          listRepoLinks: vi
+            .fn()
+            .mockReturnValue([{ repoRef: threePartRef, role: 'primary', confidence: 1 }]),
+        }) as unknown as LocalDbWorkItemRepository,
+    );
+    const item = makeWorkItem({
+      id: 'local:proj/42',
+      externalId: '42',
+      repoRef: threePartRef,
+    });
+    const source = makeStateSource();
+
+    const { runFixIssueWorkflow } = await import('./workflow.js');
+    // workflow catches the error and transitions to needs-human (does not re-throw)
+    await runFixIssueWorkflow(item, source, 'proj', '/repo', makeBitbucketDeps());
+
+    const failEvent = vi
+      .mocked(eventStore.appendEvent)
+      .mock.calls.find(([e]) => e.kind === 'agent.run-failed');
+    expect(failEvent).toBeDefined();
+    const payload = failEvent?.[0].payload as Record<string, unknown>;
+    expect(String(payload?.error)).toContain('Cannot derive Bitbucket workspace/repo');
   });
 });

--- a/slices/fix-issue/slice.test.ts
+++ b/slices/fix-issue/slice.test.ts
@@ -2864,6 +2864,8 @@ function makeBitbucketProjectConfig(postBackPullRequests = true): Record<string,
       integrations: {
         bitbucket: {
           enabled: true,
+          workspace: 'workspace',
+          repos: ['repo'],
           postBack: { pullRequests: postBackPullRequests, comments: false },
         },
       },
@@ -2978,12 +2980,24 @@ describe('runFixIssueWorkflow — Bitbucket PR delivery', () => {
   });
 
   it('emits needs-human and transitions if repoRef cannot become workspace/repo', async () => {
-    // Build a project config that accepts 'org/sub/repo' as a known repository
-    // so repo-affinity passes, but the 3-segment repoRef reaches afterImplement
-    // and triggers the "Cannot derive" guard.
+    // 'org/sub/repo' has 3 path segments — the split guard fires after routing.
+    // Use workspace: 'org' (no repos list) so the prefix fallback matches it as Bitbucket-owned,
+    // but the 3-segment split still throws "Cannot derive workspace/repo".
     const threePartRef = 'org/sub/repo';
     mockProjectConfig = {
-      ...makeBitbucketProjectConfig(),
+      ...makeProjectConfig({
+        source: {
+          kind: 'local-db',
+          stateMachine: 'db',
+          integrations: {
+            bitbucket: {
+              enabled: true,
+              workspace: 'org',
+              postBack: { pullRequests: true, comments: false },
+            },
+          },
+        },
+      }),
       repos: [threePartRef],
       repositories: [
         {

--- a/slices/fix-issue/workflow.ts
+++ b/slices/fix-issue/workflow.ts
@@ -7,6 +7,7 @@ import { readPromptWithContext } from '@goose-hub/core/agent-runtime/read-prompt
 import { buildRelatedSurfaceManifest } from '@goose-hub/core/agent-runtime/related-surface.js';
 import { toJsonSchema } from '@goose-hub/core/agent-runtime/schema-bridge.js';
 import { selectPersona } from '@goose-hub/core/agent-runtime/select-persona.js';
+import { openBitbucketPR } from '@goose-hub/core/connectors/bitbucket/open-pr.js';
 import { openPR } from '@goose-hub/core/connectors/github/open-pr.js';
 import { getEvidencePostEnabled } from '@goose-hub/core/db/repositories/project-settings.js';
 import { emitStateTransitionEvent } from '@goose-hub/core/event-stream/state-transition.js';
@@ -52,6 +53,8 @@ export interface FixIssueDeps {
   evidenceRuntime?: AgentRuntime;
   /** Override openPR (used by tests). Defaults to the real connector. */
   openPRImpl?: typeof openPR;
+  /** Override openBitbucketPR (used by tests). Defaults to the real connector. */
+  openBitbucketPRImpl?: typeof openBitbucketPR;
   /** Override the advisor wrapper (used by tests). Defaults to adviseOnPlan. */
   adviseOnPlanImpl?: typeof adviseOnPlan;
   /** Override createWorktree (used by tests). */
@@ -100,6 +103,7 @@ export async function runFixIssueWorkflow(
 ): Promise<void> {
   const runId = crypto.randomUUID();
   const openPRFn = deps.openPRImpl ?? openPR;
+  const openBitbucketPRFn = deps.openBitbucketPRImpl ?? openBitbucketPR;
   const advisorFn = deps.adviseOnPlanImpl ?? adviseOnPlan;
   const createWtFn = deps.createWorktreeImpl ?? createWorktree;
   const cleanupWtFn = deps.cleanupWorktreeImpl ?? cleanupWorktree;
@@ -334,6 +338,8 @@ export async function runFixIssueWorkflow(
           worktreePath,
           baseBranch,
           openPRFn,
+          openBitbucketPRFn,
+          sourceConfig: implementExecution.projectConfig?.source,
           evidenceRuntime: deps.evidenceRuntime ?? deps.runtime,
           evidencePostPrompt,
           evidencePostJsonSchema,
@@ -380,6 +386,8 @@ export async function runFixIssueWorkflow(
       worktreePath,
       baseBranch,
       openPRFn,
+      openBitbucketPRFn,
+      sourceConfig: implementExecution.projectConfig?.source,
       evidenceRuntime: deps.evidenceRuntime ?? deps.runtime,
       evidencePostPrompt,
       evidencePostJsonSchema,


### PR DESCRIPTION
## Summary

- **Bitbucket PR delivery**: local-db projects with `integrations.bitbucket.postBack.pullRequests: true` now open PRs via the Bitbucket REST API instead of the GitHub connector. Routing lives in `afterImplement`; `pr.opened` gains additive `provider` and `repoRef` fields.
- **Runtime artifact leak guard**: `orchestratorCommitAll` unstages `.factory/` and `.claude/` after `git add -A` so runtime state never enters target-repo commits. `observedChangedFiles` filters the same dirs before they reach PR bodies or events.
- **New connector**: `core/connectors/bitbucket/open-pr.ts` mirrors the GitHub connector shape (push branch + REST create PR). `upsertBitbucketBranchRef` added to external-refs.

## Files changed

| Area | Change |
|------|--------|
| `core/integrations/bitbucket/rest.ts` | `createBitbucketPullRequest` — POST to Bitbucket API |
| `core/connectors/bitbucket/open-pr.ts` | New — push + PR creation connector |
| `core/integrations/bitbucket/external-refs.ts` | `upsertBitbucketBranchRef` |
| `core/workspaces/orchestrator-git.ts` | Unstage `.factory`/`.claude` after `git add -A` |
| `slices/fix-issue/implement-phase.ts` | Provider routing, runtime artifact filter, `AfterImplementInput` additions |
| `slices/fix-issue/workflow.ts` | Wire `sourceConfig` + `openBitbucketPRFn` to `afterImplement` |

## Test plan

- [x] `core/workspaces/orchestrator-git.test.ts` — `.factory/` and `.claude/` not committed
- [x] `core/integrations/bitbucket/rest.test.ts` — PR creation payload, URL fallback, 4xx, missing creds
- [x] `slices/fix-issue/slice.test.ts` — Bitbucket routing, `pr.opened.provider`, GitHub fallback, bad repoRef surfaces as `agent.run-failed`
- [x] All 90 tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)