### PR TITLE
M19.XX: capture chore 2

### DIFF
--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TopBar } from './TopBar';
+
+vi.mock('@/components/search/components/SearchModal', () => ({
+  SearchModal: ({ open }: { open: boolean }) => (
+    <div data-testid="search-modal">{open ? 'open' : 'closed'}</div>
+  ),
+}));
+
+vi.mock('@/components/ui/CaptureModal', () => ({
+  CaptureModal: ({ open }: { open: boolean }) => (
+    <div data-testid="capture-modal">{open ? 'open' : 'closed'}</div>
+  ),
+}));
+
+vi.mock('./ChangelogModal', () => ({
+  ChangelogModal: ({ open }: { open: boolean }) => (
+    <div data-testid="changelog-modal">{open ? 'open' : 'closed'}</div>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe('TopBar', () => {
+  it('shows the Capture shortcut badge and title copy', () => {
+    render(<TopBar />);
+
+    const captureButton = screen.getByTestId('capture-button');
+
+    expect(captureButton.getAttribute('title')).toBe('Capture an idea or task (⌘J)');
+    expect(screen.getByText('⌘J')).toBeTruthy();
+  });
+
+  it('opens Capture with Meta+J but not plain J', () => {
+    render(<TopBar />);
+
+    expect(screen.getByTestId('capture-modal').textContent).toBe('closed');
+
+    fireEvent.keyDown(document, { key: 'j' });
+    expect(screen.getByTestId('capture-modal').textContent).toBe('closed');
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+    expect(screen.getByTestId('capture-modal').textContent).toBe('open');
+  });
+
+  it('opens Capture with Ctrl+J', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+
+    expect(screen.getByTestId('capture-modal').textContent).toBe('open');
+  });
+
+  it('keeps the Search shortcut working', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+
+    expect(screen.getByTestId('search-modal').textContent).toBe('open');
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -15,9 +15,21 @@ export function TopBar({ breadcrumb }: TopBarProps) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if (!(e.metaKey || e.ctrlKey)) {
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+
+      if (key === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
+        return;
+      }
+
+      if (key === 'j') {
+        e.preventDefault();
+        setShowCapture(true);
       }
     }
     document.addEventListener('keydown', onKey);
@@ -46,11 +58,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

capture chore 2

## Work Packages

- ✓ **WP1**: Extend `apps/web/src/components/chrome/TopBar.tsx:11` so the existing document keydown listener at `TopBar.tsx:15` handl

Local Work Item: local:goose-hub-self#45
