### PR TITLE
M19.XX: capture bug 2

### DIFF
--- a/apps/web/src/components/chrome/AppShell.test.tsx
+++ b/apps/web/src/components/chrome/AppShell.test.tsx
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppShell } from './AppShell';
+
+vi.mock('./Sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar" />,
+}));
+
+vi.mock('./slots/ProjectSwitcherSlot', () => ({
+  ProjectSwitcherSlot: () => null,
+}));
+
+function renderDetailRoute() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/projects/goose-hub-self/items/64']}>
+        <Routes>
+          <Route
+            path="/projects/:slug/items/:id"
+            element={
+              <AppShell breadcrumb={<span>Detail</span>}>
+                <div data-testid="detail-content" />
+              </AppShell>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('AppShell', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps the shared header visible on detail routes', () => {
+    renderDetailRoute();
+
+    expect(screen.getByTestId('top-bar')).toBeTruthy();
+    expect(screen.getByTestId('detail-content')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -45,4 +45,14 @@ describe('TopBar', () => {
     fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
     expect(screen.getByTestId('capture-modal')).toBeTruthy();
   });
+
+  it('keeps capture open when the shortcut is pressed again', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -21,13 +21,30 @@ afterEach(() => {
   cleanup();
 });
 
+function mockNavigatorPlatform(platform: string) {
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
 describe('TopBar', () => {
-  it('shows the capture shortcut label and tooltip copy', () => {
+  it('shows Apple capture shortcut copy on Apple platforms', () => {
+    mockNavigatorPlatform('MacIntel');
     render(<TopBar />);
 
     const captureButton = screen.getByTestId('capture-button');
     expect(captureButton.getAttribute('title')).toBe('Capture an idea or task (⌘J)');
     expect(screen.getByText('⌘J')).toBeTruthy();
+  });
+
+  it('shows Ctrl capture shortcut copy on non-Apple platforms', () => {
+    mockNavigatorPlatform('Win32');
+    render(<TopBar />);
+
+    const captureButton = screen.getByTestId('capture-button');
+    expect(captureButton.getAttribute('title')).toBe('Capture an idea or task (Ctrl+J)');
+    expect(screen.getByText('Ctrl+J')).toBeTruthy();
   });
 
   it('opens capture on Meta+J and Ctrl+J, but not on bare J', () => {

--- a/apps/web/src/components/chrome/TopBar.test.tsx
+++ b/apps/web/src/components/chrome/TopBar.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TopBar } from './TopBar';
+
+vi.mock('@/components/search/components/SearchModal', () => ({
+  SearchModal: ({ open }: { open: boolean }) => (open ? <div data-testid="search-modal" /> : null),
+}));
+
+vi.mock('@/components/ui/CaptureModal', () => ({
+  CaptureModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="capture-modal" /> : null,
+}));
+
+vi.mock('./ChangelogModal', () => ({
+  ChangelogModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="changelog-modal" /> : null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TopBar', () => {
+  it('shows the capture shortcut label and tooltip copy', () => {
+    render(<TopBar />);
+
+    const captureButton = screen.getByTestId('capture-button');
+    expect(captureButton.getAttribute('title')).toBe('Capture an idea or task (⌘J)');
+    expect(screen.getByText('⌘J')).toBeTruthy();
+  });
+
+  it('opens capture on Meta+J and Ctrl+J, but not on bare J', () => {
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j', metaKey: true });
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+
+    cleanup();
+    render(<TopBar />);
+
+    fireEvent.keyDown(document, { key: 'j' });
+    expect(screen.queryByTestId('capture-modal')).toBeNull();
+
+    fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+    expect(screen.getByTestId('capture-modal')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -15,9 +15,9 @@ export function TopBar({ breadcrumb }: TopBarProps) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
         e.preventDefault();
-        setShowSearch((prev) => !prev);
+        setShowCapture((prev) => !prev);
       }
     }
     document.addEventListener('keydown', onKey);
@@ -46,11 +46,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -17,7 +17,7 @@ export function TopBar({ breadcrumb }: TopBarProps) {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
         e.preventDefault();
-        setShowCapture((prev) => !prev);
+        setShowCapture(true);
       }
     }
     document.addEventListener('keydown', onKey);

--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -8,10 +8,18 @@ interface TopBarProps {
   breadcrumb?: React.ReactNode;
 }
 
+function getCaptureShortcutLabel() {
+  if (typeof navigator === 'undefined') return '⌘J';
+
+  const platform = `${navigator.platform} ${navigator.userAgent}`;
+  return /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘J' : 'Ctrl+J';
+}
+
 export function TopBar({ breadcrumb }: TopBarProps) {
   const [showCapture, setShowCapture] = useState(false);
   const [showChangelog, setShowChangelog] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  const captureShortcutLabel = getCaptureShortcutLabel();
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -46,13 +54,13 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task (⌘J)"
+          title={`Capture an idea or task (${captureShortcutLabel})`}
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
           <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
-            ⌘J
+            {captureShortcutLabel}
           </kbd>
         </button>
         <button


### PR DESCRIPTION
## Summary

capture bug 2

## Work Packages

- ✓ **WP1**: In `apps/web/src/components/chrome/TopBar.tsx:15`, replace the stale `Meta/Ctrl+K` handler with a capture-specific `Meta

Local Work Item: local:goose-hub-self#64
