### PR TITLE
M19.XX: capture chore 2

### DIFF
--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,62 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TopBar } from './TopBar';
+
+vi.mock('@/components/ui/CaptureModal', () => ({
+  CaptureModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="capture-modal">Capture idea</div> : null,
+}));
+
+vi.mock('@/components/search/components/SearchModal', () => ({
+  SearchModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="search-modal">Search work items</div> : null,
+}));
+
+vi.mock('./ChangelogModal', () => ({
+  ChangelogModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="changelog-modal">Last 7 days</div> : null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TopBar', () => {
+  it('shows the capture shortcut badge and tooltip copy', () => {
+    render(<TopBar />);
+
+    const captureButton = screen.getByTestId('capture-button');
+    expect(captureButton.getAttribute('title')).toBe('Capture an idea or task (⌘J)');
+    expect(screen.getByText('⌘J')).toBeTruthy();
+  });
+
+  it('opens the capture modal when the capture button is clicked', () => {
+    render(<TopBar />);
+
+    fireEvent.click(screen.getByTestId('capture-button'));
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+
+  it('opens capture on Cmd+J and keeps the search shortcut on Cmd+K', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+    expect(screen.queryByTestId('search-modal')).toBeNull();
+
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+
+    expect(screen.getByTestId('search-modal')).toBeTruthy();
+  });
+
+  it('opens capture on Ctrl+J', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'J', ctrlKey: true });
+
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -15,7 +15,19 @@ export function TopBar({ breadcrumb }: TopBarProps) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if (!(e.metaKey || e.ctrlKey)) {
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+
+      if (key === 'j') {
+        e.preventDefault();
+        setShowCapture(true);
+        return;
+      }
+
+      if (key === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
       }
@@ -46,11 +58,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

capture chore 2

## Work Packages

- ✓ **WP1**: In `apps/web/src/components/chrome/TopBar.tsx:11`, extend the existing document `keydown` handler so `metaKey || ctrlKey

Local Work Item: local:goose-hub-self#49
