### PR TITLE
M19.XX: capture chore 2

### DIFF
--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TopBar } from './TopBar';
+
+afterEach(() => {
+  cleanup();
+});
+
+function Providers({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderTopBar() {
+  return render(
+    <Providers>
+      <TopBar />
+    </Providers>,
+  );
+}
+
+describe('TopBar', () => {
+  it('opens Capture when Cmd+J is pressed', () => {
+    renderTopBar();
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+
+    expect(screen.getByText('Capture idea')).toBeTruthy();
+    expect(screen.getByTestId('capture-title-input')).toBeTruthy();
+  });
+
+  it('opens Capture when Ctrl+J is pressed', () => {
+    renderTopBar();
+
+    fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+
+    expect(screen.getByText('Capture idea')).toBeTruthy();
+    expect(screen.getByTestId('capture-title-input')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -15,6 +15,11 @@ export function TopBar({ breadcrumb }: TopBarProps) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setShowCapture(true);
+      }
+
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
@@ -46,11 +51,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -53,3 +53,18 @@ describe('chrome slice — deferred surfaces config', () => {
     expect(collapsed).toBe(false);
   });
 });
+
+describe('chrome slice — top bar shortcuts', () => {
+  const topBarSource = readFileSync(join(import.meta.dirname, 'TopBar.tsx'), 'utf-8');
+
+  it('capture button exposes a visible ⌘J shortcut label', () => {
+    expect(topBarSource).toContain('⌘J');
+  });
+
+  it('top bar binds the existing modifier chord pattern to capture on j', () => {
+    expect(topBarSource).toMatch(
+      /\(e\.metaKey \|\| e\.ctrlKey\).*e\.key\.toLowerCase\(\) === 'j'/s,
+    );
+    expect(topBarSource).toContain('setShowCapture(true)');
+  });
+});


### PR DESCRIPTION
## Summary

capture chore 2

## Work Packages

- ✓ **WP1**: Update `apps/web/src/components/chrome/TopBar.tsx:10`-anchored local modal state wiring so the existing `useEffect` keyb

Local Work Item: local:goose-hub-self#61
