### PR TITLE
M19.XX: capture chore

### DIFF
--- a/apps/web/src/components/chrome/TopBar.tsx
+++ b/apps/web/src/components/chrome/TopBar.tsx
@@ -18,6 +18,9 @@ export function TopBar({ breadcrumb }: TopBarProps) {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setShowSearch((prev) => !prev);
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setShowCapture((prev) => !prev);
       }
     }
     document.addEventListener('keydown', onKey);
@@ -46,11 +49,14 @@ export function TopBar({ breadcrumb }: TopBarProps) {
           type="button"
           data-testid="capture-button"
           onClick={() => setShowCapture(true)}
-          title="Capture an idea or task"
+          title="Capture an idea or task (⌘J)"
           className="flex items-center gap-2 h-7 px-2.5 rounded-md text-[12px] text-fg-2 border border-line bg-bg hover:bg-bg-elev cursor-pointer"
         >
           <Plus size={13} />
           <span>Capture</span>
+          <kbd className="ml-1 px-1 py-0.5 rounded border border-line text-[10px] text-fg-3 bg-bg">
+            ⌘J
+          </kbd>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/chrome/slice.test.ts
+++ b/apps/web/src/components/chrome/slice.test.ts
@@ -53,3 +53,19 @@ describe('chrome slice — deferred surfaces config', () => {
     expect(collapsed).toBe(false);
   });
 });
+
+describe('chrome slice — TopBar capture shortcut', () => {
+  const topBarSource = readFileSync(join(import.meta.dirname, 'TopBar.tsx'), 'utf-8');
+
+  it('onKey handler checks for metaKey', () => {
+    expect(topBarSource).toContain('metaKey');
+  });
+
+  it('onKey handler checks for the j key', () => {
+    expect(topBarSource).toContain("'j'");
+  });
+
+  it('Capture button renders ⌘J kbd label', () => {
+    expect(topBarSource).toContain('⌘J');
+  });
+});


### PR DESCRIPTION
## Summary

capture chore

## Work Packages

- ✓ **WP1**: TopBar.tsx line 19-21: extend the onKey handler to add `else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j'

Local Work Item: local:goose-hub-self-claude#84
